### PR TITLE
fix(startup): resolve decryption failure on app restart

### DIFF
--- a/src-tauri/crates/uc-tauri/src/events/mod.rs
+++ b/src-tauri/crates/uc-tauri/src/events/mod.rs
@@ -21,6 +21,8 @@ pub enum ClipboardEvent {
 pub enum EncryptionEvent {
     /// Encryption initialized
     Initialized,
+    /// Encryption session ready (auto-unlock completed)
+    SessionReady,
     /// Encryption failed
     Failed { reason: String },
 }

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -165,6 +165,40 @@ const DashboardPage: React.FC = () => {
     }
   }, [debouncedLoadData, t])
 
+  // Listen for encryption session ready event
+  useEffect(() => {
+    const setupEncryptionListener = async () => {
+      console.log('[Dashboard] Setting up encryption session ready listener')
+
+      try {
+        // Listen to encryption://event with type checking
+        const unlisten = await listen<{ type: string }>('encryption://event', event => {
+          console.log('[Dashboard] Received encryption event:', event.payload)
+
+          if (event.payload.type === 'SessionReady') {
+            console.log('[Dashboard] Encryption session ready, reloading clipboard data')
+            loadData(currentFilterRef.current)
+          }
+        })
+
+        return unlisten
+      } catch (err) {
+        console.error('[Dashboard] Failed to setup encryption session listener:', err)
+        return undefined
+      }
+    }
+
+    const unlistenPromise = setupEncryptionListener()
+
+    return () => {
+      unlistenPromise.then(unlisten => {
+        if (unlisten) {
+          unlisten()
+        }
+      })
+    }
+  }, [loadData])
+
   return (
     <div className="flex flex-col h-full relative pt-10">
       {/* Top search bar - Hidden in MVP */}


### PR DESCRIPTION
## Problem

After app restart, Dashboard queries clipboard entries before encryption session completes auto-unlock, causing decryption failures. Once user copies new content, everything works normally because session is ready by then.

## Solution

Use event-driven graceful degradation: return empty list when session not ready, then auto-reload when SessionReady event fires.

## Changes

- Backend: Check session readiness in `get_clipboard_entries`, return empty list if not ready
- Backend: Emit `EncryptionEvent::SessionReady` after auto-unlock completes
- Frontend: Listen for `SessionReady` event and auto-reload data
- Refactor: Use typed `EncryptionEvent` enum instead of hardcoded event strings

## Testing

Restart app and observe:
1. Dashboard initially shows empty list (no errors)
2. After 1-2 seconds, data automatically appears
3. Console shows session-ready event logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed clipboard data handling to ensure encryption is ready before display.
  * Improved encryption session readiness communication between backend and frontend.

* **New Features**
  * Dashboard now automatically refreshes clipboard data when encryption becomes available.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->