### PR TITLE
fix: stabilize quick panel preview expansion on Windows

### DIFF
--- a/src-tauri/crates/uc-tauri/src/commands/quick_panel.rs
+++ b/src-tauri/crates/uc-tauri/src/commands/quick_panel.rs
@@ -90,25 +90,27 @@ pub async fn finalize_quick_panel_show(
     .await
 }
 
-/// Expand or collapse the quick panel for inline preview.
+/// Update quick panel size and centered position from the active UI scale.
 #[tauri::command]
-pub async fn set_quick_panel_preview_expanded(
+pub async fn set_quick_panel_layout(
     app: tauri::AppHandle,
-    expanded: bool,
+    scale: f64,
+    preview_expanded: bool,
     _trace: Option<TraceMetadata>,
 ) -> Result<(), String> {
     let span = info_span!(
-        "command.quick_panel.set_preview_expanded",
+        "command.quick_panel.set_layout",
         trace_id = tracing::field::Empty,
         trace_ts = tracing::field::Empty,
-        expanded = expanded,
+        scale = scale,
+        preview_expanded = preview_expanded,
     );
     record_trace_fields(&span, &_trace);
 
     async {
         let handle = app.clone();
         app.run_on_main_thread(move || {
-            quick_panel::set_preview_expanded(&handle, expanded);
+            quick_panel::set_layout(&handle, scale, preview_expanded);
         })
         .map_err(|e| format!("Failed to dispatch to main thread: {e}"))?;
         Ok(())

--- a/src-tauri/crates/uc-tauri/src/quick_panel/mod.rs
+++ b/src-tauri/crates/uc-tauri/src/quick_panel/mod.rs
@@ -44,12 +44,13 @@ pub const DEFAULT_SHORTCUT: &str = "ctrl+alt+v";
 /// Settings key used to store the quick panel shortcut override.
 pub const SHORTCUT_SETTINGS_KEY: &str = "global.toggleQuickPanel";
 
-/// Panel dimensions (logical pixels).
-const PANEL_WIDTH: f64 = 360.0;
-const PANEL_HEIGHT: f64 = 420.0;
-const PREVIEW_WIDTH: f64 = 360.0;
+/// Panel base dimensions (logical pixels at 100% UI scale).
+const BASE_PANEL_WIDTH: f64 = 360.0;
+const BASE_PANEL_HEIGHT: f64 = 420.0;
+const BASE_PREVIEW_WIDTH: f64 = 360.0;
 const PANEL_GAP: f64 = 8.0;
-const EXPANDED_PANEL_WIDTH: f64 = PANEL_WIDTH + PANEL_GAP + PREVIEW_WIDTH;
+const MIN_UI_SCALE: f64 = 0.8;
+const MAX_UI_SCALE: f64 = 1.5;
 
 /// Tauri window label for the quick panel.
 pub(crate) const PANEL_LABEL: &str = "quick-panel";
@@ -60,11 +61,11 @@ pub(crate) const PANEL_LABEL: &str = "quick-panel";
 /// such that it appears centered on screen, like Raycast/Spotlight).
 ///
 /// 获取面板在屏幕居中时的左上角坐标（类似 Raycast/Spotlight 的位置）。
-fn screen_center_position(app: &tauri::AppHandle) -> (f64, f64) {
+fn screen_center_position(app: &tauri::AppHandle, width: f64, height: f64) -> (f64, f64) {
     #[cfg(target_os = "macos")]
     {
         let _ = app; // used only on non-macOS
-        macos::get_screen_center(PANEL_WIDTH, PANEL_HEIGHT)
+        macos::get_screen_center(width, height)
     }
     #[cfg(not(target_os = "macos"))]
     {
@@ -81,11 +82,27 @@ fn screen_center_position(app: &tauri::AppHandle) -> (f64, f64) {
                 warn!("No primary monitor detected, using 800x600 fallback for panel centering");
                 (800.0, 600.0)
             });
-        (
-            (screen_w - PANEL_WIDTH) / 2.0,
-            (screen_h - PANEL_HEIGHT) / 2.0,
-        )
+        ((screen_w - width) / 2.0, (screen_h - height) / 2.0)
     }
+}
+
+fn normalize_ui_scale(scale: f64) -> f64 {
+    if !scale.is_finite() {
+        return 1.0;
+    }
+
+    scale.clamp(MIN_UI_SCALE, MAX_UI_SCALE)
+}
+
+fn panel_dimensions(scale: f64, preview_expanded: bool) -> (f64, f64) {
+    let normalized_scale = normalize_ui_scale(scale);
+    let width = if preview_expanded {
+        (BASE_PANEL_WIDTH + PANEL_GAP + BASE_PREVIEW_WIDTH) * normalized_scale
+    } else {
+        BASE_PANEL_WIDTH * normalized_scale
+    };
+
+    (width, BASE_PANEL_HEIGHT * normalized_scale)
 }
 
 // ── Public API ─────────────────────────────────────────────────────────
@@ -107,7 +124,7 @@ pub fn pre_create(app: &tauri::AppHandle) {
     let url = WebviewUrl::App("quick-panel.html".into());
     match WebviewWindowBuilder::new(app, PANEL_LABEL, url)
         .title("Quick Panel")
-        .inner_size(PANEL_WIDTH, PANEL_HEIGHT)
+        .inner_size(BASE_PANEL_WIDTH, BASE_PANEL_HEIGHT)
         .position(-9999.0, -9999.0)
         .decorations(false)
         .transparent(true)
@@ -208,7 +225,7 @@ pub fn toggle(app: &tauri::AppHandle) {
 ///
 /// 在屏幕中央显示快捷面板（类似 Raycast）。
 pub fn show(app: &tauri::AppHandle) {
-    let (panel_x, panel_y) = screen_center_position(app);
+    let (panel_x, panel_y) = screen_center_position(app, BASE_PANEL_WIDTH, BASE_PANEL_HEIGHT);
     info!(panel_x, panel_y, "Showing quick panel centered on screen");
 
     // If panel doesn't exist yet (pre_create wasn't called), create it now
@@ -221,7 +238,9 @@ pub fn show(app: &tauri::AppHandle) {
         #[cfg(target_os = "windows")]
         windows::remember_previous_foreground(&window);
 
-        if let Err(e) = window.set_size(tauri::LogicalSize::new(PANEL_WIDTH, PANEL_HEIGHT)) {
+        if let Err(e) =
+            window.set_size(tauri::LogicalSize::new(BASE_PANEL_WIDTH, BASE_PANEL_HEIGHT))
+        {
             warn!(error = %e, "Failed to reset quick panel size");
         }
 
@@ -287,20 +306,55 @@ pub fn dismiss(app: &tauri::AppHandle) {
     }
 }
 
-/// Expand or collapse the quick panel width for inline preview.
-pub fn set_preview_expanded(app: &tauri::AppHandle, expanded: bool) {
+/// Update quick panel size and center position from the current UI scale.
+pub fn set_layout(app: &tauri::AppHandle, scale: f64, preview_expanded: bool) {
     let Some(window) = app.get_webview_window(PANEL_LABEL) else {
         return;
     };
 
-    let width = if expanded {
-        EXPANDED_PANEL_WIDTH
-    } else {
-        PANEL_WIDTH
+    let (width, height) = panel_dimensions(scale, preview_expanded);
+    let (panel_x, panel_y) = screen_center_position(app, width, height);
+
+    if let Err(e) = window.set_size(tauri::LogicalSize::new(width, height)) {
+        warn!(
+            error = %e,
+            preview_expanded,
+            scale,
+            width,
+            height,
+            "Failed to update quick panel size"
+        );
+    }
+
+    if let Err(e) = window.set_position(tauri::Position::Logical(tauri::LogicalPosition::new(
+        panel_x, panel_y,
+    ))) {
+        warn!(
+            error = %e,
+            preview_expanded,
+            scale,
+            panel_x,
+            panel_y,
+            "Failed to update quick panel position"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        panel_dimensions, BASE_PANEL_HEIGHT, BASE_PANEL_WIDTH, MAX_UI_SCALE, MIN_UI_SCALE,
     };
 
-    if let Err(e) = window.set_size(tauri::LogicalSize::new(width, PANEL_HEIGHT)) {
-        warn!(error = %e, expanded, "Failed to update quick panel size");
+    #[test]
+    fn panel_dimensions_clamp_scale_and_expand_width() {
+        let (collapsed_width, collapsed_height) = panel_dimensions(0.1, false);
+        assert_eq!(collapsed_width, BASE_PANEL_WIDTH * MIN_UI_SCALE);
+        assert_eq!(collapsed_height, BASE_PANEL_HEIGHT * MIN_UI_SCALE);
+
+        let (expanded_width, expanded_height) = panel_dimensions(9.0, true);
+        assert!(expanded_width > BASE_PANEL_WIDTH * MAX_UI_SCALE);
+        assert_eq!(expanded_height, BASE_PANEL_HEIGHT * MAX_UI_SCALE);
     }
 }
 

--- a/src-tauri/crates/uc-tauri/src/quick_panel/mod.rs
+++ b/src-tauri/crates/uc-tauri/src/quick_panel/mod.rs
@@ -22,6 +22,14 @@ use tracing::{debug, error, info, warn};
 /// the "show → instant blur → hide" race on Windows/Linux.
 static LAST_SHOW_TIME: Mutex<Option<Instant>> = Mutex::new(None);
 
+/// The logical top-left origin used for the currently shown quick panel.
+///
+/// `show()` centers the history-only panel and records that origin. Later
+/// inline preview expand/collapse operations reuse the same origin so the
+/// window grows and shrinks relative to the history pane instead of jumping
+/// to re-center the full width.
+static PANEL_ORIGIN: Mutex<Option<(f64, f64)>> = Mutex::new(None);
+
 /// How long (ms) after `show()` to suppress blur events.
 const BLUR_DEBOUNCE_MS: u128 = 300;
 
@@ -103,6 +111,25 @@ fn panel_dimensions(scale: f64, preview_expanded: bool) -> (f64, f64) {
     };
 
     (width, BASE_PANEL_HEIGHT * normalized_scale)
+}
+
+fn remember_panel_origin(x: f64, y: f64) {
+    if let Ok(mut guard) = PANEL_ORIGIN.lock() {
+        *guard = Some((x, y));
+    }
+}
+
+fn resolve_panel_origin(
+    remembered_origin: Option<(f64, f64)>,
+    centered_origin: (f64, f64),
+) -> (f64, f64) {
+    remembered_origin.unwrap_or(centered_origin)
+}
+
+fn panel_origin_or_center(app: &tauri::AppHandle, width: f64, height: f64) -> (f64, f64) {
+    let remembered_origin = PANEL_ORIGIN.lock().ok().and_then(|guard| *guard);
+    let centered_origin = screen_center_position(app, width, height);
+    resolve_panel_origin(remembered_origin, centered_origin)
 }
 
 // ── Public API ─────────────────────────────────────────────────────────
@@ -249,6 +276,8 @@ pub fn show(app: &tauri::AppHandle) {
             panel_x, panel_y,
         ))) {
             warn!(error = %e, "Failed to set quick panel position");
+        } else {
+            remember_panel_origin(panel_x, panel_y);
         }
 
         // Record show timestamp *before* the frontend finalizes show so the
@@ -313,7 +342,7 @@ pub fn set_layout(app: &tauri::AppHandle, scale: f64, preview_expanded: bool) {
     };
 
     let (width, height) = panel_dimensions(scale, preview_expanded);
-    let (panel_x, panel_y) = screen_center_position(app, width, height);
+    let (panel_x, panel_y) = panel_origin_or_center(app, width, height);
 
     if let Err(e) = window.set_size(tauri::LogicalSize::new(width, height)) {
         warn!(
@@ -337,13 +366,16 @@ pub fn set_layout(app: &tauri::AppHandle, scale: f64, preview_expanded: bool) {
             panel_y,
             "Failed to update quick panel position"
         );
+    } else {
+        remember_panel_origin(panel_x, panel_y);
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::{
-        panel_dimensions, BASE_PANEL_HEIGHT, BASE_PANEL_WIDTH, MAX_UI_SCALE, MIN_UI_SCALE,
+        panel_dimensions, resolve_panel_origin, BASE_PANEL_HEIGHT, BASE_PANEL_WIDTH, MAX_UI_SCALE,
+        MIN_UI_SCALE,
     };
 
     #[test]
@@ -355,6 +387,18 @@ mod tests {
         let (expanded_width, expanded_height) = panel_dimensions(9.0, true);
         assert!(expanded_width > BASE_PANEL_WIDTH * MAX_UI_SCALE);
         assert_eq!(expanded_height, BASE_PANEL_HEIGHT * MAX_UI_SCALE);
+    }
+
+    #[test]
+    fn remembered_origin_wins_over_recentered_origin() {
+        let resolved = resolve_panel_origin(Some((120.0, 48.0)), (300.0, 90.0));
+        assert_eq!(resolved, (120.0, 48.0));
+    }
+
+    #[test]
+    fn centered_origin_is_used_when_no_anchor_is_recorded() {
+        let resolved = resolve_panel_origin(None, (300.0, 90.0));
+        assert_eq!(resolved, (300.0, 90.0));
     }
 }
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -360,7 +360,7 @@ fn run_app(ctx: GuiBootstrapContext) {
             // Quick panel commands
             uc_tauri::commands::quick_panel::paste_to_previous_app,
             uc_tauri::commands::quick_panel::dismiss_quick_panel,
-            uc_tauri::commands::quick_panel::set_quick_panel_preview_expanded,
+            uc_tauri::commands::quick_panel::set_quick_panel_layout,
             uc_tauri::commands::quick_panel::finalize_quick_panel_show,
         ])
         .build(tauri::generate_context!())

--- a/src/lib/window-ui.ts
+++ b/src/lib/window-ui.ts
@@ -1,0 +1,28 @@
+import { initializeUiScale } from '@/lib/ui-scale'
+
+export const applyPlatformTypographyScale = () => {
+  if (typeof navigator === 'undefined' || typeof document === 'undefined') {
+    return
+  }
+
+  const ua = navigator.userAgent || ''
+  const isWindows = ua.includes('Windows')
+
+  if (!isWindows) {
+    return
+  }
+
+  const root = document.documentElement
+
+  root.style.setProperty('--font-size-caption', '0.6875rem') /* 11px */
+  root.style.setProperty('--font-size-small', '0.75rem') /* 12px */
+  root.style.setProperty('--font-size-body', '0.8125rem') /* 13px */
+  root.style.setProperty('--font-size-body-lg', '0.875rem') /* 14px */
+  root.style.setProperty('--font-size-section', '0.9375rem') /* 15px */
+  root.style.setProperty('--font-size-title', '1.125rem') /* 18px */
+}
+
+export const initializeWindowUi = (): (() => void) => {
+  applyPlatformTypographyScale()
+  return initializeUiScale()
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,13 +6,13 @@ import App from './App'
 import './i18n'
 import { store } from './store'
 import { connectDaemonWs } from '@/lib/daemon-ws-bootstrap'
-import { initializeUiScale } from '@/lib/ui-scale'
+import { initializeWindowUi } from '@/lib/window-ui'
 import { initFrontendOtlp } from '@/observability/otlp'
 import { initSentry, Sentry } from '@/observability/sentry'
 
 initSentry()
 initFrontendOtlp()
-initializeUiScale()
+initializeWindowUi()
 
 const startupTimingOrigin = Date.now()
 const logStartupTiming = (label: string) => {
@@ -30,30 +30,6 @@ if (typeof window !== 'undefined') {
     logStartupTiming('window load')
   })
 }
-
-const applyPlatformTypographyScale = () => {
-  if (typeof navigator === 'undefined' || typeof document === 'undefined') {
-    return
-  }
-
-  const ua = navigator.userAgent || ''
-  const isWindows = ua.includes('Windows')
-
-  if (!isWindows) {
-    return
-  }
-
-  const root = document.documentElement
-
-  root.style.setProperty('--font-size-caption', '0.6875rem') /* 11px */
-  root.style.setProperty('--font-size-small', '0.75rem') /* 12px */
-  root.style.setProperty('--font-size-body', '0.8125rem') /* 13px */
-  root.style.setProperty('--font-size-body-lg', '0.875rem') /* 14px */
-  root.style.setProperty('--font-size-section', '0.9375rem') /* 15px */
-  root.style.setProperty('--font-size-title', '1.125rem') /* 18px */
-}
-
-applyPlatformTypographyScale()
 
 // 初始化日志系统：将后端日志输出到浏览器 DevTools
 const initLogging = async () => {

--- a/src/quick-panel/ClipboardHistoryPanel.tsx
+++ b/src/quick-panel/ClipboardHistoryPanel.tsx
@@ -131,10 +131,13 @@ const ClipboardHistoryPanel: React.FC = () => {
   const [unlockError, setUnlockError] = useState<string | null>(null)
   const [previewEntryId, setPreviewEntryId] = useState<string | null>(null)
   const [previewExpanded, setPreviewExpanded] = useState(false)
+  const [previewReservingSpace, setPreviewReservingSpace] = useState(false)
   const [previewSuppressed, setPreviewSuppressed] = useState(false)
   const [uiScale, setUiScale] = useState(() => readStoredUiScale())
+  const [historyLockedWidth, setHistoryLockedWidth] = useState<number | null>(null)
 
   const searchInputRef = useRef<HTMLInputElement>(null)
+  const historyPaneRef = useRef<HTMLDivElement>(null)
   const itemRefs = useRef<Map<number, HTMLDivElement>>(new Map())
   const previewTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const previewLayoutTokenRef = useRef(0)
@@ -152,8 +155,10 @@ const ClipboardHistoryPanel: React.FC = () => {
     (suppressUntilNextSelection: boolean) => {
       clearPreviewTimer()
       previewLayoutTokenRef.current += 1
+      setPreviewReservingSpace(false)
       setPreviewExpanded(false)
       setPreviewEntryId(null)
+      setHistoryLockedWidth(null)
       setPreviewSuppressed(suppressUntilNextSelection)
       void setQuickPanelLayout(readStoredUiScale(), false).catch(() => {})
     },
@@ -170,8 +175,10 @@ const ClipboardHistoryPanel: React.FC = () => {
       setSkipTransition(true)
       clearPreviewTimer()
       previewLayoutTokenRef.current += 1
+      setPreviewReservingSpace(false)
       setPreviewExpanded(false)
       setPreviewEntryId(null)
+      setHistoryLockedWidth(null)
       setPreviewSuppressed(false)
       setSearchQuery('')
       setSelectedIndex(0)
@@ -273,8 +280,10 @@ const ClipboardHistoryPanel: React.FC = () => {
 
     if (!focusedItem) {
       previewLayoutTokenRef.current += 1
+      setPreviewReservingSpace(false)
       setPreviewExpanded(false)
       setPreviewEntryId(null)
+      setHistoryLockedWidth(null)
       void setQuickPanelLayout(uiScale, false).catch(() => {})
       return
     }
@@ -293,15 +302,27 @@ const ClipboardHistoryPanel: React.FC = () => {
         }
 
         const token = previewLayoutTokenRef.current + 1
+        const nextHistoryWidth = historyPaneRef.current?.getBoundingClientRect().width ?? 0
         previewLayoutTokenRef.current = token
+        setHistoryLockedWidth(nextHistoryWidth > 0 ? nextHistoryWidth : null)
+        setPreviewReservingSpace(true)
         void setQuickPanelLayout(uiScale, true)
           .then(() => {
             if (previewLayoutTokenRef.current !== token) {
               return
             }
+            setPreviewReservingSpace(false)
             setPreviewExpanded(true)
+            setHistoryLockedWidth(null)
           })
-          .catch(() => {})
+          .catch(() => {
+            if (previewLayoutTokenRef.current !== token) {
+              return
+            }
+            setPreviewReservingSpace(false)
+            setHistoryLockedWidth(null)
+            setPreviewEntryId(null)
+          })
       },
       previewEntryId ? PREVIEW_SWITCH_DELAY_MS : PREVIEW_OPEN_DELAY_MS
     )
@@ -458,7 +479,19 @@ const ClipboardHistoryPanel: React.FC = () => {
 
   return (
     <div className="flex h-screen w-screen overflow-hidden bg-transparent">
-      <div className="min-w-0 flex-1 basis-0">
+      <div
+        ref={historyPaneRef}
+        className={
+          previewReservingSpace && historyLockedWidth != null
+            ? 'min-w-0 shrink-0'
+            : 'min-w-0 flex-1 basis-0'
+        }
+        style={
+          previewReservingSpace && historyLockedWidth != null
+            ? { width: `${historyLockedWidth}px` }
+            : undefined
+        }
+      >
         <div className={quickCardClassName}>
           {isLocked && !loading ? (
             <>
@@ -576,8 +609,15 @@ const ClipboardHistoryPanel: React.FC = () => {
           'min-w-0 overflow-hidden',
           previewExpanded
             ? 'ml-2 flex-1 basis-0 opacity-100 translate-x-0'
-            : 'ml-0 w-0 opacity-0 translate-x-2 pointer-events-none',
+            : previewReservingSpace && historyLockedWidth != null
+              ? 'ml-2 shrink-0 opacity-0 translate-x-0 pointer-events-none'
+              : 'ml-0 w-0 opacity-0 translate-x-2 pointer-events-none',
         ].join(' ')}
+        style={
+          previewReservingSpace && historyLockedWidth != null
+            ? { width: `max(0px, calc(100% - ${historyLockedWidth}px - 0.5rem))` }
+            : undefined
+        }
         aria-hidden={!previewExpanded}
       >
         <div

--- a/src/quick-panel/ClipboardHistoryPanel.tsx
+++ b/src/quick-panel/ClipboardHistoryPanel.tsx
@@ -546,14 +546,21 @@ const ClipboardHistoryPanel: React.FC = () => {
       <div
         className={[
           'min-w-0 overflow-hidden',
-          skipTransition ? '' : 'transition-all duration-200 ease-out',
           previewEntryId !== null
             ? 'ml-2 flex-1 basis-0 opacity-100 translate-x-0'
             : 'ml-0 w-0 opacity-0 translate-x-2 pointer-events-none',
         ].join(' ')}
         aria-hidden={previewEntryId === null}
       >
-        <ClipboardPreviewPane entryId={previewEntryId} />
+        <div
+          className={[
+            'h-full',
+            skipTransition ? '' : 'transition-[opacity,transform] duration-200 ease-out',
+            previewEntryId !== null ? 'opacity-100 translate-x-0' : 'opacity-0 translate-x-2',
+          ].join(' ')}
+        >
+          <ClipboardPreviewPane entryId={previewEntryId} />
+        </div>
       </div>
     </div>
   )

--- a/src/quick-panel/ClipboardHistoryPanel.tsx
+++ b/src/quick-panel/ClipboardHistoryPanel.tsx
@@ -130,12 +130,14 @@ const ClipboardHistoryPanel: React.FC = () => {
   const [unlocking, setUnlocking] = useState(false)
   const [unlockError, setUnlockError] = useState<string | null>(null)
   const [previewEntryId, setPreviewEntryId] = useState<string | null>(null)
+  const [previewExpanded, setPreviewExpanded] = useState(false)
   const [previewSuppressed, setPreviewSuppressed] = useState(false)
   const [uiScale, setUiScale] = useState(() => readStoredUiScale())
 
   const searchInputRef = useRef<HTMLInputElement>(null)
   const itemRefs = useRef<Map<number, HTMLDivElement>>(new Map())
   const previewTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const previewLayoutTokenRef = useRef(0)
   const deletingRef = useRef(false)
   const [skipTransition, setSkipTransition] = useState(false)
 
@@ -149,8 +151,11 @@ const ClipboardHistoryPanel: React.FC = () => {
   const closePreview = useCallback(
     (suppressUntilNextSelection: boolean) => {
       clearPreviewTimer()
+      previewLayoutTokenRef.current += 1
+      setPreviewExpanded(false)
       setPreviewEntryId(null)
       setPreviewSuppressed(suppressUntilNextSelection)
+      void setQuickPanelLayout(readStoredUiScale(), false).catch(() => {})
     },
     [clearPreviewTimer]
   )
@@ -164,6 +169,8 @@ const ClipboardHistoryPanel: React.FC = () => {
       // 1. Clear stale state (no CSS transition — instant)
       setSkipTransition(true)
       clearPreviewTimer()
+      previewLayoutTokenRef.current += 1
+      setPreviewExpanded(false)
       setPreviewEntryId(null)
       setPreviewSuppressed(false)
       setSearchQuery('')
@@ -192,8 +199,8 @@ const ClipboardHistoryPanel: React.FC = () => {
   }, [clearPreviewTimer, reload])
 
   useEffect(() => {
-    void setQuickPanelLayout(uiScale, Boolean(previewEntryId)).catch(() => {})
-  }, [previewEntryId, uiScale])
+    void setQuickPanelLayout(uiScale, previewExpanded).catch(() => {})
+  }, [previewExpanded, uiScale])
 
   useEffect(() => {
     return subscribeUiScaleChanges(scale => {
@@ -265,7 +272,10 @@ const ClipboardHistoryPanel: React.FC = () => {
     }
 
     if (!focusedItem) {
+      previewLayoutTokenRef.current += 1
+      setPreviewExpanded(false)
       setPreviewEntryId(null)
+      void setQuickPanelLayout(uiScale, false).catch(() => {})
       return
     }
 
@@ -275,7 +285,23 @@ const ClipboardHistoryPanel: React.FC = () => {
 
     previewTimerRef.current = setTimeout(
       () => {
-        setPreviewEntryId(focusedItem.id)
+        const nextEntryId = focusedItem.id
+        setPreviewEntryId(nextEntryId)
+
+        if (previewExpanded) {
+          return
+        }
+
+        const token = previewLayoutTokenRef.current + 1
+        previewLayoutTokenRef.current = token
+        void setQuickPanelLayout(uiScale, true)
+          .then(() => {
+            if (previewLayoutTokenRef.current !== token) {
+              return
+            }
+            setPreviewExpanded(true)
+          })
+          .catch(() => {})
       },
       previewEntryId ? PREVIEW_SWITCH_DELAY_MS : PREVIEW_OPEN_DELAY_MS
     )
@@ -286,9 +312,11 @@ const ClipboardHistoryPanel: React.FC = () => {
     focusedItem,
     isLocked,
     previewEntryId,
+    previewExpanded,
     previewSuppressed,
     selectedIndex,
     hoveredIndex,
+    uiScale,
   ])
 
   const handleSelect = useCallback(
@@ -546,17 +574,17 @@ const ClipboardHistoryPanel: React.FC = () => {
       <div
         className={[
           'min-w-0 overflow-hidden',
-          previewEntryId !== null
+          previewExpanded
             ? 'ml-2 flex-1 basis-0 opacity-100 translate-x-0'
             : 'ml-0 w-0 opacity-0 translate-x-2 pointer-events-none',
         ].join(' ')}
-        aria-hidden={previewEntryId === null}
+        aria-hidden={!previewExpanded}
       >
         <div
           className={[
             'h-full',
             skipTransition ? '' : 'transition-[opacity,transform] duration-200 ease-out',
-            previewEntryId !== null ? 'opacity-100 translate-x-0' : 'opacity-0 translate-x-2',
+            previewExpanded ? 'opacity-100 translate-x-0' : 'opacity-0 translate-x-2',
           ].join(' ')}
         >
           <ClipboardPreviewPane entryId={previewEntryId} />

--- a/src/quick-panel/ClipboardHistoryPanel.tsx
+++ b/src/quick-panel/ClipboardHistoryPanel.tsx
@@ -117,7 +117,7 @@ const PanelItem: React.FC<PanelItemProps> = React.memo(
 )
 
 const quickCardClassName =
-  'flex h-screen w-[360px] min-w-[360px] max-w-[360px] flex-col overflow-hidden rounded-xl border border-border/50 bg-background/95 shadow-xl backdrop-blur-xl'
+  'flex h-screen w-full min-w-0 flex-col overflow-hidden rounded-xl border border-border/50 bg-background/95 shadow-xl backdrop-blur-xl'
 
 const ClipboardHistoryPanel: React.FC = () => {
   useThemeSync()
@@ -430,121 +430,125 @@ const ClipboardHistoryPanel: React.FC = () => {
 
   return (
     <div className="flex h-screen w-screen overflow-hidden bg-transparent">
-      <div className={quickCardClassName}>
-        {isLocked && !loading ? (
-          <>
-            <div className="flex flex-1 flex-col items-center justify-center gap-4 px-6">
-              <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-muted/30">
-                <Lock className="h-6 w-6 text-muted-foreground" />
-              </div>
-              <div className="space-y-1 text-center">
-                <h2 className="text-sm font-medium text-foreground">Clipboard is locked</h2>
-                <p className="text-[12px] text-muted-foreground">
-                  Unlock to access your clipboard history
-                </p>
-              </div>
-              <button
-                type="button"
-                onClick={handleUnlock}
-                disabled={unlocking}
-                className="flex items-center gap-1.5 rounded-md bg-primary px-4 py-1.5 text-[13px] font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:opacity-50"
-              >
-                {unlocking ? (
-                  <>
-                    <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                    Unlocking...
-                  </>
-                ) : (
-                  <>
-                    <Unlock className="h-3.5 w-3.5" />
-                    Unlock
-                  </>
+      <div className="min-w-0 flex-1 basis-0">
+        <div className={quickCardClassName}>
+          {isLocked && !loading ? (
+            <>
+              <div className="flex flex-1 flex-col items-center justify-center gap-4 px-6">
+                <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-muted/30">
+                  <Lock className="h-6 w-6 text-muted-foreground" />
+                </div>
+                <div className="space-y-1 text-center">
+                  <h2 className="text-sm font-medium text-foreground">Clipboard is locked</h2>
+                  <p className="text-[12px] text-muted-foreground">
+                    Unlock to access your clipboard history
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  onClick={handleUnlock}
+                  disabled={unlocking}
+                  className="flex items-center gap-1.5 rounded-md bg-primary px-4 py-1.5 text-[13px] font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:opacity-50"
+                >
+                  {unlocking ? (
+                    <>
+                      <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                      Unlocking...
+                    </>
+                  ) : (
+                    <>
+                      <Unlock className="h-3.5 w-3.5" />
+                      Unlock
+                    </>
+                  )}
+                </button>
+                {unlockError && (
+                  <p className="max-w-[15rem] text-center text-[12px] text-destructive">
+                    {unlockError}
+                  </p>
                 )}
-              </button>
-              {unlockError && (
-                <p className="max-w-[15rem] text-center text-[12px] text-destructive">
-                  {unlockError}
-                </p>
-              )}
-            </div>
-            <div className="flex items-center justify-center border-t border-border/50 px-3 py-1.5 text-[11px] text-muted-foreground">
-              <span>esc close</span>
-            </div>
-          </>
-        ) : (
-          <>
-            <div className="flex items-center gap-2 border-b border-border/50 px-3 py-2.5">
-              <Search className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-              <input
-                ref={searchInputRef}
-                type="text"
-                placeholder="Search clipboard history..."
-                value={searchQuery}
-                onChange={e => {
-                  setPreviewSuppressed(false)
-                  setSearchQuery(e.target.value)
+              </div>
+              <div className="flex items-center justify-center border-t border-border/50 px-3 py-1.5 text-[11px] text-muted-foreground">
+                <span>esc close</span>
+              </div>
+            </>
+          ) : (
+            <>
+              <div className="flex items-center gap-2 border-b border-border/50 px-3 py-2.5">
+                <Search className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                <input
+                  ref={searchInputRef}
+                  type="text"
+                  placeholder="Search clipboard history..."
+                  value={searchQuery}
+                  onChange={e => {
+                    setPreviewSuppressed(false)
+                    setSearchQuery(e.target.value)
+                  }}
+                  className="flex-1 bg-transparent text-[13px] text-foreground outline-none placeholder:text-muted-foreground/60"
+                />
+                {searchQuery && (
+                  <span className="tabular-nums text-[11px] text-muted-foreground">
+                    {filteredItems.length}
+                  </span>
+                )}
+              </div>
+
+              <div
+                className="scrollbar-thin flex-1 overflow-y-auto px-1.5 py-1"
+                onMouseMove={() => {
+                  if (isKeyboardNav) setIsKeyboardNav(false)
                 }}
-                className="flex-1 bg-transparent text-[13px] text-foreground outline-none placeholder:text-muted-foreground/60"
-              />
-              {searchQuery && (
-                <span className="tabular-nums text-[11px] text-muted-foreground">
-                  {filteredItems.length}
+                onMouseLeave={() => setHoveredIndex(null)}
+              >
+                {loading ? (
+                  <div className="flex h-full items-center justify-center text-[13px] text-muted-foreground">
+                    Loading…
+                  </div>
+                ) : filteredItems.length === 0 ? (
+                  <div className="flex h-full items-center justify-center text-[13px] text-muted-foreground">
+                    {searchQuery ? 'No matches' : 'No clipboard history'}
+                  </div>
+                ) : (
+                  filteredItems.map((item, index) => (
+                    <PanelItem
+                      key={item.id}
+                      item={item}
+                      index={index}
+                      isSelected={index === selectedIndex}
+                      hoverDisabled={isKeyboardNav}
+                      onSelect={handleSelect}
+                      onHover={handleHover}
+                      shortcutKey={index < 10 ? (index === 9 ? '0' : String(index + 1)) : undefined}
+                      itemRef={el => {
+                        if (el) {
+                          itemRefs.current.set(index, el)
+                        } else {
+                          itemRefs.current.delete(index)
+                        }
+                      }}
+                    />
+                  ))
+                )}
+              </div>
+
+              <div className="flex items-center justify-between gap-3 border-t border-border/50 px-3 py-1.5 text-[11px] text-muted-foreground">
+                <span className="shrink-0">{isMac ? '⌘' : '⌃'}1-0 paste</span>
+                <span className="min-w-0 flex-1 text-right truncate">
+                  ↑↓ navigate · ⏎ paste · {isMac ? '⌥' : 'Alt+'}⌫ delete · esc close
                 </span>
-              )}
-            </div>
-
-            <div
-              className="scrollbar-thin flex-1 overflow-y-auto px-1.5 py-1"
-              onMouseMove={() => {
-                if (isKeyboardNav) setIsKeyboardNav(false)
-              }}
-              onMouseLeave={() => setHoveredIndex(null)}
-            >
-              {loading ? (
-                <div className="flex h-full items-center justify-center text-[13px] text-muted-foreground">
-                  Loading…
-                </div>
-              ) : filteredItems.length === 0 ? (
-                <div className="flex h-full items-center justify-center text-[13px] text-muted-foreground">
-                  {searchQuery ? 'No matches' : 'No clipboard history'}
-                </div>
-              ) : (
-                filteredItems.map((item, index) => (
-                  <PanelItem
-                    key={item.id}
-                    item={item}
-                    index={index}
-                    isSelected={index === selectedIndex}
-                    hoverDisabled={isKeyboardNav}
-                    onSelect={handleSelect}
-                    onHover={handleHover}
-                    shortcutKey={index < 10 ? (index === 9 ? '0' : String(index + 1)) : undefined}
-                    itemRef={el => {
-                      if (el) {
-                        itemRefs.current.set(index, el)
-                      } else {
-                        itemRefs.current.delete(index)
-                      }
-                    }}
-                  />
-                ))
-              )}
-            </div>
-
-            <div className="flex items-center justify-between border-t border-border/50 px-3 py-1.5 text-[11px] text-muted-foreground">
-              <span>{isMac ? '⌘' : '⌃'}1-0 paste</span>
-              <span>↑↓ navigate · ⏎ paste · {isMac ? '⌥' : 'Alt+'}⌫ delete · esc close</span>
-            </div>
-          </>
-        )}
+              </div>
+            </>
+          )}
+        </div>
       </div>
 
       <div
         className={[
-          'overflow-hidden',
+          'min-w-0 overflow-hidden',
           skipTransition ? '' : 'transition-all duration-200 ease-out',
           previewEntryId !== null
-            ? 'ml-2 w-[360px] opacity-100 translate-x-0'
+            ? 'ml-2 flex-1 basis-0 opacity-100 translate-x-0'
             : 'ml-0 w-0 opacity-0 translate-x-2 pointer-events-none',
         ].join(' ')}
         aria-hidden={previewEntryId === null}

--- a/src/quick-panel/ClipboardHistoryPanel.tsx
+++ b/src/quick-panel/ClipboardHistoryPanel.tsx
@@ -11,7 +11,7 @@ import {
   Search,
   Unlock,
 } from 'lucide-react'
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useReducer, useRef, useState } from 'react'
 import ClipboardPreviewPane from './ClipboardPreviewPane'
 import { deleteClipboardEntry, restoreClipboardEntry } from '@/api/daemon'
 import { unlockEncryptionSession } from '@/api/security'
@@ -116,8 +116,209 @@ const PanelItem: React.FC<PanelItemProps> = React.memo(
   }
 )
 
+interface HistoryPaneProps {
+  filteredItems: DisplayItem[]
+  isKeyboardNav: boolean
+  isLocked: boolean
+  itemRefs: React.MutableRefObject<Map<number, HTMLDivElement>>
+  loading: boolean
+  onHover: (index: number) => void
+  onSearchChange: (value: string) => void
+  onSelect: (index: number) => void
+  onUnlock: () => void
+  searchInputRef: React.RefObject<HTMLInputElement | null>
+  searchQuery: string
+  selectedIndex: number
+  setHoveredIndex: React.Dispatch<React.SetStateAction<number | null>>
+  setIsKeyboardNav: React.Dispatch<React.SetStateAction<boolean>>
+  unlocking: boolean
+  unlockError: string | null
+}
+
+const HistoryPane: React.FC<HistoryPaneProps> = React.memo(
+  ({
+    filteredItems,
+    isKeyboardNav,
+    isLocked,
+    itemRefs,
+    loading,
+    onHover,
+    onSearchChange,
+    onSelect,
+    onUnlock,
+    searchInputRef,
+    searchQuery,
+    selectedIndex,
+    setHoveredIndex,
+    setIsKeyboardNav,
+    unlocking,
+    unlockError,
+  }) => (
+    <div className={quickCardClassName}>
+      {isLocked && !loading ? (
+        <>
+          <div className="flex flex-1 flex-col items-center justify-center gap-4 px-6">
+            <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-muted/30">
+              <Lock className="h-6 w-6 text-muted-foreground" />
+            </div>
+            <div className="space-y-1 text-center">
+              <h2 className="text-sm font-medium text-foreground">Clipboard is locked</h2>
+              <p className="text-[12px] text-muted-foreground">
+                Unlock to access your clipboard history
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={onUnlock}
+              disabled={unlocking}
+              className="flex items-center gap-1.5 rounded-md bg-primary px-4 py-1.5 text-[13px] font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:opacity-50"
+            >
+              {unlocking ? (
+                <>
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                  Unlocking...
+                </>
+              ) : (
+                <>
+                  <Unlock className="h-3.5 w-3.5" />
+                  Unlock
+                </>
+              )}
+            </button>
+            {unlockError && (
+              <p className="max-w-[15rem] text-center text-[12px] text-destructive">
+                {unlockError}
+              </p>
+            )}
+          </div>
+          <div className="flex items-center justify-center border-t border-border/50 px-3 py-1.5 text-[11px] text-muted-foreground">
+            <span>esc close</span>
+          </div>
+        </>
+      ) : (
+        <>
+          <div className="flex items-center gap-2 border-b border-border/50 px-3 py-2.5">
+            <Search className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+            <input
+              ref={searchInputRef}
+              type="text"
+              placeholder="Search clipboard history..."
+              value={searchQuery}
+              onChange={e => onSearchChange(e.target.value)}
+              className="flex-1 bg-transparent text-[13px] text-foreground outline-none placeholder:text-muted-foreground/60"
+            />
+            {searchQuery && (
+              <span className="tabular-nums text-[11px] text-muted-foreground">
+                {filteredItems.length}
+              </span>
+            )}
+          </div>
+
+          <div
+            className="scrollbar-thin flex-1 overflow-y-auto px-1.5 py-1"
+            onMouseMove={() => {
+              if (isKeyboardNav) setIsKeyboardNav(false)
+            }}
+            onMouseLeave={() => setHoveredIndex(null)}
+          >
+            {loading ? (
+              <div className="flex h-full items-center justify-center text-[13px] text-muted-foreground">
+                Loading…
+              </div>
+            ) : filteredItems.length === 0 ? (
+              <div className="flex h-full items-center justify-center text-[13px] text-muted-foreground">
+                {searchQuery ? 'No matches' : 'No clipboard history'}
+              </div>
+            ) : (
+              filteredItems.map((item, index) => (
+                <PanelItem
+                  key={item.id}
+                  item={item}
+                  index={index}
+                  isSelected={index === selectedIndex}
+                  hoverDisabled={isKeyboardNav}
+                  onSelect={onSelect}
+                  onHover={onHover}
+                  shortcutKey={index < 10 ? (index === 9 ? '0' : String(index + 1)) : undefined}
+                  itemRef={el => {
+                    if (el) {
+                      itemRefs.current.set(index, el)
+                    } else {
+                      itemRefs.current.delete(index)
+                    }
+                  }}
+                />
+              ))
+            )}
+          </div>
+
+          <div className="flex items-center justify-between gap-3 border-t border-border/50 px-3 py-1.5 text-[11px] text-muted-foreground">
+            <span className="shrink-0">{isMac ? '⌘' : '⌃'}1-0 paste</span>
+            <span className="min-w-0 flex-1 text-right truncate">
+              ↑↓ navigate · ⏎ paste · {isMac ? '⌥' : 'Alt+'}⌫ delete · esc close
+            </span>
+          </div>
+        </>
+      )}
+    </div>
+  )
+)
+
 const quickCardClassName =
   'flex h-screen w-full min-w-0 flex-col overflow-hidden rounded-xl border border-border/50 bg-background/95 shadow-xl backdrop-blur-xl'
+
+type PreviewMode = 'closed' | 'reserving' | 'expanded'
+
+interface PreviewState {
+  entryId: string | null
+  mode: PreviewMode
+  suppressed: boolean
+  historyLockedWidth: number | null
+}
+
+type PreviewAction =
+  | { type: 'reset'; suppressed?: boolean }
+  | { type: 'suppress'; value: boolean }
+  | { type: 'set-entry'; entryId: string | null }
+  | { type: 'reserve-space'; entryId: string; historyLockedWidth: number | null }
+  | { type: 'expand' }
+
+const initialPreviewState: PreviewState = {
+  entryId: null,
+  mode: 'closed',
+  suppressed: false,
+  historyLockedWidth: null,
+}
+
+function previewReducer(state: PreviewState, action: PreviewAction): PreviewState {
+  switch (action.type) {
+    case 'reset':
+      return {
+        ...initialPreviewState,
+        suppressed: action.suppressed ?? false,
+      }
+    case 'suppress':
+      return state.suppressed === action.value ? state : { ...state, suppressed: action.value }
+    case 'set-entry':
+      return state.entryId === action.entryId ? state : { ...state, entryId: action.entryId }
+    case 'reserve-space':
+      return {
+        entryId: action.entryId,
+        mode: 'reserving',
+        suppressed: false,
+        historyLockedWidth: action.historyLockedWidth,
+      }
+    case 'expand':
+      if (state.mode === 'expanded') {
+        return state
+      }
+      return {
+        ...state,
+        mode: 'expanded',
+        historyLockedWidth: null,
+      }
+  }
+}
 
 const ClipboardHistoryPanel: React.FC = () => {
   useThemeSync()
@@ -129,12 +330,8 @@ const ClipboardHistoryPanel: React.FC = () => {
   const [isKeyboardNav, setIsKeyboardNav] = useState(true)
   const [unlocking, setUnlocking] = useState(false)
   const [unlockError, setUnlockError] = useState<string | null>(null)
-  const [previewEntryId, setPreviewEntryId] = useState<string | null>(null)
-  const [previewExpanded, setPreviewExpanded] = useState(false)
-  const [previewReservingSpace, setPreviewReservingSpace] = useState(false)
-  const [previewSuppressed, setPreviewSuppressed] = useState(false)
   const [uiScale, setUiScale] = useState(() => readStoredUiScale())
-  const [historyLockedWidth, setHistoryLockedWidth] = useState<number | null>(null)
+  const [previewState, dispatchPreview] = useReducer(previewReducer, initialPreviewState)
 
   const searchInputRef = useRef<HTMLInputElement>(null)
   const historyPaneRef = useRef<HTMLDivElement>(null)
@@ -143,6 +340,11 @@ const ClipboardHistoryPanel: React.FC = () => {
   const previewLayoutTokenRef = useRef(0)
   const deletingRef = useRef(false)
   const [skipTransition, setSkipTransition] = useState(false)
+  const previewExpanded = previewState.mode === 'expanded'
+  const previewReservingSpace = previewState.mode === 'reserving'
+  const previewEntryId = previewState.entryId
+  const previewSuppressed = previewState.suppressed
+  const historyLockedWidth = previewState.historyLockedWidth
 
   const clearPreviewTimer = useCallback(() => {
     if (previewTimerRef.current) {
@@ -155,11 +357,7 @@ const ClipboardHistoryPanel: React.FC = () => {
     (suppressUntilNextSelection: boolean) => {
       clearPreviewTimer()
       previewLayoutTokenRef.current += 1
-      setPreviewReservingSpace(false)
-      setPreviewExpanded(false)
-      setPreviewEntryId(null)
-      setHistoryLockedWidth(null)
-      setPreviewSuppressed(suppressUntilNextSelection)
+      dispatchPreview({ type: 'reset', suppressed: suppressUntilNextSelection })
       void setQuickPanelLayout(readStoredUiScale(), false).catch(() => {})
     },
     [clearPreviewTimer]
@@ -175,11 +373,7 @@ const ClipboardHistoryPanel: React.FC = () => {
       setSkipTransition(true)
       clearPreviewTimer()
       previewLayoutTokenRef.current += 1
-      setPreviewReservingSpace(false)
-      setPreviewExpanded(false)
-      setPreviewEntryId(null)
-      setHistoryLockedWidth(null)
-      setPreviewSuppressed(false)
+      dispatchPreview({ type: 'reset' })
       setSearchQuery('')
       setSelectedIndex(0)
       setHoveredIndex(null)
@@ -280,10 +474,7 @@ const ClipboardHistoryPanel: React.FC = () => {
 
     if (!focusedItem) {
       previewLayoutTokenRef.current += 1
-      setPreviewReservingSpace(false)
-      setPreviewExpanded(false)
-      setPreviewEntryId(null)
-      setHistoryLockedWidth(null)
+      dispatchPreview({ type: 'reset' })
       void setQuickPanelLayout(uiScale, false).catch(() => {})
       return
     }
@@ -295,7 +486,7 @@ const ClipboardHistoryPanel: React.FC = () => {
     previewTimerRef.current = setTimeout(
       () => {
         const nextEntryId = focusedItem.id
-        setPreviewEntryId(nextEntryId)
+        dispatchPreview({ type: 'set-entry', entryId: nextEntryId })
 
         if (previewExpanded) {
           return
@@ -304,24 +495,23 @@ const ClipboardHistoryPanel: React.FC = () => {
         const token = previewLayoutTokenRef.current + 1
         const nextHistoryWidth = historyPaneRef.current?.getBoundingClientRect().width ?? 0
         previewLayoutTokenRef.current = token
-        setHistoryLockedWidth(nextHistoryWidth > 0 ? nextHistoryWidth : null)
-        setPreviewReservingSpace(true)
+        dispatchPreview({
+          type: 'reserve-space',
+          entryId: nextEntryId,
+          historyLockedWidth: nextHistoryWidth > 0 ? nextHistoryWidth : null,
+        })
         void setQuickPanelLayout(uiScale, true)
           .then(() => {
             if (previewLayoutTokenRef.current !== token) {
               return
             }
-            setPreviewReservingSpace(false)
-            setPreviewExpanded(true)
-            setHistoryLockedWidth(null)
+            dispatchPreview({ type: 'expand' })
           })
           .catch(() => {
             if (previewLayoutTokenRef.current !== token) {
               return
             }
-            setPreviewReservingSpace(false)
-            setHistoryLockedWidth(null)
-            setPreviewEntryId(null)
+            dispatchPreview({ type: 'reset' })
           })
       },
       previewEntryId ? PREVIEW_SWITCH_DELAY_MS : PREVIEW_OPEN_DELAY_MS
@@ -360,7 +550,7 @@ const ClipboardHistoryPanel: React.FC = () => {
   const handleHover = useCallback(
     (index: number) => {
       if (!isKeyboardNav) {
-        setPreviewSuppressed(false)
+        dispatchPreview({ type: 'suppress', value: false })
         setHoveredIndex(index)
       }
     },
@@ -377,14 +567,14 @@ const ClipboardHistoryPanel: React.FC = () => {
         deletingRef.current = true
         clearPreviewTimer()
         setHoveredIndex(null)
-        setPreviewSuppressed(false)
+        dispatchPreview({ type: 'suppress', value: false })
 
         const remainingItems = filteredItems.filter((_, itemIndex) => itemIndex !== index)
         const nextIndex = remainingItems.length > 0 ? Math.min(index, remainingItems.length - 1) : 0
         const nextItem = remainingItems[nextIndex] ?? null
 
         setSelectedIndex(nextIndex)
-        setPreviewEntryId(nextItem?.id ?? null)
+        dispatchPreview({ type: 'set-entry', entryId: nextItem?.id ?? null })
         void reload()
       } catch (err) {
         console.error('Failed to delete clipboard entry:', err)
@@ -392,6 +582,11 @@ const ClipboardHistoryPanel: React.FC = () => {
     },
     [clearPreviewTimer, filteredItems, reload]
   )
+
+  const handleSearchChange = useCallback((value: string) => {
+    dispatchPreview({ type: 'suppress', value: false })
+    setSearchQuery(value)
+  }, [])
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -423,7 +618,7 @@ const ClipboardHistoryPanel: React.FC = () => {
 
       if (e.ctrlKey && (e.key === 'n' || e.key === 'p')) {
         e.preventDefault()
-        setPreviewSuppressed(false)
+        dispatchPreview({ type: 'suppress', value: false })
         setIsKeyboardNav(true)
         setHoveredIndex(null)
         if (e.key === 'n') {
@@ -437,14 +632,14 @@ const ClipboardHistoryPanel: React.FC = () => {
       switch (e.key) {
         case 'ArrowDown':
           e.preventDefault()
-          setPreviewSuppressed(false)
+          dispatchPreview({ type: 'suppress', value: false })
           setIsKeyboardNav(true)
           setHoveredIndex(null)
           setSelectedIndex(prev => Math.min(prev + 1, filteredItems.length - 1))
           break
         case 'ArrowUp':
           e.preventDefault()
-          setPreviewSuppressed(false)
+          dispatchPreview({ type: 'suppress', value: false })
           setIsKeyboardNav(true)
           setHoveredIndex(null)
           setSelectedIndex(prev => Math.max(prev - 1, 0))
@@ -492,116 +687,24 @@ const ClipboardHistoryPanel: React.FC = () => {
             : undefined
         }
       >
-        <div className={quickCardClassName}>
-          {isLocked && !loading ? (
-            <>
-              <div className="flex flex-1 flex-col items-center justify-center gap-4 px-6">
-                <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-muted/30">
-                  <Lock className="h-6 w-6 text-muted-foreground" />
-                </div>
-                <div className="space-y-1 text-center">
-                  <h2 className="text-sm font-medium text-foreground">Clipboard is locked</h2>
-                  <p className="text-[12px] text-muted-foreground">
-                    Unlock to access your clipboard history
-                  </p>
-                </div>
-                <button
-                  type="button"
-                  onClick={handleUnlock}
-                  disabled={unlocking}
-                  className="flex items-center gap-1.5 rounded-md bg-primary px-4 py-1.5 text-[13px] font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:opacity-50"
-                >
-                  {unlocking ? (
-                    <>
-                      <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                      Unlocking...
-                    </>
-                  ) : (
-                    <>
-                      <Unlock className="h-3.5 w-3.5" />
-                      Unlock
-                    </>
-                  )}
-                </button>
-                {unlockError && (
-                  <p className="max-w-[15rem] text-center text-[12px] text-destructive">
-                    {unlockError}
-                  </p>
-                )}
-              </div>
-              <div className="flex items-center justify-center border-t border-border/50 px-3 py-1.5 text-[11px] text-muted-foreground">
-                <span>esc close</span>
-              </div>
-            </>
-          ) : (
-            <>
-              <div className="flex items-center gap-2 border-b border-border/50 px-3 py-2.5">
-                <Search className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-                <input
-                  ref={searchInputRef}
-                  type="text"
-                  placeholder="Search clipboard history..."
-                  value={searchQuery}
-                  onChange={e => {
-                    setPreviewSuppressed(false)
-                    setSearchQuery(e.target.value)
-                  }}
-                  className="flex-1 bg-transparent text-[13px] text-foreground outline-none placeholder:text-muted-foreground/60"
-                />
-                {searchQuery && (
-                  <span className="tabular-nums text-[11px] text-muted-foreground">
-                    {filteredItems.length}
-                  </span>
-                )}
-              </div>
-
-              <div
-                className="scrollbar-thin flex-1 overflow-y-auto px-1.5 py-1"
-                onMouseMove={() => {
-                  if (isKeyboardNav) setIsKeyboardNav(false)
-                }}
-                onMouseLeave={() => setHoveredIndex(null)}
-              >
-                {loading ? (
-                  <div className="flex h-full items-center justify-center text-[13px] text-muted-foreground">
-                    Loading…
-                  </div>
-                ) : filteredItems.length === 0 ? (
-                  <div className="flex h-full items-center justify-center text-[13px] text-muted-foreground">
-                    {searchQuery ? 'No matches' : 'No clipboard history'}
-                  </div>
-                ) : (
-                  filteredItems.map((item, index) => (
-                    <PanelItem
-                      key={item.id}
-                      item={item}
-                      index={index}
-                      isSelected={index === selectedIndex}
-                      hoverDisabled={isKeyboardNav}
-                      onSelect={handleSelect}
-                      onHover={handleHover}
-                      shortcutKey={index < 10 ? (index === 9 ? '0' : String(index + 1)) : undefined}
-                      itemRef={el => {
-                        if (el) {
-                          itemRefs.current.set(index, el)
-                        } else {
-                          itemRefs.current.delete(index)
-                        }
-                      }}
-                    />
-                  ))
-                )}
-              </div>
-
-              <div className="flex items-center justify-between gap-3 border-t border-border/50 px-3 py-1.5 text-[11px] text-muted-foreground">
-                <span className="shrink-0">{isMac ? '⌘' : '⌃'}1-0 paste</span>
-                <span className="min-w-0 flex-1 text-right truncate">
-                  ↑↓ navigate · ⏎ paste · {isMac ? '⌥' : 'Alt+'}⌫ delete · esc close
-                </span>
-              </div>
-            </>
-          )}
-        </div>
+        <HistoryPane
+          filteredItems={filteredItems}
+          isKeyboardNav={isKeyboardNav}
+          isLocked={isLocked}
+          itemRefs={itemRefs}
+          loading={loading}
+          onHover={handleHover}
+          onSearchChange={handleSearchChange}
+          onSelect={handleSelect}
+          onUnlock={handleUnlock}
+          searchInputRef={searchInputRef}
+          searchQuery={searchQuery}
+          selectedIndex={selectedIndex}
+          setHoveredIndex={setHoveredIndex}
+          setIsKeyboardNav={setIsKeyboardNav}
+          unlocking={unlocking}
+          unlockError={unlockError}
+        />
       </div>
 
       <div

--- a/src/quick-panel/ClipboardHistoryPanel.tsx
+++ b/src/quick-panel/ClipboardHistoryPanel.tsx
@@ -19,6 +19,7 @@ import { useClipboardCollection } from '@/hooks/useClipboardCollection'
 import { useThemeSync } from '@/hooks/useThemeSync'
 import { formatRelativeTime, getItemPreview, resolveItemType } from '@/lib/clipboard-utils'
 import type { ItemType } from '@/lib/clipboard-utils'
+import { readStoredUiScale, subscribeUiScaleChanges } from '@/lib/ui-scale'
 
 const PREVIEW_OPEN_DELAY_MS = 500
 const PREVIEW_SWITCH_DELAY_MS = 120
@@ -47,8 +48,8 @@ async function pasteToApp(): Promise<void> {
   await invoke('paste_to_previous_app')
 }
 
-async function setPreviewExpanded(expanded: boolean): Promise<void> {
-  await invoke('set_quick_panel_preview_expanded', { expanded })
+async function setQuickPanelLayout(scale: number, previewExpanded: boolean): Promise<void> {
+  await invoke('set_quick_panel_layout', { scale, previewExpanded })
 }
 
 const isMac = navigator.platform.toUpperCase().includes('MAC')
@@ -130,6 +131,7 @@ const ClipboardHistoryPanel: React.FC = () => {
   const [unlockError, setUnlockError] = useState<string | null>(null)
   const [previewEntryId, setPreviewEntryId] = useState<string | null>(null)
   const [previewSuppressed, setPreviewSuppressed] = useState(false)
+  const [uiScale, setUiScale] = useState(() => readStoredUiScale())
 
   const searchInputRef = useRef<HTMLInputElement>(null)
   const itemRefs = useRef<Map<number, HTMLDivElement>>(new Map())
@@ -174,7 +176,8 @@ const ClipboardHistoryPanel: React.FC = () => {
       //    Use setTimeout (not rAF — rAF doesn't fire while hidden).
       setTimeout(() => {
         setSkipTransition(false)
-        void invoke('finalize_quick_panel_show')
+        void setQuickPanelLayout(readStoredUiScale(), false)
+          .then(() => invoke('finalize_quick_panel_show'))
           .then(() => {
             searchInputRef.current?.focus()
           })
@@ -189,8 +192,14 @@ const ClipboardHistoryPanel: React.FC = () => {
   }, [clearPreviewTimer, reload])
 
   useEffect(() => {
-    void setPreviewExpanded(Boolean(previewEntryId)).catch(() => {})
-  }, [previewEntryId])
+    void setQuickPanelLayout(uiScale, Boolean(previewEntryId)).catch(() => {})
+  }, [previewEntryId, uiScale])
+
+  useEffect(() => {
+    return subscribeUiScaleChanges(scale => {
+      setUiScale(scale)
+    })
+  }, [])
 
   const handleUnlock = useCallback(async () => {
     setUnlocking(true)

--- a/src/quick-panel/ClipboardPreviewPane.tsx
+++ b/src/quick-panel/ClipboardPreviewPane.tsx
@@ -25,11 +25,11 @@ const ClipboardPreviewPane: React.FC<ClipboardPreviewPaneProps> = ({ entryId }) 
     preview.textContent.length > 50_000
 
   return (
-    <div className="flex h-screen w-[360px] min-w-[360px] max-w-[360px] flex-col overflow-hidden rounded-xl border border-border/50 bg-background/95 shadow-xl backdrop-blur-xl">
+    <div className="flex h-screen w-full min-w-0 flex-col overflow-hidden rounded-xl border border-border/50 bg-background/95 shadow-xl backdrop-blur-xl">
       <div className="flex items-center justify-between border-b border-border/50 px-3 py-2">
         <span className="text-[12px] font-medium text-foreground">{t('title')}</span>
         {preview && (
-          <span className="text-[11px] tabular-nums text-muted-foreground">
+          <span className="shrink-0 text-[11px] tabular-nums text-muted-foreground">
             {formatBytes(preview.sizeBytes)}
           </span>
         )}

--- a/src/quick-panel/__tests__/ClipboardHistoryPanel.single-window.test.tsx
+++ b/src/quick-panel/__tests__/ClipboardHistoryPanel.single-window.test.tsx
@@ -79,6 +79,11 @@ vi.mock('@/api/daemon/client', () => ({
   },
 }))
 
+vi.mock('../ClipboardPreviewPane', () => ({
+  default: ({ entryId }: { entryId: string | null }) =>
+    entryId ? <div>Full preview text</div> : <div data-testid="preview-empty" />,
+}))
+
 describe('ClipboardHistoryPanel single-window preview', () => {
   beforeEach(() => {
     vi.useRealTimers()
@@ -97,8 +102,9 @@ describe('ClipboardHistoryPanel single-window preview', () => {
     expect(await screen.findByText('Full preview text')).toBeInTheDocument()
 
     await waitFor(() => {
-      expect(invokeMock).toHaveBeenCalledWith('set_quick_panel_preview_expanded', {
-        expanded: true,
+      expect(invokeMock).toHaveBeenCalledWith('set_quick_panel_layout', {
+        scale: 1,
+        previewExpanded: true,
       })
     })
     expect(invokeMock).not.toHaveBeenCalledWith('show_preview_panel', expect.anything())
@@ -120,8 +126,9 @@ describe('ClipboardHistoryPanel single-window preview', () => {
     await waitFor(() => {
       expect(invokeMock).toHaveBeenCalledWith('dismiss_quick_panel')
     })
-    expect(invokeMock).not.toHaveBeenCalledWith('set_quick_panel_preview_expanded', {
-      expanded: false,
+    expect(invokeMock).not.toHaveBeenCalledWith('set_quick_panel_layout', {
+      scale: 1,
+      previewExpanded: false,
     })
   })
 })

--- a/src/quick-panel/__tests__/ClipboardHistoryPanel.single-window.test.tsx
+++ b/src/quick-panel/__tests__/ClipboardHistoryPanel.single-window.test.tsx
@@ -128,6 +128,8 @@ describe('ClipboardHistoryPanel single-window preview', () => {
 
     expect(previewWrapper?.className).toContain('basis-0')
     expect(previewWrapper?.className).toContain('flex-1')
+    expect(previewWrapper?.className).not.toContain('transition-all')
+    expect(previewWrapper?.firstElementChild?.className).toContain('transition-[opacity,transform]')
   })
 
   it('dismisses the quick window immediately when escape is pressed with preview open', async () => {

--- a/src/quick-panel/__tests__/ClipboardHistoryPanel.single-window.test.tsx
+++ b/src/quick-panel/__tests__/ClipboardHistoryPanel.single-window.test.tsx
@@ -152,16 +152,30 @@ describe('ClipboardHistoryPanel single-window preview', () => {
     })
 
     const { container } = render(<ClipboardHistoryPanel />)
+    const rootLayout = container.firstElementChild as HTMLDivElement | null
+    const historyWrapper = rootLayout?.children.item(0) as HTMLDivElement | null
+    historyWrapper!.getBoundingClientRect = vi.fn(() => ({
+      width: 360,
+      height: 420,
+      top: 0,
+      right: 360,
+      bottom: 420,
+      left: 0,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    }))
 
     await act(async () => {
       await new Promise(resolve => setTimeout(resolve, 550))
     })
 
-    const rootLayout = container.firstElementChild as HTMLDivElement | null
     const previewWrapper = rootLayout?.children.item(1) as HTMLDivElement | null
 
     expect(previewWrapper?.getAttribute('aria-hidden')).toBe('true')
-    expect(previewWrapper?.className).not.toContain('flex-1')
+    expect(historyWrapper?.className).toContain('shrink-0')
+    expect(historyWrapper?.style.width).toBe('360px')
+    expect(previewWrapper?.className).toContain('shrink-0')
 
     await act(async () => {
       pendingResize.resolve()
@@ -169,7 +183,10 @@ describe('ClipboardHistoryPanel single-window preview', () => {
     })
 
     expect(previewWrapper?.getAttribute('aria-hidden')).toBe('false')
+    expect(historyWrapper?.className).toContain('flex-1')
+    expect(historyWrapper?.style.width).toBe('')
     expect(previewWrapper?.className).toContain('flex-1')
+    expect(previewWrapper?.style.width).toBe('')
   })
 
   it('dismisses the quick window immediately when escape is pressed with preview open', async () => {

--- a/src/quick-panel/__tests__/ClipboardHistoryPanel.single-window.test.tsx
+++ b/src/quick-panel/__tests__/ClipboardHistoryPanel.single-window.test.tsx
@@ -84,6 +84,16 @@ vi.mock('../ClipboardPreviewPane', () => ({
     entryId ? <div>Full preview text</div> : <div data-testid="preview-empty" />,
 }))
 
+function deferred() {
+  let resolve!: () => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<void>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
 describe('ClipboardHistoryPanel single-window preview', () => {
   beforeEach(() => {
     vi.useRealTimers()
@@ -130,6 +140,36 @@ describe('ClipboardHistoryPanel single-window preview', () => {
     expect(previewWrapper?.className).toContain('flex-1')
     expect(previewWrapper?.className).not.toContain('transition-all')
     expect(previewWrapper?.firstElementChild?.className).toContain('transition-[opacity,transform]')
+  })
+
+  it('waits for the backend layout resize before expanding the preview column', async () => {
+    const pendingResize = deferred()
+    invokeMock.mockImplementation((command: string, payload?: { previewExpanded?: boolean }) => {
+      if (command === 'set_quick_panel_layout' && payload?.previewExpanded) {
+        return pendingResize.promise
+      }
+      return Promise.resolve(undefined)
+    })
+
+    const { container } = render(<ClipboardHistoryPanel />)
+
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 550))
+    })
+
+    const rootLayout = container.firstElementChild as HTMLDivElement | null
+    const previewWrapper = rootLayout?.children.item(1) as HTMLDivElement | null
+
+    expect(previewWrapper?.getAttribute('aria-hidden')).toBe('true')
+    expect(previewWrapper?.className).not.toContain('flex-1')
+
+    await act(async () => {
+      pendingResize.resolve()
+      await Promise.resolve()
+    })
+
+    expect(previewWrapper?.getAttribute('aria-hidden')).toBe('false')
+    expect(previewWrapper?.className).toContain('flex-1')
   })
 
   it('dismisses the quick window immediately when escape is pressed with preview open', async () => {

--- a/src/quick-panel/__tests__/ClipboardHistoryPanel.single-window.test.tsx
+++ b/src/quick-panel/__tests__/ClipboardHistoryPanel.single-window.test.tsx
@@ -110,6 +110,26 @@ describe('ClipboardHistoryPanel single-window preview', () => {
     expect(invokeMock).not.toHaveBeenCalledWith('show_preview_panel', expect.anything())
   })
 
+  it('keeps history and preview panes flexible when the inline preview opens', async () => {
+    const { container } = render(<ClipboardHistoryPanel />)
+
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 550))
+    })
+
+    expect(await screen.findByText('Full preview text')).toBeInTheDocument()
+
+    const rootLayout = container.firstElementChild as HTMLDivElement | null
+    const historyWrapper = rootLayout?.children.item(0) as HTMLDivElement | null
+    const previewWrapper = rootLayout?.children.item(1) as HTMLDivElement | null
+
+    expect(historyWrapper?.className).toContain('basis-0')
+    expect(historyWrapper?.className).toContain('min-w-0')
+
+    expect(previewWrapper?.className).toContain('basis-0')
+    expect(previewWrapper?.className).toContain('flex-1')
+  })
+
   it('dismisses the quick window immediately when escape is pressed with preview open', async () => {
     render(<ClipboardHistoryPanel />)
 

--- a/src/quick-panel/main.tsx
+++ b/src/quick-panel/main.tsx
@@ -2,10 +2,10 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import QuickPanelApp from './QuickPanelApp'
 import '@/i18n'
-import { initializeUiScale } from '@/lib/ui-scale'
+import { initializeWindowUi } from '@/lib/window-ui'
 import '@/styles/globals.css'
 
-initializeUiScale()
+initializeWindowUi()
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>


### PR DESCRIPTION
## Summary
- sync quick panel window sizing with UI scale and apply the same Windows typography initialization as the main window
- keep history and preview panes balanced at 50/50 in inline preview mode and remove layout-driven resize animation
- anchor preview expansion to the history pane and reserve preview space during backend resize so the panel does not recenter or flash

## Testing
- npx vitest run src/quick-panel/__tests__/ClipboardHistoryPanel.single-window.test.tsx src/quick-panel/__tests__/QuickPanelApp.test.tsx src/lib/__tests__/ui-scale.test.ts
- cargo test -p uc-tauri quick_panel
- cargo fmt --all --check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Quick panel now remembers its on-screen position and preserves it across repositioning.
  * Panel layout responds to UI scale changes so size and spacing adjust automatically.
  * Inline preview uses smoother animations and a three-stage reveal to reduce layout shift.

* **Improvements**
  * History and preview columns are more responsive and adapt their widths to available space.
  * Windows typography scaling is applied at startup for improved text sizing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->