### PR TITLE
refactor(theme): set Zinc as default theme and centralize UI variables

### DIFF
--- a/src-tauri/src/config/setting.rs
+++ b/src-tauri/src/config/setting.rs
@@ -43,7 +43,7 @@ pub struct GeneralSetting {
 }
 
 fn default_theme_color() -> String {
-    "catppuccin".to_string()
+    "inc".to_string()
 }
 
 fn default_language() -> String {
@@ -147,7 +147,7 @@ impl Setting {
                 silent_start: false,
                 auto_check_update: true,
                 theme: ThemeMode::System,
-                theme_color: "catppuccin".to_string(),
+                theme_color: "inc".to_string(),
                 language: default_language(),
             },
             sync: SyncSetting {

--- a/src/styles/themes/catppuccin.css
+++ b/src/styles/themes/catppuccin.css
@@ -1,6 +1,5 @@
 @layer base {
   /* Default Theme (Catppuccin) - Light */
-  :root:not(.dark),
   [data-theme='catppuccin']:not(.dark) {
     --background: oklch(0.9578 0.0058 264.5321);
     --foreground: oklch(0.4355 0.043 279.325);
@@ -34,31 +33,9 @@
     --sidebar-accent-foreground: oklch(1 0 0);
     --sidebar-border: oklch(0.8083 0.0174 271.1982);
     --sidebar-ring: oklch(0.5547 0.2503 297.0156);
-    --font-sans: Montserrat, sans-serif;
-    --font-serif: Georgia, serif;
-    --font-mono: Fira Code, monospace;
-    --radius: 0.35rem;
-    --shadow-color: hsl(240 30% 25%);
-    --shadow-opacity: 0.12;
-    --shadow-blur: 6px;
-    --shadow-spread: 0px;
-    --shadow-offset-x: 0px;
-    --shadow-offset-y: 4px;
-    --letter-spacing: 0em;
-    --spacing: 0.25rem;
-    --shadow-2xs: 0px 4px 6px 0px hsl(240 30% 25% / 0.06);
-    --shadow-xs: 0px 4px 6px 0px hsl(240 30% 25% / 0.06);
-    --shadow-sm: 0px 4px 6px 0px hsl(240 30% 25% / 0.12), 0px 1px 2px -1px hsl(240 30% 25% / 0.12);
-    --shadow: 0px 4px 6px 0px hsl(240 30% 25% / 0.12), 0px 1px 2px -1px hsl(240 30% 25% / 0.12);
-    --shadow-md: 0px 4px 6px 0px hsl(240 30% 25% / 0.12), 0px 2px 4px -1px hsl(240 30% 25% / 0.12);
-    --shadow-lg: 0px 4px 6px 0px hsl(240 30% 25% / 0.12), 0px 4px 6px -1px hsl(240 30% 25% / 0.12);
-    --shadow-xl: 0px 4px 6px 0px hsl(240 30% 25% / 0.12), 0px 8px 10px -1px hsl(240 30% 25% / 0.12);
-    --shadow-2xl: 0px 4px 6px 0px hsl(240 30% 25% / 0.3);
-    --tracking-normal: 0em;
   }
 
   /* Dark mode for default/catppuccin */
-  :root.dark,
   [data-theme='catppuccin'].dark {
     --background: oklch(0.2155 0.0254 284.0647);
     --foreground: oklch(0.8787 0.0426 272.2767);
@@ -92,26 +69,5 @@
     --sidebar-accent-foreground: oklch(0.2429 0.0304 283.911);
     --sidebar-border: oklch(0.4037 0.032 280.152);
     --sidebar-ring: oklch(0.7871 0.1187 304.7693);
-    --font-sans: Montserrat, sans-serif;
-    --font-serif: Georgia, serif;
-    --font-mono: Fira Code, monospace;
-    --radius: 0.35rem;
-    --shadow-color: hsl(240 30% 25%);
-    --shadow-opacity: 0.12;
-    --shadow-blur: 6px;
-    --shadow-spread: 0px;
-    --shadow-offset-x: 0px;
-    --shadow-offset-y: 4px;
-    --letter-spacing: 0em;
-    --spacing: 0.25rem;
-    --shadow-2xs: 0px 4px 6px 0px hsl(240 30% 25% / 0.06);
-    --shadow-xs: 0px 4px 6px 0px hsl(240 30% 25% / 0.06);
-    --shadow-sm: 0px 4px 6px 0px hsl(240 30% 25% / 0.12), 0px 1px 2px -1px hsl(240 30% 25% / 0.12);
-    --shadow: 0px 4px 6px 0px hsl(240 30% 25% / 0.12), 0px 1px 2px -1px hsl(240 30% 25% / 0.12);
-    --shadow-md: 0px 4px 6px 0px hsl(240 30% 25% / 0.12), 0px 2px 4px -1px hsl(240 30% 25% / 0.12);
-    --shadow-lg: 0px 4px 6px 0px hsl(240 30% 25% / 0.12), 0px 4px 6px -1px hsl(240 30% 25% / 0.12);
-    --shadow-xl: 0px 4px 6px 0px hsl(240 30% 25% / 0.12), 0px 8px 10px -1px hsl(240 30% 25% / 0.12);
-    --shadow-2xl: 0px 4px 6px 0px hsl(240 30% 25% / 0.3);
-    --tracking-normal: 0em;
   }
 }

--- a/src/styles/themes/claude.css
+++ b/src/styles/themes/claude.css
@@ -1,5 +1,4 @@
 @layer base {
-  :root:not(.dark),
   [data-theme='claude']:not(.dark) {
     --background: oklch(0.9818 0.0054 95.0986);
     --foreground: oklch(0.3438 0.0269 95.7226);
@@ -60,7 +59,6 @@
     --spacing: 0.25rem;
   }
 
-  :root.dark,
   [data-theme='claude'].dark {
     --background: oklch(0.2679 0.0036 106.6427);
     --foreground: oklch(0.8074 0.0142 93.0137);

--- a/src/styles/themes/zinc.css
+++ b/src/styles/themes/zinc.css
@@ -1,5 +1,7 @@
 @layer base {
   /* Zinc */
+  /* Default Theme */
+  :root:not(.dark),
   [data-theme='zinc']:not(.dark) {
     --background: oklch(1 0 0);
     --foreground: oklch(0.21 0.006 285.885);
@@ -28,8 +30,32 @@
     --sidebar-accent-foreground: oklch(0.21 0.006 285.885);
     --sidebar-border: oklch(0.897 0.01 285.444);
     --sidebar-ring: oklch(0.87 0.01 285.444);
+
+    /* default */
+    --font-sans: Montserrat, sans-serif;
+    --font-serif: Georgia, serif;
+    --font-mono: Fira Code, monospace;
+    --radius: 0.35rem;
+    --shadow-color: hsl(240 30% 25%);
+    --shadow-opacity: 0.12;
+    --shadow-blur: 6px;
+    --shadow-spread: 0px;
+    --shadow-offset-x: 0px;
+    --shadow-offset-y: 4px;
+    --letter-spacing: 0em;
+    --spacing: 0.25rem;
+    --shadow-2xs: 0px 4px 6px 0px hsl(240 30% 25% / 0.06);
+    --shadow-xs: 0px 4px 6px 0px hsl(240 30% 25% / 0.06);
+    --shadow-sm: 0px 4px 6px 0px hsl(240 30% 25% / 0.12), 0px 1px 2px -1px hsl(240 30% 25% / 0.12);
+    --shadow: 0px 4px 6px 0px hsl(240 30% 25% / 0.12), 0px 1px 2px -1px hsl(240 30% 25% / 0.12);
+    --shadow-md: 0px 4px 6px 0px hsl(240 30% 25% / 0.12), 0px 2px 4px -1px hsl(240 30% 25% / 0.12);
+    --shadow-lg: 0px 4px 6px 0px hsl(240 30% 25% / 0.12), 0px 4px 6px -1px hsl(240 30% 25% / 0.12);
+    --shadow-xl: 0px 4px 6px 0px hsl(240 30% 25% / 0.12), 0px 8px 10px -1px hsl(240 30% 25% / 0.12);
+    --shadow-2xl: 0px 4px 6px 0px hsl(240 30% 25% / 0.3);
+    --tracking-normal: 0em;
   }
 
+  :root.dark,
   [data-theme='zinc'].dark {
     --background: oklch(0.21 0.006 285.885);
     --foreground: oklch(0.985 0 0);
@@ -58,5 +84,28 @@
     --sidebar-accent-foreground: oklch(0.985 0 0);
     --sidebar-border: oklch(0.274 0.006 286.033);
     --sidebar-ring: oklch(0.83 0.01 285.444);
+
+    /* default */
+    --font-sans: Montserrat, sans-serif;
+    --font-serif: Georgia, serif;
+    --font-mono: Fira Code, monospace;
+    --radius: 0.35rem;
+    --shadow-color: hsl(240 30% 25%);
+    --shadow-opacity: 0.12;
+    --shadow-blur: 6px;
+    --shadow-spread: 0px;
+    --shadow-offset-x: 0px;
+    --shadow-offset-y: 4px;
+    --letter-spacing: 0em;
+    --spacing: 0.25rem;
+    --shadow-2xs: 0px 4px 6px 0px hsl(240 30% 25% / 0.06);
+    --shadow-xs: 0px 4px 6px 0px hsl(240 30% 25% / 0.06);
+    --shadow-sm: 0px 4px 6px 0px hsl(240 30% 25% / 0.12), 0px 1px 2px -1px hsl(240 30% 25% / 0.12);
+    --shadow: 0px 4px 6px 0px hsl(240 30% 25% / 0.12), 0px 1px 2px -1px hsl(240 30% 25% / 0.12);
+    --shadow-md: 0px 4px 6px 0px hsl(240 30% 25% / 0.12), 0px 2px 4px -1px hsl(240 30% 25% / 0.12);
+    --shadow-lg: 0px 4px 6px 0px hsl(240 30% 25% / 0.12), 0px 4px 6px -1px hsl(240 30% 25% / 0.12);
+    --shadow-xl: 0px 4px 6px 0px hsl(240 30% 25% / 0.12), 0px 8px 10px -1px hsl(240 30% 25% / 0.12);
+    --shadow-2xl: 0px 4px 6px 0px hsl(240 30% 25% / 0.3);
+    --tracking-normal: 0em;
   }
 }


### PR DESCRIPTION
- update `src-tauri/src/config/setting.rs` to set the default `theme_color` to "inc"
- remove `:root` selectors from `catppuccin.css` and `claude.css` to ensure these themes only apply when explicitly selected via `data-theme`
- centralize common UI variables such as `font-sans`, `radius`, and `shadow` definitions into `src/styles/themes/zinc.css`
- designate `zinc.css` as the new base theme by applying its styles to the `:root` element, making it the default visual theme

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Theme Updates**
  * Changed the default application theme.
  * Reorganized theme styling system for improved maintainability.
  * Consolidated typography, spacing, and shadow definitions across themes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->