### PR TITLE
fix(p2p): implement device connection status display

### DIFF
--- a/src-tauri/src/api/event.rs
+++ b/src-tauri/src/api/event.rs
@@ -60,6 +60,18 @@ pub struct P2PPairingFailedEventData {
     pub error: String,
 }
 
+/// P2P 设备连接状态变化事件数据
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct P2PPeerConnectionEvent {
+    /// Peer ID
+    pub peer_id: String,
+    /// Device name (可选，断开连接时可能为空)
+    pub device_name: Option<String>,
+    /// Connection status
+    pub connected: bool,
+}
+
 /// Onboarding 密码设置成功事件数据
 #[derive(Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -88,6 +100,8 @@ pub struct EventListenerState {
     p2p_pairing_complete_listener_id: Option<ListenerId>,
     /// P2P 配对失败事件监听器ID
     p2p_pairing_failed_listener_id: Option<ListenerId>,
+    /// P2P 设备连接状态变化事件监听器ID
+    p2p_peer_connection_changed_listener_id: Option<ListenerId>,
 }
 
 impl Default for EventListenerState {
@@ -98,6 +112,7 @@ impl Default for EventListenerState {
             p2p_pin_ready_listener_id: None,
             p2p_pairing_complete_listener_id: None,
             p2p_pairing_failed_listener_id: None,
+            p2p_peer_connection_changed_listener_id: None,
         }
     }
 }

--- a/src-tauri/src/infrastructure/runtime/handle.rs
+++ b/src-tauri/src/infrastructure/runtime/handle.rs
@@ -109,6 +109,11 @@ pub enum P2PCommand {
         session_id: String,
         respond_to: tokio::sync::oneshot::Sender<Result<(), String>>,
     },
+    /// Get paired peers with connection status
+    GetPairedPeersWithStatus {
+        respond_to:
+            tokio::sync::oneshot::Sender<Result<Vec<PairedPeerWithStatus>, String>>,
+    },
 }
 
 /// Local device info
@@ -117,6 +122,19 @@ pub enum P2PCommand {
 pub struct LocalDeviceInfo {
     pub peer_id: String,
     pub device_name: String,
+}
+
+/// Paired peer with connection status
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PairedPeerWithStatus {
+    pub peer_id: String,
+    pub device_name: String,
+    pub shared_secret: Vec<u8>,
+    pub paired_at: String,
+    pub last_seen: Option<String>,
+    pub last_known_addresses: Vec<String>,
+    pub connected: bool,
 }
 
 /// Thread-safe handle to the application runtime

--- a/src-tauri/src/infrastructure/runtime/mod.rs
+++ b/src-tauri/src/infrastructure/runtime/mod.rs
@@ -8,5 +8,5 @@ mod handle;
 mod p2p_runtime;
 
 pub use app_runtime::AppRuntime;
-pub use handle::{AppRuntimeHandle, ClipboardCommand, LocalDeviceInfo, P2PCommand};
+pub use handle::{AppRuntimeHandle, ClipboardCommand, LocalDeviceInfo, PairedPeerWithStatus, P2PCommand};
 pub use p2p_runtime::P2PRuntime;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -270,6 +270,7 @@ fn run_app(user_setting: Setting, device_id: String) {
             api::p2p::get_p2p_peers,
             api::p2p::get_local_device_info,
             api::p2p::get_paired_peers,
+            api::p2p::get_paired_peers_with_status,
             api::p2p::initiate_p2p_pairing,
             api::p2p::verify_p2p_pairing_pin,
             api::p2p::reject_p2p_pairing,

--- a/src/store/slices/devicesSlice.ts
+++ b/src/store/slices/devicesSlice.ts
@@ -1,7 +1,7 @@
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit'
 import {
   getLocalDeviceInfo,
-  getPairedPeers,
+  getPairedPeersWithStatus,
   type LocalDeviceInfo,
   type PairedPeer,
 } from '@/api/p2p'
@@ -43,7 +43,7 @@ export const fetchPairedDevices = createAsyncThunk(
   'devices/fetchPaired',
   async (_, { rejectWithValue }) => {
     try {
-      return await getPairedPeers()
+      return await getPairedPeersWithStatus()
     } catch {
       return rejectWithValue('获取已配对设备失败')
     }
@@ -59,6 +59,15 @@ const devicesSlice = createSlice({
     },
     clearPairedDevicesError: state => {
       state.pairedDevicesError = null
+    },
+    updatePeerConnectionStatus: (
+      state,
+      action: { payload: { peerId: string; connected: boolean } }
+    ) => {
+      const peer = state.pairedDevices.find(d => d.peerId === action.payload.peerId)
+      if (peer) {
+        peer.connected = action.payload.connected
+      }
     },
   },
   extraReducers: builder => {
@@ -94,5 +103,6 @@ const devicesSlice = createSlice({
   },
 })
 
-export const { clearLocalDeviceError, clearPairedDevicesError } = devicesSlice.actions
+export const { clearLocalDeviceError, clearPairedDevicesError, updatePeerConnectionStatus } =
+  devicesSlice.actions
 export default devicesSlice.reducer


### PR DESCRIPTION
## Summary

- Add PairedPeerWithStatus with connected field to backend
- Implement event-driven connection status tracking in P2PRuntime
- Add get_paired_peers_with_status API command
- Update frontend to use dynamic connection status display
- Add real-time event listener for connection changes
- Replace hardcoded "离线" with green/gray status indicators

## Test plan

- [ ] Test device pairing and verify connection status shows "在线" when connected
- [ ] Test device disconnection and verify status changes to "离线" 
- [ ] Test real-time updates when devices connect/disconnect
- [ ] Verify UI shows green indicator for online, gray for offline
- [ ] Test event listener properly updates Redux store
- [ ] Confirm backward compatibility with existing APIs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added real-time peer connection status tracking to display which paired devices are currently online or offline
  * New API endpoint to retrieve paired peers with their current connection status
  * Real-time event notifications when peer connections change, enabling the app to update device availability instantly

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->