### PR TITLE
fix: restore quick panel focus after preview panel show on Windows

### DIFF
--- a/src-tauri/crates/uc-tauri/src/preview_panel/mod.rs
+++ b/src-tauri/crates/uc-tauri/src/preview_panel/mod.rs
@@ -103,6 +103,11 @@ pub fn show(app: &tauri::AppHandle, entry_id: &str) {
     #[cfg(not(target_os = "macos"))]
     {
         let _ = preview_window.show();
+        // On Windows, show() activates the window and steals focus from the quick
+        // panel. Immediately restore focus so the quick panel remains active.
+        if let Some(quick_window) = app.get_webview_window(QUICK_PANEL_LABEL) {
+            let _ = quick_window.set_focus();
+        }
     }
 
     // Send entry ID to the frontend


### PR DESCRIPTION
## Summary

- On Windows, `window.show()` activates the new window, causing the preview panel to steal focus from the quick panel
- After showing the preview panel, immediately call `set_focus()` on the quick panel to keep it as the active window
- macOS is unaffected — it uses `orderFrontRegardless()` which shows a window without activating it

## Root Cause

The macOS code path in `preview_panel/mod.rs` correctly uses `macos::show_panel()` → `orderFrontRegardless()` (no focus steal). The non-macOS path only called `preview_window.show()`, which on Windows activates the window and transfers the "active" state away from the quick panel.

## Fix

```rust
#[cfg(not(target_os = "macos"))]
{
    let _ = preview_window.show();
    // On Windows, show() activates the window and steals focus from the quick
    // panel. Immediately restore focus so the quick panel remains active.
    if let Some(quick_window) = app.get_webview_window(QUICK_PANEL_LABEL) {
        let _ = quick_window.set_focus();
    }
}
```

## Test plan

- [x] Open quick panel on Windows (Ctrl+Alt+V)
- [x] Hover over an item to trigger preview panel
- [x] Verify quick panel remains the active (focused) window — title bar stays highlighted, keyboard input goes to quick panel
- [x] Verify arrow keys / search still work normally after preview appears
- [x] Verify preview panel still displays content correctly