### PR TITLE
Feat/windows borderless main window

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -30,6 +30,21 @@ use uc_tauri::quick_panel;
 const DAEMON_EXIT_CLEANUP_TIMEOUT: Duration = Duration::from_secs(3);
 const DAEMON_EXIT_CLEANUP_POLL_INTERVAL: Duration = Duration::from_millis(100);
 
+#[cfg(target_os = "windows")]
+fn configure_main_window_for_platform(app: &tauri::AppHandle) {
+    let Some(window) = app.get_webview_window("main") else {
+        warn!("Main window not found during Windows window configuration");
+        return;
+    };
+
+    if let Err(error) = window.set_decorations(false) {
+        warn!(error = %error, "Failed to disable Windows main window decorations");
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+fn configure_main_window_for_platform(_app: &tauri::AppHandle) {}
+
 fn main() {
     // Tracing and config are handled inside build_gui_app()
     let ctx = match uc_bootstrap::build_gui_app() {
@@ -147,6 +162,7 @@ fn run_app(ctx: GuiBootstrapContext) {
             // In Tauri 2, use app.handle() to get the AppHandle
             runtime.set_app_handle(app.handle().clone());
             info!("AppHandle set on AppRuntime for event emission");
+            configure_main_window_for_platform(app.handle());
 
             let daemon_connection_state_for_setup = daemon_connection_state.clone();
             let gui_owned_daemon_state_for_setup = gui_owned_daemon_state.clone();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -289,8 +289,8 @@ export const AppContentWithBar = () => {
   // WindowShell provides the correct window-level structure:
   // - TitleBar: Window chrome layer (full-width, drag region)
   // - Content: App layout layer (Sidebar + Main via routes)
-  const { isMac, isTauri } = usePlatform()
-  const showCustomTitleBar = !isTauri || isMac
+  const { isMac, isTauri, isWindows } = usePlatform()
+  const showCustomTitleBar = !isTauri || isMac || isWindows
   const { hydrated, setupState } = useSetupRealtimeStore()
   const [showCompletionStep, setShowCompletionStep] = useState(false)
   const previousSetupStateRef = useRef<SetupState | null>(null)

--- a/src/components/TitleBar.tsx
+++ b/src/components/TitleBar.tsx
@@ -154,7 +154,8 @@ export const TitleBar = ({
         // Window chrome layer - sits in normal document flow (not fixed)
         // No z-index needed - proper layering via DOM hierarchy
         'h-10 w-full flex-shrink-0 select-none',
-        'bg-background/70 backdrop-blur border-b border-border/60',
+        'relative z-20 bg-background/42 backdrop-blur-xl',
+        'after:pointer-events-none after:absolute after:inset-x-0 after:bottom-0 after:h-px after:bg-gradient-to-r after:from-transparent after:via-border/35 after:to-transparent',
         className
       )}
     >
@@ -170,7 +171,7 @@ export const TitleBar = ({
             // On macOS, add left padding to avoid traffic lights
             // On other platforms, use default padding
             isMac
-              ? `pl-16`
+              ? 'pl-16'
               : 'px-3' /* MVP: justify-center removed - restore with: , isDashboardPage ? 'justify-center' : '' */
           )}
         >
@@ -228,7 +229,10 @@ export const TitleBar = ({
           ) : null}
         </div>
         {isWindows && (
-          <div className="flex items-center h-full" data-tauri-drag-region="false">
+          <div
+            className="flex items-center h-full rounded-bl-2xl bg-background/18 backdrop-blur-sm"
+            data-tauri-drag-region="false"
+          >
             <TitleBarButton aria-label="最小化" onClick={handleMinimize}>
               <Minus className="h-4 w-4" />
             </TitleBarButton>

--- a/src/components/TitleBar.tsx
+++ b/src/components/TitleBar.tsx
@@ -154,8 +154,7 @@ export const TitleBar = ({
         // Window chrome layer - sits in normal document flow (not fixed)
         // No z-index needed - proper layering via DOM hierarchy
         'h-10 w-full flex-shrink-0 select-none',
-        'relative z-20 bg-muted/40 backdrop-blur-xl',
-        'after:pointer-events-none after:absolute after:inset-x-0 after:bottom-0 after:h-px after:bg-gradient-to-r after:from-transparent after:via-border/35 after:to-transparent',
+        'relative z-20 bg-transparent',
         className
       )}
     >
@@ -230,7 +229,7 @@ export const TitleBar = ({
         </div>
         {isWindows && (
           <div
-            className="flex items-center h-full rounded-bl-2xl bg-background/18 backdrop-blur-sm"
+            className="flex items-center h-full rounded-bl-2xl bg-black/4 dark:bg-white/4"
             data-tauri-drag-region="false"
           >
             <TitleBarButton aria-label="最小化" onClick={handleMinimize}>

--- a/src/components/TitleBar.tsx
+++ b/src/components/TitleBar.tsx
@@ -228,10 +228,7 @@ export const TitleBar = ({
           ) : null}
         </div>
         {isWindows && (
-          <div
-            className="flex items-center h-full rounded-bl-2xl bg-black/4 dark:bg-white/4"
-            data-tauri-drag-region="false"
-          >
+          <div className="flex items-center h-full bg-transparent" data-tauri-drag-region="false">
             <TitleBarButton aria-label="最小化" onClick={handleMinimize}>
               <Minus className="h-4 w-4" />
             </TitleBarButton>

--- a/src/components/TitleBar.tsx
+++ b/src/components/TitleBar.tsx
@@ -159,9 +159,15 @@ export const TitleBar = ({
         className
       )}
     >
+      {isWindows ? (
+        <div
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-y-0 left-0 z-0 w-14 border-r border-border/40 bg-muted/40 backdrop-blur-xl"
+        />
+      ) : null}
       <div
         data-tauri-drag-region
-        className="h-full flex items-center justify-between cursor-default"
+        className="relative z-10 h-full flex items-center justify-between cursor-default"
       >
         <div
           data-tauri-drag-region

--- a/src/components/TitleBar.tsx
+++ b/src/components/TitleBar.tsx
@@ -154,17 +154,11 @@ export const TitleBar = ({
         // Window chrome layer - sits in normal document flow (not fixed)
         // No z-index needed - proper layering via DOM hierarchy
         'h-10 w-full flex-shrink-0 select-none',
-        'relative z-20 bg-background/42 backdrop-blur-xl',
+        'relative z-20 bg-muted/40 backdrop-blur-xl',
         'after:pointer-events-none after:absolute after:inset-x-0 after:bottom-0 after:h-px after:bg-gradient-to-r after:from-transparent after:via-border/35 after:to-transparent',
         className
       )}
     >
-      {isWindows ? (
-        <div
-          aria-hidden="true"
-          className="pointer-events-none absolute inset-y-0 left-0 z-0 w-14 border-r border-border/40 bg-muted/40 backdrop-blur-xl"
-        />
-      ) : null}
       <div
         data-tauri-drag-region
         className="relative z-10 h-full flex items-center justify-between cursor-default"

--- a/src/components/clipboard/ClipboardContent.tsx
+++ b/src/components/clipboard/ClipboardContent.tsx
@@ -441,14 +441,14 @@ const ClipboardContent: React.FC<ClipboardContentProps> = ({
           orientation="horizontal"
           defaultLayout={defaultLayout}
           onLayoutChanged={onLayoutChanged}
-          className={cn('flex-1 min-h-0', isWindows && 'overflow-hidden rounded-tl-[22px]')}
+          className="flex-1 min-h-0"
         >
           {/* Left panel: item list */}
           <ResizablePanel id="clipboard-list" defaultSize="40%" minSize="25%" maxSize="60%">
             <div
               className={cn(
                 'h-full overflow-y-auto overflow-x-hidden no-scrollbar',
-                isWindows ? 'rounded-tl-[22px] bg-background/36' : 'bg-muted/20'
+                isWindows ? 'bg-transparent' : 'bg-muted/20'
               )}
               onScroll={handleScroll}
             >

--- a/src/components/clipboard/ClipboardContent.tsx
+++ b/src/components/clipboard/ClipboardContent.tsx
@@ -441,7 +441,7 @@ const ClipboardContent: React.FC<ClipboardContentProps> = ({
           orientation="horizontal"
           defaultLayout={defaultLayout}
           onLayoutChanged={onLayoutChanged}
-          className={cn('flex-1 min-h-0', isWindows && 'overflow-hidden rounded-tl-[22px]')}
+          className={cn('flex-1 min-h-0', isWindows && 'overflow-hidden')}
         >
           {/* Left panel: item list */}
           <ResizablePanel id="clipboard-list" defaultSize="40%" minSize="25%" maxSize="60%">

--- a/src/components/clipboard/ClipboardContent.tsx
+++ b/src/components/clipboard/ClipboardContent.tsx
@@ -441,14 +441,14 @@ const ClipboardContent: React.FC<ClipboardContentProps> = ({
           orientation="horizontal"
           defaultLayout={defaultLayout}
           onLayoutChanged={onLayoutChanged}
-          className="flex-1 min-h-0"
+          className={cn('flex-1 min-h-0', isWindows && 'overflow-hidden rounded-tl-[22px]')}
         >
           {/* Left panel: item list */}
           <ResizablePanel id="clipboard-list" defaultSize="40%" minSize="25%" maxSize="60%">
             <div
               className={cn(
                 'h-full overflow-y-auto overflow-x-hidden no-scrollbar',
-                isWindows ? 'bg-transparent' : 'bg-muted/20'
+                isWindows ? 'rounded-tl-[22px] bg-background/36' : 'bg-muted/20'
               )}
               onScroll={handleScroll}
             >

--- a/src/components/clipboard/ClipboardContent.tsx
+++ b/src/components/clipboard/ClipboardContent.tsx
@@ -23,8 +23,10 @@ import {
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from '@/components/ui/resizable'
 import { toast } from '@/components/ui/toast'
 import { useFileSyncNotifications } from '@/hooks/useFileSyncNotifications'
+import { usePlatform } from '@/hooks/usePlatform'
 import { useShortcut } from '@/hooks/useShortcut'
 import { useTransferProgress } from '@/hooks/useTransferProgress'
+import { cn } from '@/lib/utils'
 import { captureUserIntent } from '@/observability/breadcrumbs'
 import { useAppDispatch, useAppSelector } from '@/store/hooks'
 import { removeClipboardItem, copyToClipboard, markEntryStale } from '@/store/slices/clipboardSlice'
@@ -95,6 +97,7 @@ const ClipboardContent: React.FC<ClipboardContentProps> = ({
   onLoadMore,
 }) => {
   const { t } = useTranslation()
+  const { isWindows } = usePlatform()
 
   // Activate transfer progress event listener
   useTransferProgress()
@@ -438,12 +441,15 @@ const ClipboardContent: React.FC<ClipboardContentProps> = ({
           orientation="horizontal"
           defaultLayout={defaultLayout}
           onLayoutChanged={onLayoutChanged}
-          className="flex-1 min-h-0"
+          className={cn('flex-1 min-h-0', isWindows && 'overflow-hidden rounded-tl-[22px]')}
         >
           {/* Left panel: item list */}
           <ResizablePanel id="clipboard-list" defaultSize="40%" minSize="25%" maxSize="60%">
             <div
-              className="h-full bg-muted/20 overflow-y-auto overflow-x-hidden no-scrollbar"
+              className={cn(
+                'h-full overflow-y-auto overflow-x-hidden no-scrollbar',
+                isWindows ? 'rounded-tl-[22px] bg-background/36' : 'bg-muted/20'
+              )}
               onScroll={handleScroll}
             >
               <div className="p-3 flex flex-col gap-0.5">

--- a/src/components/clipboard/ClipboardContent.tsx
+++ b/src/components/clipboard/ClipboardContent.tsx
@@ -448,7 +448,7 @@ const ClipboardContent: React.FC<ClipboardContentProps> = ({
             <div
               className={cn(
                 'h-full overflow-y-auto overflow-x-hidden no-scrollbar',
-                isWindows ? 'rounded-tl-[22px] bg-background/36' : 'bg-muted/20'
+                isWindows ? 'bg-transparent' : 'bg-muted/20'
               )}
               onScroll={handleScroll}
             >

--- a/src/components/layout/InsetSurface.tsx
+++ b/src/components/layout/InsetSurface.tsx
@@ -1,0 +1,36 @@
+import React from 'react'
+import { usePlatform } from '@/hooks/usePlatform'
+import { cn } from '@/lib/utils'
+
+type InsetSurfaceProps = React.HTMLAttributes<HTMLDivElement>
+
+const InsetSurface: React.FC<InsetSurfaceProps> = ({ className, children, ...props }) => {
+  const { isWindows } = usePlatform()
+
+  return (
+    <div
+      className={cn(
+        'relative flex min-h-0 flex-1 flex-col overflow-hidden',
+        isWindows && 'rounded-tl-[22px] bg-background/92 backdrop-blur-sm',
+        className
+      )}
+      {...props}
+    >
+      {isWindows && (
+        <>
+          <div
+            aria-hidden="true"
+            className="pointer-events-none absolute inset-0 rounded-tl-[22px] ring-1 ring-white/12 ring-inset dark:ring-white/10"
+          />
+          <div
+            aria-hidden="true"
+            className="pointer-events-none absolute inset-x-0 top-0 h-12 rounded-tl-[22px] bg-gradient-to-b from-white/10 to-transparent dark:from-white/6"
+          />
+        </>
+      )}
+      <div className="relative z-10 flex min-h-0 flex-1 flex-col">{children}</div>
+    </div>
+  )
+}
+
+export default InsetSurface

--- a/src/components/layout/InsetSurface.tsx
+++ b/src/components/layout/InsetSurface.tsx
@@ -17,16 +17,10 @@ const InsetSurface: React.FC<InsetSurfaceProps> = ({ className, children, ...pro
       {...props}
     >
       {isWindows && (
-        <>
-          <div
-            aria-hidden="true"
-            className="pointer-events-none absolute inset-0 rounded-tl-[22px] ring-1 ring-white/12 ring-inset dark:ring-white/10"
-          />
-          <div
-            aria-hidden="true"
-            className="pointer-events-none absolute inset-x-0 top-0 h-12 rounded-tl-[22px] bg-gradient-to-b from-white/10 to-transparent dark:from-white/6"
-          />
-        </>
+        <div
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-0 rounded-tl-[22px] ring-1 ring-white/12 ring-inset dark:ring-white/10"
+        />
       )}
       <div className="relative z-10 flex min-h-0 flex-1 flex-col">{children}</div>
     </div>

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -132,15 +132,10 @@ const Sidebar: React.FC<SidebarProps> = ({ className }) => {
         data-tauri-drag-region
         className={cn(
           'relative z-10 w-14 h-full shrink-0 flex flex-col items-center py-4',
-          'bg-[linear-gradient(180deg,color-mix(in_oklab,var(--sidebar)_88%,transparent),color-mix(in_oklab,var(--sidebar)_76%,transparent))]',
-          'border-r border-border/25 backdrop-blur-2xl shadow-[inset_-1px_0_0_rgba(255,255,255,0.12)]',
+          'bg-muted/40 border-r border-border/40 backdrop-blur-xl',
           className
         )}
       >
-        <div
-          aria-hidden="true"
-          className="pointer-events-none absolute inset-x-0 top-0 h-24 bg-[radial-gradient(circle_at_top,rgba(255,255,255,0.18),transparent_72%)] dark:bg-[radial-gradient(circle_at_top,rgba(255,255,255,0.08),transparent_72%)]"
-        />
         {/* Main Navigation */}
         <div className="relative z-10 flex flex-col gap-3 w-full items-center">
           {navItems.map(item => (

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -132,7 +132,7 @@ const Sidebar: React.FC<SidebarProps> = ({ className }) => {
         data-tauri-drag-region
         className={cn(
           'relative z-10 w-14 h-full shrink-0 flex flex-col items-center py-4',
-          'bg-muted/40 backdrop-blur-xl',
+          'bg-transparent',
           className
         )}
       >

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -90,7 +90,11 @@ const NavButton: React.FC<{
   )
 }
 
-const Sidebar: React.FC = () => {
+interface SidebarProps {
+  className?: string
+}
+
+const Sidebar: React.FC<SidebarProps> = ({ className }) => {
   const { t } = useTranslation()
   const location = useLocation()
   const navigate = useNavigate()
@@ -127,11 +131,18 @@ const Sidebar: React.FC = () => {
       <aside
         data-tauri-drag-region
         className={cn(
-          'w-14 h-full flex flex-col items-center py-4 bg-muted/40 border-r border-border/40 backdrop-blur-xl shrink-0'
+          'relative z-10 w-14 h-full shrink-0 flex flex-col items-center py-4',
+          'bg-[linear-gradient(180deg,color-mix(in_oklab,var(--sidebar)_88%,transparent),color-mix(in_oklab,var(--sidebar)_76%,transparent))]',
+          'border-r border-border/25 backdrop-blur-2xl shadow-[inset_-1px_0_0_rgba(255,255,255,0.12)]',
+          className
         )}
       >
+        <div
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-x-0 top-0 h-24 bg-[radial-gradient(circle_at_top,rgba(255,255,255,0.18),transparent_72%)] dark:bg-[radial-gradient(circle_at_top,rgba(255,255,255,0.08),transparent_72%)]"
+        />
         {/* Main Navigation */}
-        <div className="flex flex-col gap-3 w-full items-center">
+        <div className="relative z-10 flex flex-col gap-3 w-full items-center">
           {navItems.map(item => (
             <NavButton
               key={item.to}
@@ -147,7 +158,7 @@ const Sidebar: React.FC = () => {
         <div data-tauri-drag-region className="flex-1 w-full min-h-0" />
 
         {/* Bottom Navigation */}
-        <div className="flex flex-col gap-3 w-full items-center">
+        <div className="relative z-10 flex flex-col gap-3 w-full items-center">
           {updateInfo && (
             <TooltipProvider delayDuration={0}>
               <Tooltip>

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -132,7 +132,7 @@ const Sidebar: React.FC<SidebarProps> = ({ className }) => {
         data-tauri-drag-region
         className={cn(
           'relative z-10 w-14 h-full shrink-0 flex flex-col items-center py-4',
-          'bg-muted/40 border-r border-border/40 backdrop-blur-xl',
+          'bg-muted/40 backdrop-blur-xl',
           className
         )}
       >

--- a/src/components/setting/SettingsSidebar.tsx
+++ b/src/components/setting/SettingsSidebar.tsx
@@ -31,7 +31,7 @@ const SettingsSidebar: FC<SettingsSidebarProps> = ({ activeCategory, onCategoryC
   }
 
   return (
-    <Sidebar collapsible="none" className="border-r border-border/50 bg-muted/30">
+    <Sidebar collapsible="none" className="bg-muted/30">
       <SidebarContent>
         <SidebarGroup>
           <SidebarGroupContent>

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -2,6 +2,7 @@ import React, { ReactNode } from 'react'
 import { Sidebar } from '@/components'
 import { usePlatform } from '@/hooks/usePlatform'
 import { cn } from '@/lib/utils'
+import { WINDOWS_INSET_PANEL_CLASS } from '@/lib/window-frame'
 
 interface MainLayoutProps {
   children: ReactNode
@@ -29,8 +30,7 @@ const MainLayout: React.FC<MainLayoutProps> = ({ children }) => {
       <main
         className={cn(
           'relative flex-1 flex flex-col overflow-hidden',
-          isWindows &&
-            'rounded-tl-[22px] bg-background/92 shadow-[inset_1px_1px_0_rgba(255,255,255,0.18)] backdrop-blur-sm'
+          isWindows && WINDOWS_INSET_PANEL_CLASS
         )}
       >
         {children}

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -30,7 +30,7 @@ const MainLayout: React.FC<MainLayoutProps> = ({ children }) => {
         className={cn(
           'relative flex-1 flex flex-col overflow-hidden',
           isWindows &&
-            'rounded-tl-[22px] bg-background/92 shadow-[inset_1px_1px_0_rgba(255,255,255,0.2)] ring-1 ring-border/35 backdrop-blur-sm'
+            'rounded-tl-[22px] bg-background/92 shadow-[inset_1px_1px_0_rgba(255,255,255,0.18)] backdrop-blur-sm'
         )}
       >
         {children}

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -1,7 +1,6 @@
 import React, { ReactNode } from 'react'
 import { Sidebar } from '@/components'
-import { usePlatform } from '@/hooks/usePlatform'
-import { cn } from '@/lib/utils'
+import InsetSurface from '@/components/layout/InsetSurface'
 
 interface MainLayoutProps {
   children: ReactNode
@@ -18,22 +17,14 @@ interface MainLayoutProps {
  * Window chrome (TitleBar) is handled by WindowShell parent.
  */
 const MainLayout: React.FC<MainLayoutProps> = ({ children }) => {
-  const { isWindows } = usePlatform()
-
   return (
     <>
       {/* Sidebar Navigation */}
       <Sidebar />
 
       {/* Main Content Area */}
-      <main
-        className={cn(
-          'relative flex-1 flex flex-col overflow-hidden',
-          isWindows &&
-            'rounded-tl-[22px] bg-background/92 shadow-[inset_1px_1px_0_rgba(255,255,255,0.18)] backdrop-blur-sm'
-        )}
-      >
-        {children}
+      <main className="relative flex min-h-0 flex-1 flex-col overflow-hidden">
+        <InsetSurface>{children}</InsetSurface>
       </main>
     </>
   )

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -1,6 +1,5 @@
 import React, { ReactNode } from 'react'
 import { Sidebar } from '@/components'
-import { usePlatform } from '@/hooks/usePlatform'
 
 interface MainLayoutProps {
   children: ReactNode
@@ -17,23 +16,13 @@ interface MainLayoutProps {
  * Window chrome (TitleBar) is handled by WindowShell parent.
  */
 const MainLayout: React.FC<MainLayoutProps> = ({ children }) => {
-  const { isWindows } = usePlatform()
-
   return (
     <>
       {/* Sidebar Navigation */}
-      <Sidebar className={isWindows ? '-mt-10 pt-14' : undefined} />
+      <Sidebar />
 
       {/* Main Content Area */}
-      <main className="relative flex-1 flex flex-col overflow-hidden">
-        {isWindows ? (
-          <div
-            aria-hidden="true"
-            className="pointer-events-none absolute inset-x-0 top-0 z-0 h-16 bg-[linear-gradient(180deg,color-mix(in_oklab,var(--background)_74%,transparent),transparent)]"
-          />
-        ) : null}
-        <div className="relative z-10 flex-1 overflow-hidden">{children}</div>
-      </main>
+      <main className="relative flex-1 flex flex-col overflow-hidden">{children}</main>
     </>
   )
 }

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -1,5 +1,7 @@
 import React, { ReactNode } from 'react'
 import { Sidebar } from '@/components'
+import { usePlatform } from '@/hooks/usePlatform'
+import { cn } from '@/lib/utils'
 
 interface MainLayoutProps {
   children: ReactNode
@@ -16,13 +18,23 @@ interface MainLayoutProps {
  * Window chrome (TitleBar) is handled by WindowShell parent.
  */
 const MainLayout: React.FC<MainLayoutProps> = ({ children }) => {
+  const { isWindows } = usePlatform()
+
   return (
     <>
       {/* Sidebar Navigation */}
       <Sidebar />
 
       {/* Main Content Area */}
-      <main className="relative flex-1 flex flex-col overflow-hidden">{children}</main>
+      <main
+        className={cn(
+          'relative flex-1 flex flex-col overflow-hidden',
+          isWindows &&
+            'rounded-tl-[22px] bg-background/92 shadow-[inset_1px_1px_0_rgba(255,255,255,0.2)] ring-1 ring-border/35 backdrop-blur-sm'
+        )}
+      >
+        {children}
+      </main>
     </>
   )
 }

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -1,5 +1,6 @@
 import React, { ReactNode } from 'react'
 import { Sidebar } from '@/components'
+import { usePlatform } from '@/hooks/usePlatform'
 
 interface MainLayoutProps {
   children: ReactNode
@@ -16,13 +17,23 @@ interface MainLayoutProps {
  * Window chrome (TitleBar) is handled by WindowShell parent.
  */
 const MainLayout: React.FC<MainLayoutProps> = ({ children }) => {
+  const { isWindows } = usePlatform()
+
   return (
     <>
       {/* Sidebar Navigation */}
-      <Sidebar />
+      <Sidebar className={isWindows ? '-mt-10 pt-14' : undefined} />
 
       {/* Main Content Area */}
-      <main className="flex-1 flex flex-col overflow-hidden relative">{children}</main>
+      <main className="relative flex-1 flex flex-col overflow-hidden">
+        {isWindows ? (
+          <div
+            aria-hidden="true"
+            className="pointer-events-none absolute inset-x-0 top-0 z-0 h-16 bg-[linear-gradient(180deg,color-mix(in_oklab,var(--background)_74%,transparent),transparent)]"
+          />
+        ) : null}
+        <div className="relative z-10 flex-1 overflow-hidden">{children}</div>
+      </main>
     </>
   )
 }

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -2,7 +2,6 @@ import React, { ReactNode } from 'react'
 import { Sidebar } from '@/components'
 import { usePlatform } from '@/hooks/usePlatform'
 import { cn } from '@/lib/utils'
-import { WINDOWS_INSET_PANEL_CLASS } from '@/lib/window-frame'
 
 interface MainLayoutProps {
   children: ReactNode
@@ -30,7 +29,8 @@ const MainLayout: React.FC<MainLayoutProps> = ({ children }) => {
       <main
         className={cn(
           'relative flex-1 flex flex-col overflow-hidden',
-          isWindows && WINDOWS_INSET_PANEL_CLASS
+          isWindows &&
+            'rounded-tl-[22px] bg-background/92 shadow-[inset_1px_1px_0_rgba(255,255,255,0.18)] backdrop-blur-sm'
         )}
       >
         {children}

--- a/src/layouts/WindowShell.tsx
+++ b/src/layouts/WindowShell.tsx
@@ -20,10 +20,10 @@ interface WindowShellProps {
  */
 export const WindowShell: React.FC<WindowShellProps> = ({ titleBar, children }) => {
   return (
-    <div className="relative h-screen flex flex-col overflow-hidden bg-background text-foreground transition-colors duration-200">
+    <div className="relative h-screen flex flex-col overflow-hidden bg-muted/40 text-foreground transition-colors duration-200">
       <div
         aria-hidden="true"
-        className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(255,255,255,0.14),transparent_34%),linear-gradient(180deg,color-mix(in_oklab,var(--background)_98%,transparent),color-mix(in_oklab,var(--background)_92%,transparent)_22%,var(--background)_100%)] dark:bg-[radial-gradient(circle_at_top_left,rgba(255,255,255,0.08),transparent_32%),linear-gradient(180deg,color-mix(in_oklab,var(--background)_96%,transparent),color-mix(in_oklab,var(--background)_90%,transparent)_22%,var(--background)_100%)]"
+        className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(255,255,255,0.16),transparent_30%),linear-gradient(180deg,color-mix(in_oklab,var(--muted)_92%,transparent),color-mix(in_oklab,var(--muted)_82%,transparent)_24%,color-mix(in_oklab,var(--background)_72%,var(--muted))_100%)] dark:bg-[radial-gradient(circle_at_top_left,rgba(255,255,255,0.08),transparent_30%),linear-gradient(180deg,color-mix(in_oklab,var(--muted)_86%,transparent),color-mix(in_oklab,var(--muted)_72%,transparent)_24%,color-mix(in_oklab,var(--background)_62%,var(--muted))_100%)]"
       />
       {/* Window Chrome Layer - Full width titlebar */}
       {titleBar}

--- a/src/layouts/WindowShell.tsx
+++ b/src/layouts/WindowShell.tsx
@@ -21,10 +21,6 @@ interface WindowShellProps {
 export const WindowShell: React.FC<WindowShellProps> = ({ titleBar, children }) => {
   return (
     <div className="relative h-screen flex flex-col overflow-hidden bg-muted/40 text-foreground transition-colors duration-200">
-      <div
-        aria-hidden="true"
-        className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(255,255,255,0.16),transparent_30%),linear-gradient(180deg,color-mix(in_oklab,var(--muted)_92%,transparent),color-mix(in_oklab,var(--muted)_82%,transparent)_24%,color-mix(in_oklab,var(--background)_72%,var(--muted))_100%)] dark:bg-[radial-gradient(circle_at_top_left,rgba(255,255,255,0.08),transparent_30%),linear-gradient(180deg,color-mix(in_oklab,var(--muted)_86%,transparent),color-mix(in_oklab,var(--muted)_72%,transparent)_24%,color-mix(in_oklab,var(--background)_62%,var(--muted))_100%)]"
-      />
       {/* Window Chrome Layer - Full width titlebar */}
       {titleBar}
 

--- a/src/layouts/WindowShell.tsx
+++ b/src/layouts/WindowShell.tsx
@@ -20,12 +20,16 @@ interface WindowShellProps {
  */
 export const WindowShell: React.FC<WindowShellProps> = ({ titleBar, children }) => {
   return (
-    <div className="h-screen flex flex-col overflow-hidden bg-background text-foreground transition-colors duration-200">
+    <div className="relative h-screen flex flex-col overflow-hidden bg-background text-foreground transition-colors duration-200">
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(255,255,255,0.14),transparent_34%),linear-gradient(180deg,color-mix(in_oklab,var(--background)_98%,transparent),color-mix(in_oklab,var(--background)_92%,transparent)_22%,var(--background)_100%)] dark:bg-[radial-gradient(circle_at_top_left,rgba(255,255,255,0.08),transparent_32%),linear-gradient(180deg,color-mix(in_oklab,var(--background)_96%,transparent),color-mix(in_oklab,var(--background)_90%,transparent)_22%,var(--background)_100%)]"
+      />
       {/* Window Chrome Layer - Full width titlebar */}
       {titleBar}
 
       {/* Content Area Layer - Sidebar + Main */}
-      <div className="flex-1 flex overflow-hidden">{children}</div>
+      <div className="relative z-10 flex-1 flex overflow-hidden">{children}</div>
     </div>
   )
 }

--- a/src/lib/window-frame.ts
+++ b/src/lib/window-frame.ts
@@ -1,2 +1,0 @@
-export const WINDOWS_INSET_PANEL_CLASS =
-  'overflow-hidden rounded-tl-[22px] bg-background/92 shadow-[inset_1px_1px_0_rgba(255,255,255,0.18)] backdrop-blur-sm'

--- a/src/lib/window-frame.ts
+++ b/src/lib/window-frame.ts
@@ -1,0 +1,2 @@
+export const WINDOWS_INSET_PANEL_CLASS =
+  'overflow-hidden rounded-tl-[22px] bg-background/92 shadow-[inset_1px_1px_0_rgba(255,255,255,0.18)] backdrop-blur-sm'

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -13,7 +13,6 @@ import { useShortcut } from '@/hooks/useShortcut'
 import { useShortcutScope } from '@/hooks/useShortcutScope'
 import { SettingContentLayout } from '@/layouts'
 import { cn } from '@/lib/utils'
-import { WINDOWS_INSET_PANEL_CLASS } from '@/lib/window-frame'
 import { captureUserIntent } from '@/observability/breadcrumbs'
 
 function SettingsPage() {
@@ -70,7 +69,13 @@ function SettingsPage() {
       className="min-h-0 h-full"
     >
       <SettingsSidebar activeCategory={activeCategory} onCategoryChange={handleCategoryChange} />
-      <SidebarInset className={cn('min-h-0', isWindows && WINDOWS_INSET_PANEL_CLASS)}>
+      <SidebarInset
+        className={cn(
+          'min-h-0',
+          isWindows &&
+            'rounded-tl-[22px] bg-background/92 shadow-[inset_1px_1px_0_rgba(255,255,255,0.18)] backdrop-blur-sm'
+        )}
+      >
         <ScrollArea className="flex-1 min-h-0">
           <div className="p-6">
             {ActiveSection && (

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
+import InsetSurface from '@/components/layout/InsetSurface'
 import {
   DEFAULT_CATEGORY,
   SETTINGS_CATEGORIES,
@@ -8,16 +9,13 @@ import {
 import SettingsSidebar from '@/components/setting/SettingsSidebar'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { SidebarProvider, SidebarInset } from '@/components/ui/sidebar'
-import { usePlatform } from '@/hooks/usePlatform'
 import { useShortcut } from '@/hooks/useShortcut'
 import { useShortcutScope } from '@/hooks/useShortcutScope'
 import { SettingContentLayout } from '@/layouts'
-import { cn } from '@/lib/utils'
 import { captureUserIntent } from '@/observability/breadcrumbs'
 
 function SettingsPage() {
   const location = useLocation()
-  const { isWindows } = usePlatform()
   const [activeCategory, setActiveCategory] = useState(
     (location.state as { category?: string } | null)?.category || DEFAULT_CATEGORY
   )
@@ -69,23 +67,19 @@ function SettingsPage() {
       className="min-h-0 h-full"
     >
       <SettingsSidebar activeCategory={activeCategory} onCategoryChange={handleCategoryChange} />
-      <SidebarInset
-        className={cn(
-          'min-h-0',
-          isWindows &&
-            'rounded-tl-[22px] bg-background/92 shadow-[inset_1px_1px_0_rgba(255,255,255,0.18)] backdrop-blur-sm'
-        )}
-      >
-        <ScrollArea className="flex-1 min-h-0">
-          <div className="p-6">
-            {ActiveSection && (
-              <SettingContentLayout>
-                <ActiveSection />
-              </SettingContentLayout>
-            )}
-          </div>
-        </ScrollArea>
-      </SidebarInset>
+      <InsetSurface>
+        <SidebarInset className="min-h-0 bg-transparent">
+          <ScrollArea className="flex-1 min-h-0">
+            <div className="p-6">
+              {ActiveSection && (
+                <SettingContentLayout>
+                  <ActiveSection />
+                </SettingContentLayout>
+              )}
+            </div>
+          </ScrollArea>
+        </SidebarInset>
+      </InsetSurface>
     </SidebarProvider>
   )
 }

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -8,13 +8,16 @@ import {
 import SettingsSidebar from '@/components/setting/SettingsSidebar'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { SidebarProvider, SidebarInset } from '@/components/ui/sidebar'
+import { usePlatform } from '@/hooks/usePlatform'
 import { useShortcut } from '@/hooks/useShortcut'
 import { useShortcutScope } from '@/hooks/useShortcutScope'
 import { SettingContentLayout } from '@/layouts'
+import { cn } from '@/lib/utils'
 import { captureUserIntent } from '@/observability/breadcrumbs'
 
 function SettingsPage() {
   const location = useLocation()
+  const { isWindows } = usePlatform()
   const [activeCategory, setActiveCategory] = useState(
     (location.state as { category?: string } | null)?.category || DEFAULT_CATEGORY
   )
@@ -66,7 +69,13 @@ function SettingsPage() {
       className="min-h-0 h-full"
     >
       <SettingsSidebar activeCategory={activeCategory} onCategoryChange={handleCategoryChange} />
-      <SidebarInset className="min-h-0">
+      <SidebarInset
+        className={cn(
+          'min-h-0',
+          isWindows &&
+            'rounded-tl-[22px] bg-background/92 shadow-[inset_1px_1px_0_rgba(255,255,255,0.18)] backdrop-blur-sm'
+        )}
+      >
         <ScrollArea className="flex-1 min-h-0">
           <div className="p-6">
             {ActiveSection && (

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -13,6 +13,7 @@ import { useShortcut } from '@/hooks/useShortcut'
 import { useShortcutScope } from '@/hooks/useShortcutScope'
 import { SettingContentLayout } from '@/layouts'
 import { cn } from '@/lib/utils'
+import { WINDOWS_INSET_PANEL_CLASS } from '@/lib/window-frame'
 import { captureUserIntent } from '@/observability/breadcrumbs'
 
 function SettingsPage() {
@@ -69,13 +70,7 @@ function SettingsPage() {
       className="min-h-0 h-full"
     >
       <SettingsSidebar activeCategory={activeCategory} onCategoryChange={handleCategoryChange} />
-      <SidebarInset
-        className={cn(
-          'min-h-0',
-          isWindows &&
-            'rounded-tl-[22px] bg-background/92 shadow-[inset_1px_1px_0_rgba(255,255,255,0.18)] backdrop-blur-sm'
-        )}
-      >
+      <SidebarInset className={cn('min-h-0', isWindows && WINDOWS_INSET_PANEL_CLASS)}>
         <ScrollArea className="flex-1 min-h-0">
           <div className="p-6">
             {ActiveSection && (


### PR DESCRIPTION
## Summary
- enable a borderless main window on Windows in the Tauri setup path
- render the custom title bar on Windows
- refine the Windows frame integration between title bar, sidebar, and inset main panel
- clean up the dashboard/settings inset corner and seam treatment

## Testing
- npx eslint src/layouts/WindowShell.tsx src/components/TitleBar.tsx src/components/layout/Sidebar.tsx
- npx eslint src/components/layout/InsetSurface.tsx src/layouts/MainLayout.tsx src/pages/SettingsPage.tsx
- npx eslint src/components/clipboard/ClipboardContent.tsx
- npx prettier --check src/layouts/WindowShell.tsx src/components/TitleBar.tsx src/components/layout/Sidebar.tsx
- npx prettier --check src/components/layout/InsetSurface.tsx src/layouts/MainLayout.tsx src/pages/SettingsPage.tsx
- npx prettier --check src/components/clipboard/ClipboardContent.tsx

## Notes
- this branch keeps the retained Windows borderless implementation after dropping intermediate experiments that did not improve the final UX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Windows platform support with custom title bar styling and platform-specific window frame configuration.
  * Introduced a new layout component to improve content structure and visual hierarchy.

* **Style**
  * Improved visual appearance with refined transparency, background colors, and layer ordering across multiple components for a more cohesive interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->