### PR TITLE
refactor: relocate back button from title bar to settings sidebar

### DIFF
--- a/src/components/TitleBar.tsx
+++ b/src/components/TitleBar.tsx
@@ -1,9 +1,9 @@
 import { enableModernWindowStyle } from '@cloudworxx/tauri-plugin-mac-rounded-corners'
 import { getCurrentWindow } from '@tauri-apps/api/window'
-import { ArrowLeft, Minus, Square, X, Search } from 'lucide-react'
+import { Minus, Square, X, Search } from 'lucide-react'
 import React, { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useLocation, useNavigate } from 'react-router-dom'
+import { useLocation } from 'react-router-dom'
 import { Input } from '@/components/ui/input'
 import { useOnboarding } from '@/contexts/OnboardingContext'
 import { usePlatform } from '@/hooks/usePlatform'
@@ -56,21 +56,8 @@ const TitleBarButton = ({
 export const TitleBar = ({ className, searchValue = '', onSearchChange }: TitleBarProps) => {
   const [isMaximized, setIsMaximized] = useState(false)
   const location = useLocation()
-  const navigate = useNavigate()
   const { t } = useTranslation()
   const { status } = useOnboarding()
-
-  // 检测是否在设置页面
-  const isSettingsPage = location.pathname === '/settings'
-
-  const handleBack = () => {
-    // Check if there's history to go back to
-    if (window.history.state && window.history.state.idx > 0) {
-      navigate(-1)
-    } else {
-      navigate('/')
-    }
-  }
 
   // 使用 usePlatform hook 获取平台信息
   const { isWindows, isMac, isTauri } = usePlatform()
@@ -181,18 +168,7 @@ export const TitleBar = ({ className, searchValue = '', onSearchChange }: TitleB
           )}
           onDoubleClick={isWindows ? handleToggleMaximize : undefined}
         >
-          {isSettingsPage ? (
-            <button
-              type="button"
-              onClick={handleBack}
-              aria-label={t('nav.back')}
-              title={t('nav.back')}
-              className="flex items-center gap-2 text-muted-foreground hover:text-foreground transition-colors px-2 py-1 rounded-md hover:bg-muted/50"
-              data-tauri-drag-region="false"
-            >
-              <ArrowLeft className="w-4 h-4" />
-            </button>
-          ) : isDashboardPage ? (
+          {isDashboardPage ? (
             <div
               className={cn(
                 'relative flex items-center w-64 max-w-xs',

--- a/src/components/setting/SettingsSidebar.tsx
+++ b/src/components/setting/SettingsSidebar.tsx
@@ -1,9 +1,20 @@
-import { Settings, Palette, RefreshCw, Shield, Wifi, HardDrive, Info } from 'lucide-react'
+import {
+  Settings,
+  Palette,
+  RefreshCw,
+  Shield,
+  Wifi,
+  HardDrive,
+  Info,
+  ArrowLeft,
+} from 'lucide-react'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
+import { useNavigate } from 'react-router-dom'
 import {
   Sidebar,
   SidebarContent,
+  SidebarFooter,
   SidebarGroup,
   SidebarGroupContent,
   SidebarMenu,
@@ -17,6 +28,15 @@ interface SettingsSidebarProps {
 
 const SettingsSidebar: React.FC<SettingsSidebarProps> = ({ activeCategory, onCategoryChange }) => {
   const { t } = useTranslation()
+  const navigate = useNavigate()
+
+  const handleBack = () => {
+    if (window.history.state && window.history.state.idx > 0) {
+      navigate(-1)
+    } else {
+      navigate('/')
+    }
+  }
 
   const settingsNavItems = [
     {
@@ -69,6 +89,7 @@ const SettingsSidebar: React.FC<SettingsSidebarProps> = ({ activeCategory, onCat
                 return (
                   <SidebarMenuItem key={item.id}>
                     <button
+                      type="button"
                       onClick={() => onCategoryChange(item.id)}
                       className={`flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm outline-none ring-sidebar-ring transition-[width,height,padding] focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0 ${
                         isActive
@@ -86,6 +107,24 @@ const SettingsSidebar: React.FC<SettingsSidebarProps> = ({ activeCategory, onCat
           </SidebarGroupContent>
         </SidebarGroup>
       </SidebarContent>
+      <SidebarFooter>
+        <SidebarGroup>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              <SidebarMenuItem>
+                <button
+                  type="button"
+                  onClick={handleBack}
+                  className="flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm outline-none ring-sidebar-ring transition-[width,height,padding] focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0 text-muted-foreground hover:bg-muted hover:text-foreground"
+                >
+                  <ArrowLeft className="h-4 w-4" />
+                  <span>{t('nav.back')}</span>
+                </button>
+              </SidebarMenuItem>
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+      </SidebarFooter>
     </Sidebar>
   )
 }

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -94,6 +94,7 @@ const SettingsPage: React.FC = () => {
           '--sidebar-width': '20rem',
         } as React.CSSProperties
       }
+      className="min-h-0 h-full"
     >
       <SettingsSidebar activeCategory={activeCategory} onCategoryChange={handleCategoryClick} />
       <SidebarInset>


### PR DESCRIPTION
## Summary
- Moved the back navigation button from the title bar to the settings sidebar footer
- Removed unused imports and code from TitleBar component
- Added SidebarFooter with back button in SettingsSidebar
- Fixed height constraint issue on SettingsPage

## Rationale
This change improves UX by placing the back button in a more intuitive location within the settings context, reducing complexity in the title bar component.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added back navigation button in the settings sidebar for convenient page navigation.

* **Bug Fixes**
  * Enhanced back button behavior to intelligently utilize browser history for improved navigation experience.

* **Style**
  * Applied layout refinements for improved visual consistency in the settings interface.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->