### PR TITLE
fix(ui): set minimum width for settings sidebar

### DIFF
--- a/src/components/setting/SettingsSidebar.tsx
+++ b/src/components/setting/SettingsSidebar.tsx
@@ -57,7 +57,10 @@ const SettingsSidebar: React.FC<SettingsSidebarProps> = ({ activeCategory, onCat
   ]
 
   return (
-    <Sidebar collapsible="none" className="border-r border-border/50 bg-muted/30 pt-10">
+    <Sidebar
+      collapsible="none"
+      className="min-w-[10.625rem] border-r border-border/50 bg-muted/30 pt-10"
+    >
       <SidebarContent>
         <SidebarGroup>
           <SidebarGroupContent>


### PR DESCRIPTION
## Summary
- Set minimum width for settings sidebar to prevent content overflow
- Use rem-based unit (10.625rem = 170px) for cross-platform compatibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)