### PR TITLE
fix: harden daemon bootstrap cleanup on windows

### DIFF
--- a/src-tauri/crates/uc-daemon/src/api/server.rs
+++ b/src-tauri/crates/uc-daemon/src/api/server.rs
@@ -286,12 +286,9 @@ pub async fn run_http_server(
     cancel: CancellationToken,
 ) -> anyhow::Result<()> {
     let addr = try_resolve_daemon_http_addr()?;
-    let connection_info = state.connection_info_for_addr(addr, std::process::id());
-    tracing::info!(
-        base_url = %connection_info.base_url,
-        ws_url = %connection_info.ws_url,
-        "daemon HTTP API listening on 127.0.0.1"
-    );
+    let listener = tokio::net::TcpListener::bind(addr).await?;
+    let listen_addr = listener.local_addr()?;
+    let connection_info = state.connection_info_for_addr(listen_addr, std::process::id());
 
     // into_make_service_with_connect_info enables ConnectInfo<SocketAddr> in handlers.
     // This is required for the /auth/connect endpoint's IP-based rate limiting.
@@ -300,8 +297,11 @@ pub async fn run_http_server(
     // TCP connection. The SlidingWindowRateLimiter unit tests cover rate limiting logic
     // independently. IP-based rate limiting works correctly in production.
     let make_service = build_router(state).into_make_service_with_connect_info::<SocketAddr>();
-
-    let listener = tokio::net::TcpListener::bind(addr).await?;
+    tracing::info!(
+        base_url = %connection_info.base_url,
+        ws_url = %connection_info.ws_url,
+        "daemon HTTP API listening on 127.0.0.1"
+    );
 
     axum::serve(listener, make_service)
         .with_graceful_shutdown(cancel.cancelled_owned())

--- a/src-tauri/crates/uc-tauri/src/bootstrap/run.rs
+++ b/src-tauri/crates/uc-tauri/src/bootstrap/run.rs
@@ -381,7 +381,8 @@ fn terminate_stale_daemon_from_pid_file_if_present() {
 fn verify_pid_is_daemon(pid: u32) -> Result<bool> {
     use windows::Win32::Foundation::{CloseHandle, HANDLE};
     use windows::Win32::System::Threading::{
-        OpenProcess, QueryFullProcessImageNameW, PROCESS_NAME_WIN32, PROCESS_QUERY_LIMITED_INFORMATION,
+        OpenProcess, QueryFullProcessImageNameW, PROCESS_NAME_WIN32,
+        PROCESS_QUERY_LIMITED_INFORMATION,
     };
 
     // Open the process with minimal rights needed for querying the image name
@@ -399,7 +400,9 @@ fn verify_pid_is_daemon(pid: u32) -> Result<bool> {
 
     unsafe {
         QueryFullProcessImageNameW(process_handle, PROCESS_NAME_WIN32, &mut buffer, &mut size)
-            .map_err(|e| anyhow::anyhow!("failed to query process image name for PID {}: {}", pid, e))?;
+            .map_err(|e| {
+                anyhow::anyhow!("failed to query process image name for PID {}: {}", pid, e)
+            })?;
     }
 
     // Convert the wide string to a Rust String

--- a/src-tauri/crates/uc-tauri/src/bootstrap/run.rs
+++ b/src-tauri/crates/uc-tauri/src/bootstrap/run.rs
@@ -330,21 +330,42 @@ fn terminate_stale_daemon_from_pid_file_if_present() {
     #[cfg(windows)]
     {
         match read_pid_file() {
-            Ok(Some(pid)) => match terminate_local_daemon_pid(pid) {
-                Ok(()) => {
-                    tracing::warn!(
-                        daemon_pid = pid,
-                        "terminated stale daemon from pid file before spawn"
-                    );
+            Ok(Some(pid)) => {
+                // Verify the process at this PID is actually our daemon before killing
+                match verify_pid_is_daemon(pid) {
+                    Ok(true) => {
+                        // PID is our daemon, safe to terminate
+                        match terminate_local_daemon_pid(pid) {
+                            Ok(()) => {
+                                tracing::warn!(
+                                    daemon_pid = pid,
+                                    "terminated stale daemon from pid file before spawn"
+                                );
+                            }
+                            Err(error) => {
+                                tracing::warn!(
+                                    daemon_pid = pid,
+                                    error = %error,
+                                    "failed to terminate stale daemon from pid file before spawn"
+                                );
+                            }
+                        }
+                    }
+                    Ok(false) => {
+                        tracing::warn!(
+                            daemon_pid = pid,
+                            "pid file contains stale/reused PID (process is not our daemon), skipping termination"
+                        );
+                    }
+                    Err(error) => {
+                        tracing::warn!(
+                            daemon_pid = pid,
+                            error = %error,
+                            "failed to verify PID identity, skipping termination for safety"
+                        );
+                    }
                 }
-                Err(error) => {
-                    tracing::warn!(
-                        daemon_pid = pid,
-                        error = %error,
-                        "failed to terminate stale daemon from pid file before spawn"
-                    );
-                }
-            },
+            }
             Ok(None) => {}
             Err(error) => {
                 tracing::warn!(
@@ -352,6 +373,60 @@ fn terminate_stale_daemon_from_pid_file_if_present() {
                     "failed to read daemon pid metadata before spawn"
                 );
             }
+        }
+    }
+}
+
+#[cfg(windows)]
+fn verify_pid_is_daemon(pid: u32) -> Result<bool> {
+    use windows::Win32::Foundation::{CloseHandle, HANDLE};
+    use windows::Win32::System::Threading::{
+        OpenProcess, QueryFullProcessImageNameW, PROCESS_NAME_WIN32, PROCESS_QUERY_LIMITED_INFORMATION,
+    };
+
+    // Open the process with minimal rights needed for querying the image name
+    let process_handle = unsafe {
+        OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, pid)
+            .map_err(|e| anyhow::anyhow!("failed to open process {}: {}", pid, e))?
+    };
+
+    // Ensure we close the handle on all exit paths
+    let _guard = ProcessHandleGuard(process_handle);
+
+    // Query the full process image path
+    let mut buffer = [0u16; 1024];
+    let mut size = buffer.len() as u32;
+
+    unsafe {
+        QueryFullProcessImageNameW(process_handle, PROCESS_NAME_WIN32, &mut buffer, &mut size)
+            .map_err(|e| anyhow::anyhow!("failed to query process image name for PID {}: {}", pid, e))?;
+    }
+
+    // Convert the wide string to a Rust String
+    let image_path = String::from_utf16_lossy(&buffer[..size as usize]);
+
+    // Check if the image name contains our daemon binary name
+    // The path might be like "C:\...\uniclipboard-daemon.exe" or with target triple suffix
+    let is_daemon = image_path.to_lowercase().contains("uniclipboard-daemon");
+
+    tracing::debug!(
+        daemon_pid = pid,
+        image_path = %image_path,
+        is_daemon = is_daemon,
+        "verified process identity"
+    );
+
+    Ok(is_daemon)
+}
+
+#[cfg(windows)]
+struct ProcessHandleGuard(windows::Win32::Foundation::HANDLE);
+
+#[cfg(windows)]
+impl Drop for ProcessHandleGuard {
+    fn drop(&mut self) {
+        unsafe {
+            let _ = windows::Win32::Foundation::CloseHandle(self.0);
         }
     }
 }

--- a/src-tauri/crates/uc-tauri/src/bootstrap/run.rs
+++ b/src-tauri/crates/uc-tauri/src/bootstrap/run.rs
@@ -171,6 +171,11 @@ pub async fn supervise_daemon<R: Runtime>(
                         respawn_backoff = SUPERVISOR_RESPAWN_BACKOFF_INITIAL;
                     }
                     Err(err) => {
+                        cleanup_failed_owned_daemon(
+                            gui_owned_daemon_state,
+                            &ownership,
+                            "daemon supervisor respawn health check failed",
+                        );
                         tracing::error!(error = %err, "Daemon supervisor respawned daemon but health check failed");
                     }
                 }
@@ -221,6 +226,7 @@ where
             let _ = gui_owned_daemon_state.clear();
         }
         ProbeOutcome::Absent => {
+            terminate_stale_daemon_from_pid_file_if_present();
             spawn_and_wait_for_compatible(
                 ownership,
                 gui_owned_daemon_state,
@@ -280,10 +286,74 @@ where
 
     let wait_result = wait_for_daemon_health(probe, timeout, poll_interval).await;
     if wait_result.is_err() {
-        let _ = gui_owned_daemon_state.clear();
-        ownership.clear_spawned_child();
+        cleanup_failed_owned_daemon(
+            gui_owned_daemon_state,
+            ownership,
+            "daemon startup health check failed",
+        );
     }
     wait_result
+}
+
+fn cleanup_failed_owned_daemon(
+    gui_owned_daemon_state: &GuiOwnedDaemonState,
+    ownership: &DaemonBootstrapOwnershipState,
+    reason: &str,
+) {
+    // Clearing GuiOwnedDaemonState only forgets the handle. If the child is still
+    // alive after a failed health check, it can keep the fixed localhost port
+    // bound and poison the next startup attempt.
+    if let Some(owned_child) = gui_owned_daemon_state.clear() {
+        let daemon_pid = owned_child.pid;
+        let spawn_reason = owned_child.spawn_reason;
+        if let Err(error) = owned_child.child.kill() {
+            tracing::warn!(
+                daemon_pid,
+                ?spawn_reason,
+                failure = reason,
+                error = %error,
+                "failed to terminate daemon sidecar after startup failure"
+            );
+        } else {
+            tracing::warn!(
+                daemon_pid,
+                ?spawn_reason,
+                failure = reason,
+                "terminated daemon sidecar after startup failure"
+            );
+        }
+    }
+    ownership.clear_spawned_child();
+}
+
+fn terminate_stale_daemon_from_pid_file_if_present() {
+    #[cfg(windows)]
+    {
+        match read_pid_file() {
+            Ok(Some(pid)) => match terminate_local_daemon_pid(pid) {
+                Ok(()) => {
+                    tracing::warn!(
+                        daemon_pid = pid,
+                        "terminated stale daemon from pid file before spawn"
+                    );
+                }
+                Err(error) => {
+                    tracing::warn!(
+                        daemon_pid = pid,
+                        error = %error,
+                        "failed to terminate stale daemon from pid file before spawn"
+                    );
+                }
+            },
+            Ok(None) => {}
+            Err(error) => {
+                tracing::warn!(
+                    error = %error,
+                    "failed to read daemon pid metadata before spawn"
+                );
+            }
+        }
+    }
 }
 
 async fn replace_incompatible_daemon<Terminate, Spawn, Probe, ProbeFuture>(


### PR DESCRIPTION
## Summary
- kill GUI-owned daemon sidecars when startup health checks fail so stale processes do not keep the fixed localhost port bound
- on Windows, attempt to terminate a stale daemon from the pid file before spawning a replacement when the daemon is absent
- log daemon HTTP listening only after bind succeeds so `10048` failures are no longer masked by a misleading success line

## Why
Windows startup logs showed two distinct issues:
- failed daemon startups could leave a stale sidecar behind, poisoning the next launch with `os error 10048`
- `run_http_server()` logged `daemon HTTP API listening` before `TcpListener::bind()`, which made bind failures look like successful startup

This does not claim to fully root-cause the original `0xC0000409` abort. It closes the deterministic stale-process/port-conflict gap and improves observability for the next Windows repro.

## Verification
- `cargo check --manifest-path src-tauri/Cargo.toml -p uc-tauri -p uc-daemon` with `TMPDIR=/dev/shm/uniclipboard-tmp CARGO_TARGET_DIR=/dev/shm/uniclipboard-target`
- attempted targeted `uc-tauri` bootstrap test, but full test-profile rebuild was skipped after compile verification because of the environment cost of rebuilding the workspace in a fresh target dir


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure reported daemon connection URLs reflect the actual bound address/port.
  * Improved daemon process cleanup when startup fails, ensuring failed child processes are properly terminated and resources freed.
  * Enhanced detection and termination of stale daemon processes on Windows during bootstrap to prevent orphaned background processes.
  * Added clearer warning logs when kill/cleanup attempts occur so failures are more observable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->