### PR TITLE
refactor(services): create AppServices container and integrate P2P sync (Phase 6)

### DIFF
--- a/src-tauri/src/api/p2p.rs
+++ b/src-tauri/src/api/p2p.rs
@@ -9,14 +9,14 @@ use tauri::State;
 
 use crate::domain::pairing::PairedPeer;
 use crate::infrastructure::p2p::DiscoveredPeer;
-use crate::infrastructure::runtime::{LocalDeviceInfo, PairedPeerWithStatus};
-use crate::services::p2p::P2PService;
+use crate::infrastructure::runtime::LocalDeviceInfo;
+use crate::services::p2p::{PairedPeerWithStatus, P2PService};
 
-/// Type alias for the P2PService state
-type P2PServiceState = Arc<Mutex<Option<P2PService>>>;
+/// Type alias for the P2PService state (using Arc<P2PService> since P2PService is not Clone)
+type P2PServiceState = Arc<Mutex<Option<Arc<P2PService>>>>;
 
 /// Helper function to get P2PService from state
-fn get_p2p_service(state: &P2PServiceState) -> Result<P2PService, String> {
+fn get_p2p_service(state: &P2PServiceState) -> Result<Arc<P2PService>, String> {
     let guard = state.lock().map_err(|e| format!("Failed to acquire lock: {}", e))?;
     guard
         .as_ref()

--- a/src-tauri/src/services/app_services.rs
+++ b/src-tauri/src/services/app_services.rs
@@ -1,0 +1,121 @@
+//! Application services container
+//!
+//! This module provides a centralized container for all core application services.
+//! It manages the initialization lifecycle and wiring between services.
+
+use log::warn;
+use std::sync::Arc;
+
+use crate::api::encryption::get_unified_encryption;
+use crate::config::Setting;
+use crate::domain::transfer_message::ClipboardTransferMessage;
+use crate::error::{AppError, Result};
+use crate::infrastructure::clipboard::LocalClipboard;
+use crate::infrastructure::p2p::ClipboardMessage;
+use crate::infrastructure::storage::db::pool::DB_POOL;
+use crate::infrastructure::storage::file_storage::FileStorageManager;
+use crate::infrastructure::sync::libp2p_sync::Libp2pSync;
+use crate::interface::RemoteClipboardSync;
+use crate::services::clipboard::ClipboardService;
+use crate::services::p2p::P2PService;
+use crate::services::storage::StorageService;
+use tauri::AppHandle;
+use tokio::sync::mpsc;
+
+/// Application services container
+///
+/// Holds all core application services with proper initialization and wiring.
+/// This is managed by Tauri and accessible via `State<'_, AppServices>`.
+pub struct AppServices {
+    /// Storage service (database + file storage)
+    pub storage: Arc<StorageService>,
+    /// Clipboard service (local + remote sync)
+    pub clipboard: Arc<ClipboardService>,
+    /// P2P service (device discovery and pairing)
+    pub p2p: Arc<P2PService>,
+}
+
+impl AppServices {
+    /// Create a new AppServices instance with all services initialized.
+    ///
+    /// This method initializes services in the correct dependency order:
+    /// 1. StorageService (no dependencies)
+    /// 2. P2PService (requires AppHandle)
+    /// 3. Libp2pSync (requires P2PService network channel + encryption)
+    /// 4. ClipboardService (requires StorageService + LocalClipboard + optional Libp2pSync)
+    ///
+    /// # Arguments
+    /// * `config` - Application configuration
+    /// * `device_id` - 6-digit device ID from database
+    /// * `device_name` - Human-readable device name
+    /// * `app_handle` - Tauri AppHandle for event emission
+    pub async fn new(
+        config: Arc<Setting>,
+        device_id: String,
+        device_name: String,
+        app_handle: AppHandle,
+    ) -> Result<Self> {
+        // 1. Initialize StorageService (synchronous)
+        let db = Arc::new(DB_POOL.pool.clone());
+        let file_storage = Arc::new(FileStorageManager::new()?);
+        let storage = Arc::new(StorageService::new(
+            db,
+            file_storage.clone(),
+            config.storage.max_history_items as usize,
+        ));
+
+        // 2. Initialize P2PService (asynchronous, spawns NetworkManager)
+        let p2p = Arc::new(
+            P2PService::new(device_name.clone(), app_handle)
+                .await
+                .map_err(|e| AppError::internal(format!("Failed to create P2PService: {}", e)))?,
+        );
+
+        // 3. Initialize Libp2pSync (P2P clipboard sync service)
+        let remote_sync: Option<Arc<dyn RemoteClipboardSync>> =
+            if let Some(encryption) = get_unified_encryption().await {
+                // Get network_cmd_tx from P2PService
+                let network_cmd_tx = p2p.get_network_cmd_tx().await?;
+
+                // Create Libp2pSync instance (keep concrete type for handle_incoming_message)
+                let libp2p_sync = Arc::new(Libp2pSync::new(
+                    network_cmd_tx,
+                    device_name.clone(),
+                    device_id.clone(),
+                    encryption,
+                ));
+
+                // Set up clipboard message handler in P2PService
+                // This connects NetworkManager's clipboard events to Libp2pSync
+                let libp2p_sync_clone = libp2p_sync.clone();
+                p2p.set_clipboard_handler(Box::new(move |msg: ClipboardMessage| {
+                    let sync = libp2p_sync_clone.clone();
+                    Box::pin(async move {
+                        if let Err(e) = sync.handle_incoming_message(msg).await {
+                            log::error!("Failed to handle incoming P2P clipboard message: {}", e);
+                        }
+                    })
+                }))
+                .await;
+
+                // Cast to trait object for ClipboardService
+                Some(libp2p_sync as Arc<dyn RemoteClipboardSync>)
+            } else {
+                warn!("Unified encryption not initialized, P2P clipboard sync disabled");
+                None
+            };
+
+        // 4. Initialize ClipboardService (synchronous, depends on StorageService)
+        let local_clipboard =
+            Arc::new(LocalClipboard::with_user_setting(config.as_ref().clone())?);
+        let clipboard = Arc::new(ClipboardService::new(
+            device_id,
+            local_clipboard,
+            remote_sync, // Integrate P2P sync
+            storage.clone(),
+            file_storage,
+        ));
+
+        Ok(Self { storage, clipboard, p2p })
+    }
+}

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -2,6 +2,9 @@
 //!
 //! High-level service interfaces for application logic.
 
+pub mod app_services;
 pub mod p2p;
 pub mod storage;
 pub mod clipboard;
+
+pub use app_services::AppServices;

--- a/src-tauri/src/services/p2p/mod.rs
+++ b/src-tauri/src/services/p2p/mod.rs
@@ -4,4 +4,4 @@
 
 pub mod service;
 
-pub use service::P2PService;
+pub use service::{PairedPeerWithStatus, P2PService};


### PR DESCRIPTION
## Summary

Phase 6 of the Rust Clean Architecture refactoring. This phase creates the `AppServices` container and integrates P2P clipboard sync.

## Changes

- **Create AppServices container** (`src-tauri/src/services/app_services.rs`)
  - Centralized service initialization for StorageService, ClipboardService, and P2PService
  - Integrated P2P clipboard sync via Libp2pSync
  - Proper service lifecycle management

- **Extend P2PService** (`src-tauri/src/services/p2p/service.rs`)
  - Add `get_network_cmd_tx()` method for creating Libp2pSync
  - Add `set_clipboard_handler()` method to wire clipboard message handling
  - Update `handle_network_events()` to process clipboard messages

- **Refactor main.rs**
  - Remove clipboard_cmd_tx/clipboard_cmd_rx channels
  - Remove AppRuntimeHandle (replaced by AppServices)
  - Initialize AppServices in setup block
  - Start ClipboardService after initialization
  - Keep P2PService placeholder for API layer compatibility (to be removed in Phase 7)

- **Update API layer** (`src-tauri/src/api/p2p.rs`)
  - Use `Arc<P2PService>` instead of cloned P2PService

## Architecture Changes

**Before**: main.rs → AppRuntimeHandle + channels → AppRuntime
**After**: main.rs → AppServices (direct service access)

## Test Plan

- [ ] Local clipboard capture works
- [ ] Clipboard history query works
- [ ] P2P pairing works
- [ ] P2P clipboard sync works (two devices)
- [ ] Favorite/delete functions work

## Related Issues

Part of #75 - Rust Clean Architecture Refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)