### PR TITLE
fix: restore 0.3 encryption recovery compatibility

### DIFF
--- a/src-tauri/crates/uc-daemon/src/entrypoint.rs
+++ b/src-tauri/crates/uc-daemon/src/entrypoint.rs
@@ -29,6 +29,23 @@ use crate::workers::inbound_clipboard_sync::InboundClipboardSyncWorker;
 use crate::workers::peer_discovery::PeerDiscoveryWorker;
 use uc_platform::clipboard::LocalClipboard;
 
+fn finalize_startup_encryption_recovery(
+    result: anyhow::Result<bool>,
+    gui_managed: bool,
+) -> anyhow::Result<bool> {
+    match result {
+        Ok(unlocked) => Ok(unlocked),
+        Err(error) if gui_managed => {
+            tracing::warn!(
+                error = %error,
+                "GUI-managed startup auto-unlock failed; continuing in locked mode for manual unlock"
+            );
+            Ok(false)
+        }
+        Err(error) => Err(error),
+    }
+}
+
 /// Run the daemon process. This is the composition root.
 ///
 /// `gui_managed` mirrors the `--gui-managed` flag: when true, the daemon
@@ -176,9 +193,10 @@ pub fn run(gui_managed: bool) -> anyhow::Result<()> {
             true
         };
 
-        crate::app::recover_encryption_session(&runtime, auto_unlock_enabled)
+        let recovery = crate::app::recover_encryption_session(&runtime, auto_unlock_enabled)
             .instrument(info_span!("daemon.startup.recover_encryption_session"))
-            .await
+            .await;
+        finalize_startup_encryption_recovery(recovery, gui_managed)
     })?;
 
     // Start background clipboard processing tasks.
@@ -286,4 +304,32 @@ pub fn run(gui_managed: bool) -> anyhow::Result<()> {
     );
 
     rt.block_on(daemon.run())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::finalize_startup_encryption_recovery;
+
+    #[test]
+    fn gui_managed_recovery_failure_falls_back_to_locked_startup() {
+        let result =
+            finalize_startup_encryption_recovery(Err(anyhow::anyhow!("wrong passphrase")), true)
+                .expect("gui-managed startup should stay alive");
+
+        assert!(
+            !result,
+            "gui-managed startup should continue in locked mode after auto-unlock failure"
+        );
+    }
+
+    #[test]
+    fn standalone_recovery_failure_remains_fatal() {
+        let result =
+            finalize_startup_encryption_recovery(Err(anyhow::anyhow!("wrong passphrase")), false);
+
+        assert!(
+            result.is_err(),
+            "standalone daemon startup should still fail on recovery errors"
+        );
+    }
 }

--- a/src-tauri/crates/uc-platform/src/file_secure_storage.rs
+++ b/src-tauri/crates/uc-platform/src/file_secure_storage.rs
@@ -38,6 +38,10 @@ impl FileSecureStorage {
         self.base_dir.join(format!("{safe}.bin"))
     }
 
+    fn legacy_file_path(&self, key: &str) -> PathBuf {
+        self.base_dir.join(format!("{key}.bin"))
+    }
+
     fn map_io_error(context: &str, err: io::Error) -> SecureStorageError {
         SecureStorageError::Other(format!("{context}: {err}"))
     }
@@ -48,7 +52,17 @@ impl SecureStoragePort for FileSecureStorage {
         let path = self.file_path(key);
         match fs::read(&path) {
             Ok(bytes) => Ok(Some(bytes)),
-            Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(None),
+            Err(err) if err.kind() == io::ErrorKind::NotFound => {
+                let legacy_path = self.legacy_file_path(key);
+                match fs::read(&legacy_path) {
+                    Ok(bytes) => Ok(Some(bytes)),
+                    Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(None),
+                    Err(err) => Err(Self::map_io_error(
+                        "failed to read legacy secure storage file",
+                        err,
+                    )),
+                }
+            }
             Err(err) => Err(Self::map_io_error(
                 "failed to read secure storage file",
                 err,
@@ -111,5 +125,20 @@ mod tests {
         let storage = FileSecureStorage::with_base_dir(temp_dir.path().to_path_buf());
         let loaded = storage.get("libp2p-identity:v1").expect("get");
         assert!(loaded.is_none());
+    }
+
+    #[test]
+    fn get_reads_legacy_file_keyring_filename_for_backward_compatibility() {
+        let temp_dir = tempfile::TempDir::new().expect("temp dir");
+        let storage = FileSecureStorage::with_base_dir(temp_dir.path().to_path_buf());
+        let legacy_path = temp_dir.path().join("kek:v1:profile:default.bin");
+
+        fs::write(&legacy_path, b"legacy-kek").expect("write legacy key file");
+
+        let loaded = storage
+            .get("kek:v1:profile:default")
+            .expect("get legacy key");
+
+        assert_eq!(loaded, Some(b"legacy-kek".to_vec()));
     }
 }

--- a/src-tauri/crates/uc-tauri/src/bootstrap/run.rs
+++ b/src-tauri/crates/uc-tauri/src/bootstrap/run.rs
@@ -525,23 +525,17 @@ fn spawn_daemon_process<R: Runtime>(
         .args(["--gui-managed"]);
 
     // Tauri v2 sidecar does NOT inherit the parent environment by default.
-    // Forward observability-related env vars so the daemon can initialize its
-    // own Seq / Sentry / log-profile layers and emit structured events
-    // directly — otherwise the only daemon logs reaching Seq would be the
-    // stdout-forwarding wrapper below, which loses target/level/span/fields.
-    for key in [
-        "UC_SEQ_URL",
-        "UC_SEQ_API_KEY",
-        "UC_LOG_PROFILE",
-        "SENTRY_DSN",
-        "RUST_LOG",
-        "RUST_BACKTRACE",
-    ] {
-        if let Ok(value) = std::env::var(key) {
-            if !value.is_empty() {
-                sidecar_cmd = sidecar_cmd.env(key, value);
-            }
-        }
+    // Forward the subset of env vars that affect:
+    // - observability setup (Seq / Sentry / log profile)
+    // - secure storage backend selection (for example macOS dev fallback and
+    //   Linux desktop keyring detection)
+    // - profile-aware daemon namespaces/ports
+    //
+    // Without these, the GUI and daemon can resolve different secure storage
+    // backends or profile namespaces and end up reading mismatched KEK/keyslot
+    // state during startup recovery.
+    for (key, value) in collect_forwarded_daemon_env() {
+        sidecar_cmd = sidecar_cmd.env(key, value);
     }
 
     let (rx, child) = sidecar_cmd.spawn().map_err(|e| {
@@ -596,6 +590,31 @@ fn spawn_daemon_process<R: Runtime>(
     });
 
     Ok((child, pid))
+}
+
+fn collect_forwarded_daemon_env() -> Vec<(String, String)> {
+    let mut envs = Vec::new();
+    for key in [
+        "UC_SEQ_URL",
+        "UC_SEQ_API_KEY",
+        "UC_LOG_PROFILE",
+        "SENTRY_DSN",
+        "RUST_LOG",
+        "RUST_BACKTRACE",
+        "UNICLIPBOARD_ENV",
+        "UC_PROFILE",
+        "DISPLAY",
+        "DBUS_SESSION_BUS_ADDRESS",
+        "XDG_RUNTIME_DIR",
+        "WAYLAND_DISPLAY",
+    ] {
+        if let Ok(value) = std::env::var(key) {
+            if !value.is_empty() {
+                envs.push((key.to_string(), value));
+            }
+        }
+    }
+    envs
 }
 
 #[cfg(test)]
@@ -891,5 +910,48 @@ mod tests {
         assert_eq!(connection_b.base_url, "http://127.0.0.1:42717");
         assert_eq!(connection_b.ws_url, "http://127.0.0.1:42717/ws");
         assert_eq!(connection_b.token, "token-b");
+    }
+
+    #[test]
+    fn forwarded_daemon_env_includes_secure_storage_related_vars() {
+        let previous_uniclipboard_env = std::env::var("UNICLIPBOARD_ENV").ok();
+        let previous_display = std::env::var("DISPLAY").ok();
+        let previous_dbus = std::env::var("DBUS_SESSION_BUS_ADDRESS").ok();
+        let previous_wayland = std::env::var("WAYLAND_DISPLAY").ok();
+
+        with_daemon_env(Some("default"), Some(Path::new("/tmp/runtime")), || {
+            std::env::set_var("UNICLIPBOARD_ENV", "development");
+            std::env::set_var("DISPLAY", ":0");
+            std::env::set_var("DBUS_SESSION_BUS_ADDRESS", "unix:path=/tmp/dbus");
+            std::env::set_var("WAYLAND_DISPLAY", "wayland-0");
+
+            let forwarded = collect_forwarded_daemon_env();
+            let keys: std::collections::HashSet<_> =
+                forwarded.into_iter().map(|(key, _)| key).collect();
+
+            assert!(keys.contains("UC_PROFILE"));
+            assert!(keys.contains("UNICLIPBOARD_ENV"));
+            assert!(keys.contains("DISPLAY"));
+            assert!(keys.contains("DBUS_SESSION_BUS_ADDRESS"));
+            assert!(keys.contains("XDG_RUNTIME_DIR"));
+            assert!(keys.contains("WAYLAND_DISPLAY"));
+        });
+
+        match previous_uniclipboard_env {
+            Some(value) => std::env::set_var("UNICLIPBOARD_ENV", value),
+            None => std::env::remove_var("UNICLIPBOARD_ENV"),
+        }
+        match previous_display {
+            Some(value) => std::env::set_var("DISPLAY", value),
+            None => std::env::remove_var("DISPLAY"),
+        }
+        match previous_dbus {
+            Some(value) => std::env::set_var("DBUS_SESSION_BUS_ADDRESS", value),
+            None => std::env::remove_var("DBUS_SESSION_BUS_ADDRESS"),
+        }
+        match previous_wayland {
+            Some(value) => std::env::set_var("WAYLAND_DISPLAY", value),
+            None => std::env::remove_var("WAYLAND_DISPLAY"),
+        }
     }
 }


### PR DESCRIPTION
## Summary
- keep GUI-managed daemon startup alive in locked mode when auto-unlock fails instead of crashing immediately
- forward secure-storage-related environment variables to the daemon sidecar so GUI and daemon resolve the same storage backend/profile namespace
- add backward compatibility for legacy file-based KEK filenames used before the secure storage migration

## Validation
- cargo test --manifest-path src-tauri/Cargo.toml -p uc-tauri forwarded_daemon_env_includes_secure_storage_related_vars -- --nocapture
- cargo test --manifest-path src-tauri/Cargo.toml -p uc-platform get_reads_legacy_file_keyring_filename_for_backward_compatibility -- --nocapture
- cargo test --manifest-path src-tauri/Cargo.toml -p uc-daemon entrypoint::tests:: -- --nocapture
- cargo check --manifest-path src-tauri/Cargo.toml -p uc-daemon --lib
- cargo check --manifest-path src-tauri/Cargo.toml -p uc-tauri --lib
- cargo fmt --manifest-path src-tauri/Cargo.toml --all