### PR TITLE
fix: resolve frontend build type errors

### DIFF
--- a/src/__tests__/api/daemon/settings.test.ts
+++ b/src/__tests__/api/daemon/settings.test.ts
@@ -150,7 +150,7 @@ describe('Settings API', () => {
       expect(mockDaemonClient.request).toHaveBeenCalledTimes(1)
       const [, opts] = mockDaemonClient.request.mock.calls[0] as [string, RequestInit]
       expect((opts as { method: string }).method).toBe('PUT')
-      const body = (opts as { body: Record<string, unknown> }).body
+      const body = (opts as unknown as { body: Record<string, unknown> }).body
       expect(body).toHaveProperty('general')
       expect(body.general as Record<string, unknown>).toHaveProperty('autoStart')
       expect(body.general as Record<string, unknown>).toHaveProperty('theme')
@@ -186,7 +186,7 @@ describe('Settings API', () => {
 
       expect(mockDaemonClient.request).toHaveBeenCalledTimes(1)
       const [, opts] = mockDaemonClient.request.mock.calls[0] as [string, RequestInit]
-      const body = (opts as { body: Record<string, unknown> }).body
+      const body = (opts as unknown as { body: Record<string, unknown> }).body
       expect(body.keyboardShortcuts).toEqual({
         shortcuts: {
           toggle_main_window: ['CommandOrControl+Shift+V', 'Alt+Shift+V'],

--- a/src/__tests__/lib/_tauri-event-helpers.ts
+++ b/src/__tests__/lib/_tauri-event-helpers.ts
@@ -19,13 +19,6 @@ import { vi } from 'vitest'
 export const _tauriEventRegistry: Map<string, (payload: unknown) => void> = new Map()
 
 vi.mock('@tauri-apps/api/event', () => {
-  const { _tauriEventRegistry: registry } = jest.requireActual('@tauri-apps/api/event' as never) as {
-    _tauriEventRegistry: typeof _tauriEventRegistry
-  }
-  // Re-assign so the closure captures the exported _tauriEventRegistry.
-  // (Jest's jest.requireActual won't work here — use the module-level export instead.)
-  // Actually we just capture the export directly:
-  // The mock captures the module's _tauriEventRegistry via closure.
   return {
     listen: vi.fn((eventName: string, handler: (event: { payload: unknown }) => void) => {
       _tauriEventRegistry.set(eventName, handler as (payload: unknown) => void)

--- a/src/__tests__/lib/daemon-auth.test.ts
+++ b/src/__tests__/lib/daemon-auth.test.ts
@@ -172,8 +172,10 @@ describe('daemon-auth module', () => {
       await loadDaemonAuth()
 
       const leaks = (spy: ReturnType<typeof vi.spyOn>) =>
-        spy.mock.calls.filter(call =>
-          call.some(value => typeof value === 'string' && value.includes('tauri-bearer-token'))
+        spy.mock.calls.filter((call: unknown[]) =>
+          call.some(
+            (value: unknown) => typeof value === 'string' && value.includes('tauri-bearer-token')
+          )
         )
 
       expect(leaks(errorSpy)).toHaveLength(0)

--- a/src/__tests__/lib/daemon-ws.test.ts
+++ b/src/__tests__/lib/daemon-ws.test.ts
@@ -52,6 +52,8 @@ vi.mock('@/api/daemon/client', () => ({
 }))
 
 const { DaemonWsClient } = await import('@/lib/daemon-ws')
+type DaemonWsEvent = import('@/lib/daemon-ws').DaemonWsEvent
+type ClientInstance = InstanceType<typeof DaemonWsClient>
 
 // ── Helpers ─────────────────────────────────────────────────
 
@@ -76,14 +78,14 @@ function closeSocket(ws: MockWebSocket): void {
   if (ws.onclose) ws.onclose(new CloseEvent('close', { wasClean: false }))
 }
 
-function freshClient(): { client: DaemonWsClient } {
+function freshClient(): { client: ClientInstance } {
   MockWebSocket._nextId = 0
   const client = new DaemonWsClient((url: string) => new MockWebSocket(url) as unknown as WebSocket)
   return { client }
 }
 
-function currentWs(client: DaemonWsClient): MockWebSocket {
-  return client['_ws'] as MockWebSocket
+function currentWs(client: ClientInstance): MockWebSocket {
+  return client['_ws'] as unknown as MockWebSocket
 }
 
 // ── connect() ─────────────────────────────────────────────────
@@ -227,7 +229,7 @@ describe('subscribe()', () => {
     await p
 
     const received: object[] = []
-    client.subscribe(['clipboard'], e => received.push(e))
+    client.subscribe(['clipboard'], (e: DaemonWsEvent) => received.push(e))
 
     receiveMessage(ws, {
       topic: 'clipboard',
@@ -255,7 +257,7 @@ describe('subscribe()', () => {
     await p
 
     const received: object[] = []
-    client.subscribe(['pairing'], e => received.push(e))
+    client.subscribe(['pairing'], (e: DaemonWsEvent) => received.push(e))
 
     receiveMessage(ws, {
       topic: 'pairing',
@@ -319,7 +321,7 @@ describe('subscribe()', () => {
     await p
 
     const received: object[] = []
-    client.subscribe(['clipboard'], e => received.push(e))
+    client.subscribe(['clipboard'], (e: DaemonWsEvent) => received.push(e))
 
     receiveMessage(ws, {
       topic: 'clipboard',
@@ -383,7 +385,7 @@ describe('reconnect', () => {
     for (let i = 1; i <= 10; i++) {
       closeSocket(ws)
       vi.advanceTimersByTime(1000 * 2 ** (i - 1))
-      const newWs = client['_ws'] as MockWebSocket
+      const newWs = client['_ws'] as unknown as MockWebSocket
       openSocket(newWs)
       Object.assign(ws, newWs)
       expect(client['_reconnectAttempt']).toBe(i)
@@ -426,11 +428,11 @@ describe('reconnect', () => {
     vi.runAllTicks()
 
     const received: object[] = []
-    client.subscribe(['clipboard'], e => received.push(e))
+    client.subscribe(['clipboard'], (e: DaemonWsEvent) => received.push(e))
 
     closeSocket(ws)
     vi.advanceTimersByTime(1000)
-    const newWs = client['_ws'] as MockWebSocket
+    const newWs = client['_ws'] as unknown as MockWebSocket
     openSocket(newWs)
 
     receiveMessage(newWs, {
@@ -459,8 +461,8 @@ describe('Topic filtering', () => {
     const clipboardEvents: object[] = []
     const encryptionEvents: object[] = []
 
-    client.subscribe(['clipboard'], e => clipboardEvents.push(e))
-    client.subscribe(['encryption'], e => encryptionEvents.push(e))
+    client.subscribe(['clipboard'], (e: DaemonWsEvent) => clipboardEvents.push(e))
+    client.subscribe(['encryption'], (e: DaemonWsEvent) => encryptionEvents.push(e))
 
     receiveMessage(ws, {
       topic: 'clipboard',
@@ -482,7 +484,7 @@ describe('Topic filtering', () => {
     await p
 
     const received: object[] = []
-    client.subscribe(['encryption'], e => received.push(e))
+    client.subscribe(['encryption'], (e: DaemonWsEvent) => received.push(e))
 
     receiveMessage(ws, {
       topic: 'encryption',
@@ -504,7 +506,7 @@ describe('Topic filtering', () => {
     await p
 
     const received: object[] = []
-    client.subscribe(['clipboard'], e => received.push(e))
+    client.subscribe(['clipboard'], (e: DaemonWsEvent) => received.push(e))
 
     receiveMessage(ws, {
       topic: 'peers',
@@ -572,7 +574,7 @@ describe('Rapid events', () => {
     await p
 
     const received: object[] = []
-    client.subscribe(['clipboard'], e => received.push(e))
+    client.subscribe(['clipboard'], (e: DaemonWsEvent) => received.push(e))
 
     for (let i = 0; i < 20; i++) {
       receiveMessage(ws, {
@@ -595,7 +597,7 @@ describe('Rapid events', () => {
     await p
 
     const received: object[] = []
-    const unsub = client.subscribe(['clipboard'], e => received.push(e))
+    const unsub = client.subscribe(['clipboard'], (e: DaemonWsEvent) => received.push(e))
 
     receiveMessage(ws, {
       topic: 'clipboard',
@@ -633,7 +635,7 @@ describe('Event latency', () => {
     await p
 
     const received: object[] = []
-    client.subscribe(['clipboard'], e => received.push(e))
+    client.subscribe(['clipboard'], (e: DaemonWsEvent) => received.push(e))
 
     for (let i = 0; i < 10; i++) {
       receiveMessage(ws, {
@@ -656,7 +658,7 @@ describe('Event latency', () => {
     await p
 
     const received: object[] = []
-    client.subscribe(['clipboard'], e => received.push(e))
+    client.subscribe(['clipboard'], (e: DaemonWsEvent) => received.push(e))
 
     for (let i = 0; i < 5; i++) {
       receiveMessage(ws, {

--- a/src/api/daemon/__tests__/clipboard.test.ts
+++ b/src/api/daemon/__tests__/clipboard.test.ts
@@ -260,7 +260,7 @@ describe('getEntryDetail HTTP contract', () => {
     const { getEntryDetail } = await import('../clipboard')
 
     const notFoundError = new Error('not found')
-    ;(notFoundError as { code: string }).code = 'NOT_FOUND'
+    ;(notFoundError as unknown as { code: string }).code = 'NOT_FOUND'
     vi.mocked(daemonClient.request).mockRejectedValue(notFoundError)
 
     const result = await getEntryDetail('nonexistent-id')
@@ -306,7 +306,7 @@ describe('getClipboardEntryResource HTTP contract', () => {
     const { getClipboardEntryResource } = await import('../clipboard')
 
     const notFoundError = new Error('not found')
-    ;(notFoundError as { code: string }).code = 'NOT_FOUND'
+    ;(notFoundError as unknown as { code: string }).code = 'NOT_FOUND'
     vi.mocked(daemonClient.request).mockRejectedValue(notFoundError)
 
     const result = await getClipboardEntryResource('nonexistent-id')

--- a/src/components/clipboard/ClipboardItem.tsx
+++ b/src/components/clipboard/ClipboardItem.tsx
@@ -70,7 +70,7 @@ const ClipboardItem: React.FC<ClipboardItemProps> = ({
     getClipboardEntryResource(entryId)
       .then(resource => {
         if (!cancelled) {
-          setOriginalImageUrl(getResourceImageUrl(resource))
+          setOriginalImageUrl(resource ? getResourceImageUrl(resource) : null)
         }
       })
       .catch(e => {
@@ -129,6 +129,9 @@ const ClipboardItem: React.FC<ClipboardItemProps> = ({
       setIsLoadingDetail(true)
       try {
         const resource = await getClipboardEntryResource(entryId)
+        if (!resource) {
+          throw new Error('Resource not found')
+        }
         const fullText = await fetchClipboardResourceText(resource)
         setDetailContent(fullText)
         setIsExpanded(true)

--- a/src/components/clipboard/ClipboardPreview.tsx
+++ b/src/components/clipboard/ClipboardPreview.tsx
@@ -81,7 +81,7 @@ const ClipboardPreview: React.FC<ClipboardPreviewProps> = ({ item }) => {
       if (textContent?.has_detail) {
         setIsLoadingText(true)
         getClipboardEntryResource(item.id)
-          .then(resource => fetchClipboardResourceText(resource))
+          .then(resource => (resource ? fetchClipboardResourceText(resource) : ''))
           .then(text => {
             if (!cancelled) setFullText(text)
           })
@@ -96,7 +96,7 @@ const ClipboardPreview: React.FC<ClipboardPreviewProps> = ({ item }) => {
       setIsLoadingImage(true)
       getClipboardEntryResource(item.id)
         .then(resource => {
-          if (!cancelled) setImageUrl(getResourceImageUrl(resource))
+          if (!cancelled) setImageUrl(resource ? getResourceImageUrl(resource) : null)
         })
         .catch(e => console.error('Failed to load image:', e))
         .finally(() => {

--- a/src/components/setting/StorageSection.tsx
+++ b/src/components/setting/StorageSection.tsx
@@ -410,7 +410,7 @@ const StorageSection: React.FC = () => {
   const handleClearCache = async () => {
     setClearingCache(true)
     try {
-      await storageApi.clearCache()
+      await storageApi.clearCache(true)
       await loadStats()
     } catch (err) {
       console.error('Failed to clear cache:', err)

--- a/src/contexts/__tests__/SettingContext.cross-window.test.tsx
+++ b/src/contexts/__tests__/SettingContext.cross-window.test.tsx
@@ -2,11 +2,11 @@ import { emit } from '@tauri-apps/api/event'
 import { act, renderHook, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { getSettings, updateSettings } from '@/api/daemon'
+import type { Settings } from '@/api/daemon/settings'
 import { SettingProvider } from '@/contexts/SettingContext'
 import { useSetting } from '@/hooks/useSetting'
 import { connectDaemonWs } from '@/lib/daemon-ws-bootstrap'
 import { invokeWithTrace } from '@/lib/tauri-command'
-import type { Settings } from '@/types/setting'
 
 vi.mock('@tauri-apps/api/event', () => ({
   emit: vi.fn(),
@@ -81,6 +81,15 @@ const baseSetting: Settings = {
     sessionTimeout: 300,
     maxRetries: 3,
     protocolVersion: '1.0.0',
+  },
+  keyboardShortcuts: {},
+  fileSync: {
+    fileSyncEnabled: true,
+    smallFileThreshold: 10 * 1024 * 1024,
+    maxFileSize: 5 * 1024 * 1024 * 1024,
+    fileCacheQuotaPerDevice: 500 * 1024 * 1024,
+    fileRetentionHours: 24,
+    fileAutoCleanup: true,
   },
 }
 

--- a/src/contexts/__tests__/SettingContext.theme.test.tsx
+++ b/src/contexts/__tests__/SettingContext.theme.test.tsx
@@ -1,12 +1,12 @@
 import { renderHook, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { getSettings } from '@/api/daemon'
+import type { Settings } from '@/api/daemon/settings'
 import { DEFAULT_THEME_COLOR } from '@/constants/theme'
 import { SettingProvider } from '@/contexts/SettingContext'
 import { useSetting } from '@/hooks/useSetting'
 import { connectDaemonWs } from '@/lib/daemon-ws-bootstrap'
 import { invokeWithTrace } from '@/lib/tauri-command'
-import type { Settings } from '@/types/setting'
 
 vi.mock('@/api/daemon', () => ({
   getSettings: vi.fn(),
@@ -75,6 +75,15 @@ const baseSetting: Settings = {
     sessionTimeout: 300,
     maxRetries: 3,
     protocolVersion: '1.0.0',
+  },
+  keyboardShortcuts: {},
+  fileSync: {
+    fileSyncEnabled: true,
+    smallFileThreshold: 10 * 1024 * 1024,
+    maxFileSize: 5 * 1024 * 1024 * 1024,
+    fileCacheQuotaPerDevice: 500 * 1024 * 1024,
+    fileRetentionHours: 24,
+    fileAutoCleanup: true,
   },
 }
 

--- a/src/hooks/__tests__/useClipboardEvents.test.ts
+++ b/src/hooks/__tests__/useClipboardEvents.test.ts
@@ -5,6 +5,7 @@ import { Provider } from 'react-redux'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { useClipboardEvents } from '../useClipboardEvents'
 import { Filter, getClipboardEntry } from '@/api/clipboardItems'
+import { getEncryptionState } from '@/api/daemon'
 import { getClipboardEntries } from '@/api/daemon/clipboard'
 import clipboardReducer from '@/store/slices/clipboardSlice'
 
@@ -105,8 +106,6 @@ function createWrapper() {
 }
 
 describe('useClipboardEvents', () => {
-  const _mockUnlisten = vi.fn()
-
   beforeEach(() => {
     vi.clearAllMocks()
     dispatchedActions = []
@@ -137,6 +136,7 @@ describe('useClipboardEvents', () => {
       capturedAt: 1000,
       updatedAt: 1000,
       activeTime: 0,
+      isEncrypted: false,
       isFavorited: false,
       isDownloaded: true,
       linkUrls: null,

--- a/src/lib/daemon-ws.ts
+++ b/src/lib/daemon-ws.ts
@@ -299,9 +299,9 @@ export class DaemonWsClient {
     this._recordActivity()
 
     const event: DaemonWsEvent = {
-      topic: raw.topic,
+      topic: raw.topic as string,
       eventType: (raw.type ?? raw.event_type) as string,
-      ts: raw.ts,
+      ts: raw.ts as number,
       sessionId: (raw.sessionId ?? raw.session_id ?? null) as string | null,
       payload: raw.payload,
     }

--- a/src/pages/__tests__/setup-peer-discovery-polling.test.tsx
+++ b/src/pages/__tests__/setup-peer-discovery-polling.test.tsx
@@ -3,9 +3,7 @@
 import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
 import type { HTMLAttributes, ReactNode } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { getP2PPeers } from '@/api/daemon/pairing'
 import { daemonWs } from '@/lib/daemon-ws'
-import { selectJoinPeer } from '@/api/daemon/setup'
 import SetupPage from '@/pages/SetupPage'
 
 // Module-level mock refs — reset in beforeEach
@@ -54,10 +52,12 @@ vi.mock('@/api/daemon/setup', () => ({
 }))
 
 // Capture daemonWs.subscribe handlers for test injection
-const capturedWsHandlers: Array<(event: { topic: string; eventType: string; payload: unknown }) => void> = []
+const capturedWsHandlers: Array<
+  (event: { topic: string; eventType: string; payload: unknown }) => void
+> = []
 vi.mock('@/lib/daemon-ws', () => ({
   daemonWs: {
-    subscribe: vi.fn((_topics: string[], handler: typeof capturedWsHandlers[number]) => {
+    subscribe: vi.fn((_topics: string[], handler: (typeof capturedWsHandlers)[number]) => {
       capturedWsHandlers.push(handler)
       return vi.fn(() => {
         const idx = capturedWsHandlers.indexOf(handler)

--- a/src/store/__tests__/setupRealtimeStore.test.ts
+++ b/src/store/__tests__/setupRealtimeStore.test.ts
@@ -1,6 +1,7 @@
 import { act, renderHook, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { getSetupState, onSetupStateChanged, onSpaceAccessCompleted } from '@/api/setup'
+import type { SetupStateChangedEvent, SpaceAccessCompletedEvent } from '@/api/setup'
 import {
   ensureSetupRealtimeSync,
   resetSetupRealtimeStoreForTests,
@@ -262,9 +263,7 @@ describe('setupRealtimeStore', () => {
 
   it('logs space_access_ignored decision when setup is already Completed on the sponsor side', async () => {
     const consoleSpy = vi.spyOn(console, 'debug').mockImplementation(() => {})
-    let spaceAccessCallback:
-      | ((event: { sessionId: string; success: boolean }) => Promise<void>)
-      | null = null
+    let spaceAccessCallback: ((event: SpaceAccessCompletedEvent) => void) | null = null
 
     vi.mocked(getSetupState).mockResolvedValue('Completed')
     vi.mocked(onSetupStateChanged).mockResolvedValue(() => {})
@@ -281,7 +280,12 @@ describe('setupRealtimeStore', () => {
 
     // Fire space access completed while setup is already 'Completed' (sponsor side behavior)
     await act(async () => {
-      await spaceAccessCallback?.({ sessionId: 'sess-sponsor', success: true })
+      spaceAccessCallback?.({
+        sessionId: 'sess-sponsor',
+        peerId: 'peer-sponsor',
+        success: true,
+        ts: 1,
+      })
     })
 
     // Observability: space_access_ignored must be logged with setup_already_completed reason
@@ -325,9 +329,7 @@ describe('setupRealtimeStore', () => {
     // The store itself should apply every callback call it receives.
     // Deduplication is the responsibility of setup.ts (onSetupStateChanged), not the store.
     // This test verifies the store applies each realtime event it receives without internal dedupe.
-    let realtimeCallback:
-      | ((event: { sessionId: string; state: unknown; ts: number }) => void)
-      | null = null
+    let realtimeCallback: ((event: SetupStateChangedEvent) => void) | null = null
 
     vi.mocked(getSetupState).mockResolvedValue('Welcome')
     vi.mocked(onSetupStateChanged).mockImplementation(async callback => {


### PR DESCRIPTION
## Summary
- fix the current frontend TypeScript/build break on latest `dev`
- tighten test helper typings and event fixture shapes to match the current API contracts
- guard nullable clipboard resource lookups and align `StorageSection` with the current `clearCache(true)` signature

## Verification
- `bunx tsc --noEmit`
- `bun run build`