### PR TITLE
chore: enable CodeRabbit review on dev and main

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,5 +1,11 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
 reviews:
+  auto_review:
+    enabled: true
+    auto_incremental_review: true
+    base_branches:
+      - dev
+      - main
   path_instructions:
     - path: '**/*.md'
       instructions: |


### PR DESCRIPTION
This updates  to enable CodeRabbit auto review for PRs targeting both  and . It keeps incremental review enabled and leaves the existing Markdown-specific review instructions unchanged. This prevents auto reviews from being skipped when the base branch is .