### PR TITLE
fix: guard blobUrl() against data URIs and absolute URLs

### DIFF
--- a/src/api/daemon/client.ts
+++ b/src/api/daemon/client.ts
@@ -159,6 +159,8 @@ class DaemonClient {
    */
   blobUrl(path: string): string | null {
     if (!this.config || !this.session?.token) return null
+    // Absolute URLs, data URIs, and blob URLs are self-contained — return as-is.
+    if (path.startsWith('data:') || path.startsWith('blob:') || path.startsWith('http')) return path
     const url = new URL(`${this.config.baseUrl}${path}`)
     url.searchParams.set('auth', `Session ${this.session.token}`)
     return url.toString()


### PR DESCRIPTION
## Summary
- Fix TypeError crash when copying images — `blobUrl()` was prepending daemon baseUrl to data URIs, producing invalid URLs like `http://127.0.0.1:44960data:image/png;base64,...`
- `blobUrl()` now returns `data:`, `blob:`, and `http(s)` URLs as-is, only prepending baseUrl + auth token for relative daemon resource paths
- Root-level fix in `DaemonClient.blobUrl()` benefits all callers (`ClipboardPreview`, `ClipboardItem`, etc.)

Closes #28

## Test plan
- [ ] Copy an image to clipboard → verify no TypeError, image preview renders correctly
- [ ] Copy text to clipboard → verify normal clipboard flow unaffected
- [ ] Verify daemon blob resources (relative paths) still load with auth token

🤖 Generated with [Claude Code](https://claude.com/claude-code)