### PR TITLE
feat(dashboard): hide search and filter UI for MVP release

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -7,9 +7,10 @@ import { cn } from '@/lib/utils'
 
 interface HeaderProps {
   onFilterChange?: (filterId: Filter) => void
+  className?: string
 }
 
-const Header: React.FC<HeaderProps> = ({ onFilterChange }) => {
+const Header: React.FC<HeaderProps> = ({ onFilterChange, className }) => {
   const { t } = useTranslation()
 
   const filterTypes = [
@@ -30,7 +31,10 @@ const Header: React.FC<HeaderProps> = ({ onFilterChange }) => {
   }
 
   return (
-    <header data-tauri-drag-region className="shrink-0 px-6 transition-all duration-300">
+    <header
+      data-tauri-drag-region
+      className={cn('shrink-0 px-6 transition-all duration-300', className)}
+    >
       {/* Glass Background */}
       <div
         data-tauri-drag-region

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -167,8 +167,8 @@ const DashboardPage: React.FC = () => {
 
   return (
     <div className="flex flex-col h-full relative pt-10">
-      {/* Top search bar */}
-      <Header onFilterChange={handleFilterChange} />
+      {/* Top search bar - Hidden in MVP */}
+      <Header onFilterChange={handleFilterChange} className="hidden" />
 
       {/* Clipboard content area - use flex-1 to make it take remaining space */}
       <div className="flex-1 overflow-hidden relative">


### PR DESCRIPTION
Hide search box and category filters in the dashboard for MVP release, as these features lack backend support. The UI is fully hidden while preserving all state management logic for future implementation. Zero code modification approach allows easy restoration when backend features are ready.

## Changes
- Add className prop support to Header component
- Hide Header component using className="hidden"
- Maintain filter and search state management
- Easy to restore: remove hidden class to re-enable

## Testing
- Verified frontend builds successfully
- Header UI completely hidden
- Clipboard content displays normally from top

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * The search bar on the Dashboard page is now hidden to streamline the interface.
  * Header component styling capabilities have been enhanced for improved customization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->