### PR TITLE
feat: enable text selection in clipboard item content area

### DIFF
--- a/src/components/clipboard/ClipboardItem.tsx
+++ b/src/components/clipboard/ClipboardItem.tsx
@@ -259,10 +259,16 @@ const ClipboardItem: React.FC<ClipboardItemProps> = ({
           ? 'bg-primary/5 border-l-4 border-l-primary'
           : 'hover:bg-muted/20 border-l-4 border-l-transparent hover:border-l-primary/30'
       )}
-      onClick={onSelect}
+      onClick={e => {
+        const selection = window.getSelection()
+        if (selection && selection.toString().length > 0) {
+          return
+        }
+        onSelect?.(e)
+      }}
     >
       {/* Main Content Area */}
-      <div className="p-4">{renderContent()}</div>
+      <div className="select-text p-4">{renderContent()}</div>
 
       {/* Footer Area */}
       <div className="flex items-center justify-between px-4 pb-2 pt-1 text-xs text-muted-foreground/60 select-none">


### PR DESCRIPTION
## Summary

- Enable browser-native text selection (drag-to-highlight) within clipboard item content areas by adding `select-text` to override the parent's `select-none`
- Prevent item-level selection from triggering when the user is actively selecting text, by checking `window.getSelection()` in the click handler
- Footer metadata (time, size, index) remains non-selectable

## Changes

- `src/components/clipboard/ClipboardItem.tsx`:
  - Content div: added `select-text` class so users can highlight and copy text
  - Click handler: skip `onSelect` callback when a text selection exists, preserving both text selection UX and existing Ctrl/Shift multi-item selection

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where selecting text inside a clipboard item could unintentionally trigger selection actions.

* **New Features**
  * ClipboardItem component now requires a new entryId prop.

* **Style**
  * Added improved text selection styling to clipboard items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->