### PR TITLE
chore(vscode): remove unused rust-analyzer probe features

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,10 +4,4 @@
         "src/i18n/locales"
     ],
     "i18n-ally.sourceLanguage": "zh-CN",
-    "rust-analyzer.cargo.features": [
-        "probe"
-    ],
-    "rust-analyzer.checkOnSave.features": [
-        "probe"
-    ]
 }


### PR DESCRIPTION
- Remove unused `rust-analyzer.cargo.features` and `rust-analyzer.checkOnSave.features` for "probe"
- Clean up VS Code workspace configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development environment configuration settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->