### PR TITLE
Enhance WebDAV client reliability

### DIFF
--- a/src-tauri/src/infrastructure/network/mod.rs
+++ b/src-tauri/src/infrastructure/network/mod.rs
@@ -1,6 +1,5 @@
 pub mod webdav;
 pub mod websocket;
 
-
-pub use webdav::WebDAVClient;
+pub use webdav::{WebDAVClient, WebDavConfig, WebDavError};
 pub use websocket::WebSocketClient;

--- a/src-tauri/src/infrastructure/network/webdav.rs
+++ b/src-tauri/src/infrastructure/network/webdav.rs
@@ -269,7 +269,7 @@ impl WebDAVClient {
 
     #[allow(dead_code)]
     pub async fn fetch_latest_file(&self, dir: String) -> WebDavResult<Payload> {
-        let entries = self.list(&dir, Depth::Number(0)).await?;
+        let entries = self.list(&dir, Depth::Number(1)).await?;
         let latest_file = entries
             .iter()
             .filter_map(|entity| match entity {
@@ -295,7 +295,11 @@ impl WebDAVClient {
                 .bytes()
                 .await
                 .map_err(|e| WebDavError::Network(format!("读取响应失败: {}", e)))?;
-            let payload = serde_json::from_slice(&content)
+            let decrypted_payload = self
+                .encryptor
+                .decrypt(&content)
+                .map_err(|e| WebDavError::Encryption(e.to_string()))?;
+            let payload = serde_json::from_slice(&decrypted_payload)
                 .map_err(|e| WebDavError::Serialization(e.to_string()))?;
             Ok(payload)
         } else {

--- a/src-tauri/src/infrastructure/network/webdav.rs
+++ b/src-tauri/src/infrastructure/network/webdav.rs
@@ -1,11 +1,29 @@
 use crate::infrastructure::security::encryption::Encryptor;
+use crate::infrastructure::security::password::{PasswordRequest, PASSWORD_SENDER};
 use crate::message::Payload;
 use crate::utils::helpers::string_to_32_bytes;
-use anyhow::Result;
-use reqwest_dav::{list_cmd::ListEntity, Auth, ClientBuilder, Depth};
 use chrono::{DateTime, Utc};
-use reqwest_dav::list_cmd::ListFile;
+use log::{debug, error, info, warn};
+use reqwest::StatusCode;
+use reqwest_dav::list_cmd::{ListEntity, ListFile};
+use reqwest_dav::{Auth, ClientBuilder, Depth};
 use serde::{Deserialize, Serialize};
+use std::fmt::{Display, Formatter};
+use std::time::Duration;
+use tokio::sync::mpsc;
+use tokio::time::sleep;
+
+type WebDavResult<T> = std::result::Result<T, WebDavError>;
+
+#[derive(Debug, Clone)]
+pub struct WebDavConfig {
+    pub host: String,
+    pub username: String,
+    pub base_path: String,
+    pub timeout: Duration,
+    pub retry_attempts: u32,
+    pub retry_backoff: Duration,
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FileMetadata {
@@ -19,9 +37,9 @@ pub struct FileMetadata {
 
 impl FileMetadata {
     pub fn from_list_file(list_file: &ListFile, host: &str) -> Self {
-        let prefix = Self::get_prefix(host).unwrap();
+        let prefix = Self::get_prefix(host).unwrap_or_default();
         let path = list_file.href.replacen(&prefix, "", 1);
-        let (dir, name) = path.rsplit_once('/').unwrap();
+        let (dir, name) = path.rsplit_once('/').unwrap_or(("", &path));
         let dir = dir.to_string();
         let name = name.to_string();
         Self {
@@ -43,7 +61,7 @@ impl FileMetadata {
     /// The filename is in the format of {device_id}_{uuid}.json
     #[allow(dead_code)]
     pub fn get_device_id(&self) -> String {
-        self.name.split("_").next().unwrap().to_string()
+        self.name.split('_').next().unwrap_or_default().to_string()
     }
 
     #[allow(dead_code)]
@@ -69,179 +87,225 @@ impl FileMetadata {
     }
 }
 
+#[derive(Debug, Clone)]
+pub enum WebDavError {
+    Timeout,
+    Authentication(String),
+    Permission(String),
+    InsufficientStorage(String),
+    AlreadyExists,
+    NotFound(String),
+    Network(String),
+    Encryption(String),
+    Serialization(String),
+    Stronghold(String),
+    Protocol(String),
+    UnexpectedStatus(StatusCode),
+}
+
+impl Display for WebDavError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            WebDavError::Timeout => write!(f, "WebDAV 请求超时"),
+            WebDavError::Authentication(msg) => write!(f, "认证失败: {}", msg),
+            WebDavError::Permission(msg) => write!(f, "权限不足: {}", msg),
+            WebDavError::InsufficientStorage(msg) => write!(f, "存储空间不足: {}", msg),
+            WebDavError::AlreadyExists => write!(f, "资源已存在"),
+            WebDavError::NotFound(msg) => write!(f, "资源未找到: {}", msg),
+            WebDavError::Network(msg) => write!(f, "网络错误: {}", msg),
+            WebDavError::Encryption(msg) => write!(f, "加密/解密失败: {}", msg),
+            WebDavError::Serialization(msg) => write!(f, "序列化失败: {}", msg),
+            WebDavError::Stronghold(msg) => write!(f, "Stronghold 错误: {}", msg),
+            WebDavError::Protocol(msg) => write!(f, "协议错误: {}", msg),
+            WebDavError::UnexpectedStatus(code) => write!(f, "意外的状态码: {}", code),
+        }
+    }
+}
+
+impl std::error::Error for WebDavError {}
+
+impl WebDavError {
+    fn should_retry(&self) -> bool {
+        matches!(self, WebDavError::Timeout | WebDavError::Network(_))
+    }
+}
+
 pub struct WebDAVClient {
     client: reqwest_dav::Client,
     encryptor: Encryptor,
+    base_path: String,
+    retry_attempts: u32,
+    retry_backoff: Duration,
 }
 
 impl WebDAVClient {
     #[allow(dead_code)]
-    pub async fn new(webdav_url: String, username: String, password: String) -> Result<Self> {
+    pub async fn new(config: WebDavConfig) -> WebDavResult<Self> {
+        let password = fetch_password_from_stronghold().await?;
         let key = string_to_32_bytes(&password);
         let encryptor = Encryptor::from_key(&key);
+
+        let agent = reqwest::Client::builder()
+            .timeout(config.timeout)
+            .build()
+            .map_err(|e| WebDavError::Network(format!("构建 HTTP 客户端失败: {}", e)))?;
+
         let client = ClientBuilder::new()
-            .set_host(webdav_url)
-            .set_auth(Auth::Basic(username, password))
-            .build()?;
-        Ok(Self { client, encryptor })
+            .set_agent(agent)
+            .set_host(config.host.clone())
+            .set_auth(Auth::Basic(config.username.clone(), password))
+            .build()
+            .map_err(WebDavError::from)?;
+
+        Ok(Self {
+            client,
+            encryptor,
+            base_path: normalize_base_path(&config.base_path),
+            retry_attempts: config.retry_attempts,
+            retry_backoff: config.retry_backoff,
+        })
     }
 
     /// 检查是否连接到 WebDAV 服务器
     #[allow(dead_code)]
     pub async fn is_connected(&self) -> bool {
-        self.client.list("/", Depth::Number(0)).await.is_ok()
+        self.list("", Depth::Number(0)).await.is_ok()
     }
 
-    /// Initializes the share directory on the WebDAV server.
-    ///
-    /// This method attempts to create a new directory at the specified base path
-    /// on the WebDAV server. This directory will be used for storing shared files.
-    ///
-    /// # Returns
-    ///
-    /// Returns a `Result` which is `Ok(())` if the directory is successfully created,
-    /// or an `Error` if the operation fails.
     #[allow(dead_code)]
-    async fn initialize_share_directory(&self, dir: String) -> anyhow::Result<()> {
-        self.client.mkcol(&dir).await?;
-        Ok(())
+    pub async fn initialize_share_directory(&self, dir: String) -> WebDavResult<()> {
+        let full_path = self.full_path(&dir);
+        self.retry("mkcol", || {
+            let path = full_path.clone();
+            async move {
+                match self.client.mkcol(&path).await.map_err(WebDavError::from) {
+                    Ok(()) => Ok(()),
+                    Err(WebDavError::AlreadyExists) => {
+                        info!("目录已存在，忽略创建: {}", path);
+                        Ok(())
+                    }
+                    Err(err) => Err(err),
+                }
+            }
+        })
+        .await
     }
 
-    /// Creates a new directory on the WebDAV server for sharing.
-    ///
-    /// This method attempts to create a new directory at the specified base path
-    /// on the WebDAV server. This directory will be used for storing shared files.
-    ///
-    /// # Returns
-    ///
-    /// Returns a `Result` which is `Ok(())` if the directory is successfully created,
-    /// or an `Error` if the operation fails.
-    ///
-    /// # Errors
-    ///
-    /// This function will return an error if:
-    /// - There's a failure in communicating with the WebDAV server
-    /// - The directory already exists
-    /// - The client doesn't have sufficient permissions to create the directory
     #[allow(dead_code)]
     pub async fn is_share_code_exists(&self) -> bool {
-        match self.client.list("/uniclipboard", Depth::Number(0)).await {
+        match self.list("uniclipboard", Depth::Number(0)).await {
             Ok(entries) => !entries.is_empty(),
-            Err(_) => false,
+            Err(err) => {
+                warn!("检查共享目录失败: {}", err);
+                false
+            }
         }
     }
 
     /// Uploads a Payload to the specified directory on the WebDAV server.
-    ///
-    /// # Arguments
-    ///
-    /// * `dir` - A String representing the directory path to upload the Payload to.
-    /// * `payload` - A Payload to be uploaded.
-    ///
-    /// # Returns
-    ///
-    /// Returns a Result containing the path of the uploaded file.
-    pub async fn upload(&self, dir: String, payload: Payload) -> Result<String> {
+    pub async fn upload(&self, dir: String, payload: Payload) -> WebDavResult<String> {
         let filename = format!("{}_{}.bin", payload.get_device_id(), payload.get_key());
-        let path: String;
-        if dir == "/" {
-            path = format!("/{}", filename);
+        let target_dir = self.full_path(&dir);
+        let path = if target_dir == "/" {
+            format!("/{}", filename)
         } else {
-            path = format!("{}/{}", dir, filename);
-        }
+            format!("{}/{}", target_dir.trim_end_matches('/'), filename)
+        };
         let json_payload = payload.to_json();
-        let encrypted_payload = self.encryptor.encrypt(&json_payload.as_bytes())?;
-        self.client.put(&path, encrypted_payload).await?;
+        let encrypted_payload = self
+            .encryptor
+            .encrypt(&json_payload.as_bytes())
+            .map_err(|e| WebDavError::Encryption(e.to_string()))?;
+
+        info!("Uploading payload to {}", path);
+        self.retry("upload", || {
+            let body = encrypted_payload.clone();
+            let path = path.clone();
+            async move {
+                self.client
+                    .put(&path, body)
+                    .await
+                    .map_err(WebDavError::from)
+            }
+        })
+        .await?;
+
         Ok(path)
     }
 
     /// Downloads a Payload from the specified path on the WebDAV server.
-    ///
-    /// # Arguments
-    ///
-    /// * `path` - A String representing the path to download the Payload from.
-    ///
-    /// # Returns   
-    ///
-    /// Returns a Result containing the Payload.
-    pub async fn download(&self, path: String) -> Result<Payload> {
-        let response = self.client.get(&path).await?;
+    pub async fn download(&self, path: String) -> WebDavResult<Payload> {
+        let full_path = self.full_path(&path);
+        info!("Downloading payload from {}", full_path);
+        let response = self
+            .retry("download", || {
+                let path = full_path.clone();
+                async move { self.client.get(&path).await.map_err(WebDavError::from) }
+            })
+            .await?;
+
         if response.status().is_success() {
-            let content = response.bytes().await?;
-            let decrypted_payload = self.encryptor.decrypt(&content)?;
-            let payload = serde_json::from_slice(&decrypted_payload)?;
+            let content = response
+                .bytes()
+                .await
+                .map_err(|e| WebDavError::Network(format!("读取响应失败: {}", e)))?;
+            let decrypted_payload = self
+                .encryptor
+                .decrypt(&content)
+                .map_err(|e| WebDavError::Encryption(e.to_string()))?;
+            let payload = serde_json::from_slice(&decrypted_payload)
+                .map_err(|e| WebDavError::Serialization(e.to_string()))?;
             Ok(payload)
         } else {
-            Err(anyhow::anyhow!("Failed to download file"))
+            Err(WebDavError::UnexpectedStatus(response.status()))
         }
     }
 
     /// Counts the number of files in the specified directory on the WebDAV server.
-    ///
-    /// # Arguments
-    ///
-    /// * `path` - A String representing the directory path to count files in.
-    ///
-    /// # Returns
-    pub async fn count_files(&self, path: String) -> Result<usize> {
-        let entries = self.client.list(&path, Depth::Number(1)).await?;
+    pub async fn count_files(&self, path: String) -> WebDavResult<usize> {
+        let entries = self.list(&path, Depth::Number(1)).await?;
         Ok(entries.len().saturating_sub(1))
     }
 
-    /// Fetches the latest file from the specified directory on the WebDAV server.
-    ///
-    /// # Arguments
-    ///
-    /// * `dir` - A String representing the directory path to search for files.
-    ///
-    /// # Returns
-    ///
-    /// Returns a Result containing the Payload of the latest file.
-    ///
-    /// # Errors
-    ///
-    /// This function will return an error if:
-    /// * The WebDAV list operation fails.
-    /// * No files are found in the specified directory.
-    /// * The latest file cannot be retrieved or deserialized.
     #[allow(dead_code)]
-    pub async fn fetch_latest_file(&self, dir: String) -> Result<Payload> {
-        let entries = self.client.list(&dir, Depth::Number(0)).await?;
+    pub async fn fetch_latest_file(&self, dir: String) -> WebDavResult<Payload> {
+        let entries = self.list(&dir, Depth::Number(0)).await?;
         let latest_file = entries
             .iter()
-            .map(|entity| match entity {
-                ListEntity::File(file) => file,
-                _ => panic!("Not a file"),
+            .filter_map(|entity| match entity {
+                ListEntity::File(file) => Some(file),
+                _ => None,
             })
             .max_by_key(|file| file.last_modified);
 
-        let response = self.client.get(&latest_file.unwrap().href).await?;
+        let target = latest_file
+            .as_ref()
+            .map(|f| f.href.clone())
+            .ok_or_else(|| WebDavError::NotFound("No files found".to_string()))?;
+
+        let response = self
+            .retry("get_latest_file", || {
+                let href = target.clone();
+                async move { self.client.get(&href).await.map_err(WebDavError::from) }
+            })
+            .await?;
+
         if response.status().is_success() {
-            let content = response.bytes().await?;
-            let payload = serde_json::from_slice(&content)?;
+            let content = response
+                .bytes()
+                .await
+                .map_err(|e| WebDavError::Network(format!("读取响应失败: {}", e)))?;
+            let payload = serde_json::from_slice(&content)
+                .map_err(|e| WebDavError::Serialization(e.to_string()))?;
             Ok(payload)
         } else {
-            Err(anyhow::anyhow!("Failed to fetch latest file"))
+            Err(WebDavError::UnexpectedStatus(response.status()))
         }
     }
 
     /// Fetches the metadata of the latest file from the specified directory on the WebDAV server.
-    ///
-    /// # Arguments
-    ///
-    /// * `dir` - A String representing the directory path to search for files.
-    ///
-    /// # Returns
-    ///
-    /// Returns a Result containing the metadata of the latest file.
-    ///
-    /// # Errors
-    ///
-    /// This function will return an error if:
-    /// * The WebDAV list operation fails.
-    /// * No files are found in the specified directory.
-    pub async fn fetch_latest_file_meta(&self, dir: String) -> Result<FileMetadata> {
-        let entries = self.client.list(&dir, Depth::Number(1)).await?;
+    pub async fn fetch_latest_file_meta(&self, dir: String) -> WebDavResult<FileMetadata> {
+        let entries = self.list(&dir, Depth::Number(1)).await?;
         let list_file = entries
             .iter()
             .filter_map(|entity| match entity {
@@ -249,29 +313,15 @@ impl WebDAVClient {
                 _ => None,
             })
             .max_by_key(|file| file.last_modified)
-            .ok_or_else(|| anyhow::anyhow!("No files found"))?;
+            .ok_or_else(|| WebDavError::NotFound("No files found".to_string()))?;
 
-        let meta = FileMetadata::from_list_file(&list_file, &self.client.host);
+        let meta = FileMetadata::from_list_file(list_file, &self.client.host);
         Ok(meta)
     }
 
     /// Fetches the metadata of the oldest file from the specified directory on the WebDAV server.
-    ///
-    /// # Arguments
-    ///
-    /// * `dir` - A String representing the directory path to search for files.
-    ///
-    /// # Returns
-    ///
-    /// Returns a Result containing the metadata of the oldest file.
-    ///
-    /// # Errors
-    ///
-    /// This function will return an error if:
-    /// * The WebDAV list operation fails.
-    /// * No files are found in the specified directory.
-    pub async fn fetch_oldest_file_meta(&self, dir: String) -> Result<FileMetadata> {
-        let entries = self.client.list(&dir, Depth::Number(1)).await?;
+    pub async fn fetch_oldest_file_meta(&self, dir: String) -> WebDavResult<FileMetadata> {
+        let entries = self.list(&dir, Depth::Number(1)).await?;
         let list_file = entries
             .iter()
             .filter_map(|entity| match entity {
@@ -279,30 +329,191 @@ impl WebDAVClient {
                 _ => None,
             })
             .min_by_key(|file| file.last_modified)
-            .ok_or_else(|| anyhow::anyhow!("No files found"))?;
+            .ok_or_else(|| WebDavError::NotFound("No files found".to_string()))?;
 
-        let meta = FileMetadata::from_list_file(&list_file, &self.client.host);
+        let meta = FileMetadata::from_list_file(list_file, &self.client.host);
         Ok(meta)
     }
 
-    /// Deletes a file from the specified path on the WebDAV server.
-    ///
-    /// # Arguments
-    ///
-    /// * `path` - A String representing the path to delete the file from.
-    ///
-    /// # Returns
-    ///
-    /// Returns a Result containing `Ok(())` if the file is successfully deleted,
-    /// or an `Error` if the operation fails.
-    ///
-    /// # Errors
-    ///
-    /// This function will return an error if:
-    /// * The WebDAV delete operation fails.
     #[allow(dead_code)]
-    pub async fn delete(&self, path: String) -> Result<()> {
-        self.client.delete(&path).await?;
-        Ok(())
+    pub async fn delete(&self, path: String) -> WebDavResult<()> {
+        let full_path = self.full_path(&path);
+        self.retry("delete", || {
+            let path = full_path.clone();
+            async move { self.client.delete(&path).await.map_err(WebDavError::from) }
+        })
+        .await
+    }
+
+    fn full_path(&self, relative: &str) -> String {
+        let relative = relative.trim_matches('/');
+        if self.base_path == "/" {
+            if relative.is_empty() {
+                "/".to_string()
+            } else {
+                format!("/{}", relative)
+            }
+        } else if relative.is_empty() {
+            self.base_path.clone()
+        } else {
+            let base_trimmed = self.base_path.trim_matches('/');
+            if relative.starts_with(base_trimmed) {
+                format!("/{}", relative)
+            } else {
+                format!("{}/{}", self.base_path.trim_end_matches('/'), relative)
+            }
+        }
+    }
+
+    async fn list(&self, path: &str, depth: Depth) -> WebDavResult<Vec<ListEntity>> {
+        let target = self.full_path(path);
+        debug!("Listing path: {} depth: {:?}", target, depth);
+        let response = self
+            .retry("list", || {
+                let target = target.clone();
+                async move {
+                    self.client
+                        .list(&target, depth)
+                        .await
+                        .map_err(WebDavError::from)
+                }
+            })
+            .await?;
+        Ok(response)
+    }
+
+    async fn retry<F, Fut, T>(&self, op: &str, mut action: F) -> WebDavResult<T>
+    where
+        F: FnMut() -> Fut,
+        Fut: std::future::Future<Output = WebDavResult<T>>,
+    {
+        for attempt in 0..=self.retry_attempts {
+            match action().await {
+                Ok(val) => return Ok(val),
+                Err(err) => {
+                    if attempt == self.retry_attempts || !err.should_retry() {
+                        error!("{} failed after {} attempts: {}", op, attempt + 1, err);
+                        return Err(err);
+                    }
+                    let backoff = self.retry_backoff * (attempt + 1);
+                    warn!(
+                        "{} failed (attempt {}): {}. retrying in {:?}",
+                        op,
+                        attempt + 1,
+                        err,
+                        backoff
+                    );
+                    sleep(backoff).await;
+                }
+            }
+        }
+
+        Err(WebDavError::Network(format!("{} 未知错误：重试耗尽", op)))
+    }
+}
+
+fn normalize_base_path(path: &str) -> String {
+    let trimmed = path.trim();
+    if trimmed.is_empty() || trimmed == "/" {
+        "/".to_string()
+    } else {
+        format!("/{}", trimmed.trim_matches('/'))
+    }
+}
+
+async fn fetch_password_from_stronghold() -> WebDavResult<String> {
+    let sender = PASSWORD_SENDER
+        .lock()
+        .unwrap()
+        .clone()
+        .ok_or_else(|| WebDavError::Stronghold("密码通道未初始化".to_string()))?;
+
+    let (tx, mut rx) = mpsc::channel(1);
+    sender
+        .send(PasswordRequest::GetEncryptionPassword(tx))
+        .await
+        .map_err(|e| WebDavError::Stronghold(format!("发送 Stronghold 请求失败: {}", e)))?;
+
+    let result = rx
+        .recv()
+        .await
+        .ok_or_else(|| WebDavError::Stronghold("Stronghold 工作线程未响应".to_string()))?;
+
+    match result {
+        Ok(Some(password)) => Ok(password),
+        Ok(None) => Err(WebDavError::Stronghold(
+            "Stronghold 中未找到加密口令".to_string(),
+        )),
+        Err(e) => Err(WebDavError::Stronghold(format!(
+            "读取 Stronghold 失败: {}",
+            e
+        ))),
+    }
+}
+
+impl From<reqwest::Error> for WebDavError {
+    fn from(error: reqwest::Error) -> Self {
+        if error.is_timeout() {
+            WebDavError::Timeout
+        } else if let Some(status) = error.status() {
+            map_status_code(status)
+        } else {
+            WebDavError::Network(error.to_string())
+        }
+    }
+}
+
+impl From<reqwest_dav::types::Error> for WebDavError {
+    fn from(error: reqwest_dav::types::Error) -> Self {
+        use reqwest_dav::types::{DecodeError, Error as DavError, ReqwestDecodeError};
+        match error {
+            DavError::Reqwest(err) => WebDavError::from(err),
+            DavError::ReqwestDecode(ReqwestDecodeError::InvalidMethod(err)) => {
+                WebDavError::Protocol(format!("无效方法: {}", err))
+            }
+            DavError::ReqwestDecode(ReqwestDecodeError::Url(err)) => {
+                WebDavError::Protocol(format!("URL 解析失败: {}", err))
+            }
+            DavError::ReqwestDecode(err) => WebDavError::Protocol(err.to_string()),
+            DavError::Decode(DecodeError::StatusMismatched(err)) => map_status_code(
+                StatusCode::from_u16(err.response_code).unwrap_or(StatusCode::BAD_REQUEST),
+            ),
+            DavError::Decode(DecodeError::Server(err)) => map_status_code(
+                StatusCode::from_u16(err.response_code).unwrap_or(StatusCode::BAD_REQUEST),
+            ),
+            DavError::Decode(DecodeError::FieldNotFound(err)) => {
+                WebDavError::Protocol(format!("字段未找到: {}", err.field))
+            }
+            DavError::Decode(DecodeError::FieldNotSupported(err)) => {
+                WebDavError::Protocol(format!("字段不支持: {}", err.field))
+            }
+            DavError::Decode(DecodeError::DigestAuth(err)) => {
+                WebDavError::Authentication(format!("摘要认证失败: {}", err))
+            }
+            DavError::Decode(DecodeError::SerdeXml(err)) => {
+                WebDavError::Protocol(format!("解析 XML 失败: {}", err))
+            }
+            DavError::Decode(DecodeError::NoAuthHeaderInResponse) => {
+                WebDavError::Authentication("认证头缺失".to_string())
+            }
+            DavError::MissingAuthContext => {
+                WebDavError::Authentication("缺少认证上下文".to_string())
+            }
+        }
+    }
+}
+
+fn map_status_code(code: StatusCode) -> WebDavError {
+    match code {
+        StatusCode::UNAUTHORIZED => WebDavError::Authentication("未授权".to_string()),
+        StatusCode::FORBIDDEN => WebDavError::Permission("禁止访问".to_string()),
+        StatusCode::NOT_FOUND => WebDavError::NotFound("资源不存在".to_string()),
+        StatusCode::CONFLICT => WebDavError::AlreadyExists,
+        StatusCode::INSUFFICIENT_STORAGE => {
+            WebDavError::InsufficientStorage("服务器存储不足".to_string())
+        }
+        StatusCode::REQUEST_TIMEOUT | StatusCode::GATEWAY_TIMEOUT => WebDavError::Timeout,
+        _ if code.is_server_error() => WebDavError::Network(format!("服务器错误: {}", code)),
+        _ => WebDavError::UnexpectedStatus(code),
     }
 }

--- a/src-tauri/src/infrastructure/network/webdav.rs
+++ b/src-tauri/src/infrastructure/network/webdav.rs
@@ -361,7 +361,7 @@ impl WebDAVClient {
             self.base_path.clone()
         } else {
             let base_trimmed = self.base_path.trim_matches('/');
-            if relative.starts_with(base_trimmed) {
+            if relative == base_trimmed || relative.starts_with(&format!("{}/", base_trimmed)) {
                 format!("/{}", relative)
             } else {
                 format!("{}/{}", self.base_path.trim_end_matches('/'), relative)

--- a/src-tauri/src/infrastructure/sync/webdav_sync.rs
+++ b/src-tauri/src/infrastructure/sync/webdav_sync.rs
@@ -125,9 +125,12 @@ impl RemoteClipboardSync for WebDavSync {
     ///
     /// This function will return an error if the upload to the WebDAV server fails.
     async fn push(&self, message: ClipboardTransferMessage) -> Result<()> {
+        let payload = message
+            .payload
+            .ok_or_else(|| anyhow::anyhow!("Payload is missing"))?;
         let _path = self
             .client
-            .upload(self.base_path.clone(), message.payload.unwrap())
+            .upload(self.base_path.clone(), payload)
             .await
             .map_err(|e| anyhow::anyhow!(e))?;
         // 删除旧的文件


### PR DESCRIPTION
## Summary
- add a configurable `WebDavConfig` and retry/backoff wrapper that uses Stronghold-stored credentials, normalized base paths, and idempotent MKCOL handling
- classify network, timeout, auth, permission, and storage errors via a new `WebDavError` and add logging/context to list/upload/download paths
- update WebDAV sync callers to propagate the richer error context while avoiding duplicate base paths

## Testing
- cargo fmt
- cargo check *(fails: missing system dependency `glib-2.0` required by `glib-sys` in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694cfc6570b083319e89d66d1743bb18)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved WebDAV connection reliability with enhanced retry mechanisms for handling transient network failures
  * Better error reporting with clearer diagnostic messages for troubleshooting
  * More informative error feedback for authentication, permission, network, and storage-related issues
  * Streamlined WebDAV configuration and connection initialization

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->