### PR TITLE
fix: keep setup welcome cards side-by-side

### DIFF
--- a/src/pages/setup/WelcomeStep.tsx
+++ b/src/pages/setup/WelcomeStep.tsx
@@ -20,7 +20,7 @@ export default function WelcomeStep({ onCreate, onJoin, loading }: WelcomeStepPr
         <p className="mt-4 text-lg text-muted-foreground">{t('subtitle')}</p>
       </div>
 
-      <div className="grid gap-4 md:grid-cols-2">
+      <div className="grid grid-cols-2 gap-4">
         <button
           type="button"
           onClick={onCreate}

--- a/src/pages/setup/__tests__/welcome-layout.test.tsx
+++ b/src/pages/setup/__tests__/welcome-layout.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import WelcomeStep from '@/pages/setup/WelcomeStep'
+
+vi.mock('framer-motion', () => ({
+  motion: new Proxy(
+    {},
+    {
+      get: () => (props: React.HTMLAttributes<HTMLDivElement>) => <div {...props} />,
+    }
+  ),
+}))
+
+describe('WelcomeStep layout', () => {
+  it('uses fixed two-column cards layout', () => {
+    const { container } = render(
+      <WelcomeStep onCreate={() => {}} onJoin={() => {}} loading={false} />
+    )
+
+    screen.getByRole('heading', { name: /create/i })
+    const cardsGrid = container.querySelector('div.grid.gap-4')
+    expect(cardsGrid).toBeTruthy()
+    expect(cardsGrid).toHaveClass('grid-cols-2')
+  })
+})


### PR DESCRIPTION
## Summary
- make the welcome step option cards always render in two columns by switching from md:grid-cols-2 to grid-cols-2
- add a WelcomeStep layout regression test that asserts the cards container uses a fixed two-column grid

## Test Plan
- attempted: bun run test src/pages/__tests__/SetupFlow.test.tsx --run
- result: blocked by existing worktree vitest setup path issue (Cannot find module '/@fs/home/wuy6/myprojects/UniClipboard/src/test/setup.ts')
- manual validation: verified the updated class in WelcomeStep enforces two-column layout at all widths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the welcome setup layout to consistently display a fixed two-column grid design across all screen sizes.

* **Tests**
  * Added test coverage for the welcome setup page layout and component behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->