### PR TITLE
fix: make cargo sweep cross-platform compatible

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "cross-env UNICLIPBOARD_ENV=development vite",
+    "dev:sweep": "node -e \"try{require('child_process').execSync('cargo sweep --time 3 --target src-tauri/target',{stdio:'ignore'})}catch{}\"",
     "build": "tsc && vite build",
     "preview": "vite preview",
     "version:bump": "node scripts/bump-version.js",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -4,7 +4,7 @@
   "version": "0.3.0-alpha.5",
   "identifier": "app.uniclipboard.desktop",
   "build": {
-    "beforeDevCommand": "cargo sweep --time 3 --target src-tauri/target 2>/dev/null; bun run dev",
+    "beforeDevCommand": "bun run dev:sweep && bun run dev",
     "devUrl": "http://localhost:1420",
     "beforeBuildCommand": "bun run build",
     "frontendDist": "../dist"


### PR DESCRIPTION
## Summary
- Replace Unix-specific `2>/dev/null` and `;` shell syntax in `beforeDevCommand` with a cross-platform `dev:sweep` script
- New script uses Node.js `execSync` + `try/catch` to silently handle `cargo sweep` failures on Windows

## Test plan
- [x] Verify `bun tauri dev` starts correctly on macOS/Linux (cargo sweep runs silently)
- [x] Verify `bun tauri dev` starts correctly on Windows (cargo sweep failure is silently ignored)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Optimized development startup sequence with an automated cleanup step that removes temporary build artifacts. This improvement enhances build environment efficiency and reduces disk space usage during development sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->