### PR TITLE
fix: prevent quick panel preview pane from being squeezed on Windows

### DIFF
--- a/src-tauri/crates/uc-daemon/src/api/server.rs
+++ b/src-tauri/crates/uc-daemon/src/api/server.rs
@@ -287,11 +287,6 @@ pub async fn run_http_server(
 ) -> anyhow::Result<()> {
     let addr = try_resolve_daemon_http_addr()?;
     let connection_info = state.connection_info_for_addr(addr, std::process::id());
-    tracing::info!(
-        base_url = %connection_info.base_url,
-        ws_url = %connection_info.ws_url,
-        "daemon HTTP API listening on 127.0.0.1"
-    );
 
     // into_make_service_with_connect_info enables ConnectInfo<SocketAddr> in handlers.
     // This is required for the /auth/connect endpoint's IP-based rate limiting.
@@ -302,6 +297,11 @@ pub async fn run_http_server(
     let make_service = build_router(state).into_make_service_with_connect_info::<SocketAddr>();
 
     let listener = tokio::net::TcpListener::bind(addr).await?;
+    tracing::info!(
+        base_url = %connection_info.base_url,
+        ws_url = %connection_info.ws_url,
+        "daemon HTTP API listening on 127.0.0.1"
+    );
 
     axum::serve(listener, make_service)
         .with_graceful_shutdown(cancel.cancelled_owned())

--- a/src-tauri/crates/uc-daemon/src/app.rs
+++ b/src-tauri/crates/uc-daemon/src/app.rs
@@ -299,7 +299,7 @@ impl DaemonApp {
         let security_for_cleanup = api_state.security.clone();
         let cleanup_cancel = self.cancel.child_token();
         let http_cancel = self.cancel.child_token();
-        let mut http_handle = tokio::spawn(run_http_server(api_state, http_cancel));
+        let mut http_handle = Some(tokio::spawn(run_http_server(api_state, http_cancel)));
 
         // Rate limiter cleanup: runs every 5 minutes, respects cleanup_cancel
         let _cleanup_handle = cleanup_rate_limiter_task(security_for_cleanup, cleanup_cancel);
@@ -324,7 +324,13 @@ impl DaemonApp {
                     info!("external shutdown signal received (parent process gone)");
                     break;
                 }
-                result = &mut http_handle => {
+                result = async {
+                    http_handle
+                        .as_mut()
+                        .expect("http task must exist while select branch is enabled")
+                        .await
+                }, if http_handle.is_some() => {
+                    let _ = http_handle.take();
                     warn!("HTTP server exited unexpectedly: {:?}", result);
                     break;
                 }
@@ -371,9 +377,11 @@ impl DaemonApp {
         .ok();
 
         // Await HTTP server with timeout
-        tokio::time::timeout(Duration::from_secs(5), http_handle)
-            .await
-            .ok();
+        if let Some(handle) = http_handle.take() {
+            tokio::time::timeout(Duration::from_secs(5), handle)
+                .await
+                .ok();
+        }
 
         // Stop services in reverse order
         for service in self.services.iter().rev() {
@@ -516,6 +524,38 @@ mod tests {
         assert!(
             recovery_pos < daemon_new_pos,
             "recover_encryption_session must be called BEFORE DaemonApp::new_with_deferred"
+        );
+    }
+
+    #[test]
+    fn http_server_logs_only_after_bind_succeeds() {
+        let source = include_str!("api/server.rs");
+        let bind_pos = source
+            .find("let listener = tokio::net::TcpListener::bind(addr).await?;")
+            .expect("run_http_server must bind the listener");
+        let log_pos = source
+            .find("\"daemon HTTP API listening on 127.0.0.1\"")
+            .expect("run_http_server must log successful startup");
+        assert!(
+            bind_pos < log_pos,
+            "startup log must be emitted only after bind succeeds"
+        );
+    }
+
+    #[test]
+    fn daemon_app_consumes_http_handle_only_once() {
+        let source = include_str!("app.rs");
+        assert!(
+            source.contains("let mut http_handle = Some(tokio::spawn(run_http_server(api_state, http_cancel)));"),
+            "http handle must be stored as Option so ownership can be consumed exactly once"
+        );
+        assert!(
+            source.contains("let _ = http_handle.take();"),
+            "select loop must remove the completed http handle before shutdown"
+        );
+        assert!(
+            source.contains("if let Some(handle) = http_handle.take() {"),
+            "shutdown must only await the http handle when it has not already been consumed"
         );
     }
 

--- a/src/quick-panel/ClipboardHistoryPanel.tsx
+++ b/src/quick-panel/ClipboardHistoryPanel.tsx
@@ -121,7 +121,7 @@ const PanelItem: React.FC<PanelItemProps> = ({
 }
 
 const quickCardClassName =
-  'flex h-screen w-[360px] min-w-[360px] max-w-[360px] shrink-0 flex-col overflow-hidden rounded-xl border border-border/50 bg-background/95 shadow-xl backdrop-blur-xl'
+  'flex h-screen w-[22.5rem] min-w-[22.5rem] max-w-[22.5rem] shrink-0 flex-col overflow-hidden rounded-xl border border-border/50 bg-background/95 shadow-xl backdrop-blur-xl'
 
 const ClipboardHistoryPanel: React.FC = () => {
   useThemeSync()

--- a/src/quick-panel/ClipboardHistoryPanel.tsx
+++ b/src/quick-panel/ClipboardHistoryPanel.tsx
@@ -121,7 +121,7 @@ const PanelItem: React.FC<PanelItemProps> = ({
 }
 
 const quickCardClassName =
-  'flex h-screen w-[360px] min-w-[360px] max-w-[360px] flex-col overflow-hidden rounded-xl border border-border/50 bg-background/95 shadow-xl backdrop-blur-xl'
+  'flex h-screen w-[360px] min-w-[360px] max-w-[360px] shrink-0 flex-col overflow-hidden rounded-xl border border-border/50 bg-background/95 shadow-xl backdrop-blur-xl'
 
 const ClipboardHistoryPanel: React.FC = () => {
   useThemeSync()
@@ -514,7 +514,7 @@ const ClipboardHistoryPanel: React.FC = () => {
         className={[
           'overflow-hidden transition-all duration-200 ease-out',
           previewEntryId !== null
-            ? 'ml-1 w-[360px] opacity-100 translate-x-0'
+            ? 'ml-1 flex-1 min-w-0 opacity-100 translate-x-0'
             : 'ml-0 w-0 opacity-0 translate-x-2 pointer-events-none',
         ].join(' ')}
         aria-hidden={previewEntryId === null}

--- a/src/quick-panel/ClipboardHistoryPanel.tsx
+++ b/src/quick-panel/ClipboardHistoryPanel.tsx
@@ -120,8 +120,10 @@ const PanelItem: React.FC<PanelItemProps> = ({
   )
 }
 
+// Width uses px to match Tauri LogicalSize exactly (360 logical px = 360 CSS px).
+// rem would break when Windows "Make text bigger" changes the root font-size.
 const quickCardClassName =
-  'flex h-screen w-[22.5rem] min-w-[22.5rem] max-w-[22.5rem] shrink-0 flex-col overflow-hidden rounded-xl border border-border/50 bg-background/95 shadow-xl backdrop-blur-xl'
+  'flex h-screen w-[360px] min-w-[360px] max-w-[360px] shrink-0 flex-col overflow-hidden rounded-xl border border-border/50 bg-background/95 shadow-xl backdrop-blur-xl'
 
 const ClipboardHistoryPanel: React.FC = () => {
   useThemeSync()

--- a/src/quick-panel/ClipboardHistoryPanel.tsx
+++ b/src/quick-panel/ClipboardHistoryPanel.tsx
@@ -120,10 +120,10 @@ const PanelItem: React.FC<PanelItemProps> = ({
   )
 }
 
-// Width uses px to match Tauri LogicalSize exactly (360 logical px = 360 CSS px).
-// rem would break when Windows "Make text bigger" changes the root font-size.
+// No fixed width — flex-1 fills whatever window size Tauri provides,
+// avoiding DPI/scaling mismatches between CSS and Tauri LogicalSize.
 const quickCardClassName =
-  'flex h-screen w-[360px] min-w-[360px] max-w-[360px] shrink-0 flex-col overflow-hidden rounded-xl border border-border/50 bg-background/95 shadow-xl backdrop-blur-xl'
+  'flex h-screen flex-1 min-w-0 flex-col overflow-hidden rounded-xl border border-border/50 bg-background/95 shadow-xl backdrop-blur-xl'
 
 const ClipboardHistoryPanel: React.FC = () => {
   useThemeSync()
@@ -516,7 +516,7 @@ const ClipboardHistoryPanel: React.FC = () => {
         className={[
           'overflow-hidden transition-all duration-200 ease-out',
           previewEntryId !== null
-            ? 'ml-1 flex-1 min-w-0 opacity-100 translate-x-0'
+            ? 'ml-1 w-1/2 min-w-0 opacity-100 translate-x-0'
             : 'ml-0 w-0 opacity-0 translate-x-2 pointer-events-none',
         ].join(' ')}
         aria-hidden={previewEntryId === null}

--- a/src/quick-panel/ClipboardPreviewPane.tsx
+++ b/src/quick-panel/ClipboardPreviewPane.tsx
@@ -25,7 +25,7 @@ const ClipboardPreviewPane: React.FC<ClipboardPreviewPaneProps> = ({ entryId }) 
     preview.textContent.length > 50_000
 
   return (
-    <div className="flex h-screen w-[360px] min-w-[360px] max-w-[360px] flex-col overflow-hidden rounded-xl border border-border/50 bg-background/95 shadow-xl backdrop-blur-xl">
+    <div className="flex h-screen w-full flex-col overflow-hidden rounded-xl border border-border/50 bg-background/95 shadow-xl backdrop-blur-xl">
       <div className="flex items-center justify-between border-b border-border/50 px-3 py-2">
         <span className="text-[12px] font-medium text-foreground">{t('title')}</span>
         {preview && (


### PR DESCRIPTION
## Summary

- On Windows with DPI scaling, sub-pixel rounding between Tauri's `inner_size` (724 logical px) and the CSS viewport can cause the preview pane to be squeezed
- The history panel has `min-w-[360px]` preventing it from shrinking, so all compression falls on the preview pane
- Fix: add `shrink-0` to the history panel and change the preview pane from fixed `w-[360px]` to `flex-1 min-w-0` so it fills remaining space dynamically

## Test plan

- [ ] On Windows: open quick panel, hover over an item to show preview — preview pane should not be visually squeezed
- [ ] On macOS: verify no regression — layout should look the same as before
- [ ] Test with different Windows display scale factors (100%, 125%, 150%)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Made the quick panel and preview areas responsive so they expand to fill available window space instead of fixed widths.
  * Adjusted preview region to use flexible/split sizing when a preview is active for smoother layout.
  * Improved show/hide transitions and responsiveness during resizing.

* **Chores**
  * Ensured server startup logging is emitted only after successful bind and refined shutdown handling to avoid double-awaiting the server.

* **Tests**
  * Added tests validating server startup logging and correct startup/shutdown handle consumption.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->