### PR TITLE
feat(devices): redesign devices page with Apple-style card layout

### DIFF
--- a/src/components/device/PairedDevicesPanel.tsx
+++ b/src/components/device/PairedDevicesPanel.tsx
@@ -1,4 +1,4 @@
-import { AlertTriangle, Monitor, MoreHorizontal, RefreshCw, Settings, Unlink } from 'lucide-react'
+import { AlertTriangle, Monitor, Plus, RefreshCw } from 'lucide-react'
 import React, { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
@@ -6,19 +6,9 @@ import { getDeviceIcon, getIconColor } from './device-utils'
 import DeviceSettingsSheet from './DeviceSettingsSheet'
 import UnpairAlertDialog from './UnpairAlertDialog'
 import { onP2PPeerConnectionChanged, onP2PPeerNameUpdated, unpairP2PDevice } from '@/api/p2p'
-import { SettingGroup } from '@/components/setting/SettingGroup'
 import { Alert, AlertDescription } from '@/components/ui/alert'
-import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu'
 import { useSetting } from '@/hooks/useSetting'
-import { formatPeerIdForDisplay } from '@/lib/utils'
 import { useAppDispatch, useAppSelector } from '@/store/hooks'
 import {
   fetchPairedDevices,
@@ -112,8 +102,11 @@ const PairedDevicesPanel: React.FC = () => {
 
   if (pairedDevicesError) {
     return (
-      <SettingGroup title={t('devices.pairedDevices.title')}>
-        <div className="px-4 py-3">
+      <div className="space-y-2">
+        <h3 className="text-xs font-medium text-muted-foreground px-1 uppercase tracking-wider">
+          {t('devices.pairedDevices.title')}
+        </h3>
+        <div className="rounded-xl border border-border/60 bg-card p-4">
           <Alert variant="destructive">
             <AlertDescription className="flex items-center gap-3">
               <span className="flex-1">{pairedDevicesError}</span>
@@ -128,20 +121,31 @@ const PairedDevicesPanel: React.FC = () => {
             </AlertDescription>
           </Alert>
         </div>
-      </SettingGroup>
+      </div>
     )
   }
 
   if (pairedDevices.length === 0) {
     return (
-      <div className="mx-auto flex h-full w-full max-w-xl flex-col items-center justify-center text-center">
-        <div className="mb-5 rounded-full bg-muted/30 p-5 ring-1 ring-border/50">
-          <Monitor className="h-10 w-10 text-muted-foreground/50" />
-        </div>
-        <h3 className="mb-2 text-xl font-semibold text-foreground">
-          {t('devices.list.empty.title')}
+      <div className="space-y-2">
+        <h3 className="text-xs font-medium text-muted-foreground px-1 uppercase tracking-wider">
+          {t('devices.pairedDevices.title')}
         </h3>
-        <p className="max-w-sm text-muted-foreground">{t('devices.list.empty.description')}</p>
+        <div className="flex flex-col items-center rounded-xl border border-dashed border-border/80 py-10 px-6 text-center">
+          <div className="mb-4 rounded-full bg-muted/50 p-4 ring-1 ring-border/50">
+            <Monitor className="h-8 w-8 text-muted-foreground/70" />
+          </div>
+          <h3 className="mb-1.5 text-sm font-medium text-foreground">
+            {t('devices.list.empty.title')}
+          </h3>
+          <p className="mb-4 max-w-xs text-xs text-muted-foreground">
+            {t('devices.list.empty.description')}
+          </p>
+          <Button variant="outline" size="sm" disabled>
+            <Plus className="h-3.5 w-3.5" />
+            {t('devices.list.actions.addDevice')}
+          </Button>
+        </div>
       </div>
     )
   }
@@ -164,76 +168,72 @@ const PairedDevicesPanel: React.FC = () => {
         </Alert>
       )}
 
-      <SettingGroup title={t('devices.pairedDevices.title')}>
-        {pairedDevices.map((device, index) => {
-          const Icon = getDeviceIcon(device.deviceName)
-          const iconColor = getIconColor(index)
+      <div className="space-y-2">
+        <h3 className="text-xs font-medium text-muted-foreground px-1 uppercase tracking-wider">
+          {t('devices.pairedDevices.title')}
+        </h3>
+        <div className="grid grid-cols-2 gap-3">
+          {pairedDevices.map((device, index) => {
+            const Icon = getDeviceIcon(device.deviceName)
+            const iconColor = getIconColor(index)
 
-          return (
-            <div
-              key={device.peerId}
-              className="flex items-center gap-3 px-4 py-3 hover:bg-accent/50 transition-colors cursor-pointer"
-              onClick={() => openSheet(device.peerId)}
-            >
+            return (
               <button
+                key={device.peerId}
                 type="button"
                 onClick={() => openSheet(device.peerId)}
-                className="flex min-w-0 flex-1 items-center gap-4 text-left outline-none cursor-pointer"
+                className="group relative flex flex-col items-center rounded-2xl bg-card p-5 pt-6 pb-4 text-center shadow-sm ring-1 ring-border/40 transition-all hover:shadow-md hover:ring-border/60 cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-ring"
               >
-                <div
-                  className={`h-10 w-10 shrink-0 rounded-lg flex items-center justify-center ring-1 shadow-sm ${iconColor}`}
+                {/* Icon with status indicator */}
+                <div className="relative mb-3">
+                  <div
+                    className={`h-14 w-14 rounded-2xl flex items-center justify-center shadow-sm ${iconColor}`}
+                  >
+                    <Icon className="h-7 w-7" />
+                  </div>
+                  {/* Online/offline dot */}
+                  <span
+                    className={`absolute -bottom-0.5 -right-0.5 h-3.5 w-3.5 rounded-full ring-2 ring-card ${
+                      device.connected ? 'bg-emerald-500' : 'bg-muted-foreground/30'
+                    }`}
+                  />
+                </div>
+
+                {/* Device name */}
+                <span className="truncate w-full font-medium text-foreground text-sm leading-tight">
+                  {device.deviceName || t('devices.list.labels.unknownDevice')}
+                </span>
+
+                {/* Status text */}
+                <span
+                  className={`mt-1 text-xs ${
+                    device.connected
+                      ? 'text-emerald-600 dark:text-emerald-400'
+                      : 'text-muted-foreground'
+                  }`}
                 >
-                  <Icon className="h-5 w-5" />
-                </div>
-                <div className="flex min-w-0 flex-col gap-0.5">
-                  <span className="truncate font-medium text-foreground text-sm">
-                    {device.deviceName || t('devices.list.labels.unknownDevice')}
-                  </span>
-                  <span className="text-xs text-muted-foreground font-mono">
-                    {formatPeerIdForDisplay(device.peerId)}
-                  </span>
-                </div>
+                  {device.connected
+                    ? t('devices.list.status.online')
+                    : t('devices.list.status.offline')}
+                </span>
               </button>
+            )
+          })}
 
-              <Badge variant={device.connected ? 'default' : 'secondary'}>
-                {device.connected
-                  ? t('devices.list.status.online')
-                  : t('devices.list.status.offline')}
-              </Badge>
-
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button variant="ghost" size="icon-sm" onClick={e => e.stopPropagation()}>
-                    <MoreHorizontal className="h-4 w-4" />
-                  </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end">
-                  <DropdownMenuItem
-                    onClick={e => {
-                      e.stopPropagation()
-                      openSheet(device.peerId)
-                    }}
-                  >
-                    <Settings className="h-4 w-4" />
-                    {t('devices.list.actions.settings')}
-                  </DropdownMenuItem>
-                  <DropdownMenuSeparator />
-                  <DropdownMenuItem
-                    variant="destructive"
-                    onClick={e => {
-                      e.stopPropagation()
-                      handleUnpairRequest(device.peerId)
-                    }}
-                  >
-                    <Unlink className="h-4 w-4" />
-                    {t('devices.list.actions.unpair')}
-                  </DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
+          {/* Add device card (disabled, pending backend) */}
+          <div
+            title={t('devices.settings.badges.comingSoon')}
+            className="flex flex-col items-center justify-center rounded-2xl border-2 border-dashed border-border/60 p-5 pt-6 pb-4 text-center opacity-50 cursor-not-allowed"
+          >
+            <div className="mb-3 h-14 w-14 rounded-2xl flex items-center justify-center bg-muted/50">
+              <Plus className="h-7 w-7 text-muted-foreground/70" />
             </div>
-          )
-        })}
-      </SettingGroup>
+            <span className="text-sm font-medium text-muted-foreground">
+              {t('devices.list.actions.addDevice')}
+            </span>
+          </div>
+        </div>
+      </div>
 
       <DeviceSettingsSheet
         open={sheetOpen}

--- a/src/components/device/ThisDeviceCard.tsx
+++ b/src/components/device/ThisDeviceCard.tsx
@@ -2,10 +2,10 @@ import { RefreshCw } from 'lucide-react'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 import { getDeviceIcon } from './device-utils'
-import { SettingGroup } from '@/components/setting/SettingGroup'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
 import { Skeleton } from '@/components/ui/skeleton'
+import { useSetting } from '@/hooks/useSetting'
 import { formatPeerIdForDisplay } from '@/lib/utils'
 import { useAppDispatch, useAppSelector } from '@/store/hooks'
 import { clearLocalDeviceError, fetchLocalDeviceInfo } from '@/store/slices/devicesSlice'
@@ -13,9 +13,11 @@ import { clearLocalDeviceError, fetchLocalDeviceInfo } from '@/store/slices/devi
 const ThisDeviceCard: React.FC = () => {
   const { t } = useTranslation()
   const dispatch = useAppDispatch()
-  const { localDevice, localDeviceLoading, localDeviceError } = useAppSelector(
+  const { localDevice, localDeviceLoading, localDeviceError, pairedDevices } = useAppSelector(
     state => state.devices
   )
+  const { setting } = useSetting()
+  const syncActive = setting?.sync.auto_sync !== false
 
   const handleRetry = () => {
     dispatch(clearLocalDeviceError())
@@ -25,52 +27,58 @@ const ThisDeviceCard: React.FC = () => {
   // Error state
   if (localDeviceError) {
     return (
-      <SettingGroup title={t('devices.thisDevice.title')}>
-        <div className="px-4 py-3">
-          <Alert variant="destructive">
-            <AlertDescription className="flex items-center gap-3">
-              <span className="flex-1">{localDeviceError}</span>
-              <Button
-                variant="ghost"
-                size="icon-sm"
-                onClick={handleRetry}
-                title={t('devices.list.actions.retry')}
-              >
-                <RefreshCw className="h-4 w-4" />
-              </Button>
-            </AlertDescription>
-          </Alert>
-        </div>
-      </SettingGroup>
+      <div className="rounded-xl border border-border/60 bg-card p-5">
+        <Alert variant="destructive">
+          <AlertDescription className="flex items-center gap-3">
+            <span className="flex-1">{localDeviceError}</span>
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              onClick={handleRetry}
+              title={t('devices.list.actions.retry')}
+            >
+              <RefreshCw className="h-4 w-4" />
+            </Button>
+          </AlertDescription>
+        </Alert>
+      </div>
     )
   }
 
-  // First-time loading: loading === true AND no cached device
+  // First-time loading
   if (localDeviceLoading && localDevice === null) {
     return (
-      <SettingGroup title={t('devices.thisDevice.title')}>
-        <div className="flex items-center gap-4 px-4 py-3">
-          <Skeleton className="h-10 w-10 rounded-lg" />
-          <div className="flex flex-col gap-1.5">
-            <Skeleton className="h-4 w-28" />
-            <Skeleton className="h-3 w-20" />
+      <div className="rounded-xl border border-border/60 bg-card p-5">
+        <div className="flex items-center gap-4">
+          <Skeleton className="h-14 w-14 rounded-xl" />
+          <div className="flex flex-col gap-2">
+            <Skeleton className="h-5 w-36" />
+            <Skeleton className="h-3.5 w-24" />
           </div>
         </div>
-      </SettingGroup>
+        <div className="mt-4 flex gap-3">
+          <Skeleton className="h-8 w-24 rounded-md" />
+          <Skeleton className="h-8 w-24 rounded-md" />
+        </div>
+      </div>
     )
   }
 
-  // Normal state (including background refresh — always show cached data)
   if (!localDevice) return null
 
+  const onlineCount = pairedDevices.filter(d => d.connected).length
+  const pairedCount = pairedDevices.length
+
   return (
-    <SettingGroup title={t('devices.thisDevice.title')}>
-      <div className="flex items-center gap-4 px-4 py-3">
-        <div className="h-10 w-10 rounded-lg flex items-center justify-center ring-1 shadow-sm text-primary bg-primary/10 border-primary/20">
-          {React.createElement(getDeviceIcon(localDevice.deviceName), { className: 'h-5 w-5' })}
+    <div className="rounded-xl border border-border/60 bg-card p-5">
+      <div className="flex items-center gap-4">
+        <div className="h-14 w-14 shrink-0 rounded-xl flex items-center justify-center ring-1 shadow-sm text-emerald-500 bg-emerald-500/10 ring-emerald-500/20">
+          {React.createElement(getDeviceIcon(localDevice.deviceName), {
+            className: 'h-7 w-7',
+          })}
         </div>
         <div className="flex flex-col gap-0.5 min-w-0">
-          <span className="text-sm font-medium text-foreground truncate">
+          <span className="text-base font-semibold text-foreground truncate">
             {localDevice.deviceName}
           </span>
           <span className="text-xs text-muted-foreground font-mono">
@@ -78,7 +86,25 @@ const ThisDeviceCard: React.FC = () => {
           </span>
         </div>
       </div>
-    </SettingGroup>
+
+      {/* Stats row */}
+      <div className="mt-4 flex items-center gap-3 text-xs text-muted-foreground">
+        <span className="inline-flex items-center gap-1.5">
+          <span
+            className={`h-1.5 w-1.5 rounded-full ${syncActive ? 'bg-emerald-500' : 'bg-amber-500'}`}
+          />
+          {syncActive ? t('devices.thisDevice.syncActive') : t('devices.thisDevice.syncPaused')}
+        </span>
+        <span className="text-border">|</span>
+        <span>{t('devices.thisDevice.pairedCount', { count: pairedCount })}</span>
+        {pairedCount > 0 && (
+          <>
+            <span className="text-border">|</span>
+            <span>{t('devices.thisDevice.onlineCount', { count: onlineCount })}</span>
+          </>
+        )}
+      </div>
+    </div>
   )
 }
 

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -522,7 +522,13 @@
     "title": "Device Management",
     "addNew": "Add New Device",
     "thisDevice": {
-      "title": "This Device"
+      "title": "This Device",
+      "syncActive": "Sync active",
+      "syncPaused": "Sync paused",
+      "pairedCount_zero": "No paired devices",
+      "pairedCount_one": "{{count}} paired",
+      "pairedCount_other": "{{count}} paired",
+      "onlineCount": "{{count}} online"
     },
     "pairedDevices": {
       "title": "Paired Devices"

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -522,7 +522,13 @@
     "title": "设备管理",
     "addNew": "添加新设备",
     "thisDevice": {
-      "title": "本设备"
+      "title": "本设备",
+      "syncActive": "同步已开启",
+      "syncPaused": "同步已暂停",
+      "pairedCount_zero": "暂无配对",
+      "pairedCount_one": "{{count}} 台已配对",
+      "pairedCount_other": "{{count}} 台已配对",
+      "onlineCount": "{{count}} 台在线"
     },
     "pairedDevices": {
       "title": "已配对设备"

--- a/src/pages/DevicesPage.tsx
+++ b/src/pages/DevicesPage.tsx
@@ -2,20 +2,21 @@ import React, { useEffect } from 'react'
 import { PairedDevicesPanel, ThisDeviceCard } from '@/components'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { useAppDispatch } from '@/store/hooks'
-import { fetchLocalDeviceInfo } from '@/store/slices/devicesSlice'
+import { fetchLocalDeviceInfo, fetchPairedDevices } from '@/store/slices/devicesSlice'
 
 const DevicesPage: React.FC = () => {
   const dispatch = useAppDispatch()
 
   useEffect(() => {
     dispatch(fetchLocalDeviceInfo())
+    dispatch(fetchPairedDevices())
   }, [dispatch])
 
   return (
     <div className="flex flex-col h-full relative">
       <div className="flex-1 overflow-hidden relative">
         <ScrollArea className="h-full">
-          <div className="px-4 pt-6 pb-8 space-y-4">
+          <div className="px-4 pt-6 pb-8 space-y-6">
             <ThisDeviceCard />
             <PairedDevicesPanel />
           </div>

--- a/src/pages/__tests__/DevicesPage.test.tsx
+++ b/src/pages/__tests__/DevicesPage.test.tsx
@@ -10,6 +10,7 @@ vi.mock('@/store/hooks', () => ({
 
 vi.mock('@/store/slices/devicesSlice', () => ({
   fetchLocalDeviceInfo: vi.fn(() => ({ type: 'devices/fetchLocalDeviceInfo' })),
+  fetchPairedDevices: vi.fn(() => ({ type: 'devices/fetchPairedDevices' })),
 }))
 
 vi.mock('@/components', () => ({
@@ -25,10 +26,11 @@ describe('DevicesPage', () => {
     expect(screen.getByTestId('paired-devices-panel')).toBeInTheDocument()
   })
 
-  it('dispatches fetchLocalDeviceInfo on mount', () => {
+  it('dispatches fetchLocalDeviceInfo and fetchPairedDevices on mount', () => {
     render(<DevicesPage />)
 
     expect(dispatchMock).toHaveBeenCalledWith({ type: 'devices/fetchLocalDeviceInfo' })
+    expect(dispatchMock).toHaveBeenCalledWith({ type: 'devices/fetchPairedDevices' })
   })
 
   it('does not render legacy sections', () => {


### PR DESCRIPTION
## Summary

- Redesign Devices page from list-based layout to Apple-style card grid
- **ThisDeviceCard**: hero card with sync status indicator, paired/online device counts
- **PairedDevicesPanel**: 2-column grid with rounded-2xl cards, shadow elevation, status dot overlay on device icon
- Empty state uses dashed-border card for visual consistency
- Add disabled "Add Device" placeholder card with "Coming Soon" tooltip
- Remove DropdownMenu from device cards (actions consolidated in DeviceSettingsSheet)
- Add i18n keys for sync status and device counts (zh-CN, en-US)

## Test plan

- [x] `bun run build` passes
- [x] `vitest run` — all device-related tests pass
- [x] Visual check: devices page with 0 paired devices (empty state)
- [x] Visual check: devices page with 1+ paired devices (card grid)
- [x] Visual check: dark mode and light mode
- [x] Hover "Add Device" card shows "Coming Soon" tooltip and not-allowed cursor
- [x] Click device card opens DeviceSettingsSheet

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Device panels redesigned with a card-based grid layout for improved visual organization and navigation.
- Sync status and paired/online device count metrics now displayed on device cards for better visibility.
- Enhanced error and empty states with improved visual styling and user feedback.
- Added "Coming soon" placeholder for future Add Device functionality.
- Extended localization support across multiple languages for device information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->