### PR TITLE
fix(release): block placeholder changelog output

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -40,6 +40,8 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+    env:
+      CODEX_API_KEY: ${{ secrets.CODEX_API_KEY }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -128,40 +130,10 @@ jobs:
       - name: Generate changelog skeleton
         run: |
           VERSION="${{ steps.version.outputs.version }}"
-          CHANGELOG_PATH="docs/changelog/${VERSION}.md"
-
-          if [ -f "$CHANGELOG_PATH" ]; then
-            echo "Changelog already exists at $CHANGELOG_PATH, skipping generation"
-          else
-            mkdir -p docs/changelog
-
-            # Create empty temp artifacts dir (script requires it but we have no artifacts yet)
-            TEMP_ARTIFACTS=$(mktemp -d)
-            PREV_TAG="${{ steps.changelog-context.outputs.previous_tag }}"
-
-            if [ "${{ inputs.channel }}" = "stable" ]; then
-              IS_PRERELEASE=false
-            else
-              IS_PRERELEASE=true
-            fi
-
-            node scripts/generate-release-notes.js \
-              --version "${VERSION}" \
-              --repo "${{ github.repository }}" \
-              --previous-tag "${PREV_TAG}" \
-              --channel "${{ inputs.channel }}" \
-              --is-prerelease "${IS_PRERELEASE}" \
-              --artifacts-dir "${TEMP_ARTIFACTS}" \
-              --template ".github/release-notes/release.md.tmpl" \
-              --output "${CHANGELOG_PATH}" || {
-                echo "Release notes generation failed, creating minimal changelog"
-                echo "# v${VERSION}" > "${CHANGELOG_PATH}"
-                echo "" >> "${CHANGELOG_PATH}"
-                echo "Release notes pending." >> "${CHANGELOG_PATH}"
-              }
-
-            rm -rf "${TEMP_ARTIFACTS}"
-          fi
+          RELEASE_DATE="$(date -u +%F)"
+          node scripts/changelog-draft.js init \
+            --version "${VERSION}" \
+            --date "${RELEASE_DATE}"
 
       - name: Install Bun
         uses: oven-sh/setup-bun@v2
@@ -188,6 +160,7 @@ jobs:
         if: env.CODEX_API_KEY != ''
         id: render-codex-changelog-prompt
         env:
+          CODEX_API_KEY: ${{ secrets.CODEX_API_KEY }}
           VERSION: ${{ steps.version.outputs.version }}
           PREVIOUS_TAG: ${{ steps.changelog-context.outputs.previous_tag }}
           PREVIOUS_VERSION: ${{ steps.changelog-context.outputs.previous_version }}
@@ -222,17 +195,23 @@ jobs:
       - name: Codex polish changelog
         if: env.CODEX_API_KEY != ''
         uses: openai/codex-action@v1
-        env:
-          CODEX_API_KEY: ${{ secrets.CODEX_API_KEY }}
         with:
           responses-api-endpoint: ${{ secrets.CODEX_API_ENDPOINT || 'https://api.openai.com/v1/responses' }}
-          openai-api-key: ${{ secrets.CODEX_API_KEY }}
+          openai-api-key: ${{ env.CODEX_API_KEY }}
           prompt: ${{ steps.render-codex-changelog-prompt.outputs.prompt }}
+
+      - name: Validate changelog output
+        run: |
+          if [ -z "${CODEX_API_KEY}" ]; then
+            echo "CODEX_API_KEY is required to generate finalized changelog files." >&2
+            exit 1
+          fi
+
+          VERSION="${{ steps.version.outputs.version }}"
+          node scripts/changelog-draft.js validate --version "${VERSION}"
 
       - name: Commit codex changes
         if: env.CODEX_API_KEY != ''
-        env:
-          CODEX_API_KEY: ${{ secrets.CODEX_API_KEY }}
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           git add docs/changelog/

--- a/scripts/__tests__/changelog-draft.test.ts
+++ b/scripts/__tests__/changelog-draft.test.ts
@@ -1,0 +1,105 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { createChangelogDraftFiles, validateChangelogFiles } from '../changelog-draft.js'
+
+describe('changelog-draft', () => {
+  const tempDirs: string[] = []
+  const originalCwd = process.cwd()
+
+  afterEach(() => {
+    process.chdir(originalCwd)
+    while (tempDirs.length > 0) {
+      const dir = tempDirs.pop()
+      if (dir) {
+        fs.rmSync(dir, { recursive: true, force: true })
+      }
+    }
+  })
+
+  function setupRepo() {
+    const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), 'changelog-draft-'))
+    tempDirs.push(repoDir)
+    process.chdir(repoDir)
+    fs.mkdirSync(path.join(repoDir, 'docs', 'changelog'), { recursive: true })
+    return repoDir
+  }
+
+  it('creates english and chinese changelog drafts for the target version', () => {
+    const repoDir = setupRepo()
+
+    createChangelogDraftFiles({
+      version: '0.4.0-alpha.6',
+      date: '2026-04-07',
+    })
+
+    const english = fs.readFileSync(path.join(repoDir, 'docs', 'changelog', '0.4.0-alpha.6.md'))
+    const chinese = fs.readFileSync(
+      path.join(repoDir, 'docs', 'changelog', '0.4.0-alpha.6.zh.md'),
+      'utf8'
+    )
+
+    expect(String(english)).toContain('## 0.4.0-alpha.6 - 2026-04-07')
+    expect(String(english)).toContain('### Features')
+    expect(String(english)).toContain('<!--')
+    expect(chinese).toContain('## 0.4.0-alpha.6 - 2026-04-07')
+    expect(chinese).toContain('### Fixes')
+    expect(chinese).toContain('<!--')
+  })
+
+  it('fails validation when the chinese changelog is missing', () => {
+    const repoDir = setupRepo()
+    fs.writeFileSync(
+      path.join(repoDir, 'docs', 'changelog', '0.4.0-alpha.6.md'),
+      '## 0.4.0-alpha.6 - 2026-04-07\n\n### Fixes\n\n- Fix startup hang.\n',
+      'utf8'
+    )
+
+    expect(() =>
+      validateChangelogFiles({
+        version: '0.4.0-alpha.6',
+      })
+    ).toThrow('Missing changelog files')
+  })
+
+  it('fails validation when placeholder release-note text is still present', () => {
+    const repoDir = setupRepo()
+    fs.writeFileSync(
+      path.join(repoDir, 'docs', 'changelog', '0.4.0-alpha.6.md'),
+      '## 0.4.0-alpha.6 - 2026-04-07\n\nRelease notes are not available yet.\n',
+      'utf8'
+    )
+    fs.writeFileSync(
+      path.join(repoDir, 'docs', 'changelog', '0.4.0-alpha.6.zh.md'),
+      '## 0.4.0-alpha.6 - 2026-04-07\n\n### Fixes\n\n- 修复启动卡住的问题。\n',
+      'utf8'
+    )
+
+    expect(() =>
+      validateChangelogFiles({
+        version: '0.4.0-alpha.6',
+      })
+    ).toThrow('unfinished placeholder content')
+  })
+
+  it('passes validation once both changelog files contain finalized content', () => {
+    const repoDir = setupRepo()
+    fs.writeFileSync(
+      path.join(repoDir, 'docs', 'changelog', '0.4.0-alpha.6.md'),
+      '## 0.4.0-alpha.6 - 2026-04-07\n\n### Fixes\n\n- Fix startup hang.\n',
+      'utf8'
+    )
+    fs.writeFileSync(
+      path.join(repoDir, 'docs', 'changelog', '0.4.0-alpha.6.zh.md'),
+      '## 0.4.0-alpha.6 - 2026-04-07\n\n### Fixes\n\n- 修复启动卡住的问题。\n',
+      'utf8'
+    )
+
+    expect(() =>
+      validateChangelogFiles({
+        version: '0.4.0-alpha.6',
+      })
+    ).not.toThrow()
+  })
+})

--- a/scripts/changelog-draft.js
+++ b/scripts/changelog-draft.js
@@ -1,0 +1,151 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs'
+import path from 'node:path'
+import process from 'node:process'
+
+function changelogPaths(version) {
+  return {
+    english: path.join('docs', 'changelog', `${version}.md`),
+    chinese: path.join('docs', 'changelog', `${version}.zh.md`),
+  }
+}
+
+function ensureChangelogDir() {
+  fs.mkdirSync(path.join('docs', 'changelog'), { recursive: true })
+}
+
+function englishDraft(version, date) {
+  return `## ${version} - ${date}
+
+### Features
+
+<!-- Replace with user-facing additions or remove this section if not needed. -->
+
+### Fixes
+
+<!-- Replace with user-facing fixes or remove this section if not needed. -->
+`
+}
+
+function chineseDraft(version, date) {
+  return `## ${version} - ${date}
+
+### Features
+
+<!-- 填写本次版本中用户能直接感受到的新增或改进；若没有可删除整个小节。 -->
+
+### Fixes
+
+<!-- 填写本次版本中修复的用户可感知问题；若没有可删除整个小节。 -->
+`
+}
+
+export function createChangelogDraftFiles({ version, date }) {
+  ensureChangelogDir()
+  const paths = changelogPaths(version)
+
+  if (!fs.existsSync(paths.english)) {
+    fs.writeFileSync(paths.english, englishDraft(version, date), 'utf8')
+  }
+
+  if (!fs.existsSync(paths.chinese)) {
+    fs.writeFileSync(paths.chinese, chineseDraft(version, date), 'utf8')
+  }
+
+  return paths
+}
+
+function assertFinalizedContent(filePath, version) {
+  const content = fs.readFileSync(filePath, 'utf8')
+  const placeholderMarkers = [
+    'Release notes are not available yet.',
+    'Release notes pending.',
+    'Pending release notes.',
+    'No installer artifacts found for this release.',
+    'No CLI artifacts found for this release.',
+    '<!--',
+  ]
+
+  if (!content.startsWith(`## ${version} - `)) {
+    throw new Error(`Unexpected changelog heading in ${filePath}`)
+  }
+
+  if (placeholderMarkers.some(marker => content.includes(marker))) {
+    throw new Error(`Changelog file ${filePath} still contains unfinished placeholder content`)
+  }
+}
+
+export function validateChangelogFiles({ version }) {
+  const paths = changelogPaths(version)
+  const missing = Object.values(paths).filter(filePath => !fs.existsSync(filePath))
+
+  if (missing.length > 0) {
+    throw new Error(`Missing changelog files: ${missing.join(', ')}`)
+  }
+
+  assertFinalizedContent(paths.english, version)
+  assertFinalizedContent(paths.chinese, version)
+
+  return paths
+}
+
+function parseArgs(argv = process.argv.slice(2)) {
+  const [command, ...rest] = argv
+  const options = { command }
+
+  for (let index = 0; index < rest.length; index += 1) {
+    const arg = rest[index]
+    const next = rest[index + 1]
+
+    if (!arg.startsWith('--')) {
+      continue
+    }
+
+    options[arg.slice(2)] = next
+    index += 1
+  }
+
+  return options
+}
+
+function ensureOption(options, key) {
+  if (!options[key]) {
+    throw new Error(`Missing required option: --${key}`)
+  }
+}
+
+function main() {
+  const options = parseArgs()
+
+  if (options.command === 'init') {
+    ensureOption(options, 'version')
+    ensureOption(options, 'date')
+    createChangelogDraftFiles({
+      version: options.version,
+      date: options.date,
+    })
+    return
+  }
+
+  if (options.command === 'validate') {
+    ensureOption(options, 'version')
+    validateChangelogFiles({
+      version: options.version,
+    })
+    return
+  }
+
+  throw new Error(
+    'Usage: node scripts/changelog-draft.js <init|validate> --version <ver> [--date <YYYY-MM-DD>]'
+  )
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  try {
+    main()
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error))
+    process.exit(1)
+  }
+}


### PR DESCRIPTION
## Summary
- replace placeholder changelog generation with bilingual draft files under `docs/changelog`
- fail prepare-release if changelog output is still unfinished or the chinese file is missing
- keep the release workflow from silently shipping "Release notes are not available yet"

## Verification
- `bun test scripts/__tests__/changelog-draft.test.ts scripts/__tests__/previous-published-release.test.ts`
- `bunx prettier --check .github/workflows/prepare-release.yml scripts/changelog-draft.js scripts/__tests__/changelog-draft.test.ts`
- `bunx eslint scripts/changelog-draft.js scripts/__tests__/changelog-draft.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release note generation workflow with enhanced validation to ensure consistency and completeness of changelog documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->