### PR TITLE
fix: persist resizable panel layout on dashboard

### DIFF
--- a/src/components/clipboard/ClipboardContent.tsx
+++ b/src/components/clipboard/ClipboardContent.tsx
@@ -92,7 +92,7 @@ const ClipboardContent: React.FC<ClipboardContentProps> = ({
   const dispatch = useAppDispatch()
 
   // Persist panel layout to localStorage
-  const { defaultLayout } = useDefaultLayout({
+  const { defaultLayout, onLayoutChanged } = useDefaultLayout({
     id: 'clipboard-panels',
     panelIds: ['clipboard-list', 'clipboard-preview'],
     storage: localStorage,
@@ -337,6 +337,7 @@ const ClipboardContent: React.FC<ClipboardContentProps> = ({
           id="clipboard-panels"
           orientation="horizontal"
           defaultLayout={defaultLayout}
+          onLayoutChanged={onLayoutChanged}
           className="flex-1 min-h-0"
         >
           {/* Left panel: item list */}


### PR DESCRIPTION
## Summary
- Pass `onLayoutChanged` callback from `useDefaultLayout` hook to `ResizablePanelGroup`, so panel sizes are saved to `localStorage` after dragging the separator
- Previously only `defaultLayout` (read) was wired up but not `onLayoutChanged` (write), causing the separator to reset on re-render

## Test plan
- [x] Drag the clipboard list/preview separator to a custom position
- [x] Navigate away from the dashboard and return — separator should retain its position
- [x] Refresh the app — separator should still be at the saved position

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced layout change event propagation in the clipboard interface panel for improved control and responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->