### PR TITLE
perf(settings): memoize SETTING_CATEGORIES to prevent unnecessary re-renders

Add useMemo to wrap SETTING_CATEGORIES array with translation function dependency to optimize performance and avoid unnecessary array recreation on every render.

## Summary

- Wrap SETTING_CATEGORIES array in useMemo to memoize it
- Include translation function 't' in dependency array
- Import useMemo from React
- Prevents unnecessary re-renders when translation doesn't change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### DIFF
--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -12,7 +12,7 @@ import SettingHeader, { CategoryItem } from "@/components/setting/SettingHeader"
 import { useTranslation } from "react-i18next";
 
 const SettingsPage: React.FC = () => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const [activeCategory, setActiveCategory] = useState("general");
   const scrollContainerRef = useRef<HTMLDivElement>(null);
 
@@ -24,7 +24,7 @@ const SettingsPage: React.FC = () => {
     { id: "network", name: t("settings.categories.network") },
     { id: "storage", name: t("settings.categories.storage") },
     { id: "about", name: t("settings.categories.about") },
-  ], [t]);
+  ], [i18n.language]);
 
   // 创建对各个section的引用
   const sectionRefs = {


### PR DESCRIPTION
## Summary

- Wrap SETTING_CATEGORIES array in useMemo to memoize it
- Include translation function 't' in dependency array
- Import useMemo from React
- Prevents unnecessary re-renders when translation doesn't change

## Test plan

- [ ] Verify the application builds successfully
- [ ] Check that settings page renders correctly
- [ ] Confirm translations still work as expected
- [ ] Verify memoization works by checking component re-renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved settings page rendering performance by memoizing the settings category list to avoid unnecessary recalculations.
  * Ensured category names re-evaluate when the app language changes so translations update correctly.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->