### PR TITLE
fix(ui): remove encryption controls from security section

### DIFF
--- a/.decisions/2026-01-31.md
+++ b/.decisions/2026-01-31.md
@@ -4,10 +4,13 @@
 - Risk: none
   [17:25] Make device header sticky
 - Why: Keep primary actions visible during long lists
-[18:00] Enable Sentry Feedback integration
+  [18:00] Enable Sentry Feedback integration
 
 - Why: Allow users to submit feedback directly via Sentry widget
 - Risk: none
   [18:06] Add feedback button to sidebar
 - Why: Allow users to submit feedback via Sentry widget
 - Risk: None (gated by sentryEnabled)
+  [23:02] Remove encryption controls from security settings UI
+- Why: Frontend no longer uses local encryption toggle or password input to avoid config drift
+- Risk: Security settings page no longer provides encryption toggle or password input

--- a/src/components/setting/SecuritySection.tsx
+++ b/src/components/setting/SecuritySection.tsx
@@ -1,8 +1,6 @@
-import { Eye, EyeOff } from 'lucide-react'
 import React, { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { setEncryptionPassword, getEncryptionPassword } from '@/api/security'
-import { Switch, Input } from '@/components/ui'
+import { Switch } from '@/components/ui'
 import { Card, CardContent } from '@/components/ui/card'
 import { useSetting } from '@/hooks/useSetting'
 
@@ -10,37 +8,14 @@ const SecuritySection: React.FC = () => {
   const { t } = useTranslation()
   const { setting, error, updateSecuritySetting } = useSetting()
 
-  // Local state
-  const [endToEndEncryption, setEndToEndEncryption] = useState(true)
   const [autoUnlockEnabled, setAutoUnlockEnabled] = useState(false)
-  const [encryptionPassword, setEncryptionPasswordInput] = useState('')
-  const [showPassword, setShowPassword] = useState(false)
-
-  // Debounce save password
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      setEncryptionPassword(encryptionPassword)
-    }, 500)
-    return () => clearTimeout(timer)
-  }, [encryptionPassword])
 
   // Update local state when settings are loaded
   useEffect(() => {
     if (setting) {
-      setEndToEndEncryption(setting.security.encryption_enabled)
       setAutoUnlockEnabled(setting.security.auto_unlock_enabled)
-      getEncryptionPassword().then(password => {
-        setEncryptionPasswordInput(password || '')
-      })
     }
   }, [setting])
-
-  // Handle end-to-end encryption toggle change
-  const handleEndToEndEncryptionChange = (checked: boolean) => {
-    const newValue = checked
-    setEndToEndEncryption(newValue)
-    updateSecuritySetting({ encryption_enabled: newValue })
-  }
 
   const handleAutoUnlockChange = (checked: boolean) => {
     setAutoUnlockEnabled(checked)
@@ -59,47 +34,6 @@ const SecuritySection: React.FC = () => {
   return (
     <Card>
       <CardContent className="pt-6 space-y-4">
-        {/* End-to-end encryption */}
-        <div className="flex items-center justify-between py-2">
-          <div className="space-y-0.5">
-            <h4 className="text-sm font-medium">
-              {t('settings.sections.security.endToEndEncryption.label')}
-            </h4>
-            <p className="text-xs text-muted-foreground">
-              {t('settings.sections.security.endToEndEncryption.description')}
-            </p>
-          </div>
-          <Switch checked={endToEndEncryption} onCheckedChange={handleEndToEndEncryptionChange} />
-        </div>
-
-        {/* Encryption password */}
-        <div className="flex items-center justify-between gap-4 py-2">
-          <div className="space-y-0.5">
-            <h4 className="text-sm font-medium">
-              {t('settings.sections.security.encryptionPassword.label')}
-            </h4>
-            <p className="text-xs text-muted-foreground">
-              {t('settings.sections.security.encryptionPassword.description')}
-            </p>
-          </div>
-          <div className="relative flex items-center">
-            <Input
-              type={showPassword ? 'text' : 'password'}
-              value={encryptionPassword}
-              onChange={e => setEncryptionPasswordInput(e.target.value)}
-              placeholder={t('settings.sections.security.encryptionPassword.placeholder')}
-              className="w-64 pr-10"
-            />
-            <button
-              type="button"
-              onClick={() => setShowPassword(!showPassword)}
-              className="absolute right-2 text-muted-foreground hover:text-foreground transition-colors"
-            >
-              {showPassword ? <EyeOff size={18} /> : <Eye size={18} />}
-            </button>
-          </div>
-        </div>
-
         {/* Auto unlock */}
         <div className="flex items-center justify-between py-2">
           <div className="space-y-0.5">


### PR DESCRIPTION
## Summary
- remove the end-to-end encryption toggle and password input from the security settings UI
- align the security section with current behavior and simplify the settings surface

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed encryption controls from the security settings UI, including the local encryption toggle and password input options.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->