### PR TITLE
fix: add Apple notarization to CLI build workflow

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -160,8 +160,8 @@ jobs:
             --team-id "$APPLE_TEAM_ID" \
             --wait
 
-          # Staple the notarization ticket to the binary
-          xcrun stapler staple "$BIN_PATH"
+          # Note: stapler staple only works on .app/.dmg/.pkg bundles, not bare binaries.
+          # For standalone CLI binaries, Gatekeeper checks the notarization ticket online.
 
       - name: package CLI binary
         id: package


### PR DESCRIPTION
## Summary

- Add `xcrun notarytool` submission step to `build-cli.yml` for macOS targets, reusing existing Apple credentials (`APPLE_ID`, `APPLE_PASSWORD`, `APPLE_TEAM_ID`)
- Resolves macOS Gatekeeper warning: "Apple无法验证uniclipboard-cli是否包含可能危害Mac安全或泄漏隐私的恶意软件"
- Note: `stapler staple` is not used because it only supports `.app/.dmg/.pkg` bundles — Gatekeeper checks the notarization ticket online for standalone binaries

## Test plan

- [x] Trigger `Build CLI` workflow for `macos-aarch64` and verify notarization step passes
- [x] Download the built CLI binary on macOS and confirm no Gatekeeper warning appears

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added macOS binary notarization to the build process, ensuring the CLI binary is trusted and can run on macOS systems without security warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->