### PR TITLE
feat(recovery): wire up all 4 recovery subsystem components

### DIFF
--- a/.claude/skills/seq/SKILL.md
+++ b/.claude/skills/seq/SKILL.md
@@ -74,6 +74,40 @@ The script exits with specific codes:
 | 5         | Other HTTP error      | Show the error details                       |
 | 6         | JSON parse error      | Show raw response for debugging              |
 
+## Raw JSON Event Structure
+
+When using `--raw`, events are returned as a JSON array. Each event has this structure:
+
+```json
+{
+  "Timestamp": "2026-04-12T04:06:22.446550Z",
+  "Level": "OK",           // "INFO", "OK", "Warning", "Error", "Fatal", "Information" (= INFO alias)
+  "MessageTemplateTokens": [
+    { "Text": "literal text" },
+    { "PropertyName": "variable_name" }
+  ],
+  "Properties": [           // NOTE: array of {Name, Value} pairs, NOT a dict
+    { "Name": "busy_ns", "Value": 252276041 },
+    { "Name": "representation_count", "Value": "14" },
+    { "Name": "code", "Value": { "file": { "path": "..." }, "line": { "number": 161 } } }
+  ],
+  "EventType": "$07366932",
+  "SpanKind": "Internal",
+  "Resource": [...],
+  "Scope": [{ "Name": "name", "Value": "module::path" }],
+  "Id": "event-...",
+  "Links": { "Self": "...", "Group": "..." }
+}
+```
+
+Key points for parsing raw JSON:
+- **Properties is an array**, not a dict. Convert with: `{p['Name']: p['Value'] for p in e.get('Properties', [])}`
+- Timing spans use `busy_ns` and `idle_ns` (nanoseconds). Convert to ms: `int(value) / 1e6`
+- `Level: "OK"` indicates a completed tracing span (not a log level)
+- `Level: "Information"` is an alias for `"INFO"` — treat them the same
+- String values in Properties may be stringified even when numeric (e.g., `"14"` instead of `14`)
+- Nested dict values (like `code`) contain source location info
+
 ## Example Usage
 
 - `/seq setup` - Configure Seq API key

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,6 +32,9 @@ When documentation conflicts with code, treat the code as the source of truth an
 **For Reference:**
 
 - [DeepWiki Documentation](https://deepwiki.com/UniClipboard/UniClipboard) - Interactive diagrams and flows
+- [Connection Stability Recovery PRD](p2p/2026-04-11-connection-stability-recovery-prd.md) - Focused product requirements for self-healing after temporary mDNS loss
+- [Paired Sync Reliability Draft](p2p/2026-04-11-paired-sync-reliability-draft.md) - Product behavior draft for durable paired-device clipboard delivery
+- [Paired Sync Reliability Worklist](p2p/2026-04-11-paired-sync-reliability-worklist.md) - Build-ready checklist for the first reliability fix
 
 ## Architecture at a Glance
 

--- a/docs/p2p/2026-04-11-connection-stability-recovery-prd.md
+++ b/docs/p2p/2026-04-11-connection-stability-recovery-prd.md
@@ -474,14 +474,14 @@ Do not consider this phase fixed unless:
 1. The recovery events and fields defined in this PRD must be added to the existing Seq runbook (`docs/p2p/2026-04-06-transport-observability-runbook.md`) in the same implementation wave.
 2. Recovery events must be emitted from the transport layer alongside the existing `network.*` and `peer.*` events so that a single `@TraceId` can follow one recovery cycle end to end.
 
-### New Platform Work Required
+### Platform Signal Integration
 
-Today the codebase has **no** subscription to device sleep/wake or local network interface changes — no IOKit / SystemConfiguration / netlink / reachability listeners exist in the tree. Implementing the following required triggers therefore involves net-new platform integration code:
+The codebase now includes `platform_signals.rs` which provides the following triggers via `spawn_platform_signal_listener()`:
 
-- `wake from sleep` trigger
-- `local network interface or IP change` trigger
+- **Wake from sleep** — IOKit-based sleep/wake hook on macOS.
+- **Local network interface or IP change** — LAN-IP polling listener on all platforms.
 
-Planners must budget for this. Without it, Wave 1 would silently fall back to reactive recovery only (mDNS expiry + dial failure + first outbound attempt after idle), which would weaken the release gate on sleep/wake behavior.
+The returned receiver is threaded through each `run_swarm` invocation so that sleep/wake and IP-change events survive session rebuilds.
 
 ### Constants Location
 

--- a/docs/p2p/2026-04-11-connection-stability-recovery-prd.md
+++ b/docs/p2p/2026-04-11-connection-stability-recovery-prd.md
@@ -320,13 +320,13 @@ The recovery phase is not complete if later diagnosis still depends on guessing.
 
 Required structured events:
 
-- `peer.recovery_started`
+- `peer.recovery_cycle_started`
 - `peer.recovery_probe_attempt`
 - `peer.recovery_probe_succeeded`
 - `peer.recovery_probe_failed`
 - `peer.recovery_escalated`
-- `peer.recovery_succeeded`
-- `peer.recovery_failed`
+- `peer.recovery_cycle_succeeded`
+- `peer.recovery_window_exhausted`
 - `peer.state_transition`
 - `network.session_rebuild_started`
 - `network.session_rebuild_succeeded`

--- a/docs/p2p/2026-04-11-connection-stability-recovery-prd.md
+++ b/docs/p2p/2026-04-11-connection-stability-recovery-prd.md
@@ -1,0 +1,510 @@
+# Connection Stability Recovery PRD
+
+## Document Status
+
+- PRD
+- Approved for implementation planning
+- Date: 2026-04-11
+- Scope: LAN paired-peer connection recovery after discovery loss
+
+## Purpose
+
+This document narrows the current reliability discussion to one problem only:
+
+- when both paired devices are still open and should be reachable
+- but mDNS visibility is lost
+- the product must recover connection automatically instead of remaining stuck offline
+
+This PRD is intentionally narrower than the broader clipboard reliability discussion.
+
+## Focused Problem
+
+Today the product is too fragile when discovery drops temporarily.
+
+From the user's point of view, the failure looks like this:
+
+1. both devices are still open
+2. both devices should still be on the same LAN
+3. discovery disappears
+4. the product keeps treating the peer as unavailable
+5. clipboard sync stops until the user restarts the app
+
+That behavior is the core problem for this phase.
+
+## Core Product Rule
+
+Loss of mDNS visibility must not immediately become long-lived offline state.
+
+For paired peers, mDNS should be treated as:
+
+- a live discovery signal
+- a path refresh signal
+- a confidence boost
+
+It must not be treated as:
+
+- the only proof that the peer may still be reachable
+- the only condition under which the product attempts recovery
+
+## Phase Goal
+
+When mDNS drops but both devices are still practically online, the product should restore connection by itself.
+
+The target user experience is:
+
+- the product enters a short recovery state
+- the product retries and rebuilds its connection path automatically
+- the peer returns to online state without restart in common cases
+
+## Definitions
+
+These terms are load-bearing throughout the rest of this PRD and must be read before the behavior sections.
+
+### Local Network Session
+
+The **local network session** is the runtime object created by `Libp2pNetworkAdapter::spawn_swarm()` (`src-tauri/crates/uc-platform/src/adapters/libp2p_network/mod.rs:252`). Concretely:
+
+- the `Swarm<Libp2pBehaviour>` instance
+- its embedded `mdns::tokio::Behaviour` and `libp2p_stream::Behaviour`
+- the associated `stream::Control`
+- the runtime `PeerCaches` (`discovered_peers`, `address_registry`, `active_connections`)
+
+**Rebuilding the local network session** means tearing down and recreating all of the above via a fresh `spawn_swarm()` call.
+
+It explicitly does **not** mean rebuilding:
+
+- the persisted paired-device database (`src-tauri/crates/uc-infra/src/db/models/paired_device_row.rs`)
+- the local peer identity (keypair)
+- `PeerCaches.last_dial_observations`
+
+`last_dial_observations` is **preserved across a rebuild**, so the first retry after a rebuild can still target the last known usable address.
+
+### Recovery Probe
+
+A **recovery probe** is a sender-side action defined as:
+
+1. attempt to open a business stream to the target peer
+2. do not write any payload
+3. close the stream immediately after the open call returns
+
+The existing receiver already treats "stream opened, EOF before header" as a probe (`src-tauri/crates/uc-platform/src/adapters/libp2p_network/stream_handler.rs:71-72`), so this probe requires no protocol changes and no receiver-side work.
+
+A probe is **successful** when the business stream open call returns success. No receiver response is required. No round-trip payload exchange is required.
+
+A probe is **failed** when open returns an error or exceeds `BUSINESS_STREAM_OPEN_TIMEOUT` (`mod.rs:62`, currently `10s`).
+
+### Usable Path
+
+A **usable path** is one concrete multiaddr stored in `PeerCaches.last_dial_observations[peer_id]` (`peer_cache.rs:73`). It represents the last observed working dial target for that peer. Escalation Step 1 retries **only** this single multiaddr; it does not iterate over all known addresses.
+
+### Recovery Cycle
+
+A **recovery cycle** starts the moment a paired peer transitions from `Online` into the recovery path. It ends when the peer transitions to either `Online` or `Offline`.
+
+Each cycle has a fresh `recovery_cycle_id`. If mDNS briefly reappears and disappears again, the second loss starts a **new** cycle; one cycle never spans an mDNS flicker.
+
+### Silent Phase / Visible Phase
+
+- **Silent phase** = the first 15 seconds of a recovery cycle. The user-facing state remains `Online` in the UI during this window even though internal recovery is already in progress.
+- **Visible phase** = 15s to 120s of a recovery cycle. During this window the user-facing state is `Recovering`.
+- After 120 seconds, if recovery has not succeeded and the escalation sequence has been exhausted, the peer is allowed to transition to `Offline`.
+
+## Required Behavior
+
+### 1. Do Not Mark Paired Peers Offline Immediately On Discovery Loss
+
+If mDNS visibility disappears, the product must not immediately move a paired peer from "online" to durable "offline".
+
+Instead it should enter a recovery window.
+
+Required rule:
+
+- recovery window lasts up to 120 seconds before the peer is allowed to transition to `Offline`
+
+### 2. Keep Recent Working Reachability Long Enough To Recover
+
+The product should retain recent working peer reachability information for paired peers for a recovery period.
+
+This retained information is used only to support reconnection and should not be confused with permanent truth.
+
+### 3. Actively Rebuild Connection After Discovery Loss
+
+The product should not wait passively for fresh discovery forever.
+
+It must actively try to restore connectivity when recovery is needed.
+
+### 4. Recovery Must Trigger On Real-World Interruption Events
+
+At minimum, recovery should trigger on:
+
+- mDNS expiry for paired peers
+- repeated connection or delivery setup failure
+- first outbound sync attempt after a long idle period
+- wake from sleep
+- local network interface or IP change
+
+### 5. Recovery Must Escalate
+
+If lightweight recovery does not work, the product should escalate automatically.
+
+Example escalation levels:
+
+1. retry recent known path
+2. refresh discovery and connection attempts
+3. rebuild the local network session
+
+The exact implementation is left for planning, but passive waiting is not acceptable.
+
+### 6. Offline Must Mean Recovery Exhausted
+
+For this phase, a paired peer should only be considered truly offline after the product has already attempted its defined recovery steps and failed.
+
+Required rule:
+
+- `Offline` is only allowed after the 120-second recovery window has elapsed and defined recovery steps have been exhausted
+
+## User-Facing State Model
+
+This phase only needs a minimal state model:
+
+- Online
+- Recovering
+- Offline
+
+Required meaning:
+
+- `Online`: the peer is currently reachable or has just confirmed a healthy path
+- `Recovering`: discovery or connection health was lost, and automatic recovery is in progress
+- `Offline`: defined recovery attempts have failed
+
+The product should not jump directly from `Online` to `Offline` on first discovery loss.
+
+Required timing model:
+
+- `0-15s`: **silent phase** — internal recovery in progress, user-facing state stays `Online`
+- `15-120s`: **visible phase** — user-facing state is `Recovering`
+- `>120s`: `Offline` is allowed only after the escalation sequence (see "Recovery Escalation Ceiling") has been exhausted
+
+Required probe cadence:
+
+- during the silent phase, attempt one recovery probe every `5s`, for a maximum of 3 attempts
+- this cadence aligns with the existing mDNS `query_interval` (`behaviour.rs:35`) and QUIC `keepalive` (`mod.rs:73`), and it naturally feeds the Timed Rebuild Trigger (3 consecutive probe failures evaluated at the 15s mark)
+- during the visible phase, continue probing at the same `5s` cadence until recovery succeeds, escalation triggers, or the 120s window elapses
+
+## Recovery Success Criteria
+
+The product should treat a peer as recovered only when there is **direct transport-level evidence** that the peer is usable again.
+
+Accepted recovery proof for Wave 1 (any one of the following is sufficient):
+
+1. a successful **Recovery Probe** as defined in Definitions — i.e., a business stream open call that returns success
+2. a fresh libp2p `ConnectionEstablished` event for the target peer arriving from the swarm event loop for any reason (e.g., an incoming connection initiated by the peer itself)
+
+Explicit non-proof:
+
+- **rediscovery via mDNS alone is not sufficient.** mDNS only restores a discovery record; it does not prove that the transport layer can actually open a stream. Recovery must be confirmed by an actual connection-level or stream-level success event.
+- time passing without a new error is not proof either.
+
+## Probe Mechanism
+
+The recovery probe is defined in the Definitions section above. Key points recap:
+
+- probe = open business stream, send nothing, close immediately
+- the receiver already handles this pattern as a probe (`stream_handler.rs:71-72`)
+- no new protocol, no receiver-side work, no round-trip payload required
+- probe success = business stream open call returns success
+- probe failure = open returns an error or exceeds `BUSINESS_STREAM_OPEN_TIMEOUT` (`mod.rs:62`, currently `10s`)
+
+Rationale:
+
+- lowest possible transport cost
+- reuses an existing, already-tested code path
+- aligns recovery proof with the same stream path used by real clipboard delivery
+- keeps the receiver completely unchanged in Wave 1
+
+## Recovery Escalation Ceiling
+
+This phase is allowed to escalate up to rebuilding the local network session (as defined in Definitions).
+
+Required escalation sequence:
+
+1. **Step 1 — retry the usable path.** Send a recovery probe targeted at the single multiaddr stored in `PeerCaches.last_dial_observations[peer_id]`. Do not iterate over other known addresses in this step.
+2. **Step 2 — refresh discovery and broaden dialing.** Allow dialing across all known candidate addresses in `PeerCaches.discovered_peers[peer_id].addresses` plus any fresh mDNS responses. Discovery refresh must reuse the existing rate-limited discovery API; do not force a cache flush more than once per recovery cycle.
+3. **Step 3 — rebuild the local network session.** Tear down and recreate the session as defined in Definitions, subject to the Rebuild Escalation Trigger rules below. `last_dial_observations` is preserved across the rebuild, so Step 1 remains available after a rebuild completes.
+
+The escalation ceiling stops at Step 3.
+
+It must not require:
+
+- app restart
+- re-pairing
+- user intervention as the default recovery path
+
+## Rebuild Escalation Trigger
+
+The product should not rebuild the local network session on the first failed retry.
+
+The rebuild step should be reserved for situations that are likely local-session problems rather than normal short peer fluctuation.
+
+Required rebuild triggers:
+
+### Immediate Rebuild Trigger
+
+Allow one immediate local network-session rebuild when either of these happens during recovery:
+
+- the device has just resumed from sleep and the first recovery probe fails
+- the local network interface or local IP has changed and the first recovery probe fails
+
+Reason:
+
+- these events strongly suggest local transport state may be stale
+
+Interaction with the silent phase: if an immediate rebuild triggers during the silent phase, the user-facing state transitions to `Recovering` immediately — the silent phase ends early. This is intentional; a rebuild is a real event the user deserves to see, not background noise.
+
+### Timed Rebuild Trigger
+
+Allow one local network-session rebuild when both of these are true:
+
+- the peer has been in recovery for at least 15 seconds (i.e., the silent phase has ended)
+- and at least 3 consecutive recovery probes have failed
+
+Reason:
+
+- avoids rebuilding too early
+- avoids waiting passively when the lighter path is clearly not working
+- the 15s threshold deliberately coincides with the silent-to-visible phase transition, so the first rebuild (if any) is the same event that surfaces `Recovering` in the UI
+
+### Multi-Peer Rebuild Trigger
+
+Evaluate this trigger at the moment the first peer's silent phase ends (i.e., 15s after the first peer entered recovery). Allow one local network-session rebuild when **all** of the following are true at that evaluation point:
+
+- 2 or more paired peers have entered recovery since the first peer entered recovery
+- none of those peers has recovered during their own silent phase (0–15s)
+
+"Early recovery window" is equivalent to the silent phase as defined in Definitions.
+
+Reason:
+
+- simultaneous failures across multiple peers strongly suggest a local session problem rather than a single-peer problem
+- evaluating at a unified 15s mark (rather than the instant the second peer enters recovery) avoids false positives from two unrelated short fluctuations that happen to land close together in time
+
+### Rebuild Guardrails
+
+Required guardrails:
+
+- rebuild at most once per recovery cycle
+- after rebuild, continue lighter retries inside the same 120-second recovery window
+- if rebuild already happened and recovery still fails, do not keep rebuilding repeatedly in the same cycle
+
+### Required Rebuild Log Fields
+
+Every rebuild decision should log:
+
+- `rebuild_id` (unique per rebuild; shared across all peers participating in a multi-peer rebuild)
+- `rebuild_reason` (one of: `immediate_sleep_wake`, `immediate_network_change`, `timed_probe_failures`, `multi_peer`)
+- `rebuild_allowed`
+- `rebuild_already_used`
+- `recovering_peer_count`
+- `consecutive_probe_failures`
+- `recovery_elapsed_ms`
+
+## Tracing And Log Requirements
+
+This phase must add tracing and logs specifically for recovery behavior.
+
+This is a hard requirement, not optional polish.
+
+The recovery phase is not complete if later diagnosis still depends on guessing.
+
+### Required Recovery Events
+
+Required structured events:
+
+- `peer.recovery_started`
+- `peer.recovery_probe_attempt`
+- `peer.recovery_probe_succeeded`
+- `peer.recovery_probe_failed`
+- `peer.recovery_escalated`
+- `peer.recovery_succeeded`
+- `peer.recovery_failed`
+- `peer.state_transition`
+- `network.session_rebuild_started`
+- `network.session_rebuild_succeeded`
+- `network.session_rebuild_failed`
+
+### Required Recovery Fields
+
+Recovery logs should include at least:
+
+- `peer_id`
+- `recovery_cycle_id`
+- `rebuild_id` (present only when a session rebuild is in progress; multiple peers participating in the same multi-peer rebuild must share one `rebuild_id`)
+- `previous_state`
+- `next_state`
+- `trigger`
+- `elapsed_ms`
+- `attempt`
+- `escalation_level`
+- `probe_method`
+- `result`
+- `error`
+
+When relevant, also include:
+
+- `candidate_address_count`
+- `candidate_addresses` (truncated to the first 5 entries; the full set is derivable from `candidate_address_count` plus per-address dial events)
+- `last_seen_age_ms`
+- `discovered_age_ms`
+- `connected_age_ms`
+- `chosen_dial_addr`
+- `chosen_dial_addr_resolution`
+
+`recovery_cycle_id` semantics:
+
+- a new cycle id is minted at every transition **from** `Online` **into** the recovery path
+- if mDNS briefly reappears and disappears again inside the same 120s window, the second loss starts a new cycle id; one cycle never spans an mDNS flicker
+- multi-peer rebuild participants each keep their own `recovery_cycle_id` and share one `rebuild_id`, enabling both per-peer and rebuild-wide queries in Seq
+
+### Required Trace Shape
+
+One recovery cycle should be traceable end to end.
+
+At minimum, logs must let us answer:
+
+1. what triggered recovery
+2. how many times we retried
+3. whether a probe succeeded
+4. whether we escalated to network-session rebuild
+5. why the peer ended in `Online`, `Recovering`, or `Offline`
+
+### Logging Outcome Standard
+
+After Wave 1 ships, an engineer should be able to inspect one affected peer and determine:
+
+- discovery was lost
+- recovery started
+- probe was attempted
+- escalation did or did not happen
+- local network session was or was not rebuilt
+- final state and reason
+
+## Non-Goals
+
+This phase does not require:
+
+- clipboard backlog or pending stack work
+- file transfer reliability redesign
+- internet-wide sync
+- relay or NAT traversal
+- full delivery-status UX for every queued clipboard item
+- any change to how new outbound clipboard content is handled **while a peer is in `Recovering` state** — that behavior continues to follow the current implementation in this wave, and is the subject of the companion `paired-sync-reliability` documents
+
+Those may be addressed later, but must not expand this first phase.
+
+## Acceptance Criteria
+
+This phase is only successful if these outcomes are true.
+
+### Idle Recovery
+
+1. Two paired devices can remain idle for an extended period and still recover connectivity automatically on the next sync attempt.
+2. A temporary mDNS gap does not leave both devices stuck offline forever.
+3. During the first 120 seconds after discovery loss, the peer is treated as recovering rather than immediately offline.
+
+### Sleep/Wake Recovery
+
+1. If one device sleeps and wakes, the product restores paired-peer connectivity without requiring restart.
+2. The first new sync attempt after wake triggers automatic recovery if the peer is not immediately visible.
+
+### Network Change Recovery
+
+1. If the local interface or IP changes but both devices become mutually reachable again, the product restores connectivity automatically.
+2. The user does not need to re-pair or restart to recover the connection.
+
+### Offline Accuracy
+
+1. `Offline` is shown only after recovery has already been attempted and failed.
+2. Temporary discovery loss is shown as `Recovering`, not permanent offline.
+3. Recovery success requires transport-level evidence (successful probe or fresh `ConnectionEstablished`); mDNS rediscovery alone does not count as recovery proof.
+
+### Observability
+
+1. One recovery cycle can be followed in logs from trigger to final state.
+2. Probe attempts and rebuild escalation are visible as separate structured events.
+3. Recovery failure can be explained from logs without guessing.
+
+## Suggested Rollout
+
+### Wave 1
+
+Deliver first:
+
+- recovery window instead of immediate offline on discovery loss
+- retention of recent working peer reachability for paired peers
+- automatic recovery triggers
+- escalating self-heal behavior
+- 120-second recovery window with 15-second silent phase
+- explicit recovery success criteria
+- reuse of existing lightweight business-stream probe for active recovery proof
+- recovery escalation ceiling at local network-session rebuild
+- recovery-specific tracing and structured logs
+- minimal `Online / Recovering / Offline` state model
+
+### Wave 2
+
+Deliver later if needed:
+
+- better UI messaging
+- richer diagnostics
+- integration with broader clipboard delivery reliability work
+
+## Release Gate
+
+Do not consider this phase fixed unless:
+
+1. restart is no longer the normal way to recover after temporary mDNS loss
+2. paired peers commonly return from `Recovering` to `Online` by themselves
+3. the product no longer treats one mDNS drop as a durable offline verdict
+4. `Offline` is not shown before the defined 120-second recovery process is exhausted
+
+## Implementation Notes
+
+### Observability Wiring
+
+1. The recovery events and fields defined in this PRD must be added to the existing Seq runbook (`docs/p2p/2026-04-06-transport-observability-runbook.md`) in the same implementation wave.
+2. Recovery events must be emitted from the transport layer alongside the existing `network.*` and `peer.*` events so that a single `@TraceId` can follow one recovery cycle end to end.
+
+### New Platform Work Required
+
+Today the codebase has **no** subscription to device sleep/wake or local network interface changes — no IOKit / SystemConfiguration / netlink / reachability listeners exist in the tree. Implementing the following required triggers therefore involves net-new platform integration code:
+
+- `wake from sleep` trigger
+- `local network interface or IP change` trigger
+
+Planners must budget for this. Without it, Wave 1 would silently fall back to reactive recovery only (mDNS expiry + dial failure + first outbound attempt after idle), which would weaken the release gate on sleep/wake behavior.
+
+### Constants Location
+
+All timing constants introduced by this PRD are hard-coded for Wave 1:
+
+- `silent phase duration = 15s`
+- `recovery window = 120s`
+- `probe cadence = 5s`
+- `silent phase max probe attempts = 3`
+- `timed rebuild probe failure threshold = 3`
+- `multi-peer rebuild evaluation offset = 15s from first peer`
+
+They should live alongside the existing timeout constants in `src-tauri/crates/uc-platform/src/adapters/libp2p_network/mod.rs:55-76`, matching the style of `BUSINESS_STREAM_OPEN_TIMEOUT`, `QUIC_KEEP_ALIVE_INTERVAL`, and `QUIC_MAX_IDLE_TIMEOUT_MS`. Configuration surface is explicitly deferred.
+
+### Current Behavior To Replace
+
+The grace period does not exist today:
+
+- `swarm_event_loop.rs::handle_mdns_expired` emits `PeerLost` immediately when mDNS expires (`src-tauri/crates/uc-platform/src/adapters/libp2p_network/swarm_event_loop.rs:283-342`)
+- `peer_cache.rs::remove_discovered` drops the discovered record on the spot (`peer_cache.rs:170-193`)
+
+The Wave 1 implementation must insert the recovery window between these code paths and any external "peer is offline" signal.
+
+### Identity Is Already Persistent
+
+Paired-peer identity is already persisted in SQLite (`src-tauri/crates/uc-infra/src/db/models/paired_device_row.rs:6-14`), so recovery logic can safely assume that a paired peer's identity outlives any mDNS cache entry. No new persistence work is needed for this PRD.

--- a/docs/p2p/2026-04-11-paired-sync-reliability-draft.md
+++ b/docs/p2p/2026-04-11-paired-sync-reliability-draft.md
@@ -1,0 +1,228 @@
+# Paired Sync Reliability Draft
+
+## Status
+
+- Draft
+- Date: 2026-04-11
+- Scope: paired clipboard sync reliability on LAN
+- Companion worklist: [Paired Sync Reliability Worklist](2026-04-11-paired-sync-reliability-worklist.md)
+
+## Problem Statement
+
+Today the product treats "can discover peer right now" and "can deliver clipboard content right now" as tightly coupled.
+
+That behavior is not acceptable from the user's point of view.
+
+If two devices are already paired, open, and recently working, the user expects them to remain a long-lived relationship. A short discovery gap, sleep/wake cycle, or temporary LAN instability must not silently turn into clipboard loss.
+
+The product problem is therefore:
+
+- delivery is too dependent on momentary peer visibility
+- recovery is too dependent on rediscovery
+- failed sends are too easy to lose silently
+- the product does not clearly communicate whether content is delivered, pending, or blocked
+
+## User Promise
+
+For paired devices, the product should feel persistent.
+
+The user should be able to assume:
+
+1. "If both devices are basically online, sync will recover by itself."
+2. "If sync cannot complete immediately, my latest clipboard content is not lost."
+3. "If there is still a problem, the app will tell me clearly."
+
+## Product Principles
+
+1. Pairing is a durable relationship.
+2. Discovery is an accelerator, not the only prerequisite for delivery.
+3. Temporary transport failure must degrade to pending delivery, not silent loss.
+4. Recent clipboard content should be prioritized through a bounded pending stack.
+5. Recovery should be automatic first, user-visible second, user-actionable last.
+
+## Required Product Behavior
+
+### 1. Separate Relationship From Visibility
+
+A paired device must remain eligible for delivery even when it is not currently rediscovered.
+
+Temporary loss of live LAN visibility must not immediately remove the peer from send consideration.
+
+### 2. Always Create a Pending Delivery Record
+
+Every outbound clipboard change for paired peers must first become a pending delivery attempt.
+
+If immediate delivery succeeds, the pending state can be cleared.
+
+If immediate delivery fails, the content must remain pending until one of these happens:
+
+- delivery succeeds
+- the content is evicted by bounded stack overflow
+- the user explicitly discards it
+- the product reaches a clearly defined terminal failure policy
+
+### 3. Use a Bounded Per-Peer Pending Stack
+
+For normal clipboard sync, the system should maintain one pending stack per target peer.
+
+Wave 1 locked rules are:
+
+- each peer keeps at most 10 pending clipboard records
+- the limit is hard-coded for now and may become configurable later
+- new clipboard content is pushed onto the top of the stack
+- delivery always chooses the topmost pending item next
+- if the stack is full, the oldest pending item at the bottom is removed first
+- if one item is already being sent, it is not interrupted mid-flight
+
+This gives the product two properties the user can feel:
+
+- recent clipboard content is prioritized
+- short-term delivery history is still preserved in a bounded way
+
+### 4. Automatic Recovery Must Be Aggressive
+
+The product must try to heal itself without requiring restart.
+
+Recovery should be triggered by at least:
+
+- local app startup
+- daemon startup
+- device wake from sleep
+- network interface or IP change
+- repeated delivery failure
+- prolonged idle period followed by new outbound activity
+- peer visibility loss followed by pending outbound work
+
+### 5. Delivery Must Not Depend on Fresh Discovery Alone
+
+The system should retain and reuse recent working peer reachability information for paired peers.
+
+Fresh discovery should improve confidence and routing quality, but lack of immediate rediscovery must not be the sole reason to skip delivery attempts.
+
+### 6. Delivery Success And Failure Must Be Explicit
+
+For a given peer, clipboard delivery is complete only after:
+
+- the receiver has fully accepted the payload
+- the receiver has returned an acknowledgement
+
+For a given peer, delivery attempt failure should be declared when:
+
+- 60 seconds pass without observable transfer progress
+- or the payload is fully sent but the final acknowledgement does not arrive within 60 seconds
+
+When multiple peers are targeted, success and failure must be tracked independently per peer.
+
+### 7. User-Facing States Must Be Explicit
+
+The product must expose clear, simple states for clipboard delivery:
+
+- Synced
+- Sending
+- Recovering
+- Pending, will retry automatically
+- Attention needed
+
+The product must avoid silent failure states where content is neither delivered nor clearly pending.
+
+### 8. Escalation Must Match Real User Impact
+
+Short failures should stay quiet and self-heal.
+
+Visible warnings should appear only when:
+
+- pending delivery lasts longer than the normal recovery budget
+- the target device appears unavailable for a meaningful duration
+- repeated automatic recovery attempts fail
+
+When surfaced, the message must be understandable without transport knowledge.
+
+## Non-Goals
+
+This draft does not require:
+
+- replaying historical clipboard backlog beyond the bounded pending stack
+- solving global internet delivery
+- changing trust or pairing semantics
+- merging clipboard and file transfer reliability into one queue
+
+File transfer reliability may reuse some ideas later, but should not block clipboard sync recovery.
+
+## Acceptance Criteria
+
+The draft is only successful if the following user-visible outcomes are true.
+
+### Baseline Reliability
+
+1. Two paired devices remain able to sync after being idle for an extended period.
+2. A short discovery gap does not cause silent clipboard loss.
+3. If delivery cannot happen immediately, recent clipboard content is retained in the bounded per-peer stack and retried.
+4. If more than 10 items accumulate for one peer, the oldest pending item is removed first.
+
+### Sleep/Wake Recovery
+
+1. If one device sleeps and wakes, sync recovers without restarting the app.
+2. The first clipboard action after wake either succeeds quickly or enters a visible retry state.
+3. A recovered connection automatically resumes delivery from the current in-flight item or the top of the remaining pending stack.
+
+### Network Change Recovery
+
+1. If LAN conditions change but both devices are still reachable again shortly after, sync recovers automatically.
+2. The user does not need to re-pair or restart to restore normal clipboard sync.
+
+### Failure Visibility
+
+1. The app can tell the difference between synced, retrying, and blocked.
+2. The user can understand when content is still waiting to be delivered.
+3. The app does not imply success before delivery is actually confirmed.
+4. Multi-device fanout can show mixed outcomes when some peers succeeded and others did not.
+
+## Rollout Order
+
+### Phase 1: Prevent Silent Loss
+
+Deliver first:
+
+- pending delivery for clipboard outbound sync
+- bounded per-peer pending stack with 10-item cap
+- stack dispatch rules that prioritize newer pending content
+- explicit acknowledgement-based success
+- 60-second no-progress failure handling
+- explicit delivery states
+
+This phase is the minimum bar because it changes the user experience from "lost" to "pending".
+
+### Phase 2: Strong Self-Recovery
+
+Deliver next:
+
+- automatic recovery triggers
+- stronger reuse of recent working peer reachability
+- retry behavior after wake, network change, and repeated failure
+
+This phase reduces how often the user ever sees pending state.
+
+### Phase 3: Polish and Confidence
+
+Deliver last:
+
+- better status messaging
+- better device-level visibility in the UI
+- operational telemetry to verify recovery quality in real environments
+
+## Release Gate
+
+Do not consider the problem fixed unless all of the following are true:
+
+1. Clipboard content is no longer silently dropped during temporary peer visibility loss.
+2. Restarting the app is no longer the primary recovery method.
+3. Paired devices behave like a durable relationship instead of a fragile moment-to-moment discovery session.
+4. User-visible status matches actual delivery reality.
+
+## Open Questions
+
+These questions should be resolved before implementation planning is finalized:
+
+1. What retry window should be considered normal before the UI escalates?
+2. Which wake and network-change signals are available in both desktop runtimes we care about?
+3. How should mixed per-peer outcomes be summarized in the top-level UI when fanout is partial?

--- a/docs/p2p/2026-04-11-paired-sync-reliability-worklist.md
+++ b/docs/p2p/2026-04-11-paired-sync-reliability-worklist.md
@@ -1,0 +1,273 @@
+# Paired Sync Reliability Worklist
+
+## Status
+
+- Draft
+- Date: 2026-04-11
+- Companion to: [Paired Sync Reliability Draft](2026-04-11-paired-sync-reliability-draft.md)
+
+## Purpose
+
+This document converts the product draft into a build-ready worklist.
+
+It is intentionally focused on:
+
+- what must be true before implementation starts
+- what must ship first
+- what may wait until later
+- how to judge whether the work actually fixed the user problem
+
+It does not prescribe code structure in detail.
+
+## Core Outcome
+
+For paired devices, clipboard sync should behave like a durable relationship instead of a fragile discovery session.
+
+The minimum acceptable user outcome is:
+
+1. The latest clipboard content is not silently lost.
+2. Recovery happens automatically in common interruption cases.
+3. The app can clearly say whether content is synced, retrying, or stuck.
+
+## Wave 1 Decisions Locked
+
+These rules are now fixed for Wave 1.
+
+### 1. Pending State Model
+
+- one pending stack per peer
+- maximum 10 pending clipboard records per peer
+- hard-coded for now, configurable later if needed
+
+### 2. Ordering Model
+
+- dispatch is last-in, first-out
+- new clipboard content is pushed on top
+- the next item to send is always taken from the top
+- an item already being sent is not interrupted mid-flight
+
+### 3. Overflow Model
+
+- if the stack is full and a new record arrives, remove the oldest pending record at the bottom first
+- then push the new record onto the top
+
+### 4. Success And Failure Model
+
+- a peer is marked synced only after the receiver finishes and returns an acknowledgement
+- a peer delivery attempt fails if 60 seconds pass with no transfer progress
+- a peer delivery attempt also fails if the final acknowledgement does not arrive within 60 seconds
+- fanout to multiple peers is evaluated independently per peer
+
+## Still Needs Decision
+
+These are the remaining decisions that should be locked before detailed engineering planning.
+
+### 1. Escalation Budget
+
+Choose how long the product may stay in automatic retry before visible escalation.
+
+Recommended starting point:
+
+- short silent retry window
+- visible pending state after that
+- stronger warning only after a clearly longer timeout
+
+Exact values should be set during implementation planning.
+
+### 2. Top-Level Partial Success State
+
+Choose how the UI summarizes multi-peer fanout when some peers succeed and others fail or remain pending.
+
+## Must Ship In Wave 1
+
+Wave 1 is the minimum bar for claiming user-visible improvement.
+
+### A. Pending Outbound Clipboard
+
+Must exist:
+
+- every outbound clipboard attempt creates a pending record in the target peer's stack
+- immediate success clears it
+- failure leaves it pending
+
+Wave 1 is incomplete without this.
+
+### B. Bounded Stack Behavior
+
+Must exist:
+
+- per-peer stack cap of 10 pending items
+- newest content pushed on top
+- oldest pending item evicted first on overflow
+
+Wave 1 should not ship with unbounded pending growth.
+
+### C. LIFO Dispatch With No Mid-Flight Interruption
+
+Must exist:
+
+- dispatch always chooses the topmost pending item next
+- an item already being sent is allowed to finish or fail before the stack picks the next item
+
+Wave 1 should not ship with ambiguous dispatch order.
+
+### D. Paired Peer Eligibility Must Survive Discovery Gaps
+
+Must exist:
+
+- paired peers remain send candidates during temporary visibility loss
+
+Wave 1 should not require fresh rediscovery as the only path to a send attempt.
+
+### E. Recent Reachability Reuse
+
+Must exist:
+
+- the system retains recent working reachability information long enough to support recovery attempts
+
+Wave 1 should no longer behave as if a recently working peer becomes unknown immediately after a short gap.
+
+### F. Explicit Ack-Based Success And Timeout Failure
+
+Must exist:
+
+- sync success only after receiver acknowledgement
+- 60-second no-progress timeout
+- 60-second final-ack timeout
+- per-peer result tracking for multi-peer fanout
+
+Wave 1 should not ship with guessed success.
+
+### G. Basic Delivery States
+
+Must exist:
+
+- Synced
+- Sending
+- Recovering
+- Pending, will retry automatically
+
+Wave 1 should not ship if the product still fails silently.
+
+### H. Automatic Recovery Triggers
+
+Must exist at minimum for:
+
+- app start
+- daemon start
+- wake from sleep
+- repeated delivery failure
+- new outbound activity after idle period
+
+Wave 1 should reduce restart dependence materially.
+
+## Should Ship In Wave 2
+
+Wave 2 makes recovery more reliable and more understandable.
+
+### A. Better Recovery Coverage
+
+Add:
+
+- network change triggers
+- stronger full-session rebuild behavior after repeated failed recovery
+- better handling for prolonged peer invisibility
+
+### B. Better Device-Level Visibility
+
+Add:
+
+- device-specific delivery status
+- clearer distinction between retrying and blocked
+
+### C. Better Operational Validation
+
+Add:
+
+- telemetry and logs specifically tied to pending, recovered, delivered, and expired clipboard delivery states
+
+## Can Wait Until Later
+
+These are valuable but should not block the first fix.
+
+- richer retry heuristics
+- user controls for retry/discard behavior
+- unifying clipboard and file transfer reliability behavior
+- advanced delivery diagnostics in the UI
+
+## Explicitly Out Of Scope
+
+Do not let these expand the first fix:
+
+- internet-wide sync
+- relay or NAT traversal work
+- replaying a long historical clipboard backlog beyond the bounded stack
+- redesigning pairing trust semantics
+- solving file transfer reliability in the same first wave
+
+## Engineering Guardrails
+
+Implementation planning should enforce these rules:
+
+1. One clear owner for outbound delivery state.
+2. One clear owner for delivery confirmation.
+3. Discovery and delivery eligibility must not be treated as the same thing.
+4. Recovery logic must replace restart dependency, not hide it behind more retry noise.
+5. User-visible state must come from real delivery state, not guesswork.
+
+## Release Checklist
+
+Do not consider the work done unless all items below pass.
+
+### Reliability Checks
+
+1. Two paired devices sync again after a long idle period without restart.
+2. Temporary visibility loss does not silently drop recent clipboard content that is still inside the 10-item stack.
+3. A failed immediate send becomes pending and is retried automatically.
+4. When more than 10 pending records build up for one peer, the oldest pending record is evicted first.
+
+### Sleep/Wake Checks
+
+1. One device sleeps and wakes without requiring app restart.
+2. The first copy after wake either delivers or enters visible retry state.
+3. Recovery eventually delivers the current in-flight item or the top of the remaining pending stack.
+
+### Network Change Checks
+
+1. Recovery works after a local IP or interface change.
+2. Recovery works after brief LAN disruption when both devices become reachable again.
+
+### User State Checks
+
+1. The app never reports success before actual delivery.
+2. The app can show pending state without implying permanent failure too early.
+3. The app can escalate when recovery has clearly failed.
+4. The app can represent partial fanout results when peers diverge.
+
+### Regression Checks
+
+1. Normal active sync remains fast.
+2. Rapid repeated copies do not create an ever-growing pending backlog.
+3. Restarting the app is no longer the main recovery path in ordinary interruption scenarios.
+4. New clipboard content can overtake older pending content without interrupting an item already in flight.
+
+## Suggested Execution Order
+
+1. Lock the remaining pre-implementation decisions.
+2. Build per-peer pending stack state with 10-item cap.
+3. Add LIFO dispatch plus overflow eviction rules.
+4. Add acknowledgement-based completion and 60-second failure rules.
+5. Decouple paired-peer eligibility from momentary discovery visibility.
+6. Add recent reachability reuse for recovery attempts.
+7. Add user-visible delivery states.
+8. Add automatic recovery triggers.
+9. Run the release checklist in real sleep, idle, and network-change scenarios.
+
+## Exit Criteria
+
+This work should only be called complete when the product experience changes in a way the user can feel:
+
+- content no longer disappears silently
+- restart is no longer the normal recovery method
+- paired devices feel persistent
+- the app tells the truth about delivery state

--- a/src-tauri/crates/uc-app/src/usecases/clipboard/sync_outbound.rs
+++ b/src-tauri/crates/uc-app/src/usecases/clipboard/sync_outbound.rs
@@ -257,9 +257,12 @@ impl SyncOutboundClipboardUseCase {
             representations: binary_reps,
         };
 
-        let plaintext_bytes = v3_payload
-            .encode_to_vec()
-            .context("failed to encode V3 clipboard binary payload")?;
+        let plaintext_bytes = {
+            let _guard = info_span!("clipboard.encode_payload").entered();
+            v3_payload
+                .encode_to_vec()
+                .context("failed to encode V3 clipboard binary payload")?
+        };
         let plaintext_bytes_len = plaintext_bytes.len();
         if plaintext_bytes_len > RECEIVE_PLAINTEXT_CAP {
             bail!(
@@ -319,21 +322,33 @@ impl SyncOutboundClipboardUseCase {
         // Parallel: run prepare path in its own task so CPU-heavy encrypt/frame work
         // cannot starve the business-path ensure branch.
         let prepare_future = async move {
-            let master_key = encryption_session
-                .get_master_key()
-                .await
-                .map_err(anyhow::Error::from)
-                .context("failed to access encryption session master key for outbound sync")?;
+            let master_key = async {
+                encryption_session
+                    .get_master_key()
+                    .await
+                    .map_err(anyhow::Error::from)
+                    .context("failed to access encryption session master key for outbound sync")
+            }
+            .instrument(info_span!("clipboard.get_master_key"))
+            .await?;
 
-            let encrypted_content = transfer_encryptor
-                .encrypt(&master_key, &plaintext_bytes)
-                .map_err(|e| {
-                    anyhow::anyhow!("failed to encrypt outbound clipboard payload: {e}")
-                })?;
+            let encrypted_content = {
+                let _guard = info_span!("clipboard.encrypt", plaintext_len = plaintext_bytes.len())
+                    .entered();
+                transfer_encryptor
+                    .encrypt(&master_key, &plaintext_bytes)
+                    .map_err(|e| {
+                        anyhow::anyhow!("failed to encrypt outbound clipboard payload: {e}")
+                    })?
+            };
 
-            let framed = ProtocolMessage::Clipboard(clipboard_header)
-                .frame_to_bytes(Some(&encrypted_content))
-                .context("failed to frame outbound V3 clipboard message")?;
+            let framed = {
+                let _guard = info_span!("clipboard.frame", encrypted_len = encrypted_content.len())
+                    .entered();
+                ProtocolMessage::Clipboard(clipboard_header)
+                    .frame_to_bytes(Some(&encrypted_content))
+                    .context("failed to frame outbound V3 clipboard message")?
+            };
 
             Ok::<Arc<[u8]>, anyhow::Error>(Arc::from(framed.into_boxed_slice()))
         }

--- a/src-tauri/crates/uc-app/src/usecases/internal/capture_clipboard.rs
+++ b/src-tauri/crates/uc-app/src/usecases/internal/capture_clipboard.rs
@@ -157,7 +157,14 @@ impl CaptureClipboardUseCase {
             let event_id = EventId::new();
             let captured_at_ms = snapshot.ts_ms;
             let source_device = self.device_identity.current_device_id();
-            let snapshot_hash = snapshot.snapshot_hash();
+            let snapshot_hash = {
+                let _guard = info_span!(
+                    "clipboard.snapshot_hash",
+                    representation_count = snapshot.representations.len(),
+                )
+                .entered();
+                snapshot.snapshot_hash()
+            };
 
             // 1. 生成 event + snapshot representations
             let new_event = ClipboardEvent::new(

--- a/src-tauri/crates/uc-app/src/usecases/internal/capture_clipboard.rs
+++ b/src-tauri/crates/uc-app/src/usecases/internal/capture_clipboard.rs
@@ -192,8 +192,11 @@ impl CaptureClipboardUseCase {
                 let mut staged_with_preview = 0usize;
                 let mut staged = 0usize;
                 let mut total_bytes: i64 = 0;
+                // Build "format_id:size_bytes" pairs for diagnostics.
+                let mut breakdown_parts: Vec<String> = Vec::with_capacity(normalized_reps.len());
                 for rep in &normalized_reps {
                     total_bytes += rep.size_bytes;
+                    breakdown_parts.push(format!("{}:{}", rep.format_id, rep.size_bytes));
                     match rep.payload_state() {
                         PayloadAvailability::Inline => inline += 1,
                         PayloadAvailability::Staged if rep.inline_data.is_some() => {
@@ -203,12 +206,14 @@ impl CaptureClipboardUseCase {
                         _ => {}
                     }
                 }
-                debug!(
+                let breakdown = breakdown_parts.join(", ");
+                info!(
                     representations = normalized_reps.len(),
                     inline,
                     staged_with_preview,
                     staged,
                     total_bytes,
+                    breakdown = %breakdown,
                     "Normalized clipboard representations"
                 );
             }

--- a/src-tauri/crates/uc-core/src/device/status.rs
+++ b/src-tauri/crates/uc-core/src/device/status.rs
@@ -6,6 +6,7 @@ pub enum DeviceStatus {
     Online = 0,
     Offline = 1,
     Unknown = 2,
+    Recovering = 3,
 }
 
 impl PartialEq for DeviceStatus {
@@ -42,7 +43,31 @@ impl TryFrom<i32> for DeviceStatus {
             0 => Ok(DeviceStatus::Online),
             1 => Ok(DeviceStatus::Offline),
             2 => Ok(DeviceStatus::Unknown),
+            3 => Ok(DeviceStatus::Recovering),
             _ => Err(()),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn recovering_variant_round_trips_through_i32() {
+        let status = DeviceStatus::Recovering;
+        let as_i32: i32 = status.into();
+        assert_eq!(as_i32, 3);
+        let back: DeviceStatus = DeviceStatus::try_from(3).expect("3 should decode");
+        assert_eq!(back, DeviceStatus::Recovering);
+    }
+
+    #[test]
+    fn recovering_orders_after_unknown() {
+        // Ordering is by discriminant; Recovering must not silently collide
+        // with existing variants.
+        assert!(DeviceStatus::Online < DeviceStatus::Recovering);
+        assert!(DeviceStatus::Offline < DeviceStatus::Recovering);
+        assert!(DeviceStatus::Unknown < DeviceStatus::Recovering);
     }
 }

--- a/src-tauri/crates/uc-core/src/network/events.rs
+++ b/src-tauri/crates/uc-core/src/network/events.rs
@@ -49,6 +49,47 @@ pub struct ConnectedPeer {
     pub connected_at: DateTime<Utc>,
 }
 
+/// Live per-peer runtime state driven by the recovery coordinator.
+///
+/// `PeerRuntimeState` is the user-facing three-state model defined in the
+/// Connection Stability Recovery PRD
+/// (`docs/p2p/2026-04-11-connection-stability-recovery-prd.md`). It is kept
+/// distinct from [`crate::device::DeviceStatus`], which is a database-adjacent
+/// DTO.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PeerRuntimeState {
+    Online,
+    Recovering,
+    Offline,
+}
+
+/// What triggered a recovery cycle.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RecoveryTrigger {
+    /// mDNS record for a paired peer expired.
+    MdnsExpired,
+    /// Several consecutive dial failures to the same paired peer.
+    DialFailureStreak,
+    /// First outbound attempt after a sustained idle window.
+    FirstAttemptAfterIdle,
+    /// Local device has just resumed from sleep.
+    WakeFromSleep,
+    /// Local network interface or IP address changed.
+    NetworkInterfaceChanged,
+}
+
+/// Transport-level proof that justified closing a recovery cycle as recovered.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RecoveryProof {
+    /// A recovery probe's business-stream open call returned success.
+    BusinessStreamOpen,
+    /// A fresh libp2p `ConnectionEstablished` event arrived from the swarm.
+    ConnectionEstablished,
+}
+
 /// Core network events (domain layer)
 /// Infrastructure-specific events should extend this
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -65,6 +106,39 @@ pub enum NetworkEvent {
     // Connection events
     PeerConnected(ConnectedPeer),
     PeerDisconnected(String), // peer_id
+
+    // Recovery events (Connection Stability Recovery wave 1).
+    // See docs/p2p/2026-04-11-connection-stability-recovery-prd.md.
+    /// Per-peer runtime state changed. The coordinator is the only producer.
+    PeerStateChanged {
+        peer_id: String,
+        state: PeerRuntimeState,
+        /// Present while a recovery cycle is active.
+        cycle_id: Option<String>,
+    },
+    /// A recovery cycle has begun. User-facing state may still be `Online`
+    /// during the initial silent phase.
+    PeerRecoveryStarted {
+        peer_id: String,
+        cycle_id: String,
+        trigger: RecoveryTrigger,
+    },
+    /// A recovery cycle ended successfully with transport-level proof.
+    PeerRecovered {
+        peer_id: String,
+        cycle_id: String,
+        elapsed_ms: u64,
+        proof: RecoveryProof,
+    },
+    /// A recovery cycle exhausted its escalation ladder without restoring the
+    /// peer. The user-facing state transitions to `Offline` at this point.
+    PeerRecoveryFailed {
+        peer_id: String,
+        cycle_id: String,
+        elapsed_ms: u64,
+        /// Last escalation level reached (1, 2, or 3).
+        last_escalation: u8,
+    },
 
     // Readiness events (protocol-agnostic)
     /// A peer is now ready to receive broadcast messages
@@ -251,6 +325,69 @@ mod tests {
             let json2 = serde_json::to_string(&restored).unwrap();
             assert_eq!(json, json2);
         }
+    }
+
+    #[test]
+    fn recovery_events_round_trip_through_serde() {
+        let events = vec![
+            NetworkEvent::PeerStateChanged {
+                peer_id: "peer-1".to_string(),
+                state: PeerRuntimeState::Recovering,
+                cycle_id: Some("cycle-abc".to_string()),
+            },
+            NetworkEvent::PeerStateChanged {
+                peer_id: "peer-1".to_string(),
+                state: PeerRuntimeState::Online,
+                cycle_id: None,
+            },
+            NetworkEvent::PeerRecoveryStarted {
+                peer_id: "peer-1".to_string(),
+                cycle_id: "cycle-abc".to_string(),
+                trigger: RecoveryTrigger::MdnsExpired,
+            },
+            NetworkEvent::PeerRecoveryStarted {
+                peer_id: "peer-2".to_string(),
+                cycle_id: "cycle-def".to_string(),
+                trigger: RecoveryTrigger::WakeFromSleep,
+            },
+            NetworkEvent::PeerRecovered {
+                peer_id: "peer-1".to_string(),
+                cycle_id: "cycle-abc".to_string(),
+                elapsed_ms: 7200,
+                proof: RecoveryProof::BusinessStreamOpen,
+            },
+            NetworkEvent::PeerRecovered {
+                peer_id: "peer-1".to_string(),
+                cycle_id: "cycle-abc".to_string(),
+                elapsed_ms: 42_000,
+                proof: RecoveryProof::ConnectionEstablished,
+            },
+            NetworkEvent::PeerRecoveryFailed {
+                peer_id: "peer-3".to_string(),
+                cycle_id: "cycle-xyz".to_string(),
+                elapsed_ms: 120_000,
+                last_escalation: 3,
+            },
+        ];
+
+        for event in &events {
+            let json = serde_json::to_string(event).unwrap();
+            let restored: NetworkEvent = serde_json::from_str(&json).unwrap();
+            let json2 = serde_json::to_string(&restored).unwrap();
+            assert_eq!(json, json2, "round-trip mismatch for {event:?}");
+        }
+    }
+
+    #[test]
+    fn peer_runtime_state_serializes_as_snake_case() {
+        let json = serde_json::to_string(&PeerRuntimeState::Recovering).unwrap();
+        assert_eq!(json, "\"recovering\"");
+    }
+
+    #[test]
+    fn recovery_trigger_serializes_as_snake_case() {
+        let json = serde_json::to_string(&RecoveryTrigger::NetworkInterfaceChanged).unwrap();
+        assert_eq!(json, "\"network_interface_changed\"");
     }
 
     #[test]

--- a/src-tauri/crates/uc-infra/Cargo.toml
+++ b/src-tauri/crates/uc-infra/Cargo.toml
@@ -55,7 +55,7 @@ blake3 = "1.8.2"
 hex = "0.4.3"
 config = "0.15.19"
 image = { version = "0.25", default-features = false, features = ["png", "jpeg", "webp", "tiff"] }
-zstd = "0.13"
+zstd = { version = "0.13", features = ["zstdmt"] }
 
 [dependencies.uuid]
 version = "1.10.0"

--- a/src-tauri/crates/uc-infra/src/clipboard/chunked_transfer.rs
+++ b/src-tauri/crates/uc-infra/src/clipboard/chunked_transfer.rs
@@ -27,6 +27,7 @@ use chacha20poly1305::{
     aead::{Aead, Payload},
     KeyInit, XChaCha20Poly1305, XNonce,
 };
+use tracing::info_span;
 use uc_core::config::RECEIVE_PLAINTEXT_CAP;
 use uc_core::ports::{
     TransferCryptoError, TransferPayloadDecryptorPort, TransferPayloadEncryptorPort,
@@ -58,6 +59,11 @@ pub const MAX_DECOMPRESSED_SIZE: usize = RECEIVE_PLAINTEXT_CAP;
 
 /// Zstd compression level (consistent with Phase 4 blob at-rest choice).
 pub const ZSTD_LEVEL: i32 = 3;
+
+/// Payloads larger than this use multi-threaded zstd compression.
+/// Below this threshold, single-threaded `zstd::bulk::compress` is used to
+/// avoid thread-pool startup overhead for small payloads.
+const PARALLEL_COMPRESSION_THRESHOLD: usize = 1024 * 1024; // 1 MiB
 
 /// Errors that can occur during chunked transfer encoding or decoding.
 ///
@@ -397,6 +403,26 @@ impl ChunkedDecoder {
     }
 }
 
+/// Compress `data` with zstd, using multi-threaded mode for large payloads.
+///
+/// Payloads above `PARALLEL_COMPRESSION_THRESHOLD` (1 MiB) use zstd's
+/// built-in worker pool (one thread per core), which significantly reduces
+/// wall-clock time for multi-megabyte clipboard content. Smaller payloads
+/// use single-threaded `zstd::bulk::compress` to avoid thread-pool overhead.
+fn compress_zstd(data: &[u8], level: i32) -> std::io::Result<Vec<u8>> {
+    if data.len() < PARALLEL_COMPRESSION_THRESHOLD {
+        return zstd::bulk::compress(data, level)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e));
+    }
+    let n_workers = std::thread::available_parallelism()
+        .map(|n| n.get() as u32)
+        .unwrap_or(1);
+    let mut encoder = zstd::Encoder::new(Vec::new(), level)?;
+    encoder.multithread(n_workers)?;
+    encoder.write_all(data)?;
+    encoder.finish()
+}
+
 /// Adapter implementing `TransferPayloadEncryptorPort` via `ChunkedEncoder`.
 ///
 /// Generates `transfer_id` internally (UUID v4) -- callers do not need to manage it.
@@ -419,7 +445,8 @@ impl TransferPayloadEncryptorPort for TransferPayloadEncryptorAdapter {
         })?;
 
         let (data_to_encrypt, compression_algo) = if plaintext.len() > COMPRESSION_THRESHOLD {
-            let compressed = zstd::bulk::compress(plaintext, ZSTD_LEVEL).map_err(|e| {
+            let _guard = info_span!("transfer.compress", input_len = plaintext.len()).entered();
+            let compressed = compress_zstd(plaintext, ZSTD_LEVEL).map_err(|e| {
                 TransferCryptoError::EncryptionFailed(format!("compression failed: {e}"))
             })?;
 
@@ -433,14 +460,18 @@ impl TransferPayloadEncryptorPort for TransferPayloadEncryptorAdapter {
         };
 
         let mut buf = Vec::new();
-        ChunkedEncoder::encode_to(
-            &mut buf,
-            master_key,
-            &transfer_id,
-            &data_to_encrypt,
-            compression_algo,
-            uncompressed_len,
-        )?;
+        {
+            let _guard =
+                info_span!("transfer.chunked_encrypt", data_len = data_to_encrypt.len(),).entered();
+            ChunkedEncoder::encode_to(
+                &mut buf,
+                master_key,
+                &transfer_id,
+                &data_to_encrypt,
+                compression_algo,
+                uncompressed_len,
+            )?;
+        }
         Ok(buf)
     }
 }

--- a/src-tauri/crates/uc-platform/src/adapters/libp2p_network/business_stream.rs
+++ b/src-tauri/crates/uc-platform/src/adapters/libp2p_network/business_stream.rs
@@ -46,9 +46,12 @@ async fn wait_for_preferred_connection(
     required_priority: u8,
     wait_budget: Duration,
 ) -> Result<()> {
-    let deadline = tokio::time::Instant::now() + wait_budget;
+    let started = tokio::time::Instant::now();
+    let deadline = started + wait_budget;
+    let mut poll_count: u32 = 0;
 
     loop {
+        poll_count += 1;
         let snapshot = {
             let caches = caches.read().await;
             snapshot_peer_addresses(&caches, peer_id, Utc::now())
@@ -58,10 +61,25 @@ async fn wait_for_preferred_connection(
             .is_some_and(|priority| priority <= required_priority);
 
         if snapshot.peer_marked_reachable && best_connection_ready {
+            debug!(
+                peer_id = %peer_id,
+                poll_count,
+                elapsed_ms = started.elapsed().as_millis() as u64,
+                "wait_for_preferred_connection succeeded"
+            );
             return Ok(());
         }
 
         if tokio::time::Instant::now() >= deadline {
+            warn!(
+                peer_id = %peer_id,
+                poll_count,
+                elapsed_ms = started.elapsed().as_millis() as u64,
+                peer_marked_reachable = snapshot.peer_marked_reachable,
+                best_connected_priority = ?snapshot.best_connected_effective_priority,
+                required_priority,
+                "wait_for_preferred_connection timed out"
+            );
             return Err(anyhow!(
                 "timed out waiting for explicit connection with priority <= {required_priority}"
             ));

--- a/src-tauri/crates/uc-platform/src/adapters/libp2p_network/business_stream.rs
+++ b/src-tauri/crates/uc-platform/src/adapters/libp2p_network/business_stream.rs
@@ -173,6 +173,7 @@ async fn ensure_explicit_connection(
                 peer,
                 addresses: addrs,
                 allow_connected_dial: dial_decision == "upgrade_to_better_connection",
+                bypass_address_filter: false,
                 result_tx: tx,
             }),
         )

--- a/src-tauri/crates/uc-platform/src/adapters/libp2p_network/business_stream.rs
+++ b/src-tauri/crates/uc-platform/src/adapters/libp2p_network/business_stream.rs
@@ -422,6 +422,18 @@ pub(super) async fn execute_business_stream(
                 );
                 Err(anyhow!("business stream pre-dial failed: {err}"))
             }
+            Ok(()) if payload.is_none() => {
+                // 方案B: ensure only establishes the connection (dial),
+                // no dummy stream open/close needed.
+                debug!(
+                    event = "business_stream.ensure_dial_only",
+                    operation = denied_operation,
+                    peer_id = %peer_id_str,
+                    dial_decision,
+                    "ensure completed via dial-only (no stream probe)"
+                );
+                Ok(())
+            }
             Ok(()) => match tokio::time::timeout(
                 open_timeout
                     .checked_sub(open_started_at.elapsed())
@@ -431,111 +443,105 @@ pub(super) async fn execute_business_stream(
             .await
             {
             Ok(Ok(mut stream)) => {
-                if let Some(data) = payload {
-                    // Write payload in NETWORK_CHUNK_SIZE chunks with progress tracking
-                    let total = data.len() as u64;
-                    let total_chunks =
-                        ((data.len() + NETWORK_CHUNK_SIZE - 1) / NETWORK_CHUNK_SIZE) as u32;
-                    let transfer_id = if data.len() >= 25 {
-                        // Extract transfer_id from V3 header bytes [9..25] if payload is large enough
-                        data[9..25]
-                            .iter()
-                            .map(|b| format!("{b:02x}"))
-                            .collect::<String>()
-                    } else {
-                        format!("outbound-{}", peer_id_str)
-                    };
+                // payload is guaranteed Some here — the None case
+                // returns early after ensure_explicit_connection above.
+                let Some(data) = payload else {
+                    return Ok(());
+                };
+                // Write payload in NETWORK_CHUNK_SIZE chunks with progress tracking
+                let total = data.len() as u64;
+                let total_chunks =
+                    ((data.len() + NETWORK_CHUNK_SIZE - 1) / NETWORK_CHUNK_SIZE) as u32;
+                let transfer_id = if data.len() >= 25 {
+                    // Extract transfer_id from V3 header bytes [9..25] if payload is large enough
+                    data[9..25]
+                        .iter()
+                        .map(|b| format!("{b:02x}"))
+                        .collect::<String>()
+                } else {
+                    format!("outbound-{}", peer_id_str)
+                };
 
+                debug!(
+                    peer_id = %peer_id_str,
+                    transfer_id = %transfer_id,
+                    total_bytes = total,
+                    total_chunks,
+                    chunk_size = NETWORK_CHUNK_SIZE,
+                    "outbound chunked write started"
+                );
+
+                let write_result = tokio::time::timeout(write_timeout, async {
+                    let mut written = 0u64;
+                    let mut chunks_completed = 0u32;
+                    let mut last_progress = std::time::Instant::now();
+
+                    for chunk in data.chunks(NETWORK_CHUNK_SIZE) {
+                        stream.write_all(chunk).await?;
+                        written += chunk.len() as u64;
+                        chunks_completed += 1;
+
+                        debug!(
+                            transfer_id = %transfer_id,
+                            chunk = chunks_completed,
+                            total_chunks,
+                            chunk_bytes = chunk.len(),
+                            bytes_written = written,
+                            total_bytes = total,
+                            "outbound chunk written"
+                        );
+
+                        // Throttle progress events: emit first, last, and at most every 100ms
+                        if chunks_completed == 1
+                            || chunks_completed == total_chunks
+                            || last_progress.elapsed() >= Duration::from_millis(100)
+                        {
+                            let _ = try_send_event(
+                                &event_tx,
+                                NetworkEvent::TransferProgress(TransferProgress {
+                                    transfer_id: transfer_id.clone(),
+                                    peer_id: peer_id_str.to_string(),
+                                    direction: TransferDirection::Sending,
+                                    chunks_completed,
+                                    total_chunks,
+                                    bytes_transferred: written,
+                                    total_bytes: Some(total),
+                                }),
+                                "TransferProgress",
+                            );
+                            last_progress = std::time::Instant::now();
+                        }
+                    }
+                    stream.flush().await?;
                     debug!(
-                        peer_id = %peer_id_str,
                         transfer_id = %transfer_id,
                         total_bytes = total,
                         total_chunks,
-                        chunk_size = NETWORK_CHUNK_SIZE,
-                        "outbound chunked write started"
+                        "outbound chunked write completed"
                     );
+                    Ok::<(), std::io::Error>(())
+                })
+                .await;
 
-                    let write_result = tokio::time::timeout(write_timeout, async {
-                        let mut written = 0u64;
-                        let mut chunks_completed = 0u32;
-                        let mut last_progress = std::time::Instant::now();
-
-                        for chunk in data.chunks(NETWORK_CHUNK_SIZE) {
-                            stream.write_all(chunk).await?;
-                            written += chunk.len() as u64;
-                            chunks_completed += 1;
-
-                            debug!(
-                                transfer_id = %transfer_id,
-                                chunk = chunks_completed,
-                                total_chunks,
-                                chunk_bytes = chunk.len(),
-                                bytes_written = written,
-                                total_bytes = total,
-                                "outbound chunk written"
-                            );
-
-                            // Throttle progress events: emit first, last, and at most every 100ms
-                            if chunks_completed == 1
-                                || chunks_completed == total_chunks
-                                || last_progress.elapsed() >= Duration::from_millis(100)
-                            {
-                                let _ = try_send_event(
-                                    &event_tx,
-                                    NetworkEvent::TransferProgress(TransferProgress {
-                                        transfer_id: transfer_id.clone(),
-                                        peer_id: peer_id_str.to_string(),
-                                        direction: TransferDirection::Sending,
-                                        chunks_completed,
-                                        total_chunks,
-                                        bytes_transferred: written,
-                                        total_bytes: Some(total),
-                                    }),
-                                    "TransferProgress",
-                                );
-                                last_progress = std::time::Instant::now();
-                            }
-                        }
-                        stream.flush().await?;
-                        debug!(
-                            transfer_id = %transfer_id,
-                            total_bytes = total,
-                            total_chunks,
-                            "outbound chunked write completed"
-                        );
-                        Ok::<(), std::io::Error>(())
-                    })
-                    .await;
-
-                    match write_result {
-                        Ok(Ok(())) => match tokio::time::timeout(close_timeout, stream.close()).await {
-                            Ok(Ok(())) => Ok(()),
-                            Ok(Err(err)) => {
-                                warn!("business stream close failed: {err}");
-                                Err(anyhow!("business stream close failed: {err}"))
-                            }
-                            Err(_) => {
-                                warn!(peer_id = %peer_id_str, "business stream close timed out");
-                                Err(anyhow!("business stream close timed out"))
-                            }
-                        },
-                        Ok(Err(err)) => {
-                            warn!("business stream write failed: {err}");
-                            Err(anyhow!("business stream write failed: {err}"))
-                        }
-                        Err(_) => {
-                            warn!(peer_id = %peer_id_str, "business stream write timed out");
-                            Err(anyhow!("business stream write timed out"))
-                        }
-                    }
-                } else {
-                    match tokio::time::timeout(close_timeout, stream.close()).await {
+                match write_result {
+                    Ok(Ok(())) => match tokio::time::timeout(close_timeout, stream.close()).await {
                         Ok(Ok(())) => Ok(()),
-                        Ok(Err(err)) => Err(anyhow!("ensure business stream close failed: {err}")),
-                        Err(_) => {
-                            warn!(peer_id = %peer_id_str, "ensure business stream close timed out");
-                            Err(anyhow!("ensure business stream close timed out"))
+                        Ok(Err(err)) => {
+                            warn!("business stream close failed: {err}");
+                            Err(anyhow!("business stream close failed: {err}"))
                         }
+                        Err(_) => {
+                            warn!(peer_id = %peer_id_str, "business stream close timed out");
+                            Err(anyhow!("business stream close timed out"))
+                        }
+                    },
+                    Ok(Err(err)) => {
+                        warn!("business stream write failed: {err}");
+                        Err(anyhow!("business stream write failed: {err}"))
+                    }
+                    Err(_) => {
+                        warn!(peer_id = %peer_id_str, "business stream write timed out");
+                        Err(anyhow!("business stream write timed out"))
                     }
                 }
             }
@@ -551,43 +557,23 @@ pub(super) async fn execute_business_stream(
                     dial_decision,
                     attempt_started_at,
                 );
-                if payload.is_some() {
-                    warn!(
-                        event = "business_stream.open_failed",
-                        operation = denied_operation,
-                        peer_id = %peer_id_str,
-                        dial_decision,
-                        candidate_address_count = failure_snapshot.candidate_addresses.len(),
-                        candidate_addresses = ?failure_snapshot.candidate_addresses,
-                        chosen_dial_addr = %chosen_dial_addr.unwrap_or("-"),
-                        chosen_dial_addr_resolution,
-                        dial_attempt_address_count = failure_snapshot.dial_attempt_address_count,
-                        dial_attempt_addresses = ?failure_snapshot.dial_attempt_addresses,
-                        last_dial_outcome = failure_snapshot.last_dial_outcome.unwrap_or("unknown"),
-                        last_dial_age_ms = ?failure_snapshot.last_dial_age_ms,
-                        error = %err,
-                        "business stream open failed"
-                    );
-                    Err(anyhow!("business stream open failed: {err}"))
-                } else {
-                    warn!(
-                        event = "business_stream.ensure_open_failed",
-                        operation = denied_operation,
-                        peer_id = %peer_id_str,
-                        dial_decision,
-                        candidate_address_count = failure_snapshot.candidate_addresses.len(),
-                        candidate_addresses = ?failure_snapshot.candidate_addresses,
-                        chosen_dial_addr = %chosen_dial_addr.unwrap_or("-"),
-                        chosen_dial_addr_resolution,
-                        dial_attempt_address_count = failure_snapshot.dial_attempt_address_count,
-                        dial_attempt_addresses = ?failure_snapshot.dial_attempt_addresses,
-                        last_dial_outcome = failure_snapshot.last_dial_outcome.unwrap_or("unknown"),
-                        last_dial_age_ms = ?failure_snapshot.last_dial_age_ms,
-                        error = %err,
-                        "ensure business stream open failed"
-                    );
-                    Err(anyhow!("ensure business stream open failed: {err}"))
-                }
+                warn!(
+                    event = "business_stream.open_failed",
+                    operation = denied_operation,
+                    peer_id = %peer_id_str,
+                    dial_decision,
+                    candidate_address_count = failure_snapshot.candidate_addresses.len(),
+                    candidate_addresses = ?failure_snapshot.candidate_addresses,
+                    chosen_dial_addr = %chosen_dial_addr.unwrap_or("-"),
+                    chosen_dial_addr_resolution,
+                    dial_attempt_address_count = failure_snapshot.dial_attempt_address_count,
+                    dial_attempt_addresses = ?failure_snapshot.dial_attempt_addresses,
+                    last_dial_outcome = failure_snapshot.last_dial_outcome.unwrap_or("unknown"),
+                    last_dial_age_ms = ?failure_snapshot.last_dial_age_ms,
+                    error = %err,
+                    "business stream open failed"
+                );
+                Err(anyhow!("business stream open failed: {err}"))
             }
             Err(_) => {
                 let timeout_snapshot = {
@@ -601,43 +587,23 @@ pub(super) async fn execute_business_stream(
                     dial_decision,
                     attempt_started_at,
                 );
-                if payload.is_some() {
-                    warn!(
-                        event = "business_stream.open_timeout",
-                        operation = denied_operation,
-                        peer_id = %peer_id_str,
-                        dial_decision,
-                        candidate_address_count = timeout_snapshot.candidate_addresses.len(),
-                        candidate_addresses = ?timeout_snapshot.candidate_addresses,
-                        chosen_dial_addr = %chosen_dial_addr.unwrap_or("-"),
-                        chosen_dial_addr_resolution,
-                        dial_attempt_address_count = timeout_snapshot.dial_attempt_address_count,
-                        dial_attempt_addresses = ?timeout_snapshot.dial_attempt_addresses,
-                        last_dial_outcome = timeout_snapshot.last_dial_outcome.unwrap_or("unknown"),
-                        last_dial_age_ms = ?timeout_snapshot.last_dial_age_ms,
-                        timeout_ms = open_timeout.as_millis() as u64,
-                        "business stream open timed out"
-                    );
-                    Err(anyhow!("business stream open timed out"))
-                } else {
-                    warn!(
-                        event = "business_stream.ensure_open_timeout",
-                        operation = denied_operation,
-                        peer_id = %peer_id_str,
-                        dial_decision,
-                        candidate_address_count = timeout_snapshot.candidate_addresses.len(),
-                        candidate_addresses = ?timeout_snapshot.candidate_addresses,
-                        chosen_dial_addr = %chosen_dial_addr.unwrap_or("-"),
-                        chosen_dial_addr_resolution,
-                        dial_attempt_address_count = timeout_snapshot.dial_attempt_address_count,
-                        dial_attempt_addresses = ?timeout_snapshot.dial_attempt_addresses,
-                        last_dial_outcome = timeout_snapshot.last_dial_outcome.unwrap_or("unknown"),
-                        last_dial_age_ms = ?timeout_snapshot.last_dial_age_ms,
-                        timeout_ms = open_timeout.as_millis() as u64,
-                        "ensure business stream open timed out"
-                    );
-                    Err(anyhow!("ensure business stream open timed out"))
-                }
+                warn!(
+                    event = "business_stream.open_timeout",
+                    operation = denied_operation,
+                    peer_id = %peer_id_str,
+                    dial_decision,
+                    candidate_address_count = timeout_snapshot.candidate_addresses.len(),
+                    candidate_addresses = ?timeout_snapshot.candidate_addresses,
+                    chosen_dial_addr = %chosen_dial_addr.unwrap_or("-"),
+                    chosen_dial_addr_resolution,
+                    dial_attempt_address_count = timeout_snapshot.dial_attempt_address_count,
+                    dial_attempt_addresses = ?timeout_snapshot.dial_attempt_addresses,
+                    last_dial_outcome = timeout_snapshot.last_dial_outcome.unwrap_or("unknown"),
+                    last_dial_age_ms = ?timeout_snapshot.last_dial_age_ms,
+                    timeout_ms = open_timeout.as_millis() as u64,
+                    "business stream open timed out"
+                );
+                Err(anyhow!("business stream open timed out"))
             }
         }};
 

--- a/src-tauri/crates/uc-platform/src/adapters/libp2p_network/discovery.rs
+++ b/src-tauri/crates/uc-platform/src/adapters/libp2p_network/discovery.rs
@@ -61,9 +61,17 @@ pub(crate) fn apply_mdns_expired(
     expired
         .into_iter()
         .filter_map(|peer_id| {
-            caches
-                .remove_discovered(&peer_id)
-                .map(|_| NetworkEvent::PeerLost(peer_id))
+            // Only emit PeerLost when there is no live connection; if a
+            // connection is still active the peer remains reachable and
+            // mark_connection_closed() will handle teardown later.
+            let has_live_connection = caches.active_connections.contains_key(peer_id.as_str());
+            caches.remove_discovered(&peer_id).and_then(|_| {
+                if has_live_connection {
+                    None
+                } else {
+                    Some(NetworkEvent::PeerLost(peer_id))
+                }
+            })
         })
         .collect()
 }

--- a/src-tauri/crates/uc-platform/src/adapters/libp2p_network/mod.rs
+++ b/src-tauri/crates/uc-platform/src/adapters/libp2p_network/mod.rs
@@ -878,7 +878,7 @@ impl PairingTransportPort for Libp2pNetworkAdapter {
         let event = {
             let mut caches = self.caches.write().await;
             caches
-                .remove_discovered(&peer_id)
+                .forget_peer(&peer_id)
                 .map(|_| NetworkEvent::PeerLost(peer_id.clone()))
         };
         if let Some(event) = event {

--- a/src-tauri/crates/uc-platform/src/adapters/libp2p_network/mod.rs
+++ b/src-tauri/crates/uc-platform/src/adapters/libp2p_network/mod.rs
@@ -91,6 +91,9 @@ pub(crate) const RECOVERY_PROBE_CADENCE: Duration = Duration::from_secs(5);
 pub(crate) const RECOVERY_SILENT_PHASE_MAX_PROBES: u32 = 3;
 /// Consecutive probe failure count that triggers the timed session rebuild.
 pub(crate) const RECOVERY_TIMED_REBUILD_PROBE_THRESHOLD: u32 = 3;
+/// Consecutive outgoing dial failures for a paired peer before starting a
+/// recovery cycle via `on_dial_failure_streak`.
+pub(crate) const DIAL_FAILURE_STREAK_THRESHOLD: u32 = 3;
 /// Offset from the first peer's recovery start used to evaluate the
 /// multi-peer rebuild trigger (coincides with the silent-phase duration).
 pub(crate) const RECOVERY_MULTI_PEER_REBUILD_OFFSET: Duration = Duration::from_secs(15);

--- a/src-tauri/crates/uc-platform/src/adapters/libp2p_network/mod.rs
+++ b/src-tauri/crates/uc-platform/src/adapters/libp2p_network/mod.rs
@@ -172,7 +172,7 @@ pub struct Libp2pNetworkAdapter {
     dial_tx: mpsc::Sender<DialRequest>,
     dial_rx: Mutex<Option<mpsc::Receiver<DialRequest>>>,
     keypair: Mutex<identity::Keypair>,
-    start_state: AtomicU8,
+    start_state: Arc<AtomicU8>,
     policy_resolver: Arc<dyn ConnectionPolicyResolverPort>,
     encryption_session: Arc<dyn EncryptionSessionPort>,
     transfer_decryptor: Arc<dyn TransferPayloadDecryptorPort>,
@@ -227,7 +227,7 @@ impl Libp2pNetworkAdapter {
             dial_tx,
             dial_rx: Mutex::new(Some(dial_rx)),
             keypair: Mutex::new(keypair),
-            start_state: AtomicU8::new(START_STATE_IDLE),
+            start_state: Arc::new(AtomicU8::new(START_STATE_IDLE)),
             policy_resolver,
             encryption_session,
             transfer_decryptor,
@@ -274,6 +274,13 @@ impl Libp2pNetworkAdapter {
         Ok(())
     }
 
+    /// Build and spawn the libp2p swarm event loop.
+    ///
+    /// # Panics
+    ///
+    /// Must be called from within an entered Tokio runtime — the function calls
+    /// `tokio::spawn` internally (via `spawn_platform_signal_listener` and
+    /// directly).
     pub fn spawn_swarm(&self) -> Result<()> {
         let mdns_config = build_mdns_config();
         info!(
@@ -422,6 +429,7 @@ impl Libp2pNetworkAdapter {
         // The initial swarm was already built above; move it into the restart
         // loop along with the keypair so the loop can rebuild on demand.
         let keypair_for_restart = keypair.clone();
+        let spawn_start_state = Arc::clone(&self.start_state);
 
         tokio::spawn(async move {
             let mut current_business_rx = business_rx;
@@ -450,6 +458,7 @@ impl Libp2pNetworkAdapter {
                     None => {
                         // Normal exit (channel closed or swarm stopped).
                         info!("swarm event loop exited normally");
+                        spawn_start_state.store(START_STATE_IDLE, Ordering::Release);
                         break;
                     }
                     Some((returned_business_rx, returned_dial_rx, returned_platform_signal_rx)) => {
@@ -494,6 +503,7 @@ impl Libp2pNetworkAdapter {
                                     error = %err,
                                     "failed to rebuild swarm; giving up"
                                 );
+                                spawn_start_state.store(START_STATE_IDLE, Ordering::Release);
                                 break;
                             }
                         }

--- a/src-tauri/crates/uc-platform/src/adapters/libp2p_network/mod.rs
+++ b/src-tauri/crates/uc-platform/src/adapters/libp2p_network/mod.rs
@@ -143,6 +143,10 @@ pub(super) struct DialRequest {
     pub peer: PeerId,
     pub addresses: Vec<Multiaddr>,
     pub allow_connected_dial: bool,
+    /// When `true`, skip the live-address filter in `handle_dial_request` so
+    /// historical addresses (e.g. from `last_dial_observations`) are not
+    /// discarded by the mDNS registry check.  Used by recovery probes.
+    pub bypass_address_filter: bool,
     pub result_tx: oneshot::Sender<Result<()>>,
 }
 

--- a/src-tauri/crates/uc-platform/src/adapters/libp2p_network/mod.rs
+++ b/src-tauri/crates/uc-platform/src/adapters/libp2p_network/mod.rs
@@ -4,6 +4,9 @@ mod business_stream;
 mod dial_strategy;
 mod discovery;
 pub(crate) mod peer_cache;
+mod platform_signals;
+pub(crate) mod recovery_coordinator;
+mod recovery_probe;
 mod stream_handler;
 mod swarm_event_loop;
 #[cfg(test)]
@@ -74,6 +77,23 @@ const QUIC_KEEP_ALIVE_INTERVAL: Duration = Duration::from_secs(5);
 const QUIC_MAX_CONCURRENT_STREAM_LIMIT: u32 = 1024;
 const QUIC_MAX_STREAM_DATA_BYTES: u32 = 32 * 1024 * 1024;
 const QUIC_MAX_CONNECTION_DATA_BYTES: u32 = 128 * 1024 * 1024;
+// ── Connection Stability Recovery timing constants ─────────────────────────
+// See docs/p2p/2026-04-11-connection-stability-recovery-prd.md §Constants Location
+/// Silent phase: recovery is in progress but the user-facing state stays
+/// `Online`. After this window the state transitions to `Recovering`.
+pub(crate) const RECOVERY_SILENT_PHASE_DURATION: Duration = Duration::from_secs(15);
+/// Total recovery window. After this elapses and all escalation steps have
+/// been exhausted the peer is allowed to transition to `Offline`.
+pub(crate) const RECOVERY_WINDOW: Duration = Duration::from_secs(120);
+/// Interval between consecutive recovery probes.
+pub(crate) const RECOVERY_PROBE_CADENCE: Duration = Duration::from_secs(5);
+/// Maximum number of probe attempts during the silent phase (0-15 s).
+pub(crate) const RECOVERY_SILENT_PHASE_MAX_PROBES: u32 = 3;
+/// Consecutive probe failure count that triggers the timed session rebuild.
+pub(crate) const RECOVERY_TIMED_REBUILD_PROBE_THRESHOLD: u32 = 3;
+/// Offset from the first peer's recovery start used to evaluate the
+/// multi-peer rebuild trigger (coincides with the silent-phase duration).
+pub(crate) const RECOVERY_MULTI_PEER_REBUILD_OFFSET: Duration = Duration::from_secs(15);
 const START_STATE_IDLE: u8 = 0;
 const START_STATE_STARTING: u8 = 1;
 const START_STATE_STARTED: u8 = 2;
@@ -154,10 +174,14 @@ pub struct Libp2pNetworkAdapter {
     encryption_session: Arc<dyn EncryptionSessionPort>,
     transfer_decryptor: Arc<dyn TransferPayloadDecryptorPort>,
     _transfer_encryptor: Arc<dyn TransferPayloadEncryptorPort>,
-    stream_control: Mutex<Option<stream::Control>>,
+    /// Wrapped in `Arc` so the swarm restart loop can update this handle when
+    /// rebuilding the session without needing a reference back to `self`.
+    stream_control: Arc<Mutex<Option<stream::Control>>>,
     pairing_runtime_owner: PairingRuntimeOwner,
-    pairing_service: Mutex<Option<PairingStreamService>>,
-    file_transfer_service: Mutex<Option<FileTransferService>>,
+    /// Same `Arc` rationale as `stream_control`.
+    pairing_service: Arc<Mutex<Option<PairingStreamService>>>,
+    /// Same `Arc` rationale as `stream_control`.
+    file_transfer_service: Arc<Mutex<Option<FileTransferService>>>,
     file_cache_dir: PathBuf,
 }
 
@@ -185,8 +209,6 @@ impl Libp2pNetworkAdapter {
         let (clipboard_tx, clipboard_rx) = mpsc::channel(64);
         let (business_tx, business_rx) = mpsc::channel(64);
         let (dial_tx, dial_rx) = mpsc::channel(32);
-        let pairing_service = Mutex::new(None);
-
         Ok(Self {
             local_peer_id,
             local_identity_pubkey,
@@ -207,10 +229,10 @@ impl Libp2pNetworkAdapter {
             encryption_session,
             transfer_decryptor,
             _transfer_encryptor: transfer_encryptor,
-            stream_control: Mutex::new(None),
+            stream_control: Arc::new(Mutex::new(None)),
             pairing_runtime_owner,
-            pairing_service,
-            file_transfer_service: Mutex::new(None),
+            pairing_service: Arc::new(Mutex::new(None)),
+            file_transfer_service: Arc::new(Mutex::new(None)),
             file_cache_dir,
         })
     }
@@ -263,7 +285,7 @@ impl Libp2pNetworkAdapter {
         let behaviour = Libp2pBehaviour::new(local_peer_id)
             .map_err(|e| anyhow!("failed to create libp2p behaviour: {e}"))?;
 
-        let mut swarm = SwarmBuilder::with_existing_identity(keypair)
+        let mut swarm = SwarmBuilder::with_existing_identity(keypair.clone())
             .with_tokio()
             .with_tcp(
                 tcp::Config::default().nodelay(true),
@@ -374,22 +396,107 @@ impl Libp2pNetworkAdapter {
         let caches = self.caches.clone();
         let event_tx = self.event_tx.clone();
         let policy_resolver = self.policy_resolver.clone();
+        let clipboard_tx = self.clipboard_tx.clone();
+        let encryption_session = self.encryption_session.clone();
+        let transfer_decryptor = self.transfer_decryptor.clone();
+        let file_cache_dir = self.file_cache_dir.clone();
+        let pairing_runtime_owner = self.pairing_runtime_owner;
+        let stream_control_holder = Arc::clone(&self.stream_control);
+        let pairing_service_holder = Arc::clone(&self.pairing_service);
+        let file_transfer_service_holder = Arc::clone(&self.file_transfer_service);
         let business_rx = Self::take_receiver(&self.business_rx, "business command")?;
         let dial_rx = Self::take_receiver(&self.dial_rx, "dial request")?;
         let dial_tx = self.dial_tx.clone();
         let local_peer_id: Arc<str> = self.local_peer_id.clone().into();
+
+        // Spawn platform-signal listeners (network-change polling on all
+        // platforms, IOKit sleep/wake on macOS). The returned receiver lives
+        // for the whole restart loop lifetime and is threaded through each
+        // `run_swarm` invocation so sleep/wake and IP-change events survive
+        // session rebuilds.
+        let platform_signal_rx = platform_signals::spawn_platform_signal_listener();
+
+        // The initial swarm was already built above; move it into the restart
+        // loop along with the keypair so the loop can rebuild on demand.
+        let keypair_for_restart = keypair.clone();
+
         tokio::spawn(async move {
-            run_swarm(
-                swarm,
-                caches,
-                event_tx,
-                policy_resolver,
-                business_rx,
-                dial_rx,
-                dial_tx,
-                local_peer_id,
-            )
-            .await;
+            let mut current_business_rx = business_rx;
+            let mut current_dial_rx = dial_rx;
+            let mut current_platform_signal_rx: Option<_> = Some(platform_signal_rx);
+
+            // Track how many times we have rebuilt so we can log it.
+            let mut rebuild_count: u32 = 0;
+            let mut current_swarm = swarm;
+
+            loop {
+                let result = run_swarm(
+                    current_swarm,
+                    caches.clone(),
+                    event_tx.clone(),
+                    policy_resolver.clone(),
+                    current_business_rx,
+                    current_dial_rx,
+                    dial_tx.clone(),
+                    local_peer_id.clone(),
+                    current_platform_signal_rx.take(),
+                )
+                .await;
+
+                match result {
+                    None => {
+                        // Normal exit (channel closed or swarm stopped).
+                        info!("swarm event loop exited normally");
+                        break;
+                    }
+                    Some((returned_business_rx, returned_dial_rx, returned_platform_signal_rx)) => {
+                        // The recovery coordinator requested a session rebuild.
+                        rebuild_count += 1;
+                        info!(
+                            event = "network.session_rebuild_attempt",
+                            rebuild_count, "rebuilding local network session"
+                        );
+
+                        current_business_rx = returned_business_rx;
+                        current_dial_rx = returned_dial_rx;
+                        current_platform_signal_rx = returned_platform_signal_rx;
+
+                        // Build a fresh swarm and re-register all services.
+                        match build_swarm_for_restart(
+                            keypair_for_restart.clone(),
+                            pairing_runtime_owner,
+                            &caches,
+                            &event_tx,
+                            &clipboard_tx,
+                            &policy_resolver,
+                            &encryption_session,
+                            &transfer_decryptor,
+                            &file_cache_dir,
+                            &stream_control_holder,
+                            &pairing_service_holder,
+                            &file_transfer_service_holder,
+                        ) {
+                            Ok(new_swarm) => {
+                                info!(
+                                    event = "network.session_rebuild_succeeded",
+                                    rebuild_count,
+                                    "new swarm built successfully; resuming event loop"
+                                );
+                                current_swarm = new_swarm;
+                            }
+                            Err(err) => {
+                                error!(
+                                    event = "network.session_rebuild_failed",
+                                    rebuild_count,
+                                    error = %err,
+                                    "failed to rebuild swarm; giving up"
+                                );
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
         });
         Ok(())
     }
@@ -421,6 +528,126 @@ impl Libp2pNetworkAdapter {
             }
         }
     }
+}
+
+/// Build a fresh libp2p swarm, register all services, and start listening.
+///
+/// Used by the swarm restart loop in `spawn_swarm` after the recovery
+/// coordinator has requested a full session rebuild.  All service handles
+/// stored in the shared `Arc<Mutex<...>>` holders are replaced with fresh
+/// instances backed by the new swarm's `stream::Control`.
+///
+/// The old swarm has already been dropped by the time this is called (it is
+/// consumed by `run_swarm` and is gone once that future returns).
+#[allow(clippy::too_many_arguments)]
+fn build_swarm_for_restart(
+    keypair: identity::Keypair,
+    pairing_runtime_owner: PairingRuntimeOwner,
+    caches: &Arc<RwLock<PeerCaches>>,
+    event_tx: &mpsc::Sender<NetworkEvent>,
+    clipboard_tx: &mpsc::Sender<(ClipboardMessage, Option<Vec<u8>>)>,
+    policy_resolver: &Arc<dyn ConnectionPolicyResolverPort>,
+    encryption_session: &Arc<dyn EncryptionSessionPort>,
+    transfer_decryptor: &Arc<dyn TransferPayloadDecryptorPort>,
+    file_cache_dir: &PathBuf,
+    stream_control_holder: &Arc<Mutex<Option<stream::Control>>>,
+    pairing_service_holder: &Arc<Mutex<Option<PairingStreamService>>>,
+    file_transfer_service_holder: &Arc<Mutex<Option<FileTransferService>>>,
+) -> Result<libp2p::swarm::Swarm<Libp2pBehaviour>> {
+    let local_peer_id = PeerId::from(keypair.public());
+    let behaviour = Libp2pBehaviour::new(local_peer_id)
+        .map_err(|e| anyhow!("rebuild: failed to create libp2p behaviour: {e}"))?;
+
+    let mut swarm = SwarmBuilder::with_existing_identity(keypair)
+        .with_tokio()
+        .with_tcp(
+            tcp::Config::default().nodelay(true),
+            noise::Config::new,
+            yamux::Config::default,
+        )
+        .map_err(|e| anyhow!("rebuild: failed to configure tcp transport: {e}"))?
+        .with_quic_config(build_quic_config)
+        .with_behaviour(move |_| behaviour)
+        .map_err(|e| anyhow!("rebuild: failed to attach libp2p behaviour: {e}"))?
+        .build();
+
+    let stream_control = swarm.behaviour().stream.new_control();
+
+    // Update shared stream control handle.
+    {
+        let mut guard = stream_control_holder
+            .lock()
+            .map_err(|_| anyhow!("rebuild: stream_control mutex poisoned"))?;
+        *guard = Some(stream_control.clone());
+    }
+
+    // Recreate pairing service if this process owns the pairing runtime.
+    if pairing_runtime_owner == PairingRuntimeOwner::CurrentProcess {
+        let pairing_service = PairingStreamService::new(
+            stream_control.clone(),
+            event_tx.clone(),
+            PairingStreamConfig::default(),
+        );
+        pairing_service.spawn_accept_loop();
+        let mut guard = pairing_service_holder
+            .lock()
+            .map_err(|_| anyhow!("rebuild: pairing_service mutex poisoned"))?;
+        *guard = Some(pairing_service);
+    }
+
+    // Recreate file transfer service.
+    let file_transfer_service = FileTransferService::new(
+        stream_control.clone(),
+        event_tx.clone(),
+        Arc::new(NetworkEventTransferProgressPort {
+            event_tx: event_tx.clone(),
+        }),
+        FileTransferConfig::new(file_cache_dir.clone()),
+    );
+    file_transfer_service.spawn_accept_loop();
+    {
+        let mut guard = file_transfer_service_holder
+            .lock()
+            .map_err(|_| anyhow!("rebuild: file_transfer_service mutex poisoned"))?;
+        *guard = Some(file_transfer_service);
+    }
+
+    // Spawn new business stream handler backed by the new stream control.
+    spawn_business_stream_handler(
+        stream_control,
+        caches.clone(),
+        event_tx.clone(),
+        clipboard_tx.clone(),
+        policy_resolver.clone(),
+        encryption_session.clone(),
+        transfer_decryptor.clone(),
+    );
+
+    // Bind to a fresh port for the rebuild.
+    let listen_ip = match crate::net_utils::get_physical_lan_ip() {
+        Some(ip) => ip.to_string(),
+        None => {
+            warn!("rebuild: no physical LAN IP detected, falling back to 0.0.0.0");
+            "0.0.0.0".to_string()
+        }
+    };
+    let quic_addr: libp2p::Multiaddr = format!("/ip4/{listen_ip}/udp/0/quic-v1")
+        .parse()
+        .map_err(|e| anyhow!("rebuild: failed to parse quic address: {e}"))?;
+    let tcp_addr: libp2p::Multiaddr = format!("/ip4/{listen_ip}/tcp/0")
+        .parse()
+        .map_err(|e| anyhow!("rebuild: failed to parse tcp address: {e}"))?;
+
+    let quic_ok = listen_on_swarm(&mut swarm, quic_addr).is_ok();
+    let tcp_ok = listen_on_swarm(&mut swarm, tcp_addr).is_ok();
+
+    if !quic_ok && !tcp_ok {
+        return Err(anyhow!(
+            "rebuild: failed to listen on any transport (tried QUIC and TCP)"
+        ));
+    }
+
+    Ok(swarm)
 }
 
 fn build_quic_config(mut config: libp2p::quic::Config) -> libp2p::quic::Config {

--- a/src-tauri/crates/uc-platform/src/adapters/libp2p_network/peer_cache.rs
+++ b/src-tauri/crates/uc-platform/src/adapters/libp2p_network/peer_cache.rs
@@ -194,9 +194,12 @@ impl PeerCaches {
             return None;
         }
 
-        self.reachable_peers.remove(peer_id);
-        self.connected_at.remove(peer_id);
-        self.active_connections.remove(peer_id);
+        // Only strip connection state when there is no live connection.
+        // mark_connection_closed() / forget_peer() own connection teardown.
+        if !self.active_connections.contains_key(peer_id) {
+            self.reachable_peers.remove(peer_id);
+            self.connected_at.remove(peer_id);
+        }
         self.discovered_peers.remove(peer_id)
     }
 

--- a/src-tauri/crates/uc-platform/src/adapters/libp2p_network/peer_cache.rs
+++ b/src-tauri/crates/uc-platform/src/adapters/libp2p_network/peer_cache.rs
@@ -167,6 +167,11 @@ impl PeerCaches {
     ///
     /// Returns `Some(DiscoveredPeer)` if fully removed; `None` if retained or
     /// did not exist.
+    ///
+    /// `last_dial_observations` is intentionally preserved: the recovery layer
+    /// uses the last known usable dial target to retry after a transient mDNS
+    /// drop or a local-session rebuild. Call [`PeerCaches::forget_peer`] to
+    /// fully erase a peer (e.g. on unpair).
     pub fn remove_discovered(&mut self, peer_id: &str) -> Option<DiscoveredPeer> {
         self.address_registry
             .remove_peer_source(peer_id, AddressSource::Mdns);
@@ -189,6 +194,16 @@ impl PeerCaches {
         self.reachable_peers.remove(peer_id);
         self.connected_at.remove(peer_id);
         self.active_connections.remove(peer_id);
+        self.discovered_peers.remove(peer_id)
+    }
+
+    /// Fully erase a peer from every cache, including `last_dial_observations`
+    /// and the address registry. Intended for unpair / explicit forget flows.
+    pub fn forget_peer(&mut self, peer_id: &str) -> Option<DiscoveredPeer> {
+        self.address_registry.remove_peer(peer_id);
+        self.reachable_peers.remove(peer_id);
+        self.connected_at.remove(peer_id);
+        self.active_connections.remove(peer_id);
         self.last_dial_observations.remove(peer_id);
         self.discovered_peers.remove(peer_id)
     }
@@ -205,11 +220,15 @@ impl PeerCaches {
         }
     }
 
+    /// Mark a peer as unreachable, returning `true` if it was previously
+    /// reachable.
+    ///
+    /// `last_dial_observations` is intentionally preserved so the recovery
+    /// layer can retry the last known usable path after a transient outage.
     pub fn mark_unreachable(&mut self, peer_id: &str) -> bool {
         let removed = self.reachable_peers.remove(peer_id);
         self.connected_at.remove(peer_id);
         self.active_connections.remove(peer_id);
-        self.last_dial_observations.remove(peer_id);
         removed
     }
 
@@ -297,6 +316,12 @@ impl PeerCaches {
         !was_reachable && self.is_reachable(peer_id)
     }
 
+    /// Mark a connection as closed. Returns `true` if the peer transitioned
+    /// from reachable to unreachable (i.e., the last active connection closed).
+    ///
+    /// `last_dial_observations` is intentionally preserved so the recovery
+    /// coordinator can retry the last known usable path after a transient
+    /// connection drop. Call [`PeerCaches::forget_peer`] to fully erase a peer.
     pub(crate) fn mark_connection_closed(
         &mut self,
         peer_id: &str,
@@ -310,7 +335,8 @@ impl PeerCaches {
                 self.active_connections.remove(peer_id);
                 self.reachable_peers.remove(peer_id);
                 self.connected_at.remove(peer_id);
-                self.last_dial_observations.remove(peer_id);
+                // last_dial_observations intentionally not removed here;
+                // recovery layer needs the last usable path.
             } else if let Some(first_connected_at) =
                 connections.values().map(|conn| conn.connected_at).min()
             {

--- a/src-tauri/crates/uc-platform/src/adapters/libp2p_network/peer_cache.rs
+++ b/src-tauri/crates/uc-platform/src/adapters/libp2p_network/peer_cache.rs
@@ -72,6 +72,8 @@ pub struct PeerCaches {
     pub(crate) active_connections: HashMap<String, HashMap<ConnectionId, ActivePeerConnection>>,
     pub(crate) last_dial_observations: HashMap<String, PeerDialObservation>,
     pub(crate) address_registry: AddressRegistry,
+    /// Consecutive outgoing dial failures per peer, reset on connection success.
+    pub(crate) consecutive_dial_failures: HashMap<String, u32>,
 }
 
 impl PeerCaches {
@@ -84,6 +86,7 @@ impl PeerCaches {
             active_connections: HashMap::new(),
             last_dial_observations: HashMap::new(),
             address_registry: AddressRegistry::new(),
+            consecutive_dial_failures: HashMap::new(),
         }
     }
 
@@ -205,6 +208,7 @@ impl PeerCaches {
         self.connected_at.remove(peer_id);
         self.active_connections.remove(peer_id);
         self.last_dial_observations.remove(peer_id);
+        self.consecutive_dial_failures.remove(peer_id);
         self.discovered_peers.remove(peer_id)
     }
 
@@ -214,6 +218,7 @@ impl PeerCaches {
             self.connected_at
                 .entry(peer_id.to_string())
                 .or_insert(connected_at);
+            self.consecutive_dial_failures.remove(peer_id);
             true
         } else {
             false
@@ -275,6 +280,17 @@ impl PeerCaches {
             .insert(peer_id.to_string(), observation);
     }
 
+    /// Increment the consecutive dial failure counter for `peer_id` and return
+    /// the new count.
+    pub(crate) fn record_dial_failure(&mut self, peer_id: &str) -> u32 {
+        let count = self
+            .consecutive_dial_failures
+            .entry(peer_id.to_string())
+            .or_insert(0);
+        *count += 1;
+        *count
+    }
+
     pub(crate) fn record_address_success(&mut self, peer_id: &str, addr: &str) {
         self.address_registry.record_success(peer_id, addr);
     }
@@ -312,6 +328,8 @@ impl PeerCaches {
                     .insert(peer_id.to_string(), first_connected_at);
             }
         }
+
+        self.consecutive_dial_failures.remove(peer_id);
 
         !was_reachable && self.is_reachable(peer_id)
     }

--- a/src-tauri/crates/uc-platform/src/adapters/libp2p_network/platform_signals.rs
+++ b/src-tauri/crates/uc-platform/src/adapters/libp2p_network/platform_signals.rs
@@ -197,11 +197,23 @@ mod macos {
                     event = "platform.sleep_wake_detected",
                     "system woke from sleep"
                 );
-                // try_send is sufficient: if the channel is full (16 slots)
-                // the swarm has plenty of signals already and one more is
-                // redundant. If the receiver is dropped, the listener keeps
-                // running but signals become no-ops, which is acceptable.
-                let _ = ctx.tx.try_send(PlatformSignal::SleepWake);
+                match ctx.tx.try_send(PlatformSignal::SleepWake) {
+                    Ok(()) => {}
+                    Err(mpsc::error::TrySendError::Full(_)) => {
+                        warn!(
+                            event = "platform.sleep_wake_signal_dropped",
+                            reason = "channel_full",
+                            "sleep/wake signal dropped; channel full — swarm has queued signals"
+                        );
+                    }
+                    Err(mpsc::error::TrySendError::Closed(_)) => {
+                        info!(
+                            event = "platform.sleep_wake_signal_dropped",
+                            reason = "receiver_closed",
+                            "sleep/wake signal dropped; receiver closed"
+                        );
+                    }
+                }
             }
             _ => {}
         }

--- a/src-tauri/crates/uc-platform/src/adapters/libp2p_network/platform_signals.rs
+++ b/src-tauri/crates/uc-platform/src/adapters/libp2p_network/platform_signals.rs
@@ -1,0 +1,262 @@
+//! Platform signal listeners for recovery triggers.
+//!
+//! Emits two kinds of [`PlatformSignal`] into a single channel consumed by
+//! `run_swarm`:
+//!
+//! - `NetworkChange` — the physical LAN IPv4 address changed (all platforms,
+//!   via polling [`get_physical_lan_ip`])
+//! - `SleepWake`    — the device just resumed from sleep (macOS via IOKit)
+//!
+//! Non-macOS platforms currently receive only network-change signals. Linux
+//! (D-Bus / logind) and Windows (WM_POWERBROADCAST) sleep/wake integration is
+//! deferred; the recovery coordinator still has reactive triggers (mDNS expiry,
+//! dial-failure streak, first-attempt-after-idle) that keep Wave 1 functional
+//! without platform notifications.
+
+use std::net::Ipv4Addr;
+use std::time::Duration;
+
+use tokio::sync::mpsc;
+use tracing::{debug, info};
+
+use super::swarm_event_loop::PlatformSignal;
+use crate::net_utils::get_physical_lan_ip;
+
+/// Bounded buffer for platform signals. Signals are rare and the swarm loop
+/// drains them promptly, so a small capacity is sufficient and bounds memory
+/// if the consumer ever stalls.
+const PLATFORM_SIGNAL_CHANNEL_CAPACITY: usize = 16;
+
+/// Polling cadence for the network-change listener. 3s is fast enough to
+/// trigger recovery well inside the 120s window and slow enough to be
+/// negligible.
+const NETWORK_POLL_INTERVAL: Duration = Duration::from_secs(3);
+
+/// Spawn all available platform signal listeners and return the receiver.
+///
+/// Exactly one call per `spawn_swarm` invocation. Listeners live for the
+/// remainder of the process; dropping the receiver simply turns subsequent
+/// `Sender::send` calls into no-ops because the polling task will notice the
+/// closed channel and exit.
+pub(super) fn spawn_platform_signal_listener() -> mpsc::Receiver<PlatformSignal> {
+    let (tx, rx) = mpsc::channel(PLATFORM_SIGNAL_CHANNEL_CAPACITY);
+
+    spawn_network_change_listener(tx.clone());
+
+    #[cfg(all(target_os = "macos", not(test)))]
+    macos::spawn_sleep_wake_listener(tx);
+
+    #[cfg(not(all(target_os = "macos", not(test))))]
+    {
+        // Suppress unused warning on platforms without a sleep/wake listener.
+        let _ = tx;
+        info!(
+            event = "platform.sleep_wake_listener_unavailable",
+            "sleep/wake listener not active on this build; recovery will fall back to reactive triggers (mDNS expiry, dial failures, first-attempt-after-idle)"
+        );
+    }
+
+    rx
+}
+
+/// Poll the physical LAN IPv4 at [`NETWORK_POLL_INTERVAL`] and emit
+/// `NetworkChange` whenever the observed address differs from the previous
+/// sample.
+fn spawn_network_change_listener(tx: mpsc::Sender<PlatformSignal>) {
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(NETWORK_POLL_INTERVAL);
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        // The first tick fires immediately; consume it so the *next* tick is
+        // one interval from now.
+        interval.tick().await;
+
+        let mut last_ip: Option<Ipv4Addr> = get_physical_lan_ip();
+        info!(
+            event = "platform.network_change_listener_started",
+            initial_ip = ?last_ip,
+            poll_interval_secs = NETWORK_POLL_INTERVAL.as_secs(),
+            "network-change listener started"
+        );
+
+        loop {
+            interval.tick().await;
+            let current = get_physical_lan_ip();
+            if current != last_ip {
+                info!(
+                    event = "platform.network_change_detected",
+                    previous_ip = ?last_ip,
+                    current_ip = ?current,
+                    "local LAN IPv4 changed"
+                );
+                last_ip = current;
+                if tx.send(PlatformSignal::NetworkChange).await.is_err() {
+                    debug!(
+                        event = "platform.network_change_listener_exit",
+                        "platform signal receiver dropped; network-change listener exiting"
+                    );
+                    return;
+                }
+            }
+        }
+    });
+}
+
+#[cfg(all(target_os = "macos", not(test)))]
+mod macos {
+    //! macOS sleep/wake listener via IOKit.
+    //!
+    //! Registers with `IORegisterForSystemPower` on a dedicated std::thread
+    //! that runs a `CFRunLoop`. The power callback acknowledges
+    //! `CanSystemSleep` / `SystemWillSleep` immediately so we don't delay
+    //! system sleep, and forwards `SystemHasPoweredOn` into the signal channel.
+
+    use std::ffi::c_void;
+    use std::ptr;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    use libc::{c_int, c_uint};
+    use tokio::sync::mpsc;
+    use tracing::{info, warn};
+
+    use super::PlatformSignal;
+
+    // ── IOKit / CoreFoundation opaque handle types ────────────────────────
+    type IONotificationPortRef = *mut c_void;
+    #[allow(non_camel_case_types)]
+    type io_object_t = c_uint;
+    #[allow(non_camel_case_types)]
+    type io_connect_t = io_object_t;
+    #[allow(non_camel_case_types)]
+    type io_service_t = io_object_t;
+    type CFRunLoopRef = *mut c_void;
+    type CFRunLoopSourceRef = *mut c_void;
+    type CFStringRef = *const c_void;
+
+    type IOServiceInterestCallback = extern "C" fn(
+        refcon: *mut c_void,
+        service: io_service_t,
+        message_type: u32,
+        message_argument: *mut c_void,
+    );
+
+    // IOMessage.h — IOKit power-management notification message types.
+    const K_IO_MESSAGE_CAN_SYSTEM_SLEEP: u32 = 0xe000_0270;
+    const K_IO_MESSAGE_SYSTEM_WILL_SLEEP: u32 = 0xe000_0280;
+    const K_IO_MESSAGE_SYSTEM_HAS_POWERED_ON: u32 = 0xe000_0300;
+
+    #[link(name = "IOKit", kind = "framework")]
+    extern "C" {
+        fn IORegisterForSystemPower(
+            refcon: *mut c_void,
+            the_port_ref: *mut IONotificationPortRef,
+            callback: IOServiceInterestCallback,
+            notifier: *mut io_object_t,
+        ) -> io_connect_t;
+        fn IONotificationPortGetRunLoopSource(notify: IONotificationPortRef) -> CFRunLoopSourceRef;
+        fn IOAllowPowerChange(kernel_port: io_connect_t, notification_id: isize) -> c_int;
+    }
+
+    #[link(name = "CoreFoundation", kind = "framework")]
+    extern "C" {
+        fn CFRunLoopGetCurrent() -> CFRunLoopRef;
+        fn CFRunLoopAddSource(rl: CFRunLoopRef, source: CFRunLoopSourceRef, mode: CFStringRef);
+        fn CFRunLoopRun();
+        static kCFRunLoopDefaultMode: CFStringRef;
+    }
+
+    /// Callback state stored behind `Box::into_raw` and passed to IOKit as
+    /// the `refcon`. `root_port` is filled in after `IORegisterForSystemPower`
+    /// returns and read atomically by the callback.
+    struct PowerContext {
+        tx: mpsc::Sender<PlatformSignal>,
+        root_port: AtomicU32,
+    }
+
+    extern "C" fn power_callback(
+        refcon: *mut c_void,
+        _service: io_service_t,
+        message_type: u32,
+        message_argument: *mut c_void,
+    ) {
+        // Safety: `refcon` was created via `Box::into_raw` and remains valid
+        // for the lifetime of the listener thread (which is the only thread
+        // invoking this callback).
+        let ctx = unsafe { &*(refcon as *const PowerContext) };
+
+        match message_type {
+            K_IO_MESSAGE_CAN_SYSTEM_SLEEP | K_IO_MESSAGE_SYSTEM_WILL_SLEEP => {
+                // Acknowledge immediately so we do not delay system sleep.
+                // Failing to respond causes a ~30s sleep-delay timeout.
+                let root_port = ctx.root_port.load(Ordering::Acquire);
+                unsafe {
+                    IOAllowPowerChange(root_port, message_argument as isize);
+                }
+            }
+            K_IO_MESSAGE_SYSTEM_HAS_POWERED_ON => {
+                info!(
+                    event = "platform.sleep_wake_detected",
+                    "system woke from sleep"
+                );
+                // try_send is sufficient: if the channel is full (16 slots)
+                // the swarm has plenty of signals already and one more is
+                // redundant. If the receiver is dropped, the listener keeps
+                // running but signals become no-ops, which is acceptable.
+                let _ = ctx.tx.try_send(PlatformSignal::SleepWake);
+            }
+            _ => {}
+        }
+    }
+
+    pub(super) fn spawn_sleep_wake_listener(tx: mpsc::Sender<PlatformSignal>) {
+        let result = std::thread::Builder::new()
+            .name("platform-sleep-wake".into())
+            .spawn(move || unsafe { run_listener(tx) });
+
+        if let Err(err) = result {
+            warn!(
+                event = "platform.sleep_wake_listener_spawn_failed",
+                error = %err,
+                "failed to spawn macOS sleep/wake listener thread"
+            );
+        }
+    }
+
+    unsafe fn run_listener(tx: mpsc::Sender<PlatformSignal>) {
+        let ctx = Box::into_raw(Box::new(PowerContext {
+            tx,
+            root_port: AtomicU32::new(0),
+        }));
+
+        let mut port: IONotificationPortRef = ptr::null_mut();
+        let mut notifier: io_object_t = 0;
+
+        let root_port =
+            IORegisterForSystemPower(ctx as *mut c_void, &mut port, power_callback, &mut notifier);
+
+        if root_port == 0 || port.is_null() {
+            warn!(
+                event = "platform.sleep_wake_listener_failed",
+                "IORegisterForSystemPower failed; macOS sleep/wake detection disabled"
+            );
+            drop(Box::from_raw(ctx));
+            return;
+        }
+
+        (*ctx).root_port.store(root_port, Ordering::Release);
+
+        let source = IONotificationPortGetRunLoopSource(port);
+        let rl = CFRunLoopGetCurrent();
+        CFRunLoopAddSource(rl, source, kCFRunLoopDefaultMode);
+
+        info!(
+            event = "platform.sleep_wake_listener_started",
+            "macOS sleep/wake listener started"
+        );
+
+        // Blocks this thread forever. The process exit tears the thread down.
+        CFRunLoopRun();
+
+        // Reached only if CFRunLoopRun ever returns (it normally does not).
+        drop(Box::from_raw(ctx));
+    }
+}

--- a/src-tauri/crates/uc-platform/src/adapters/libp2p_network/recovery_coordinator.rs
+++ b/src-tauri/crates/uc-platform/src/adapters/libp2p_network/recovery_coordinator.rs
@@ -565,14 +565,9 @@ impl RecoveryCoordinator {
                 cycle.escalation_level = cycle.escalation_level.max(2);
                 cmds.push(CoordinatorCmd::DialBroad {
                     peer_id: peer_id.to_string(),
-                    cycle_id: cid.clone(),
+                    cycle_id: cid,
                     escalation_level: 2,
                 });
-                cmds.push(CoordinatorCmd::EmitEvent(NetworkEvent::PeerStateChanged {
-                    peer_id: peer_id.to_string(),
-                    state: PeerRuntimeState::Recovering,
-                    cycle_id: Some(cid),
-                }));
             }
         }
 

--- a/src-tauri/crates/uc-platform/src/adapters/libp2p_network/recovery_coordinator.rs
+++ b/src-tauri/crates/uc-platform/src/adapters/libp2p_network/recovery_coordinator.rs
@@ -257,6 +257,7 @@ impl RecoveryCoordinator {
             event = "peer.recovery_cycle_succeeded",
             peer_id = %peer_id,
             recovery_cycle_id = %cycle.cycle_id,
+            trigger = ?cycle.trigger,
             elapsed_ms,
             proof = "connection_established",
             "recovery cycle ended by fresh ConnectionEstablished"
@@ -316,11 +317,13 @@ impl RecoveryCoordinator {
         if success {
             let elapsed_ms = cycle.elapsed(now).as_millis() as u64;
             let cid = cycle.cycle_id.clone();
+            let trigger = cycle.trigger;
             self.cycles.remove(peer_id);
             info!(
                 event = "peer.recovery_cycle_succeeded",
                 peer_id = %peer_id,
                 recovery_cycle_id = %cid,
+                trigger = ?trigger,
                 elapsed_ms,
                 proof = "business_stream_open",
                 "recovery cycle ended by successful probe"
@@ -580,6 +583,7 @@ impl RecoveryCoordinator {
             };
             if cycle.elapsed(now) >= RECOVERY_WINDOW {
                 let cid = cycle.cycle_id.clone();
+                let trigger = cycle.trigger;
                 let last_escalation = cycle.escalation_level;
                 let elapsed_ms = cycle.elapsed(now).as_millis() as u64;
                 let total_probes = cycle.total_probes;
@@ -588,6 +592,7 @@ impl RecoveryCoordinator {
                     event = "peer.recovery_window_exhausted",
                     peer_id = %peer_id,
                     recovery_cycle_id = %cid,
+                    trigger = ?trigger,
                     elapsed_ms,
                     last_escalation,
                     total_probes,

--- a/src-tauri/crates/uc-platform/src/adapters/libp2p_network/recovery_coordinator.rs
+++ b/src-tauri/crates/uc-platform/src/adapters/libp2p_network/recovery_coordinator.rs
@@ -1,0 +1,1165 @@
+//! Recovery coordinator for the Connection Stability Recovery wave-1 feature.
+//!
+//! See `docs/p2p/2026-04-11-connection-stability-recovery-prd.md` for the
+//! full specification this module implements.
+//!
+//! # Design
+//!
+//! [`RecoveryCoordinator`] is a **synchronous** state machine.  It holds no
+//! async tasks and performs no I/O.  Every method either accepts an external
+//! signal or performs a time-driven tick and returns a `Vec<CoordinatorCmd>`
+//! that the caller (the swarm event loop) must execute.
+//!
+//! The coordinator is driven from the swarm loop's `select!` block via:
+//!
+//! 1. A `tokio::time::interval` of [`RECOVERY_PROBE_CADENCE`] that calls
+//!    `tick()` on every fire.
+//! 2. One-shot signal calls for external events: `on_mdns_expired`,
+//!    `on_connection_established`, `on_probe_result`, `on_sleep_wake`,
+//!    `on_network_change`.
+//!
+//! # Per-peer state
+//!
+//! Each peer in recovery is tracked in a [`RecoveryCycle`].  The cycle starts
+//! when a trigger fires and ends when the peer transitions to `Online` or
+//! `Offline`.
+//!
+//! # Silent / Visible phases (PRD §User-Facing State Model)
+//!
+//! - **0–15 s (silent phase):** internal recovery in progress; user-facing
+//!   state remains `Online`.
+//! - **15–120 s (visible phase):** user-facing state is `Recovering`.
+//! - **>120 s:** allowed to transition to `Offline` only after the escalation
+//!   ladder has been exhausted.
+//!
+//! # Escalation ladder
+//!
+//! 1. Step 1 — retry the usable path (`last_dial_observations`).
+//! 2. Step 2 — refresh discovery; dial all known candidate addresses.
+//! 3. Step 3 — rebuild the local network session.
+
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+use tracing::{debug, info, instrument, warn};
+use uuid::Uuid;
+
+use uc_core::network::events::{PeerRuntimeState, RecoveryProof, RecoveryTrigger};
+use uc_core::network::NetworkEvent;
+
+use super::{
+    RECOVERY_MULTI_PEER_REBUILD_OFFSET, RECOVERY_PROBE_CADENCE, RECOVERY_SILENT_PHASE_DURATION,
+    RECOVERY_SILENT_PHASE_MAX_PROBES, RECOVERY_TIMED_REBUILD_PROBE_THRESHOLD, RECOVERY_WINDOW,
+};
+
+// ── Command type ─────────────────────────────────────────────────────────────
+
+/// Commands returned by the coordinator for the swarm loop to execute.
+#[derive(Debug)]
+pub(crate) enum CoordinatorCmd {
+    /// Open a business stream to `peer_id`, write nothing, close immediately.
+    /// Uses the address in `last_dial_observations` (Step 1).
+    SendProbe {
+        peer_id: String,
+        cycle_id: String,
+        attempt: u32,
+    },
+    /// Dial all known candidate addresses for `peer_id` (Step 2 escalation).
+    DialBroad {
+        peer_id: String,
+        cycle_id: String,
+        escalation_level: u8,
+    },
+    /// Rebuild the local network session (Step 3 escalation).
+    RebuildSession {
+        rebuild_id: String,
+        reason: RebuildReason,
+        /// Peer IDs whose cycles are participating in this rebuild.
+        participating_peer_ids: Vec<String>,
+    },
+    /// Emit a `NetworkEvent` to the application via the event channel.
+    EmitEvent(NetworkEvent),
+}
+
+/// Reason a session rebuild was triggered.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RebuildReason {
+    ImmediateSleepWake,
+    ImmediateNetworkChange,
+    TimedProbeFailures,
+    MultiPeer,
+}
+
+impl RebuildReason {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            RebuildReason::ImmediateSleepWake => "immediate_sleep_wake",
+            RebuildReason::ImmediateNetworkChange => "immediate_network_change",
+            RebuildReason::TimedProbeFailures => "timed_probe_failures",
+            RebuildReason::MultiPeer => "multi_peer",
+        }
+    }
+}
+
+// ── Per-peer recovery cycle ───────────────────────────────────────────────────
+
+/// Flags that signal an immediate rebuild context.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ImmediateContext {
+    SleepWake,
+    NetworkChange,
+}
+
+/// Runtime state for one recovery cycle for one peer.
+#[derive(Debug)]
+struct RecoveryCycle {
+    cycle_id: String,
+    peer_id: String,
+    started_at: Instant,
+    trigger: RecoveryTrigger,
+
+    /// Current escalation level (0 = not yet escalated beyond initial probe).
+    escalation_level: u8,
+
+    /// Number of probes dispatched this cycle.
+    total_probes: u32,
+
+    /// Consecutive probe failures without an intervening success.
+    consecutive_probe_failures: u32,
+
+    /// Whether a session rebuild has been used in this cycle.
+    rebuild_used: bool,
+
+    /// When the last probe was dispatched.
+    last_probe_at: Option<Instant>,
+
+    /// Whether a probe is currently in flight (we avoid stacking probes).
+    probe_in_flight: bool,
+
+    /// Whether the silent phase has ended (15 s elapsed or early-ended).
+    silent_phase_ended: bool,
+
+    /// Pending immediate rebuild context (sleep/wake or network change).
+    immediate_context: Option<ImmediateContext>,
+}
+
+impl RecoveryCycle {
+    fn new(peer_id: String, trigger: RecoveryTrigger, now: Instant) -> Self {
+        Self {
+            cycle_id: Uuid::new_v4().to_string(),
+            peer_id,
+            started_at: now,
+            trigger,
+            escalation_level: 0,
+            total_probes: 0,
+            consecutive_probe_failures: 0,
+            rebuild_used: false,
+            last_probe_at: None,
+            probe_in_flight: false,
+            silent_phase_ended: false,
+            immediate_context: None,
+        }
+    }
+
+    fn elapsed(&self, now: Instant) -> Duration {
+        now.duration_since(self.started_at)
+    }
+
+    fn in_silent_phase(&self, now: Instant) -> bool {
+        !self.silent_phase_ended && self.elapsed(now) < RECOVERY_SILENT_PHASE_DURATION
+    }
+
+    /// Whether the next probe is due based on cadence and in-flight state.
+    fn probe_due(&self, now: Instant) -> bool {
+        if self.probe_in_flight {
+            return false;
+        }
+        match self.last_probe_at {
+            None => true,
+            Some(last) => now.duration_since(last) >= RECOVERY_PROBE_CADENCE,
+        }
+    }
+
+    /// Maximum probes allowed during the silent phase.
+    fn silent_phase_probe_limit_reached(&self, now: Instant) -> bool {
+        self.in_silent_phase(now) && self.total_probes >= RECOVERY_SILENT_PHASE_MAX_PROBES
+    }
+}
+
+// ── Coordinator ───────────────────────────────────────────────────────────────
+
+/// Central recovery state machine, driven synchronously by the swarm loop.
+pub(crate) struct RecoveryCoordinator {
+    /// Active recovery cycles keyed by peer_id.
+    cycles: HashMap<String, RecoveryCycle>,
+
+    /// When the *first* peer entered recovery in the current wave; used for
+    /// the multi-peer rebuild evaluation.
+    first_recovery_at: Option<Instant>,
+
+    /// Whether the multi-peer rebuild has already been evaluated (once per
+    /// first-peer silent-phase boundary).
+    multi_peer_rebuild_evaluated: bool,
+}
+
+impl RecoveryCoordinator {
+    pub(crate) fn new() -> Self {
+        Self {
+            cycles: HashMap::new(),
+            first_recovery_at: None,
+            multi_peer_rebuild_evaluated: false,
+        }
+    }
+
+    /// Returns `true` if `peer_id` is currently in a recovery cycle.
+    pub(crate) fn is_recovering(&self, peer_id: &str) -> bool {
+        self.cycles.contains_key(peer_id)
+    }
+
+    // ── External signal handlers ──────────────────────────────────────────
+
+    /// mDNS expiry for `peer_id`.  The caller must only call this when the
+    /// peer is *paired* (`Trusted` pairing state); unpaired peers are not
+    /// subject to recovery.
+    ///
+    /// If the peer is already in a recovery cycle this starts a **new** cycle
+    /// (a fresh mDNS flicker resets the cycle id per the PRD).
+    #[instrument(
+        name = "recovery.on_mdns_expired",
+        level = "debug",
+        skip(self, now),
+        fields(peer_id = %peer_id)
+    )]
+    pub(crate) fn on_mdns_expired(&mut self, peer_id: String, now: Instant) -> Vec<CoordinatorCmd> {
+        self.start_recovery_cycle(peer_id, RecoveryTrigger::MdnsExpired, now)
+    }
+
+    /// A fresh `ConnectionEstablished` swarm event arrived for `peer_id`.
+    ///
+    /// This is transport-level proof of recovery per PRD §Recovery Success
+    /// Criteria.
+    #[instrument(
+        name = "recovery.on_connection_established",
+        level = "debug",
+        skip(self, now),
+        fields(peer_id = %peer_id)
+    )]
+    pub(crate) fn on_connection_established(
+        &mut self,
+        peer_id: &str,
+        now: Instant,
+    ) -> Vec<CoordinatorCmd> {
+        let Some(cycle) = self.cycles.remove(peer_id) else {
+            return Vec::new();
+        };
+        let elapsed_ms = cycle.elapsed(now).as_millis() as u64;
+        info!(
+            event = "peer.recovery_cycle_succeeded",
+            peer_id = %peer_id,
+            recovery_cycle_id = %cycle.cycle_id,
+            elapsed_ms,
+            proof = "connection_established",
+            "recovery cycle ended by fresh ConnectionEstablished"
+        );
+        self.check_reset_multi_peer_tracking();
+
+        vec![
+            CoordinatorCmd::EmitEvent(NetworkEvent::PeerStateChanged {
+                peer_id: peer_id.to_string(),
+                state: PeerRuntimeState::Online,
+                cycle_id: None,
+            }),
+            CoordinatorCmd::EmitEvent(NetworkEvent::PeerRecovered {
+                peer_id: peer_id.to_string(),
+                cycle_id: cycle.cycle_id,
+                elapsed_ms,
+                proof: RecoveryProof::ConnectionEstablished,
+            }),
+        ]
+    }
+
+    /// Result of a recovery probe dispatched earlier.
+    #[instrument(
+        name = "recovery.on_probe_result",
+        level = "debug",
+        skip(self, error, now),
+        fields(peer_id = %peer_id, recovery_cycle_id = %cycle_id, success)
+    )]
+    pub(crate) fn on_probe_result(
+        &mut self,
+        peer_id: &str,
+        cycle_id: &str,
+        success: bool,
+        error: Option<&str>,
+        now: Instant,
+    ) -> Vec<CoordinatorCmd> {
+        let Some(cycle) = self.cycles.get_mut(peer_id) else {
+            debug!(
+                event = "peer.recovery_probe_result_ignored",
+                reason = "no_active_cycle",
+                "ignoring probe result for peer without active recovery cycle"
+            );
+            return Vec::new();
+        };
+        if cycle.cycle_id != cycle_id {
+            // Stale result from a superseded cycle; discard.
+            debug!(
+                event = "peer.recovery_probe_result_ignored",
+                reason = "stale_cycle",
+                active_cycle_id = %cycle.cycle_id,
+                "ignoring probe result from superseded cycle"
+            );
+            return Vec::new();
+        }
+        cycle.probe_in_flight = false;
+
+        if success {
+            let elapsed_ms = cycle.elapsed(now).as_millis() as u64;
+            let cid = cycle.cycle_id.clone();
+            self.cycles.remove(peer_id);
+            info!(
+                event = "peer.recovery_cycle_succeeded",
+                peer_id = %peer_id,
+                recovery_cycle_id = %cid,
+                elapsed_ms,
+                proof = "business_stream_open",
+                "recovery cycle ended by successful probe"
+            );
+            self.check_reset_multi_peer_tracking();
+            return vec![
+                CoordinatorCmd::EmitEvent(NetworkEvent::PeerStateChanged {
+                    peer_id: peer_id.to_string(),
+                    state: PeerRuntimeState::Online,
+                    cycle_id: None,
+                }),
+                CoordinatorCmd::EmitEvent(NetworkEvent::PeerRecovered {
+                    peer_id: peer_id.to_string(),
+                    cycle_id: cid,
+                    elapsed_ms,
+                    proof: RecoveryProof::BusinessStreamOpen,
+                }),
+            ];
+        }
+
+        // Probe failed.
+        let cycle = self.cycles.get_mut(peer_id).unwrap();
+        cycle.consecutive_probe_failures += 1;
+        debug!(
+            event = "peer.recovery_probe_failure_recorded",
+            consecutive_failures = cycle.consecutive_probe_failures,
+            total_probes = cycle.total_probes,
+            silent_phase_active = !cycle.silent_phase_ended,
+            "probe failure accounted"
+        );
+        // The structured failure cause is logged at warn level by
+        // `recovery_probe.rs` with stable fields — don't repeat-bomb here.
+        let _ = error;
+
+        // Immediate rebuild: if context set and first probe just failed.
+        if !cycle.rebuild_used {
+            if let Some(ctx) = cycle.immediate_context.take() {
+                let reason = match ctx {
+                    ImmediateContext::SleepWake => RebuildReason::ImmediateSleepWake,
+                    ImmediateContext::NetworkChange => RebuildReason::ImmediateNetworkChange,
+                };
+                return self.trigger_rebuild(peer_id, reason, now);
+            }
+        }
+
+        Vec::new()
+    }
+
+    /// The local device just resumed from sleep.  Marks all active cycles so
+    /// the next probe failure for each triggers an immediate rebuild.
+    #[instrument(
+        name = "recovery.on_sleep_wake",
+        level = "info",
+        skip(self, now),
+        fields(active_cycles = self.cycles.len())
+    )]
+    pub(crate) fn on_sleep_wake(&mut self, now: Instant) -> Vec<CoordinatorCmd> {
+        let mut marked = 0u32;
+        for cycle in self.cycles.values_mut() {
+            // Only override if not already set (first context wins).
+            if cycle.immediate_context.is_none() {
+                cycle.immediate_context = Some(ImmediateContext::SleepWake);
+                marked += 1;
+            }
+        }
+        info!(
+            event = "peer.recovery_immediate_context_set",
+            context = "sleep_wake",
+            marked_cycles = marked,
+            "sleep/wake signal armed immediate rebuild on next probe failure"
+        );
+
+        // For peers not yet in recovery, the trigger will be handled when
+        // their next outbound sync attempt fails (FirstAttemptAfterIdle) or
+        // when mDNS expires.  Peers that were already online and connected
+        // may still be fine; don't start recovery proactively here.
+        let _ = now;
+        Vec::new()
+    }
+
+    /// The local network interface or IP address changed.  Same semantics as
+    /// `on_sleep_wake` for active cycles.
+    #[instrument(
+        name = "recovery.on_network_change",
+        level = "info",
+        skip(self, now),
+        fields(active_cycles = self.cycles.len())
+    )]
+    pub(crate) fn on_network_change(&mut self, now: Instant) -> Vec<CoordinatorCmd> {
+        let mut marked = 0u32;
+        for cycle in self.cycles.values_mut() {
+            if cycle.immediate_context.is_none() {
+                cycle.immediate_context = Some(ImmediateContext::NetworkChange);
+                marked += 1;
+            }
+        }
+        info!(
+            event = "peer.recovery_immediate_context_set",
+            context = "network_change",
+            marked_cycles = marked,
+            "network-change signal armed immediate rebuild on next probe failure"
+        );
+        let _ = now;
+        Vec::new()
+    }
+
+    /// Dial failure streak for `peer_id` (used when outbound delivery to a
+    /// paired peer fails repeatedly).  Starts a recovery cycle if not already
+    /// in one.
+    #[instrument(
+        name = "recovery.on_dial_failure_streak",
+        level = "debug",
+        skip(self, now),
+        fields(peer_id = %peer_id)
+    )]
+    pub(crate) fn on_dial_failure_streak(
+        &mut self,
+        peer_id: String,
+        now: Instant,
+    ) -> Vec<CoordinatorCmd> {
+        if self.cycles.contains_key(&peer_id) {
+            debug!(
+                event = "peer.recovery_dial_streak_ignored",
+                reason = "already_recovering",
+                "dial failure streak ignored — peer already in recovery"
+            );
+            return Vec::new();
+        }
+        self.start_recovery_cycle(peer_id, RecoveryTrigger::DialFailureStreak, now)
+    }
+
+    // ── Time-driven tick ──────────────────────────────────────────────────
+
+    /// Drive the coordinator forward.  Must be called on every
+    /// `RECOVERY_PROBE_CADENCE` interval tick from the swarm loop.
+    ///
+    /// Returns commands to execute for this tick.
+    pub(crate) fn tick(&mut self, now: Instant) -> Vec<CoordinatorCmd> {
+        let mut cmds = Vec::new();
+
+        // Collect peer_ids to process (avoids borrow issues).
+        let peer_ids: Vec<String> = self.cycles.keys().cloned().collect();
+
+        for peer_id in peer_ids {
+            let cmds_for_peer = self.tick_peer(&peer_id, now);
+            cmds.extend(cmds_for_peer);
+        }
+
+        // Multi-peer rebuild evaluation — runs once when the first peer's
+        // silent phase ends (15 s mark).
+        if !self.multi_peer_rebuild_evaluated {
+            if let Some(first_at) = self.first_recovery_at {
+                if now.duration_since(first_at) >= RECOVERY_MULTI_PEER_REBUILD_OFFSET {
+                    let multi_cmds = self.evaluate_multi_peer_rebuild(now);
+                    cmds.extend(multi_cmds);
+                    self.multi_peer_rebuild_evaluated = true;
+                }
+            }
+        }
+
+        cmds
+    }
+
+    // ── Internal helpers ──────────────────────────────────────────────────
+
+    fn start_recovery_cycle(
+        &mut self,
+        peer_id: String,
+        trigger: RecoveryTrigger,
+        now: Instant,
+    ) -> Vec<CoordinatorCmd> {
+        // Remove any existing cycle (mDNS flicker = new cycle id).
+        let superseded = self.cycles.remove(&peer_id).is_some();
+
+        let cycle = RecoveryCycle::new(peer_id.clone(), trigger, now);
+        let cycle_id = cycle.cycle_id.clone();
+
+        if self.first_recovery_at.is_none() {
+            self.first_recovery_at = Some(now);
+            self.multi_peer_rebuild_evaluated = false;
+        }
+
+        self.cycles.insert(peer_id.clone(), cycle);
+
+        info!(
+            event = "peer.recovery_cycle_started",
+            peer_id = %peer_id,
+            recovery_cycle_id = %cycle_id,
+            trigger = ?trigger,
+            active_cycle_count = self.cycles.len(),
+            superseded_previous_cycle = superseded,
+            "recovery cycle started"
+        );
+
+        // During silent phase the user-facing state stays Online.
+        // We still emit PeerRecoveryStarted so tracing can follow the cycle.
+        vec![CoordinatorCmd::EmitEvent(
+            NetworkEvent::PeerRecoveryStarted {
+                peer_id: peer_id.clone(),
+                cycle_id: cycle_id.clone(),
+                trigger,
+            },
+        )]
+    }
+
+    fn tick_peer(&mut self, peer_id: &str, now: Instant) -> Vec<CoordinatorCmd> {
+        let mut cmds = Vec::new();
+
+        // --- Phase transition: silent → visible ---
+        {
+            let Some(cycle) = self.cycles.get_mut(peer_id) else {
+                return cmds;
+            };
+            if !cycle.silent_phase_ended && cycle.elapsed(now) >= RECOVERY_SILENT_PHASE_DURATION {
+                cycle.silent_phase_ended = true;
+                let cid = cycle.cycle_id.clone();
+                let elapsed_ms = cycle.elapsed(now).as_millis() as u64;
+                let total_probes = cycle.total_probes;
+
+                info!(
+                    event = "peer.recovery_silent_phase_ended",
+                    peer_id = %peer_id,
+                    recovery_cycle_id = %cid,
+                    elapsed_ms,
+                    total_probes,
+                    from_state = "Online",
+                    to_state = "Recovering",
+                    escalation_level = 2u8,
+                    "silent phase ended; escalating to Step 2 broad dial"
+                );
+
+                cmds.push(CoordinatorCmd::EmitEvent(NetworkEvent::PeerStateChanged {
+                    peer_id: peer_id.to_string(),
+                    state: PeerRuntimeState::Recovering,
+                    cycle_id: Some(cid.clone()),
+                }));
+
+                // Step 2 escalation: broaden dialing.
+                cycle.escalation_level = cycle.escalation_level.max(2);
+                cmds.push(CoordinatorCmd::DialBroad {
+                    peer_id: peer_id.to_string(),
+                    cycle_id: cid.clone(),
+                    escalation_level: 2,
+                });
+                cmds.push(CoordinatorCmd::EmitEvent(NetworkEvent::PeerStateChanged {
+                    peer_id: peer_id.to_string(),
+                    state: PeerRuntimeState::Recovering,
+                    cycle_id: Some(cid),
+                }));
+            }
+        }
+
+        // --- Recovery window exhausted → Offline ---
+        {
+            let Some(cycle) = self.cycles.get(peer_id) else {
+                return cmds;
+            };
+            if cycle.elapsed(now) >= RECOVERY_WINDOW {
+                let cid = cycle.cycle_id.clone();
+                let last_escalation = cycle.escalation_level;
+                let elapsed_ms = cycle.elapsed(now).as_millis() as u64;
+                let total_probes = cycle.total_probes;
+                let rebuild_used = cycle.rebuild_used;
+                warn!(
+                    event = "peer.recovery_window_exhausted",
+                    peer_id = %peer_id,
+                    recovery_cycle_id = %cid,
+                    elapsed_ms,
+                    last_escalation,
+                    total_probes,
+                    rebuild_used,
+                    error_kind = "recovery_window_exhausted",
+                    retryable = false,
+                    "recovery window exhausted; transitioning peer to Offline"
+                );
+                self.cycles.remove(peer_id);
+                self.check_reset_multi_peer_tracking();
+
+                cmds.push(CoordinatorCmd::EmitEvent(NetworkEvent::PeerStateChanged {
+                    peer_id: peer_id.to_string(),
+                    state: PeerRuntimeState::Offline,
+                    cycle_id: None,
+                }));
+                cmds.push(CoordinatorCmd::EmitEvent(
+                    NetworkEvent::PeerRecoveryFailed {
+                        peer_id: peer_id.to_string(),
+                        cycle_id: cid,
+                        elapsed_ms,
+                        last_escalation,
+                    },
+                ));
+                return cmds;
+            }
+        }
+
+        // --- Timed rebuild trigger ---
+        {
+            let Some(cycle) = self.cycles.get(peer_id) else {
+                return cmds;
+            };
+            if cycle.silent_phase_ended
+                && !cycle.rebuild_used
+                && cycle.consecutive_probe_failures >= RECOVERY_TIMED_REBUILD_PROBE_THRESHOLD
+            {
+                let rebuild_cmds =
+                    self.trigger_rebuild(peer_id, RebuildReason::TimedProbeFailures, now);
+                cmds.extend(rebuild_cmds);
+                // trigger_rebuild may have removed the cycle; return early.
+                if !self.cycles.contains_key(peer_id) {
+                    return cmds;
+                }
+            }
+        }
+
+        // --- Probe cadence ---
+        {
+            let Some(cycle) = self.cycles.get_mut(peer_id) else {
+                return cmds;
+            };
+
+            // During silent phase respect max-probe limit.
+            if cycle.silent_phase_probe_limit_reached(now) {
+                return cmds;
+            }
+
+            if cycle.probe_due(now) {
+                cycle.total_probes += 1;
+                cycle.probe_in_flight = true;
+                cycle.last_probe_at = Some(now);
+                let attempt = cycle.total_probes;
+                let cid = cycle.cycle_id.clone();
+
+                cmds.push(CoordinatorCmd::SendProbe {
+                    peer_id: peer_id.to_string(),
+                    cycle_id: cid,
+                    attempt,
+                });
+            }
+        }
+
+        cmds
+    }
+
+    /// Issue a session rebuild command for `peer_id`'s cycle.
+    fn trigger_rebuild(
+        &mut self,
+        peer_id: &str,
+        reason: RebuildReason,
+        now: Instant,
+    ) -> Vec<CoordinatorCmd> {
+        let Some(cycle) = self.cycles.get_mut(peer_id) else {
+            return Vec::new();
+        };
+        if cycle.rebuild_used {
+            debug!(
+                event = "peer.recovery_rebuild_skipped",
+                peer_id = %peer_id,
+                recovery_cycle_id = %cycle.cycle_id,
+                reason = "rebuild_already_used",
+                "rebuild suppressed: already used in this cycle"
+            );
+            return Vec::new();
+        }
+        cycle.rebuild_used = true;
+        cycle.escalation_level = cycle.escalation_level.max(3);
+        let was_silent_phase = !cycle.silent_phase_ended;
+        let elapsed_ms = cycle.elapsed(now).as_millis() as u64;
+
+        // Immediate rebuild ends the silent phase early.
+        if !cycle.silent_phase_ended {
+            cycle.silent_phase_ended = true;
+            let cid = cycle.cycle_id.clone();
+            let rebuild_id = Uuid::new_v4().to_string();
+
+            info!(
+                event = "peer.recovery_rebuild_triggered",
+                peer_id = %peer_id,
+                recovery_cycle_id = %cid,
+                rebuild_id = %rebuild_id,
+                rebuild_reason = reason.as_str(),
+                escalation_level = 3u8,
+                elapsed_ms,
+                ended_silent_phase_early = was_silent_phase,
+                "session rebuild triggered (silent-phase early exit)"
+            );
+
+            return vec![
+                CoordinatorCmd::EmitEvent(NetworkEvent::PeerStateChanged {
+                    peer_id: peer_id.to_string(),
+                    state: PeerRuntimeState::Recovering,
+                    cycle_id: Some(cid),
+                }),
+                CoordinatorCmd::RebuildSession {
+                    rebuild_id,
+                    reason,
+                    participating_peer_ids: vec![peer_id.to_string()],
+                },
+            ];
+        }
+
+        let rebuild_id = Uuid::new_v4().to_string();
+
+        info!(
+            event = "peer.recovery_rebuild_triggered",
+            peer_id = %peer_id,
+            rebuild_id = %rebuild_id,
+            rebuild_reason = reason.as_str(),
+            escalation_level = 3u8,
+            elapsed_ms,
+            ended_silent_phase_early = false,
+            "session rebuild triggered"
+        );
+
+        vec![CoordinatorCmd::RebuildSession {
+            rebuild_id,
+            reason,
+            participating_peer_ids: vec![peer_id.to_string()],
+        }]
+    }
+
+    /// Multi-peer rebuild evaluation.  Called once at the 15 s mark after the
+    /// first peer entered recovery.
+    fn evaluate_multi_peer_rebuild(&mut self, now: Instant) -> Vec<CoordinatorCmd> {
+        // Collect peers still in recovery that haven't recovered during their
+        // own silent phase.
+        let candidates: Vec<String> = self
+            .cycles
+            .values()
+            .filter(|c| c.silent_phase_ended || c.elapsed(now) >= RECOVERY_SILENT_PHASE_DURATION)
+            .map(|c| c.peer_id.clone())
+            .collect();
+
+        if candidates.len() < 2 {
+            debug!(
+                event = "peer.recovery_multi_peer_rebuild_skipped",
+                candidate_count = candidates.len(),
+                reason = "below_threshold",
+                "multi-peer rebuild not triggered"
+            );
+            return Vec::new();
+        }
+
+        // Check: none of them have already used a rebuild.
+        let any_rebuilt = candidates
+            .iter()
+            .any(|pid| self.cycles.get(pid).is_some_and(|c| c.rebuild_used));
+        if any_rebuilt {
+            debug!(
+                event = "peer.recovery_multi_peer_rebuild_skipped",
+                candidate_count = candidates.len(),
+                reason = "already_rebuilt",
+                "multi-peer rebuild not triggered: one or more peers already used rebuild"
+            );
+            return Vec::new();
+        }
+
+        let rebuild_id = Uuid::new_v4().to_string();
+
+        info!(
+            event = "peer.recovery_rebuild_triggered",
+            rebuild_id = %rebuild_id,
+            rebuild_reason = "multi_peer",
+            participating_peer_count = candidates.len(),
+            "multi-peer session rebuild triggered"
+        );
+
+        // Mark all participating cycles as having used the rebuild.
+        for pid in &candidates {
+            if let Some(cycle) = self.cycles.get_mut(pid) {
+                cycle.rebuild_used = true;
+                cycle.escalation_level = cycle.escalation_level.max(3);
+                if !cycle.silent_phase_ended {
+                    cycle.silent_phase_ended = true;
+                }
+            }
+        }
+
+        // Emit Recovering for any that are still in silent phase.
+        let mut cmds: Vec<CoordinatorCmd> = candidates
+            .iter()
+            .filter_map(|pid| {
+                self.cycles.get(pid).map(|c| {
+                    CoordinatorCmd::EmitEvent(NetworkEvent::PeerStateChanged {
+                        peer_id: pid.clone(),
+                        state: PeerRuntimeState::Recovering,
+                        cycle_id: Some(c.cycle_id.clone()),
+                    })
+                })
+            })
+            .collect();
+
+        cmds.push(CoordinatorCmd::RebuildSession {
+            rebuild_id,
+            reason: RebuildReason::MultiPeer,
+            participating_peer_ids: candidates,
+        });
+
+        cmds
+    }
+
+    /// Reset multi-peer tracking when no cycles remain.
+    fn check_reset_multi_peer_tracking(&mut self) {
+        if self.cycles.is_empty() {
+            self.first_recovery_at = None;
+            self.multi_peer_rebuild_evaluated = false;
+        }
+    }
+}
+
+// ── Unit tests ────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn peer(id: &str) -> String {
+        id.to_string()
+    }
+
+    fn advance(base: Instant, secs: u64) -> Instant {
+        base + Duration::from_secs(secs)
+    }
+
+    fn has_probe(cmds: &[CoordinatorCmd]) -> bool {
+        cmds.iter()
+            .any(|c| matches!(c, CoordinatorCmd::SendProbe { .. }))
+    }
+
+    fn has_event<F: Fn(&NetworkEvent) -> bool>(cmds: &[CoordinatorCmd], pred: F) -> bool {
+        cmds.iter().any(|c| {
+            if let CoordinatorCmd::EmitEvent(ev) = c {
+                pred(ev)
+            } else {
+                false
+            }
+        })
+    }
+
+    fn has_rebuild(cmds: &[CoordinatorCmd], reason: RebuildReason) -> bool {
+        cmds.iter()
+            .any(|c| matches!(c, CoordinatorCmd::RebuildSession { reason: r, .. } if *r == reason))
+    }
+
+    // ── Silent phase: user-facing state stays Online, probes fire ───────
+
+    #[test]
+    fn silent_phase_does_not_emit_recovering_state() {
+        let mut coord = RecoveryCoordinator::new();
+        let t0 = Instant::now();
+
+        let cmds = coord.on_mdns_expired(peer("p1"), t0);
+        // Only PeerRecoveryStarted, no PeerStateChanged(Recovering)
+        assert!(!has_event(&cmds, |ev| matches!(
+            ev,
+            NetworkEvent::PeerStateChanged {
+                state: PeerRuntimeState::Recovering,
+                ..
+            }
+        )));
+        assert!(has_event(&cmds, |ev| matches!(
+            ev,
+            NetworkEvent::PeerRecoveryStarted { .. }
+        )));
+    }
+
+    #[test]
+    fn silent_phase_fires_first_probe_on_tick() {
+        let mut coord = RecoveryCoordinator::new();
+        let t0 = Instant::now();
+        coord.on_mdns_expired(peer("p1"), t0);
+
+        let cmds = coord.tick(t0 + Duration::from_millis(100));
+        assert!(has_probe(&cmds));
+    }
+
+    #[test]
+    fn silent_phase_limits_probes_to_max() {
+        let mut coord = RecoveryCoordinator::new();
+        let t0 = Instant::now();
+        coord.on_mdns_expired(peer("p1"), t0);
+
+        // Tick only within the silent phase window (< 15 s) to count probes
+        // that fire before the visible phase starts.
+        let mut probe_count = 0u32;
+        let mut t = t0;
+        while t < t0 + RECOVERY_SILENT_PHASE_DURATION {
+            t += RECOVERY_PROBE_CADENCE;
+            // Don't cross the boundary — stop just before 15 s.
+            if t >= t0 + RECOVERY_SILENT_PHASE_DURATION {
+                break;
+            }
+            let cmds = coord.tick(t);
+            if has_probe(&cmds) {
+                probe_count += 1;
+                // Mark probe complete (failure) so the next tick can schedule
+                // another one if under the limit.
+                if let Some(cycle) = coord.cycles.get_mut("p1") {
+                    cycle.probe_in_flight = false;
+                }
+            }
+        }
+        // At 5 s cadence within 15 s we expect exactly RECOVERY_SILENT_PHASE_MAX_PROBES
+        // probes (at t+5 s and t+10 s qualify; the 3rd would be at t+15 s which is
+        // the boundary — we stop just before it above, so the count is 2 here).
+        // The more important invariant: the limit is enforced, not exceeded.
+        assert!(
+            probe_count <= RECOVERY_SILENT_PHASE_MAX_PROBES,
+            "expected at most {} probes during silent phase, got {}",
+            RECOVERY_SILENT_PHASE_MAX_PROBES,
+            probe_count
+        );
+    }
+
+    // ── Visible phase starts at 15 s ─────────────────────────────────────
+
+    #[test]
+    fn visible_phase_emits_recovering_at_15s() {
+        let mut coord = RecoveryCoordinator::new();
+        let t0 = Instant::now();
+        coord.on_mdns_expired(peer("p1"), t0);
+
+        let cmds = coord.tick(advance(t0, 15));
+        assert!(has_event(&cmds, |ev| matches!(
+            ev,
+            NetworkEvent::PeerStateChanged {
+                state: PeerRuntimeState::Recovering,
+                ..
+            }
+        )));
+        assert!(cmds
+            .iter()
+            .any(|c| matches!(c, CoordinatorCmd::DialBroad { .. })));
+    }
+
+    // ── Recovery success via probe ────────────────────────────────────────
+
+    #[test]
+    fn probe_success_ends_recovery_emits_online() {
+        let mut coord = RecoveryCoordinator::new();
+        let t0 = Instant::now();
+        let cmds = coord.on_mdns_expired(peer("p1"), t0);
+        let cycle_id = if let CoordinatorCmd::EmitEvent(NetworkEvent::PeerRecoveryStarted {
+            cycle_id,
+            ..
+        }) = &cmds[0]
+        {
+            cycle_id.clone()
+        } else {
+            panic!("expected PeerRecoveryStarted");
+        };
+
+        let cmds = coord.on_probe_result("p1", &cycle_id, true, None, advance(t0, 3));
+        assert!(!coord.is_recovering("p1"));
+        assert!(has_event(&cmds, |ev| matches!(
+            ev,
+            NetworkEvent::PeerStateChanged {
+                state: PeerRuntimeState::Online,
+                ..
+            }
+        )));
+        assert!(has_event(&cmds, |ev| matches!(
+            ev,
+            NetworkEvent::PeerRecovered { .. }
+        )));
+    }
+
+    // ── Recovery success via ConnectionEstablished ────────────────────────
+
+    #[test]
+    fn connection_established_ends_recovery() {
+        let mut coord = RecoveryCoordinator::new();
+        let t0 = Instant::now();
+        coord.on_mdns_expired(peer("p1"), t0);
+
+        let cmds = coord.on_connection_established("p1", advance(t0, 5));
+        assert!(!coord.is_recovering("p1"));
+        assert!(has_event(&cmds, |ev| matches!(
+            ev,
+            NetworkEvent::PeerStateChanged {
+                state: PeerRuntimeState::Online,
+                ..
+            }
+        )));
+    }
+
+    // ── Recovery window exhausted → Offline ──────────────────────────────
+
+    #[test]
+    fn recovery_window_exhausted_transitions_to_offline() {
+        let mut coord = RecoveryCoordinator::new();
+        let t0 = Instant::now();
+        coord.on_mdns_expired(peer("p1"), t0);
+
+        let cmds = coord.tick(advance(t0, 121));
+        assert!(!coord.is_recovering("p1"));
+        assert!(has_event(&cmds, |ev| matches!(
+            ev,
+            NetworkEvent::PeerStateChanged {
+                state: PeerRuntimeState::Offline,
+                ..
+            }
+        )));
+        assert!(has_event(&cmds, |ev| matches!(
+            ev,
+            NetworkEvent::PeerRecoveryFailed { .. }
+        )));
+    }
+
+    // ── Timed rebuild trigger ─────────────────────────────────────────────
+
+    #[test]
+    fn timed_rebuild_triggers_after_3_failures_post_silent_phase() {
+        let mut coord = RecoveryCoordinator::new();
+        let t0 = Instant::now();
+        let start_cmds = coord.on_mdns_expired(peer("p1"), t0);
+        let cycle_id = if let CoordinatorCmd::EmitEvent(NetworkEvent::PeerRecoveryStarted {
+            cycle_id,
+            ..
+        }) = &start_cmds[0]
+        {
+            cycle_id.clone()
+        } else {
+            panic!();
+        };
+
+        // End silent phase first.
+        coord.tick(advance(t0, 15));
+        if let Some(c) = coord.cycles.get_mut("p1") {
+            c.silent_phase_ended = true;
+        }
+
+        // Simulate 3 consecutive probe failures.
+        for _ in 0..3 {
+            coord.on_probe_result("p1", &cycle_id, false, Some("timeout"), advance(t0, 16));
+        }
+
+        let cmds = coord.tick(advance(t0, 20));
+        assert!(has_rebuild(&cmds, RebuildReason::TimedProbeFailures));
+    }
+
+    // ── Immediate rebuild (sleep/wake) ────────────────────────────────────
+
+    #[test]
+    fn sleep_wake_context_triggers_immediate_rebuild_on_first_probe_failure() {
+        let mut coord = RecoveryCoordinator::new();
+        let t0 = Instant::now();
+        let start_cmds = coord.on_mdns_expired(peer("p1"), t0);
+        let cycle_id = if let CoordinatorCmd::EmitEvent(NetworkEvent::PeerRecoveryStarted {
+            cycle_id,
+            ..
+        }) = &start_cmds[0]
+        {
+            cycle_id.clone()
+        } else {
+            panic!();
+        };
+
+        coord.on_sleep_wake(advance(t0, 1));
+
+        let cmds = coord.on_probe_result("p1", &cycle_id, false, Some("err"), advance(t0, 2));
+        assert!(has_rebuild(&cmds, RebuildReason::ImmediateSleepWake));
+    }
+
+    // ── Multi-peer rebuild ────────────────────────────────────────────────
+
+    #[test]
+    fn multi_peer_rebuild_triggers_when_two_peers_fail_silent_phase() {
+        let mut coord = RecoveryCoordinator::new();
+        let t0 = Instant::now();
+
+        coord.on_mdns_expired(peer("p1"), t0);
+        coord.on_mdns_expired(peer("p2"), t0 + Duration::from_secs(1));
+
+        // Tick past 15 s to trigger multi-peer evaluation.
+        let cmds = coord.tick(advance(t0, 16));
+        assert!(has_rebuild(&cmds, RebuildReason::MultiPeer));
+    }
+
+    // ── mDNS flicker creates new cycle id ────────────────────────────────
+
+    #[test]
+    fn mdns_flicker_creates_new_cycle_id() {
+        let mut coord = RecoveryCoordinator::new();
+        let t0 = Instant::now();
+
+        let cmds1 = coord.on_mdns_expired(peer("p1"), t0);
+        let id1 = if let CoordinatorCmd::EmitEvent(NetworkEvent::PeerRecoveryStarted {
+            cycle_id,
+            ..
+        }) = &cmds1[0]
+        {
+            cycle_id.clone()
+        } else {
+            panic!();
+        };
+
+        let cmds2 = coord.on_mdns_expired(peer("p1"), advance(t0, 5));
+        let id2 = if let CoordinatorCmd::EmitEvent(NetworkEvent::PeerRecoveryStarted {
+            cycle_id,
+            ..
+        }) = &cmds2[0]
+        {
+            cycle_id.clone()
+        } else {
+            panic!();
+        };
+
+        assert_ne!(id1, id2);
+    }
+
+    // ── Rebuild guardrail: at most once per cycle ─────────────────────────
+
+    #[test]
+    fn rebuild_used_at_most_once_per_cycle() {
+        let mut coord = RecoveryCoordinator::new();
+        let t0 = Instant::now();
+        coord.on_mdns_expired(peer("p1"), t0);
+        coord.on_sleep_wake(t0);
+
+        // Force silent phase end and 3 failures.
+        if let Some(c) = coord.cycles.get_mut("p1") {
+            c.silent_phase_ended = true;
+            c.consecutive_probe_failures = 3;
+        }
+
+        // First rebuild from timed trigger should succeed.
+        let cmds1 = coord.tick(advance(t0, 20));
+        let rebuild_count1 = cmds1
+            .iter()
+            .filter(|c| matches!(c, CoordinatorCmd::RebuildSession { .. }))
+            .count();
+        assert_eq!(rebuild_count1, 1);
+
+        // Subsequent tick should not trigger another rebuild.
+        let cmds2 = coord.tick(advance(t0, 25));
+        let rebuild_count2 = cmds2
+            .iter()
+            .filter(|c| matches!(c, CoordinatorCmd::RebuildSession { .. }))
+            .count();
+        assert_eq!(rebuild_count2, 0);
+    }
+}

--- a/src-tauri/crates/uc-platform/src/adapters/libp2p_network/recovery_probe.rs
+++ b/src-tauri/crates/uc-platform/src/adapters/libp2p_network/recovery_probe.rs
@@ -14,6 +14,7 @@
 //! (`stream_handler.rs:71-72`), so no receiver-side changes are needed.
 
 use anyhow::{anyhow, Result};
+use futures::AsyncWriteExt;
 use libp2p::{Multiaddr, PeerId, StreamProtocol};
 use libp2p_stream as stream;
 use tokio::sync::{mpsc, oneshot};
@@ -204,9 +205,19 @@ async fn run_probe(
             );
             Err(anyhow!("probe: stream open error: {err}"))
         }
-        Ok(Ok(stream)) => {
-            // Close immediately without writing any payload.
-            // The receiver handles "EOF before header" as a probe.
+        Ok(Ok(mut stream)) => {
+            // Close gracefully so the remote observes EOF before header
+            // (rather than a RST from drop).
+            if let Err(err) = stream.close().await {
+                warn!(
+                    event = "peer.recovery_probe_close_error",
+                    peer_id = %peer_id_str,
+                    recovery_cycle_id = %cycle_id,
+                    attempt,
+                    error = %err,
+                    "recovery probe stream close failed (probe still counts as success)"
+                );
+            }
             drop(stream);
             info!(
                 event = "peer.recovery_probe_succeeded",

--- a/src-tauri/crates/uc-platform/src/adapters/libp2p_network/recovery_probe.rs
+++ b/src-tauri/crates/uc-platform/src/adapters/libp2p_network/recovery_probe.rs
@@ -1,0 +1,223 @@
+//! Recovery probe — lightweight stream open used to confirm peer reachability.
+//!
+//! # What a probe is (from the PRD)
+//!
+//! 1. Attempt to open a business stream to the target peer.
+//! 2. Do not write any payload.
+//! 3. Close the stream immediately after the open call returns.
+//!
+//! A probe is **successful** when `open_stream` returns `Ok`.
+//! A probe is **failed** when it returns an error or exceeds
+//! [`BUSINESS_STREAM_OPEN_TIMEOUT`].
+//!
+//! The receiver already treats "stream opened, EOF before header" as a probe
+//! (`stream_handler.rs:71-72`), so no receiver-side changes are needed.
+
+use anyhow::{anyhow, Result};
+use libp2p::{Multiaddr, PeerId, StreamProtocol};
+use libp2p_stream as stream;
+use tokio::sync::{mpsc, oneshot};
+use tracing::{debug, info, instrument, warn};
+
+use super::{DialRequest, BUSINESS_PROTOCOL_ID, BUSINESS_STREAM_OPEN_TIMEOUT};
+
+/// Outcome of a dispatched recovery probe, sent back to the swarm loop.
+#[derive(Debug)]
+pub(crate) struct ProbeOutcome {
+    /// Peer the probe targeted.
+    pub peer_id: String,
+    /// Recovery cycle this probe belongs to.
+    pub cycle_id: String,
+    /// Probe attempt number within the cycle (1-based).
+    pub attempt: u32,
+    /// `Ok(())` = probe succeeded (stream open returned success).
+    /// `Err(...)` = probe failed (stream open error or timeout).
+    pub result: Result<()>,
+}
+
+/// Send a single recovery probe to `peer_id`.
+///
+/// Step 1 path: if `usable_addr` is `Some`, dial that specific address first,
+/// then open a stream.  This is the "retry usable path" step from the PRD.
+/// Pass `None` to skip the explicit dial (peer already connected, or Step 2
+/// broad dial is already in progress).
+///
+/// The result is sent to `outcome_tx` so the swarm loop's `select!` can feed
+/// it back into the [`RecoveryCoordinator`].
+#[instrument(
+    name = "recovery.probe",
+    level = "debug",
+    skip(control, dial_tx, outcome_tx, peer),
+    fields(
+        peer_id = %peer_id_str,
+        recovery_cycle_id = %cycle_id,
+        attempt,
+        has_usable_addr = usable_addr.is_some()
+    )
+)]
+pub(crate) async fn send_recovery_probe(
+    mut control: stream::Control,
+    dial_tx: mpsc::Sender<DialRequest>,
+    peer_id_str: String,
+    peer: PeerId,
+    cycle_id: String,
+    attempt: u32,
+    usable_addr: Option<String>,
+    outcome_tx: mpsc::Sender<ProbeOutcome>,
+) {
+    let result = run_probe(
+        &mut control,
+        &dial_tx,
+        &peer_id_str,
+        peer,
+        &cycle_id,
+        attempt,
+        usable_addr,
+    )
+    .await;
+
+    let outcome = ProbeOutcome {
+        peer_id: peer_id_str,
+        cycle_id,
+        attempt,
+        result,
+    };
+    // Ignore send error: the swarm loop may have shut down.
+    let _ = outcome_tx.send(outcome).await;
+}
+
+async fn run_probe(
+    control: &mut stream::Control,
+    dial_tx: &mpsc::Sender<DialRequest>,
+    peer_id_str: &str,
+    peer: PeerId,
+    cycle_id: &str,
+    attempt: u32,
+    usable_addr: Option<String>,
+) -> Result<()> {
+    // Step 1: if we have a specific address, dial it before opening the stream.
+    if let Some(addr_str) = usable_addr {
+        let addr: Multiaddr = addr_str
+            .parse()
+            .map_err(|e| anyhow!("probe: failed to parse usable_addr {addr_str}: {e}"))?;
+
+        let (result_tx, result_rx) = oneshot::channel();
+        dial_tx
+            .send(DialRequest {
+                peer,
+                addresses: vec![addr.clone()],
+                allow_connected_dial: false,
+                result_tx,
+            })
+            .await
+            .map_err(|_| anyhow!("probe: dial_tx closed"))?;
+
+        let dial_result = tokio::time::timeout(BUSINESS_STREAM_OPEN_TIMEOUT, result_rx).await;
+        match dial_result {
+            Err(_elapsed) => {
+                warn!(
+                    event = "peer.recovery_probe_failed",
+                    peer_id = %peer_id_str,
+                    recovery_cycle_id = %cycle_id,
+                    attempt,
+                    probe_method = "business_stream_open",
+                    result = "failure",
+                    error = "dial timed out",
+                    "recovery probe dial timed out"
+                );
+                return Err(anyhow!("probe: dial timed out"));
+            }
+            Ok(Err(_channel_err)) => {
+                return Err(anyhow!("probe: dial result channel dropped"));
+            }
+            Ok(Ok(Err(err))) => {
+                // Dial errors that mean "already in progress" are fine — the
+                // existing dial will establish the connection we need.
+                let msg = err.to_string();
+                if !msg.contains("dial is in progress") {
+                    warn!(
+                        event = "peer.recovery_probe_failed",
+                        peer_id = %peer_id_str,
+                        recovery_cycle_id = %cycle_id,
+                        attempt,
+                        probe_method = "business_stream_open",
+                        result = "failure",
+                        error_kind = "dial_error",
+                        retryable = true,
+                        error = %err,
+                        "recovery probe dial error"
+                    );
+                    return Err(anyhow!("probe: dial error: {err}"));
+                }
+                debug!(
+                    event = "peer.recovery_probe_dial_in_progress",
+                    peer_id = %peer_id_str,
+                    recovery_cycle_id = %cycle_id,
+                    attempt,
+                    "dial already in progress; piggy-backing on existing dial and proceeding to stream open"
+                );
+            }
+            Ok(Ok(Ok(()))) => {
+                // Dial initiated successfully.
+                debug!(
+                    event = "peer.recovery_probe_dial_ok",
+                    peer_id = %peer_id_str,
+                    recovery_cycle_id = %cycle_id,
+                    attempt,
+                    "dial initiated; proceeding to stream open"
+                );
+            }
+        }
+    }
+
+    // Step 2: open the business stream (the actual probe).
+    let open_result = tokio::time::timeout(
+        BUSINESS_STREAM_OPEN_TIMEOUT,
+        control.open_stream(peer, StreamProtocol::new(BUSINESS_PROTOCOL_ID)),
+    )
+    .await;
+
+    match open_result {
+        Err(_elapsed) => {
+            warn!(
+                event = "peer.recovery_probe_failed",
+                peer_id = %peer_id_str,
+                recovery_cycle_id = %cycle_id,
+                attempt,
+                probe_method = "business_stream_open",
+                result = "failure",
+                error = "stream open timed out",
+                "recovery probe stream open timed out"
+            );
+            Err(anyhow!("probe: stream open timed out"))
+        }
+        Ok(Err(err)) => {
+            warn!(
+                event = "peer.recovery_probe_failed",
+                peer_id = %peer_id_str,
+                recovery_cycle_id = %cycle_id,
+                attempt,
+                probe_method = "business_stream_open",
+                result = "failure",
+                error = %err,
+                "recovery probe stream open failed"
+            );
+            Err(anyhow!("probe: stream open error: {err}"))
+        }
+        Ok(Ok(stream)) => {
+            // Close immediately without writing any payload.
+            // The receiver handles "EOF before header" as a probe.
+            drop(stream);
+            info!(
+                event = "peer.recovery_probe_succeeded",
+                peer_id = %peer_id_str,
+                recovery_cycle_id = %cycle_id,
+                attempt,
+                probe_method = "business_stream_open",
+                result = "success",
+                "recovery probe succeeded"
+            );
+            Ok(())
+        }
+    }
+}

--- a/src-tauri/crates/uc-platform/src/adapters/libp2p_network/recovery_probe.rs
+++ b/src-tauri/crates/uc-platform/src/adapters/libp2p_network/recovery_probe.rs
@@ -108,6 +108,7 @@ async fn run_probe(
                 peer,
                 addresses: vec![addr.clone()],
                 allow_connected_dial: false,
+                bypass_address_filter: true,
                 result_tx,
             })
             .await

--- a/src-tauri/crates/uc-platform/src/adapters/libp2p_network/swarm_event_loop.rs
+++ b/src-tauri/crates/uc-platform/src/adapters/libp2p_network/swarm_event_loop.rs
@@ -5,12 +5,13 @@ use libp2p::futures::StreamExt;
 use libp2p::swarm::{Swarm, SwarmEvent};
 use libp2p::{mdns, Multiaddr, PeerId};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tokio::sync::{mpsc, RwLock, Semaphore};
 
 use tracing::{debug, error, info, instrument, warn};
 use uc_core::network::address_registry;
-use uc_core::network::NetworkEvent;
+use uc_core::network::events::PeerRuntimeState;
+use uc_core::network::{NetworkEvent, PairingState};
 use uc_core::ports::ConnectionPolicyResolverPort;
 
 use super::behaviour::{Libp2pBehaviour, Libp2pBehaviourEvent};
@@ -25,7 +26,12 @@ use super::discovery::{
     collect_mdns_discovered, collect_mdns_expired,
 };
 use super::peer_cache::{snapshot_peer_addresses, PeerCaches};
-use super::{try_send_event, BusinessCommand, DialRequest, MAX_IN_FLIGHT_BUSINESS_COMMANDS};
+use super::recovery_coordinator::{CoordinatorCmd, RecoveryCoordinator};
+use super::recovery_probe::{send_recovery_probe, ProbeOutcome};
+use super::{
+    try_send_event, BusinessCommand, DialRequest, MAX_IN_FLIGHT_BUSINESS_COMMANDS,
+    RECOVERY_PROBE_CADENCE,
+};
 
 /// Drives the libp2p Swarm event loop, processing network events, managing peer caches,
 /// handling business commands, and emitting network events to the application.
@@ -47,6 +53,19 @@ use super::{try_send_event, BusinessCommand, DialRequest, MAX_IN_FLIGHT_BUSINESS
 /// // tokio::spawn(run_swarm(swarm, caches, event_tx, policy_resolver, business_rx, local_peer_id));
 /// # }
 /// ```
+/// Drive the libp2p swarm with recovery coordinator support.
+///
+/// See module-level doc for the full event loop description.
+///
+/// `platform_signal_rx` — optional channel from the platform integration layer
+/// (sleep/wake, network change).  `None` when platform integration is not yet
+/// wired (Wave 1 graceful degradation).
+///
+/// Returns `Some((business_rx, dial_rx, platform_signal_rx))` when a session
+/// rebuild was requested by the recovery coordinator — the caller is expected
+/// to tear down the current swarm, build a fresh one, and call `run_swarm`
+/// again with the returned receivers. Returns `None` on normal exit (channels
+/// closed).
 #[instrument(name = "run_swarm", skip_all, fields(local_peer_id = %local_peer_id))]
 pub(super) async fn run_swarm(
     mut swarm: Swarm<Libp2pBehaviour>,
@@ -57,13 +76,26 @@ pub(super) async fn run_swarm(
     mut dial_rx: mpsc::Receiver<DialRequest>,
     dial_tx: mpsc::Sender<DialRequest>,
     local_peer_id: Arc<str>,
-) {
+    mut platform_signal_rx: Option<mpsc::Receiver<PlatformSignal>>,
+) -> Option<(
+    mpsc::Receiver<BusinessCommand>,
+    mpsc::Receiver<DialRequest>,
+    Option<mpsc::Receiver<PlatformSignal>>,
+)> {
     info!("libp2p mDNS swarm started");
     let mut next_business_command_id: u64 = 1;
     let business_command_semaphore = Arc::new(Semaphore::new(MAX_IN_FLIGHT_BUSINESS_COMMANDS));
     let mut pending_business_command: Option<(u64, BusinessCommand)> = None;
     let mut gc_interval =
         tokio::time::interval(Duration::from_secs(address_registry::GC_INTERVAL_SECS));
+
+    // ── Recovery coordinator ──────────────────────────────────────────────
+    let mut coordinator = RecoveryCoordinator::new();
+    let mut recovery_tick_interval = tokio::time::interval(RECOVERY_PROBE_CADENCE);
+    // Channel on which spawned probe tasks send back their outcomes.
+    let (probe_outcome_tx, mut probe_outcome_rx) = mpsc::channel::<ProbeOutcome>(32);
+    // Set to true when the coordinator requests a full session rebuild.
+    let mut should_rebuild = false;
 
     loop {
         tokio::select! {
@@ -74,7 +106,14 @@ pub(super) async fn run_swarm(
                             handle_mdns_discovered(peers, &mut swarm, &caches, &event_tx, &local_peer_id).await;
                         }
                         mdns::Event::Expired(peers) => {
-                            handle_mdns_expired(peers, &caches, &event_tx, &local_peer_id).await;
+                            handle_mdns_expired(
+                                peers,
+                                &caches,
+                                &event_tx,
+                                &policy_resolver,
+                                &local_peer_id,
+                                &mut coordinator,
+                            ).await;
                         }
                     },
                     SwarmEvent::Behaviour(Libp2pBehaviourEvent::Stream) => {}
@@ -84,9 +123,21 @@ pub(super) async fn run_swarm(
                         endpoint,
                         ..
                     } => {
+                        let peer_id_str = peer_id.to_string();
                         handle_connection_established(
                             peer_id, connection_id, endpoint, &mut swarm, &caches, &event_tx, &local_peer_id,
                         ).await;
+                        // Notify coordinator: this may end a recovery cycle.
+                        let recovery_cmds = coordinator.on_connection_established(&peer_id_str, Instant::now());
+                        // Obtain stream control BEFORE the await boundary (Swarm is !Sync).
+                        let sc = swarm.behaviour().stream.new_control();
+                        if dispatch_coordinator_cmds(
+                            recovery_cmds, sc, &caches, &event_tx, &dial_tx,
+                            &probe_outcome_tx,
+                        ).await {
+                            should_rebuild = true;
+                            break;
+                        }
                     }
                     SwarmEvent::ConnectionClosed {
                         peer_id,
@@ -123,6 +174,66 @@ pub(super) async fn run_swarm(
                     _ => {}
                 }
             }
+
+            // ── Recovery probe tick ───────────────────────────────────────
+            _ = recovery_tick_interval.tick() => {
+                let cmds = coordinator.tick(Instant::now());
+                let sc = swarm.behaviour().stream.new_control();
+                if dispatch_coordinator_cmds(
+                    cmds, sc, &caches, &event_tx, &dial_tx,
+                    &probe_outcome_tx,
+                ).await {
+                    should_rebuild = true;
+                    break;
+                }
+            }
+
+            // ── Probe outcome ─────────────────────────────────────────────
+            Some(outcome) = probe_outcome_rx.recv() => {
+                let cmds = coordinator.on_probe_result(
+                    &outcome.peer_id,
+                    &outcome.cycle_id,
+                    outcome.result.is_ok(),
+                    outcome.result.as_ref().err().map(|e| e.to_string()).as_deref(),
+                    Instant::now(),
+                );
+                let sc = swarm.behaviour().stream.new_control();
+                if dispatch_coordinator_cmds(
+                    cmds, sc, &caches, &event_tx, &dial_tx,
+                    &probe_outcome_tx,
+                ).await {
+                    should_rebuild = true;
+                    break;
+                }
+            }
+
+            // ── Platform signal (sleep/wake, network change) ──────────────
+            Some(signal) = async {
+                if let Some(rx) = platform_signal_rx.as_mut() { rx.recv().await } else { None }
+            } => {
+                let signal_kind = match signal {
+                    PlatformSignal::SleepWake => "sleep_wake",
+                    PlatformSignal::NetworkChange => "network_change",
+                };
+                info!(
+                    event = "platform.signal_received",
+                    signal = signal_kind,
+                    "platform signal received; forwarding to recovery coordinator"
+                );
+                let cmds = match signal {
+                    PlatformSignal::SleepWake => coordinator.on_sleep_wake(Instant::now()),
+                    PlatformSignal::NetworkChange => coordinator.on_network_change(Instant::now()),
+                };
+                let sc = swarm.behaviour().stream.new_control();
+                if dispatch_coordinator_cmds(
+                    cmds, sc, &caches, &event_tx, &dial_tx,
+                    &probe_outcome_tx,
+                ).await {
+                    should_rebuild = true;
+                    break;
+                }
+            }
+
             Some(command) = business_rx.recv(), if pending_business_command.is_none() => {
                 let command_id = next_business_command_id;
                 next_business_command_id = next_business_command_id.wrapping_add(1);
@@ -213,6 +324,198 @@ pub(super) async fn run_swarm(
             }
         }
     }
+
+    if should_rebuild {
+        info!(
+            event = "network.session_rebuild_loop_exited",
+            "run_swarm exiting to allow session rebuild"
+        );
+        Some((business_rx, dial_rx, platform_signal_rx))
+    } else {
+        info!("run_swarm exiting normally");
+        None
+    }
+}
+
+// ── Platform integration types ────────────────────────────────────────────────
+
+/// Platform-level signals that can trigger recovery actions.
+///
+/// The platform integration layer (task #8 — IOKit / SCNetworkReachability on
+/// macOS, netlink on Linux, etc.) sends these into the swarm loop via the
+/// optional `platform_signal_rx` channel.
+#[derive(Debug, Clone, Copy)]
+pub(super) enum PlatformSignal {
+    /// The local device just woke from sleep.
+    //
+    // Only constructed on non-test macOS builds where IOKit is wired up
+    // (see `platform_signals::macos`). Test and non-macOS builds rely on
+    // reactive recovery triggers instead.
+    #[allow(dead_code)]
+    SleepWake,
+    /// A local network interface or IP address changed.
+    NetworkChange,
+}
+
+// ── Coordinator command dispatcher ────────────────────────────────────────────
+
+/// Execute a batch of coordinator commands returned from a signal or tick.
+///
+/// `stream_control` must be obtained from `swarm.behaviour().stream.new_control()`
+/// by the caller **before** the await boundary (so `Swarm` is not held across
+/// any `.await` inside this function — `Swarm` is `!Sync` and causes non-`Send`
+/// futures if held over an await point).
+/// Returns `true` if the coordinator requested a full session rebuild
+/// (`CoordinatorCmd::RebuildSession`), in which case `run_swarm` should break
+/// its event loop and return the receivers to the caller for restart.
+async fn dispatch_coordinator_cmds(
+    cmds: Vec<CoordinatorCmd>,
+    stream_control: libp2p_stream::Control,
+    caches: &Arc<RwLock<PeerCaches>>,
+    event_tx: &mpsc::Sender<NetworkEvent>,
+    dial_tx: &mpsc::Sender<DialRequest>,
+    probe_outcome_tx: &mpsc::Sender<ProbeOutcome>,
+) -> bool {
+    for cmd in cmds {
+        match cmd {
+            CoordinatorCmd::EmitEvent(event) => {
+                let label = match &event {
+                    NetworkEvent::PeerStateChanged { state, .. } => match state {
+                        PeerRuntimeState::Online => "PeerStateOnline",
+                        PeerRuntimeState::Recovering => "PeerStateRecovering",
+                        PeerRuntimeState::Offline => "PeerStateOffline",
+                    },
+                    NetworkEvent::PeerRecoveryStarted { .. } => "PeerRecoveryStarted",
+                    NetworkEvent::PeerRecovered { .. } => "PeerRecovered",
+                    NetworkEvent::PeerRecoveryFailed { .. } => "PeerRecoveryFailed",
+                    _ => "recovery_event",
+                };
+                let _ = try_send_event(event_tx, event, label);
+            }
+
+            CoordinatorCmd::SendProbe {
+                peer_id,
+                cycle_id,
+                attempt,
+            } => {
+                let Ok(peer) = peer_id.parse::<PeerId>() else {
+                    warn!(
+                        event = "peer.recovery_probe_failed",
+                        peer_id = %peer_id,
+                        recovery_cycle_id = %cycle_id,
+                        attempt,
+                        error = "invalid peer id",
+                        "recovery probe skipped: could not parse peer id"
+                    );
+                    continue;
+                };
+
+                // Retrieve the last known usable address for Step 1.
+                let usable_addr = {
+                    let caches = caches.read().await;
+                    caches
+                        .last_dial_observations
+                        .get(&peer_id)
+                        .and_then(|obs| obs.chosen_dial_addr.clone())
+                };
+
+                info!(
+                    event = "peer.recovery_probe_attempt",
+                    peer_id = %peer_id,
+                    recovery_cycle_id = %cycle_id,
+                    attempt,
+                    probe_method = "business_stream_open",
+                    usable_addr = usable_addr.as_deref().unwrap_or("-"),
+                    "dispatching recovery probe"
+                );
+
+                let probe_control = stream_control.clone();
+                let probe_dial_tx = dial_tx.clone();
+                let probe_outcome_tx = probe_outcome_tx.clone();
+                tokio::spawn(send_recovery_probe(
+                    probe_control,
+                    probe_dial_tx,
+                    peer_id,
+                    peer,
+                    cycle_id,
+                    attempt,
+                    usable_addr,
+                    probe_outcome_tx,
+                ));
+            }
+
+            CoordinatorCmd::DialBroad {
+                peer_id,
+                cycle_id,
+                escalation_level,
+            } => {
+                // Step 2: dial all known candidate addresses for the peer.
+                let Ok(peer) = peer_id.parse::<PeerId>() else {
+                    continue;
+                };
+
+                let candidate_addresses: Vec<libp2p::Multiaddr> = {
+                    let caches = caches.read().await;
+                    caches
+                        .address_registry
+                        .candidates_for(&peer_id)
+                        .iter()
+                        .filter_map(|r| r.addr.parse().ok())
+                        .collect()
+                };
+
+                if candidate_addresses.is_empty() {
+                    info!(
+                        event = "peer.recovery_escalated",
+                        peer_id = %peer_id,
+                        recovery_cycle_id = %cycle_id,
+                        escalation_level,
+                        candidate_address_count = 0,
+                        "Step 2 broad dial skipped: no candidate addresses"
+                    );
+                    continue;
+                }
+
+                info!(
+                    event = "peer.recovery_escalated",
+                    peer_id = %peer_id,
+                    recovery_cycle_id = %cycle_id,
+                    escalation_level,
+                    candidate_address_count = candidate_addresses.len(),
+                    "Step 2 broad dial: dialing all known candidate addresses"
+                );
+
+                let (result_tx, _result_rx) = tokio::sync::oneshot::channel();
+                let _ = dial_tx
+                    .send(DialRequest {
+                        peer,
+                        addresses: candidate_addresses,
+                        allow_connected_dial: false,
+                        result_tx,
+                    })
+                    .await;
+            }
+
+            CoordinatorCmd::RebuildSession {
+                rebuild_id,
+                reason,
+                participating_peer_ids,
+            } => {
+                info!(
+                    event = "network.session_rebuild_started",
+                    rebuild_id = %rebuild_id,
+                    rebuild_reason = reason.as_str(),
+                    recovering_peer_count = participating_peer_ids.len(),
+                    "local network session rebuild requested; exiting run_swarm for restart"
+                );
+                // Signal the caller to tear down the current swarm and
+                // rebuild.  Remaining commands (if any) are intentionally
+                // dropped — they're moot once the swarm is being torn down.
+                return true;
+            }
+        }
+    }
+    false
 }
 
 // ---------------------------------------------------------------------------
@@ -279,12 +582,19 @@ async fn handle_mdns_discovered(
     }
 }
 
+/// Handle mDNS expiry.
+///
+/// For **paired** peers (`Trusted` pairing state), recovery is started instead
+/// of immediately emitting `PeerLost`.  For unpaired peers the original
+/// behavior is preserved.
 #[instrument(name = "network.mdns_expired", skip_all, fields(expired_count = peers.len()))]
 async fn handle_mdns_expired(
     peers: Vec<(PeerId, Multiaddr)>,
     caches: &Arc<RwLock<PeerCaches>>,
     event_tx: &mpsc::Sender<NetworkEvent>,
+    policy_resolver: &Arc<dyn ConnectionPolicyResolverPort>,
     local_peer_id: &str,
+    coordinator: &mut RecoveryCoordinator,
 ) {
     let peers: Vec<(PeerId, Multiaddr)> = peers
         .into_iter()
@@ -338,6 +648,33 @@ async fn handle_mdns_expired(
     }
 
     for event in events {
+        // For paired peers, start a recovery cycle instead of emitting PeerLost
+        // immediately.  The coordinator will emit PeerLost (as PeerStateOffline)
+        // only after the 120-second recovery window has been exhausted.
+        if let NetworkEvent::PeerLost(ref peer_id_str) = event {
+            let peer_id_core = uc_core::PeerId::from(peer_id_str.clone());
+            let is_paired = match policy_resolver.resolve_for_peer(&peer_id_core).await {
+                Ok(policy) => policy.pairing_state == PairingState::Trusted,
+                Err(_) => false,
+            };
+
+            if is_paired {
+                debug!(
+                    peer_id = %peer_id_str,
+                    "mDNS expired for paired peer — starting recovery cycle instead of PeerLost"
+                );
+                // Recovery cycle emits PeerRecoveryStarted; PeerLost is suppressed.
+                let recovery_cmds =
+                    coordinator.on_mdns_expired(peer_id_str.clone(), Instant::now());
+                for cmd in recovery_cmds {
+                    if let CoordinatorCmd::EmitEvent(ev) = cmd {
+                        let _ = try_send_event(event_tx, ev, "PeerRecoveryStarted");
+                    }
+                }
+                continue;
+            }
+        }
+
         let _ = try_send_event(event_tx, event, "PeerLost");
     }
 }

--- a/src-tauri/crates/uc-platform/src/adapters/libp2p_network/swarm_event_loop.rs
+++ b/src-tauri/crates/uc-platform/src/adapters/libp2p_network/swarm_event_loop.rs
@@ -29,8 +29,8 @@ use super::peer_cache::{snapshot_peer_addresses, PeerCaches};
 use super::recovery_coordinator::{CoordinatorCmd, RecoveryCoordinator};
 use super::recovery_probe::{send_recovery_probe, ProbeOutcome};
 use super::{
-    try_send_event, BusinessCommand, DialRequest, MAX_IN_FLIGHT_BUSINESS_COMMANDS,
-    RECOVERY_PROBE_CADENCE,
+    try_send_event, BusinessCommand, DialRequest, DIAL_FAILURE_STREAK_THRESHOLD,
+    MAX_IN_FLIGHT_BUSINESS_COMMANDS, RECOVERY_PROBE_CADENCE,
 };
 
 /// Drives the libp2p Swarm event loop, processing network events, managing peer caches,
@@ -150,9 +150,50 @@ pub(super) async fn run_swarm(
                         ).await;
                     }
                     SwarmEvent::OutgoingConnectionError { peer_id, error, .. } => {
-                        handle_outgoing_connection_error(
+                        let failure_info = handle_outgoing_connection_error(
                             peer_id, error, &caches, &event_tx, &local_peer_id,
                         ).await;
+
+                        // Wire dial failure streak → recovery coordinator.
+                        if let Some((peer_id_str, consecutive_failures)) = failure_info {
+                            if consecutive_failures >= DIAL_FAILURE_STREAK_THRESHOLD
+                                && !coordinator.is_recovering(&peer_id_str)
+                            {
+                                let peer_id_core = uc_core::PeerId::from(peer_id_str.clone());
+                                let is_paired = async {
+                                    match policy_resolver.resolve_for_peer(&peer_id_core).await {
+                                        Ok(policy) => policy.pairing_state == PairingState::Trusted,
+                                        Err(_) => false,
+                                    }
+                                }
+                                .instrument(info_span!(
+                                    "recovery.resolve_pairing_state",
+                                    peer_id = %peer_id_str
+                                ))
+                                .await;
+
+                                if is_paired {
+                                    info!(
+                                        event = "peer.dial_failure_streak_detected",
+                                        peer_id = %peer_id_str,
+                                        consecutive_failures,
+                                        threshold = DIAL_FAILURE_STREAK_THRESHOLD,
+                                        "dial failure streak for paired peer — starting recovery"
+                                    );
+                                    let recovery_cmds = coordinator.on_dial_failure_streak(
+                                        peer_id_str, Instant::now(),
+                                    );
+                                    let sc = swarm.behaviour().stream.new_control();
+                                    if dispatch_coordinator_cmds(
+                                        recovery_cmds, sc, &caches, &event_tx, &dial_tx,
+                                        &probe_outcome_tx,
+                                    ).await {
+                                        should_rebuild = true;
+                                        break;
+                                    }
+                                }
+                            }
+                        }
                     }
                     SwarmEvent::IncomingConnectionError {
                         send_back_addr,
@@ -190,6 +231,14 @@ pub(super) async fn run_swarm(
 
             // ── Probe outcome ─────────────────────────────────────────────
             Some(outcome) = probe_outcome_rx.recv() => {
+                debug!(
+                    event = "peer.recovery_probe_outcome_received",
+                    peer_id = %outcome.peer_id,
+                    recovery_cycle_id = %outcome.cycle_id,
+                    attempt = outcome.attempt,
+                    success = outcome.result.is_ok(),
+                    "received probe outcome from spawned task"
+                );
                 let cmds = coordinator.on_probe_result(
                     &outcome.peer_id,
                     &outcome.cycle_id,
@@ -851,11 +900,11 @@ async fn handle_outgoing_connection_error(
     caches: &Arc<RwLock<PeerCaches>>,
     event_tx: &mpsc::Sender<NetworkEvent>,
     _local_peer_id: &str,
-) {
+) -> Option<(String, u32)> {
     let peer_id_str = peer_id.as_ref().map(ToString::to_string);
     let observed_at = Utc::now();
 
-    let snapshot = if let Some(peer_id) = peer_id_str.as_ref() {
+    let (snapshot, consecutive_failures) = if let Some(peer_id) = peer_id_str.as_ref() {
         let mut caches = caches.write().await;
         let observation = dial_observation_from_error(&error, observed_at);
         let error_msg = error.to_string();
@@ -863,9 +912,13 @@ async fn handle_outgoing_connection_error(
             caches.record_address_failure(peer_id, addr, &error_msg);
         }
         caches.record_dial_observation(peer_id, observation);
-        Some(snapshot_peer_addresses(&caches, peer_id, observed_at))
+        let failures = caches.record_dial_failure(peer_id);
+        (
+            Some(snapshot_peer_addresses(&caches, peer_id, observed_at)),
+            Some(failures),
+        )
     } else {
-        None
+        (None, None)
     };
 
     error!(
@@ -917,6 +970,8 @@ async fn handle_outgoing_connection_error(
     {
         warn!("failed to publish network error event: {err}");
     }
+
+    peer_id_str.zip(consecutive_failures)
 }
 
 #[instrument(name = "network.incoming_connection_error", skip_all, fields(send_back_addr = %send_back_addr))]

--- a/src-tauri/crates/uc-platform/src/adapters/libp2p_network/swarm_event_loop.rs
+++ b/src-tauri/crates/uc-platform/src/adapters/libp2p_network/swarm_event_loop.rs
@@ -168,9 +168,13 @@ pub(super) async fn run_swarm(
                                                 event = "recovery.resolve_pairing_state_failed",
                                                 peer_id = %peer_id_str,
                                                 error = %err,
-                                                "failed to resolve pairing state; treating as unpaired"
+                                                "failed to resolve pairing state; treating as paired (optimistic)"
                                             );
-                                            false
+                                            // Optimistic: allow recovery to proceed so transient
+                                            // lookup failures don't silently suppress it.  If the
+                                            // peer turns out to be unpaired the probe will fail
+                                            // fast with no side-effects.
+                                            true
                                         }
                                     }
                                 }
@@ -572,6 +576,7 @@ async fn dispatch_coordinator_cmds(
                         peer,
                         addresses: candidate_addresses,
                         allow_connected_dial: false,
+                        bypass_address_filter: false,
                         result_tx,
                     })
                     .await
@@ -1052,26 +1057,34 @@ async fn handle_dial_request(
 
     use libp2p::swarm::dial_opts::{DialOpts, PeerCondition};
 
-    // Filter stale mDNS addresses before dialing
-    let live_addresses: std::collections::HashSet<String> = {
-        let caches = caches.read().await;
-        caches
-            .address_registry
-            .candidates_for(&dial_req.peer.to_string())
-            .iter()
-            .map(|r| r.addr.clone())
+    // Filter stale mDNS addresses before dialing.  Recovery probes pass
+    // historical addresses from `last_dial_observations` that are deliberately
+    // absent from the live registry; honour `bypass_address_filter` so they
+    // are not discarded.
+    let filtered_addresses: Vec<libp2p::Multiaddr> = if dial_req.bypass_address_filter {
+        dial_req.addresses
+    } else {
+        let live_addresses: std::collections::HashSet<String> = {
+            let caches = caches.read().await;
+            caches
+                .address_registry
+                .candidates_for(&dial_req.peer.to_string())
+                .iter()
+                .map(|r| r.addr.clone())
+                .collect()
+        };
+
+        dial_req
+            .addresses
+            .into_iter()
+            .filter(|a| live_addresses.contains(&a.to_string()))
             .collect()
     };
-
-    let filtered_addresses: Vec<libp2p::Multiaddr> = dial_req
-        .addresses
-        .into_iter()
-        .filter(|a| live_addresses.contains(&a.to_string()))
-        .collect();
 
     if filtered_addresses.is_empty() {
         warn!(
             peer_id = %dial_req.peer,
+            bypass_filter = dial_req.bypass_address_filter,
             "pre-dial: all explicit addresses expired in PeerCaches"
         );
         let _ = dial_req.result_tx.send(Err(anyhow!(

--- a/src-tauri/crates/uc-platform/src/adapters/libp2p_network/swarm_event_loop.rs
+++ b/src-tauri/crates/uc-platform/src/adapters/libp2p_network/swarm_event_loop.rs
@@ -163,7 +163,15 @@ pub(super) async fn run_swarm(
                                 let is_paired = async {
                                     match policy_resolver.resolve_for_peer(&peer_id_core).await {
                                         Ok(policy) => policy.pairing_state == PairingState::Trusted,
-                                        Err(_) => false,
+                                        Err(err) => {
+                                            warn!(
+                                                event = "recovery.resolve_pairing_state_failed",
+                                                peer_id = %peer_id_str,
+                                                error = %err,
+                                                "failed to resolve pairing state; treating as unpaired"
+                                            );
+                                            false
+                                        }
                                     }
                                 }
                                 .instrument(info_span!(
@@ -374,6 +382,18 @@ pub(super) async fn run_swarm(
         }
     }
 
+    // Fail any buffered business command so its oneshot receiver doesn't hang.
+    if let Some((_cmd_id, cmd)) = pending_business_command {
+        match cmd {
+            BusinessCommand::SendClipboard { result_tx, .. }
+            | BusinessCommand::EnsureBusinessPath { result_tx, .. }
+            | BusinessCommand::UnpairPeer { result_tx, .. } => {
+                let _ = result_tx.send(Err(anyhow!("session rebuild in progress")));
+            }
+            BusinessCommand::AnnounceDeviceName { .. } => {}
+        }
+    }
+
     if should_rebuild {
         info!(
             event = "network.session_rebuild_loop_exited",
@@ -500,8 +520,19 @@ async fn dispatch_coordinator_cmds(
                 escalation_level,
             } => {
                 // Step 2: dial all known candidate addresses for the peer.
-                let Ok(peer) = peer_id.parse::<PeerId>() else {
-                    continue;
+                let peer = match peer_id.parse::<PeerId>() {
+                    Ok(p) => p,
+                    Err(err) => {
+                        error!(
+                            event = "peer.recovery_dial_broad_parse_failed",
+                            peer_id = %peer_id,
+                            recovery_cycle_id = %cycle_id,
+                            escalation_level,
+                            error = %err,
+                            "Step 2 broad dial: failed to parse peer id"
+                        );
+                        continue;
+                    }
                 };
 
                 let candidate_addresses: Vec<libp2p::Multiaddr> = {
@@ -536,14 +567,24 @@ async fn dispatch_coordinator_cmds(
                 );
 
                 let (result_tx, _result_rx) = tokio::sync::oneshot::channel();
-                let _ = dial_tx
+                if let Err(err) = dial_tx
                     .send(DialRequest {
                         peer,
                         addresses: candidate_addresses,
                         allow_connected_dial: false,
                         result_tx,
                     })
-                    .await;
+                    .await
+                {
+                    error!(
+                        event = "peer.recovery_dial_broad_send_failed",
+                        peer_id = %peer_id,
+                        recovery_cycle_id = %cycle_id,
+                        escalation_level,
+                        error = %err,
+                        "Step 2 broad dial: failed to send dial request"
+                    );
+                }
             }
 
             CoordinatorCmd::RebuildSession {

--- a/src-tauri/crates/uc-platform/src/adapters/libp2p_network/swarm_event_loop.rs
+++ b/src-tauri/crates/uc-platform/src/adapters/libp2p_network/swarm_event_loop.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::{mpsc, RwLock, Semaphore};
 
-use tracing::{debug, error, info, instrument, warn};
+use tracing::{debug, error, info, info_span, instrument, warn, Instrument};
 use uc_core::network::address_registry;
 use uc_core::network::events::PeerRuntimeState;
 use uc_core::network::{NetworkEvent, PairingState};
@@ -368,6 +368,7 @@ pub(super) enum PlatformSignal {
 /// Returns `true` if the coordinator requested a full session rebuild
 /// (`CoordinatorCmd::RebuildSession`), in which case `run_swarm` should break
 /// its event loop and return the receivers to the caller for restart.
+#[instrument(name = "recovery.dispatch_cmds", skip_all, fields(cmd_count = cmds.len()))]
 async fn dispatch_coordinator_cmds(
     cmds: Vec<CoordinatorCmd>,
     stream_control: libp2p_stream::Control,
@@ -653,10 +654,17 @@ async fn handle_mdns_expired(
         // only after the 120-second recovery window has been exhausted.
         if let NetworkEvent::PeerLost(ref peer_id_str) = event {
             let peer_id_core = uc_core::PeerId::from(peer_id_str.clone());
-            let is_paired = match policy_resolver.resolve_for_peer(&peer_id_core).await {
-                Ok(policy) => policy.pairing_state == PairingState::Trusted,
-                Err(_) => false,
-            };
+            let is_paired = async {
+                match policy_resolver.resolve_for_peer(&peer_id_core).await {
+                    Ok(policy) => policy.pairing_state == PairingState::Trusted,
+                    Err(_) => false,
+                }
+            }
+            .instrument(info_span!(
+                "recovery.resolve_pairing_state",
+                peer_id = %peer_id_str
+            ))
+            .await;
 
             if is_paired {
                 debug!(

--- a/src-tauri/crates/uc-platform/src/adapters/libp2p_network/tests.rs
+++ b/src-tauri/crates/uc-platform/src/adapters/libp2p_network/tests.rs
@@ -167,7 +167,11 @@ fn reachable_is_best_effort_and_requires_discovery() {
 }
 
 #[test]
-fn regression_mark_unreachable_clears_last_dial_observation() {
+fn mark_unreachable_preserves_last_dial_observation_for_recovery() {
+    // Recovery-wave-1 contract: mark_unreachable must keep
+    // `last_dial_observations` around so the recovery coordinator can retry
+    // the last known usable path after a transient drop. See
+    // docs/p2p/2026-04-11-connection-stability-recovery-prd.md §Definitions.
     let mut caches = PeerCaches::new();
     let t0 = Utc::now();
     let dial_addr = "/ip4/10.0.0.8/tcp/4001";
@@ -178,11 +182,93 @@ fn regression_mark_unreachable_clears_last_dial_observation() {
 
     assert!(caches.mark_unreachable("peer-1"));
 
-    let snapshot = snapshot_peer_addresses(&caches, "peer-1", t0 + chrono::TimeDelta::seconds(1));
-    assert!(snapshot.chosen_dial_addr.is_none());
-    assert!(snapshot.last_dial_observed_at.is_none());
-    assert!(snapshot.last_dial_outcome.is_none());
-    assert_eq!(snapshot.dial_attempt_address_count, 0);
+    assert!(
+        caches.last_dial_observations.contains_key("peer-1"),
+        "mark_unreachable must preserve last_dial_observations"
+    );
+
+    let observation = caches
+        .last_dial_observations
+        .get("peer-1")
+        .expect("observation should still be present");
+    assert_eq!(observation.chosen_dial_addr.as_deref(), Some(dial_addr));
+}
+
+#[test]
+fn remove_discovered_preserves_last_dial_observation_for_recovery() {
+    // Recovery-wave-1 contract: mDNS expiry must not erase the usable path.
+    let mut caches = PeerCaches::new();
+    let t0 = Utc::now();
+    let dial_addr = "/ip4/10.0.0.8/tcp/4001";
+
+    caches.upsert_discovered("peer-1".to_string(), vec![dial_addr.to_string()], t0);
+    assert!(caches.mark_reachable("peer-1", t0));
+    caches.record_dial_observation("peer-1", successful_dial_observation(dial_addr, t0));
+
+    let removed = caches.remove_discovered("peer-1");
+    assert!(
+        removed.is_some(),
+        "peer should be fully removed from discovered_peers"
+    );
+
+    assert!(
+        caches.last_dial_observations.contains_key("peer-1"),
+        "remove_discovered must preserve last_dial_observations"
+    );
+}
+
+#[test]
+fn forget_peer_clears_last_dial_observation() {
+    // Explicit forget (unpair) must erase everything including the usable path.
+    let mut caches = PeerCaches::new();
+    let t0 = Utc::now();
+    let dial_addr = "/ip4/10.0.0.8/tcp/4001";
+
+    caches.upsert_discovered("peer-1".to_string(), vec![dial_addr.to_string()], t0);
+    assert!(caches.mark_reachable("peer-1", t0));
+    caches.record_dial_observation("peer-1", successful_dial_observation(dial_addr, t0));
+
+    let removed = caches.forget_peer("peer-1");
+    assert!(
+        removed.is_some(),
+        "forget_peer should return the removed entry"
+    );
+
+    assert!(
+        !caches.last_dial_observations.contains_key("peer-1"),
+        "forget_peer must clear last_dial_observations"
+    );
+    assert!(caches.discovered_peers.get("peer-1").is_none());
+    assert!(!caches.is_reachable("peer-1"));
+}
+
+#[test]
+fn mark_connection_closed_preserves_last_dial_observation_for_recovery() {
+    // Recovery-wave-1 contract: closing the last active connection must NOT
+    // erase last_dial_observations. The recovery coordinator needs the last
+    // known usable path to issue a Step-1 probe after connection drop.
+    let mut caches = PeerCaches::new();
+    let t0 = Utc::now();
+    let dial_addr = "/ip4/10.0.0.8/tcp/4001";
+    let conn_id = ConnectionId::new_unchecked(1);
+
+    caches.upsert_discovered("peer-1".to_string(), vec![dial_addr.to_string()], t0);
+    caches.mark_connection_established("peer-1", conn_id, Some(dial_addr.to_string()), t0);
+    caches.record_dial_observation("peer-1", successful_dial_observation(dial_addr, t0));
+
+    let became_unreachable = caches.mark_connection_closed("peer-1", conn_id);
+    assert!(
+        became_unreachable,
+        "closing the last connection should mark peer unreachable"
+    );
+    assert!(!caches.is_reachable("peer-1"));
+
+    assert!(
+        caches.last_dial_observations.contains_key("peer-1"),
+        "mark_connection_closed must preserve last_dial_observations"
+    );
+    let obs = caches.last_dial_observations.get("peer-1").unwrap();
+    assert_eq!(obs.chosen_dial_addr.as_deref(), Some(dial_addr));
 }
 
 #[test]

--- a/src-tauri/crates/uc-platform/src/clipboard/common.rs
+++ b/src-tauri/crates/uc-platform/src/clipboard/common.rs
@@ -11,6 +11,13 @@ use uc_core::ids::RepresentationId;
 #[cfg(target_os = "macos")]
 const TIFF_ALIASES: &[&str] = &["public.tiff", "NeXT TIFF v4.0 pasteboard type"];
 
+/// macOS pasteboard formats that embed entire page resources (images, CSS, JS)
+/// and can bloat a simple two-character browser copy to 20 MB+.
+/// The useful content (text, HTML, RTF) is already captured by the high-level
+/// clipboard APIs, so these archive formats are pure overhead for sync.
+#[cfg(target_os = "macos")]
+const WEBARCHIVE_FORMATS: &[&str] = &["com.apple.webarchive", "Apple Web Archive pasteboard type"];
+
 /// Convert TIFF bytes to PNG, returning the PNG bytes.
 ///
 /// macOS clipboard stores images as raw uncompressed TIFF (~18 MB for a
@@ -101,6 +108,15 @@ fn should_skip_raw_format(
             && (format_id == "public.file-url" || format_id == "NSFilenamesPboardType")
         {
             return true;
+        }
+
+        // Web-archive formats embed full page resources (images, CSS, JS).
+        // A two-character browser copy can produce a 20 MB+ web archive.
+        // Text, HTML, and RTF are already captured by high-level APIs.
+        for wa in WEBARCHIVE_FORMATS {
+            if format_id.eq_ignore_ascii_case(wa) {
+                return true;
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Complete implementation of Connection Stability Recovery wave-1:
- Wire `on_dial_failure_streak()` to detect consecutive outgoing dial failures for paired peers
- Add trigger field logging to recovery cycle lifecycle (completion/failure)
- Add attempt field logging to probe outcome reception
- All 4 dead_code items now integrated into swarm event loop

Also includes clipboard optimizations from prior commits:
- Skip macOS web archive formats to avoid 20 MB+ payloads from 2-character browser copies
- Promote clipboard representation logging to info level with per-format breakdown
- Update Seq skill documentation with raw JSON event structure

## Changes

- **chore(recovery)**: Add consecutive dial failure counter to peer cache
- **feat(recovery)**: Wire dial failure streak detection to recovery coordinator
- **feat(recovery)**: Add trigger field logging to recovery cycle lifecycle  
- **perf(clipboard)**: Skip web archive formats on macOS
- **perf(clipboard)**: Upgrade representation log to info level with breakdown
- **docs(seq)**: Document raw JSON event structure

## Test plan

- [x] Cargo check passes with zero dead_code warnings
- [x] All 4 previously-unused items now have call sites
- [x] Compilation succeeds for all crates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Connection stability recovery with probe-based reachability checks, session rebuilds, and a Recovering device state; clearer paired-clipboard delivery states (Sending, Recovering, Synced, Attention).

* **Documentation**
  * Added PRD, design draft, and worklist for recovery and paired-sync reliability; expanded skill docs with raw JSON payload format, timing/level notes, and parsing guidance.

* **Chores**
  * Improved tracing/observability across clipboard flows and optimized compression behavior for large payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->