### PR TITLE
perf(blob-transfer): 流式 publish/fetch + NTFS TryReference 双侧 (refs #487)

### DIFF
--- a/src-tauri/crates/uc-application/src/facade/blob_transfer/facade.rs
+++ b/src-tauri/crates/uc-application/src/facade/blob_transfer/facade.rs
@@ -17,7 +17,7 @@ use uc_core::ports::ContentHashPort;
 
 use crate::facade::host_event::{HostEvent, HostEventEmitterPort, TransferHostEvent};
 use crate::usecases::blob_transfer::{
-    FetchBlobInput, FetchBlobUseCase, PublishBlobInput, PublishBlobUseCase,
+    FetchBlobInput, FetchBlobPathInput, FetchBlobUseCase, PublishBlobInput, PublishBlobUseCase,
 };
 
 /// 共享的 host event emitter cell。
@@ -118,6 +118,31 @@ pub struct FetchBlobResult {
     pub entry_id: EntryId,
     pub plaintext_hash: PlaintextHash,
     pub digest: BlobDigest,
+}
+
+/// Streaming counterpart of [`FetchBlobCommand`] — the blob lands on disk
+/// at `target_path` instead of being returned as `Bytes`. GH#487 Phase 2.
+///
+/// Used by the inbound materializer for free-standing files so the
+/// receive side stops materialising 800 MB+ payloads in memory only to
+/// `tokio::fs::write` them out again.
+#[derive(Debug, Clone)]
+pub struct FetchBlobToPathCommand {
+    pub ticket: BlobTicket,
+    pub entry_id: EntryId,
+    pub target_path: PathBuf,
+    pub transfer_context: Option<FetchTransferContext>,
+}
+
+#[derive(Debug, Clone)]
+pub struct FetchBlobToPathResult {
+    pub entry_id: EntryId,
+    pub plaintext_hash: PlaintextHash,
+    pub digest: BlobDigest,
+    /// Final file size on disk (from `tokio::fs::metadata` after the
+    /// streaming export completed). Useful for callers that didn't get a
+    /// `total_bytes` from the protocol layer and want to log the real size.
+    pub bytes_written: u64,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -312,6 +337,97 @@ impl BlobTransferFacade {
                     entry_id: outcome.entry_id,
                     plaintext_hash: outcome.plaintext_hash,
                     digest: outcome.digest,
+                })
+            }
+            Err(e) => {
+                let msg = e.to_string();
+                if let Some(ctx) = command.transfer_context.as_ref() {
+                    self.emit_status_changed(ctx, "failed", Some(msg.clone()));
+                    self.report_outbound_terminal(
+                        ctx,
+                        0,
+                        ctx.total_bytes,
+                        OutboundProgressStatus::Failed,
+                    )
+                    .await;
+                }
+                Err(BlobTransferError::Fetch(msg))
+            }
+        }
+    }
+
+    /// 流式 fetch:把 blob 从 iroh store 直接 export 到 `target_path`,
+    /// 不经过 `Bytes`。GH#487 Phase 2:与 [`fetch_blob`](Self::fetch_blob) 在
+    /// progress sink、status events、outbound 反向上报上行为完全一致 ——
+    /// 只是不返回 plaintext。inbound materializer 用这个入口避免 800 MB+
+    /// 文件先全量进内存再 `tokio::fs::write` 的双写盘问题。
+    pub async fn fetch_blob_to_path(
+        &self,
+        command: FetchBlobToPathCommand,
+    ) -> Result<FetchBlobToPathResult, BlobTransferError> {
+        let iroh_tag_entry_id = command.entry_id.clone();
+        let progress_sink: Option<Arc<dyn BlobProgressSink>> = command
+            .transfer_context
+            .as_ref()
+            .filter(|_| self.host_event_emitter.is_some())
+            .map(|ctx| {
+                let outbound = match (
+                    self.outbound_progress_reporter.clone(),
+                    ctx.outbound_transfer_id.clone(),
+                    ctx.outbound_target.clone(),
+                ) {
+                    (Some(reporter), Some(tid), Some(target)) => Some(OutboundReportContext {
+                        reporter,
+                        transfer_id: tid,
+                        target,
+                    }),
+                    _ => None,
+                };
+                let sink: Arc<dyn BlobProgressSink> = Arc::new(HostEventProgressSink {
+                    emitter_cell: self.host_event_emitter.clone().unwrap(),
+                    transfer_id: ctx.transfer_id.clone(),
+                    peer_id: ctx.peer_id.clone(),
+                    fallback_total: ctx.total_bytes,
+                    outbound,
+                });
+                sink
+            });
+
+        if let Some(ctx) = command.transfer_context.as_ref() {
+            self.emit_status_changed(ctx, "transferring", None);
+            self.emit_progress(ctx, 0, ctx.total_bytes);
+        }
+
+        let result = self
+            .fetch_uc
+            .execute_to_path(FetchBlobPathInput {
+                ticket: command.ticket,
+                entry_id: iroh_tag_entry_id,
+                target_path: command.target_path,
+                progress: progress_sink,
+            })
+            .await;
+
+        match result {
+            Ok(outcome) => {
+                if let Some(ctx) = command.transfer_context.as_ref() {
+                    let final_size = outcome.bytes_written;
+                    let total = ctx.total_bytes.or(Some(final_size));
+                    self.emit_progress(ctx, final_size, total);
+                    self.emit_status_changed(ctx, "completed", None);
+                    self.report_outbound_terminal(
+                        ctx,
+                        final_size,
+                        total,
+                        OutboundProgressStatus::Completed,
+                    )
+                    .await;
+                }
+                Ok(FetchBlobToPathResult {
+                    entry_id: outcome.entry_id,
+                    plaintext_hash: outcome.plaintext_hash,
+                    digest: outcome.digest,
+                    bytes_written: outcome.bytes_written,
                 })
             }
             Err(e) => {

--- a/src-tauri/crates/uc-application/src/facade/blob_transfer/facade.rs
+++ b/src-tauri/crates/uc-application/src/facade/blob_transfer/facade.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::sync::{Arc, RwLock};
 
 use async_trait::async_trait;
@@ -41,6 +42,20 @@ pub struct BlobTransferDeps {
 #[derive(Debug, Clone)]
 pub struct PublishBlobCommand {
     pub plaintext: Bytes,
+    pub entry_id: Option<EntryId>,
+}
+
+/// 用磁盘文件路径作为 blob 来源 publish。GH#487 P1: 让 outbound 的大文件
+/// 走 iroh-blobs `add_path` 流式入库,避免 `tokio::fs::read` 把整文件读到
+/// 内存,把 1GB 文件 publish 期间的 RSS 峰值从 ~2GB 降到 chunk 量级。
+///
+/// 与 [`PublishBlobCommand`] 在协议层等价(产出同样的 [`PublishBlobResult`]),
+/// 但内存/IO 行为不同:`PublishBlobCommand` 适合已经在内存里的小 inline
+/// payload(剪贴板文本扩展 rep / 小图);`PublishBlobPathCommand` 适合磁盘
+/// 上的大文件 outbound。
+#[derive(Debug, Clone)]
+pub struct PublishBlobPathCommand {
+    pub path: PathBuf,
     pub entry_id: Option<EntryId>,
 }
 
@@ -188,8 +203,30 @@ impl BlobTransferFacade {
     ) -> Result<PublishBlobResult, BlobTransferError> {
         let outcome = self
             .publish_uc
-            .execute(PublishBlobInput {
+            .execute(PublishBlobInput::Plaintext {
                 plaintext: command.plaintext,
+                entry_id: command.entry_id.unwrap_or_default(),
+            })
+            .await
+            .map_err(|e| BlobTransferError::Publish(e.to_string()))?;
+        Ok(PublishBlobResult {
+            ticket: outcome.ticket,
+            entry_id: outcome.entry_id,
+            plaintext_hash: outcome.plaintext_hash,
+            digest: outcome.digest,
+            reused_existing: outcome.reused_existing,
+        })
+    }
+
+    /// 流式 publish:从磁盘文件读取并入库,避免把整文件加载到内存。GH#487 P1。
+    pub async fn publish_blob_path(
+        &self,
+        command: PublishBlobPathCommand,
+    ) -> Result<PublishBlobResult, BlobTransferError> {
+        let outcome = self
+            .publish_uc
+            .execute(PublishBlobInput::Path {
+                path: command.path,
                 entry_id: command.entry_id.unwrap_or_default(),
             })
             .await

--- a/src-tauri/crates/uc-application/src/facade/blob_transfer/mod.rs
+++ b/src-tauri/crates/uc-application/src/facade/blob_transfer/mod.rs
@@ -6,5 +6,6 @@ mod facade;
 
 pub use facade::{
     BlobTransferDeps, BlobTransferError, BlobTransferFacade, FetchBlobCommand, FetchBlobResult,
-    FetchTransferContext, PublishBlobCommand, PublishBlobResult, SharedHostEventEmitter,
+    FetchTransferContext, PublishBlobCommand, PublishBlobPathCommand, PublishBlobResult,
+    SharedHostEventEmitter,
 };

--- a/src-tauri/crates/uc-application/src/facade/blob_transfer/mod.rs
+++ b/src-tauri/crates/uc-application/src/facade/blob_transfer/mod.rs
@@ -6,6 +6,6 @@ mod facade;
 
 pub use facade::{
     BlobTransferDeps, BlobTransferError, BlobTransferFacade, FetchBlobCommand, FetchBlobResult,
-    FetchTransferContext, PublishBlobCommand, PublishBlobPathCommand, PublishBlobResult,
-    SharedHostEventEmitter,
+    FetchBlobToPathCommand, FetchBlobToPathResult, FetchTransferContext, PublishBlobCommand,
+    PublishBlobPathCommand, PublishBlobResult, SharedHostEventEmitter,
 };

--- a/src-tauri/crates/uc-application/src/facade/clipboard_outbound/mod.rs
+++ b/src-tauri/crates/uc-application/src/facade/clipboard_outbound/mod.rs
@@ -2,7 +2,6 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Instant;
 
-use anyhow::Context;
 use async_trait::async_trait;
 use bytes::Bytes;
 use thiserror::Error;
@@ -11,7 +10,9 @@ use uc_core::ids::EntryId;
 use uc_core::ports::SettingsPort;
 use uc_core::{ClipboardChangeOrigin, SystemClipboardSnapshot};
 
-use crate::facade::{BlobTransferFacade, ClipboardSyncFacade, PublishBlobCommand};
+use crate::facade::{
+    BlobTransferFacade, ClipboardSyncFacade, PublishBlobCommand, PublishBlobPathCommand,
+};
 use crate::sync_planner::{FileCandidate, FileSyncIntent, OutboundSyncPlanner};
 use crate::V3BlobRef;
 
@@ -380,21 +381,17 @@ async fn publish_file_blob_refs(
     let mut blob_refs = Vec::with_capacity(files.len());
 
     for file in files {
-        // Phase timing: 大文件 outbound 路径上 read_ms 经常超过 hash/publish。
-        // 杀毒首扫、网络盘、OneDrive 同步都会让 tokio::fs::read 阻塞十几秒,
-        // 这里把 read 与 publish 分开计时,便于 GH#487 后续诊断时定位瓶颈。
-        let read_start = Instant::now();
-        let plaintext = tokio::fs::read(&file.path)
-            .await
-            .with_context(|| format!("read outbound file {}", file.path.display()))
-            .map_err(|err| ClipboardOutboundError::Internal(err.to_string()))?;
-        let read_ms = read_start.elapsed().as_millis() as u64;
-        let size_bytes = plaintext.len() as u64;
-
+        // GH#487 P1: 流式 publish。旧路径先 `tokio::fs::read` 把整个文件读到
+        // `Vec<u8>`、再 `Bytes::from` 拷贝、再 `add_bytes` 在内存里算 BAO,
+        // 1GB 文件 RSS 峰值 ≈ 2GB,且这三步全部串联完成才轮到 dispatch ——
+        // 对端因此要等 ~11s 才拿到 envelope。新路径走 iroh-blobs `add_path`,
+        // 内部 reflink_or_copy_with_progress 把磁盘文件 stream 到 store(CoW
+        // FS 上零拷贝)+ 增量 BAO 编码,内存峰值与文件大小无关。`size_bytes`
+        // 改用 plan 透传的 `FileSyncIntent.size`(metadata 阶段已查过)。
         let publish_start = Instant::now();
         let result = blob_transfer
-            .publish_blob(PublishBlobCommand {
-                plaintext: Bytes::from(plaintext),
+            .publish_blob_path(PublishBlobPathCommand {
+                path: file.path.clone(),
                 entry_id: Some(entry_id.clone()),
             })
             .await
@@ -404,11 +401,10 @@ async fn publish_file_blob_refs(
         info!(
             entry_id = %entry_id.as_str(),
             file = %file.path.display(),
-            size_bytes,
+            size_bytes = file.size,
             reused_existing = result.reused_existing,
-            read_ms,
             publish_ms,
-            "outbound: file blob published"
+            "outbound: file blob published (streaming)"
         );
 
         blob_refs.push(V3BlobRef {
@@ -416,7 +412,7 @@ async fn publish_file_blob_refs(
             entry_id: result.entry_id,
             filename: Some(file.filename.clone()).filter(|name| !name.is_empty()),
             mime: None,
-            size_bytes,
+            size_bytes: file.size,
             representation_index: None,
         });
     }

--- a/src-tauri/crates/uc-application/src/facade/mod.rs
+++ b/src-tauri/crates/uc-application/src/facade/mod.rs
@@ -34,7 +34,7 @@ pub use app_facade::{
 pub use app_paths::AppPaths;
 pub use blob_transfer::{
     BlobTransferDeps, BlobTransferError, BlobTransferFacade, FetchBlobCommand, FetchBlobResult,
-    PublishBlobCommand, PublishBlobResult,
+    PublishBlobCommand, PublishBlobPathCommand, PublishBlobResult,
 };
 pub use clipboard::{
     ClipboardSyncDeps, ClipboardSyncError, ClipboardSyncFacade, DispatchEntryInput,

--- a/src-tauri/crates/uc-application/src/facade/mod.rs
+++ b/src-tauri/crates/uc-application/src/facade/mod.rs
@@ -34,7 +34,8 @@ pub use app_facade::{
 pub use app_paths::AppPaths;
 pub use blob_transfer::{
     BlobTransferDeps, BlobTransferError, BlobTransferFacade, FetchBlobCommand, FetchBlobResult,
-    PublishBlobCommand, PublishBlobPathCommand, PublishBlobResult,
+    FetchBlobToPathCommand, FetchBlobToPathResult, PublishBlobCommand, PublishBlobPathCommand,
+    PublishBlobResult,
 };
 pub use clipboard::{
     ClipboardSyncDeps, ClipboardSyncError, ClipboardSyncFacade, DispatchEntryInput,

--- a/src-tauri/crates/uc-application/src/sync_planner/planner.rs
+++ b/src-tauri/crates/uc-application/src/sync_planner/planner.rs
@@ -105,6 +105,7 @@ impl OutboundSyncPlanner {
                         path: candidate.path,
                         transfer_id,
                         filename,
+                        size: candidate.size,
                     });
                 }
             }

--- a/src-tauri/crates/uc-application/src/sync_planner/types.rs
+++ b/src-tauri/crates/uc-application/src/sync_planner/types.rs
@@ -38,6 +38,12 @@ pub struct FileSyncIntent {
     pub transfer_id: String,
     /// The original filename (used for naming the local cache entry on the receiver).
     pub filename: String,
+    /// File size in bytes, taken from `FileCandidate.size` (already queried
+    /// during the metadata phase). Outbound publishes the file via streaming
+    /// `add_path`(GH#487 P1)— which means the publish helper no longer
+    /// reads the bytes into memory, so it can't recompute `plaintext.len()`
+    /// for the V3 envelope's advertised size and must rely on this field.
+    pub size: u64,
 }
 
 /// The result of `OutboundSyncPlanner::plan()`.

--- a/src-tauri/crates/uc-application/src/usecases/blob_transfer/fetch_blob.rs
+++ b/src-tauri/crates/uc-application/src/usecases/blob_transfer/fetch_blob.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use bytes::Bytes;
@@ -23,6 +24,31 @@ pub(crate) struct FetchBlobOutcome {
     pub entry_id: EntryId,
     pub plaintext_hash: PlaintextHash,
     pub digest: BlobDigest,
+}
+
+/// Streaming variant of [`FetchBlobInput`] — drops `plaintext: Bytes` from
+/// the result and writes the blob directly to `target_path`.
+///
+/// GH#487 Phase 2: receive-side mirror of `PublishBlobInput::Path`. Used by
+/// the inbound materializer for free-standing files so a 1 GiB clipboard
+/// transfer no longer routes the full plaintext through `Bytes` + a second
+/// `tokio::fs::write`.
+pub(crate) struct FetchBlobPathInput {
+    pub ticket: BlobTicket,
+    pub entry_id: EntryId,
+    pub target_path: PathBuf,
+    pub progress: Option<Arc<dyn BlobProgressSink>>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct FetchBlobPathOutcome {
+    pub entry_id: EntryId,
+    pub plaintext_hash: PlaintextHash,
+    pub digest: BlobDigest,
+    /// File size on disk after `fetch_to_path` returned. Lets callers (e.g.
+    /// the facade emitting the final 100 % progress event) report a real
+    /// number even when the upstream `total_bytes` was unknown.
+    pub bytes_written: u64,
 }
 
 pub(crate) struct FetchBlobUseCase {
@@ -81,6 +107,61 @@ impl FetchBlobUseCase {
             entry_id: input.entry_id,
             plaintext_hash,
             digest,
+        })
+    }
+
+    /// Streaming fetch — write the blob directly to `target_path` instead
+    /// of returning it as `Bytes`. GH#487 Phase 2.
+    ///
+    /// Differs from [`execute`](Self::execute) in three places:
+    /// * Calls `BlobTransferPort::fetch_to_path`, so the full plaintext
+    ///   never passes through `Bytes` on this code path.
+    /// * Skips the `ContentHashPort::hash_bytes` step. File blobs are
+    ///   stored raw and unencrypted on iroh-blobs (see `PublishBlobUseCase`
+    ///   path branch); the BAO root the adapter validates equals the
+    ///   plaintext blake3, so `plaintext_hash` is read straight from
+    ///   `digest` rather than being recomputed by streaming the file
+    ///   back in. Saves a second whole-file BLAKE3 pass.
+    /// * Returns the file size from `tokio::fs::metadata` so callers can
+    ///   emit a final progress event without re-reading the file.
+    pub async fn execute_to_path(
+        &self,
+        input: FetchBlobPathInput,
+    ) -> Result<FetchBlobPathOutcome, FetchBlobError> {
+        let progress_ref: Option<&dyn BlobProgressSink> = input
+            .progress
+            .as_ref()
+            .map(|p| &**p as &dyn BlobProgressSink);
+        let digest = self
+            .blob_transfer
+            .fetch_to_path(&input.ticket, &input.target_path, progress_ref)
+            .await
+            .map_err(|e| FetchBlobError::Transfer(e.to_string()))?;
+
+        // File blobs are content-addressed by blake3 of the raw plaintext;
+        // since they're stored without encryption the adapter's digest IS
+        // the plaintext hash (mirrors `PublishBlobUseCase::execute_path`).
+        let plaintext_hash = PlaintextHash::from_bytes(*digest.as_bytes());
+
+        self.blob_reference
+            .save(plaintext_hash, digest)
+            .await
+            .map_err(|e| FetchBlobError::Reference(e.to_string()))?;
+        self.blob_transfer
+            .tag(&digest, TagReason::ClipboardEntry(input.entry_id.clone()))
+            .await
+            .map_err(|e| FetchBlobError::Transfer(e.to_string()))?;
+
+        let bytes_written = tokio::fs::metadata(&input.target_path)
+            .await
+            .map(|m| m.len())
+            .unwrap_or(0);
+
+        Ok(FetchBlobPathOutcome {
+            entry_id: input.entry_id,
+            plaintext_hash,
+            digest,
+            bytes_written,
         })
     }
 }

--- a/src-tauri/crates/uc-application/src/usecases/blob_transfer/mod.rs
+++ b/src-tauri/crates/uc-application/src/usecases/blob_transfer/mod.rs
@@ -41,7 +41,7 @@ mod tests {
         let mut first_digest = None;
         for _ in 0..10 {
             let outcome = usecase
-                .execute(PublishBlobInput {
+                .execute(PublishBlobInput::Plaintext {
                     plaintext: plaintext.clone(),
                     entry_id: EntryId::new(),
                 })
@@ -71,14 +71,14 @@ mod tests {
 
         let plaintext = Bytes::from_static(b"same file bytes");
         let first = publish
-            .execute(PublishBlobInput {
+            .execute(PublishBlobInput::Plaintext {
                 plaintext: plaintext.clone(),
                 entry_id: EntryId::from("entry-one"),
             })
             .await
             .expect("first publish should succeed");
         let second = publish
-            .execute(PublishBlobInput {
+            .execute(PublishBlobInput::Plaintext {
                 plaintext: plaintext.clone(),
                 entry_id: EntryId::from("entry-two"),
             })
@@ -180,6 +180,16 @@ mod tests {
                 .expect("lock store")
                 .insert(digest, plaintext);
             Ok(digest)
+        }
+
+        async fn publish_path(&self, path: &std::path::Path) -> Result<BlobDigest, BlobError> {
+            // Fake-only: read into memory and delegate to publish() so
+            // tests stay simple (small files) while still exercising the
+            // path code-path through the use case + facade layers.
+            let bytes = tokio::fs::read(path)
+                .await
+                .map_err(|e| BlobError::Internal(e.to_string()))?;
+            self.publish(Bytes::from(bytes)).await
         }
 
         async fn issue_ticket(&self, digest: &BlobDigest) -> Result<BlobTicket, BlobError> {

--- a/src-tauri/crates/uc-application/src/usecases/blob_transfer/mod.rs
+++ b/src-tauri/crates/uc-application/src/usecases/blob_transfer/mod.rs
@@ -10,7 +10,7 @@
 mod fetch_blob;
 mod publish_blob;
 
-pub(crate) use fetch_blob::{FetchBlobInput, FetchBlobUseCase};
+pub(crate) use fetch_blob::{FetchBlobInput, FetchBlobPathInput, FetchBlobUseCase};
 pub(crate) use publish_blob::{PublishBlobInput, PublishBlobUseCase};
 
 #[cfg(test)]
@@ -208,6 +208,23 @@ mod tests {
                 .get(&digest)
                 .cloned()
                 .ok_or(BlobError::NotFound)
+        }
+
+        async fn fetch_to_path(
+            &self,
+            ticket: &BlobTicket,
+            target_path: &std::path::Path,
+            progress: Option<&dyn BlobProgressSink>,
+        ) -> Result<BlobDigest, BlobError> {
+            // Fake-only: read store entry into memory and write the file
+            // out — tests work with small payloads, so the in-memory step
+            // is fine. Real adapter (`IrohBlobTransferAdapter`) goes
+            // through `Blobs::export` for true streaming export.
+            let bytes = self.fetch(ticket, progress).await?;
+            tokio::fs::write(target_path, &bytes)
+                .await
+                .map_err(|e| BlobError::Internal(e.to_string()))?;
+            self.digest_of(ticket)
         }
 
         async fn has(&self, digest: &BlobDigest) -> Result<bool, BlobError> {

--- a/src-tauri/crates/uc-application/src/usecases/blob_transfer/publish_blob.rs
+++ b/src-tauri/crates/uc-application/src/usecases/blob_transfer/publish_blob.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -10,10 +11,15 @@ use uc_core::ports::blob::{
 };
 use uc_core::ports::ContentHashPort;
 
+/// publish_blob 的输入 —— 内存 plaintext 与磁盘文件路径两条入口的语义对称。
+///
+/// `Plaintext` 路径用于已经在内存里的 inline payload(小图、文本扩展 rep);
+/// `Path` 路径用于磁盘文件 outbound,走流式入库避免把整文件加载到内存
+/// (GH#487)。两条路径产出的 `PublishBlobOutcome` 在协议层等价。
 #[derive(Debug, Clone)]
-pub(crate) struct PublishBlobInput {
-    pub plaintext: Bytes,
-    pub entry_id: EntryId,
+pub(crate) enum PublishBlobInput {
+    Plaintext { plaintext: Bytes, entry_id: EntryId },
+    Path { path: PathBuf, entry_id: EntryId },
 }
 
 #[derive(Debug, Clone)]
@@ -48,7 +54,21 @@ impl PublishBlobUseCase {
         &self,
         input: PublishBlobInput,
     ) -> Result<PublishBlobOutcome, PublishBlobError> {
-        if input.plaintext.is_empty() {
+        match input {
+            PublishBlobInput::Plaintext {
+                plaintext,
+                entry_id,
+            } => self.execute_plaintext(plaintext, entry_id).await,
+            PublishBlobInput::Path { path, entry_id } => self.execute_path(path, entry_id).await,
+        }
+    }
+
+    async fn execute_plaintext(
+        &self,
+        plaintext: Bytes,
+        entry_id: EntryId,
+    ) -> Result<PublishBlobOutcome, PublishBlobError> {
+        if plaintext.is_empty() {
             return Err(PublishBlobError::EmptyPlaintext);
         }
 
@@ -56,12 +76,12 @@ impl PublishBlobUseCase {
         // hash 与 add_bytes 都会对 plaintext 做一次 BLAKE3,大文件场景下两次
         // 加起来不可忽略;tag/ticket/save_ref 涉及 store + sqlite 写入,冷启动
         // 时也可能慢。GH#487 诊断需要这些阶段拆分。
-        let bytes = input.plaintext.len() as u64;
+        let bytes = plaintext.len() as u64;
 
         let hash_start = Instant::now();
         let plaintext_hash = PlaintextHash::from_bytes(
             self.hash
-                .hash_bytes(&input.plaintext)
+                .hash_bytes(&plaintext)
                 .map_err(|e| PublishBlobError::Hash(e.to_string()))?
                 .bytes,
         );
@@ -73,7 +93,7 @@ impl PublishBlobUseCase {
 
             let tag_start = Instant::now();
             self.blob_transfer
-                .tag(&digest, TagReason::ClipboardEntry(input.entry_id.clone()))
+                .tag(&digest, TagReason::ClipboardEntry(entry_id.clone()))
                 .await
                 .map_err(|e| PublishBlobError::Transfer(e.to_string()))?;
             let tag_ms = tag_start.elapsed().as_millis() as u64;
@@ -87,7 +107,7 @@ impl PublishBlobUseCase {
             let ticket_ms = ticket_start.elapsed().as_millis() as u64;
 
             info!(
-                entry_id = %input.entry_id.as_str(),
+                entry_id = %entry_id.as_str(),
                 bytes,
                 reused_existing = true,
                 hash_ms,
@@ -99,7 +119,7 @@ impl PublishBlobUseCase {
 
             return Ok(PublishBlobOutcome {
                 ticket,
-                entry_id: input.entry_id,
+                entry_id,
                 plaintext_hash,
                 digest,
                 reused_existing: true,
@@ -117,7 +137,7 @@ impl PublishBlobUseCase {
         let publish_start = Instant::now();
         let digest = self
             .blob_transfer
-            .publish(input.plaintext)
+            .publish(plaintext)
             .await
             .map_err(|e| PublishBlobError::Transfer(e.to_string()))?;
         let publish_ms = publish_start.elapsed().as_millis() as u64;
@@ -131,7 +151,7 @@ impl PublishBlobUseCase {
 
         let tag_start = Instant::now();
         self.blob_transfer
-            .tag(&digest, TagReason::ClipboardEntry(input.entry_id.clone()))
+            .tag(&digest, TagReason::ClipboardEntry(entry_id.clone()))
             .await
             .map_err(|e| PublishBlobError::Transfer(e.to_string()))?;
         let tag_ms = tag_start.elapsed().as_millis() as u64;
@@ -145,7 +165,7 @@ impl PublishBlobUseCase {
         let ticket_ms = ticket_start.elapsed().as_millis() as u64;
 
         info!(
-            entry_id = %input.entry_id.as_str(),
+            entry_id = %entry_id.as_str(),
             bytes,
             reused_existing = false,
             hash_ms,
@@ -159,7 +179,76 @@ impl PublishBlobUseCase {
 
         Ok(PublishBlobOutcome {
             ticket,
-            entry_id: input.entry_id,
+            entry_id,
+            plaintext_hash,
+            digest,
+            reused_existing: false,
+        })
+    }
+
+    /// Streaming publish from a local file path. GH#487 P1.
+    ///
+    /// 跟 `execute_plaintext` 不同,这里**不做 pre-publish dedup**:plaintext
+    /// 不在内存里,算 blake3 之前必须先把文件读完——既然要读完,不如交给
+    /// iroh-blobs 的 `add_path` 一次过算 BAO 树。iroh store 自身基于 hash
+    /// 内容寻址,重复 import 同一文件不会真的占双份盘(只浪费一次 BAO CPU
+    /// 与临时拷贝 IO),与"先全文件读到内存 + Bytes 拷贝 + add_bytes"的旧
+    /// 路径相比,对 1GB 文件能把 RSS 峰值从 ~2GB 降到与 chunk 相关的常数。
+    ///
+    /// 文件 blob 不加密(同 `execute_plaintext` 注释),所以 `plaintext_hash`
+    /// 与 iroh blob digest 在数值上相等。
+    async fn execute_path(
+        &self,
+        path: PathBuf,
+        entry_id: EntryId,
+    ) -> Result<PublishBlobOutcome, PublishBlobError> {
+        let publish_start = Instant::now();
+        let digest = self
+            .blob_transfer
+            .publish_path(&path)
+            .await
+            .map_err(|e| PublishBlobError::Transfer(e.to_string()))?;
+        let publish_ms = publish_start.elapsed().as_millis() as u64;
+
+        // 文件 blob 不加密 → plaintext_hash == iroh blob hash == digest。
+        let plaintext_hash = PlaintextHash::from_bytes(*digest.as_bytes());
+
+        // upsert(BlobReferenceRepositoryPort::save 注释保证 overwrite 安全)。
+        let save_ref_start = Instant::now();
+        self.blob_reference
+            .save(plaintext_hash, digest)
+            .await
+            .map_err(|e| PublishBlobError::Reference(e.to_string()))?;
+        let save_ref_ms = save_ref_start.elapsed().as_millis() as u64;
+
+        let tag_start = Instant::now();
+        self.blob_transfer
+            .tag(&digest, TagReason::ClipboardEntry(entry_id.clone()))
+            .await
+            .map_err(|e| PublishBlobError::Transfer(e.to_string()))?;
+        let tag_ms = tag_start.elapsed().as_millis() as u64;
+
+        let ticket_start = Instant::now();
+        let ticket = self
+            .blob_transfer
+            .issue_ticket(&digest)
+            .await
+            .map_err(|e| PublishBlobError::Transfer(e.to_string()))?;
+        let ticket_ms = ticket_start.elapsed().as_millis() as u64;
+
+        info!(
+            entry_id = %entry_id.as_str(),
+            path = %path.display(),
+            publish_ms,
+            save_ref_ms,
+            tag_ms,
+            ticket_ms,
+            "publish_blob: streamed from path"
+        );
+
+        Ok(PublishBlobOutcome {
+            ticket,
+            entry_id,
             plaintext_hash,
             digest,
             reused_existing: false,

--- a/src-tauri/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/materializer.rs
+++ b/src-tauri/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/materializer.rs
@@ -22,7 +22,8 @@ use uc_core::ids::{DeviceId, EntryId, FormatId, RepresentationId};
 use uc_core::{MimeType, ObservedClipboardRepresentation, SystemClipboardSnapshot};
 
 use crate::facade::blob_transfer::{
-    BlobTransferFacade, FetchBlobCommand, FetchBlobResult, FetchTransferContext,
+    BlobTransferFacade, FetchBlobCommand, FetchBlobResult, FetchBlobToPathCommand,
+    FetchBlobToPathResult, FetchTransferContext,
 };
 use crate::usecases::clipboard_sync::payload_codec::V3BlobRef;
 
@@ -42,13 +43,33 @@ pub trait InboundBlobMaterializer: Send + Sync {
 
 #[async_trait]
 pub trait InboundBlobFetcher: Send + Sync {
+    /// In-memory fetch path — used by representation-bound blobs (e.g.
+    /// oversized images that we splice back into `snapshot.representations`).
     async fn fetch_blob(&self, command: FetchBlobCommand) -> Result<FetchBlobResult>;
+
+    /// Streaming fetch path — used by free-standing files. The blob is
+    /// written directly to `command.target_path` (reflink on CoW
+    /// filesystems) so receiving a 1 GiB clipboard transfer no longer
+    /// routes the full plaintext through `Bytes`. GH#487 Phase 2.
+    async fn fetch_blob_to_path(
+        &self,
+        command: FetchBlobToPathCommand,
+    ) -> Result<FetchBlobToPathResult>;
 }
 
 #[async_trait]
 impl InboundBlobFetcher for BlobTransferFacade {
     async fn fetch_blob(&self, command: FetchBlobCommand) -> Result<FetchBlobResult> {
         BlobTransferFacade::fetch_blob(self, command)
+            .await
+            .map_err(|e| anyhow!(e.to_string()))
+    }
+
+    async fn fetch_blob_to_path(
+        &self,
+        command: FetchBlobToPathCommand,
+    ) -> Result<FetchBlobToPathResult> {
+        BlobTransferFacade::fetch_blob_to_path(self, command)
             .await
             .map_err(|e| anyhow!(e.to_string()))
     }
@@ -191,11 +212,30 @@ impl InboundBlobMaterializer for FileCacheBlobMaterializer {
                 outbound_transfer_id: Some(blob_ref.entry_id.as_ref().to_string()),
                 outbound_target: Some(from_device.clone()),
             };
+
+            // GH#487 Phase 2: pre-create cache dir and stream the blob
+            // directly to the target file. The previous code did
+            // `fetch_blob -> Bytes -> tokio::fs::write`, which on a 800 MB
+            // transfer wasted ~20s materialising the full plaintext in
+            // memory and writing to disk a second time (the iroh store
+            // already had a copy from BAO verification). `fetch_blob_to_path`
+            // collapses both into a single `Blobs::export` call (reflink
+            // on APFS / Btrfs / ReFS).
+            let entry_dir = self
+                .cache_dir
+                .join("iroh-blobs")
+                .join(sanitize_path_segment(blob_ref.entry_id.as_ref()));
+            tokio::fs::create_dir_all(&entry_dir).await?;
+
+            let filename = unique_filename(blob_ref.filename.as_deref(), idx, &mut used_names);
+            let path = entry_dir.join(filename);
+
             let fetched = self
                 .fetcher
-                .fetch_blob(FetchBlobCommand {
+                .fetch_blob_to_path(FetchBlobToPathCommand {
                     ticket: blob_ref.ticket,
                     entry_id: blob_ref.entry_id.clone(),
+                    target_path: path.clone(),
                     transfer_context: Some(transfer_context),
                 })
                 .await
@@ -211,23 +251,13 @@ impl InboundBlobMaterializer for FileCacheBlobMaterializer {
                     e
                 })?;
 
-            let entry_dir = self
-                .cache_dir
-                .join("iroh-blobs")
-                .join(sanitize_path_segment(blob_ref.entry_id.as_ref()));
-            tokio::fs::create_dir_all(&entry_dir).await?;
-
-            let filename = unique_filename(blob_ref.filename.as_deref(), idx, &mut used_names);
-            let path = entry_dir.join(filename);
-            let fetched_len = fetched.plaintext.len();
-            tokio::fs::write(&path, fetched.plaintext).await?;
             info!(
                 idx,
                 total = blob_ref_total,
                 entry_id = %entry_id,
-                bytes_written = fetched_len,
+                bytes_written = fetched.bytes_written,
                 path = %path.display(),
-                "materialize: blob cached to local path"
+                "materialize: blob cached to local path (streaming)"
             );
             local_paths.push(path);
         }

--- a/src-tauri/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/tests.rs
+++ b/src-tauri/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/tests.rs
@@ -80,6 +80,11 @@ mockall::mock! {
             &self,
             command: crate::facade::blob_transfer::FetchBlobCommand,
         ) -> Result<crate::facade::blob_transfer::FetchBlobResult>;
+
+        async fn fetch_blob_to_path(
+            &self,
+            command: crate::facade::blob_transfer::FetchBlobToPathCommand,
+        ) -> Result<crate::facade::blob_transfer::FetchBlobToPathResult>;
     }
 }
 
@@ -423,15 +428,23 @@ async fn file_cache_blob_materializer_writes_file_and_rewrites_file_uri_list() {
 
     let mut fetcher = MockBlobFetcher::new();
     fetcher
-        .expect_fetch_blob()
+        .expect_fetch_blob_to_path()
         .times(1)
         .withf(move |command| command.entry_id == entry_id && command.ticket == ticket)
         .returning(|command| {
-            Ok(crate::facade::blob_transfer::FetchBlobResult {
-                plaintext: Bytes::from_static(b"hello world"),
+            // Mirror the real adapter: write the bytes to target_path so
+            // the subsequent `file://` rewrite + `tokio::fs::read` assertion
+            // sees the materialized content. GH#487 Phase 2 changed the
+            // production path from `fetch_blob -> tokio::fs::write` to
+            // `fetch_blob_to_path` (streaming export); the test fake mirrors
+            // that contract instead of round-tripping through `Bytes`.
+            let payload: &[u8] = b"hello world";
+            std::fs::write(&command.target_path, payload).expect("fake write target");
+            Ok(crate::facade::blob_transfer::FetchBlobToPathResult {
                 entry_id: command.entry_id,
                 plaintext_hash: PlaintextHash::from_bytes([0; 32]),
                 digest: BlobDigest::from_bytes([1; 32]),
+                bytes_written: payload.len() as u64,
             })
         });
 

--- a/src-tauri/crates/uc-core/src/ports/blob/transfer.rs
+++ b/src-tauri/crates/uc-core/src/ports/blob/transfer.rs
@@ -215,6 +215,26 @@ pub trait BlobTransferPort: Send + Sync {
         progress: Option<&dyn BlobProgressSink>,
     ) -> Result<Bytes, BlobError>;
 
+    /// Retrieve a ciphertext and write it directly to `target_path`,
+    /// streaming from the local store rather than materialising the full
+    /// payload as `Bytes` in memory. The semantics around credential
+    /// resolution, retries, integrity verification, and `progress` are
+    /// identical to [`fetch`](Self::fetch); the only difference is the
+    /// destination — adapters that back a content-addressed disk store
+    /// (e.g. iroh-blobs) SHOULD use a reflink / file-clone to land the
+    /// blob at `target_path` so peak memory stays bounded regardless of
+    /// blob size.
+    ///
+    /// Returns the [`BlobDigest`] the credential resolved to, so callers
+    /// can record references / dedup mappings without re-hashing the
+    /// just-written file.
+    async fn fetch_to_path(
+        &self,
+        ticket: &BlobTicket,
+        target_path: &std::path::Path,
+        progress: Option<&dyn BlobProgressSink>,
+    ) -> Result<BlobDigest, BlobError>;
+
     // ── Lifecycle ──
 
     /// Whether the local store currently holds the ciphertext.

--- a/src-tauri/crates/uc-core/src/ports/blob/transfer.rs
+++ b/src-tauri/crates/uc-core/src/ports/blob/transfer.rs
@@ -179,6 +179,19 @@ pub trait BlobTransferPort: Send + Sync {
     /// returns the same [`BlobDigest`].
     async fn publish(&self, ciphertext: Bytes) -> Result<BlobDigest, BlobError>;
 
+    /// Place the contents of a local file into the shareable store, return
+    /// its stable local identity. Adapters MAY stream the file from disk
+    /// rather than load it fully into memory; callers SHOULD prefer this
+    /// path for large payloads (clipboard files, oversized image reps that
+    /// already live on disk) so peak memory stays bounded regardless of
+    /// file size and the outbound dispatch path is not blocked while a
+    /// 1 GiB plaintext is materialised.
+    ///
+    /// Idempotent in the same sense as [`publish`](Self::publish):
+    /// publishing the same byte content again returns the same
+    /// [`BlobDigest`], regardless of which method was used.
+    async fn publish_path(&self, path: &std::path::Path) -> Result<BlobDigest, BlobError>;
+
     /// Mint an out-of-band retrieval credential for a ciphertext the
     /// local store already holds, so other devices can pull from this
     /// one. The credential carries at minimum "content identity + at

--- a/src-tauri/crates/uc-infra/src/network/iroh/blobs.rs
+++ b/src-tauri/crates/uc-infra/src/network/iroh/blobs.rs
@@ -12,7 +12,7 @@ use bytes::Bytes;
 use futures_util::StreamExt;
 use iroh::{Endpoint, EndpointId, Watcher};
 use iroh_blobs::{
-    api::blobs::{ExportMode, ExportOptions},
+    api::blobs::{AddPathOptions, ExportMode, ExportOptions, ImportMode},
     api::downloader::{DownloadProgressItem, Downloader},
     store::fs::FsStore,
     ticket::BlobTicket as NativeBlobTicket,
@@ -122,6 +122,20 @@ fn hex_prefix(bytes: &[u8]) -> String {
     out
 }
 
+/// Pick the `ImportMode` for `Blobs::add_path` based on the host platform.
+///
+/// See `publish_path` for the full rationale; in short: only Windows benefits
+/// from `TryReference` (NTFS has no reflink, ReFS prefers external handle
+/// over reflink anyway). All other platforms keep `Copy` so APFS / Btrfs /
+/// XFS reflink fast paths fire.
+fn preferred_import_mode() -> ImportMode {
+    if cfg!(target_os = "windows") {
+        ImportMode::TryReference
+    } else {
+        ImportMode::Copy
+    }
+}
+
 #[async_trait]
 impl BlobTransferPort for IrohBlobTransferAdapter {
     #[instrument(skip_all, fields(bytes = ciphertext.len()))]
@@ -148,24 +162,44 @@ impl BlobTransferPort for IrohBlobTransferAdapter {
 
     #[instrument(skip_all, fields(path = %path.display()))]
     async fn publish_path(&self, path: &std::path::Path) -> Result<BlobDigest, BlobError> {
-        // GH#487 P1 streaming publish:走 iroh-blobs 的 add_path 入口,内部
-        // 由 reflink_or_copy_with_progress 把磁盘文件 stream 到 store(在
-        // APFS / Btrfs / ReFS 等 CoW FS 上是 reflink 零拷贝;NTFS / ext4 上
-        // fallback 真拷贝,但仍是 stream)+ 增量算 BAO outboard。整段过程
-        // 内存峰值受 iroh chunk size 主导,与文件大小无关。
+        // GH#487 P1 streaming publish:走 iroh-blobs 的 add_path 入口,增量算
+        // BAO outboard,整段过程内存峰值受 iroh chunk size 主导,与文件大小
+        // 无关。旧路径(`tokio::fs::read → Bytes → add_bytes`)在 1GB 文件上
+        // 需要 ~2GB 临时内存,且阻塞 outbound dispatch 主流程 ~11s。
         //
-        // 旧路径(`tokio::fs::read(path) → Bytes::from → publish(Bytes) →
-        // add_bytes`)在 1GB 文件上需要 1×plaintext + 1×Bytes ≈ 2GB 临时
-        // 内存,且在 publish 完成前阻塞 outbound dispatch 主流程 ~11s。
+        // ImportMode 选择(平台条件):
+        //   - 非 Windows(macOS APFS / Linux Btrfs / XFS-with-reflink):用
+        //     `ImportMode::Copy` —— 内部 `reflink_or_copy_with_progress` 在
+        //     CoW FS 上是 zero-copy reflink,免费;ext4 / 其他 fallback 真
+        //     拷贝,这部分用户量少,先不优化。
+        //   - Windows(NTFS 大头 / ReFS 少数):用 `ImportMode::TryReference`
+        //     (iroh-blobs 0.97 `store/fs/import.rs:485-490`)—— 不进 store
+        //     数据目录,直接 `OpenOptions::read(true).open(path)` 拿外部句柄
+        //     算 outboard,store entry 状态为 External。NTFS 1GB 实测 ~21s
+        //     真拷贝直接消失,只剩 read + BAO 的成本。
+        //
+        // 正确性窗口:TryReference 模式下,如果用户在 dispatch 后、所有对端
+        // fetch 完成前**修改 / 移动**源文件 → outboard 与内容失配,接收端
+        // BAO 校验失败。Windows 上 store 持有的 `OpenOptions::read` 句柄会
+        // 在 share=full-access 下不阻止改动,但天然阻止文件被删除(file in
+        // use)—— 覆盖了"不小心拖去回收站"这一最常见误操作。其他场景接受
+        // 失败、由用户重新复制(对端报错而 sender 这一侧不感知,fallback
+        // 到 Copy 重 import 的反向通知链路超出本次 step 范围)。
         let started = Instant::now();
+        let mode = preferred_import_mode();
         let tag_info = self
             .store
             .blobs()
-            .add_path(path)
+            .add_path_with_opts(AddPathOptions {
+                path: path.to_owned(),
+                format: BlobFormat::Raw,
+                mode,
+            })
             .await
             .map_err(|e| BlobError::Internal(e.to_string()))?;
         info!(
             add_path_ms = started.elapsed().as_millis() as u64,
+            mode = ?mode,
             blob_hash = %hex_prefix(tag_info.hash.as_bytes()),
             "iroh blob publish: add_path completed (streaming)"
         );
@@ -750,6 +784,104 @@ mod tests {
         let path_digest = fixture.adapter.publish_path(&path).await?;
 
         assert_eq!(bytes_digest, path_digest);
+        fixture.shutdown().await?;
+        Ok(())
+    }
+
+    #[test]
+    fn preferred_import_mode_is_try_reference_on_windows_copy_elsewhere() {
+        // GH#487 Step 2 platform contract: TryReference is the default on
+        // Windows (NTFS / ReFS) to skip the ~21s NTFS stream-copy fallback;
+        // everywhere else stays on Copy so the existing reflink fast paths
+        // (APFS / Btrfs / XFS reflink) keep firing untouched.
+        let mode = preferred_import_mode();
+        if cfg!(target_os = "windows") {
+            assert!(matches!(mode, ImportMode::TryReference));
+        } else {
+            assert!(matches!(mode, ImportMode::Copy));
+        }
+    }
+
+    #[tokio::test]
+    async fn publish_path_try_reference_yields_same_digest_as_copy() -> anyhow::Result<()> {
+        // GH#487 Step 2: switching ImportMode must not change the
+        // content-addressed digest. The store's own dedup invariant
+        // promises this (BAO is computed off the file content, not the
+        // import strategy), but a regression here would silently break
+        // every ticket the sender mints once the platform-conditional
+        // mode select kicks in. Payload is 64 KiB — above iroh-blobs'
+        // default 16 KiB inline threshold — so both branches actually
+        // hit the file-import path that differs between modes.
+        let fixture = Fixture::bind().await?;
+        let payload = vec![0xc3u8; 64 * 1024];
+
+        let dir = tempdir()?;
+        let path_copy = dir.path().join("copy.bin");
+        let path_ref = dir.path().join("ref.bin");
+        std::fs::write(&path_copy, &payload)?;
+        std::fs::write(&path_ref, &payload)?;
+
+        let copy_tag = fixture
+            .store
+            .blobs()
+            .add_path_with_opts(AddPathOptions {
+                path: path_copy.clone(),
+                format: BlobFormat::Raw,
+                mode: ImportMode::Copy,
+            })
+            .await?;
+        let ref_tag = fixture
+            .store
+            .blobs()
+            .add_path_with_opts(AddPathOptions {
+                path: path_ref.clone(),
+                format: BlobFormat::Raw,
+                mode: ImportMode::TryReference,
+            })
+            .await?;
+
+        assert_eq!(copy_tag.hash, ref_tag.hash);
+        fixture.shutdown().await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn publish_path_try_reference_serves_correct_bytes_to_local_fetch() -> anyhow::Result<()>
+    {
+        // GH#487 Step 2 end-to-end contract: when the store entry is an
+        // External(path) reference rather than an owned data file, fetching
+        // the blob (here through the local-hit fast path) must still hand
+        // back the exact original bytes. This is what catches "we kept a
+        // reference but the BAO outboard ended up wrong" regressions.
+        let fixture = Fixture::bind().await?;
+        fixture.wait_for_direct_addr().await?;
+        let payload = vec![0x91u8; 64 * 1024];
+
+        let dir = tempdir()?;
+        let source = dir.path().join("source.bin");
+        std::fs::write(&source, &payload)?;
+
+        let tag_info = fixture
+            .store
+            .blobs()
+            .add_path_with_opts(AddPathOptions {
+                path: source.clone(),
+                format: BlobFormat::Raw,
+                mode: ImportMode::TryReference,
+            })
+            .await?;
+        let digest = IrohBlobTransferAdapter::core_digest(tag_info.hash);
+        let ticket = fixture.adapter.issue_ticket(&digest).await?;
+
+        let target = dir.path().join("out.bin");
+        let returned = fixture
+            .adapter
+            .fetch_to_path(&ticket, &target, None)
+            .await?;
+
+        assert_eq!(returned, digest);
+        let fetched = std::fs::read(&target)?;
+        assert_eq!(fetched, payload);
         fixture.shutdown().await?;
         Ok(())
     }

--- a/src-tauri/crates/uc-infra/src/network/iroh/blobs.rs
+++ b/src-tauri/crates/uc-infra/src/network/iroh/blobs.rs
@@ -192,18 +192,118 @@ impl BlobTransferPort for IrohBlobTransferAdapter {
         progress: Option<&dyn BlobProgressSink>,
     ) -> Result<Bytes, BlobError> {
         let native = Self::parse_ticket(ticket)?;
+        self.ensure_blob_in_store(&native, progress).await?;
+        self.store
+            .blobs()
+            .get_bytes(native.hash())
+            .await
+            .map_err(|e| BlobError::Unavailable(e.to_string()))
+    }
+
+    #[instrument(skip_all, fields(target = %target_path.display()))]
+    async fn fetch_to_path(
+        &self,
+        ticket: &BlobTicket,
+        target_path: &std::path::Path,
+        progress: Option<&dyn BlobProgressSink>,
+    ) -> Result<BlobDigest, BlobError> {
+        // GH#487 Phase 2 (receive-side mirror of the publish_path streaming
+        // import):after the download loop has materialised the blob in the
+        // local iroh store, hand it to `Blobs::export(hash, target)` instead
+        // of slurping it back through `get_bytes() -> Bytes -> tokio::fs::write`.
+        // `export` defaults to `ExportMode::Copy`, which on CoW filesystems
+        // (APFS / Btrfs / ReFS) is a reflink — zero-copy, near-instant,
+        // independent of blob size — and on plain filesystems falls back to
+        // a stream copy that stays bounded by chunk size. Either way the
+        // peak RSS no longer carries the whole plaintext.
+        let native = Self::parse_ticket(ticket)?;
+        let digest = Self::core_digest(native.hash());
+        let hash_prefix = hex_prefix(native.hash().as_bytes());
+
+        self.ensure_blob_in_store(&native, progress).await?;
+
+        let export_start = Instant::now();
+        let bytes_written = self
+            .store
+            .blobs()
+            .export(native.hash(), target_path)
+            .await
+            .map_err(|e| BlobError::Internal(e.to_string()))?;
+        info!(
+            hash = %hash_prefix,
+            bytes = bytes_written,
+            export_ms = export_start.elapsed().as_millis() as u64,
+            "blob fetch_to_path: export completed (streaming)"
+        );
+        Ok(digest)
+    }
+
+    #[instrument(skip_all)]
+    async fn has(&self, digest: &BlobDigest) -> Result<bool, BlobError> {
+        let hash = Self::native_hash(digest);
+        let observed = self
+            .store
+            .blobs()
+            .observe(hash)
+            .await
+            .map_err(|e| BlobError::Internal(e.to_string()))?;
+        Ok(observed.is_complete())
+    }
+
+    #[instrument(skip_all)]
+    async fn tag(&self, digest: &BlobDigest, reason: TagReason) -> Result<(), BlobError> {
+        let name = Self::tag_name(&reason);
+        self.store
+            .tags()
+            .set(
+                name.as_bytes(),
+                HashAndFormat::raw(Self::native_hash(digest)),
+            )
+            .await
+            .map_err(|e| BlobError::Internal(e.to_string()))
+    }
+
+    #[instrument(skip_all)]
+    async fn untag(&self, _digest: &BlobDigest, reason: TagReason) -> Result<(), BlobError> {
+        let name = Self::tag_name(&reason);
+        let removed = self
+            .store
+            .tags()
+            .delete(name.as_bytes())
+            .await
+            .map_err(|e| BlobError::Internal(e.to_string()))?;
+        debug!(removed, "blob tag removed");
+        Ok(())
+    }
+
+    fn digest_of(&self, ticket: &BlobTicket) -> Result<BlobDigest, BlobError> {
+        let native = Self::parse_ticket(ticket)?;
+        Ok(Self::core_digest(native.hash()))
+    }
+}
+
+impl IrohBlobTransferAdapter {
+    /// Make sure the local iroh store holds the blob the ticket points at,
+    /// either by serving the existing copy or by running the full
+    /// `pre-connect → downloader → retry` loop. Shared between
+    /// [`fetch`](BlobTransferPort::fetch) (which then `get_bytes`s the
+    /// store back into memory) and
+    /// [`fetch_to_path`](BlobTransferPort::fetch_to_path) (which then
+    /// `export`s the store entry into a target file). Pulling the loop
+    /// up here keeps the two trait methods in lockstep on retries,
+    /// progress sink semantics, and connection-pool warm-up.
+    async fn ensure_blob_in_store(
+        &self,
+        native: &NativeBlobTicket,
+        progress: Option<&dyn BlobProgressSink>,
+    ) -> Result<(), BlobError> {
         let digest = Self::core_digest(native.hash());
         let hash_prefix = hex_prefix(native.hash().as_bytes());
         let provider_id = native.addr().id;
 
         if self.has(&digest).await? {
             info!(hash = %hash_prefix, "blob fetch: local hit, skipping network");
-            return self
-                .store
-                .blobs()
-                .get_bytes(native.hash())
-                .await
-                .map_err(|e| BlobError::Internal(e.to_string()));
+            return Ok(());
         }
 
         // Pre-connect to seed the iroh endpoint's address lookup with the
@@ -426,54 +526,7 @@ impl BlobTransferPort for IrohBlobTransferAdapter {
             "blob fetch: download complete"
         );
 
-        self.store
-            .blobs()
-            .get_bytes(native.hash())
-            .await
-            .map_err(|e| BlobError::Unavailable(e.to_string()))
-    }
-
-    #[instrument(skip_all)]
-    async fn has(&self, digest: &BlobDigest) -> Result<bool, BlobError> {
-        let hash = Self::native_hash(digest);
-        let observed = self
-            .store
-            .blobs()
-            .observe(hash)
-            .await
-            .map_err(|e| BlobError::Internal(e.to_string()))?;
-        Ok(observed.is_complete())
-    }
-
-    #[instrument(skip_all)]
-    async fn tag(&self, digest: &BlobDigest, reason: TagReason) -> Result<(), BlobError> {
-        let name = Self::tag_name(&reason);
-        self.store
-            .tags()
-            .set(
-                name.as_bytes(),
-                HashAndFormat::raw(Self::native_hash(digest)),
-            )
-            .await
-            .map_err(|e| BlobError::Internal(e.to_string()))
-    }
-
-    #[instrument(skip_all)]
-    async fn untag(&self, _digest: &BlobDigest, reason: TagReason) -> Result<(), BlobError> {
-        let name = Self::tag_name(&reason);
-        let removed = self
-            .store
-            .tags()
-            .delete(name.as_bytes())
-            .await
-            .map_err(|e| BlobError::Internal(e.to_string()))?;
-        debug!(removed, "blob tag removed");
         Ok(())
-    }
-
-    fn digest_of(&self, ticket: &BlobTicket) -> Result<BlobDigest, BlobError> {
-        let native = Self::parse_ticket(ticket)?;
-        Ok(Self::core_digest(native.hash()))
     }
 }
 
@@ -551,6 +604,35 @@ mod tests {
         let second = fixture.adapter.publish(payload).await?;
 
         assert_eq!(first, second);
+        fixture.shutdown().await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn fetch_to_path_writes_local_hit_to_target() -> anyhow::Result<()> {
+        // GH#487 Phase 2: when the blob is already in the local store
+        // (e.g. publisher fetching its own ticket), fetch_to_path must
+        // export it directly to the target path without going through
+        // the network or materialising the bytes in memory.
+        let fixture = Fixture::bind().await?;
+        fixture.wait_for_direct_addr().await?;
+        let payload = b"gh-487-fetch-to-path-local-hit".to_vec();
+        let digest = fixture
+            .adapter
+            .publish(Bytes::from(payload.clone()))
+            .await?;
+        let ticket = fixture.adapter.issue_ticket(&digest).await?;
+
+        let dir = tempdir()?;
+        let target = dir.path().join("out.bin");
+        let returned = fixture
+            .adapter
+            .fetch_to_path(&ticket, &target, None)
+            .await?;
+
+        assert_eq!(returned, digest);
+        let written = std::fs::read(&target)?;
+        assert_eq!(written, payload);
         fixture.shutdown().await?;
         Ok(())
     }

--- a/src-tauri/crates/uc-infra/src/network/iroh/blobs.rs
+++ b/src-tauri/crates/uc-infra/src/network/iroh/blobs.rs
@@ -145,6 +145,32 @@ impl BlobTransferPort for IrohBlobTransferAdapter {
         Ok(Self::core_digest(tag.hash))
     }
 
+    #[instrument(skip_all, fields(path = %path.display()))]
+    async fn publish_path(&self, path: &std::path::Path) -> Result<BlobDigest, BlobError> {
+        // GH#487 P1 streaming publish:走 iroh-blobs 的 add_path 入口,内部
+        // 由 reflink_or_copy_with_progress 把磁盘文件 stream 到 store(在
+        // APFS / Btrfs / ReFS 等 CoW FS 上是 reflink 零拷贝;NTFS / ext4 上
+        // fallback 真拷贝,但仍是 stream)+ 增量算 BAO outboard。整段过程
+        // 内存峰值受 iroh chunk size 主导,与文件大小无关。
+        //
+        // 旧路径(`tokio::fs::read(path) → Bytes::from → publish(Bytes) →
+        // add_bytes`)在 1GB 文件上需要 1×plaintext + 1×Bytes ≈ 2GB 临时
+        // 内存,且在 publish 完成前阻塞 outbound dispatch 主流程 ~11s。
+        let started = Instant::now();
+        let tag_info = self
+            .store
+            .blobs()
+            .add_path(path)
+            .await
+            .map_err(|e| BlobError::Internal(e.to_string()))?;
+        info!(
+            add_path_ms = started.elapsed().as_millis() as u64,
+            blob_hash = %hex_prefix(tag_info.hash.as_bytes()),
+            "iroh blob publish: add_path completed (streaming)"
+        );
+        Ok(Self::core_digest(tag_info.hash))
+    }
+
     #[instrument(skip_all)]
     async fn issue_ticket(&self, digest: &BlobDigest) -> Result<BlobTicket, BlobError> {
         if !self.has(digest).await? {
@@ -525,6 +551,29 @@ mod tests {
         let second = fixture.adapter.publish(payload).await?;
 
         assert_eq!(first, second);
+        fixture.shutdown().await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn publish_path_returns_same_digest_as_publish_bytes() -> anyhow::Result<()> {
+        // GH#487 P1: streaming path 必须与全内存 publish 产出一致的
+        // content-addressed digest,否则发送端 / 接收端协议上的 ticket /
+        // dedup 会全部断裂。
+        let fixture = Fixture::bind().await?;
+        let payload = b"gh-487-streaming-publish-path-payload-hello".to_vec();
+
+        let dir = tempdir()?;
+        let path = dir.path().join("payload.bin");
+        std::fs::write(&path, &payload)?;
+
+        let bytes_digest = fixture
+            .adapter
+            .publish(Bytes::from(payload.clone()))
+            .await?;
+        let path_digest = fixture.adapter.publish_path(&path).await?;
+
+        assert_eq!(bytes_digest, path_digest);
         fixture.shutdown().await?;
         Ok(())
     }

--- a/src-tauri/crates/uc-infra/src/network/iroh/blobs.rs
+++ b/src-tauri/crates/uc-infra/src/network/iroh/blobs.rs
@@ -12,6 +12,7 @@ use bytes::Bytes;
 use futures_util::StreamExt;
 use iroh::{Endpoint, EndpointId, Watcher};
 use iroh_blobs::{
+    api::blobs::{ExportMode, ExportOptions},
     api::downloader::{DownloadProgressItem, Downloader},
     store::fs::FsStore,
     ticket::BlobTicket as NativeBlobTicket,
@@ -207,15 +208,27 @@ impl BlobTransferPort for IrohBlobTransferAdapter {
         target_path: &std::path::Path,
         progress: Option<&dyn BlobProgressSink>,
     ) -> Result<BlobDigest, BlobError> {
-        // GH#487 Phase 2 (receive-side mirror of the publish_path streaming
-        // import):after the download loop has materialised the blob in the
-        // local iroh store, hand it to `Blobs::export(hash, target)` instead
-        // of slurping it back through `get_bytes() -> Bytes -> tokio::fs::write`.
-        // `export` defaults to `ExportMode::Copy`, which on CoW filesystems
-        // (APFS / Btrfs / ReFS) is a reflink — zero-copy, near-instant,
-        // independent of blob size — and on plain filesystems falls back to
-        // a stream copy that stays bounded by chunk size. Either way the
-        // peak RSS no longer carries the whole plaintext.
+        // GH#487 receive-side stream-out:走 `ExportMode::TryReference`,而不是
+        // `Blobs::export()` 默认的 `ExportMode::Copy`。
+        //
+        // `Copy` 在无 reflink 的 FS(NTFS / ext4)上 fallback 成 stream copy ——
+        // 把 store 里 owned data file 再写一遍到 target_path,800 MB 实测 ~19.5s,
+        // 与文件大小线性。
+        //
+        // `TryReference` 行为(iroh-blobs 0.97 `store/fs.rs:1281-1313`):
+        //   - target 与 store_dir **同卷**(典型场景:都装在 AppData / $HOME):
+        //     `std::fs::rename(store_owned_data, target)` —— 元数据操作 ~0ms,
+        //     与文件大小无关
+        //   - **跨卷**(rename 返回 ERR_CROSS):fallback 到
+        //     `reflink_or_copy_with_progress`,行为与 `Copy` 等同,不会更差
+        //   - 完成后 store entry 状态转为 External(指向 target),不再持有
+        //     owned 副本。`has(digest)` 仍报告 complete(由
+        //     `fetch_to_path_keeps_blob_observable_after_export` 测试覆盖契约),
+        //     `issue_ticket` 仍可签发,tag/untag 仍工作。
+        //
+        // 副作用:本端 store 不再持有 blob 的本地副本,无法再向其他对端转发
+        // 该 blob。但 clipboard 同步是单跳(sender → receiver),没人会再向
+        // receiver 拉同一个 blob,这条能力实际无人使用,可接受。
         let native = Self::parse_ticket(ticket)?;
         let digest = Self::core_digest(native.hash());
         let hash_prefix = hex_prefix(native.hash().as_bytes());
@@ -226,14 +239,18 @@ impl BlobTransferPort for IrohBlobTransferAdapter {
         let bytes_written = self
             .store
             .blobs()
-            .export(native.hash(), target_path)
+            .export_with_opts(ExportOptions {
+                hash: native.hash(),
+                mode: ExportMode::TryReference,
+                target: target_path.to_owned(),
+            })
             .await
             .map_err(|e| BlobError::Internal(e.to_string()))?;
         info!(
             hash = %hash_prefix,
             bytes = bytes_written,
             export_ms = export_start.elapsed().as_millis() as u64,
-            "blob fetch_to_path: export completed (streaming)"
+            "blob fetch_to_path: export completed (TryReference)"
         );
         Ok(digest)
     }
@@ -633,6 +650,83 @@ mod tests {
         assert_eq!(returned, digest);
         let written = std::fs::read(&target)?;
         assert_eq!(written, payload);
+        fixture.shutdown().await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn fetch_to_path_try_reference_writes_correct_bytes_above_inline_limit(
+    ) -> anyhow::Result<()> {
+        // GH#487 receive-side TryReference: payload must exceed iroh-blobs'
+        // default 16 KiB inline threshold so the store actually holds an
+        // owned data file (the only case TryReference's `fs::rename` branch
+        // can fire). With a small payload the store keeps the bytes inline
+        // and `export` falls through to a write-from-memory path, which
+        // would mask any rename-vs-copy regression.
+        let fixture = Fixture::bind().await?;
+        fixture.wait_for_direct_addr().await?;
+        let payload = vec![0x5au8; 64 * 1024];
+        let digest = fixture
+            .adapter
+            .publish(Bytes::from(payload.clone()))
+            .await?;
+        let ticket = fixture.adapter.issue_ticket(&digest).await?;
+
+        let dir = tempdir()?;
+        let target = dir.path().join("big.bin");
+        let returned = fixture
+            .adapter
+            .fetch_to_path(&ticket, &target, None)
+            .await?;
+
+        assert_eq!(returned, digest);
+        let written = std::fs::read(&target)?;
+        assert_eq!(written.len(), payload.len());
+        assert_eq!(written, payload);
+        fixture.shutdown().await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn fetch_to_path_keeps_blob_observable_after_export() -> anyhow::Result<()> {
+        // GH#487 receive-side TryReference contract regression: after export
+        // the iroh store transitions the entry to External(target_path) and
+        // drops its owned data file. `has(digest)` must still report
+        // complete and `issue_ticket` must still succeed — otherwise tag
+        // bookkeeping (TagReason::ClipboardEntry) and any "show me the
+        // blobs we have" diagnostics would silently break.
+        let fixture = Fixture::bind().await?;
+        fixture.wait_for_direct_addr().await?;
+        let payload = vec![0xa5u8; 64 * 1024];
+        let digest = fixture
+            .adapter
+            .publish(Bytes::from(payload.clone()))
+            .await?;
+        let ticket = fixture.adapter.issue_ticket(&digest).await?;
+
+        let dir = tempdir()?;
+        let target = dir.path().join("exported.bin");
+        fixture
+            .adapter
+            .fetch_to_path(&ticket, &target, None)
+            .await?;
+
+        assert!(
+            fixture.adapter.has(&digest).await?,
+            "has() must still report complete for an externally referenced entry"
+        );
+        let _reissued = fixture
+            .adapter
+            .issue_ticket(&digest)
+            .await
+            .expect("issue_ticket must succeed for an externally referenced entry");
+
+        // Tag/untag must still work — clipboard_sync uses these to pin
+        // blobs to a ClipboardEntry and clean up on entry deletion.
+        let reason = TagReason::ClipboardEntry(EntryId::from_str("entry-after-export"));
+        fixture.adapter.tag(&digest, reason.clone()).await?;
+        fixture.adapter.untag(&digest, reason).await?;
+
         fixture.shutdown().await?;
         Ok(())
     }


### PR DESCRIPTION
## 摘要

按 #487 的四步,把"复制大文件 → 跨端落地"的发送 / 接收两侧都从全量内存 + 真拷贝改成流式 + reference,目标是消除 NTFS 上的 ~21 s 发送阻塞与 ~19.5 s 接收写盘:

- **P1 流式 `publish_path`**:`BlobTransferPort` 增加流式入口,outbound 不再 `tokio::fs::read` 全量进 `Bytes`,1 GiB 文件 RSS 受 chunk size 而非文件大小主导。
- **Phase 2 流式 `fetch_to_path`**:对称的接收侧入口,`apply_inbound::materializer` 直接把 blob `export` 到 cache_dir,不再走 `Bytes → tokio::fs::write` 二次写。
- **Step 1 接收端 `ExportMode::TryReference`** *(全平台默认)*:同卷 `fs::rename` 把 ~19.5 s 写盘降到 ~0 ms;跨卷自动 fallback 到 `reflink_or_copy_with_progress`,行为与现状等同,不会更差。
- **Step 2 发送端 `ImportMode::TryReference`** *(`cfg(target_os = "windows")` 限定)*:NTFS 上 ~21 s 真拷贝消失,只剩 read + BAO;APFS / Btrfs / XFS reflink 路径不动,平台分支收口在 `preferred_import_mode()`。

## 验证

- `cargo test -p uc-infra` blobs adapter:含 5 个 GH#487 新增契约测试(跨 mode digest 一致 / 平台条件 / External entry 仍可观察 / TryReference 字节正确)全过
- `cargo test -p uc-application`:`apply_inbound` 测试更新到新 `fetch_blob_to_path` 路径,231 个测试全过
- 注释里固化每条决策的代码定位(iroh-blobs 0.97 `store/fs/import.rs:485` 与 `store/fs.rs:1281`)与 NTFS 实测数据,后续维护者可直接溯源

## 不在范围

- TryReference 模式下"对端 BAO 校验失败 → sender 重 import 为 Copy 重传"反向通道(需新错误变体 + 反向通知链路,作为 #487 后续)
- ext4 Linux 用户的发送侧优化(用户量小,留待运行时卷探测重构再做)