### PR TITLE
fix: preserve user-owned files when deleting clipboard entries

### DIFF
--- a/src-tauri/crates/uc-app/src/usecases/delete_clipboard_entry.rs
+++ b/src-tauri/crates/uc-app/src/usecases/delete_clipboard_entry.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use std::path::PathBuf;
 use std::sync::Arc;
 use tracing::{info, info_span, warn, Instrument};
 use uc_core::ids::EntryId;
@@ -14,6 +15,10 @@ pub struct DeleteClipboardEntry {
     selection_repo: Arc<dyn ClipboardSelectionRepositoryPort>,
     event_writer: Arc<dyn ClipboardEventWriterPort>,
     representation_repo: Arc<dyn ClipboardRepresentationRepositoryPort>,
+    /// The managed file-cache directory. Only files located inside this directory
+    /// are deleted from disk when an entry is removed. Files outside this boundary
+    /// are user-owned originals and must never be touched.
+    file_cache_dir: Option<PathBuf>,
 }
 
 impl DeleteClipboardEntry {
@@ -29,7 +34,17 @@ impl DeleteClipboardEntry {
             selection_repo,
             event_writer,
             representation_repo,
+            file_cache_dir: None,
         }
+    }
+
+    /// Sets the managed file-cache directory.
+    ///
+    /// Only files whose path is inside this directory will be deleted from disk when
+    /// an entry is removed. This prevents the deletion of user-owned original files.
+    pub fn with_file_cache_dir(mut self, dir: PathBuf) -> Self {
+        self.file_cache_dir = Some(dir);
+        self
     }
 
     /// Deletes a clipboard entry and its associated selection, event, and snapshot representations in the required order.
@@ -61,8 +76,15 @@ impl DeleteClipboardEntry {
         .await?;
         let event_id = entry.event_id.clone();
 
-        // 1b. Check for file representations and delete cache files
+        // 1b. Check for file representations and delete cache files.
+        // Only files that live inside the managed file_cache_dir are deleted.
+        // Files outside that boundary are user-owned originals and must not be touched.
         async {
+            let Some(ref cache_dir) = self.file_cache_dir else {
+                // No cache dir configured — skip file deletion entirely to be safe.
+                return;
+            };
+
             if let Ok(representations) = self
                 .representation_repo
                 .get_representations_for_event(&event_id)
@@ -71,7 +93,7 @@ impl DeleteClipboardEntry {
                 for rep in &representations {
                     let mime = rep.mime_type.as_ref().map(|m| m.as_str()).unwrap_or("");
                     if mime.contains("uri-list") {
-                        // Parse URI list content and delete each file
+                        // Parse URI list content and delete only files inside the cache dir
                         if let Some(ref inline) = rep.inline_data {
                             let uri_text = String::from_utf8_lossy(inline);
                             for line in uri_text.lines() {
@@ -79,19 +101,49 @@ impl DeleteClipboardEntry {
                                 if line.is_empty() || line.starts_with('#') {
                                     continue;
                                 }
-                                if let Ok(url) = url::Url::parse(line) {
-                                    if let Ok(path) = url.to_file_path() {
-                                        if let Err(e) = tokio::fs::remove_file(&path).await {
-                                            warn!(
-                                                path = %path.display(),
-                                                error = %e,
-                                                "Failed to delete cache file during entry cleanup"
-                                            );
-                                        } else {
-                                            info!(
-                                                path = %path.display(),
-                                                "Deleted cache file during entry cleanup"
-                                            );
+                                // Support both file:// URIs and native paths
+                                let path = if line.starts_with("file://") {
+                                    url::Url::parse(line)
+                                        .ok()
+                                        .and_then(|u| u.to_file_path().ok())
+                                } else {
+                                    Some(std::path::PathBuf::from(line))
+                                };
+
+                                let Some(path) = path else {
+                                    continue;
+                                };
+
+                                // Guard: only delete files that are inside the managed cache dir.
+                                // This prevents accidental deletion of user-owned original files.
+                                if !path.starts_with(cache_dir) {
+                                    info!(
+                                        path = %path.display(),
+                                        cache_dir = %cache_dir.display(),
+                                        "Skipping file deletion — path is outside the managed file-cache directory (user-owned file)"
+                                    );
+                                    continue;
+                                }
+
+                                if let Err(e) = tokio::fs::remove_file(&path).await {
+                                    warn!(
+                                        path = %path.display(),
+                                        error = %e,
+                                        "Failed to delete cache file during entry cleanup"
+                                    );
+                                } else {
+                                    info!(
+                                        path = %path.display(),
+                                        "Deleted cache file during entry cleanup"
+                                    );
+                                    // Try to remove the parent directory (e.g. UUID dir) if it's
+                                    // now empty and still inside the cache boundary.
+                                    if let Some(parent) = path.parent() {
+                                        if parent != cache_dir.as_path()
+                                            && parent.starts_with(cache_dir)
+                                        {
+                                            // remove_dir only succeeds when dir is empty
+                                            let _ = tokio::fs::remove_dir(parent).await;
                                         }
                                     }
                                 }
@@ -550,6 +602,231 @@ mod tests {
         assert!(!delete_selection_called.load(std::sync::atomic::Ordering::SeqCst));
         assert!(!delete_event_called.load(std::sync::atomic::Ordering::SeqCst));
         assert!(!delete_entry_called.load(std::sync::atomic::Ordering::SeqCst));
+    }
+
+    /// A representation repository that returns a single text/uri-list representation
+    /// with configurable inline content. Used for file-ownership tests.
+    struct MockRepresentationRepoWithUriList {
+        uri_list_content: String,
+    }
+
+    #[async_trait]
+    impl ClipboardRepresentationRepositoryPort for MockRepresentationRepoWithUriList {
+        async fn get_representation(
+            &self,
+            _event_id: &EventId,
+            _representation_id: &uc_core::ids::RepresentationId,
+        ) -> Result<Option<PersistedClipboardRepresentation>> {
+            Ok(None)
+        }
+
+        async fn get_representation_by_id(
+            &self,
+            _representation_id: &uc_core::ids::RepresentationId,
+        ) -> Result<Option<PersistedClipboardRepresentation>> {
+            Ok(None)
+        }
+
+        async fn get_representation_by_blob_id(
+            &self,
+            _blob_id: &uc_core::BlobId,
+        ) -> Result<Option<PersistedClipboardRepresentation>> {
+            Ok(None)
+        }
+
+        async fn update_blob_id(
+            &self,
+            _representation_id: &uc_core::ids::RepresentationId,
+            _blob_id: &uc_core::BlobId,
+        ) -> Result<()> {
+            Ok(())
+        }
+
+        async fn update_blob_id_if_none(
+            &self,
+            _representation_id: &uc_core::ids::RepresentationId,
+            _blob_id: &uc_core::BlobId,
+        ) -> Result<bool> {
+            Ok(false)
+        }
+
+        async fn update_processing_result(
+            &self,
+            _rep_id: &uc_core::ids::RepresentationId,
+            _expected_states: &[uc_core::clipboard::PayloadAvailability],
+            _blob_id: Option<&uc_core::BlobId>,
+            _new_state: uc_core::clipboard::PayloadAvailability,
+            _last_error: Option<&str>,
+        ) -> Result<uc_core::ports::clipboard::ProcessingUpdateOutcome> {
+            Ok(uc_core::ports::clipboard::ProcessingUpdateOutcome::NotFound)
+        }
+
+        async fn get_representations_for_event(
+            &self,
+            _event_id: &EventId,
+        ) -> Result<Vec<PersistedClipboardRepresentation>> {
+            use uc_core::clipboard::MimeType;
+            use uc_core::ids::{FormatId, RepresentationId};
+            let rep = PersistedClipboardRepresentation::new(
+                RepresentationId::new(),
+                FormatId::from("files"),
+                Some(MimeType::uri_list()),
+                self.uri_list_content.len() as i64,
+                Some(self.uri_list_content.as_bytes().to_vec()),
+                None,
+            );
+            Ok(vec![rep])
+        }
+    }
+
+    fn make_test_use_case_with_uri_list(
+        uri_list: &str,
+        file_cache_dir: Option<std::path::PathBuf>,
+    ) -> DeleteClipboardEntry {
+        use std::sync::atomic::AtomicBool;
+        let entry_id = EntryId::from("test-entry".to_string());
+        let event_id = EventId::from("test-event".to_string());
+        let entry = ClipboardEntry::new(
+            entry_id.clone(),
+            event_id.clone(),
+            1234567890,
+            Some("Test Entry".to_string()),
+            1024,
+        );
+        let entry_repo = MockEntryRepo {
+            entry: Some(entry),
+            should_fail_get: false,
+            should_fail_delete: false,
+            delete_called: Arc::new(AtomicBool::new(false)),
+        };
+        let selection_repo = MockSelectionRepo {
+            should_fail_delete: false,
+            delete_called: Arc::new(AtomicBool::new(false)),
+        };
+        let event_writer = MockEventWriter {
+            should_fail_delete: false,
+            delete_called: Arc::new(AtomicBool::new(false)),
+        };
+        let rep_repo = MockRepresentationRepoWithUriList {
+            uri_list_content: uri_list.to_string(),
+        };
+
+        let uc = DeleteClipboardEntry::from_ports(
+            Arc::new(entry_repo),
+            Arc::new(selection_repo),
+            Arc::new(event_writer),
+            Arc::new(rep_repo),
+        );
+        if let Some(dir) = file_cache_dir {
+            uc.with_file_cache_dir(dir)
+        } else {
+            uc
+        }
+    }
+
+    /// Synced (cache) files whose path is inside file_cache_dir SHOULD be deleted.
+    #[tokio::test]
+    async fn test_cache_file_is_deleted_when_inside_cache_dir() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let cache_dir = tmp.path().join("file-cache");
+        std::fs::create_dir_all(&cache_dir).unwrap();
+
+        // Create a real file inside the cache dir to be deleted
+        let cached_file = cache_dir.join("transfer-abc").join("photo.png");
+        std::fs::create_dir_all(cached_file.parent().unwrap()).unwrap();
+        std::fs::write(&cached_file, b"fake file data").unwrap();
+        assert!(cached_file.exists());
+
+        let uri_list = cached_file.to_string_lossy().to_string();
+        let entry_id = EntryId::from("test-entry".to_string());
+
+        let uc = make_test_use_case_with_uri_list(&uri_list, Some(cache_dir.clone()));
+        uc.execute(&entry_id).await.unwrap();
+
+        assert!(
+            !cached_file.exists(),
+            "Cached file inside cache_dir should have been deleted"
+        );
+        assert!(
+            !cached_file.parent().unwrap().exists(),
+            "Empty parent directory inside cache_dir should also be removed"
+        );
+    }
+
+    /// Local (user-owned) files whose path is OUTSIDE file_cache_dir must NOT be deleted.
+    #[tokio::test]
+    async fn test_local_file_is_not_deleted_when_outside_cache_dir() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let cache_dir = tmp.path().join("file-cache");
+        std::fs::create_dir_all(&cache_dir).unwrap();
+
+        // Create a user-owned file OUTSIDE the cache dir
+        let user_file = tmp.path().join("documents").join("report.pdf");
+        std::fs::create_dir_all(user_file.parent().unwrap()).unwrap();
+        std::fs::write(&user_file, b"important document").unwrap();
+        assert!(user_file.exists());
+
+        let uri_list = user_file.to_string_lossy().to_string();
+        let entry_id = EntryId::from("test-entry".to_string());
+
+        let uc = make_test_use_case_with_uri_list(&uri_list, Some(cache_dir.clone()));
+        uc.execute(&entry_id).await.unwrap();
+
+        assert!(
+            user_file.exists(),
+            "User-owned file outside cache_dir must NOT be deleted"
+        );
+    }
+
+    /// When no file_cache_dir is configured, no files should be deleted (safe default).
+    #[tokio::test]
+    async fn test_no_files_deleted_when_cache_dir_not_configured() {
+        let tmp = tempfile::TempDir::new().unwrap();
+
+        let some_file = tmp.path().join("file.txt");
+        std::fs::write(&some_file, b"data").unwrap();
+        assert!(some_file.exists());
+
+        let uri_list = some_file.to_string_lossy().to_string();
+        let entry_id = EntryId::from("test-entry".to_string());
+
+        // No file_cache_dir provided
+        let uc = make_test_use_case_with_uri_list(&uri_list, None);
+        uc.execute(&entry_id).await.unwrap();
+
+        assert!(
+            some_file.exists(),
+            "File must not be deleted when no cache_dir is configured"
+        );
+    }
+
+    /// Synced files referenced via file:// URI scheme inside cache_dir should also be deleted.
+    #[tokio::test]
+    async fn test_cache_file_uri_scheme_is_deleted() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let cache_dir = tmp.path().join("file-cache");
+        std::fs::create_dir_all(&cache_dir).unwrap();
+
+        let cached_file = cache_dir.join("xfer-1").join("image.jpg");
+        std::fs::create_dir_all(cached_file.parent().unwrap()).unwrap();
+        std::fs::write(&cached_file, b"image bytes").unwrap();
+        assert!(cached_file.exists());
+
+        // Use file:// URI format (legacy format used by older synced entries)
+        let uri = url::Url::from_file_path(&cached_file).unwrap().to_string();
+        let entry_id = EntryId::from("test-entry".to_string());
+
+        let uc = make_test_use_case_with_uri_list(&uri, Some(cache_dir.clone()));
+        uc.execute(&entry_id).await.unwrap();
+
+        assert!(
+            !cached_file.exists(),
+            "Cached file referenced via file:// URI inside cache_dir should have been deleted"
+        );
+        assert!(
+            !cached_file.parent().unwrap().exists(),
+            "Empty parent directory inside cache_dir should also be removed (file:// URI case)"
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/crates/uc-tauri/src/bootstrap/runtime.rs
+++ b/src-tauri/crates/uc-tauri/src/bootstrap/runtime.rs
@@ -511,6 +511,7 @@ impl<'a> UseCases<'a> {
             self.runtime.deps.clipboard.clipboard_event_repo.clone(),
             self.runtime.deps.clipboard.representation_repo.clone(),
         )
+        .with_file_cache_dir(self.runtime.storage_paths.file_cache_dir.clone())
     }
 
     /// Create a `ClearClipboardHistory` use case wired with this runtime's clipboard, selection, and event repositories.


### PR DESCRIPTION
## Summary

- When deleting a clipboard entry, only delete files that reside inside the managed `file-cache` directory (synced from other devices). User-owned local files are now left untouched.
- Clean up empty parent directories (e.g. UUID dirs) inside the cache after file removal.
- Added `file_cache_dir` boundary check to `DeleteClipboardEntry` use case with safe default (no deletion if unconfigured).

## Test plan

- [x] Unit tests: 7 tests pass including 4 new file-ownership tests (cache file deleted, local file preserved, no-cache-dir safe default, file:// URI handling)
- [ ] Manual: copy a local file → delete entry → verify original file still exists
- [ ] Manual: sync a file from another device → delete entry → verify cached file and UUID directory are removed