### PR TITLE
fix(ui): enable TitleBar drag region on devices page

### DIFF
--- a/src/components/device/Header.tsx
+++ b/src/components/device/Header.tsx
@@ -19,10 +19,7 @@ const Header: React.FC<HeaderProps> = ({ addDevice, activeTab, onTabChange }) =>
   ]
 
   return (
-    <header
-      data-tauri-drag-region
-      className="sticky top-10 z-40 pt-6 pb-2 px-8 transition-all duration-300"
-    >
+    <header data-tauri-drag-region className="shrink-0 pt-6 pb-2 px-8 transition-all duration-300">
       {/* Glass Background */}
       <div
         data-tauri-drag-region

--- a/src/pages/DevicesPage.tsx
+++ b/src/pages/DevicesPage.tsx
@@ -104,7 +104,7 @@ const DevicesPage: React.FC = () => {
   }, [])
 
   return (
-    <div className="flex flex-col h-full relative">
+    <div className="flex flex-col h-full relative pt-10">
       {/* 顶部标题栏 */}
       <DeviceHeader
         addDevice={handleAddDevice}


### PR DESCRIPTION
## Summary
- Remove sticky positioning from DeviceHeader component which was interfering with Tauri drag region
- Add top padding to DevicesPage container for consistent TitleBar spacing
- Ensure TitleBar drag functionality works consistently across all pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)