### PR TITLE
feat(settings): implement settings window as independent window

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -206,6 +206,7 @@ fn run_app(uniclipboard_app: Arc<UniClipboard>, user_setting: Setting) {
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
+            api::setting::open_settings_window,
             api::setting::save_setting,
             api::setting::get_setting,
             api::setting::get_encryption_password,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,7 @@ import { Toaster } from '@/components/ui/sonner'
 import { SearchProvider, useSearch } from '@/contexts/SearchContext'
 import { SettingProvider } from '@/contexts/SettingContext'
 import { ShortcutProvider } from '@/contexts/ShortcutContext'
-import { MainLayout } from '@/layouts'
+import { MainLayout, SettingsWindowLayout } from '@/layouts'
 import DashboardPage from '@/pages/DashboardPage'
 import DevicesPage from '@/pages/DevicesPage'
 import SettingsPage from '@/pages/SettingsPage'
@@ -16,15 +16,6 @@ const AuthenticatedLayout = () => {
     <MainLayout>
       <Outlet />
     </MainLayout>
-  )
-}
-
-// Settings 页面布局 - 不包含主 Sidebar
-const SettingsLayout = () => {
-  return (
-    <div className="h-screen w-full flex bg-background text-foreground transition-colors duration-200">
-      <Outlet />
-    </div>
   )
 }
 
@@ -45,7 +36,7 @@ const AppContent = () => {
             />
             <Route path="/devices" element={<DevicesPage />} />
           </Route>
-          <Route element={<SettingsLayout />}>
+          <Route element={<SettingsWindowLayout />}>
             <Route path="/settings" element={<SettingsPage />} />
           </Route>
           <Route path="*" element={<Navigate to="/" replace />} />

--- a/src/api/window.ts
+++ b/src/api/window.ts
@@ -1,0 +1,9 @@
+import { invoke } from '@tauri-apps/api/core'
+
+/**
+ * Opens the settings window in a new independent window.
+ * If the settings window is already open, it will be focused.
+ */
+export async function openSettingsWindow(): Promise<void> {
+  return invoke<void>('open_settings_window')
+}

--- a/src/layouts/SettingsWindowLayout.tsx
+++ b/src/layouts/SettingsWindowLayout.tsx
@@ -1,0 +1,15 @@
+import { Outlet } from 'react-router-dom'
+
+/**
+ * Layout for the standalone settings window.
+ * This window does not include the main sidebar and has a simpler structure.
+ */
+const SettingsWindowLayout = () => {
+  return (
+    <div className="h-screen w-full flex flex-col bg-background text-foreground transition-colors duration-200">
+      <Outlet />
+    </div>
+  )
+}
+
+export default SettingsWindowLayout

--- a/src/layouts/index.ts
+++ b/src/layouts/index.ts
@@ -1,3 +1,4 @@
 export { default as MainLayout } from './MainLayout'
 export { default as SettingsLayout } from './SettingsLayout'
+export { default as SettingsWindowLayout } from './SettingsWindowLayout'
 export { default as SettingContentLayout } from './SettingContentLayout'


### PR DESCRIPTION
## Summary
- Implement settings page as an independent window
- Settings window only opens when user clicks the settings button in sidebar
- Main window no longer includes settings route

## Technical Changes
- Add Tauri window configuration for settings window
- Create Tauri API command `open_settings_window` to create/manage settings window
- Add frontend API wrapper `openSettingsWindow()` in `src/api/window.ts`
- Update Sidebar component to call `openSettingsWindow()` on settings button click
- Create `SettingsWindowLayout` for standalone settings window
- Remove auto-creation of settings window from tauri.conf.json
- Fix lint error by moving `NavButton` component outside render

## Test plan
- [ ] Verify settings window opens when clicking settings button
- [ ] Verify main window does not auto-open settings window
- [ ] Verify settings window can be focused if already open
- [ ] Verify settings window maintains proper size and decorations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Settings now opens in a dedicated, independent window for improved organization and focused access
* Opening settings multiple times automatically focuses the existing window rather than creating duplicates
* Settings interface redesigned with a cleaner, streamlined layout providing an uncluttered configuration experience

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->