### PR TITLE
Fix quick panel search input ref typing

### DIFF
--- a/src/quick-panel/ClipboardHistoryPanel.tsx
+++ b/src/quick-panel/ClipboardHistoryPanel.tsx
@@ -131,7 +131,7 @@ interface HistoryPaneProps {
   onSearchChange: (value: string) => void
   onSelect: (index: number) => void
   onUnlock: () => void
-  searchInputRef: React.Ref<HTMLInputElement>
+  searchInputRef: React.RefObject<HTMLInputElement>
   searchQuery: string
   selectedIndex: number
   setHoveredIndex: React.Dispatch<React.SetStateAction<number | null>>
@@ -350,7 +350,7 @@ const ClipboardHistoryPanel: React.FC = () => {
   const [hasPointerMovedSinceShow, setHasPointerMovedSinceShow] = useState(false)
   const [previewTargetId, setPreviewTargetId] = useState<string | null>(null)
 
-  const searchInputRef = useRef<HTMLInputElement>(null)
+  const searchInputRef = useRef<HTMLInputElement>(null!)
   const historyPaneRef = useRef<HTMLDivElement>(null)
   const itemRefs = useRef<Map<number, HTMLDivElement>>(new Map())
   const previewTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)


### PR DESCRIPTION
## Summary
- fix the quick panel search input ref type to match the input element expectation
- unblock the frontend build used by Tauri packaging

## Verification
- bun run build
- bun run tauri build --target aarch64-apple-darwin (confirmed it passed the previous TypeScript failure point and continued into native packaging)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal type definitions to enhance code quality and maintainability. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->