### PR TITLE
feat: add Cmd+comma global shortcut to navigate to settings page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { BrowserRouter as Router, Routes, Route, Navigate, Outlet } from 'react-
 import { type EncryptionSessionStatus } from '@/api/security'
 import { getSetupState, type SetupState } from '@/api/setup'
 import { TitleBar } from '@/components'
+import { GlobalShortcuts } from '@/components/GlobalShortcuts'
 import { PairingNotificationProvider } from '@/components/PairingNotificationProvider'
 import { Toaster } from '@/components/ui/sonner'
 import { useSearch } from '@/contexts/search-context'
@@ -111,6 +112,7 @@ const AppContent = ({
 
   return (
     <ShortcutProvider>
+      <GlobalShortcuts />
       <Routes>
         <Route element={<AuthenticatedLayout />}>
           <Route

--- a/src/components/GlobalShortcuts.tsx
+++ b/src/components/GlobalShortcuts.tsx
@@ -1,0 +1,28 @@
+import { useLocation, useNavigate } from 'react-router-dom'
+import { useShortcut } from '@/hooks/useShortcut'
+import { SHORTCUT_DEFINITIONS } from '@/shortcuts/definitions'
+
+const settingsDef = SHORTCUT_DEFINITIONS.find(d => d.id === 'nav.settings')!
+
+/**
+ * 全局快捷键注册组件
+ *
+ * 无渲染组件，集中注册所有 global scope 快捷键。
+ * 必须放在 ShortcutProvider 和 Router 内部。
+ */
+export const GlobalShortcuts = () => {
+  const navigate = useNavigate()
+  const location = useLocation()
+
+  useShortcut({
+    key: settingsDef.key,
+    scope: 'global',
+    handler: () => {
+      if (location.pathname !== '/settings') {
+        navigate('/settings')
+      }
+    },
+  })
+
+  return null
+}

--- a/src/hooks/useShortcut.ts
+++ b/src/hooks/useShortcut.ts
@@ -6,8 +6,8 @@ import { ShortcutScope } from '@/shortcuts/definitions'
  * useShortcut Hook 选项
  */
 interface UseShortcutOptions {
-  /** 快捷键组合，如 "esc", "cmd+a" */
-  key: string
+  /** 快捷键组合，如 "esc", "cmd+a", "mod+comma"，支持字符串或数组形式 */
+  key: string | string[]
   /** 作用域 */
   scope: ShortcutScope
   /** 是否启用（可选，默认 true） */
@@ -40,10 +40,11 @@ export const useShortcut = ({
   handler,
   preventDefault = true,
 }: UseShortcutOptions): void => {
-  const { activeScope } = useShortcutContext()
+  const { activeScope, activeLayer } = useShortcutContext()
 
-  // 只有当作用域匹配且启用时才注册快捷键
-  const isActive = activeScope === scope && enabled
+  // global scope 在非 modal 层时始终激活，其他 scope 保持精确匹配
+  const isActive =
+    scope === 'global' ? activeLayer !== 'modal' && enabled : activeScope === scope && enabled
 
   useHotkeys(
     key,
@@ -53,7 +54,9 @@ export const useShortcut = ({
       preventDefault,
       enableOnFormTags: false,
       enableOnContentEditable: false,
+      // 使用非逗号字符作为多快捷键分隔符，避免 "mod+," 中的逗号被误判为分隔符
+      delimiter: '§',
     },
-    [key, scope, enabled, activeScope, handler, preventDefault]
+    [key, scope, enabled, activeScope, activeLayer, handler, preventDefault]
   )
 }

--- a/src/shortcuts/conflicts.ts
+++ b/src/shortcuts/conflicts.ts
@@ -34,7 +34,8 @@ export const resolveShortcuts = (
   scopeLayer: Record<ShortcutScope, ShortcutLayer> = DEFAULT_SCOPE_LAYER
 ): ResolvedShortcut[] => {
   return definitions.map(def => {
-    const resolvedKey = overrides[def.id] ?? def.key
+    const rawKey = overrides[def.id] ?? def.key
+    const resolvedKey = Array.isArray(rawKey) ? (rawKey[0] ?? '') : rawKey
     const normalizedKey = normalizeHotkey(resolvedKey)
     const layer = scopeLayer[def.scope] ?? 'page'
     return { ...def, resolvedKey, normalizedKey, layer }

--- a/src/shortcuts/definitions.ts
+++ b/src/shortcuts/definitions.ts
@@ -44,8 +44,8 @@ export const DEFAULT_SCOPE_LAYER: Record<ShortcutScope, ShortcutLayer> = {
 export interface ShortcutDefinition {
   /** 唯一标识符 */
   id: string
-  /** 快捷键组合，如 "esc", "cmd+a", "ctrl+shift+d" */
-  key: string
+  /** 快捷键组合，如 "esc", "cmd+a", "mod+comma"，支持字符串或数组形式 */
+  key: string | string[]
   /** 动作类型 */
   action: ShortcutAction
   /** 作用域 */
@@ -106,13 +106,13 @@ export const SHORTCUT_DEFINITIONS: ShortcutDefinition[] = [
   //   scope: "global",
   //   description: "前往设备",
   // },
-  // {
-  //   id: "nav.settings",
-  //   key: "cmd+,",
-  //   action: "navigation.settings",
-  //   scope: "global",
-  //   description: "前往设置",
-  // },
+  {
+    id: 'nav.settings',
+    key: 'mod+comma',
+    action: 'navigation.settings',
+    scope: 'global',
+    description: '前往设置',
+  },
 
   // ===== 搜索 =====
   // {

--- a/src/shortcuts/normalize.ts
+++ b/src/shortcuts/normalize.ts
@@ -17,8 +17,9 @@ const MODIFIER_ORDER = ['ctrl', 'alt', 'shift', 'cmd'] as const
  * - "esc"
  * - "ctrl+alt+/"
  */
-export const normalizeHotkey = (key: string): string => {
-  const tokens = key
+export const normalizeHotkey = (key: string | string[]): string => {
+  const raw = Array.isArray(key) ? (key[0] ?? '') : key
+  const tokens = raw
     .split('+')
     .map(t => t.trim().toLowerCase())
     .filter(Boolean)


### PR DESCRIPTION
## Summary

- Add `Cmd+,` (macOS) / `Ctrl+,` (Windows/Linux) global keyboard shortcut to navigate to the Settings page, matching the standard macOS convention.
- Use code-based key name `mod+comma` instead of literal `,` character to correctly match `react-hotkeys-hook`'s `event.code` normalization (`Comma` → `comma`).
- Introduce `GlobalShortcuts` component for centralized global shortcut registration, mounted inside `ShortcutProvider`.

## Key Changes

| File | Change |
|------|--------|
| `src/components/GlobalShortcuts.tsx` | New renderless component that registers all global-scope shortcuts |
| `src/shortcuts/definitions.ts` | Enable `nav.settings` shortcut with `mod+comma`; widen `key` type to `string \| string[]` |
| `src/hooks/useShortcut.ts` | Support array key form; activate global scope outside modal layer; add `delimiter: '§'` safety for comma-containing keys |
| `src/shortcuts/normalize.ts` | Handle `string \| string[]` key input |
| `src/shortcuts/conflicts.ts` | Handle array key type in conflict resolution |
| `src/App.tsx` | Mount `GlobalShortcuts` inside `ShortcutProvider` |

## Why `mod+comma` instead of `mod+,`

`react-hotkeys-hook` v5 matches keys via `event.code` by default. Pressing the comma key produces `event.code = 'Comma'`, which the library normalizes to `'comma'`. Using the literal `','` character in the hotkey definition results in a permanent mismatch (`','` ≠ `'comma'`), so the handler never fires. Using the code-based name `'comma'` resolves this.

## Note

If `Cmd+,` is still intercepted on macOS after this change, Tauri v2's default native menu may be consuming the keystroke before it reaches the webview. A follow-up change to customize the Tauri menu in `src-tauri/src/main.rs` would be needed in that case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added global keyboard shortcut for quick navigation to the settings page. Use `Mod+Comma` (`Cmd+,` on Mac, `Ctrl+,` on Windows/Linux) to access settings from anywhere in the application.

* **Enhancements**
  * Extended the keyboard shortcut system to support multiple key combinations for a single action, enabling users to choose their preferred alternative shortcuts for better accessibility and workflow customization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->