### PR TITLE
fix(ui): suppress selection highlight on loading buttons

### DIFF
--- a/src/components/ui/__tests__/button.test.tsx
+++ b/src/components/ui/__tests__/button.test.tsx
@@ -1,0 +1,14 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { Button } from '@/components/ui/button'
+
+describe('Button', () => {
+  it('suppresses text selection highlight styles on button content', () => {
+    render(<Button>创建空间</Button>)
+
+    const button = screen.getByRole('button', { name: '创建空间' })
+
+    expect(button.className).toContain('selection:bg-transparent')
+    expect(button.className).toContain('selection:text-current')
+  })
+})

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -4,7 +4,7 @@ import * as React from 'react'
 import { cn } from '@/lib/utils'
 
 const buttonVariants = cva(
-  "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none selection:bg-transparent selection:text-current focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {


### PR DESCRIPTION
## Summary
- neutralize selection highlight styling in the shared Button primitive so loading-state labels no longer look selected on Windows
- add a focused regression test for the button primitive styling

## Verification
- npx -y node@22.13.1 node_modules/vitest/vitest.mjs run src/components/ui/__tests__/button.test.tsx
- npx -y node@22.13.1 node_modules/eslint/bin/eslint.js src/components/ui/button.tsx src/components/ui/__tests__/button.test.tsx
- npx -y prettier --check src/components/ui/button.tsx src/components/ui/__tests__/button.test.tsx
- npx -y node@22.13.1 node_modules/typescript/bin/tsc --noEmit
- npx -y node@22.13.1 node_modules/vite/bin/vite.js build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  - Improved Button component visual presentation by refining selection styling, ensuring transparent backgrounds and consistent text appearance when users highlight button content.

* **Tests**
  - Added automated test coverage for Button component selection styling to maintain quality standards and prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->