### PR TITLE
fix(ui): fix sonner toast theme and remove redundant error banner

### DIFF
--- a/src/components/clipboard/ClipboardContent.tsx
+++ b/src/components/clipboard/ClipboardContent.tsx
@@ -14,7 +14,6 @@ import {
   ClipboardCodeItem,
   ClipboardFileItem,
 } from '@/api/clipboardItems'
-import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Skeleton } from '@/components/ui/skeleton'
 import { toast } from '@/components/ui/sonner'
 import { useShortcut } from '@/hooks/useShortcut'
@@ -22,7 +21,6 @@ import { useAppDispatch, useAppSelector } from '@/store/hooks'
 import {
   removeClipboardItem,
   copyToClipboard,
-  clearError as clearReduxError,
   toggleFavoriteItem,
 } from '@/store/slices/clipboardSlice'
 
@@ -52,7 +50,7 @@ const ClipboardContent: React.FC<ClipboardContentProps> = ({ filter, searchQuery
 
   // Use Redux state and dispatch
   const dispatch = useAppDispatch()
-  const { items: reduxItems, loading, error } = useAppSelector(state => state.clipboard)
+  const { items: reduxItems, loading } = useAppSelector(state => state.clipboard)
 
   // Local state for converted display items
   const [clipboardItems, setClipboardItems] = useState<DisplayClipboardItem[]>([])
@@ -219,16 +217,6 @@ const ClipboardContent: React.FC<ClipboardContentProps> = ({ filter, searchQuery
     }
   }
 
-  // 清除错误信息
-  useEffect(() => {
-    if (error) {
-      const timer = setTimeout(() => {
-        dispatch(clearReduxError())
-      }, 3000)
-      return () => clearTimeout(timer)
-    }
-  }, [error, dispatch])
-
   // 当列表变化时，清理已经不存在的选择
   useEffect(() => {
     setSelectedIds(prev => {
@@ -370,12 +358,6 @@ const ClipboardContent: React.FC<ClipboardContentProps> = ({ filter, searchQuery
   return (
     <div className="h-full relative">
       <div className="h-full overflow-y-auto scrollbar-thin px-4 pb-32 pt-2">
-        {error && (
-          <Alert variant="destructive" className="mb-4 mx-1">
-            <AlertDescription>{error}</AlertDescription>
-          </Alert>
-        )}
-
         {clipboardItems.length > 0 ? (
           <div className="flex flex-col">
             {clipboardItems.map((item, index) => (

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -19,6 +19,26 @@ function Toaster({ ...props }: ToasterProps) {
           cancelButton: 'group-[.toast]:bg-muted group-[.toast]:text-muted-foreground',
         },
       }}
+      style={
+        {
+          '--normal-bg': 'var(--background)',
+          '--normal-text': 'var(--foreground)',
+          '--normal-border': 'var(--border)',
+          '--success-bg': 'var(--primary)',
+          '--success-border': 'var(--primary)',
+          '--success-text': 'var(--primary-foreground)',
+          '--error-bg': 'var(--destructive)',
+          '--error-border': 'var(--destructive)',
+          '--error-text': 'var(--destructive-foreground)',
+          '--warning-bg': 'var(--accent)',
+          '--warning-border': 'var(--accent)',
+          '--warning-text': 'var(--accent-foreground)',
+          '--info-bg': 'var(--primary)',
+          '--info-border': 'var(--primary)',
+          '--info-text': 'var(--primary-foreground)',
+          '--border-radius': 'var(--radius)',
+        } as React.CSSProperties
+      }
       {...props}
     />
   )


### PR DESCRIPTION
- Add inline CSS variables to Sonner Toaster component for proper theme inheritance
- Remove duplicate error alert banner since toast already handles error display
- Ensure toast colors follow catppuccin/zinc/t3chat themes across light/dark modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CSS variable support for notification theming, enabling customization of success, error, warning, and info states.

* **Refactor**
  * Simplified clipboard operations by removing error alert UI components and streamlining error state handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->