### PR TITLE
Enforce minimum window size

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -17,7 +17,7 @@ use infrastructure::storage::db::pool::DB_POOL;
 use infrastructure::uniclipboard::{UniClipboard, UniClipboardBuilder};
 use log::error;
 use std::sync::Arc;
-use tauri::{TitleBarStyle, WebviewUrl, WebviewWindowBuilder};
+use tauri::{LogicalSize, Size, TitleBarStyle, WebviewUrl, WebviewWindowBuilder};
 use utils::logging;
 
 // 初始化UniClipboard
@@ -163,7 +163,8 @@ fn run_app(uniclipboard_app: Arc<UniClipboard>, user_setting: Setting) {
 
             let win_builder = WebviewWindowBuilder::new(app, "main", WebviewUrl::default())
                 .title("")
-                .inner_size(800.0, 600.0);
+                .inner_size(800.0, 600.0)
+                .min_inner_size(Size::Logical(LogicalSize::new(800.0, 600.0)));
 
             // set transparent title bar only when building for macOS
             #[cfg(target_os = "macos")]


### PR DESCRIPTION
## Summary
- enforce a minimum 800x600 size for the main window to prevent resizing too small
- keep the initial window dimensions aligned with the enforced minimum

## Testing
- cargo fmt --manifest-path src-tauri/Cargo.toml

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d0442dfc48331bf4ce2163a163a9e)