### PR TITLE
feat(frontend): 设备页加入空间前添加确认对话框

### DIFF
--- a/src/components/device/JoinSpaceConfirmDialog.tsx
+++ b/src/components/device/JoinSpaceConfirmDialog.tsx
@@ -1,0 +1,47 @@
+import React from 'react'
+import { useTranslation } from 'react-i18next'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
+
+interface JoinSpaceConfirmDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onConfirm: () => void
+}
+
+const JoinSpaceConfirmDialog: React.FC<JoinSpaceConfirmDialogProps> = ({
+  open,
+  onOpenChange,
+  onConfirm,
+}) => {
+  const { t } = useTranslation()
+
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{t('devices.list.actions.joinSpaceConfirm.title')}</AlertDialogTitle>
+          <AlertDialogDescription>
+            {t('devices.list.actions.joinSpaceConfirm.description')}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>{t('devices.list.actions.joinSpaceConfirm.cancel')}</AlertDialogCancel>
+          <AlertDialogAction onClick={onConfirm}>
+            {t('devices.list.actions.joinSpaceConfirm.confirm')}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}
+
+export default JoinSpaceConfirmDialog

--- a/src/components/device/PairedDevicesPanel.tsx
+++ b/src/components/device/PairedDevicesPanel.tsx
@@ -4,8 +4,10 @@ import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
 import { getDeviceIcon, getIconColor } from './device-utils'
 import DeviceSettingsSheet from './DeviceSettingsSheet'
+import JoinSpaceConfirmDialog from './JoinSpaceConfirmDialog'
 import UnpairAlertDialog from './UnpairAlertDialog'
 import { unpairP2PDevice } from '@/api/daemon/pairing'
+import { startJoinSpace } from '@/api/daemon/setup'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
 import { useSetting } from '@/hooks/useSetting'
@@ -31,6 +33,12 @@ const PairedDevicesPanel: React.FC = () => {
   const [sheetOpen, setSheetOpen] = useState(false)
   const [unpairDialogOpen, setUnpairDialogOpen] = useState(false)
   const [unpairTargetId, setUnpairTargetId] = useState<string | null>(null)
+  const [joinConfirmOpen, setJoinConfirmOpen] = useState(false)
+
+  const handleJoinConfirm = async () => {
+    setJoinConfirmOpen(false)
+    await startJoinSpace()
+  }
 
   useEffect(() => {
     dispatch(fetchPairedDevices())
@@ -132,7 +140,7 @@ const PairedDevicesPanel: React.FC = () => {
           <p className="mb-4 max-w-xs text-xs text-muted-foreground">
             {t('devices.list.empty.description')}
           </p>
-          <Button variant="outline" size="sm" disabled>
+          <Button variant="outline" size="sm" onClick={() => setJoinConfirmOpen(true)}>
             <Plus className="h-3.5 w-3.5" />
             {t('devices.list.actions.addDevice')}
           </Button>
@@ -211,10 +219,11 @@ const PairedDevicesPanel: React.FC = () => {
             )
           })}
 
-          {/* Add device card (disabled, pending backend) */}
-          <div
-            title={t('devices.settings.badges.comingSoon')}
-            className="flex flex-col items-center justify-center rounded-2xl border-2 border-dashed border-border/60 p-5 pt-6 pb-4 text-center opacity-50 cursor-not-allowed"
+          {/* Add device card */}
+          <button
+            type="button"
+            onClick={() => setJoinConfirmOpen(true)}
+            className="flex flex-col items-center justify-center rounded-2xl border-2 border-dashed border-border/60 p-5 pt-6 pb-4 text-center cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-ring"
           >
             <div className="mb-3 h-14 w-14 rounded-2xl flex items-center justify-center bg-muted/50">
               <Plus className="h-7 w-7 text-muted-foreground/70" />
@@ -222,7 +231,7 @@ const PairedDevicesPanel: React.FC = () => {
             <span className="text-sm font-medium text-muted-foreground">
               {t('devices.list.actions.addDevice')}
             </span>
-          </div>
+          </button>
         </div>
       </div>
 
@@ -241,6 +250,12 @@ const PairedDevicesPanel: React.FC = () => {
         onOpenChange={setUnpairDialogOpen}
         deviceName={unpairTargetDevice?.deviceName || t('devices.list.labels.unknownDevice')}
         onConfirm={handleUnpairConfirm}
+      />
+
+      <JoinSpaceConfirmDialog
+        open={joinConfirmOpen}
+        onOpenChange={setJoinConfirmOpen}
+        onConfirm={handleJoinConfirm}
       />
     </>
   )

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -572,8 +572,14 @@
         "retry": "Retry",
         "unpair": "Unpair",
         "settings": "Settings",
-        "addDevice": "Add Device",
-        "addAnotherDevice": "Add another device"
+        "addDevice": "Join Another Encrypted Space",
+        "addAnotherDevice": "Join Another Encrypted Space",
+        "joinSpaceConfirm": {
+          "title": "Join Another Encrypted Space",
+          "description": "This is not a merge. You will join the encrypted space that the selected device is currently in. After joining, your locally encrypted history will no longer be accessible. Back up your data first if needed.",
+          "cancel": "Cancel",
+          "confirm": "Continue Joining"
+        }
       }
     },
     "syncPaused": {

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -563,8 +563,14 @@
         "retry": "重试",
         "unpair": "取消配对",
         "settings": "设置",
-        "addDevice": "添加设备",
-        "addAnotherDevice": "添加另一台设备"
+        "addDevice": "加入另一个加密空间",
+        "addAnotherDevice": "加入另一个加密空间",
+        "joinSpaceConfirm": {
+          "title": "加入另一个加密空间",
+          "description": "这不是合并操作。你将加入所选设备当前所在的加密空间。加入后，本机当前已加密的历史内容将无法继续访问。若需保留，请先备份。",
+          "cancel": "取消",
+          "confirm": "继续加入"
+        }
       }
     },
     "syncPaused": {


### PR DESCRIPTION
## Summary
- 文案"添加设备"改为"加入另一个加密空间"
- 点击按钮弹出确认对话框，明确提示用户：
  - 这不是合并操作
  - 你将加入所选设备当前所在的加密空间
  - 加入后本机历史加密内容将无法访问，若需保留请先备份
- 用户确认后才进入 join 流程

## Files
- `src/components/device/PairedDevicesPanel.tsx` — 启用按钮 + 添加确认对话框
- `src/components/device/JoinSpaceConfirmDialog.tsx` — 新增确认对话框组件
- `src/i18n/locales/zh-CN.json` — 更新文案
- `src/i18n/locales/en-US.json` — 更新文案

## Test plan
- [x] `bun run lint` 通过