### PR TITLE
fix(theme): prevent initial flash in appearance settings

### DIFF
--- a/src/components/setting/AppearanceSection.tsx
+++ b/src/components/setting/AppearanceSection.tsx
@@ -1,5 +1,4 @@
 import { type LucideIcon, Check, Monitor, Moon, Sun } from 'lucide-react'
-import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Card, CardContent } from '@/components/ui/card'
 import { DEFAULT_THEME_COLOR, THEME_COLORS } from '@/constants/theme'
@@ -53,18 +52,13 @@ function ThemeOption({ value, icon: Icon, label, theme, handleThemeChange }: The
 export default function AppearanceSection() {
   const { t } = useTranslation()
   const { setting, updateGeneralSetting } = useSetting()
-  const [theme, setTheme] = useState<ThemeMode>('system')
 
-  useEffect(() => {
-    if (setting?.general) {
-      setTheme(setting.general.theme || 'system')
-    }
-  }, [setting])
+  // Use derived state instead of local state to avoid initial flash
+  const theme = setting?.general?.theme || 'system'
 
   const handleThemeChange = async (newTheme: ThemeMode) => {
     try {
       await updateGeneralSetting({ theme: newTheme })
-      setTheme(newTheme)
     } catch (error) {
       console.error('Failed to change theme:', error)
     }


### PR DESCRIPTION
## Summary

- Fix visual flash in appearance settings where "follow system" was briefly shown even when user had selected "dark" theme
- Replace problematic local state + useEffect pattern with derived state approach

## Test plan

- [ ] Open app with dark theme selected
- [ ] Navigate to appearance settings
- [ ] Verify correct theme is selected immediately (no flash)
- [ ] Click through all theme options to verify functionality
- [ ] Test on both light and dark system modes

## Technical details

### Root cause
The component was initializing with `theme = 'system'` in `useState()`, then updating asynchronously in `useEffect()`. This caused a brief flash of the wrong selection.

### Solution
- Removed `useState` and `useEffect` for theme state
- Used derived state directly: `const theme = setting?.general?.theme || 'system'`
- Removed unnecessary `setTheme()` call after `updateGeneralSetting()`

## Files changed
- `src/components/setting/AppearanceSection.tsx`: Simplify theme state management

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified theme setting management by eliminating redundant state synchronization. Theme preference now derives directly from settings, reducing code complexity while preserving existing functionality and user experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->