### PR TITLE
feat(about): display dynamic version with channel badge

### DIFF
--- a/src/components/setting/AboutSection.tsx
+++ b/src/components/setting/AboutSection.tsx
@@ -1,3 +1,4 @@
+import { getVersion } from '@tauri-apps/api/app'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { SettingSectionHeader } from './SettingSectionHeader'
@@ -11,6 +12,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
+import { Badge } from '@/components/ui/badge'
 import { Card, CardContent } from '@/components/ui/card'
 import {
   Select,
@@ -25,16 +27,42 @@ import { useSetting } from '@/hooks/useSetting'
 import { useUpdate } from '@/hooks/useUpdate'
 import type { UpdateChannel } from '@/types/setting'
 
+function parseChannel(version: string): string {
+  const match = version.match(/-(alpha|beta|rc)/)
+  return match ? match[1] : 'stable'
+}
+
+function getChannelBadgeVariant(channel: string): 'outline' | 'secondary' {
+  return channel === 'stable' ? 'secondary' : 'outline'
+}
+
+function getChannelLabel(channel: string): string {
+  const labels: Record<string, string> = {
+    alpha: 'Alpha',
+    beta: 'Beta',
+    rc: 'RC',
+    stable: 'Stable',
+  }
+  return labels[channel] ?? channel
+}
+
 const AboutSection: React.FC = () => {
   const { t } = useTranslation()
   const { setting, loading: settingLoading, updateGeneralSetting } = useSetting()
   const { updateInfo, isCheckingUpdate, checkForUpdates, installUpdate } = useUpdate()
+  const [appVersion, setAppVersion] = useState<string>('')
   const [autoCheckUpdate, setAutoCheckUpdate] = useState(true)
   const [updateChannel, setUpdateChannel] = useState<UpdateChannel | null>(null)
   const [updateDialogOpen, setUpdateDialogOpen] = useState(false)
   const [isInstallingUpdate, setIsInstallingUpdate] = useState(false)
   const [saving, setSaving] = useState(false)
   const isBusy = settingLoading || saving
+
+  const channel = appVersion ? parseChannel(appVersion) : null
+
+  useEffect(() => {
+    getVersion().then(setAppVersion).catch(console.error)
+  }, [])
 
   useEffect(() => {
     if (!setting?.general) return
@@ -129,9 +157,18 @@ const AboutSection: React.FC = () => {
               </svg>
             </div>
             <div className="ml-4 space-y-0.5">
-              <h4 className="text-lg font-medium">{t('settings.sections.about.appName')}</h4>
+              <div className="flex items-center gap-2">
+                <h4 className="text-lg font-medium">{t('settings.sections.about.appName')}</h4>
+                {channel && (
+                  <Badge variant={getChannelBadgeVariant(channel)}>
+                    {getChannelLabel(channel)}
+                  </Badge>
+                )}
+              </div>
               <p className="text-sm text-muted-foreground">
-                {t('settings.sections.about.version')}
+                {appVersion
+                  ? t('settings.sections.about.version', { version: appVersion })
+                  : t('settings.sections.about.version', { version: '...' })}
               </p>
             </div>
           </div>
@@ -185,13 +222,9 @@ const AboutSection: React.FC = () => {
               <SelectItem value="stable">
                 {t('settings.sections.about.updateChannel.stable')}
               </SelectItem>
-              <SelectItem value="beta">
-                {t('settings.sections.about.updateChannel.beta')}
-              </SelectItem>
               <SelectItem value="alpha">
                 {t('settings.sections.about.updateChannel.alpha')}
               </SelectItem>
-              <SelectItem value="rc">{t('settings.sections.about.updateChannel.rc')}</SelectItem>
             </SelectContent>
           </Select>
         </div>

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -202,7 +202,7 @@
       "about": {
         "title": "About",
         "appName": "UniClipboard",
-        "version": "Version 0.1.0",
+        "version": "Version {{version}}",
         "checkUpdate": "Check for updates",
         "autoCheckUpdate": {
           "label": "Auto-check for updates",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -202,7 +202,7 @@
       "about": {
         "title": "关于",
         "appName": "UniClipboard",
-        "version": "版本 0.1.0",
+        "version": "版本 {{version}}",
         "checkUpdate": "检查更新",
         "autoCheckUpdate": {
           "label": "自动检查更新",


### PR DESCRIPTION
## Summary

Displays real application version fetched from Tauri API instead of hardcoded string, with automatic channel (alpha/beta/rc/stable) parsing and visual badge display. Simplifies update channel selector to only stable and alpha options.

## Changes

- Fetch real app version dynamically from Tauri instead of hardcoded translation
- Parse pre-release channel from version string and display channel badge with appropriate styling
- Templatize version strings in i18n files with `{{version}}` interpolation for automatic updates
- Simplify update channel selector to only auto-detect, stable, and alpha options

## Test Plan

- Build frontend with `bun run build` to verify TypeScript compilation
- Run `bun tauri dev` and navigate to Settings → About
- Verify version number displays the real version (e.g., `0.1.0-alpha.3`)
- Verify channel badge displays correctly next to app name (Alpha, Beta, RC, or Stable)
- Verify update channel dropdown only shows Auto-detect, Stable, and Alpha options

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added channel indicator badge displayed next to the app name in the About section to show release channel status.
  * Dynamic app version display now shows the actual version number.

* **Improvements**
  * Streamlined update channel selection by removing beta and release candidate options; only auto, stable, and alpha channels are available.
  * Immediate update check triggered when changing the update channel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->