### PR TITLE
Fix default theme color

### DIFF
--- a/src-tauri/src-legacy/config/setting.rs
+++ b/src-tauri/src-legacy/config/setting.rs
@@ -49,7 +49,7 @@ fn default_device_name() -> String {
 }
 
 fn default_theme_color() -> String {
-    "inc".to_string()
+    "zinc".to_string()
 }
 
 fn default_language() -> String {
@@ -164,7 +164,7 @@ impl Setting {
                 silent_start: false,
                 auto_check_update: true,
                 theme: ThemeMode::System,
-                theme_color: "inc".to_string(),
+                theme_color: "zinc".to_string(),
                 language: default_language(),
                 device_name: default_device_name(),
             },

--- a/src/contexts/SettingContext.tsx
+++ b/src/contexts/SettingContext.tsx
@@ -1,6 +1,7 @@
 import { invoke } from '@tauri-apps/api/core'
 import { listen } from '@tauri-apps/api/event'
 import React, { useState, useEffect, ReactNode } from 'react'
+import { DEFAULT_THEME_COLOR } from '@/constants/theme'
 import i18n, { normalizeLanguage, persistLanguage } from '@/i18n'
 import type { SettingChangedEvent } from '@/types/events'
 import { SettingContext, type SettingContextType, type Setting } from '@/types/setting'
@@ -164,7 +165,7 @@ export const SettingProvider: React.FC<SettingProviderProps> = ({ children }) =>
 
     const applyTheme = () => {
       const theme = setting?.general.theme
-      const themeColor = setting?.general.theme_color || 'catppuccin'
+      const themeColor = setting?.general.theme_color || DEFAULT_THEME_COLOR
 
       // 1. Apply Mode (Light/Dark)
       root.classList.remove('light', 'dark')


### PR DESCRIPTION
Fix default theme color from catppuccin to zinc

- Fix backend typo in setting.rs where inc was used instead of zinc
- Update frontend to use DEFAULT_THEME_COLOR constant instead of hard-coded value
- Ensures consistent default theme across app startup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed default theme color configuration to ensure consistent theme initialization throughout the application.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->