### PR TITLE
feat(logging): filter Tauri internal spans to reduce noise

### DIFF
--- a/src-tauri/crates/uc-tauri/src/bootstrap/tracing.rs
+++ b/src-tauri/crates/uc-tauri/src/bootstrap/tracing.rs
@@ -76,6 +76,8 @@ pub fn init_tracing_subscriber() -> anyhow::Result<()> {
     let filter_directives = [
         if is_dev { "debug" } else { "info" },
         "libp2p_mdns=warn", // Filter noisy proxy errors
+        "wry=off",          // Filter Tauri internal spans (custom_protocol)
+        "ipc::request=off", // Filter Tauri IPC handler spans
         if is_dev {
             "uc_platform=debug"
         } else {


### PR DESCRIPTION
## Summary

- Add 'wry=off' to filter Tauri custom_protocol spans  
- Add 'ipc::request=off' to filter Tauri IPC handler spans
- Eliminates redundant internal logging information from wry/ipc
- Improves log readability by removing non-developer-facing traces

## Changes

- `src-tauri/crates/uc-tauri/src/bootstrap/tracing.rs`: Added two filters to reduce log noise

## Test plan

- [ ] Run `bun tauri dev` and verify that Tauri internal spans no longer appear in logs
- [ ] Confirm that user application logs (command spans, error logs) are still visible
- [ ] Verify that the functionality remains unchanged

## Example

**Before:**
```
wry::custom_protocol::handle{uri="ipc://localhost/get_clipboard_entries"}:wry::custom_protocol::call_handler:ipc::request::run:command.clipboard.get_entries{device_id=3d33b6f7-e441-4afa-a29a-bbf7b558de05 limit=50 offset=0}: uc_tauri::commands::clipboard: crates/.../clipboard.rs:59: Retrieved clipboard entries count=2
```

**After:**
```
command.clipboard.get_entries{device_id=3d33b6f7-e441-4afa-a29a-bbf7b558de05 limit=50 offset=0}: uc_tauri::commands::clipboard: clipboard.rs:59: Retrieved clipboard entries count=2
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved logging output by filtering internal framework spans to reduce noise in trace logs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->