### PR TITLE
Add circular reveal animation for settings navigation

### DIFF
--- a/src/components/GlobalShortcuts.tsx
+++ b/src/components/GlobalShortcuts.tsx
@@ -1,5 +1,10 @@
 import { useLocation, useNavigate } from 'react-router-dom'
 import { useShortcut } from '@/hooks/useShortcut'
+import {
+  getSettingsIconPosition,
+  startCircularCollapse,
+  startCircularReveal,
+} from '@/lib/theme-transition'
 import { SHORTCUT_DEFINITIONS } from '@/shortcuts/definitions'
 
 /**
@@ -19,8 +24,19 @@ export const GlobalShortcuts = () => {
     scope: 'global',
     enabled: settingsShortcutEnabled,
     handler: () => {
-      if (location.pathname !== '/settings') {
-        navigate('/settings')
+      const { x, y } = getSettingsIconPosition()
+      if (location.pathname.startsWith('/settings')) {
+        const doNavigate = () => {
+          const idx = (window.history.state as { idx?: number } | null)?.idx
+          if (typeof idx === 'number' && idx > 0) {
+            navigate(-1)
+          } else {
+            navigate('/')
+          }
+        }
+        startCircularCollapse(x, y, doNavigate)
+      } else {
+        startCircularReveal(x, y, () => navigate('/settings'))
       }
     },
   })

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -30,13 +30,23 @@ const NavButton: React.FC<{
   isActive: boolean
   layoutId: string
   onClick?: (e: React.MouseEvent<HTMLAnchorElement>) => void
-}> = ({ to, icon: Icon, label, isActive, layoutId, onClick }) => {
+  'data-settings-icon'?: boolean
+}> = ({
+  to,
+  icon: Icon,
+  label,
+  isActive,
+  layoutId,
+  onClick,
+  'data-settings-icon': dataSettingsIcon,
+}) => {
   return (
     <TooltipProvider delayDuration={0}>
       <Tooltip>
         <TooltipTrigger asChild>
           <Link
             data-tauri-drag-region="false"
+            data-settings-icon={dataSettingsIcon || undefined}
             to={to}
             className="relative group"
             onClick={
@@ -206,9 +216,15 @@ const Sidebar: React.FC = () => {
             label={t('nav.settings')}
             isActive={location.pathname.startsWith('/settings')}
             layoutId="sidebar-nav-bottom"
+            data-settings-icon
             onClick={e => {
               if (location.pathname.startsWith('/settings')) return
-              startCircularReveal(e.clientX, e.clientY, () => navigate('/settings'))
+              const isKeyboard = e.clientX === 0 && e.clientY === 0
+              startCircularReveal(
+                isKeyboard ? null : e.clientX,
+                isKeyboard ? null : e.clientY,
+                () => navigate('/settings')
+              )
             }}
           />
         </div>

--- a/src/components/setting/SettingsSidebar.tsx
+++ b/src/components/setting/SettingsSidebar.tsx
@@ -12,7 +12,7 @@ import {
   SidebarMenu,
   SidebarMenuItem,
 } from '@/components/ui/sidebar'
-import { startCircularReveal } from '@/lib/theme-transition'
+import { getSettingsIconPosition, startCircularCollapse } from '@/lib/theme-transition'
 
 interface SettingsSidebarProps {
   activeCategory: string
@@ -23,7 +23,7 @@ const SettingsSidebar: FC<SettingsSidebarProps> = ({ activeCategory, onCategoryC
   const { t } = useTranslation()
   const navigate = useNavigate()
 
-  const handleBack = (e: React.MouseEvent) => {
+  const handleBack = () => {
     const doNavigate = () => {
       if (window.history.state && window.history.state.idx > 0) {
         navigate(-1)
@@ -31,7 +31,8 @@ const SettingsSidebar: FC<SettingsSidebarProps> = ({ activeCategory, onCategoryC
         navigate('/')
       }
     }
-    startCircularReveal(e.clientX, e.clientY, doNavigate)
+    const { x, y } = getSettingsIconPosition()
+    startCircularCollapse(x, y, doNavigate)
   }
 
   return (

--- a/src/lib/theme-transition.ts
+++ b/src/lib/theme-transition.ts
@@ -1,7 +1,9 @@
 /**
  * View Transition utility using the View Transition API.
- * Creates a circular reveal animation from a given origin point.
+ * Creates circular reveal / collapse animations from a given origin point.
  */
+
+import { flushSync } from 'react-dom'
 
 let lastClickX = 0
 let lastClickY = 0
@@ -16,9 +18,10 @@ export function setTransitionOrigin(x: number, y: number) {
  * Execute a DOM update wrapped in a View Transition with circular reveal.
  * Animates from (x, y) outward to cover the entire viewport.
  * Falls back to immediate execution if View Transition API is not supported.
+ * Pass null for x or y to skip the reveal animation (e.g. keyboard/ESC activations).
  */
-export function startCircularReveal(x: number, y: number, updateDOM: () => void) {
-  if (!document.startViewTransition) {
+export function startCircularReveal(x: number | null, y: number | null, updateDOM: () => void) {
+  if (x === null || y === null || !document.startViewTransition) {
     updateDOM()
     return
   }
@@ -28,7 +31,9 @@ export function startCircularReveal(x: number, y: number, updateDOM: () => void)
     Math.max(y, window.innerHeight - y)
   )
 
-  const transition = document.startViewTransition(updateDOM)
+  const transition = document.startViewTransition(() => {
+    flushSync(updateDOM)
+  })
 
   transition.ready.then(() => {
     document.documentElement.animate(
@@ -42,6 +47,58 @@ export function startCircularReveal(x: number, y: number, updateDOM: () => void)
       }
     )
   })
+}
+
+/**
+ * Execute a DOM update wrapped in a View Transition with circular collapse.
+ * The OLD view shrinks from full viewport down to (x, y).
+ * This is the reverse of startCircularReveal.
+ */
+export function startCircularCollapse(x: number, y: number, updateDOM: () => void) {
+  if (!document.startViewTransition) {
+    updateDOM()
+    return
+  }
+
+  const startRadius = Math.hypot(
+    Math.max(x, window.innerWidth - x),
+    Math.max(y, window.innerHeight - y)
+  )
+
+  // Swap z-index so old view (settings) is on top and collapses away
+  document.documentElement.classList.add('view-transition-collapse')
+
+  const transition = document.startViewTransition(() => {
+    flushSync(updateDOM)
+  })
+
+  transition.ready.then(() => {
+    document.documentElement.animate(
+      {
+        clipPath: [`circle(${startRadius}px at ${x}px ${y}px)`, `circle(0px at ${x}px ${y}px)`],
+      },
+      {
+        duration: 500,
+        easing: 'ease-in-out',
+        pseudoElement: '::view-transition-old(root)',
+      }
+    )
+  })
+
+  transition.finished.then(() => {
+    document.documentElement.classList.remove('view-transition-collapse')
+  })
+}
+
+/** Get the center position of the settings icon in the sidebar */
+export function getSettingsIconPosition(): { x: number; y: number } {
+  const el = document.querySelector('[data-settings-icon]')
+  if (el) {
+    const rect = el.getBoundingClientRect()
+    return { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 }
+  }
+  // Fallback: bottom-left area where settings icon typically is
+  return { x: 28, y: window.innerHeight - 28 }
 }
 
 /**

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -9,23 +9,28 @@ import SettingsSidebar from '@/components/setting/SettingsSidebar'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { SidebarProvider, SidebarInset } from '@/components/ui/sidebar'
 import { SettingContentLayout } from '@/layouts'
+import { getSettingsIconPosition, startCircularCollapse } from '@/lib/theme-transition'
 import { captureUserIntent } from '@/observability/breadcrumbs'
 
 function SettingsPage() {
   const [activeCategory, setActiveCategory] = useState(DEFAULT_CATEGORY)
   const navigate = useNavigate()
 
-  // Handle ESC key to navigate back
+  // Handle ESC key to navigate back with collapse animation
   useEffect(() => {
     captureUserIntent('open_settings')
     const handleEsc = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
-        const idx = (window.history.state as { idx?: number } | null)?.idx
-        if (typeof idx === 'number' && idx > 0) {
-          navigate(-1)
-        } else {
-          navigate('/')
+        const doNavigate = () => {
+          const idx = (window.history.state as { idx?: number } | null)?.idx
+          if (typeof idx === 'number' && idx > 0) {
+            navigate(-1)
+          } else {
+            navigate('/')
+          }
         }
+        const { x, y } = getSettingsIconPosition()
+        startCircularCollapse(x, y, doNavigate)
       }
     }
     window.addEventListener('keydown', handleEsc)

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -274,6 +274,15 @@
   z-index: 9999;
 }
 
+/* Collapse mode: old view on top, shrinks away to reveal new view */
+.view-transition-collapse::view-transition-old(root) {
+  z-index: 9999;
+}
+
+.view-transition-collapse::view-transition-new(root) {
+  z-index: 1;
+}
+
 @layer base {
   html,
   body,


### PR DESCRIPTION
## Summary

Implements circular reveal animation (expanding from origin point) when navigating to/from the settings page, matching the existing theme-switching animation pattern.

**Changes:**
- Extracted `startCircularReveal(x, y, updateDOM)` utility from theme-transition.ts for reusable animation logic
- Settings icon click now triggers circular reveal from the icon position before navigating to /settings
- Settings back button click triggers circular reveal from button position before returning to previous page
- Reuses existing View Transition API infrastructure and CSS pseudo-elements (::view-transition-new)

**Browser compatibility:** Gracefully degrades to instant navigation on unsupported browsers.

## Test plan

- Click settings icon from dashboard/devices page → should see circular expand animation from icon center
- Click back button in settings → should see circular expand animation from button position
- Already in settings and click settings icon → navigation is skipped (no animation)
- ESC key in settings → returns without animation (no cursor coordinates)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Smooth circular reveal when opening Settings (including via shortcut)
  * Circular collapse animation when leaving Settings (back, ESC, or shortcut), with navigation deferred until animation completes
* **Style**
  * View-transition styling added to ensure proper layering during collapse animations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->