### PR TITLE
fix(logging): suppress noisy mDNS error and reduce Tauri startup logs

### DIFF
--- a/src-tauri/crates/uc-tauri/src/bootstrap/logging.rs
+++ b/src-tauri/crates/uc-tauri/src/bootstrap/logging.rs
@@ -47,6 +47,8 @@ pub fn get_builder() -> tauri_plugin_log::Builder {
     let mut builder = tauri_plugin_log::Builder::new()
         .timezone_strategy(TimezoneStrategy::UseLocal)
         .level(default_log_level)
+        // Suppress libp2p-mdns iface send errors (No route to host)
+        .level_for("libp2p_mdns::behaviour::iface", LevelFilter::Off)
         // Filter libp2p_mdns ERROR logs (harmless errors from proxy software virtual interfaces)
         .level_for("libp2p_mdns", LevelFilter::Warn)
         // Filter out tauri-plugin-log's own logs to avoid infinite loops

--- a/src-tauri/crates/uc-tauri/src/bootstrap/tracing.rs
+++ b/src-tauri/crates/uc-tauri/src/bootstrap/tracing.rs
@@ -75,9 +75,11 @@ pub fn init_tracing_subscriber() -> anyhow::Result<()> {
     // - Can be overridden with RUST_LOG environment variable
     let filter_directives = [
         if is_dev { "debug" } else { "info" },
-        "libp2p_mdns=warn", // Filter noisy proxy errors
-        "wry=off",          // Filter Tauri internal spans (custom_protocol)
-        "ipc::request=off", // Filter Tauri IPC handler spans
+        "libp2p_mdns::behaviour::iface=off", // Suppress iface send errors (No route to host)
+        "libp2p_mdns=warn",                  // Filter noisy proxy errors
+        "tauri=warn",                        // Filter noisy setup spans (app::setup)
+        "wry=off",                           // Filter Tauri internal spans (custom_protocol)
+        "ipc::request=off",                  // Filter Tauri IPC handler spans
         if is_dev {
             "uc_platform=debug"
         } else {


### PR DESCRIPTION
## Summary
- **mDNS Noise Suppression**: Set `libp2p_mdns::behaviour::iface` log level to `off` to suppress "No route to host" errors caused by virtual/unreachable interfaces during startup.
- **Tauri Log Reduction**: Set `tauri` log level to `warn` to filter out extremely long `app::setup` spans that include full application configuration in every log entry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized internal logging configuration with refined filter settings for improved log management across the application.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->