### PR TITLE
fix: preserve final frame in settings transition animations

### DIFF
--- a/src/lib/theme-transition.ts
+++ b/src/lib/theme-transition.ts
@@ -43,6 +43,7 @@ export function startCircularReveal(x: number | null, y: number | null, updateDO
       {
         duration: 500,
         easing: 'ease-in-out',
+        fill: 'forwards',
         pseudoElement: '::view-transition-new(root)',
       }
     )
@@ -80,6 +81,7 @@ export function startCircularCollapse(x: number, y: number, updateDOM: () => voi
       {
         duration: 500,
         easing: 'ease-in-out',
+        fill: 'forwards',
         pseudoElement: '::view-transition-old(root)',
       }
     )


### PR DESCRIPTION
### Motivation
- Prevent a one-frame flash of the settings page that appears after the close animation by ensuring the view-transition pseudo-element retains its final clipped frame.

### Description
- Add `fill: 'forwards'` to the circular reveal animation on `::view-transition-new(root)` and to the circular collapse animation on `::view-transition-old(root)` in `src/lib/theme-transition.ts` so the pseudo-element stays at its final keyframe until transition teardown.

### Testing
- Ran `bun run lint` which failed in this environment due to a missing dependency (`@eslint/compat`).
- Ran `bun run build` which failed in this environment with a TypeScript error `Cannot find type definition file for 'vitest'` so a full build could not be validated here.
- Attempted `bun run dev` which failed due to missing `cross-env`, so live browser verification was not possible in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0df13bdf88331b97861f314321a7d)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed animation state retention to ensure animated elements properly maintain their final appearance after transitions complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->