### PR TITLE
fix(macos): align traffic lights with titlebar center by adjusting offsetY

### DIFF
--- a/src/components/TitleBar.tsx
+++ b/src/components/TitleBar.tsx
@@ -17,7 +17,7 @@ interface TitleBarProps {
 const MAC_WINDOW_STYLE = {
   cornerRadius: 12,
   offsetX: -15,
-  offsetY: 0,
+  offsetY: -3,
 } as const
 
 const isTauriEnv = () =>


### PR DESCRIPTION
## Summary
- Adjusted macOS traffic light position to align with titlebar center
- Changed offsetY from 0 to -3 to move traffic lights up slightly

## Test plan
- [ ] Verify traffic lights are centered vertically with titlebar on macOS
- [ ] Confirm the change doesn't affect other platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)