### PR TITLE
fix(ci): make deploy-worker manual-only and fix bun error

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -1,10 +1,6 @@
 name: Deploy Update Server Worker
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'workers/update-server/**'
   workflow_dispatch:
 
 jobs:
@@ -21,3 +17,4 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: workers/update-server
+          packageManager: npm


### PR DESCRIPTION
## Summary
- Remove automatic `push` trigger from `deploy-worker.yml` — Cloudflare handles repo sync for Worker deployments automatically
- Keep `workflow_dispatch` for manual deployments when needed
- Add `packageManager: npm` to fix `Unable to locate executable file: bun` error on ubuntu runner

## Test plan
- [ ] Verify workflow no longer triggers on push to main with worker path changes
- [ ] Manually trigger workflow via GitHub Actions and confirm it deploys successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflow to require manual triggering instead of automatically deploying on push to main.
  * Updated deployment configuration to explicitly specify npm as the package manager.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->