### PR TITLE
chore: auto-sweep incremental build cache before dev server start

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -4,7 +4,7 @@
   "version": "0.3.0-alpha.5",
   "identifier": "app.uniclipboard.desktop",
   "build": {
-    "beforeDevCommand": "bun run dev",
+    "beforeDevCommand": "cargo sweep --time 3 --target src-tauri/target 2>/dev/null; bun run dev",
     "devUrl": "http://localhost:1420",
     "beforeBuildCommand": "bun run build",
     "frontendDist": "../dist"
@@ -25,9 +25,7 @@
         "visible": false,
         "devtools": true,
         "windowEffects": {
-          "effects": [
-            "hudWindow"
-          ],
+          "effects": ["hudWindow"],
           "state": "active",
           "radius": 16
         }


### PR DESCRIPTION
## Summary
- Add `cargo-sweep --time 3` to Tauri's `beforeDevCommand` to automatically clean incremental compilation artifacts older than 3 days
- Prevents `target/debug/incremental/` from growing unbounded (~80GB over time)
- Silently skipped if `cargo-sweep` is not installed

## Test plan
- [x] Verify `bun tauri:dev` starts normally with `cargo-sweep` installed
- [x] Verify `bun tauri:dev` starts normally without `cargo-sweep` installed (no errors)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized development build configuration with automatic cleanup processes to enhance build efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->