### PR TITLE
Add GitHub Releases auto-updater and migrate to UniClipboard org

### DIFF
--- a/.github/workflows/alpha-build.yml
+++ b/.github/workflows/alpha-build.yml
@@ -1,9 +1,6 @@
-name: 'Build Tauri App'
-run-name: "build-${{ inputs.platform || 'all' }}-v${{ inputs.version || github.ref_name }}"
+name: 'Build Alpha'
+run-name: 'alpha-${{ inputs.platform }}-v${{ inputs.version }}'
 on:
-  push:
-    tags:
-      - 'v*'
   workflow_dispatch:
     inputs:
       platform:
@@ -18,10 +15,10 @@ on:
           - 'all'
         default: 'all'
       version:
-        description: '版本号 (例如: 1.0.0)'
+        description: 'Alpha 版本号 (例如: 1.0.0-alpha.1)'
         required: true
         type: string
-        default: '1.0.0'
+        default: '0.0.0-alpha.1'
 
 jobs:
   setup-matrix:
@@ -44,7 +41,7 @@ jobs:
             echo 'matrix=[{"platform":"windows-latest","target":"x86_64-pc-windows-msvc","args":""}]' >> "$GITHUB_OUTPUT"
           fi
 
-  build-tauri:
+  build-alpha:
     name: Build ${{ matrix.target }}
     needs: setup-matrix
     runs-on: ${{ matrix.platform }}
@@ -82,17 +79,17 @@ jobs:
       - name: install frontend dependencies
         run: bun install
 
-      - name: build Tauri app
+      - name: build alpha release
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
-          tagName: v${{ inputs.version || github.ref_name }}
-          releaseName: UniClipboard v${{ inputs.version || github.ref_name }}
-          releaseBody: See the assets to download this version and install.
+          tagName: v${{ inputs.version }}
+          releaseName: UniClipboard Alpha v${{ inputs.version }}
+          releaseBody: Alpha build for testing.
           releaseDraft: true
-          prerelease: false
+          prerelease: true
           uploadUpdaterJson: true
           args: ${{ matrix.args }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ uniclipboard-desktop is a cross-platform clipboard synchronization tool built wi
 
 For detailed architecture design, interaction flows, and system overview, refer to the project's DeepWiki documentation:
 
-- **URL**: https://deepwiki.com/mkdir700/uniclipboard-desktop
+- **URL**: https://deepwiki.com/UniClipboard/UniClipboard
 - **Access**: Use `mcp-deepwiki` MCP server to query the documentation programmatically
 
 This resource provides comprehensive diagrams, flow explanations, and design decisions that complement the code structure.

--- a/README.md
+++ b/README.md
@@ -12,19 +12,19 @@ It enables seamless and secure syncing of text, images, and files across multipl
 <div align="center">
   <br/>
 
-  <a href="https://github.com/mkdir700/uniclipboard-desktop/releases">
+  <a href="https://github.com/UniClipboard/UniClipboard/releases">
     <img
       alt="Windows"
       src="https://img.shields.io/badge/-Windows-blue?style=flat-square&logo=data:image/svg+xml;base64,PHN2ZyB0PSIxNzI2MzA1OTcxMDA2IiBjbGFzcz0iaWNvbiIgdmlld0JveD0iMCAwIDEwMjQgMTAyNCIgdmVyc2lvbj0iMS4xIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHAtaWQ9IjE1NDgiIHdpZHRoPSIxMjgiIGhlaWdodD0iMTI4Ij48cGF0aCBkPSJNNTI3LjI3NTU1MTYxIDk2Ljk3MTAzMDEzdjM3My45OTIxMDY2N2g0OTQuNTEzNjE5NzVWMTUuMDI2NzU3NTN6TTUyNy4yNzU1NTE2MSA5MjguMzIzNTA4MTVsNDk0LjUxMzYxOTc1IDgwLjUyMDI4MDQ5di00NTUuNjc3NDcxNjFoLTQ5NC41MTM2MTk3NXpNNi42NzA0NTEzNiA0NzAuODMzNjgyOTdINDIyLjY3Njg1OTI1VjExMC41NjM2ODE5N2wtNDE4LjAwNjQwNzg5IDY5LjI1Nzc5NzUzek00LjY3MDQ1MTM2IDg0Ni43Njc1OTcwM0w0MjIuNjc2ODU5MjUgOTE0Ljg2MDMxMDEzVjU1My4xNjYzMTcwM0g0LjY3MDQ1MTM2eiIgcC1pZD0iMTU0OSIgZmlsbD0iI2ZmZmZmZiI+PC9wYXRoPjwvc3ZnPg=="
     />
   </a>
-  <a href="https://github.com/mkdir700/uniclipboard-desktop/releases">
+  <a href="https://github.com/UniClipboard/UniClipboard/releases">
     <img
       alt="MacOS"
       src="https://img.shields.io/badge/-MacOS-black?style=flat-square&logo=apple&logoColor=white"
     />
   </a >
-  <a href="https://github.com/mkdir700/uniclipboard-desktop/releases">
+  <a href="https://github.com/UniClipboard/UniClipboard/releases">
     <img
       alt="Linux"
       src="https://img.shields.io/badge/-Linux-purple?style=flat-square&logo=linux&logoColor=white"
@@ -34,12 +34,12 @@ It enables seamless and secure syncing of text, images, and files across multipl
   <div>
     <a href="./LICENSE">
       <img
-        src="https://img.shields.io/github/license/mkdir700/uniclipboard-desktop?style=flat-square"
+        src="https://img.shields.io/github/license/UniClipboard/UniClipboard?style=flat-square"
       />
     </a >
-    <a href="https://github.com/mkdir700/uniclipboard-desktop/releases">
+    <a href="https://github.com/UniClipboard/UniClipboard/releases">
       <img
-        src="https://img.shields.io/github/v/release/mkdir700/uniclipboard-desktop?include_prereleases&style=flat-square"
+        src="https://img.shields.io/github/v/release/UniClipboard/UniClipboard?include_prereleases&style=flat-square"
       />
     </a >
     <a href="https://codecov.io/gh/UniClipboard/UniClipboard" >
@@ -65,14 +65,14 @@ It enables seamless and secure syncing of text, images, and files across multipl
 
 ### Download from Releases
 
-Visit the [GitHub Releases](https://github.com/mkdir700/uniclipboard-desktop/releases) page to download the installation package for your operating system.
+Visit the [GitHub Releases](https://github.com/UniClipboard/UniClipboard/releases) page to download the installation package for your operating system.
 
 ### Build from Source
 
 ```bash
 # Clone the repository
-git clone https://github.com/mkdir700/uniclipboard-desktop.git
-cd uniclipboard-desktop
+git clone https://github.com/UniClipboard/UniClipboard.git
+cd UniClipboard
 
 # Install dependencies
 bun install
@@ -147,4 +147,4 @@ This project is licensed under the Apache-2.0 License - see the [LICENSE](./LICE
 
 ---
 
-**Have questions or suggestions?** [Create an Issue](https://github.com/mkdir700/uniclipboard-desktop/issues/new) or contact us to discuss!
+**Have questions or suggestions?** [Create an Issue](https://github.com/UniClipboard/UniClipboard/issues/new) or contact us to discuss!

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -1,4 +1,4 @@
-![UniClipboard](https://socialify.git.ci/mkdir700/uniclipboard-desktop/image?custom_description=A+privacy-first%2C+end-to-end+encrypted%2C+cross-device+clipboard+sync+built+with+Rust+and+Tauri.&description=1&font=KoHo&forks=1&issues=1&name=1&owner=1&pattern=Floating+Cogs&pulls=1&stargazers=1&theme=Auto)
+![UniClipboard](https://socialify.git.ci/UniClipboard/UniClipboard/image?custom_description=A+privacy-first%2C+end-to-end+encrypted%2C+cross-device+clipboard+sync+built+with+Rust+and+Tauri.&description=1&font=KoHo&forks=1&issues=1&name=1&owner=1&pattern=Floating+Cogs&pulls=1&stargazers=1&theme=Auto)
 
 ## 📝 项目介绍
 
@@ -12,19 +12,19 @@ UniClipboard 是一款以**隐私优先**为核心理念的跨设备剪贴板同
 
   <br/>
 
-  <a href="https://github.com/mkdir700/uniclipboard-desktop/releases">
+  <a href="https://github.com/UniClipboard/UniClipboard/releases">
     <img
       alt="Windows"
       src="https://img.shields.io/badge/-Windows-blue?style=flat-square&logo=data:image/svg+xml;base64,PHN2ZyB0PSIxNzI2MzA1OTcxMDA2IiBjbGFzcz0iaWNvbiIgdmlld0JveD0iMCAwIDEwMjQgMTAyNCIgdmVyc2lvbj0iMS4xIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHAtaWQ9IjE1NDgiIHdpZHRoPSIxMjgiIGhlaWdodD0iMTI4Ij48cGF0aCBkPSJNNTI3LjI3NTU1MTYxIDk2Ljk3MTAzMDEzdjM3My45OTIxMDY2N2g0OTQuNTEzNjE5NzVWMTUuMDI2NzU3NTN6TTUyNy4yNzU1NTE2MSA5MjguMzIzNTA4MTVsNDk0LjUxMzYxOTc1IDgwLjUyMDI4MDQ5di00NTUuNjc3NDcxNjFoLTQ5NC41MTM2MTk3NXpNNC42NzA0NTEzNiA0NzAuODMzNjgyOTdINDIyLjY3Njg1OTI1VjExMC41NjM2ODE5N2wtNDE4LjAwNjQwNzg5IDY5LjI1Nzc5NzUzek00LjY3MDQ1MTM2IDg0Ni43Njc1OTcwM0w0MjIuNjc2ODU5MjUgOTE0Ljg2MDMxMDEzVjU1My4xNjYzMTcwM0g0LjY3MDQ1MTM2eiIgcC1pZD0iMTU0OSIgZmlsbD0iI2ZmZmZmZiI+PC9wYXRoPjwvc3ZnPg=="
     />
   </a>  
-  <a href="https://github.com/mkdir700/uniclipboard-desktop/releases">
+  <a href="https://github.com/UniClipboard/UniClipboard/releases">
     <img
       alt="MacOS"
       src="https://img.shields.io/badge/-MacOS-black?style=flat-square&logo=apple&logoColor=white"
     />
   </a>
-  <a href="https://github.com/mkdir700/uniclipboard-desktop/releases">
+  <a href="https://github.com/UniClipboard/UniClipboard/releases">
     <img
       alt="Linux"
       src="https://img.shields.io/badge/-Linux-purple?style=flat-square&logo=linux&logoColor=white"
@@ -34,16 +34,16 @@ UniClipboard 是一款以**隐私优先**为核心理念的跨设备剪贴板同
   <div>
     <a href="./LICENSE">
       <img
-        src="https://img.shields.io/github/license/mkdir700/uniclipboard-desktop?style=flat-square"
+        src="https://img.shields.io/github/license/UniClipboard/UniClipboard?style=flat-square"
       />
     </a>
-    <a href="https://github.com/mkdir700/uniclipboard-desktop/releases">
+    <a href="https://github.com/UniClipboard/UniClipboard/releases">
       <img
-        src="https://img.shields.io/github/v/release/mkdir700/uniclipboard-desktop?include_prereleases&style=flat-square"
+        src="https://img.shields.io/github/v/release/UniClipboard/UniClipboard?include_prereleases&style=flat-square"
       />
     </a>
-    <a href="https://codecov.io/gh/mkdir700/uniclipboard-desktop" >
-      <img src="https://codecov.io/gh/mkdir700/uniclipboard-desktop/branch/main/graph/badge.svg?token=QZfjXOsQTp"/>
+    <a href="https://codecov.io/gh/UniClipboard/UniClipboard" >
+      <img src="https://codecov.io/gh/UniClipboard/UniClipboard/branch/main/graph/badge.svg?token=QZfjXOsQTp"/>
     </a>
   </div>
 
@@ -65,14 +65,14 @@ UniClipboard 是一款以**隐私优先**为核心理念的跨设备剪贴板同
 
 ### 从 Releases 下载
 
-访问 [GitHub Releases](https://github.com/mkdir700/uniclipboard-desktop/releases) 页面，下载适合您操作系统的安装包。
+访问 [GitHub Releases](https://github.com/UniClipboard/UniClipboard/releases) 页面，下载适合您操作系统的安装包。
 
 ### 从源码构建
 
 ```bash
 # 克隆仓库
-git clone https://github.com/mkdir700/uniclipboard-desktop.git
-cd uniclipboard-desktop
+git clone https://github.com/UniClipboard/UniClipboard.git
+cd UniClipboard
 
 # 安装依赖
 bun install
@@ -147,4 +147,4 @@ bun tauri build
 
 ---
 
-💡 **有问题或建议?** [创建 Issue](https://github.com/mkdir700/uniclipboard-desktop/issues/new) 或联系我们讨论!
+💡 **有问题或建议?** [创建 Issue](https://github.com/UniClipboard/UniClipboard/issues/new) 或联系我们讨论!

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,7 @@ UniClipboard Desktop is a cross-platform clipboard synchronization tool built wi
 - [Module Boundaries](architecture/module-boundaries.md) - What each module can/cannot do
 - [Snapshot Cache Pipeline ADR](architecture/snapshot-cache/adr-001-snapshot-cache-pipeline.md) - Cache/spool/worker design decisions
 - [Error Handling](guides/error-handling.md) - Error handling strategy
+- [GitHub Releases Updater](guides/github-releases-updater.md) - Auto-update pipeline with latest.json
 
 **For Code Review:**
 

--- a/docs/archive/plans/2026-01-12-bootstrap-architecture-design.md
+++ b/docs/archive/plans/2026-01-12-bootstrap-architecture-design.md
@@ -618,7 +618,7 @@ git commit -m "refactor: remove legacy AppBuilder and cleanup"
 
 ## References / 参考
 
-- **Project DeepWiki**: https://deepwiki.com/mkdir700/uniclipboard-desktop
+- **Project DeepWiki**: https://deepwiki.com/UniClipboard/UniClipboard
 - **Hexagonal Architecture**: Alistair Cockburn's Ports and Adapters pattern
 - **Clean Architecture**: Robert C. Martin's layered architecture principles
 

--- a/docs/archive/plans/2026-01-12-bootstrap-phase1-foundation.md
+++ b/docs/archive/plans/2026-01-12-bootstrap-phase1-foundation.md
@@ -735,7 +735,7 @@ After Phase 1, run the validation checklist from the design doc:
 ## Related Documentation / 相关文档
 
 - **Design Document**: [docs/plans/2026-01-12-bootstrap-architecture-design.md](docs/plans/2026-01-12-bootstrap-architecture-design.md)
-- **Project DeepWiki**: https://deepwiki.com/mkdir700/uniclipboard-desktop
+- **Project DeepWiki**: https://deepwiki.com/UniClipboard/UniClipboard
 
 ---
 

--- a/docs/archive/plans/2026-01-12-bootstrap-phase2-creation.md
+++ b/docs/archive/plans/2026-01-12-bootstrap-phase2-creation.md
@@ -1177,7 +1177,7 @@ After Phase 2, run the validation checklist from the design doc:
 - **Design Document**: [docs/plans/2026-01-12-bootstrap-architecture-design.md](docs/plans/2026-01-12-bootstrap-architecture-design.md)
 - **Phase 1 Plan**: [docs/plans/2026-01-12-bootstrap-phase1-foundation.md](docs/plans/2026-01-12-bootstrap-phase1-foundation.md)
 - **Phase 1 Summary**: [docs/plans/phase1-summary.md](docs/plans/phase1-summary.md)
-- **Project DeepWiki**: https://deepwiki.com/mkdir700/uniclipboard-desktop
+- **Project DeepWiki**: https://deepwiki.com/UniClipboard/UniClipboard
 
 ---
 

--- a/docs/guides/github-releases-updater.md
+++ b/docs/guides/github-releases-updater.md
@@ -1,0 +1,132 @@
+# GitHub Releases Updater
+
+This guide documents how UniClipboard publishes Tauri updater artifacts to GitHub Releases and serves `latest.json` for auto-updates.
+
+## Prerequisites
+
+- Tauri updater plugin enabled in `src-tauri/tauri.conf.json`.
+- `createUpdaterArtifacts` enabled so `.sig` files are generated.
+- A signing keypair generated with `cargo tauri signer generate`.
+
+## Required Tauri Configuration
+
+Update `src-tauri/tauri.conf.json`:
+
+```json
+{
+  "bundle": {
+    "createUpdaterArtifacts": true
+  },
+  "plugins": {
+    "updater": {
+      "endpoints": [
+        "https://github.com/UniClipboard/UniClipboard/releases/latest/download/latest.json"
+      ],
+      "pubkey": "<PUBLIC_KEY_CONTENT>"
+    }
+  }
+}
+```
+
+We keep the main workflow in `.github/workflows/build.yml` and allow both tag pushes and manual runs.
+
+Notes:
+
+- `pubkey` must be the content of the generated `.key.pub` file (not a path).
+- `latest.json` is a static updater manifest. Tauri validates the JSON structure and uses the `.sig` files uploaded with the release.
+
+## Signing Keys
+
+Generate the keypair locally:
+
+```bash
+cargo tauri signer generate -w ~/.tauri/uniclipboard.key
+```
+
+Store these in CI secrets:
+
+- `TAURI_SIGNING_PRIVATE_KEY` (contents or path to the private key)
+- `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` (if you set one)
+
+## Release Workflow (Example)
+
+The `tauri-apps/tauri-action` workflow can build bundles, upload updater artifacts, and generate `latest.json` on GitHub Releases.
+
+```yaml
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+
+      - name: install Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+
+      - name: install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: install frontend dependencies
+        run: bun install
+
+      - name: build and publish
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        with:
+          tagName: ${{ github.ref_name }}
+          releaseName: UniClipboard ${{ github.ref_name }}
+          releaseBody: 'See the assets to download.'
+          releaseDraft: true
+```
+
+## Alpha Manual Builds
+
+Use the manual alpha workflow for prerelease builds:
+
+- Workflow: `.github/workflows/alpha-build.yml`
+- Trigger: GitHub Actions → `Build Alpha` (workflow_dispatch)
+- Output: GitHub Release marked as `prerelease` + `draft`
+- Endpoint: still uses the same `latest.json` in the release assets
+
+This lets us publish alpha drafts without affecting the stable release flow.
+
+References:
+
+- Tauri Updater docs: https://v2.tauri.app/plugin/updater/
+- Tauri Action: https://github.com/tauri-apps/tauri-action
+
+## Static JSON Format (latest.json)
+
+When using a static updater file, Tauri expects JSON in this shape (simplified):
+
+```json
+{
+  "version": "1.2.3",
+  "notes": "Release notes",
+  "pub_date": "2026-01-01T00:00:00Z",
+  "platforms": {
+    "darwin-aarch64": {
+      "url": "https://github.com/UniClipboard/UniClipboard/releases/download/v1.2.3/UniClipboard.app.tar.gz",
+      "signature": "<SIG_CONTENT>"
+    }
+  }
+}
+```
+
+Tauri Action generates this file automatically when updater artifacts are enabled.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -373,4 +373,4 @@ RUST_LOG=debug cargo test --workspace
 - [Bootstrap System](architecture/bootstrap.md) - How dependency injection works
 - [Module Boundaries](architecture/module-boundaries.md) - What each module can/cannot do
 - [Error Handling](guides/error-handling.md) - Error handling strategy
-- [DeepWiki](https://deepwiki.com/mkdir700/uniclipboard-desktop) - Interactive diagrams
+- [DeepWiki](https://deepwiki.com/UniClipboard/UniClipboard) - Interactive diagrams

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4633,7 +4633,7 @@ dependencies = [
  "tar",
  "ureq",
  "vcpkg",
- "zip",
+ "zip 7.0.0",
 ]
 
 [[package]]
@@ -5706,6 +5706,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-osa-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f112d1746737b0da274ef79a23aac283376f335f4095a083a267a082f21db0c0"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2 0.6.3",
+ "objc2-app-kit",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-quartz-core"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5852,6 +5864,20 @@ checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
 dependencies = [
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "osakit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732c71caeaa72c065bb69d7ea08717bd3f4863a4f451402fc9513e29dbd5261b"
+dependencies = [
+ "objc2 0.6.3",
+ "objc2-foundation",
+ "objc2-osa-kit",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -8437,6 +8463,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-updater"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27cbc31740f4d507712550694749572ec0e43bdd66992db7599b89fbfd6b167b"
+dependencies = [
+ "base64 0.22.1",
+ "dirs 6.0.0",
+ "flate2",
+ "futures-util",
+ "http 1.4.0",
+ "infer",
+ "log",
+ "minisign-verify",
+ "osakit",
+ "percent-encoding",
+ "reqwest",
+ "semver",
+ "serde",
+ "serde_json",
+ "tar",
+ "tauri",
+ "tauri-plugin",
+ "tempfile",
+ "thiserror 2.0.17",
+ "time",
+ "tokio",
+ "url",
+ "windows-sys 0.60.2",
+ "zip 4.6.1",
+]
+
+[[package]]
 name = "tauri-runtime"
 version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9402,6 +9460,7 @@ dependencies = [
  "tauri-plugin-opener",
  "tauri-plugin-single-instance",
  "tauri-plugin-stronghold",
+ "tauri-plugin-updater",
  "tempfile",
  "tokio",
  "tokio-util",
@@ -11002,6 +11061,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.112",
+]
+
+[[package]]
+name = "zip"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "indexmap 2.12.1",
+ "memchr",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -130,6 +130,7 @@ winapi = { version = "0.3.9", features = [
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-autostart = "2"
 tauri-plugin-single-instance = "2"
+tauri-plugin-updater = "2"
 
 [dependencies.uuid]
 version = "1.10.0"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -19,6 +19,7 @@
     "autostart:allow-is-enabled",
     "stronghold:default",
     "log:default",
-    "decorum:allow-show-snap-overlay"
+    "decorum:allow-show-snap-overlay",
+    "updater:default"
   ]
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -481,6 +481,9 @@ fn run_app(config: AppConfig) {
             runtime_for_handler.set_app_handle(app.handle().clone());
             info!("AppHandle set on AppRuntime for event emission");
 
+            #[cfg(not(any(target_os = "android", target_os = "ios")))]
+            app.handle().plugin(tauri_plugin_updater::Builder::new().build())?;
+
             // Start background spooler and blob worker tasks
             start_background_tasks(background, &runtime_for_handler.deps);
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -44,6 +44,15 @@
       "icons/128x128@2x.png",
       "icons/icon.icns",
       "icons/icon.ico"
-    ]
+    ],
+    "createUpdaterArtifacts": true
+  },
+  "plugins": {
+    "updater": {
+      "endpoints": [
+        "https://github.com/UniClipboard/UniClipboard/releases/latest/download/latest.json"
+      ],
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEIyNjgwODM2ODY1QzI3MzgKUldRNEoxeUdOZ2hvc3RZOXRMNTRiOHBWQ1d2RkljN2ViTzlpRDExSHZmMmZxY01ZZW1Zd3RJV2IK"
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Integrate tauri-plugin-updater with GitHub Releases backend for automatic updates
- Enhance build workflow to support tag-triggered releases with draft creation
- Migrate all repository URLs from mkdir700/uniclipboard-desktop to UniClipboard/UniClipboard
- Add alpha build workflow for pre-release testing
- Add comprehensive updater documentation guide

This PR implements the GitHub Releases auto-updater system and completes the repository organization migration to UniClipboard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added auto-update functionality enabling users to receive application updates via GitHub Releases with cryptographic verification.

* **Documentation**
  * Updated repository documentation links; added guide covering auto-update configuration and release workflows.

* **Chores**
  * Enhanced GitHub Actions workflows to support both alpha and release builds with signing and artifact generation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->