### PR TITLE
feat: add telemetry metrics meter

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5331,6 +5331,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8488,6 +8497,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.33.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fc858248ea01b66f19d8e8a6d55f41deaf91e9d495246fd01368d99935c6c01"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+ "memchr",
+ "ntapi",
+ "windows 0.57.0",
+]
+
+[[package]]
 name = "system-configuration"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9886,6 +9908,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serial_test",
+ "sysinfo",
  "tempfile",
  "tokio",
  "tracing",
@@ -10591,7 +10614,7 @@ dependencies = [
  "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-implement 0.60.2",
- "windows-interface",
+ "windows-interface 0.59.3",
 ]
 
 [[package]]
@@ -10699,6 +10722,16 @@ dependencies = [
 
 [[package]]
 name = "windows"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
+dependencies = [
+ "windows-core 0.57.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f919aee0a93304be7f62e8e5027811bbba96bcb1de84d6618be56e43f8a32a1"
@@ -10741,12 +10774,24 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
+dependencies = [
+ "windows-implement 0.57.0",
+ "windows-interface 0.57.0",
+ "windows-result 0.1.2",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "810ce18ed2112484b0d4e15d022e5f598113e220c53e373fb31e67e21670c1ce"
 dependencies = [
  "windows-implement 0.59.0",
- "windows-interface",
+ "windows-interface 0.59.3",
  "windows-result 0.3.4",
  "windows-strings 0.3.1",
  "windows-targets 0.53.5",
@@ -10759,7 +10804,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
  "windows-implement 0.60.2",
- "windows-interface",
+ "windows-interface 0.59.3",
  "windows-link 0.1.3",
  "windows-result 0.3.4",
  "windows-strings 0.4.2",
@@ -10772,7 +10817,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement 0.60.2",
- "windows-interface",
+ "windows-interface 0.59.3",
  "windows-link 0.2.1",
  "windows-result 0.4.1",
  "windows-strings 0.5.1",
@@ -10791,6 +10836,17 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.112",
+]
+
+[[package]]
+name = "windows-implement"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83577b051e2f49a058c308f17f273b570a6a758386fc291b5f6a934dd84e48c1"
@@ -10805,6 +10861,17 @@ name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.112",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src-tauri/crates/uc-app/src/usecases/clipboard/sync_inbound.rs
+++ b/src-tauri/crates/uc-app/src/usecases/clipboard/sync_inbound.rs
@@ -18,6 +18,7 @@ use uc_core::network::protocol::{
     BinaryRepresentation, ClipboardBinaryPayload, ClipboardPayloadVersion, MIME_IMAGE_PREFIX,
     MIME_TEXT_HTML, MIME_TEXT_PLAIN, MIME_TEXT_RTF,
 };
+use uc_observability::metrics;
 use uc_observability::otlp::propagator::extract_remote_context;
 
 use uc_core::network::ClipboardMessage;
@@ -255,7 +256,7 @@ impl SyncInboundClipboardUseCase {
                 return Ok(InboundApplyOutcome::Skipped);
             }
 
-            match message.payload_version {
+            let outcome = match message.payload_version {
                 ClipboardPayloadVersion::V3 => {
                     self.apply_v3_inbound(message, pre_decoded_plaintext).await
                 }
@@ -264,7 +265,11 @@ impl SyncInboundClipboardUseCase {
                     error!(version = ?other, "Unsupported inbound payload version — dropping message");
                     Ok(InboundApplyOutcome::Skipped)
                 }
+            }?;
+            if matches!(outcome, InboundApplyOutcome::Applied { .. }) {
+                metrics::record_clipboard_sync_inbound();
             }
+            Ok(outcome)
         }
         .instrument(inbound_span)
         .await

--- a/src-tauri/crates/uc-app/src/usecases/clipboard/sync_outbound.rs
+++ b/src-tauri/crates/uc-app/src/usecases/clipboard/sync_outbound.rs
@@ -19,7 +19,7 @@ use uc_core::ports::{
 
 use crate::usecases::pairing::list_sendable_peers::ListSendablePeers;
 use uc_core::{ClipboardChangeOrigin, PeerId, SystemClipboardSnapshot};
-use uc_observability::otlp::propagator::inject_current_context;
+use uc_observability::{metrics, otlp::propagator::inject_current_context};
 
 pub struct SyncOutboundClipboardUseCase {
     local_clipboard: Arc<dyn SystemClipboardPort>,
@@ -483,6 +483,7 @@ impl SyncOutboundClipboardUseCase {
             failures.extend(connect_failures);
             failures.extend(send_failures);
             let failure_count = failures.len();
+            metrics::record_clipboard_sync_outbound(sent_count as u64);
             warn!(
                 sent_count,
                 failure_count,
@@ -498,6 +499,7 @@ impl SyncOutboundClipboardUseCase {
             ));
         }
 
+        metrics::record_clipboard_sync_outbound(sent_count as u64);
         info!(
             sent_count,
             connect_success_count, "Outbound clipboard sync sent to sendable peers"

--- a/src-tauri/crates/uc-app/src/usecases/clipboard/sync_outbound.rs
+++ b/src-tauri/crates/uc-app/src/usecases/clipboard/sync_outbound.rs
@@ -483,7 +483,7 @@ impl SyncOutboundClipboardUseCase {
             failures.extend(connect_failures);
             failures.extend(send_failures);
             let failure_count = failures.len();
-            metrics::record_clipboard_sync_outbound(sent_count as u64);
+            metrics::record_clipboard_sync_outbound();
             warn!(
                 sent_count,
                 failure_count,
@@ -499,7 +499,7 @@ impl SyncOutboundClipboardUseCase {
             ));
         }
 
-        metrics::record_clipboard_sync_outbound(sent_count as u64);
+        metrics::record_clipboard_sync_outbound();
         info!(
             sent_count,
             connect_success_count, "Outbound clipboard sync sent to sendable peers"

--- a/src-tauri/crates/uc-app/src/usecases/internal/capture_clipboard.rs
+++ b/src-tauri/crates/uc-app/src/usecases/internal/capture_clipboard.rs
@@ -4,7 +4,7 @@ use std::time::SystemTime;
 use anyhow::Result;
 use futures::future::try_join_all;
 use tracing::{debug, info, info_span, warn, Instrument};
-use uc_observability::stages;
+use uc_observability::{metrics, stages};
 
 use uc_core::ids::{EntryId, EventId};
 use uc_core::ports::clipboard::{RepresentationCachePort, SpoolQueuePort, SpoolRequest};
@@ -271,6 +271,9 @@ impl CaptureClipboardUseCase {
             .await?;
 
             info!(event_id = %event_id, entry_id = %entry_id, "Clipboard capture completed");
+            if origin == ClipboardChangeOrigin::LocalCapture {
+                metrics::record_clipboard_copy();
+            }
 
             // Queue large representations for durable spool-to-disk in a background task.
             // The entry is already persisted and bytes are in the in-memory cache, so the

--- a/src-tauri/crates/uc-observability/Cargo.toml
+++ b/src-tauri/crates/uc-observability/Cargo.toml
@@ -25,11 +25,12 @@ tokio = { version = "1", features = ["sync", "time", "rt", "macros"] }
 # but silently dropping all spans. Blocking reqwest manages its own internal
 # tokio runtime and therefore works from any caller context.
 opentelemetry = "0.31"
-opentelemetry_sdk = { version = "0.31", features = ["rt-tokio", "logs"] }
-opentelemetry-otlp = { version = "0.31", default-features = false, features = ["http-proto", "reqwest-blocking-client", "reqwest-rustls", "trace", "logs"] }
+opentelemetry_sdk = { version = "0.31", features = ["rt-tokio", "logs", "metrics"] }
+opentelemetry-otlp = { version = "0.31", default-features = false, features = ["http-proto", "reqwest-blocking-client", "reqwest-rustls", "trace", "logs", "metrics"] }
 opentelemetry-semantic-conventions = "0.31"
 opentelemetry-appender-tracing = "0.31"
 tracing-opentelemetry = "0.32"
+sysinfo = { version = "0.33", default-features = false, features = ["system"] }
 
 [dev-dependencies]
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "chrono", "json", "registry"] }

--- a/src-tauri/crates/uc-observability/src/lib.rs
+++ b/src-tauri/crates/uc-observability/src/lib.rs
@@ -47,6 +47,7 @@ mod context;
 pub mod flow;
 pub mod format;
 mod init;
+pub mod metrics;
 pub mod otlp;
 pub mod profile;
 pub(crate) mod span_fields;

--- a/src-tauri/crates/uc-observability/src/metrics.rs
+++ b/src-tauri/crates/uc-observability/src/metrics.rs
@@ -148,11 +148,8 @@ pub fn record_clipboard_sync_inbound() {
     record_clipboard_operation(1, "sync", Some("inbound"));
 }
 
-pub fn record_clipboard_sync_outbound(delivery_count: u64) {
-    if delivery_count == 0 {
-        return;
-    }
-    record_clipboard_operation(delivery_count, "sync", Some("outbound"));
+pub fn record_clipboard_sync_outbound() {
+    record_clipboard_operation(1, "sync", Some("outbound"));
 }
 
 fn record_clipboard_operation(
@@ -191,7 +188,7 @@ mod tests {
         record_clipboard_copy();
         record_clipboard_paste();
         record_clipboard_sync_inbound();
-        record_clipboard_sync_outbound(2);
+        record_clipboard_sync_outbound();
 
         clear();
         provider

--- a/src-tauri/crates/uc-observability/src/metrics.rs
+++ b/src-tauri/crates/uc-observability/src/metrics.rs
@@ -1,0 +1,201 @@
+use std::sync::{Arc, LazyLock, Mutex, RwLock};
+use std::time::{Duration, Instant};
+
+use opentelemetry::metrics::{Counter, MeterProvider as _, ObservableGauge};
+use opentelemetry::KeyValue;
+use opentelemetry_sdk::metrics::SdkMeterProvider;
+use sysinfo::{get_current_pid, ProcessRefreshKind, ProcessesToUpdate, System};
+
+const CLIPBOARD_OPERATIONS_METRIC: &str = "uniclipboard.clipboard.operations";
+const PROCESS_CPU_UTILIZATION_METRIC: &str = "process.cpu.utilization";
+const PROCESS_MEMORY_USAGE_METRIC: &str = "process.memory.usage";
+const PROCESS_SAMPLE_CACHE_TTL: Duration = Duration::from_millis(250);
+
+static METRICS_STATE: LazyLock<RwLock<Option<MetricsState>>> = LazyLock::new(|| RwLock::new(None));
+
+struct MetricsState {
+    clipboard_operations: Counter<u64>,
+    _process_cpu_utilization: Option<ObservableGauge<f64>>,
+    _process_memory_usage: Option<ObservableGauge<u64>>,
+}
+
+#[derive(Clone, Copy)]
+struct ProcessSample {
+    cpu_utilization: f64,
+    memory_usage_bytes: u64,
+}
+
+struct ProcessSampler {
+    system: System,
+    pid: sysinfo::Pid,
+    last_sample: Option<ProcessSample>,
+    last_sample_at: Option<Instant>,
+}
+
+impl ProcessSampler {
+    fn new() -> Option<Self> {
+        let pid = get_current_pid().ok()?;
+        let mut system = System::new_all();
+        system.refresh_processes_specifics(
+            ProcessesToUpdate::Some(&[pid]),
+            false,
+            ProcessRefreshKind::nothing().with_cpu().with_memory(),
+        );
+        Some(Self {
+            system,
+            pid,
+            last_sample: None,
+            last_sample_at: None,
+        })
+    }
+
+    fn sample(&mut self) -> Option<ProcessSample> {
+        if let (Some(last_sample), Some(last_sample_at)) = (self.last_sample, self.last_sample_at) {
+            if last_sample_at.elapsed() < PROCESS_SAMPLE_CACHE_TTL {
+                return Some(last_sample);
+            }
+        }
+
+        self.system.refresh_processes_specifics(
+            ProcessesToUpdate::Some(&[self.pid]),
+            false,
+            ProcessRefreshKind::nothing().with_cpu().with_memory(),
+        );
+
+        let process = self.system.process(self.pid)?;
+        let cpu_count = self.system.cpus().len().max(1) as f64;
+        let sample = ProcessSample {
+            cpu_utilization: (process.cpu_usage() as f64 / 100.0 / cpu_count).clamp(0.0, 1.0),
+            memory_usage_bytes: process.memory(),
+        };
+
+        self.last_sample = Some(sample);
+        self.last_sample_at = Some(Instant::now());
+
+        Some(sample)
+    }
+}
+
+pub(crate) fn install(meter_provider: &SdkMeterProvider) {
+    let meter = meter_provider.meter("uniclipboard-desktop.metrics");
+    let clipboard_operations = meter
+        .u64_counter(CLIPBOARD_OPERATIONS_METRIC)
+        .with_description("Counts UniClipboard clipboard copy, paste, and sync operations.")
+        .with_unit("{operation}")
+        .build();
+
+    let (process_cpu_utilization, process_memory_usage) =
+        if let Some(process_sampler) = ProcessSampler::new().map(|s| Arc::new(Mutex::new(s))) {
+            let cpu_sampler = Arc::clone(&process_sampler);
+            let process_cpu_utilization = meter
+                .f64_observable_gauge(PROCESS_CPU_UTILIZATION_METRIC)
+                .with_description(
+                    "Current process CPU utilization normalized to available logical CPUs.",
+                )
+                .with_unit("1")
+                .with_callback(move |observer| {
+                    if let Ok(mut sampler) = cpu_sampler.lock() {
+                        if let Some(sample) = sampler.sample() {
+                            observer.observe(sample.cpu_utilization, &[]);
+                        }
+                    }
+                })
+                .build();
+
+            let memory_sampler = Arc::clone(&process_sampler);
+            let process_memory_usage = meter
+                .u64_observable_gauge(PROCESS_MEMORY_USAGE_METRIC)
+                .with_description("Current process resident memory usage in bytes.")
+                .with_unit("By")
+                .with_callback(move |observer| {
+                    if let Ok(mut sampler) = memory_sampler.lock() {
+                        if let Some(sample) = sampler.sample() {
+                            observer.observe(sample.memory_usage_bytes, &[]);
+                        }
+                    }
+                })
+                .build();
+
+            (Some(process_cpu_utilization), Some(process_memory_usage))
+        } else {
+            (None, None)
+        };
+
+    if let Ok(mut guard) = METRICS_STATE.write() {
+        *guard = Some(MetricsState {
+            clipboard_operations,
+            _process_cpu_utilization: process_cpu_utilization,
+            _process_memory_usage: process_memory_usage,
+        });
+    }
+}
+
+pub(crate) fn clear() {
+    if let Ok(mut guard) = METRICS_STATE.write() {
+        *guard = None;
+    }
+}
+
+pub fn record_clipboard_copy() {
+    record_clipboard_operation(1, "copy", None);
+}
+
+pub fn record_clipboard_paste() {
+    record_clipboard_operation(1, "paste", None);
+}
+
+pub fn record_clipboard_sync_inbound() {
+    record_clipboard_operation(1, "sync", Some("inbound"));
+}
+
+pub fn record_clipboard_sync_outbound(delivery_count: u64) {
+    if delivery_count == 0 {
+        return;
+    }
+    record_clipboard_operation(delivery_count, "sync", Some("outbound"));
+}
+
+fn record_clipboard_operation(
+    value: u64,
+    operation: &'static str,
+    direction: Option<&'static str>,
+) {
+    let guard = match METRICS_STATE.read() {
+        Ok(guard) => guard,
+        Err(_) => return,
+    };
+    let Some(state) = guard.as_ref() else {
+        return;
+    };
+
+    let mut attributes = Vec::with_capacity(2);
+    attributes.push(KeyValue::new("operation", operation));
+    if let Some(direction) = direction {
+        attributes.push(KeyValue::new("direction", direction));
+    }
+
+    state.clipboard_operations.add(value, &attributes);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn record_clipboard_operations_after_install_do_not_panic() {
+        clear();
+
+        let provider = SdkMeterProvider::builder().build();
+        install(&provider);
+
+        record_clipboard_copy();
+        record_clipboard_paste();
+        record_clipboard_sync_inbound();
+        record_clipboard_sync_outbound(2);
+
+        clear();
+        provider
+            .shutdown()
+            .expect("meter provider should shut down");
+    }
+}

--- a/src-tauri/crates/uc-observability/src/otlp/mod.rs
+++ b/src-tauri/crates/uc-observability/src/otlp/mod.rs
@@ -31,7 +31,9 @@ mod tests;
 pub use provider::OtlpGuard;
 pub use resource::build_resource;
 
-use opentelemetry_sdk::{logs::SdkLoggerProvider, trace::SdkTracerProvider};
+use opentelemetry_sdk::{
+    logs::SdkLoggerProvider, metrics::SdkMeterProvider, trace::SdkTracerProvider,
+};
 use tracing_subscriber::{registry::LookupSpan, Layer};
 
 use crate::profile::LogProfile;
@@ -44,6 +46,7 @@ pub type OtlpLayer = Box<dyn Layer<tracing_subscriber::Registry> + Send + Sync +
 pub struct OtlpProviders {
     pub tracer_provider: SdkTracerProvider,
     pub logger_provider: SdkLoggerProvider,
+    pub meter_provider: SdkMeterProvider,
 }
 
 /// Initialize the OTLP exporters and providers, without creating the tracing layers.
@@ -63,7 +66,7 @@ pub fn init_otlp_provider(
     device_id: Option<&str>,
     telemetry_enabled: bool,
 ) -> anyhow::Result<Option<(OtlpProviders, OtlpGuard)>> {
-    let Some((tracer_provider, logger_provider, guard)) =
+    let Some((tracer_provider, logger_provider, meter_provider, guard)) =
         provider::init_provider_and_guard(profile, device_id, telemetry_enabled)?
     else {
         return Ok(None);
@@ -72,6 +75,7 @@ pub fn init_otlp_provider(
         OtlpProviders {
             tracer_provider,
             logger_provider,
+            meter_provider,
         },
         guard,
     )))

--- a/src-tauri/crates/uc-observability/src/otlp/provider.rs
+++ b/src-tauri/crates/uc-observability/src/otlp/provider.rs
@@ -1,7 +1,8 @@
 use opentelemetry::global;
-use opentelemetry_otlp::{Protocol, SpanExporter, WithExportConfig};
+use opentelemetry_otlp::{MetricExporter, Protocol, SpanExporter, WithExportConfig};
 use opentelemetry_sdk::{
-    logs::SdkLoggerProvider, propagation::TraceContextPropagator, trace::SdkTracerProvider,
+    logs::SdkLoggerProvider, metrics::SdkMeterProvider, propagation::TraceContextPropagator,
+    trace::SdkTracerProvider,
 };
 
 use crate::profile::LogProfile;
@@ -13,10 +14,21 @@ use super::{config, redact, resource};
 pub struct OtlpGuard {
     tracer_provider: Option<SdkTracerProvider>,
     logger_provider: Option<SdkLoggerProvider>,
+    meter_provider: Option<SdkMeterProvider>,
 }
 
 impl Drop for OtlpGuard {
     fn drop(&mut self) {
+        crate::metrics::clear();
+
+        if let Some(provider) = self.meter_provider.take() {
+            match provider.shutdown() {
+                Ok(()) => {}
+                Err(e) => {
+                    tracing::warn!(error = %e, "OTLP meter provider shutdown failed");
+                }
+            }
+        }
         if let Some(provider) = self.logger_provider.take() {
             match provider.shutdown() {
                 Ok(()) => {}
@@ -65,13 +77,23 @@ fn build_log_exporter_from_env() -> anyhow::Result<opentelemetry_otlp::LogExport
         .map_err(|e| anyhow::anyhow!("build OTLP log exporter: {e}"))
 }
 
+fn build_metric_exporter_from_env() -> anyhow::Result<MetricExporter> {
+    MetricExporter::builder()
+        .with_http()
+        .with_protocol(Protocol::HttpBinary)
+        .build()
+        .map_err(|e| anyhow::anyhow!("build OTLP metric exporter: {e}"))
+}
+
 fn build_otlp_guard(
     tracer_provider: &SdkTracerProvider,
     logger_provider: &SdkLoggerProvider,
+    meter_provider: &SdkMeterProvider,
 ) -> OtlpGuard {
     OtlpGuard {
         tracer_provider: Some(tracer_provider.clone()),
         logger_provider: Some(logger_provider.clone()),
+        meter_provider: Some(meter_provider.clone()),
     }
 }
 
@@ -82,11 +104,19 @@ pub(super) fn init_provider_and_guard(
     profile: &LogProfile,
     device_id: Option<&str>,
     telemetry_enabled: bool,
-) -> anyhow::Result<Option<(SdkTracerProvider, SdkLoggerProvider, OtlpGuard)>> {
+) -> anyhow::Result<
+    Option<(
+        SdkTracerProvider,
+        SdkLoggerProvider,
+        SdkMeterProvider,
+        OtlpGuard,
+    )>,
+> {
     // Always install the W3C propagator.
     global::set_text_map_propagator(TraceContextPropagator::new());
 
     if !otlp_is_enabled(profile, telemetry_enabled) || !config::otlp_endpoint_is_configured() {
+        crate::metrics::clear();
         return Ok(None);
     }
 
@@ -105,10 +135,23 @@ pub(super) fn init_provider_and_guard(
     let log_exporter = build_log_exporter_from_env()?;
     let logger_provider = SdkLoggerProvider::builder()
         .with_batch_exporter(log_exporter)
-        .with_resource(resource)
+        .with_resource(resource.clone())
         .build();
 
-    let guard = build_otlp_guard(&tracer_provider, &logger_provider);
+    let metric_exporter = build_metric_exporter_from_env()?;
+    let meter_provider = SdkMeterProvider::builder()
+        .with_periodic_exporter(metric_exporter)
+        .with_resource(resource)
+        .build();
+    global::set_meter_provider(meter_provider.clone());
+    crate::metrics::install(&meter_provider);
 
-    Ok(Some((tracer_provider, logger_provider, guard)))
+    let guard = build_otlp_guard(&tracer_provider, &logger_provider, &meter_provider);
+
+    Ok(Some((
+        tracer_provider,
+        logger_provider,
+        meter_provider,
+        guard,
+    )))
 }

--- a/src-tauri/crates/uc-observability/src/otlp/resource.rs
+++ b/src-tauri/crates/uc-observability/src/otlp/resource.rs
@@ -2,10 +2,14 @@ use opentelemetry::KeyValue;
 use opentelemetry_sdk::Resource;
 use opentelemetry_semantic_conventions::resource as semconv;
 
+const PROCESS_EXECUTABLE_NAME_ATTR: &str = "process.executable.name";
+const PROCESS_PID_ATTR: &str = "process.pid";
+
 pub fn build_resource(device_id: Option<&str>) -> Resource {
     let mut kvs: Vec<KeyValue> = vec![
         KeyValue::new(semconv::SERVICE_NAME, "uniclipboard-desktop"),
         KeyValue::new(semconv::SERVICE_VERSION, env!("CARGO_PKG_VERSION")),
+        KeyValue::new(PROCESS_PID_ATTR, std::process::id() as i64),
         // TODO: use semconv::OS_TYPE when `semconv_experimental` feature is stable in 0.31.x
         KeyValue::new("os.type", std::env::consts::OS),
         // TODO: semconv const when stabilized in opentelemetry-semantic-conventions 0.31
@@ -18,6 +22,9 @@ pub fn build_resource(device_id: Option<&str>) -> Resource {
             },
         ),
     ];
+    if let Some(process_name) = current_process_name() {
+        kvs.push(KeyValue::new(PROCESS_EXECUTABLE_NAME_ATTR, process_name));
+    }
     let resolved = device_id
         .map(|s| s.to_string())
         .or_else(|| crate::context::global_device_id().map(|s| s.to_string()));
@@ -29,9 +36,18 @@ pub fn build_resource(device_id: Option<&str>) -> Resource {
     Resource::builder().with_attributes(kvs).build()
 }
 
+fn current_process_name() -> Option<String> {
+    std::env::current_exe()
+        .ok()?
+        .file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+}
+
 #[cfg(test)]
 mod tests {
-    use super::build_resource;
+    use opentelemetry::Value;
+
+    use super::{build_resource, current_process_name};
 
     #[test]
     fn build_resource_includes_device_id_attribute_when_present() {
@@ -44,5 +60,34 @@ mod tests {
             .expect("device_id should be present when device id is supplied");
 
         assert_eq!(device_id_value, "device-xyz");
+    }
+
+    #[test]
+    fn build_resource_includes_process_identity_attributes() {
+        let resource = build_resource(None);
+
+        let process_name = resource
+            .iter()
+            .find(|(key, _)| key.as_str() == "process.executable.name")
+            .map(|(_, value)| value.as_str().to_string());
+        let process_pid = resource
+            .iter()
+            .find(|(key, _)| key.as_str() == "process.pid")
+            .map(|(_, value)| match value {
+                Value::I64(pid) => Some(*pid),
+                _ => None,
+            })
+            .flatten();
+
+        assert_eq!(
+            process_name.as_deref(),
+            current_process_name().as_deref(),
+            "process.executable.name should match the current executable"
+        );
+        assert_eq!(
+            process_pid,
+            Some(std::process::id() as i64),
+            "process.pid should match the current process id"
+        );
     }
 }

--- a/src-tauri/crates/uc-observability/src/otlp/tests.rs
+++ b/src-tauri/crates/uc-observability/src/otlp/tests.rs
@@ -1,8 +1,8 @@
-use std::io::{Read, Write};
-use std::net::TcpListener;
+use std::io::{ErrorKind, Read, Write};
+use std::net::{TcpListener, TcpStream};
 use std::sync::mpsc;
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use serial_test::serial;
 use tracing_subscriber::prelude::*;
@@ -43,57 +43,79 @@ impl Drop for EnvVarGuard {
     }
 }
 
-fn spawn_http_probe() -> (String, mpsc::Receiver<String>, thread::JoinHandle<()>) {
-    let listener = TcpListener::bind("127.0.0.1:0").expect("bind OTLP probe");
-    let address = listener.local_addr().expect("read OTLP probe address");
-    let (tx, rx) = mpsc::channel();
-    let handle = thread::spawn(move || {
-        let (mut stream, _) = listener.accept().expect("accept OTLP request");
-        stream
-            .set_read_timeout(Some(Duration::from_secs(5)))
-            .expect("set probe timeout");
+fn read_probe_request_line(mut stream: TcpStream) -> String {
+    stream
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .expect("set probe timeout");
 
-        let mut buffer = Vec::new();
-        let mut chunk = [0_u8; 4096];
-        let mut header_end = None;
-        let mut content_length = 0_usize;
+    let mut buffer = Vec::new();
+    let mut chunk = [0_u8; 4096];
+    let mut header_end = None;
+    let mut content_length = 0_usize;
 
-        loop {
-            let read = stream.read(&mut chunk).expect("read OTLP request");
-            if read == 0 {
-                break;
-            }
+    loop {
+        let read = stream.read(&mut chunk).expect("read OTLP request");
+        if read == 0 {
+            break;
+        }
 
-            buffer.extend_from_slice(&chunk[..read]);
+        buffer.extend_from_slice(&chunk[..read]);
 
-            if header_end.is_none() {
-                header_end = buffer.windows(4).position(|window| window == b"\r\n\r\n");
-                if let Some(index) = header_end {
-                    let header_bytes = &buffer[..index + 4];
-                    let headers = String::from_utf8_lossy(header_bytes);
-                    for line in headers.lines() {
-                        if let Some(value) = line.strip_prefix("Content-Length:") {
-                            content_length = value.trim().parse().expect("parse content length");
-                        }
-                    }
-                }
-            }
-
+        if header_end.is_none() {
+            header_end = buffer.windows(4).position(|window| window == b"\r\n\r\n");
             if let Some(index) = header_end {
-                let expected_len = index + 4 + content_length;
-                if buffer.len() >= expected_len {
-                    break;
+                let header_bytes = &buffer[..index + 4];
+                let headers = String::from_utf8_lossy(header_bytes);
+                for line in headers.lines() {
+                    if let Some(value) = line.strip_prefix("Content-Length:") {
+                        content_length = value.trim().parse().expect("parse content length");
+                    }
                 }
             }
         }
 
-        let request = String::from_utf8_lossy(&buffer);
-        let first_line = request.lines().next().unwrap_or_default().to_string();
-        tx.send(first_line).expect("send request line");
+        if let Some(index) = header_end {
+            let expected_len = index + 4 + content_length;
+            if buffer.len() >= expected_len {
+                break;
+            }
+        }
+    }
 
-        stream
-            .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n")
-            .expect("write probe response");
+    let request = String::from_utf8_lossy(&buffer);
+    let first_line = request.lines().next().unwrap_or_default().to_string();
+
+    stream
+        .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n")
+        .expect("write probe response");
+
+    first_line
+}
+
+fn spawn_http_probe_multi(
+    max_requests: usize,
+) -> (String, mpsc::Receiver<Vec<String>>, thread::JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind OTLP probe");
+    listener
+        .set_nonblocking(true)
+        .expect("set probe listener nonblocking");
+    let address = listener.local_addr().expect("read OTLP probe address");
+    let (tx, rx) = mpsc::channel();
+    let handle = thread::spawn(move || {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let mut requests = Vec::new();
+
+        while requests.len() < max_requests && Instant::now() < deadline {
+            match listener.accept() {
+                Ok((stream, _)) => requests.push(read_probe_request_line(stream)),
+                Err(err) if err.kind() == ErrorKind::WouldBlock => {
+                    thread::sleep(Duration::from_millis(50));
+                }
+                Err(err) => panic!("accept OTLP request: {err}"),
+            }
+        }
+
+        tx.send(requests).expect("send request lines");
     });
 
     (format!("http://{}", address), rx, handle)
@@ -150,7 +172,7 @@ fn prod_profile_disables_otlp_when_telemetry_disabled() {
 #[test]
 #[serial]
 fn generic_runtime_endpoint_uses_standard_traces_path() {
-    let (base_url, rx, handle) = spawn_http_probe();
+    let (base_url, rx, handle) = spawn_http_probe_multi(4);
     let _generic = EnvVarGuard::set(OTEL_ENDPOINT_VAR, &format!("{base_url}/ingest/otlp"));
     let _signal = EnvVarGuard::unset(OTEL_TRACES_ENDPOINT_VAR);
     let _headers = EnvVarGuard::unset(OTEL_HEADERS_VAR);
@@ -167,10 +189,15 @@ fn generic_runtime_endpoint_uses_standard_traces_path() {
 
     drop(guard);
 
-    let request_line = rx
+    let request_lines = rx
         .recv_timeout(Duration::from_secs(5))
-        .expect("receive OTLP request line");
+        .expect("receive OTLP request lines");
     handle.join().expect("join OTLP probe");
 
-    assert_eq!(request_line, "POST /ingest/otlp/v1/traces HTTP/1.1");
+    assert!(
+        request_lines
+            .iter()
+            .any(|line| line == "POST /ingest/otlp/v1/traces HTTP/1.1"),
+        "expected OTLP trace export request, got: {request_lines:?}"
+    );
 }

--- a/src-tauri/crates/uc-tauri/src/commands/quick_panel.rs
+++ b/src-tauri/crates/uc-tauri/src/commands/quick_panel.rs
@@ -4,6 +4,7 @@
 use crate::commands::record_trace_fields;
 use crate::quick_panel;
 use tracing::{info_span, Instrument};
+use uc_observability::metrics;
 use uc_platform::ports::observability::TraceMetadata;
 
 /// Dismiss the quick panel and return focus to the previous app (no paste).
@@ -56,8 +57,13 @@ pub async fn paste_to_previous_app(
             let _ = tx.send(result);
         })
         .map_err(|e| format!("Failed to dispatch to main thread: {e}"))?;
-        rx.await
-            .map_err(|_| "Main thread dropped result".to_string())?
+        let result = rx
+            .await
+            .map_err(|_| "Main thread dropped result".to_string())?;
+        if result.is_ok() {
+            metrics::record_clipboard_paste();
+        }
+        result
     }
     .instrument(span)
     .await


### PR DESCRIPTION
## Summary
- extend the existing OTLP pipeline to export metrics through the same telemetry provider
- add clipboard operation counters for local copy, quick-panel paste, inbound sync, and outbound sync deliveries
- report per-process CPU utilization and memory usage, and include process identity in OTLP resource attributes

## Validation
- cargo check -p uc-observability
- cargo check -p uc-app
- cargo check -p uc-tauri
- cargo test -p uc-observability --lib

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added metrics tracking for clipboard operations: copy, paste, sync inbound, and sync outbound.
  * Metrics are now emitted conditionally on successful operations to avoid noise from failures.
  * Introduced process-level resource sampling (CPU and memory) to enrich telemetry.
  * Exposed metrics initialization/cleanup so telemetry can be enabled or disabled at startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->