### PR TITLE
refactor: remove unused keyring_dir from AppPaths

### DIFF
--- a/src-tauri/crates/uc-app/src/app_paths.rs
+++ b/src-tauri/crates/uc-app/src/app_paths.rs
@@ -7,7 +7,6 @@ pub struct AppPaths {
     pub db_path: PathBuf,
     pub vault_dir: PathBuf,
     pub settings_path: PathBuf,
-    pub keyring_dir: PathBuf,
     pub logs_dir: PathBuf,
     pub cache_dir: PathBuf,
 }
@@ -31,7 +30,6 @@ impl AppPaths {
     /// assert_eq!(paths.db_path, PathBuf::from("/tmp/uniclipboard/uniclipboard.db"));
     /// assert_eq!(paths.vault_dir, PathBuf::from("/tmp/uniclipboard/vault"));
     /// assert_eq!(paths.settings_path, PathBuf::from("/tmp/uniclipboard/settings.json"));
-    /// assert_eq!(paths.keyring_dir, PathBuf::from("/tmp/uniclipboard/keyring"));
     /// assert_eq!(paths.logs_dir, PathBuf::from("/tmp/uniclipboard/logs"));
     /// ```
     pub fn from_app_dirs(dirs: &AppDirs) -> Self {
@@ -39,7 +37,6 @@ impl AppPaths {
             db_path: dirs.app_data_root.join("uniclipboard.db"),
             vault_dir: dirs.app_data_root.join("vault"),
             settings_path: dirs.app_data_root.join("settings.json"),
-            keyring_dir: dirs.app_data_root.join("keyring"),
             logs_dir: dirs.app_data_root.join("logs"),
             cache_dir: dirs.app_cache_root.clone(),
         }
@@ -69,10 +66,6 @@ mod tests {
         assert_eq!(
             paths.settings_path,
             PathBuf::from("/tmp/uniclipboard/settings.json")
-        );
-        assert_eq!(
-            paths.keyring_dir,
-            PathBuf::from("/tmp/uniclipboard/keyring")
         );
         assert_eq!(paths.logs_dir, PathBuf::from("/tmp/uniclipboard/logs"));
     }


### PR DESCRIPTION
## Summary

Removes the unused `keyring_dir` field from the `AppPaths` struct. This field was defined but never consumed by production code—the actual keyring path is independently derived inside `FileSecureStorage::new_in_app_data_root()`, creating drift risk.

## Changes

- Removed `keyring_dir` field from `AppPaths` struct
- Removed initialization from `from_app_dirs()` constructor
- Removed related assertions from doc example and tests

All 192 uc-app tests pass, full workspace cargo check clean.

Fixes #113