### PR TITLE
docs: enforce cargo command execution location rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,12 @@ Repeated workarounds indicate architectural flaws.
 Short-term compromises must be reversible
 Never break boundaries; always leave explicit TODOs.
 
+## Cargo Command Location
+
+**CRITICAL**: All Rust-related commands (cargo build, cargo test, cargo check, etc.) MUST be executed from `src-tauri/`.
+Never run any Cargo command from the project root.
+If Cargo.toml is not present in the current directory, stop immediately and do not retry.
+
 ## Rustdoc Bilingual Documentation Guide
 
 ### Recommended Approach: Structured Bilingual Side-by-Side

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,24 @@ Building is handled via GitHub Actions. Trigger manually from GitHub Actions tab
 - **platform**: macos-aarch64, macos-x86_64, ubuntu-22.04, windows-latest, or all
 - **version**: Version number (e.g., 1.0.0)
 
+### Cargo Command Location
+
+**CRITICAL**: All Rust-related commands (cargo build, cargo test, cargo check, etc.) MUST be executed from `src-tauri/`.
+
+```bash
+# ✅ CORRECT - Always run from src-tauri/
+cd src-tauri && cargo build
+cd src-tauri && cargo test
+cd src-tauri && cargo check
+
+# ❌ FORBIDDEN - Never run from project root
+cargo build
+cargo test
+```
+
+**Never run any Cargo command from the project root.**
+**If Cargo.toml is not present in the current directory, stop immediately and do not retry.**
+
 ### Test Coverage
 
 Generate local coverage report using cargo-llvm-cov:


### PR DESCRIPTION
- Add explicit instructions to run all Cargo commands from src-tauri/
- Prevent accidental execution from project root directory
- Include examples in CLAUDE.md and brief rule in AGENTS.md

Co-Authored-By: Claude <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance clarifying where Rust cargo commands should be executed in the project structure.
  * Included examples of correct and incorrect command usage to prevent common operational errors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->