### PR TITLE
fix: reduce noisy libp2p recovery logs

### DIFF
--- a/src-tauri/crates/uc-platform/src/adapters/libp2p_network/swarm_event_loop.rs
+++ b/src-tauri/crates/uc-platform/src/adapters/libp2p_network/swarm_event_loop.rs
@@ -441,7 +441,12 @@ pub(super) enum PlatformSignal {
 /// Returns `true` if the coordinator requested a full session rebuild
 /// (`CoordinatorCmd::RebuildSession`), in which case `run_swarm` should break
 /// its event loop and return the receivers to the caller for restart.
-#[instrument(name = "recovery.dispatch_cmds", skip_all, fields(cmd_count = cmds.len()))]
+#[instrument(
+    name = "recovery.dispatch_cmds",
+    level = "debug",
+    skip_all,
+    fields(cmd_count = cmds.len())
+)]
 async fn dispatch_coordinator_cmds(
     cmds: Vec<CoordinatorCmd>,
     stream_control: libp2p_stream::Control,

--- a/src-tauri/crates/uc-platform/src/net_utils.rs
+++ b/src-tauri/crates/uc-platform/src/net_utils.rs
@@ -1,6 +1,6 @@
 use local_ip_address::list_afinet_netifas;
 use std::net::{IpAddr, Ipv4Addr};
-use tracing::{debug, info, warn};
+use tracing::{debug, warn};
 
 /// Detect the best physical LAN IPv4 address for libp2p to listen on.
 ///
@@ -44,7 +44,7 @@ pub fn get_physical_lan_ip() -> Option<Ipv4Addr> {
             }
 
             if is_private_ipv4(v4) {
-                info!(ip = %v4, interface = %iface_name, "detected physical LAN IP");
+                debug!(ip = %v4, interface = %iface_name, "detected physical LAN IP");
                 return Some(v4);
             }
 


### PR DESCRIPTION
## Summary
- reduce repeated recovery dispatch log output in normal production flow
- stop logging detected physical LAN IP as a normal info message on every poll
- keep real warning signals unchanged so actual failures are still visible

## Verification
- cargo test -p uc-platform

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal logging configuration to improve development diagnostics and troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->