### PR TITLE
ci: upgrade build workflow actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,17 +62,17 @@ jobs:
         include: ${{ fromJSON(needs.setup-matrix.outputs.matrix) }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.branch || github.ref }}
 
       - name: setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: lts/*
 
       - name: install Bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
 
@@ -88,7 +88,7 @@ jobs:
           shared-key: ${{ matrix.target }}
 
       - name: Cache Bun dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
@@ -144,7 +144,7 @@ jobs:
           fi
 
       - name: upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: uniclipboard-${{ matrix.target }}
           path: src-tauri/target/**/release/bundle/**


### PR DESCRIPTION
## Summary
- upgrade build workflow actions that GitHub flagged as running on deprecated Node 20
- keep workflow behavior unchanged otherwise
- document task #8 context: Windows delay was observed in cache post-steps, not in the actual build step

## Testing
- not run locally (workflow-only change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal development tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->