### PR TITLE
fix: remove legacy sync max file size setting

### DIFF
--- a/src-tauri/crates/uc-app/src/usecases/clipboard/sync_outbound.rs
+++ b/src-tauri/crates/uc-app/src/usecases/clipboard/sync_outbound.rs
@@ -1497,7 +1497,6 @@ mod tests {
                     auto_sync: false,
                     sync_frequency: SyncFrequency::Realtime,
                     content_types: ContentTypes::default(),
-                    max_file_size_mb: 100,
                 }),
             ),
         );
@@ -1534,7 +1533,6 @@ mod tests {
                         code_snippet: true,
                         rich_text: true,
                     },
-                    max_file_size_mb: 100,
                 }),
             ),
         );
@@ -1571,7 +1569,6 @@ mod tests {
                         code_snippet: false,
                         rich_text: false,
                     },
-                    max_file_size_mb: 100,
                 }),
             ),
         );
@@ -1608,7 +1605,6 @@ mod tests {
                         code_snippet: true,
                         rich_text: true,
                     },
-                    max_file_size_mb: 100,
                 }),
             ),
         );

--- a/src-tauri/crates/uc-app/src/usecases/file_sync/sync_outbound.rs
+++ b/src-tauri/crates/uc-app/src/usecases/file_sync/sync_outbound.rs
@@ -401,7 +401,6 @@ mod tests {
                 auto_sync: false,
                 sync_frequency: SyncFrequency::Realtime,
                 content_types: ContentTypes::default(),
-                max_file_size_mb: 10,
             }),
         };
 

--- a/src-tauri/crates/uc-app/src/usecases/file_sync/sync_policy.rs
+++ b/src-tauri/crates/uc-app/src/usecases/file_sync/sync_policy.rs
@@ -212,7 +212,6 @@ mod tests {
                 code_snippet: true,
                 rich_text: true,
             },
-            max_file_size_mb: 10,
         };
         let repo: Arc<dyn PairedDeviceRepositoryPort> = Arc::new(MockPairedDeviceRepo {
             devices: vec![make_paired_device("peer-1", Some(device_sync))],
@@ -232,7 +231,6 @@ mod tests {
             auto_sync: false, // auto_sync off for this device
             sync_frequency: SyncFrequency::Realtime,
             content_types: ContentTypes::default(),
-            max_file_size_mb: 10,
         };
         let repo: Arc<dyn PairedDeviceRepositoryPort> = Arc::new(MockPairedDeviceRepo {
             devices: vec![make_paired_device("peer-1", Some(device_sync))],

--- a/src-tauri/crates/uc-app/src/usecases/update_settings.rs
+++ b/src-tauri/crates/uc-app/src/usecases/update_settings.rs
@@ -215,7 +215,6 @@ impl GeneralSettingsDiff {
 struct SyncSettingsDiff {
     auto_sync: Option<(bool, bool)>,
     sync_frequency: Option<(String, String)>,
-    max_file_size_mb: Option<(u32, u32)>,
     content_types: Option<(ContentTypes, ContentTypes)>,
 }
 
@@ -226,8 +225,6 @@ impl SyncSettingsDiff {
             format!("{:?}", old.sync_frequency),
             format!("{:?}", new.sync_frequency),
         ));
-        let max_file_size_mb = (old.max_file_size_mb != new.max_file_size_mb)
-            .then_some((old.max_file_size_mb, new.max_file_size_mb));
         let content_types_changed = old.content_types.text != new.content_types.text
             || old.content_types.image != new.content_types.image
             || old.content_types.link != new.content_types.link
@@ -237,17 +234,12 @@ impl SyncSettingsDiff {
         let content_types =
             content_types_changed.then_some((old.content_types.clone(), new.content_types.clone()));
 
-        if auto_sync.is_none()
-            && sync_frequency.is_none()
-            && max_file_size_mb.is_none()
-            && content_types.is_none()
-        {
+        if auto_sync.is_none() && sync_frequency.is_none() && content_types.is_none() {
             None
         } else {
             Some(Self {
                 auto_sync,
                 sync_frequency,
-                max_file_size_mb,
                 content_types,
             })
         }
@@ -261,9 +253,6 @@ impl SyncSettingsDiff {
         }
         if let Some((old, new)) = &self.sync_frequency {
             parts.push(format!("{}.sync_frequency: {} → {}", prefix, old, new));
-        }
-        if let Some((old, new)) = &self.max_file_size_mb {
-            parts.push(format!("{}.max_file_size_mb: {} → {}", prefix, old, new));
         }
         if let Some((old, new)) = &self.content_types {
             parts.push(format!("{}.content_types: {:?} → {:?}", prefix, old, new));

--- a/src-tauri/crates/uc-core/src/network/paired_device.rs
+++ b/src-tauri/crates/uc-core/src/network/paired_device.rs
@@ -81,14 +81,12 @@ mod tests {
             auto_sync: true,
             sync_frequency: SyncFrequency::Realtime,
             content_types: ContentTypes::default(),
-            max_file_size_mb: 10,
         };
 
         let device_settings = SyncSettings {
             auto_sync: false,
             sync_frequency: SyncFrequency::Interval,
             content_types: ContentTypes::default(),
-            max_file_size_mb: 5,
         };
 
         let device = PairedDevice {
@@ -103,7 +101,7 @@ mod tests {
 
         let resolved = resolve_sync_settings(&device, &global);
         assert!(!resolved.auto_sync);
-        assert_eq!(resolved.max_file_size_mb, 5);
+        assert_eq!(resolved.sync_frequency, SyncFrequency::Interval);
     }
 
     #[test]
@@ -114,7 +112,6 @@ mod tests {
             auto_sync: true,
             sync_frequency: SyncFrequency::Realtime,
             content_types: ContentTypes::default(),
-            max_file_size_mb: 10,
         };
 
         let device = PairedDevice {
@@ -129,6 +126,6 @@ mod tests {
 
         let resolved = resolve_sync_settings(&device, &global);
         assert!(resolved.auto_sync);
-        assert_eq!(resolved.max_file_size_mb, 10);
+        assert_eq!(resolved.sync_frequency, SyncFrequency::Realtime);
     }
 }

--- a/src-tauri/crates/uc-core/src/settings/defaults.rs
+++ b/src-tauri/crates/uc-core/src/settings/defaults.rs
@@ -95,8 +95,8 @@ impl Default for ContentTypes {
 impl Default for SyncSettings {
     /// Creates a `SyncSettings` populated with sensible defaults.
     ///
-    /// The defaults enable automatic syncing, use realtime sync frequency, include the
-    /// default content types, and limit individual files to 100 MB.
+    /// The defaults enable automatic syncing, use realtime sync frequency, and include the
+    /// default content types.
     ///
     /// # Examples
     ///
@@ -106,14 +106,12 @@ impl Default for SyncSettings {
     /// let s = SyncSettings::default();
     /// assert!(s.auto_sync);
     /// assert_eq!(s.sync_frequency, SyncFrequency::Realtime);
-    /// assert_eq!(s.max_file_size_mb, 100);
     /// ```
     fn default() -> Self {
         Self {
             auto_sync: true,
             sync_frequency: SyncFrequency::Realtime,
             content_types: ContentTypes::default(),
-            max_file_size_mb: 100,
         }
     }
 }

--- a/src-tauri/crates/uc-core/src/settings/model.rs
+++ b/src-tauri/crates/uc-core/src/settings/model.rs
@@ -66,8 +66,6 @@ pub struct SyncSettings {
 
     #[serde(default)]
     pub content_types: ContentTypes,
-
-    pub max_file_size_mb: u32,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -362,6 +360,28 @@ mod tests {
         assert_eq!(fs.file_cache_quota_per_device, 500 * 1024 * 1024);
         assert_eq!(fs.file_retention_hours, 24);
         assert!(fs.file_auto_cleanup);
+    }
+
+    #[test]
+    fn test_sync_settings_ignores_legacy_max_file_size_mb_field() {
+        let value = serde_json::json!({
+            "auto_sync": true,
+            "sync_frequency": "realtime",
+            "content_types": {
+                "text": true,
+                "image": true,
+                "link": true,
+                "file": true,
+                "code_snippet": true,
+                "rich_text": true
+            },
+            "max_file_size_mb": 42
+        });
+
+        let settings: super::SyncSettings =
+            serde_json::from_value(value).expect("deserialize sync settings");
+        assert!(settings.auto_sync);
+        assert_eq!(settings.sync_frequency, SyncFrequency::Realtime);
     }
 
     #[test]

--- a/src-tauri/crates/uc-daemon/src/api/device.rs
+++ b/src-tauri/crates/uc-daemon/src/api/device.rs
@@ -174,10 +174,6 @@ fn merge_device_sync_settings_patch(
         existing.sync_frequency = sync_frequency.into();
     }
 
-    if let Some(max_file_size_mb) = patch.max_file_size_mb {
-        existing.max_file_size_mb = max_file_size_mb;
-    }
-
     if let Some(content_types) = patch.content_types {
         if let Some(ct) = content_types.text {
             existing.content_types.text = ct;

--- a/src-tauri/crates/uc-daemon/src/api/dto/device.rs
+++ b/src-tauri/crates/uc-daemon/src/api/dto/device.rs
@@ -42,7 +42,6 @@ pub struct DeviceSyncSettingsDto {
     pub auto_sync: bool,
     pub sync_frequency: SyncFrequencyDto,
     pub content_types: ContentTypesDto,
-    pub max_file_size_mb: u32,
 }
 
 /// Content type toggles for sync filtering.
@@ -75,7 +74,6 @@ pub struct DeviceSyncSettingsPatchDto {
     pub auto_sync: Option<bool>,
     pub sync_frequency: Option<SyncFrequencyDto>,
     pub content_types: Option<ContentTypesPatchDto>,
-    pub max_file_size_mb: Option<u32>,
 }
 
 /// Partial content types for PATCH.
@@ -116,7 +114,6 @@ impl From<CoreSyncSettings> for DeviceSyncSettingsDto {
             auto_sync: value.auto_sync,
             sync_frequency: value.sync_frequency.into(),
             content_types: value.content_types.into(),
-            max_file_size_mb: value.max_file_size_mb,
         }
     }
 }

--- a/src-tauri/crates/uc-daemon/src/api/dto/settings.rs
+++ b/src-tauri/crates/uc-daemon/src/api/dto/settings.rs
@@ -83,7 +83,6 @@ pub struct SyncSettingsDto {
     pub auto_sync: bool,
     pub sync_frequency: SyncFrequencyDto,
     pub content_types: ContentTypesDto,
-    pub max_file_size_mb: u32,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
@@ -241,7 +240,6 @@ pub struct SyncSettingsPatchDto {
     pub auto_sync: Option<bool>,
     pub sync_frequency: Option<SyncFrequencyDto>,
     pub content_types: Option<ContentTypesPatchDto>,
-    pub max_file_size_mb: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
@@ -389,7 +387,6 @@ impl From<core::SyncSettings> for SyncSettingsDto {
             auto_sync: value.auto_sync,
             sync_frequency: value.sync_frequency.into(),
             content_types: value.content_types.into(),
-            max_file_size_mb: value.max_file_size_mb,
         }
     }
 }

--- a/src-tauri/crates/uc-daemon/src/api/settings.rs
+++ b/src-tauri/crates/uc-daemon/src/api/settings.rs
@@ -140,9 +140,6 @@ fn merge_settings_patch(
         if let Some(v) = sync.sync_frequency {
             existing.sync.sync_frequency = v.into();
         }
-        if let Some(v) = sync.max_file_size_mb {
-            existing.sync.max_file_size_mb = v;
-        }
         if let Some(content_types) = sync.content_types {
             if let Some(v) = content_types.text {
                 existing.sync.content_types.text = v;

--- a/src/__tests__/api/daemon/_test-helpers.ts
+++ b/src/__tests__/api/daemon/_test-helpers.ts
@@ -171,7 +171,6 @@ export function makeSettingsDto(overrides: Partial<Settings> = {}): Settings {
         codeSnippet: true,
         richText: true,
       },
-      maxFileSizeMb: 50,
     },
     retentionPolicy: {
       enabled: false,

--- a/src/__tests__/api/daemon/settings.test.ts
+++ b/src/__tests__/api/daemon/settings.test.ts
@@ -88,7 +88,6 @@ describe('Settings API', () => {
             codeSnippet: true,
             richText: false,
           },
-          maxFileSizeMb: 25,
         },
       })
       mockDaemonClient.request.mockResolvedValueOnce({ data: settings, ts: Date.now() })

--- a/src/api/daemon/device.ts
+++ b/src/api/daemon/device.ts
@@ -41,7 +41,6 @@ export interface DeviceSyncSettings {
   autoSync: boolean
   syncFrequency: SyncFrequency
   contentTypes: ContentTypes
-  maxFileSizeMb: number
 }
 
 /**
@@ -52,7 +51,6 @@ export interface DeviceSyncSettingsPatch {
   autoSync?: boolean
   syncFrequency?: SyncFrequency
   contentTypes?: ContentTypesPatch
-  maxFileSizeMb?: number
 }
 
 /** Partial content types for PATCH. */

--- a/src/api/daemon/pairing.ts
+++ b/src/api/daemon/pairing.ts
@@ -120,7 +120,6 @@ export interface SyncSettings {
   autoSync: boolean
   syncFrequency: 'realtime' | 'interval'
   contentTypes: ContentTypes
-  maxFileSizeMb: number
 }
 
 export { classifyPairingError } from '@/api/daemon/events'

--- a/src/api/daemon/settings.ts
+++ b/src/api/daemon/settings.ts
@@ -58,7 +58,6 @@ export interface SyncSettings {
   autoSync: boolean
   syncFrequency: SyncFrequency
   contentTypes: ContentTypes
-  maxFileSizeMb: number
 }
 
 /** Security / encryption settings. / 安全/加密设置。 */
@@ -234,12 +233,11 @@ function toSettingsPatchRequest(settings: Partial<Settings>): SettingsPatchReque
   }
 
   if (settings.sync) {
-    const { autoSync, syncFrequency, contentTypes, maxFileSizeMb } = settings.sync
+    const { autoSync, syncFrequency, contentTypes } = settings.sync
     patch.sync = {
       autoSync,
       syncFrequency,
       contentTypes,
-      maxFileSizeMb,
     }
   }
 

--- a/src/components/layout/__tests__/SidebarUpdateIndicator.test.tsx
+++ b/src/components/layout/__tests__/SidebarUpdateIndicator.test.tsx
@@ -28,7 +28,6 @@ const baseSetting: Settings = {
       codeSnippet: true,
       richText: true,
     },
-    maxFileSizeMb: 10,
   },
   retentionPolicy: {
     enabled: false,

--- a/src/components/setting/SyncSection.tsx
+++ b/src/components/setting/SyncSection.tsx
@@ -32,9 +32,6 @@ const SyncSection: React.FC = () => {
     setting?.sync.syncFrequency ?? 'realtime'
   )
 
-  const [maxFileSize, setMaxFileSize] = useState(setting?.sync.maxFileSizeMb ?? 10)
-  const [maxFileSizeError, setMaxFileSizeError] = useState<string | null>(null)
-
   // File sync local state
   const [fileSyncEnabled, setFileSyncEnabled] = useState(setting?.fileSync?.fileSyncEnabled ?? true)
   const [smallFileThreshold, setSmallFileThreshold] = useState(
@@ -67,7 +64,6 @@ const SyncSection: React.FC = () => {
     if (setting) {
       setAutoSync(setting.sync.autoSync)
       setSyncFrequency(setting.sync.syncFrequency)
-      setMaxFileSize(setting.sync.maxFileSizeMb)
 
       // File sync settings
       setFileSyncEnabled(setting.fileSync?.fileSyncEnabled ?? true)
@@ -89,34 +85,6 @@ const SyncSection: React.FC = () => {
   const handleSyncFrequencyChange = (value: string) => {
     setSyncFrequency(value)
     updateSyncSetting({ syncFrequency: value as 'realtime' | 'interval' })
-  }
-
-  // Handle max file size change
-  const handleMaxFileSizeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const value = e.target.value
-
-    if (!value.trim()) {
-      setMaxFileSizeError(null)
-      setMaxFileSize(0)
-      return
-    }
-
-    if (!/^\d+$/.test(value)) {
-      setMaxFileSizeError(t('settings.sections.sync.maxFileSize.errors.invalid'))
-      setMaxFileSize(parseInt(value) || 0)
-      return
-    }
-
-    const size = parseInt(value)
-    setMaxFileSize(size)
-
-    if (size < 1 || size > 50) {
-      setMaxFileSizeError(t('settings.sections.sync.maxFileSize.errors.range'))
-      return
-    }
-
-    setMaxFileSizeError(null)
-    updateSyncSetting({ maxFileSizeMb: size })
   }
 
   // --- File sync handlers ---
@@ -285,24 +253,6 @@ const SyncSection: React.FC = () => {
               ))}
             </SelectContent>
           </Select>
-        </SettingRow>
-
-        <SettingRow
-          label={t('settings.sections.sync.maxFileSize.label')}
-          description={t('settings.sections.sync.maxFileSize.description')}
-        >
-          <div className="flex flex-col items-end gap-1">
-            <div className="flex items-center gap-2">
-              <Input
-                type="text"
-                value={maxFileSize.toString()}
-                onChange={handleMaxFileSizeChange}
-                className={maxFileSizeError ? 'border-red-500 w-32' : 'w-32'}
-              />
-              <span className="text-sm text-muted-foreground">MB</span>
-            </div>
-            {maxFileSizeError && <p className="text-xs text-red-500">{maxFileSizeError}</p>}
-          </div>
         </SettingRow>
       </SettingGroup>
 

--- a/src/components/setting/__tests__/AboutSection.test.tsx
+++ b/src/components/setting/__tests__/AboutSection.test.tsx
@@ -37,7 +37,6 @@ const baseSetting: Settings = {
       codeSnippet: true,
       richText: true,
     },
-    maxFileSizeMb: 10,
   },
   retentionPolicy: {
     enabled: false,

--- a/src/components/setting/__tests__/AppearanceSection.test.tsx
+++ b/src/components/setting/__tests__/AppearanceSection.test.tsx
@@ -32,7 +32,6 @@ const baseSetting: Settings = {
       codeSnippet: true,
       richText: true,
     },
-    maxFileSizeMb: 10,
   },
   retentionPolicy: {
     enabled: false,

--- a/src/contexts/__tests__/UpdateContext.test.tsx
+++ b/src/contexts/__tests__/UpdateContext.test.tsx
@@ -38,7 +38,6 @@ const baseSetting: Settings = {
       codeSnippet: true,
       richText: true,
     },
-    maxFileSizeMb: 10,
   },
   retentionPolicy: {
     enabled: false,

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -93,15 +93,6 @@
           "5m": "每5分钟",
           "15m": "每15分钟"
         },
-        "maxFileSize": {
-          "label": "最大同步文件大小",
-          "description": "限制单个文件的最大同步大小",
-          "unit": "MB",
-          "errors": {
-            "invalid": "请输入有效的数字",
-            "range": "必须在 1 到 50 MB 之间"
-          }
-        },
         "loadError": "加载设置失败:",
         "fileSync": {
           "title": "文件同步",

--- a/src/types/setting.ts
+++ b/src/types/setting.ts
@@ -50,7 +50,6 @@ export interface SyncSettings {
   autoSync: boolean
   syncFrequency: SyncFrequency
   contentTypes: ContentTypes
-  maxFileSizeMb: number
 }
 
 /**


### PR DESCRIPTION
## Summary
- remove the legacy `sync.max_file_size_mb` / `maxFileSizeMb` setting from the current frontend and daemon API surface
- delete the obsolete Sync settings UI control and related localized copy
- remove the field from the shared Rust `SyncSettings` model, daemon patch merge logic, settings diff logging, and affected tests/fixtures
- keep backward compatibility for older persisted JSON by relying on serde's default unknown-field handling, with a regression test covering legacy payload deserialization

## Validation
- `cargo test -p uc-core test_sync_settings_ignores_legacy_max_file_size_mb_field -- --nocapture`
- `cargo test -p uc-core resolve_sync_settings -- --nocapture`
- `cargo test -p uc-app ...` could not complete in this environment because `pkg-config` / `dbus-1` development headers are missing for `libdbus-sys`
- frontend Vitest run could not start in this environment because the local optional `rolldown` native binding was unavailable under `npm exec`

Closes #300

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the maximum file size limit setting from sync settings configuration across the application. This setting is no longer available in the UI, API, or settings interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->