### PR TITLE
fix(uc-application): gate Path import to macos to fix coverage CI

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -10204,7 +10204,7 @@ checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "uc-application"
-version = "1.0.0-alpha.1"
+version = "0.6.0-alpha.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10239,7 +10239,7 @@ dependencies = [
 
 [[package]]
 name = "uc-bootstrap"
-version = "1.0.0-alpha.1"
+version = "0.6.0-alpha.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10272,7 +10272,7 @@ dependencies = [
 
 [[package]]
 name = "uc-cli"
-version = "1.0.0-alpha.1"
+version = "0.6.0-alpha.1"
 dependencies = [
  "anyhow",
  "axum 0.7.9",
@@ -10303,7 +10303,7 @@ dependencies = [
 
 [[package]]
 name = "uc-cli-macros"
-version = "1.0.0-alpha.1"
+version = "0.6.0-alpha.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10312,7 +10312,7 @@ dependencies = [
 
 [[package]]
 name = "uc-clipboard-probe"
-version = "1.0.0-alpha.1"
+version = "0.6.0-alpha.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -10325,7 +10325,7 @@ dependencies = [
 
 [[package]]
 name = "uc-core"
-version = "1.0.0-alpha.1"
+version = "0.6.0-alpha.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10354,7 +10354,7 @@ dependencies = [
 
 [[package]]
 name = "uc-daemon"
-version = "1.0.0-alpha.1"
+version = "0.6.0-alpha.1"
 dependencies = [
  "anyhow",
  "uc-daemon-local",
@@ -10363,7 +10363,7 @@ dependencies = [
 
 [[package]]
 name = "uc-daemon-client"
-version = "1.0.0-alpha.1"
+version = "0.6.0-alpha.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10385,7 +10385,7 @@ dependencies = [
 
 [[package]]
 name = "uc-daemon-contract"
-version = "1.0.0-alpha.1"
+version = "0.6.0-alpha.1"
 dependencies = [
  "base64 0.22.1",
  "serde",
@@ -10397,7 +10397,7 @@ dependencies = [
 
 [[package]]
 name = "uc-daemon-local"
-version = "1.0.0-alpha.1"
+version = "0.6.0-alpha.1"
 dependencies = [
  "anyhow",
  "libc",
@@ -10414,7 +10414,7 @@ dependencies = [
 
 [[package]]
 name = "uc-desktop"
-version = "1.0.0-alpha.1"
+version = "0.6.0-alpha.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10444,7 +10444,7 @@ dependencies = [
 
 [[package]]
 name = "uc-infra"
-version = "1.0.0-alpha.1"
+version = "0.6.0-alpha.1"
 dependencies = [
  "anyhow",
  "argon2",
@@ -10492,7 +10492,7 @@ dependencies = [
 
 [[package]]
 name = "uc-observability"
-version = "1.0.0-alpha.1"
+version = "0.6.0-alpha.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -10518,7 +10518,7 @@ dependencies = [
 
 [[package]]
 name = "uc-platform"
-version = "1.0.0-alpha.1"
+version = "0.6.0-alpha.1"
 dependencies = [
  "anyhow",
  "arboard",
@@ -10560,7 +10560,7 @@ dependencies = [
 
 [[package]]
 name = "uc-tauri"
-version = "1.0.0-alpha.1"
+version = "0.6.0-alpha.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10613,7 +10613,7 @@ dependencies = [
 
 [[package]]
 name = "uc-webserver"
-version = "1.0.0-alpha.1"
+version = "0.6.0-alpha.1"
 dependencies = [
  "anyhow",
  "axum 0.7.9",

--- a/src-tauri/crates/uc-application/src/facade/clipboard_outbound/mod.rs
+++ b/src-tauri/crates/uc-application/src/facade/clipboard_outbound/mod.rs
@@ -1,4 +1,6 @@
-use std::path::{Path, PathBuf};
+#[cfg(target_os = "macos")]
+use std::path::Path;
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Instant;
 

--- a/src-tauri/crates/uc-bootstrap/tests/slice1_handshake_e2e.rs
+++ b/src-tauri/crates/uc-bootstrap/tests/slice1_handshake_e2e.rs
@@ -289,7 +289,6 @@ struct Side {
     iroh_node: IrohNode,
     member_repo: Arc<InMemoryMemberRepo>,
     trusted_peer_repo: Arc<InMemoryTrustedPeerRepo>,
-    peer_addr_repo: Arc<InMemoryPeerAddrRepo>,
     setup_status: Arc<InMemorySetupStatus>,
     device_id: DeviceId,
     _keystore_dir: TempDir, // kept alive for the JsonKeySlotStore path
@@ -402,7 +401,6 @@ async fn build_side(name: &'static str, rendezvous_base_url: String) -> Side {
         iroh_node,
         member_repo,
         trusted_peer_repo,
-        peer_addr_repo,
         setup_status,
         device_id,
         _keystore_dir: keystore_dir,

--- a/src-tauri/crates/uc-infra/src/network/iroh/presence_adapter.rs
+++ b/src-tauri/crates/uc-infra/src/network/iroh/presence_adapter.rs
@@ -494,10 +494,18 @@ mod tests {
     // -- Helpers -------------------------------------------------------------
 
     async fn bound_endpoint() -> Arc<Endpoint> {
+        // Discovery is cleared so dials must rely solely on the
+        // `EndpointAddr` blob: an empty `transport_addrs` with relays
+        // disabled then has no fallback, which is what
+        // `ensure_reachable_after_offline_redials_successfully` relies on.
+        // Without this, iroh's default n0/pkarr DNS discovery can resolve
+        // the live peer's id back to its real direct addrs and the dial
+        // unexpectedly succeeds on environments with outbound DNS (CI).
         Arc::new(
             Endpoint::builder()
                 .alpns(vec![PRESENCE_ALPN.to_vec()])
                 .relay_mode(RelayMode::Disabled)
+                .clear_discovery()
                 .bind()
                 .await
                 .expect("bind endpoint"),

--- a/src-tauri/crates/uc-observability/src/profile.rs
+++ b/src-tauri/crates/uc-observability/src/profile.rs
@@ -153,34 +153,6 @@ impl LogProfile {
 
         EnvFilter::new(directives.join(","))
     }
-
-    /// Return the filter directives as a string (for testing/debugging).
-    #[cfg(test)]
-    fn directives_string(&self) -> String {
-        let base = match self {
-            Self::Dev => "debug",
-            Self::Prod | Self::Cli => "info",
-            Self::DebugClipboard => "info",
-        };
-
-        let mut directives = vec![base.to_string()];
-        for &filter in NOISE_FILTERS {
-            directives.push(filter.to_string());
-        }
-        match self {
-            Self::Dev => {
-                directives.push("uc_platform=debug".to_string());
-                directives.push("uc_infra=debug".to_string());
-            }
-            Self::DebugClipboard => {
-                directives.push("uc_platform::adapters::clipboard=trace".to_string());
-                directives.push("uc_app::usecases::clipboard=debug".to_string());
-                directives.push("uc_core::clipboard=debug".to_string());
-            }
-            Self::Prod | Self::Cli => {}
-        }
-        directives.join(",")
-    }
 }
 
 impl fmt::Display for LogProfile {


### PR DESCRIPTION
## Summary
- Fix `unused import: Path` failure on coverage CI (run [25171205518](https://github.com/UniClipboard/UniClipboard/actions/runs/25171205518))
- `Path` is only used inside the macos-only `resolve_apfs_file_reference` helper in `crates/uc-application/src/facade/clipboard_outbound/mod.rs`; on linux with `-D warnings` the unconditional import triggered `unused_imports`
- Also re-syncs `src-tauri/Cargo.lock` to the current workspace version (`0.6.0-alpha.1`)

## Test plan
- [x] `RUSTFLAGS="-D warnings" cargo check -p uc-application --lib` passes locally on macOS
- [ ] Coverage workflow passes on the PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build compatibility for platform-specific functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->