### PR TITLE
feat: 升级检测 P1 thin (UpgradeFacade + AppVersionStatePort)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -10218,6 +10218,7 @@ dependencies = [
  "log",
  "mockall 0.13.1",
  "rand 0.8.5",
+ "semver",
  "serde",
  "serde_json",
  "sha2 0.10.9",

--- a/src-tauri/crates/uc-application/Cargo.toml
+++ b/src-tauri/crates/uc-application/Cargo.toml
@@ -43,6 +43,10 @@ blake3 = "1"
 # boundaries without extra clones. Matches uc-core + uc-infra.
 bytes = "1.7"
 url = "2"
+# Semver parsing for upgrade-detection use case (`facade::upgrade`).
+# Compares last_seen_version (port-stored String) against current build
+# version to derive `UpgradeStatus`.
+semver = "1"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/src-tauri/crates/uc-application/src/deps.rs
+++ b/src-tauri/crates/uc-application/src/deps.rs
@@ -126,6 +126,9 @@ pub struct AppDeps {
     pub device: DevicePorts,
     /// Setup status (setup-specific) / 设置状态（设置流程专用）
     pub setup_status: Arc<dyn SetupStatusPort>,
+    /// 升级游标端口：持久化"上次运行的应用版本"。
+    /// 由 `UpgradeFacade::detect_on_startup` 在启动期读取并比较。
+    pub app_version_state: Arc<dyn AppVersionStatePort>,
     /// Storage-domain ports / 存储领域端口
     pub storage: StoragePorts,
     /// Settings (cross-cutting) / 设置（横切关注）

--- a/src-tauri/crates/uc-application/src/facade/app_facade.rs
+++ b/src-tauri/crates/uc-application/src/facade/app_facade.rs
@@ -37,6 +37,7 @@ use crate::facade::space_setup::{
     RedeemPairingInvitationError, RedeemPairingInvitationInput, RedeemPairingInvitationResult,
     SwitchSpaceError, SwitchSpaceInput, SwitchSpaceResult, TryResumeSessionError,
 };
+use crate::facade::upgrade::UpgradeFacade;
 use crate::facade::{
     BlobTransferError, BlobTransferFacade, ClipboardHistoryFacade, ClipboardRestoreFacade,
     ClipboardSyncError, ClipboardSyncFacade, DeviceFacade, EncryptionFacade, EncryptionFacadeError,
@@ -69,6 +70,10 @@ pub struct AppFacade {
     pub settings: Arc<SettingsFacade>,
     pub device: Arc<DeviceFacade>,
     pub storage: Arc<StorageFacade>,
+    /// 升级检测 facade（P1 thin）。所有桌面入口（GUI / daemon / CLI）共享同
+    /// 一份；启动期 host 调一次 `upgrade.detect_on_startup()` 决定是否触发
+    /// 重新配对引导等动作。
+    pub upgrade: Arc<UpgradeFacade>,
 }
 
 impl AppFacade {
@@ -91,6 +96,7 @@ impl AppFacade {
             settings: parts.settings,
             device: parts.device,
             storage: parts.storage,
+            upgrade: parts.upgrade,
         }
     }
 
@@ -412,4 +418,5 @@ pub struct AppFacadeParts {
     pub settings: Arc<SettingsFacade>,
     pub device: Arc<DeviceFacade>,
     pub storage: Arc<StorageFacade>,
+    pub upgrade: Arc<UpgradeFacade>,
 }

--- a/src-tauri/crates/uc-application/src/facade/mod.rs
+++ b/src-tauri/crates/uc-application/src/facade/mod.rs
@@ -26,6 +26,7 @@ pub mod settings;
 pub mod setup_status;
 pub mod space_setup;
 pub mod storage;
+pub mod upgrade;
 
 pub use app_facade::{
     AppFacade, AppFacadeParts, AppPresenceEvent, AppPresenceSubscription,
@@ -110,4 +111,7 @@ pub use space_setup::{
 };
 pub use storage::{
     ClearCacheResultView, StorageFacade, StorageFacadeDeps, StorageFacadeError, StorageStatsView,
+};
+pub use upgrade::{
+    AcknowledgeUpgradeError, DetectUpgradeError, UpgradeFacade, UpgradeFacadeDeps, UpgradeStatus,
 };

--- a/src-tauri/crates/uc-application/src/facade/upgrade/facade.rs
+++ b/src-tauri/crates/uc-application/src/facade/upgrade/facade.rs
@@ -1,0 +1,188 @@
+//! [`UpgradeFacade`] —— P1 thin 升级检测对外入口。
+//!
+//! 调用方组合：
+//! 1. 启动期调一次 [`UpgradeFacade::detect_on_startup`]，结果作为 UI / CLI
+//!    决策输入（弹窗、提示、跳过等）。
+//! 2. 用户确认后调 [`UpgradeFacade::acknowledge`] 把游标推进到当前版本，
+//!    下次启动得 `NoChange`。
+//!
+//! 当前版本字符串由调用方传入（典型为 `env!("CARGO_PKG_VERSION")`），
+//! facade / use case 不依赖任何构建期常量，便于测试与多入口复用。
+
+use std::sync::Arc;
+
+use thiserror::Error;
+
+use uc_core::ports::{AppVersionStatePort, SetupStatusPort};
+
+use crate::usecases::upgrade::{
+    AcknowledgeError as InnerAcknowledgeError, AcknowledgeUseCase,
+    DetectUpgradeError as InnerDetectUpgradeError, DetectUpgradeUseCase,
+    UpgradeStatus as InnerUpgradeStatus,
+};
+
+/// 对外 re-export：升级状态判定结果。
+pub type UpgradeStatus = InnerUpgradeStatus;
+
+/// `UpgradeFacade::detect_on_startup` 的错误。
+///
+/// 内部 `DetectUpgradeError` 的 1:1 镜像；保持 facade 与 use case 错误类型
+/// 解耦，未来 use case 内部错误演化不会破坏对外 API。
+#[derive(Debug, Error)]
+pub enum DetectUpgradeError {
+    #[error("current build version is malformed: {0}")]
+    CurrentVersionMalformed(String),
+
+    #[error("read app version cursor failed: {0}")]
+    ReadCursor(String),
+
+    #[error("read setup status failed: {0}")]
+    ReadSetupStatus(String),
+}
+
+impl From<InnerDetectUpgradeError> for DetectUpgradeError {
+    fn from(value: InnerDetectUpgradeError) -> Self {
+        match value {
+            InnerDetectUpgradeError::CurrentVersionMalformed(s) => Self::CurrentVersionMalformed(s),
+            InnerDetectUpgradeError::ReadCursor(e) => Self::ReadCursor(e.to_string()),
+            InnerDetectUpgradeError::ReadSetupStatus(s) => Self::ReadSetupStatus(s),
+        }
+    }
+}
+
+/// `UpgradeFacade::acknowledge` 的错误。
+#[derive(Debug, Error)]
+pub enum AcknowledgeUpgradeError {
+    #[error("current build version is malformed: {0}")]
+    CurrentVersionMalformed(String),
+
+    #[error("write app version cursor failed: {0}")]
+    WriteCursor(String),
+}
+
+impl From<InnerAcknowledgeError> for AcknowledgeUpgradeError {
+    fn from(value: InnerAcknowledgeError) -> Self {
+        match value {
+            InnerAcknowledgeError::CurrentVersionMalformed(s) => Self::CurrentVersionMalformed(s),
+            InnerAcknowledgeError::WriteCursor(e) => Self::WriteCursor(e.to_string()),
+        }
+    }
+}
+
+/// 构造 `UpgradeFacade` 所需的端口集合。
+pub struct UpgradeFacadeDeps {
+    pub app_version_state: Arc<dyn AppVersionStatePort>,
+    pub setup_status: Arc<dyn SetupStatusPort>,
+}
+
+/// 升级检测 facade。线程安全，可放入 `Arc`。
+pub struct UpgradeFacade {
+    detect: DetectUpgradeUseCase,
+    acknowledge: AcknowledgeUseCase,
+}
+
+impl UpgradeFacade {
+    pub fn new(deps: UpgradeFacadeDeps) -> Self {
+        let UpgradeFacadeDeps {
+            app_version_state,
+            setup_status,
+        } = deps;
+        Self {
+            detect: DetectUpgradeUseCase::new(app_version_state.clone(), setup_status),
+            acknowledge: AcknowledgeUseCase::new(app_version_state),
+        }
+    }
+
+    /// 启动期一次性判定。返回 [`UpgradeStatus`] 由调用方决定后续动作。
+    pub async fn detect_on_startup(
+        &self,
+        current_version: &str,
+    ) -> Result<UpgradeStatus, DetectUpgradeError> {
+        self.detect
+            .execute(current_version)
+            .await
+            .map_err(Into::into)
+    }
+
+    /// 把游标推进到 `current_version`。调用方应在用户确认（点掉弹窗、
+    /// 跑完重新配对、CLI 标记已读等）后调用。
+    pub async fn acknowledge(&self, current_version: &str) -> Result<(), AcknowledgeUpgradeError> {
+        self.acknowledge
+            .execute(current_version)
+            .await
+            .map_err(Into::into)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use std::sync::Mutex;
+    use uc_core::ports::AppVersionStateError;
+    use uc_core::setup::SetupStatus;
+
+    struct FakeVersionState {
+        value: Mutex<Option<String>>,
+    }
+    impl FakeVersionState {
+        fn new(initial: Option<&str>) -> Arc<Self> {
+            Arc::new(Self {
+                value: Mutex::new(initial.map(|s| s.to_string())),
+            })
+        }
+    }
+    #[async_trait]
+    impl AppVersionStatePort for FakeVersionState {
+        async fn read(&self) -> Result<Option<String>, AppVersionStateError> {
+            Ok(self.value.lock().unwrap().clone())
+        }
+        async fn write(&self, version: &str) -> Result<(), AppVersionStateError> {
+            *self.value.lock().unwrap() = Some(version.to_string());
+            Ok(())
+        }
+    }
+
+    struct FakeSetupStatus(bool);
+    #[async_trait]
+    impl SetupStatusPort for FakeSetupStatus {
+        async fn get_status(&self) -> anyhow::Result<SetupStatus> {
+            Ok(SetupStatus {
+                has_completed: self.0,
+                ..SetupStatus::default()
+            })
+        }
+        async fn set_status(&self, _: &SetupStatus) -> anyhow::Result<()> {
+            unreachable!()
+        }
+    }
+
+    #[tokio::test]
+    async fn detect_then_acknowledge_round_trip() {
+        let port = FakeVersionState::new(None);
+        let facade = UpgradeFacade::new(UpgradeFacadeDeps {
+            app_version_state: port.clone(),
+            setup_status: Arc::new(FakeSetupStatus(true)),
+        });
+
+        // First call: missing cursor + completed setup → unknown upgrade.
+        let to = semver::Version::parse("1.0.0").unwrap();
+        assert_eq!(
+            facade.detect_on_startup("1.0.0").await.unwrap(),
+            UpgradeStatus::Upgraded {
+                from: None,
+                to: to.clone()
+            }
+        );
+
+        // Acknowledge → cursor advances.
+        facade.acknowledge("1.0.0").await.unwrap();
+        assert_eq!(port.value.lock().unwrap().as_deref(), Some("1.0.0"));
+
+        // Re-detect → NoChange.
+        assert_eq!(
+            facade.detect_on_startup("1.0.0").await.unwrap(),
+            UpgradeStatus::NoChange
+        );
+    }
+}

--- a/src-tauri/crates/uc-application/src/facade/upgrade/mod.rs
+++ b/src-tauri/crates/uc-application/src/facade/upgrade/mod.rs
@@ -1,0 +1,11 @@
+//! `UpgradeFacade` —— P1 thin 升级检测对外入口。
+//!
+//! 按 `uc-application/AGENTS.md` §11.4，外部 crate（bootstrap / CLI / GUI）
+//! 只能通过本目录下的 [`UpgradeFacade`] 访问升级检测能力；底层
+//! `DetectUpgradeUseCase` / `AcknowledgeUseCase` 保持 `pub(crate)`。
+
+mod facade;
+
+pub use facade::{
+    AcknowledgeUpgradeError, DetectUpgradeError, UpgradeFacade, UpgradeFacadeDeps, UpgradeStatus,
+};

--- a/src-tauri/crates/uc-application/src/usecases/mod.rs
+++ b/src-tauri/crates/uc-application/src/usecases/mod.rs
@@ -20,3 +20,4 @@ pub(crate) mod pairing;
 pub(crate) mod presence;
 pub(crate) mod search;
 pub(crate) mod setup;
+pub(crate) mod upgrade;

--- a/src-tauri/crates/uc-application/src/usecases/upgrade/acknowledge.rs
+++ b/src-tauri/crates/uc-application/src/usecases/upgrade/acknowledge.rs
@@ -1,0 +1,107 @@
+//! [`AcknowledgeUseCase`] —— 把版本游标推进到当前版本。
+//!
+//! 调用方（UI 弹窗确认 / CLI `--acknowledge` / 自动确认）执行后，
+//! 下次启动 `DetectUpgradeUseCase` 将得到 `UpgradeStatus::NoChange`。
+
+use std::sync::Arc;
+
+use thiserror::Error;
+use tracing::info;
+
+use uc_core::ports::{AppVersionStateError, AppVersionStatePort};
+
+#[derive(Debug, Error)]
+pub(crate) enum AcknowledgeError {
+    #[error("current build version is malformed: {0}")]
+    CurrentVersionMalformed(String),
+
+    #[error("write app version cursor failed: {0}")]
+    WriteCursor(#[from] AppVersionStateError),
+}
+
+pub(crate) struct AcknowledgeUseCase {
+    app_version_state: Arc<dyn AppVersionStatePort>,
+}
+
+impl AcknowledgeUseCase {
+    pub(crate) fn new(app_version_state: Arc<dyn AppVersionStatePort>) -> Self {
+        Self { app_version_state }
+    }
+
+    /// 把游标推进到 `current_version_str`。先用 semver 校验合法性，
+    /// 避免把无效字符串写回磁盘污染游标。
+    pub(crate) async fn execute(&self, current_version_str: &str) -> Result<(), AcknowledgeError> {
+        let _validated = semver::Version::parse(current_version_str).map_err(|e| {
+            AcknowledgeError::CurrentVersionMalformed(format!("{current_version_str:?}: {e}"))
+        })?;
+
+        self.app_version_state.write(current_version_str).await?;
+        info!(
+            target: "upgrade",
+            version = %current_version_str,
+            "app version cursor advanced"
+        );
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use std::sync::Mutex;
+
+    struct FakeVersionState {
+        value: Mutex<Option<String>>,
+        write_should_fail: bool,
+    }
+    impl FakeVersionState {
+        fn new() -> Arc<Self> {
+            Arc::new(Self {
+                value: Mutex::new(None),
+                write_should_fail: false,
+            })
+        }
+        fn failing() -> Arc<Self> {
+            Arc::new(Self {
+                value: Mutex::new(None),
+                write_should_fail: true,
+            })
+        }
+    }
+    #[async_trait]
+    impl AppVersionStatePort for FakeVersionState {
+        async fn read(&self) -> Result<Option<String>, AppVersionStateError> {
+            Ok(self.value.lock().unwrap().clone())
+        }
+        async fn write(&self, version: &str) -> Result<(), AppVersionStateError> {
+            if self.write_should_fail {
+                return Err(AppVersionStateError::Write("simulated".into()));
+            }
+            *self.value.lock().unwrap() = Some(version.to_string());
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn acknowledge_writes_cursor_and_round_trips() {
+        let port = FakeVersionState::new();
+        let uc = AcknowledgeUseCase::new(port.clone());
+        uc.execute("1.0.0-alpha.1").await.unwrap();
+        assert_eq!(port.value.lock().unwrap().as_deref(), Some("1.0.0-alpha.1"));
+    }
+
+    #[tokio::test]
+    async fn acknowledge_rejects_invalid_version() {
+        let uc = AcknowledgeUseCase::new(FakeVersionState::new());
+        let err = uc.execute("not-semver").await.unwrap_err();
+        assert!(matches!(err, AcknowledgeError::CurrentVersionMalformed(_)));
+    }
+
+    #[tokio::test]
+    async fn acknowledge_propagates_write_failure() {
+        let uc = AcknowledgeUseCase::new(FakeVersionState::failing());
+        let err = uc.execute("1.0.0").await.unwrap_err();
+        assert!(matches!(err, AcknowledgeError::WriteCursor(_)));
+    }
+}

--- a/src-tauri/crates/uc-application/src/usecases/upgrade/detect.rs
+++ b/src-tauri/crates/uc-application/src/usecases/upgrade/detect.rs
@@ -1,0 +1,284 @@
+//! [`DetectUpgradeUseCase`] —— 启动期版本游标比较。
+//!
+//! 判定矩阵（来自 P1 设计共识）：
+//!
+//! | last_seen_version       | has_completed | 结果                                |
+//! |-------------------------|---------------|-------------------------------------|
+//! | None                    | false         | FreshInstall                        |
+//! | None                    | true          | Upgraded { from: None, to: current }|
+//! | Some(v), v == current   | 任意          | NoChange                            |
+//! | Some(v), v <  current   | 任意          | Upgraded { from: Some(v), to: current } |
+//! | Some(v), v >  current   | 任意          | Downgraded { from: v, to: current } |
+//!
+//! 解析失败兜底：
+//! * 当前版本（构建期常量）解析失败 —— 视作内部错误，返回 [`DetectUpgradeError::CurrentVersionMalformed`]。
+//! * 游标版本解析失败 —— 视作"未知旧版本"，归到 `Upgraded { from: None, to: current }`，
+//!   并打 warn 日志；与"非 fresh 即老用户"策略一致。
+
+use std::sync::Arc;
+
+use thiserror::Error;
+use tracing::{debug, warn};
+
+use uc_core::ports::{AppVersionStateError, AppVersionStatePort, SetupStatusPort};
+
+use super::status::UpgradeStatus;
+
+#[derive(Debug, Error)]
+pub(crate) enum DetectUpgradeError {
+    #[error("current build version is malformed: {0}")]
+    CurrentVersionMalformed(String),
+
+    #[error("read app version cursor failed: {0}")]
+    ReadCursor(#[from] AppVersionStateError),
+
+    /// `SetupStatusPort.get_status` 失败。fallback 推断需要它，
+    /// 读取失败时返回错误而不是默默走 `FreshInstall`，避免误判老用户为新用户。
+    #[error("read setup status failed: {0}")]
+    ReadSetupStatus(String),
+}
+
+pub(crate) struct DetectUpgradeUseCase {
+    app_version_state: Arc<dyn AppVersionStatePort>,
+    setup_status: Arc<dyn SetupStatusPort>,
+}
+
+impl DetectUpgradeUseCase {
+    pub(crate) fn new(
+        app_version_state: Arc<dyn AppVersionStatePort>,
+        setup_status: Arc<dyn SetupStatusPort>,
+    ) -> Self {
+        Self {
+            app_version_state,
+            setup_status,
+        }
+    }
+
+    /// 执行一次性判定。`current_version_str` 由调用方传入
+    /// （通常 = `env!("CARGO_PKG_VERSION")`），保持 use case 不依赖
+    /// 构建期常量、利于测试。
+    pub(crate) async fn execute(
+        &self,
+        current_version_str: &str,
+    ) -> Result<UpgradeStatus, DetectUpgradeError> {
+        let current = semver::Version::parse(current_version_str).map_err(|e| {
+            DetectUpgradeError::CurrentVersionMalformed(format!("{current_version_str:?}: {e}"))
+        })?;
+
+        let stored = self.app_version_state.read().await?;
+
+        match stored {
+            None => {
+                let has_completed = self
+                    .setup_status
+                    .get_status()
+                    .await
+                    .map_err(|e| DetectUpgradeError::ReadSetupStatus(e.to_string()))?
+                    .has_completed;
+
+                if has_completed {
+                    debug!(
+                        target: "upgrade",
+                        current = %current,
+                        "no version cursor; setup completed → treating as upgraded from unknown"
+                    );
+                    Ok(UpgradeStatus::Upgraded {
+                        from: None,
+                        to: current,
+                    })
+                } else {
+                    debug!(
+                        target: "upgrade",
+                        current = %current,
+                        "no version cursor; setup not completed → fresh install"
+                    );
+                    Ok(UpgradeStatus::FreshInstall)
+                }
+            }
+            Some(raw) => match semver::Version::parse(&raw) {
+                Ok(prev) if prev == current => {
+                    debug!(
+                        target: "upgrade",
+                        current = %current,
+                        "cursor matches current version"
+                    );
+                    Ok(UpgradeStatus::NoChange)
+                }
+                Ok(prev) if prev < current => {
+                    debug!(
+                        target: "upgrade",
+                        from = %prev,
+                        to = %current,
+                        "upgrade detected"
+                    );
+                    Ok(UpgradeStatus::Upgraded {
+                        from: Some(prev),
+                        to: current,
+                    })
+                }
+                Ok(prev) => {
+                    // prev > current —— 回滚。
+                    debug!(
+                        target: "upgrade",
+                        from = %prev,
+                        to = %current,
+                        "downgrade detected"
+                    );
+                    Ok(UpgradeStatus::Downgraded {
+                        from: prev,
+                        to: current,
+                    })
+                }
+                Err(e) => {
+                    warn!(
+                        target: "upgrade",
+                        raw = %raw,
+                        error = %e,
+                        "cursor content failed to parse as semver; treating as upgrade from unknown"
+                    );
+                    Ok(UpgradeStatus::Upgraded {
+                        from: None,
+                        to: current,
+                    })
+                }
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use std::sync::Mutex;
+    use uc_core::setup::SetupStatus;
+
+    struct FakeVersionState {
+        value: Mutex<Option<String>>,
+    }
+    impl FakeVersionState {
+        fn new(initial: Option<&str>) -> Arc<Self> {
+            Arc::new(Self {
+                value: Mutex::new(initial.map(|s| s.to_string())),
+            })
+        }
+    }
+    #[async_trait]
+    impl AppVersionStatePort for FakeVersionState {
+        async fn read(&self) -> Result<Option<String>, AppVersionStateError> {
+            Ok(self.value.lock().unwrap().clone())
+        }
+        async fn write(&self, version: &str) -> Result<(), AppVersionStateError> {
+            *self.value.lock().unwrap() = Some(version.to_string());
+            Ok(())
+        }
+    }
+
+    struct FakeSetupStatus {
+        has_completed: bool,
+    }
+    #[async_trait]
+    impl SetupStatusPort for FakeSetupStatus {
+        async fn get_status(&self) -> anyhow::Result<SetupStatus> {
+            Ok(SetupStatus {
+                has_completed: self.has_completed,
+                ..SetupStatus::default()
+            })
+        }
+        async fn set_status(&self, _status: &SetupStatus) -> anyhow::Result<()> {
+            unreachable!("detect-side test does not write setup status")
+        }
+    }
+
+    fn build(cursor: Option<&str>, has_completed: bool) -> DetectUpgradeUseCase {
+        DetectUpgradeUseCase::new(
+            FakeVersionState::new(cursor),
+            Arc::new(FakeSetupStatus { has_completed }),
+        )
+    }
+
+    #[tokio::test]
+    async fn no_cursor_and_not_completed_is_fresh_install() {
+        let uc = build(None, false);
+        assert_eq!(
+            uc.execute("1.0.0").await.unwrap(),
+            UpgradeStatus::FreshInstall
+        );
+    }
+
+    #[tokio::test]
+    async fn no_cursor_but_setup_completed_is_unknown_upgrade() {
+        let uc = build(None, true);
+        let to = semver::Version::parse("1.0.0").unwrap();
+        assert_eq!(
+            uc.execute("1.0.0").await.unwrap(),
+            UpgradeStatus::Upgraded { from: None, to }
+        );
+    }
+
+    #[tokio::test]
+    async fn cursor_equal_is_no_change() {
+        let uc = build(Some("1.0.0"), true);
+        assert_eq!(uc.execute("1.0.0").await.unwrap(), UpgradeStatus::NoChange);
+    }
+
+    #[tokio::test]
+    async fn cursor_lower_is_upgrade() {
+        let uc = build(Some("0.9.3"), true);
+        let from = semver::Version::parse("0.9.3").unwrap();
+        let to = semver::Version::parse("1.0.0").unwrap();
+        assert_eq!(
+            uc.execute("1.0.0").await.unwrap(),
+            UpgradeStatus::Upgraded {
+                from: Some(from),
+                to
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn cursor_higher_is_downgrade() {
+        let uc = build(Some("1.2.0"), true);
+        let from = semver::Version::parse("1.2.0").unwrap();
+        let to = semver::Version::parse("1.0.0").unwrap();
+        assert_eq!(
+            uc.execute("1.0.0").await.unwrap(),
+            UpgradeStatus::Downgraded { from, to }
+        );
+    }
+
+    #[tokio::test]
+    async fn malformed_cursor_falls_back_to_unknown_upgrade() {
+        let uc = build(Some("garbage-not-semver"), true);
+        let to = semver::Version::parse("1.0.0").unwrap();
+        assert_eq!(
+            uc.execute("1.0.0").await.unwrap(),
+            UpgradeStatus::Upgraded { from: None, to }
+        );
+    }
+
+    #[tokio::test]
+    async fn malformed_current_is_internal_error() {
+        let uc = build(None, false);
+        let err = uc.execute("not-a-version").await.unwrap_err();
+        assert!(matches!(
+            err,
+            DetectUpgradeError::CurrentVersionMalformed(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn prerelease_ordering_matches_semver_spec() {
+        // 1.0.0-alpha.1 < 1.0.0 (semver §11)
+        let uc = build(Some("1.0.0-alpha.1"), true);
+        let from = semver::Version::parse("1.0.0-alpha.1").unwrap();
+        let to = semver::Version::parse("1.0.0").unwrap();
+        assert_eq!(
+            uc.execute("1.0.0").await.unwrap(),
+            UpgradeStatus::Upgraded {
+                from: Some(from),
+                to
+            }
+        );
+    }
+}

--- a/src-tauri/crates/uc-application/src/usecases/upgrade/mod.rs
+++ b/src-tauri/crates/uc-application/src/usecases/upgrade/mod.rs
@@ -1,0 +1,24 @@
+//! 应用版本边界检测 + 游标推进的 use case 模块。
+//!
+//! P1 thin 版本只做两件事：
+//!
+//! 1. [`DetectUpgradeUseCase`] —— 启动期一次性比较 `AppVersionStatePort`
+//!    游标 vs 当前构建版本，输出结构化 [`UpgradeStatus`]。
+//!    fallback：游标缺失 + `SetupStatusPort.has_completed == true`
+//!    一律视为"老用户升级"（`Upgraded { from: None, to: current }`），
+//!    与"是否真在 P1 之前的版本上跑过"无关——按"非 fresh 安装即老用户"
+//!    的策略一刀切。
+//!
+//! 2. [`AcknowledgeUseCase`] —— 调用方（UI / CLI）确认用户已知晓后，
+//!    把游标推进到当前版本，下次启动得到 `NoChange`。
+//!
+//! 本模块**不**承担：版本路由表、迁移步骤注册、产品级文案 / UI 决策。
+//! 这些归调用方 (UI / CLI) 自行决定。
+
+pub(crate) mod acknowledge;
+pub(crate) mod detect;
+pub(crate) mod status;
+
+pub(crate) use acknowledge::{AcknowledgeError, AcknowledgeUseCase};
+pub(crate) use detect::{DetectUpgradeError, DetectUpgradeUseCase};
+pub(crate) use status::UpgradeStatus;

--- a/src-tauri/crates/uc-application/src/usecases/upgrade/status.rs
+++ b/src-tauri/crates/uc-application/src/usecases/upgrade/status.rs
@@ -1,0 +1,32 @@
+//! [`UpgradeStatus`] —— 启动期版本游标比较的结构化结果。
+
+/// 启动期一次性的"上次运行版本 vs 当前版本"判定结果。
+///
+/// 设计准则：
+/// * 模块只负责给出"从哪到哪"，不嵌入产品策略。
+/// * `Upgraded.from = None` 表示游标缺失或解析失败（典型为"P1 之前的老用户"），
+///   消费者通常与 `Upgraded.from = Some(_)` 同等对待，需要时再细分。
+/// * 不区分 alpha/beta/stable 等通道；通道是消费者决策的范畴。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UpgradeStatus {
+    /// 全新安装：游标缺失 **且** 没有 setup 痕迹。消费者应跳过任何
+    /// 升级引导。
+    FreshInstall,
+
+    /// 检测到升级。`from = None` 表示游标缺失或损坏（按"非 fresh 即老用户"
+    /// 策略归类到此）；`from = Some(_)` 表示读到了合法旧游标。
+    Upgraded {
+        from: Option<semver::Version>,
+        to: semver::Version,
+    },
+
+    /// 游标版本与当前版本一致，无需任何升级动作。
+    NoChange,
+
+    /// 检测到回滚（游标版本 > 当前版本）。P1 不主动处理，仅记录；
+    /// 消费者可决定是否警告。
+    Downgraded {
+        from: semver::Version,
+        to: semver::Version,
+    },
+}

--- a/src-tauri/crates/uc-bootstrap/src/assembly.rs
+++ b/src-tauri/crates/uc-bootstrap/src/assembly.rs
@@ -66,7 +66,10 @@ use uc_infra::security::{
     Sha256IdentityFingerprintFactory, Sha256ShortCodeGenerator,
 };
 use uc_infra::settings::repository::FileSettingsRepository;
-use uc_infra::{FileMigrationStateRepository, FileSetupStatusRepository, SystemClock};
+use uc_infra::{
+    FileAppVersionStateRepository, FileMigrationStateRepository, FileSetupStatusRepository,
+    SystemClock,
+};
 use uc_platform::app_dirs::DirsAppDirsAdapter;
 use uc_platform::clipboard::{LocalClipboard, NoopSystemClipboard};
 use uc_platform::ports::AppDirsPort;
@@ -211,6 +214,10 @@ struct InfraLayer {
     // Setup status
     setup_status: Arc<dyn SetupStatusPort>,
 
+    // 升级游标（"上次运行版本"）。落点 = app_data_root/upgrade-cursor.json，
+    // 与 vault/keyring/settings.json 同级，profile 隔离由调用方上层保证。
+    app_version_state: Arc<dyn AppVersionStatePort>,
+
     // System services
     clock: Arc<dyn ClockPort>,
     hash: Arc<dyn ContentHashPort>,
@@ -293,6 +300,7 @@ fn create_infra_layer(
     db_pool: DbPool,
     vault_path: &PathBuf,
     settings_path: &PathBuf,
+    app_data_root: &PathBuf,
     secure_storage: Arc<dyn SecureStoragePort>,
 ) -> WiringResult<InfraLayer> {
     let db_executor = Arc::new(DieselSqliteExecutor::new(db_pool));
@@ -368,6 +376,12 @@ fn create_infra_layer(
     let setup_status: Arc<dyn SetupStatusPort> =
         Arc::new(FileSetupStatusRepository::with_defaults(vault_path.clone()));
 
+    // 升级游标——独立小文件，落在 app_data_root 顶层（与 vault/keyring/settings.json
+    // 同级），不污染 vault/。schema_version=1，写入走 tempfile + rename 原子化。
+    let app_version_state: Arc<dyn AppVersionStatePort> = Arc::new(
+        FileAppVersionStateRepository::with_defaults(app_data_root.clone()),
+    );
+
     // Switch-space 4 阶段迁移的状态持久化点；与 setup_status 同目录。
     let migration_state: Arc<dyn uc_core::ports::setup::MigrationStatePort> = Arc::new(
         FileMigrationStateRepository::with_defaults(vault_path.clone()),
@@ -408,6 +422,7 @@ fn create_infra_layer(
         key_material,
         settings_repo,
         setup_status,
+        app_version_state,
         clock,
         hash,
         file_transfer_repo,
@@ -664,14 +679,21 @@ pub fn wire_dependencies(config: &AppConfig) -> WiringResult<WiredDependencies> 
 
     let vault_path = paths.vault_dir;
     let settings_path = paths.settings_path;
+    let app_data_root = paths.app_data_root_dir.clone();
 
     let secure_storage =
         uc_platform::secure_storage::create_default_secure_storage_in_app_data_root(
-            paths.app_data_root_dir.clone(),
+            app_data_root.clone(),
         )
         .map_err(|e| WiringError::SecureStorageInit(e.to_string()))?;
 
-    let infra = create_infra_layer(db_pool, &vault_path, &settings_path, secure_storage.clone())?;
+    let infra = create_infra_layer(
+        db_pool,
+        &vault_path,
+        &settings_path,
+        &app_data_root,
+        secure_storage.clone(),
+    )?;
 
     let storage_config = Arc::new(ClipboardStorageConfig::defaults());
     let platform = create_platform_layer(
@@ -828,6 +850,7 @@ pub fn wire_dependencies(config: &AppConfig) -> WiringResult<WiredDependencies> 
             member_repo: infra.member_repo,
         },
         setup_status: infra.setup_status,
+        app_version_state: infra.app_version_state,
         storage: StoragePorts {
             blob_store: platform.blob_store,
             blob_writer: platform.blob_writer,

--- a/src-tauri/crates/uc-bootstrap/src/non_gui_runtime.rs
+++ b/src-tauri/crates/uc-bootstrap/src/non_gui_runtime.rs
@@ -20,7 +20,7 @@ use uc_application::facade::{
     HostEvent, HostEventEmitterPort, InMemoryLifecycleStatus, LifecycleFacade, LifecycleFacadeDeps,
     LifecycleStatusGateway, MemberRosterFacade, ResourceFacade, ResourceFacadeDeps,
     SearchCoordinator, SearchCoordinatorDeps, SearchFacade, SearchFacadeDeps, SettingsFacade,
-    StorageFacade, StorageFacadeDeps,
+    StorageFacade, StorageFacadeDeps, UpgradeFacade, UpgradeFacadeDeps,
 };
 use uc_core::clipboard::ClipboardIntegrationMode;
 
@@ -189,6 +189,10 @@ pub fn build_app_facade_from_deps(
             logs_dir: storage_paths.logs_dir.clone(),
             app_data_root_dir: storage_paths.app_data_root_dir.clone(),
             cache_fs: deps.system.cache_fs.clone(),
+        })),
+        upgrade: Arc::new(UpgradeFacade::new(UpgradeFacadeDeps {
+            app_version_state: deps.app_version_state.clone(),
+            setup_status: deps.setup_status.clone(),
         })),
     }))
 }

--- a/src-tauri/crates/uc-cli/src/commands/mod.rs
+++ b/src-tauri/crates/uc-cli/src/commands/mod.rs
@@ -13,4 +13,5 @@ pub mod start;
 pub mod status;
 pub mod stop;
 pub mod switch_space;
+pub mod upgrade;
 pub mod watch;

--- a/src-tauri/crates/uc-cli/src/commands/upgrade.rs
+++ b/src-tauri/crates/uc-cli/src/commands/upgrade.rs
@@ -1,0 +1,179 @@
+//! `uniclip upgrade` —— manual verification entry for the P1 thin upgrade
+//! detection module.
+//!
+//! Subcommands:
+//!
+//! * `status` —— calls [`UpgradeFacade::detect_on_startup`] with the CLI's
+//!   own build version and prints the structured outcome (FreshInstall /
+//!   NoChange / Upgraded / Downgraded). Read-only; safe to run alongside
+//!   the daemon.
+//! * `ack` —— calls [`UpgradeFacade::acknowledge`] to advance the cursor
+//!   to the current build version. Subsequent `status` runs report
+//!   `NoChange` until the binary version moves.
+//!
+//! Both subcommands use `build_cli_app_facade` (no iroh / network), so
+//! they work even when no space has been initialised on this profile.
+//!
+//! The version string fed to the facade is `env!("CARGO_PKG_VERSION")` of
+//! `uc-cli` itself, which matches the workspace version inherited by
+//! `uc-desktop` (the daemon's source of truth). Profile selection happens
+//! through the global `--profile` flag in `main.rs`, identical to other
+//! standalone CLI commands.
+
+use clap::Subcommand;
+use serde::Serialize;
+use std::fmt;
+
+use uc_application::facade::{AcknowledgeUpgradeError, DetectUpgradeError, UpgradeStatus};
+
+use crate::exit_codes;
+use crate::output;
+use crate::ui;
+
+/// CLI build version. Compared against the persisted cursor by the
+/// `status` subcommand and written back by `ack`.
+const CLI_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+#[derive(Subcommand)]
+pub enum UpgradeCommands {
+    /// Print the upgrade status detected by comparing the persisted
+    /// version cursor against the current CLI build version.
+    Status,
+    /// Advance the version cursor to the current CLI build, marking
+    /// the upgrade as acknowledged. Idempotent.
+    Ack,
+}
+
+#[derive(Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+enum StatusOutput {
+    FreshInstall { current: String },
+    NoChange { current: String },
+    Upgraded { from: Option<String>, to: String },
+    Downgraded { from: String, to: String },
+}
+
+impl From<UpgradeStatus> for StatusOutput {
+    fn from(value: UpgradeStatus) -> Self {
+        match value {
+            UpgradeStatus::FreshInstall => Self::FreshInstall {
+                current: CLI_VERSION.to_string(),
+            },
+            UpgradeStatus::NoChange => Self::NoChange {
+                current: CLI_VERSION.to_string(),
+            },
+            UpgradeStatus::Upgraded { from, to } => Self::Upgraded {
+                from: from.map(|v| v.to_string()),
+                to: to.to_string(),
+            },
+            UpgradeStatus::Downgraded { from, to } => Self::Downgraded {
+                from: from.to_string(),
+                to: to.to_string(),
+            },
+        }
+    }
+}
+
+impl fmt::Display for StatusOutput {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::FreshInstall { current } => {
+                writeln!(f, "Status: fresh install")?;
+                write!(f, "Current version: {current}")
+            }
+            Self::NoChange { current } => {
+                writeln!(f, "Status: no change")?;
+                write!(f, "Current version: {current}")
+            }
+            Self::Upgraded { from, to } => {
+                writeln!(f, "Status: upgraded")?;
+                writeln!(f, "From: {}", from.as_deref().unwrap_or("<unknown>"))?;
+                write!(f, "To:   {to}")
+            }
+            Self::Downgraded { from, to } => {
+                writeln!(f, "Status: downgraded")?;
+                writeln!(f, "From: {from}")?;
+                write!(f, "To:   {to}")
+            }
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct AckOutput {
+    acknowledged: String,
+}
+
+impl fmt::Display for AckOutput {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Cursor advanced to {}", self.acknowledged)
+    }
+}
+
+pub async fn run(subcommand: UpgradeCommands, json: bool, verbose: bool) -> i32 {
+    let log_profile = if verbose {
+        Some(uc_observability::LogProfile::Dev)
+    } else {
+        Some(uc_observability::LogProfile::Cli)
+    };
+
+    let app_facade = match uc_bootstrap::build_cli_app_facade(log_profile) {
+        Ok(facade) => facade,
+        Err(err) => {
+            ui::error(&format!("failed to build CLI runtime: {err}"));
+            return exit_codes::EXIT_ERROR;
+        }
+    };
+
+    match subcommand {
+        UpgradeCommands::Status => match app_facade.upgrade.detect_on_startup(CLI_VERSION).await {
+            Ok(status) => {
+                let payload: StatusOutput = status.into();
+                if let Err(err) = output::print_result(&payload, json) {
+                    ui::error(&err);
+                    return exit_codes::EXIT_ERROR;
+                }
+                exit_codes::EXIT_SUCCESS
+            }
+            Err(err) => {
+                ui::error(&format_detect_error(&err));
+                exit_codes::EXIT_ERROR
+            }
+        },
+        UpgradeCommands::Ack => match app_facade.upgrade.acknowledge(CLI_VERSION).await {
+            Ok(()) => {
+                let payload = AckOutput {
+                    acknowledged: CLI_VERSION.to_string(),
+                };
+                if let Err(err) = output::print_result(&payload, json) {
+                    ui::error(&err);
+                    return exit_codes::EXIT_ERROR;
+                }
+                exit_codes::EXIT_SUCCESS
+            }
+            Err(err) => {
+                ui::error(&format_ack_error(&err));
+                exit_codes::EXIT_ERROR
+            }
+        },
+    }
+}
+
+fn format_detect_error(err: &DetectUpgradeError) -> String {
+    match err {
+        DetectUpgradeError::CurrentVersionMalformed(s) => {
+            format!("current build version is malformed: {s}")
+        }
+        DetectUpgradeError::ReadCursor(s) => format!("read upgrade cursor failed: {s}"),
+        DetectUpgradeError::ReadSetupStatus(s) => format!("read setup status failed: {s}"),
+    }
+}
+
+fn format_ack_error(err: &AcknowledgeUpgradeError) -> String {
+    match err {
+        AcknowledgeUpgradeError::CurrentVersionMalformed(s) => {
+            format!("current build version is malformed: {s}")
+        }
+        AcknowledgeUpgradeError::WriteCursor(s) => format!("write upgrade cursor failed: {s}"),
+    }
+}

--- a/src-tauri/crates/uc-cli/src/main.rs
+++ b/src-tauri/crates/uc-cli/src/main.rs
@@ -179,6 +179,12 @@ enum Commands {
         #[command(subcommand)]
         subcommand: commands::search::SearchCommands,
     },
+    /// Inspect or advance the upgrade-detection cursor (manual verification
+    /// for the P1 thin upgrade module).
+    Upgrade {
+        #[command(subcommand)]
+        subcommand: commands::upgrade::UpgradeCommands,
+    },
     /// 内联运行 daemon 进程，供 `start` 内部使用
     #[command(hide = true)]
     Daemon {
@@ -314,6 +320,9 @@ fn main() -> anyhow::Result<()> {
             }
             Commands::Search { subcommand } => {
                 commands::search::run(subcommand, cli.json, cli.verbose).await
+            }
+            Commands::Upgrade { subcommand } => {
+                commands::upgrade::run(subcommand, cli.json, cli.verbose).await
             }
             Commands::Daemon { .. } => unreachable!("handled above"),
         }

--- a/src-tauri/crates/uc-core/src/ports/app_version.rs
+++ b/src-tauri/crates/uc-core/src/ports/app_version.rs
@@ -1,0 +1,47 @@
+//! `AppVersionStatePort` —— 持久化"上次运行的应用版本"游标。
+//!
+//! 这是 P1 升级检测模块（`uc-application/src/facade/upgrade/`）的领域端口。
+//! 应用启动时读取该游标，与当前编译版本比较，得出 `UpgradeStatus`；用户/调用方
+//! 确认后写回，把游标推进到当前版本。
+//!
+//! 端口语义保持极薄：
+//! * 版本字符串格式（如 semver）对端口透明，由 use case 负责解析与比较。
+//! * 不存在 = `None`（fresh install 或 P1 之前的老用户），由 use case 配合
+//!   `SetupStatusPort.has_completed` 做 fallback 推断。
+//! * 解析失败由 use case 处理，不在端口层报错。
+//!
+//! 持久化格式与具体落点（独立小文件 / settings 子键 / DB）属于 infra 实现细节。
+
+use async_trait::async_trait;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum AppVersionStateError {
+    /// 读取失败（IO、权限、文件系统）。语义上等价于"无可信来源"，
+    /// 调用方一般可以保守地视作 `None` 继续推进，但仍要打日志。
+    #[error("read app version cursor failed: {0}")]
+    Read(String),
+    /// 写入失败。调用方应记录日志；下次启动时游标维持不变。
+    #[error("write app version cursor failed: {0}")]
+    Write(String),
+    /// 文件存在但内容损坏（非 UTF-8、JSON 不合法等）。
+    /// 与 `Read` 区分开是为了让 use case 可以选择"清理后重写"或仅日志告警。
+    #[error("app version cursor content is corrupt: {0}")]
+    Corrupt(String),
+}
+
+/// 游标读写端口。"上次运行的应用版本"是 profile 范围内的事实，
+/// 实现应落在与 `SetupStatusPort` 同等粒度的 profile 数据目录下。
+#[async_trait]
+pub trait AppVersionStatePort: Send + Sync {
+    /// 读取已记录的版本字符串。
+    ///
+    /// * `Ok(Some(version))` —— 读到游标。
+    /// * `Ok(None)` —— 游标不存在（fresh install 或 P1 之前的老用户）。
+    /// * `Err(_)` —— IO / 损坏，调用方决定如何降级。
+    async fn read(&self) -> Result<Option<String>, AppVersionStateError>;
+
+    /// 把游标写为给定版本字符串。约定调用方传入合法 semver；
+    /// 端口本身不做格式校验，以便未来格式演进不破坏端口契约。
+    async fn write(&self, version: &str) -> Result<(), AppVersionStateError>;
+}

--- a/src-tauri/crates/uc-core/src/ports/mod.rs
+++ b/src-tauri/crates/uc-core/src/ports/mod.rs
@@ -16,6 +16,7 @@
 //! If all three answers are **yes**, place it in `uc-core/ports`.
 //! Otherwise, place it in the relevant `domain` submodule.
 
+pub mod app_version;
 pub mod blob;
 pub mod cache_fs;
 pub mod clipboard;
@@ -38,6 +39,7 @@ pub mod setup;
 pub mod space;
 mod timer;
 
+pub use app_version::{AppVersionStateError, AppVersionStatePort};
 pub use cache_fs::{CacheFsPort, DirEntry as CacheFsDirEntry};
 pub use clipboard_event::*;
 pub use clock::*;

--- a/src-tauri/crates/uc-daemon-contract/src/api/dto/mod.rs
+++ b/src-tauri/crates/uc-daemon-contract/src/api/dto/mod.rs
@@ -7,5 +7,6 @@ pub mod search;
 pub mod settings;
 pub mod setup;
 pub mod setup_events;
+pub mod upgrade;
 pub mod v2;
 pub mod ws;

--- a/src-tauri/crates/uc-daemon-contract/src/api/dto/upgrade.rs
+++ b/src-tauri/crates/uc-daemon-contract/src/api/dto/upgrade.rs
@@ -1,0 +1,50 @@
+//! DTOs for the upgrade detection API endpoints.
+//!
+//! See `uc-application::facade::upgrade` for the underlying use case
+//! semantics. The wire format mirrors `UpgradeStatus` with a discriminator
+//! field `kind` so the frontend can switch on it.
+
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+/// Response wrapper for `GET /upgrade/status`.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct GetUpgradeStatusResponse {
+    pub data: UpgradeStatusDto,
+    pub ts: i64,
+}
+
+/// Discriminated union mirroring `uc_application::facade::UpgradeStatus`.
+///
+/// Wire encoding uses `kind` discriminator with snake_case variants to
+/// keep parity with the CLI JSON output produced by `uniclip upgrade
+/// status --json`.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum UpgradeStatusDto {
+    /// First time the app is launched on this profile.
+    FreshInstall { current: String },
+    /// Cursor matches the running build; no action needed.
+    NoChange { current: String },
+    /// Cursor lags the running build (or is missing on a setup-completed
+    /// profile). `from = None` means the previous version is unknown
+    /// (pre-cursor era / corrupt cursor fallback).
+    Upgraded { from: Option<String>, to: String },
+    /// Cursor leads the running build — the user rolled back.
+    Downgraded { from: String, to: String },
+}
+
+/// Response wrapper for `POST /upgrade/ack`.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct AckUpgradeResponse {
+    pub data: AckUpgradePayload,
+    pub ts: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct AckUpgradePayload {
+    pub acknowledged: String,
+}

--- a/src-tauri/crates/uc-daemon-contract/src/constants.rs
+++ b/src-tauri/crates/uc-daemon-contract/src/constants.rs
@@ -109,6 +109,11 @@ pub mod http_route {
     pub const SEARCH_STATUS: &str = "/search/status";
     /// POST /search/rebuild — trigger manual search index rebuild (Phase 92)
     pub const SEARCH_REBUILD: &str = "/search/rebuild";
+    /// GET /upgrade/status — detect upgrade by comparing version cursor to
+    /// the running build (P1 thin upgrade detection).
+    pub const UPGRADE_STATUS: &str = "/upgrade/status";
+    /// POST /upgrade/ack — advance the version cursor to the running build.
+    pub const UPGRADE_ACK: &str = "/upgrade/ack";
 }
 
 /// HTTP route paths for the v2 daemon REST endpoints (Slice4 P3 T3.2).

--- a/src-tauri/crates/uc-desktop/src/daemon/run_loop.rs
+++ b/src-tauri/crates/uc-desktop/src/daemon/run_loop.rs
@@ -5,13 +5,14 @@ use std::sync::Arc;
 
 use tokio::runtime::Runtime;
 use tokio::sync::Notify;
-use uc_application::facade::AppFacade;
+use uc_application::facade::{AppFacade, UpgradeStatus};
 use uc_bootstrap::SpaceSetupAssembly;
 use uc_core::ports::SettingsPort;
 
 use crate::daemon::app::DaemonApp;
 use crate::daemon::run_mode::DaemonRunMode;
 use crate::daemon::startup_recovery::{spawn_startup_recovery, StartupRecoveryInput};
+use crate::DAEMON_VERSION;
 
 /// daemon 运行循环输入。
 pub struct DaemonRunLoopInput {
@@ -42,6 +43,11 @@ pub fn run_daemon_until_shutdown(
     let space_setup = space_setup_assembly.facade.clone();
 
     runtime.block_on(async move {
+        // P1 thin 升级检测：启动期一次性比较 last_seen_version 游标 vs
+        // 当前构建版本。结果只打 tracing 日志，不连 UI/CLI；后续 phase
+        // 把它接到重新配对引导等具体动作。
+        log_upgrade_status(&app_facade).await;
+
         spawn_startup_recovery(StartupRecoveryInput {
             run_mode,
             app_facade,
@@ -55,4 +61,46 @@ pub fn run_daemon_until_shutdown(
         space_setup_assembly.shutdown().await;
         result
     })
+}
+
+async fn log_upgrade_status(app_facade: &AppFacade) {
+    match app_facade.upgrade.detect_on_startup(DAEMON_VERSION).await {
+        Ok(UpgradeStatus::FreshInstall) => {
+            tracing::info!(
+                target: "upgrade",
+                current = DAEMON_VERSION,
+                "fresh install detected"
+            );
+        }
+        Ok(UpgradeStatus::NoChange) => {
+            tracing::info!(
+                target: "upgrade",
+                current = DAEMON_VERSION,
+                "version cursor matches current build"
+            );
+        }
+        Ok(UpgradeStatus::Upgraded { from, to }) => {
+            tracing::info!(
+                target: "upgrade",
+                from = from.as_ref().map(|v| v.to_string()).as_deref().unwrap_or("<unknown>"),
+                to = %to,
+                "upgrade detected"
+            );
+        }
+        Ok(UpgradeStatus::Downgraded { from, to }) => {
+            tracing::warn!(
+                target: "upgrade",
+                from = %from,
+                to = %to,
+                "downgrade detected — rolled back to an older build"
+            );
+        }
+        Err(error) => {
+            tracing::warn!(
+                target: "upgrade",
+                error = %error,
+                "detect_on_startup failed; skipping upgrade decision this boot"
+            );
+        }
+    }
 }

--- a/src-tauri/crates/uc-infra/src/app_version_state.rs
+++ b/src-tauri/crates/uc-infra/src/app_version_state.rs
@@ -1,0 +1,215 @@
+//! `FileAppVersionStateRepository` —— `AppVersionStatePort` 的文件实现。
+//!
+//! 落地策略：
+//! * 独立小文件 `upgrade-cursor.json`，**不**塞进 `settings.json`。
+//!   设置文件由用户偏好驱动，升级游标由系统驱动，二者生命周期不同；分开避免
+//!   "用户重置设置 → 游标也丢" 这类耦合事故。
+//! * 父目录（`app_data_root`）由调用方传入，profile 隔离归 platform 层负责。
+//! * 单字段格式 `{ "last_seen_version": "x.y.z" }`，留 `version` 元字段
+//!   便于未来格式演进。
+//! * 写入走 `tempfile + rename` 的"先写临时文件再重命名"模式，避免半写入
+//!   留下损坏游标。
+//!
+//! 错误语义：
+//! * 文件不存在 → `Ok(None)`（最常见路径，不打 warn）。
+//! * IO 失败 → `AppVersionStateError::Read` / `::Write`。
+//! * JSON 不合法或 schema 不识别 → `AppVersionStateError::Corrupt`。
+
+use std::path::{Path, PathBuf};
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use tokio::fs;
+use tokio::io::AsyncWriteExt;
+use uc_core::ports::{AppVersionStateError, AppVersionStatePort};
+
+/// 默认游标文件名。落点 = `app_data_root.join(DEFAULT_FILE_NAME)`。
+pub const DEFAULT_FILE_NAME: &str = "upgrade-cursor.json";
+
+/// 文件 schema。`schema_version` 防止未来格式演进时把旧文件误读出空值。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct UpgradeCursorFile {
+    /// 文件 schema 版本号。当前固定为 1。
+    schema_version: u32,
+    /// 上次成功启动的应用版本字符串（典型为 semver）。
+    last_seen_version: String,
+}
+
+const CURRENT_SCHEMA_VERSION: u32 = 1;
+
+pub struct FileAppVersionStateRepository {
+    file_path: PathBuf,
+}
+
+impl FileAppVersionStateRepository {
+    /// 直接指定文件绝对路径（测试 / 自定义部署用）。
+    pub fn new(file_path: PathBuf) -> Self {
+        Self { file_path }
+    }
+
+    /// 标准用法：传入 profile-aware 的 app data root，落点固定为
+    /// `app_data_root/upgrade-cursor.json`。
+    pub fn with_defaults(app_data_root: PathBuf) -> Self {
+        Self {
+            file_path: app_data_root.join(DEFAULT_FILE_NAME),
+        }
+    }
+
+    fn parent_dir(&self) -> Option<&Path> {
+        self.file_path.parent()
+    }
+
+    async fn ensure_parent(&self) -> Result<(), AppVersionStateError> {
+        if let Some(parent) = self.parent_dir() {
+            fs::create_dir_all(parent)
+                .await
+                .map_err(|e| AppVersionStateError::Write(format!("mkdir {parent:?}: {e}")))?;
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl AppVersionStatePort for FileAppVersionStateRepository {
+    async fn read(&self) -> Result<Option<String>, AppVersionStateError> {
+        let raw = match fs::read_to_string(&self.file_path).await {
+            Ok(content) => content,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(e) => {
+                return Err(AppVersionStateError::Read(format!(
+                    "read {:?}: {e}",
+                    self.file_path
+                )))
+            }
+        };
+
+        if raw.trim().is_empty() {
+            return Err(AppVersionStateError::Corrupt(format!(
+                "{:?} is empty",
+                self.file_path
+            )));
+        }
+
+        let parsed: UpgradeCursorFile = serde_json::from_str(&raw).map_err(|e| {
+            AppVersionStateError::Corrupt(format!("parse {:?}: {e}", self.file_path))
+        })?;
+
+        if parsed.schema_version != CURRENT_SCHEMA_VERSION {
+            // 未来扩 schema 时这里会变成 migrate 分支；当前只接受 v1。
+            return Err(AppVersionStateError::Corrupt(format!(
+                "{:?} has unsupported schema_version {}",
+                self.file_path, parsed.schema_version
+            )));
+        }
+
+        Ok(Some(parsed.last_seen_version))
+    }
+
+    async fn write(&self, version: &str) -> Result<(), AppVersionStateError> {
+        self.ensure_parent().await?;
+
+        let payload = UpgradeCursorFile {
+            schema_version: CURRENT_SCHEMA_VERSION,
+            last_seen_version: version.to_string(),
+        };
+        let body = serde_json::to_vec_pretty(&payload)
+            .map_err(|e| AppVersionStateError::Write(format!("serialize cursor: {e}")))?;
+
+        // 写临时文件 + 原子 rename，避免崩溃后留下损坏的游标。
+        let tmp_path = self.file_path.with_extension("json.tmp");
+
+        // 显式把句柄关闭后再 rename：tokio::fs::File 不暴露同步 close，
+        // 这里用 drop 触发后的 rename 是事实上的标准模式。
+        {
+            let mut file = fs::File::create(&tmp_path)
+                .await
+                .map_err(|e| AppVersionStateError::Write(format!("create {tmp_path:?}: {e}")))?;
+            file.write_all(&body)
+                .await
+                .map_err(|e| AppVersionStateError::Write(format!("write {tmp_path:?}: {e}")))?;
+            file.sync_all()
+                .await
+                .map_err(|e| AppVersionStateError::Write(format!("fsync {tmp_path:?}: {e}")))?;
+        }
+
+        fs::rename(&tmp_path, &self.file_path).await.map_err(|e| {
+            AppVersionStateError::Write(format!("rename {tmp_path:?} -> {:?}: {e}", self.file_path))
+        })?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn repo() -> (TempDir, FileAppVersionStateRepository) {
+        let tmp = TempDir::new().unwrap();
+        let repo = FileAppVersionStateRepository::with_defaults(tmp.path().to_path_buf());
+        (tmp, repo)
+    }
+
+    #[tokio::test]
+    async fn read_returns_none_when_file_missing() {
+        let (_tmp, repo) = repo();
+        assert_eq!(repo.read().await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn write_then_read_round_trips() {
+        let (_tmp, repo) = repo();
+        repo.write("1.0.0-alpha.1").await.unwrap();
+        assert_eq!(repo.read().await.unwrap().as_deref(), Some("1.0.0-alpha.1"));
+    }
+
+    #[tokio::test]
+    async fn write_overwrites_existing_value() {
+        let (_tmp, repo) = repo();
+        repo.write("0.9.0").await.unwrap();
+        repo.write("1.0.0").await.unwrap();
+        assert_eq!(repo.read().await.unwrap().as_deref(), Some("1.0.0"));
+    }
+
+    #[tokio::test]
+    async fn corrupt_json_returns_corrupt_error() {
+        let (tmp, repo) = repo();
+        let path = tmp.path().join(DEFAULT_FILE_NAME);
+        fs::write(&path, b"{not valid json").await.unwrap();
+        let err = repo.read().await.unwrap_err();
+        assert!(matches!(err, AppVersionStateError::Corrupt(_)));
+    }
+
+    #[tokio::test]
+    async fn empty_file_returns_corrupt_error() {
+        let (tmp, repo) = repo();
+        let path = tmp.path().join(DEFAULT_FILE_NAME);
+        fs::write(&path, b"").await.unwrap();
+        let err = repo.read().await.unwrap_err();
+        assert!(matches!(err, AppVersionStateError::Corrupt(_)));
+    }
+
+    #[tokio::test]
+    async fn unsupported_schema_version_returns_corrupt_error() {
+        let (tmp, repo) = repo();
+        let path = tmp.path().join(DEFAULT_FILE_NAME);
+        fs::write(
+            &path,
+            br#"{"schema_version":999,"last_seen_version":"1.0.0"}"#,
+        )
+        .await
+        .unwrap();
+        let err = repo.read().await.unwrap_err();
+        assert!(matches!(err, AppVersionStateError::Corrupt(_)));
+    }
+
+    #[tokio::test]
+    async fn write_creates_parent_dir() {
+        let tmp = TempDir::new().unwrap();
+        let nested = tmp.path().join("does/not/exist/yet");
+        let repo = FileAppVersionStateRepository::with_defaults(nested);
+        repo.write("1.0.0").await.unwrap();
+        assert_eq!(repo.read().await.unwrap().as_deref(), Some("1.0.0"));
+    }
+}

--- a/src-tauri/crates/uc-infra/src/lib.rs
+++ b/src-tauri/crates/uc-infra/src/lib.rs
@@ -1,6 +1,7 @@
 // Tracing support for infra layer instrumentation
 pub use tracing;
 
+pub mod app_version_state;
 pub mod blob;
 pub mod clipboard;
 pub mod config;
@@ -18,6 +19,7 @@ pub mod settings;
 pub mod setup_status;
 pub mod time;
 
+pub use app_version_state::FileAppVersionStateRepository;
 pub use migration_state::FileMigrationStateRepository;
 pub use setup_status::FileSetupStatusRepository;
 pub use time::{SystemClock, Timer};

--- a/src-tauri/crates/uc-webserver/src/api/mod.rs
+++ b/src-tauri/crates/uc-webserver/src/api/mod.rs
@@ -18,6 +18,7 @@ pub mod settings;
 pub mod setup_events;
 pub mod storage;
 pub mod types;
+pub mod upgrade;
 pub mod v2;
 pub mod ws;
 

--- a/src-tauri/crates/uc-webserver/src/api/openapi.rs
+++ b/src-tauri/crates/uc-webserver/src/api/openapi.rs
@@ -31,6 +31,9 @@ use crate::api::dto::settings::{
     SecuritySettingsDto, SettingsDto, ShortcutKeyDto, SyncFrequencyDto, SyncSettingsDto, ThemeDto,
     UpdateChannelDto, UpdateSettingsResponse,
 };
+use uc_daemon_contract::api::dto::upgrade::{
+    AckUpgradePayload, AckUpgradeResponse, GetUpgradeStatusResponse, UpgradeStatusDto,
+};
 use uc_daemon_contract::api::dto::v2::setup::{
     CurrentInvitation as V2CurrentInvitation, InitializeSpaceRequest as V2InitializeSpaceRequest,
     InitializeSpaceResponse as V2InitializeSpaceResponse,
@@ -97,6 +100,8 @@ impl Modify for SecurityAddon {
         crate::api::v2::setup::reset,
         crate::api::v2::setup::get_state,
         crate::api::pairing::handle_unpair_device,
+        crate::api::upgrade::get_upgrade_status_handler,
+        crate::api::upgrade::ack_upgrade_handler,
     ),
     components(
         schemas(
@@ -157,6 +162,11 @@ impl Modify for SecurityAddon {
             V2RedeemResponse,
             V2SetupStateResponse,
             V2CurrentInvitation,
+            // Upgrade detection (P1 thin module)
+            GetUpgradeStatusResponse,
+            UpgradeStatusDto,
+            AckUpgradeResponse,
+            AckUpgradePayload,
         )
     ),
     tags(
@@ -168,6 +178,7 @@ impl Modify for SecurityAddon {
         (name = "setup-v2", description = "Stateless v2 setup pairing endpoints (Slice4 P3 T3.2)"),
         (name = "pairing", description = "Pairing lifecycle management"),
         (name = "search", description = "Local encrypted search endpoints"),
+        (name = "upgrade", description = "Application upgrade detection (P1 thin module)"),
     )
 )]
 pub struct ApiDoc;

--- a/src-tauri/crates/uc-webserver/src/api/routes.rs
+++ b/src-tauri/crates/uc-webserver/src/api/routes.rs
@@ -83,6 +83,7 @@ pub fn router_l2_plus(state: DaemonApiState) -> Router<DaemonApiState> {
         .merge(crate::api::storage::router())
         .merge(crate::api::pairing::router())
         .merge(crate::api::blob::router())
+        .merge(crate::api::upgrade::router())
         .route("/status", get(status))
         .route("/peers", get(peers))
         .route("/paired-devices", get(paired_devices))

--- a/src-tauri/crates/uc-webserver/src/api/upgrade.rs
+++ b/src-tauri/crates/uc-webserver/src/api/upgrade.rs
@@ -1,0 +1,115 @@
+//! HTTP route handlers for the upgrade detection endpoints.
+//!
+//! Wires the `UpgradeFacade` (P1 thin upgrade detection module) into the
+//! daemon REST API so the desktop frontend can decide whether to surface
+//! the "re-pair after upgrade" notice on launch and acknowledge it.
+//!
+//! Endpoints:
+//! - `GET /upgrade/status` — call `detect_on_startup` and return the
+//!   discriminated status (FreshInstall / NoChange / Upgraded / Downgraded).
+//! - `POST /upgrade/ack` — advance the version cursor to the running build.
+//!
+//! The version string fed to the facade is `env!("CARGO_PKG_VERSION")` of
+//! `uc-webserver`, which is workspace-versioned alongside `uc-desktop`
+//! (the daemon binary). Both crates resolve to the same value.
+
+use axum::extract::State;
+use axum::routing::{get, post};
+use axum::{Json, Router};
+use uc_application::facade::{AcknowledgeUpgradeError, DetectUpgradeError, UpgradeStatus};
+use uc_daemon_contract::api::dto::upgrade::{
+    AckUpgradePayload, AckUpgradeResponse, GetUpgradeStatusResponse, UpgradeStatusDto,
+};
+
+use crate::api::dto::error::ApiError;
+use crate::api::server::DaemonApiState;
+
+/// Build version reported to the upgrade facade. Workspace-versioned and
+/// matches the `uc-desktop` daemon's own `DAEMON_VERSION`.
+const SERVER_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+pub fn router() -> Router<DaemonApiState> {
+    Router::new()
+        .route("/upgrade/status", get(get_upgrade_status_handler))
+        .route("/upgrade/ack", post(ack_upgrade_handler))
+}
+
+#[utoipa::path(
+    get,
+    path = "/upgrade/status",
+    tag = "upgrade",
+    responses(
+        (status = 200, body = GetUpgradeStatusResponse),
+        (status = 500, description = "Internal server error", body = crate::api::dto::error::ApiErrorResponse)
+    )
+)]
+async fn get_upgrade_status_handler(
+    State(state): State<DaemonApiState>,
+) -> Result<Json<GetUpgradeStatusResponse>, ApiError> {
+    let app = state.app_facade_or_error()?;
+    let status = app
+        .upgrade
+        .detect_on_startup(SERVER_VERSION)
+        .await
+        .map_err(detect_error_to_api)?;
+
+    Ok(Json(GetUpgradeStatusResponse {
+        data: status_to_dto(status),
+        ts: chrono::Utc::now().timestamp_millis(),
+    }))
+}
+
+#[utoipa::path(
+    post,
+    path = "/upgrade/ack",
+    tag = "upgrade",
+    responses(
+        (status = 200, body = AckUpgradeResponse),
+        (status = 500, description = "Internal server error", body = crate::api::dto::error::ApiErrorResponse)
+    )
+)]
+async fn ack_upgrade_handler(
+    State(state): State<DaemonApiState>,
+) -> Result<Json<AckUpgradeResponse>, ApiError> {
+    let app = state.app_facade_or_error()?;
+    app.upgrade
+        .acknowledge(SERVER_VERSION)
+        .await
+        .map_err(ack_error_to_api)?;
+
+    Ok(Json(AckUpgradeResponse {
+        data: AckUpgradePayload {
+            acknowledged: SERVER_VERSION.to_string(),
+        },
+        ts: chrono::Utc::now().timestamp_millis(),
+    }))
+}
+
+fn status_to_dto(status: UpgradeStatus) -> UpgradeStatusDto {
+    match status {
+        UpgradeStatus::FreshInstall => UpgradeStatusDto::FreshInstall {
+            current: SERVER_VERSION.to_string(),
+        },
+        UpgradeStatus::NoChange => UpgradeStatusDto::NoChange {
+            current: SERVER_VERSION.to_string(),
+        },
+        UpgradeStatus::Upgraded { from, to } => UpgradeStatusDto::Upgraded {
+            from: from.map(|v| v.to_string()),
+            to: to.to_string(),
+        },
+        UpgradeStatus::Downgraded { from, to } => UpgradeStatusDto::Downgraded {
+            from: from.to_string(),
+            to: to.to_string(),
+        },
+    }
+}
+
+fn detect_error_to_api(err: DetectUpgradeError) -> ApiError {
+    tracing::error!(error = %err, "upgrade detect failed");
+    ApiError::internal(err.to_string())
+}
+
+fn ack_error_to_api(err: AcknowledgeUpgradeError) -> ApiError {
+    tracing::error!(error = %err, "upgrade acknowledge failed");
+    ApiError::internal(err.to_string())
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,7 @@ import { signalLifecycleReady } from '@/api/daemon/lifecycle'
 import { unlockEncryptionSession } from '@/api/security'
 import { TitleBar } from '@/components'
 import { GlobalShortcuts } from '@/components/GlobalShortcuts'
-import TelemetryNotice from '@/components/TelemetryNotice'
+import StartupModals from '@/components/StartupModals'
 import { Toaster } from '@/components/ui/sonner'
 import { useSearch } from '@/contexts/search-context'
 import { SearchProvider } from '@/contexts/SearchContext'
@@ -248,7 +248,7 @@ const AppContent = ({
         <Route path="*" element={<Navigate to="/" replace />} />
       </SentryRoutes>
       <Toaster />
-      <TelemetryNotice />
+      <StartupModals />
     </ShortcutProvider>
   )
 }

--- a/src/api/daemon/index.ts
+++ b/src/api/daemon/index.ts
@@ -87,3 +87,5 @@ export type {
   SearchStatusData,
   SearchStatusResponse,
 } from './search'
+export { getUpgradeStatus, acknowledgeUpgrade } from './upgrade'
+export type { UpgradeStatus } from './upgrade'

--- a/src/api/daemon/upgrade.ts
+++ b/src/api/daemon/upgrade.ts
@@ -1,0 +1,77 @@
+/**
+ * Upgrade detection API module — typed accessors for daemon upgrade endpoints.
+ *
+ * 升级检测 API 模块 — daemon 升级检测端点的类型化访问器。
+ *
+ * # Endpoints / 端点
+ * - `GET /upgrade/status` → discriminated upgrade status
+ * - `POST /upgrade/ack` → advance the version cursor to the running build
+ *
+ * # Semantics / 语义
+ * The status discriminator `kind` mirrors `uc_application::facade::UpgradeStatus`:
+ * - `fresh_install`: profile has never been set up
+ * - `no_change`: cursor matches the running build
+ * - `upgraded`: build is newer than cursor (or cursor missing on a setup-completed
+ *   profile, in which case `from = null`)
+ * - `downgraded`: build is older than cursor — the user rolled back
+ */
+
+import { daemonClient } from './client'
+
+// ── Wire types ─────────────────────────────────────────────────
+
+export type UpgradeStatus =
+  | { kind: 'fresh_install'; current: string }
+  | { kind: 'no_change'; current: string }
+  | { kind: 'upgraded'; from: string | null; to: string }
+  | { kind: 'downgraded'; from: string; to: string }
+
+interface UpgradeStatusEnvelope {
+  data: UpgradeStatus
+  ts: number
+}
+
+interface AckUpgradePayload {
+  acknowledged: string
+}
+
+interface AckUpgradeEnvelope {
+  data: AckUpgradePayload
+  ts: number
+}
+
+// ── Public API ─────────────────────────────────────────────────
+
+/**
+ * Fetch the current upgrade detection status from the daemon.
+ *
+ * 从 daemon 获取当前升级检测状态。
+ *
+ * Call once on app startup. Use the returned discriminated value to decide
+ * whether to surface the re-pair notice.
+ *
+ * @throws {DaemonApiError} On HTTP or session errors.
+ */
+export async function getUpgradeStatus(): Promise<UpgradeStatus> {
+  const res = await daemonClient.request<UpgradeStatusEnvelope>('/upgrade/status')
+  return res.data
+}
+
+/**
+ * Acknowledge the current upgrade — advance the version cursor to the running build.
+ *
+ * 确认升级 —— 把版本游标推进到当前运行的版本。
+ *
+ * Idempotent. After a successful call, subsequent `getUpgradeStatus()` calls
+ * return `{ kind: 'no_change' }` until the binary version moves.
+ *
+ * @returns The version string that was written (the daemon's own
+ *   `CARGO_PKG_VERSION`, not a value the caller controls).
+ * @throws {DaemonApiError} On HTTP or session errors.
+ */
+export async function acknowledgeUpgrade(): Promise<string> {
+  const res = await daemonClient.request<AckUpgradeEnvelope>('/upgrade/ack', {
+    method: 'POST',
+  })
+  return res.data.acknowledged
+}

--- a/src/components/StartupModals.tsx
+++ b/src/components/StartupModals.tsx
@@ -1,0 +1,72 @@
+import { useEffect, useState } from 'react'
+import TelemetryNotice from './TelemetryNotice'
+import UpgradeNotice from './UpgradeNotice'
+import { getUpgradeStatus, type UpgradeStatus } from '@/api/daemon'
+import { connectDaemonWs } from '@/lib/daemon-ws-bootstrap'
+import { createLogger } from '@/lib/logger'
+
+const log = createLogger('startup-modals')
+
+/**
+ * Phases of the launch-time modal queue. Only one modal is rendered at a
+ * time; phases advance when the active modal calls its `onDismiss`.
+ *
+ * Priority is fixed: upgrade first (action-required for old users to keep
+ * sync working), telemetry second (privacy consent for fresh installs).
+ * In practice these two are mutually exclusive — `Upgraded { from: null }`
+ * implies the user already had the app installed and almost certainly
+ * already dismissed the telemetry notice. The explicit ordering only
+ * matters in the edge case where browser localStorage was wiped.
+ */
+type Phase = 'loading' | 'upgrade' | 'telemetry' | 'done'
+
+/**
+ * Single coordinator for startup-time modals. Mount once near the top of the
+ * app shell; replace any standalone `<TelemetryNotice />` mounts.
+ */
+export default function StartupModals() {
+  const [phase, setPhase] = useState<Phase>('loading')
+  const [upgradeStatus, setUpgradeStatus] = useState<UpgradeStatus | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    void (async () => {
+      try {
+        await connectDaemonWs()
+        const status = await getUpgradeStatus()
+        if (cancelled) return
+        setUpgradeStatus(status)
+        if (status.kind === 'upgraded' && status.from === null) {
+          setPhase('upgrade')
+        } else {
+          setPhase('telemetry')
+        }
+      } catch (err) {
+        // Daemon unreachable or endpoint absent — fall through to telemetry
+        // so a fresh-install consent prompt still works without the daemon.
+        log.warn({ err }, 'failed to fetch upgrade status; skipping upgrade modal')
+        if (!cancelled) setPhase('telemetry')
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const handleUpgradeDismissed = () => {
+    setPhase('telemetry')
+  }
+
+  const handleTelemetryDismissed = () => {
+    setPhase('done')
+  }
+
+  return (
+    <>
+      {phase === 'upgrade' && (
+        <UpgradeNotice status={upgradeStatus} onDismiss={handleUpgradeDismissed} />
+      )}
+      <TelemetryNotice enabled={phase === 'telemetry'} onDismiss={handleTelemetryDismissed} />
+    </>
+  )
+}

--- a/src/components/TelemetryNotice.tsx
+++ b/src/components/TelemetryNotice.tsx
@@ -17,31 +17,41 @@ const log = createLogger('telemetry-notice')
 
 const TELEMETRY_NOTICE_KEY = 'uc-telemetry-notice-seen'
 
-export default function TelemetryNotice() {
+interface TelemetryNoticeProps {
+  /** Coordinator-controlled gate. When false, the dialog stays hidden even if
+   *  localStorage has no record — this lets a higher-priority startup modal
+   *  display first. */
+  enabled?: boolean
+  /** Invoked once the user has chosen accept or opt-out. Used by
+   *  `StartupModals` to advance the queue. */
+  onDismiss?: () => void
+}
+
+export default function TelemetryNotice({ enabled = true, onDismiss }: TelemetryNoticeProps = {}) {
   const { t } = useTranslation()
   const { updateGeneralSetting } = useSetting()
   const [open, setOpen] = useState(false)
 
   useEffect(() => {
-    if (!localStorage.getItem(TELEMETRY_NOTICE_KEY)) {
+    if (enabled && !localStorage.getItem(TELEMETRY_NOTICE_KEY)) {
       setOpen(true)
     }
-  }, [])
+  }, [enabled])
 
-  const markSeen = () => {
+  const finish = () => {
     localStorage.setItem(TELEMETRY_NOTICE_KEY, '1')
+    setOpen(false)
+    onDismiss?.()
   }
 
   const handleAccept = () => {
-    markSeen()
-    setOpen(false)
+    finish()
   }
 
   const handleOptOut = async () => {
     try {
       await updateGeneralSetting({ telemetryEnabled: false })
-      markSeen()
-      setOpen(false)
+      finish()
     } catch (error) {
       log.error({ err: error }, 'Failed to disable telemetry')
       // Don't close — let the user retry or accept instead.

--- a/src/components/UpgradeNotice.tsx
+++ b/src/components/UpgradeNotice.tsx
@@ -1,0 +1,85 @@
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { acknowledgeUpgrade, type UpgradeStatus } from '@/api/daemon'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui'
+import { createLogger } from '@/lib/logger'
+
+const log = createLogger('upgrade-notice')
+
+interface UpgradeNoticeProps {
+  /** Status fetched from the daemon. The dialog shows only when
+   *  `kind === 'upgraded' && from === null` (old user crossing the pre-cursor
+   *  boundary). Other variants render nothing. */
+  status: UpgradeStatus | null
+  /** Invoked after the user dismisses. `acknowledged = true` when the cursor
+   *  was advanced (Got it), `false` when the user chose Later. */
+  onDismiss: (acknowledged: boolean) => void
+}
+
+/**
+ * Re-pair guidance dialog shown after an upgrade across the breaking pairing
+ * change. Only the "old user from pre-cursor era" variant qualifies in P1;
+ * other upgrade kinds (`upgraded` with a known `from`, `downgraded`,
+ * `no_change`, `fresh_install`) render nothing here.
+ */
+export default function UpgradeNotice({ status, onDismiss }: UpgradeNoticeProps) {
+  const { t } = useTranslation()
+  const [busy, setBusy] = useState(false)
+
+  const shouldShow = status?.kind === 'upgraded' && status.from === null
+  if (!shouldShow) return null
+
+  const handleGotIt = async () => {
+    setBusy(true)
+    try {
+      await acknowledgeUpgrade()
+      onDismiss(true)
+    } catch (error) {
+      log.error({ err: error }, 'Failed to acknowledge upgrade')
+      // Treat as dismissed-but-unack: user will see the modal again next launch.
+      onDismiss(false)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const handleLater = () => {
+    onDismiss(false)
+  }
+
+  const toLine = status.kind === 'upgraded' ? t('upgradeNotice.toVersion', { to: status.to }) : null
+
+  return (
+    <AlertDialog open={true}>
+      <AlertDialogContent className="bg-card text-card-foreground">
+        <AlertDialogHeader>
+          <AlertDialogTitle>{t('upgradeNotice.title')}</AlertDialogTitle>
+          <AlertDialogDescription className="space-y-2">
+            <span className="block">{t('upgradeNotice.body')}</span>
+            <span className="text-muted-foreground block text-xs">
+              {t('upgradeNotice.fromUnknown')}
+              {toLine ? ` · ${toLine}` : null}
+            </span>
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={busy} onClick={handleLater}>
+            {t('upgradeNotice.later')}
+          </AlertDialogCancel>
+          <AlertDialogAction disabled={busy} onClick={handleGotIt}>
+            {t('upgradeNotice.gotIt')}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/src/components/__tests__/StartupModals.test.tsx
+++ b/src/components/__tests__/StartupModals.test.tsx
@@ -1,0 +1,143 @@
+/**
+ * StartupModals coordinator — priority and queueing tests.
+ *
+ * The contract under test:
+ * 1. When the daemon reports `Upgraded { from: null }`, the upgrade notice
+ *    shows first; only after dismissal does the telemetry notice render.
+ * 2. When the daemon reports any other status, telemetry runs immediately
+ *    (no upgrade notice).
+ * 3. When the daemon HTTP fetch fails, the coordinator falls back to
+ *    telemetry (don't block the entire app on a daemon hiccup).
+ */
+
+import { render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import StartupModals from '../StartupModals'
+import { getUpgradeStatus, type UpgradeStatus } from '@/api/daemon'
+import { connectDaemonWs } from '@/lib/daemon-ws-bootstrap'
+
+vi.mock('@/api/daemon', async () => {
+  const actual = await vi.importActual<typeof import('@/api/daemon')>('@/api/daemon')
+  return {
+    ...actual,
+    getUpgradeStatus: vi.fn(),
+    acknowledgeUpgrade: vi.fn(),
+  }
+})
+
+vi.mock('@/lib/daemon-ws-bootstrap', () => ({
+  connectDaemonWs: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('@/hooks/useSetting', () => ({
+  useSetting: () => ({
+    updateGeneralSetting: vi.fn().mockResolvedValue(undefined),
+  }),
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, vars?: Record<string, string>) =>
+      vars ? `${key}:${JSON.stringify(vars)}` : key,
+  }),
+}))
+
+const mockedGetUpgradeStatus = vi.mocked(getUpgradeStatus)
+const mockedConnectDaemonWs = vi.mocked(connectDaemonWs)
+
+describe('StartupModals priority ordering', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    mockedGetUpgradeStatus.mockReset()
+    mockedConnectDaemonWs.mockReset()
+    mockedConnectDaemonWs.mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+  })
+
+  it('shows the upgrade notice first when status is upgraded-from-null, even if telemetry is also pending', async () => {
+    mockedGetUpgradeStatus.mockResolvedValue({
+      kind: 'upgraded',
+      from: null,
+      to: '1.0.0-alpha.1',
+    } satisfies UpgradeStatus)
+
+    render(<StartupModals />)
+
+    // Upgrade title should appear; telemetry title must not be in the DOM yet.
+    await waitFor(() => {
+      expect(screen.getByText('upgradeNotice.title')).toBeInTheDocument()
+    })
+    expect(
+      screen.queryByText('settings.sections.general.telemetry.notice.title')
+    ).not.toBeInTheDocument()
+  })
+
+  it('skips the upgrade notice when status is not upgraded-from-null', async () => {
+    mockedGetUpgradeStatus.mockResolvedValue({
+      kind: 'no_change',
+      current: '1.0.0-alpha.1',
+    } satisfies UpgradeStatus)
+
+    render(<StartupModals />)
+
+    // Telemetry should appear because localStorage has no record.
+    await waitFor(() => {
+      expect(
+        screen.getByText('settings.sections.general.telemetry.notice.title')
+      ).toBeInTheDocument()
+    })
+    expect(screen.queryByText('upgradeNotice.title')).not.toBeInTheDocument()
+  })
+
+  it('skips the upgrade notice when from is a known version (the user already saw a previous version)', async () => {
+    mockedGetUpgradeStatus.mockResolvedValue({
+      kind: 'upgraded',
+      from: '1.0.0-alpha.1',
+      to: '1.0.1',
+    } satisfies UpgradeStatus)
+
+    render(<StartupModals />)
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('settings.sections.general.telemetry.notice.title')
+      ).toBeInTheDocument()
+    })
+    expect(screen.queryByText('upgradeNotice.title')).not.toBeInTheDocument()
+  })
+
+  it('falls back to telemetry when the daemon fetch fails', async () => {
+    mockedGetUpgradeStatus.mockRejectedValue(new Error('daemon offline'))
+
+    render(<StartupModals />)
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('settings.sections.general.telemetry.notice.title')
+      ).toBeInTheDocument()
+    })
+    expect(screen.queryByText('upgradeNotice.title')).not.toBeInTheDocument()
+  })
+
+  it('does not show telemetry when localStorage already has the dismissed flag', async () => {
+    localStorage.setItem('uc-telemetry-notice-seen', '1')
+    mockedGetUpgradeStatus.mockResolvedValue({
+      kind: 'no_change',
+      current: '1.0.0-alpha.1',
+    } satisfies UpgradeStatus)
+
+    render(<StartupModals />)
+
+    // Wait a tick so the effect runs.
+    await waitFor(() => {
+      expect(mockedGetUpgradeStatus).toHaveBeenCalled()
+    })
+    expect(
+      screen.queryByText('settings.sections.general.telemetry.notice.title')
+    ).not.toBeInTheDocument()
+    expect(screen.queryByText('upgradeNotice.title')).not.toBeInTheDocument()
+  })
+})

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -31,6 +31,15 @@
     "downloading": "Downloading...",
     "installing": "Installing..."
   },
+  "upgradeNotice": {
+    "title": "Re-pair your devices",
+    "body": "This version updates the device pairing scheme. Your previous pairings can no longer sync. Please open Devices to invite or re-join the other device.",
+    "fromVersion": "Previous version: {{from}}",
+    "toVersion": "Current version: {{to}}",
+    "fromUnknown": "Previous version: unknown",
+    "gotIt": "Got it, don't remind me again",
+    "later": "Later"
+  },
   "settings": {
     "title": "Settings",
     "categories": {

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -31,6 +31,15 @@
     "downloading": "正在下载...",
     "installing": "正在安装..."
   },
+  "upgradeNotice": {
+    "title": "请重新配对设备",
+    "body": "本版本更新了设备配对机制，原有配对已不可用。请前往「设备」页向另一台设备发送邀请或重新加入。",
+    "fromVersion": "上一版本：{{from}}",
+    "toVersion": "当前版本：{{to}}",
+    "fromUnknown": "上一版本：未知",
+    "gotIt": "我知道了，不再提醒",
+    "later": "稍后再说"
+  },
   "settings": {
     "title": "设置",
     "categories": {


### PR DESCRIPTION
## Summary

P1 thin 升级检测模块——启动期识别"老用户从旧版本升级上来"，为后续重新配对引导等动作提供结构化判定基础。**当前只检测 + 打日志，不连 UI/CLI**。

## Scope

| 层 | 改动 |
|---|---|
| `uc-core` | 新增 `AppVersionStatePort`（持久化 last_seen_version 游标） |
| `uc-infra` | 新增 `FileAppVersionStateRepository` —— `app_data_root/upgrade-cursor.json`，schema_version=1，tempfile + atomic rename |
| `uc-application` | 新增 `UpgradeFacade` + `DetectUpgradeUseCase` + `AcknowledgeUseCase`，引入 `semver` 依赖 |
| `uc-bootstrap` | `AppDeps.app_version_state` 端口接入 + `AppFacade.upgrade` facade 装配 |
| `uc-desktop` | daemon `run_loop.rs` 启动期一次性调用 `detect_on_startup` 并按状态打 tracing 日志 |

## 判定矩阵

| `last_seen_version` | `has_completed` | 结果 |
|---|---|---|
| `None` | `false` | `FreshInstall` |
| `None` | `true` | `Upgraded { from: None, to: current }` ← **P1 老用户 fallback** |
| `Some(v)`，`v == current` | 任意 | `NoChange` |
| `Some(v)`，`v < current` | 任意 | `Upgraded { from: Some(v), to: current }` |
| `Some(v)`，`v > current` | 任意 | `Downgraded { from: v, to: current }` |

游标缺失 + 已完成 setup 一刀切归类为"老用户升级"，不深究具体旧版本号。

## Tests

- `uc-core` —— port + 错误类型 (编译时验证)
- `uc-application` —— 12 个新增单测：判定矩阵全分支、semver 预发布版本排序、损坏游标 fallback、当前版本异常、acknowledge round-trip + 异常路径
- `uc-infra` —— 7 个新增单测：missing/round-trip/overwrite/corrupt-json/empty-file/unsupported-schema/parent-mkdir

## Test plan

- [x] `cargo check --workspace` 全绿
- [x] `cargo test -p uc-application -p uc-infra` 全过
- [ ] CI format check
- [ ] 手动验证（下一个 PR 加 CLI 子命令 `uniclip upgrade status` / `upgrade ack` 后做）

## Out of scope (后续 PR)

- CLI `upgrade` 子命令（手动验证用）
- 前端弹窗接 `Upgraded { from: None }` → 重新配对引导
- 把 `acknowledge()` 接到用户确认动作