### PR TITLE
Fix WebDAV latest fetch and path handling

### DIFF
--- a/src-tauri/src/infrastructure/sync/webdav_sync.rs
+++ b/src-tauri/src/infrastructure/sync/webdav_sync.rs
@@ -125,9 +125,12 @@ impl RemoteClipboardSync for WebDavSync {
     ///
     /// This function will return an error if the upload to the WebDAV server fails.
     async fn push(&self, message: ClipboardTransferMessage) -> Result<()> {
+        let payload = message
+            .payload
+            .ok_or_else(|| anyhow::anyhow!("Payload is missing"))?;
         let _path = self
             .client
-            .upload(self.base_path.clone(), message.payload.unwrap())
+            .upload(self.base_path.clone(), payload)
             .await
             .map_err(|e| anyhow::anyhow!(e))?;
         // 删除旧的文件


### PR DESCRIPTION
## Summary
- use Depth::Number(1) when listing for the latest file and decrypt the response before deserializing
- guard full_path base path concatenation with segment-aware checks to avoid partial matches
- prevent push panics by returning an error when payload is missing before upload

## Testing
- cargo fmt (in src-tauri)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d013c26d083318e23eb89b90d26e5)