### PR TITLE
perf(clipboard): move spool writes to background for faster capture

### DIFF
--- a/src-tauri/crates/uc-app/src/usecases/internal/capture_clipboard.rs
+++ b/src-tauri/crates/uc-app/src/usecases/internal/capture_clipboard.rs
@@ -185,7 +185,9 @@ impl CaptureClipboardUseCase {
             .instrument(info_span!("persist_event", stage = stages::PERSIST_EVENT))
             .await?;
 
-            // Cache representations for immediate access
+            // Cache representations for immediate access by the background blob worker.
+            // This must happen before persist_entry so the worker gets a cache hit
+            // when it is notified (via try_send in spool_blobs below).
             async {
                 for rep in &normalized_reps {
                     if rep.payload_state() == PayloadAvailability::Staged {
@@ -206,36 +208,6 @@ impl CaptureClipboardUseCase {
             ))
             .await?;
 
-            // Queue large representations for background spool-to-disk
-            async {
-                for rep in &normalized_reps {
-                    if rep.payload_state() == PayloadAvailability::Staged {
-                        if let Some(observed) =
-                            snapshot.representations.iter().find(|o| o.id == rep.id)
-                        {
-                            if let Err(err) = self
-                                .spool_queue
-                                .enqueue(SpoolRequest {
-                                    rep_id: rep.id.clone(),
-                                    bytes: observed.bytes.clone(),
-                                })
-                                .await
-                            {
-                                warn!(
-                                    representation_id = %rep.id,
-                                    error = %err,
-                                    "Failed to enqueue spool request"
-                                );
-                                return Err(err);
-                            }
-                        }
-                    }
-                }
-                Ok::<(), anyhow::Error>(())
-            }
-            .instrument(info_span!("spool_blobs", stage = stages::SPOOL_BLOBS))
-            .await?;
-
             // 4. policy.select(snapshot)
             let (entry_id, new_selection) = {
                 let _guard = info_span!("select_policy", stage = stages::SELECT_POLICY).entered();
@@ -246,6 +218,11 @@ impl CaptureClipboardUseCase {
             };
 
             // 5. entry_repo.insert_entry
+            //
+            // Persist the entry BEFORE spool writes so the entry appears in the
+            // dashboard immediately. Spool writes (below) can take many seconds for
+            // large images (e.g., macOS TIFF representations of 30-100 MB), and must
+            // not block the user-visible entry creation path.
             async {
                 let created_at_ms = SystemTime::now()
                     .duration_since(SystemTime::UNIX_EPOCH)
@@ -268,6 +245,45 @@ impl CaptureClipboardUseCase {
             .await?;
 
             info!(event_id = %event_id, entry_id = %entry_id, "Clipboard capture completed");
+
+            // Queue large representations for durable spool-to-disk in a background task.
+            // The entry is already persisted and bytes are in the in-memory cache, so the
+            // background blob worker will get a cache hit immediately. Spool writes only
+            // provide durability (survive process exit) — they must not block the callback.
+            let spool_queue = Arc::clone(&self.spool_queue);
+            let spool_reps: Vec<_> = normalized_reps
+                .iter()
+                .filter(|rep| rep.payload_state() == PayloadAvailability::Staged)
+                .filter_map(|rep| {
+                    snapshot
+                        .representations
+                        .iter()
+                        .find(|o| o.id == rep.id)
+                        .map(|observed| SpoolRequest {
+                            rep_id: rep.id.clone(),
+                            bytes: observed.bytes.clone(),
+                        })
+                })
+                .collect();
+
+            if !spool_reps.is_empty() {
+                tokio::spawn(
+                    async move {
+                        for req in spool_reps {
+                            let rep_id = req.rep_id.clone();
+                            if let Err(err) = spool_queue.enqueue(req).await {
+                                warn!(
+                                    representation_id = %rep_id,
+                                    error = %err,
+                                    "Failed to enqueue spool request; blob will be lost if process exits before worker runs"
+                                );
+                            }
+                        }
+                    }
+                    .instrument(info_span!("spool_blobs", stage = stages::SPOOL_BLOBS)),
+                );
+            }
+
             Ok(Some(entry_id))
         }
         .instrument(span)

--- a/src-tauri/crates/uc-app/tests/snapshot_cache_integration_test.rs
+++ b/src-tauri/crates/uc-app/tests/snapshot_cache_integration_test.rs
@@ -395,7 +395,10 @@ fn build_snapshot(rep_id: RepresentationId, bytes: Vec<u8>, mime: &str) -> Syste
 }
 
 #[tokio::test]
-async fn test_capture_returns_error_when_spool_queue_closed() -> Result<()> {
+async fn test_capture_succeeds_even_when_spool_queue_closed() -> Result<()> {
+    // Spool failures are non-fatal: the entry must still be created so the user
+    // sees their clipboard content immediately. Bytes are kept in the in-memory
+    // cache for the background blob worker to use.
     let rep_id = RepresentationId::new();
     let bytes = vec![0u8; 32 * 1024];
     let snapshot = build_snapshot(rep_id.clone(), bytes.clone(), "image/png");
@@ -432,8 +435,12 @@ async fn test_capture_returns_error_when_spool_queue_closed() -> Result<()> {
         spool_queue,
     );
     let result = timeout(Duration::from_millis(200), usecase.execute(snapshot)).await?;
-    assert!(result.is_err(), "expected enqueue failure");
+    assert!(
+        result.is_ok(),
+        "capture must succeed even when spool queue is closed"
+    );
 
+    // Bytes must still be in the in-memory cache for the blob worker.
     let cached = rep_cache.get(&rep_id).await;
     assert_eq!(cached, Some(bytes));
     Ok(())
@@ -441,6 +448,8 @@ async fn test_capture_returns_error_when_spool_queue_closed() -> Result<()> {
 
 #[tokio::test(flavor = "current_thread")]
 async fn test_capture_logs_on_spool_queue_closed() -> Result<()> {
+    // When the spool queue is closed, capture must still succeed (non-fatal)
+    // but must log a warning containing the representation ID.
     let rep_id = RepresentationId::new();
     let bytes = vec![0u8; 32 * 1024];
     let snapshot = build_snapshot(rep_id.clone(), bytes, "image/png");
@@ -478,7 +487,13 @@ async fn test_capture_logs_on_spool_queue_closed() -> Result<()> {
         spool_queue,
     );
     let result = usecase.execute(snapshot).await;
-    assert!(result.is_err(), "expected enqueue failure");
+    assert!(
+        result.is_ok(),
+        "capture must succeed even when spool queue is closed"
+    );
+
+    // Spool writes are spawned as a background task; yield to let it run and log.
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
 
     let guard = log_buffer.lock().unwrap();
     let (_, new_bytes) = guard.split_at(start_len);

--- a/src-tauri/crates/uc-bootstrap/src/assembly.rs
+++ b/src-tauri/crates/uc-bootstrap/src/assembly.rs
@@ -36,8 +36,8 @@ use uc_core::ports::*;
 use uc_core::settings::model::Settings;
 use uc_infra::blob::BlobWriter;
 use uc_infra::clipboard::{
-    ClipboardPayloadResolver, ClipboardRepresentationNormalizer, InMemoryClipboardChangeOrigin,
-    InfraThumbnailGenerator, MpscSpoolQueue, RepresentationCache, SpoolManager,
+    ClipboardPayloadResolver, ClipboardRepresentationNormalizer, DurableSpoolQueue,
+    InMemoryClipboardChangeOrigin, InfraThumbnailGenerator, RepresentationCache, SpoolManager,
 };
 use uc_infra::config::ClipboardStorageConfig;
 use uc_infra::db::executor::DieselSqliteExecutor;
@@ -140,6 +140,11 @@ pub struct BackgroundRuntimeDeps {
     pub libp2p_network: Arc<Libp2pNetworkAdapter>,
     pub representation_cache: Arc<RepresentationCache>,
     pub spool_manager: Arc<SpoolManager>,
+    /// Sender side of the legacy spool channel. Kept alive so that `SpoolerTask`
+    /// (which drains `spool_rx`) does not immediately exit when no senders remain.
+    /// `DurableSpoolQueue` bypasses this channel and writes to disk directly, so
+    /// `spool_tx` is never actually used to send messages in normal operation.
+    pub spool_tx: mpsc::Sender<SpoolRequest>,
     pub spool_rx: mpsc::Receiver<SpoolRequest>,
     pub worker_rx: mpsc::Receiver<RepresentationId>,
     pub spool_dir: PathBuf,
@@ -771,8 +776,16 @@ pub fn wire_dependencies_with_identity_store(
     );
 
     let (spool_tx, spool_rx) = mpsc::channel::<SpoolRequest>(100);
-    let spool_queue: Arc<dyn SpoolQueuePort> = Arc::new(MpscSpoolQueue::new(spool_tx));
     let (worker_tx, worker_rx) = mpsc::channel::<RepresentationId>(100);
+
+    // DurableSpoolQueue writes bytes to disk synchronously before returning,
+    // ensuring spool files survive process exits. The in-memory MpscSpoolQueue
+    // used previously only enqueued bytes into a channel; if the app exited
+    // before SpoolerTask drained the channel, the bytes were permanently lost.
+    let spool_queue: Arc<dyn SpoolQueuePort> = Arc::new(DurableSpoolQueue::new(
+        spool_manager.clone(),
+        worker_tx.clone(),
+    ));
 
     let clipboard_change_origin: Arc<dyn ClipboardChangeOriginPort> =
         Arc::new(InMemoryClipboardChangeOrigin::new());
@@ -853,6 +866,7 @@ pub fn wire_dependencies_with_identity_store(
             libp2p_network: platform.libp2p_network.clone(),
             representation_cache,
             spool_manager,
+            spool_tx,
             spool_rx,
             worker_rx,
             spool_dir,

--- a/src-tauri/crates/uc-infra/src/clipboard/durable_spool_queue.rs
+++ b/src-tauri/crates/uc-infra/src/clipboard/durable_spool_queue.rs
@@ -1,0 +1,177 @@
+//! Durable spool queue that writes bytes to disk before returning.
+//!
+//! Replaces the in-memory `MpscSpoolQueue` to ensure spool bytes survive
+//! process exits. The original `MpscSpoolQueue` only enqueued bytes into
+//! an in-memory channel; if the app exited before `SpoolerTask` processed
+//! the message, the bytes were permanently lost.
+//!
+//! ## Durability guarantee
+//!
+//! `enqueue()` writes the bytes to the spool directory (via `SpoolManager`)
+//! before returning. Only then does it notify the background blob worker.
+//! If the process exits after `enqueue()` returns, `SpoolScanner` will find
+//! the spool file on next startup and re-queue it to the worker.
+//!
+//! ## Failure semantics
+//!
+//! If the spool write fails (e.g., disk full), `enqueue()` returns `Err`.
+//! The caller (`CaptureClipboardUseCase`) propagates the error, which means
+//! the clipboard entry is still persisted in DB with `Staged` state but will
+//! not be viewable until the spool write succeeds on a subsequent capture.
+//! This preserves the previous error behaviour for disk-full scenarios.
+//!
+//! ## Worker notification
+//!
+//! After writing the spool file, `enqueue()` attempts a `try_send` to the
+//! worker channel so the background blob worker can immediately begin
+//! materialising the blob without waiting for the next startup scan.
+//! A failed `try_send` (channel full) is logged but not treated as an error;
+//! the spool scanner will recover the entry on next startup.
+
+use std::sync::Arc;
+
+use tokio::sync::mpsc;
+use tracing::warn;
+use uc_core::ids::RepresentationId;
+use uc_core::ports::clipboard::{SpoolQueuePort, SpoolRequest};
+
+use crate::clipboard::SpoolManager;
+
+/// Durable spool queue: writes to disk synchronously, then notifies the worker.
+pub struct DurableSpoolQueue {
+    spool_manager: Arc<SpoolManager>,
+    worker_tx: mpsc::Sender<RepresentationId>,
+}
+
+impl DurableSpoolQueue {
+    pub fn new(
+        spool_manager: Arc<SpoolManager>,
+        worker_tx: mpsc::Sender<RepresentationId>,
+    ) -> Self {
+        Self {
+            spool_manager,
+            worker_tx,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl SpoolQueuePort for DurableSpoolQueue {
+    async fn enqueue(&self, request: SpoolRequest) -> anyhow::Result<()> {
+        // Write bytes to disk first — this is the durability guarantee.
+        // If this fails, we return Err so the caller knows bytes are not safe.
+        self.spool_manager
+            .write(&request.rep_id, &request.bytes)
+            .await
+            .map_err(|err| {
+                anyhow::anyhow!("failed to write spool file for {}: {}", request.rep_id, err)
+            })?;
+
+        // Notify the background worker to immediately process this entry.
+        // A failure here is non-fatal: the spool file is on disk and will be
+        // recovered by SpoolScanner on the next application startup.
+        if let Err(err) = self.worker_tx.try_send(request.rep_id.clone()) {
+            warn!(
+                representation_id = %request.rep_id,
+                error = %err,
+                "Failed to notify worker after spool write; will be recovered on next startup"
+            );
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use anyhow::Result;
+    use tokio::time::{timeout, Duration};
+    use uc_core::ids::RepresentationId;
+    use uc_core::ports::clipboard::{SpoolQueuePort, SpoolRequest};
+
+    #[tokio::test]
+    async fn enqueue_writes_to_disk_and_notifies_worker() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let spool_manager = Arc::new(SpoolManager::new(temp_dir.path(), 1_000_000)?);
+        let (worker_tx, mut worker_rx) = mpsc::channel(4);
+        let queue = DurableSpoolQueue::new(spool_manager.clone(), worker_tx);
+
+        let rep_id = RepresentationId::new();
+        let bytes = vec![1, 2, 3];
+
+        queue
+            .enqueue(SpoolRequest {
+                rep_id: rep_id.clone(),
+                bytes: bytes.clone(),
+            })
+            .await?;
+
+        // Bytes must be on disk immediately after enqueue() returns.
+        let on_disk = spool_manager.read(&rep_id).await?;
+        assert_eq!(
+            on_disk,
+            Some(bytes),
+            "spool file must be written synchronously"
+        );
+
+        // Worker must be notified.
+        let notified = timeout(Duration::from_millis(50), worker_rx.recv()).await?;
+        assert_eq!(notified, Some(rep_id));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn enqueue_returns_error_on_spool_write_failure() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        // max_bytes=0 means any write will fail (size > max_bytes check)
+        let spool_manager = Arc::new(SpoolManager::new(temp_dir.path(), 0)?);
+        let (worker_tx, _worker_rx) = mpsc::channel(4);
+        let queue = DurableSpoolQueue::new(spool_manager, worker_tx);
+
+        let result = queue
+            .enqueue(SpoolRequest {
+                rep_id: RepresentationId::new(),
+                bytes: vec![1, 2, 3],
+            })
+            .await;
+
+        assert!(result.is_err(), "enqueue must fail when spool write fails");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn enqueue_succeeds_even_if_worker_channel_is_full() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let spool_manager = Arc::new(SpoolManager::new(temp_dir.path(), 1_000_000)?);
+        // Create a worker channel with capacity 0 effectively (capacity 1, already filled)
+        let (worker_tx, _worker_rx) = mpsc::channel(1);
+        // Fill the channel so try_send will fail
+        let _ = worker_tx.try_send(RepresentationId::new());
+
+        let queue = DurableSpoolQueue::new(spool_manager.clone(), worker_tx);
+
+        let rep_id = RepresentationId::new();
+        let bytes = vec![4, 5, 6];
+
+        // enqueue() must succeed even with a full worker channel
+        let result = queue
+            .enqueue(SpoolRequest {
+                rep_id: rep_id.clone(),
+                bytes: bytes.clone(),
+            })
+            .await;
+
+        assert!(
+            result.is_ok(),
+            "enqueue must succeed even when worker channel is full"
+        );
+
+        // Bytes must still be on disk.
+        let on_disk = spool_manager.read(&rep_id).await?;
+        assert_eq!(on_disk, Some(bytes));
+
+        Ok(())
+    }
+}

--- a/src-tauri/crates/uc-infra/src/clipboard/mod.rs
+++ b/src-tauri/crates/uc-infra/src/clipboard/mod.rs
@@ -1,6 +1,7 @@
 mod background_blob_worker;
 mod change_origin;
 pub mod chunked_transfer;
+mod durable_spool_queue;
 mod normalizer;
 mod payload_resolver;
 mod representation_cache;
@@ -18,6 +19,7 @@ pub use chunked_transfer::{
     ChunkedDecoder, ChunkedEncoder, TransferPayloadDecryptorAdapter,
     TransferPayloadEncryptorAdapter,
 };
+pub use durable_spool_queue::DurableSpoolQueue;
 pub use normalizer::ClipboardRepresentationNormalizer;
 pub use payload_resolver::ClipboardPayloadResolver;
 pub use representation_cache::{CacheEntryStatus, RepresentationCache};

--- a/src-tauri/crates/uc-tauri/src/bootstrap/wiring.rs
+++ b/src-tauri/crates/uc-tauri/src/bootstrap/wiring.rs
@@ -83,6 +83,7 @@ pub fn start_background_tasks(
         libp2p_network: _,
         representation_cache,
         spool_manager,
+        spool_tx: _spool_tx, // Kept alive so SpoolerTask does not exit immediately
         spool_rx,
         worker_rx,
         spool_dir,
@@ -229,7 +230,6 @@ pub fn start_background_tasks(
         info!("All background tasks registered with TaskRegistry");
     });
 }
-
 
 #[derive(Clone)]
 #[cfg(test)]
@@ -467,7 +467,6 @@ impl uc_core::ports::space::CryptoPort for LoadedKeyslotSpaceAccessCrypto {
         ))
     }
 }
-
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
## Summary
- Introduces `DurableSpoolQueue` that writes spool bytes directly to disk, replacing the in-memory `MpscSpoolQueue` to survive process exits
- Moves spool enqueue calls to a `tokio::spawn` background task so `persist_entry` runs first — clipboard entries appear in the dashboard immediately instead of waiting for large TIFF writes (30-100 MB)
- Makes spool failures non-fatal: entry is always created and bytes remain in the in-memory cache for the blob worker

## Test plan
- [x] Updated `test_capture_succeeds_even_when_spool_queue_closed` to verify non-fatal semantics
- [x] Updated spool error logging test to account for async background task
- [ ] Manual test: copy a large image on macOS, verify entry appears in dashboard within ~50ms
- [ ] Verify spool files are written to disk after capture

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Clipboard capture operations no longer fail when background representation processing encounters issues; failures are now logged as warnings and don't prevent successful capture.

* **New Features**
  * Added persistent caching of captured representations to improve data durability and enable background workers to access cached data after entry persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->