### PR TITLE
Fix Windows title bar buttons detection in Tauri

### DIFF
--- a/src/components/TitleBar.tsx
+++ b/src/components/TitleBar.tsx
@@ -8,9 +8,26 @@ interface TitleBarProps {
   className?: string;
 }
 
-const isTauriEnv = () =>
-  typeof window !== "undefined" &&
-  Boolean((window as unknown as { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__);
+const isTauriEnv = () => {
+  if (typeof window === "undefined") return false;
+
+  const globalWindow = window as unknown as {
+    __TAURI_INTERNALS__?: unknown;
+    __TAURI__?: unknown;
+    __TAURI_METADATA__?: unknown;
+  };
+
+  if (globalWindow.__TAURI_INTERNALS__ || globalWindow.__TAURI__ || globalWindow.__TAURI_METADATA__) {
+    return true;
+  }
+
+  if (typeof navigator !== "undefined") {
+    const userAgent = navigator.userAgent?.toLowerCase?.();
+    if (userAgent?.includes("tauri")) return true;
+  }
+
+  return false;
+};
 
 const isWindowsPlatform = () => {
   if (typeof navigator === "undefined") return false;


### PR DESCRIPTION
## Summary
- expand Tauri environment detection to include additional globals and user agent hints so Windows title bar controls render

## Testing
- bun run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694dfd72b2c483318cc6c6b57a88e908)