### PR TITLE
Add sccache to build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,6 +59,16 @@ jobs:
 
       - name: Setup sccache
         uses: Mozilla-Actions/sccache-action@v0.0.5
+
+      - name: Cache cargo registry + index
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
       
       - name: setup node
         uses: actions/setup-node@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,6 +45,10 @@ jobs:
     name: Build ${{ matrix.target }}
     needs: setup-matrix
     runs-on: ${{ matrix.platform }}
+    env:
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: 'true'
+      SCCACHE_CACHE_SIZE: 2G
     strategy:
       fail-fast: false
       matrix:
@@ -52,6 +56,9 @@ jobs:
     
     steps:
       - uses: actions/checkout@v4
+
+      - name: Setup sccache
+        uses: Mozilla-Actions/sccache-action@v0.0.5
       
       - name: setup node
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
- enable sccache for the build workflow to accelerate Rust compilation
- configure cache-related environment variables and invoke the Mozilla sccache action before tooling setup

## Testing
- not run (CI workflow change only)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694dfbeb59908331ae4dd1de94e4ac8f)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized the build pipeline with caching improvements to reduce build times.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->