### PR TITLE
style(clipboard-ui): drop transfer-state ring on row

### DIFF
--- a/src/components/clipboard/ClipboardItemRow.tsx
+++ b/src/components/clipboard/ClipboardItemRow.tsx
@@ -143,9 +143,6 @@ const ClipboardItemRow = React.forwardRef<HTMLDivElement, ClipboardItemRowProps>
         className={cn(
           'flex flex-col gap-1 py-2.5 px-3 rounded-lg cursor-pointer select-none transition-colors shrink-0 overflow-hidden',
           isActive ? 'bg-primary/10 text-foreground' : 'hover:bg-muted/50 text-foreground/80',
-          isTransferring && 'ring-1 ring-primary/20',
-          isTransferFailed && 'ring-1 ring-destructive/20',
-          isPending && 'ring-1 ring-muted-foreground/20',
           extraClassName
         )}
         onClick={onClick}


### PR DESCRIPTION
## Summary
- Remove `ring-1` classes on `ClipboardItemRow` for `pending` / `transferring` / `failed` states — they rendered a border-like outline that looked out of place against the rest of the list.
- Transfer status is still surfaced by the right-side icon badges (`Clock`, `Loader2`, `AlertCircle`), so no information is lost.

## Test plan
- [ ] Trigger a file transfer and confirm the row no longer shows a 1px ring while pending / transferring / failed.
- [ ] Verify the right-side status icon (clock / spinner / alert) still appears in each state.
- [ ] Confirm the active row's `bg-primary/10` highlight and hover state are unchanged.