### PR TITLE
ci: add Rust dependency caching to coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -20,6 +20,12 @@ jobs:
       - name: Setup Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1.15.2
 
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "src-tauri -> target"
+          shared-key: coverage
+
       - name: Install system dependencies
         run: |
           sudo apt-get update


### PR DESCRIPTION
## Summary
- Add `Swatinem/rust-cache@v2` to the coverage CI workflow, matching the caching strategy used in `build.yml`
- Uses `shared-key: coverage` to avoid cache collisions with build jobs

## Test plan
- [x] Verify coverage workflow runs successfully with cache miss (first run)
- [x] Verify subsequent runs hit the cache and complete faster

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the CI/CD workflow with dependency caching optimization for faster, more efficient builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->