### PR TITLE
fix(ci): align CLI bin name with cargo target (uniclip) in build workflow

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -127,7 +127,7 @@ jobs:
           echo "Signing with: $IDENTITY"
 
           TARGET="${{ matrix.target }}"
-          BIN_NAME="uniclipboard-cli"
+          BIN_NAME="uniclip"
           BIN_PATH="src-tauri/target/${TARGET}/release/${BIN_NAME}"
           if [ ! -f "$BIN_PATH" ]; then
             BIN_PATH="src-tauri/target/release/${BIN_NAME}"
@@ -144,7 +144,7 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
           TARGET="${{ matrix.target }}"
-          BIN_NAME="uniclipboard-cli"
+          BIN_NAME="uniclip"
           BIN_PATH="src-tauri/target/${TARGET}/release/${BIN_NAME}"
           if [ ! -f "$BIN_PATH" ]; then
             BIN_PATH="src-tauri/target/release/${BIN_NAME}"
@@ -169,7 +169,7 @@ jobs:
         run: |
           VERSION=$(node -p "require('./package.json').version")
           TARGET="${{ matrix.target }}"
-          BIN_NAME="uniclipboard-cli"
+          BIN_NAME="uniclip"
 
           if [ "${{ matrix.platform }}" = "windows-latest" ]; then
             BIN_SRC="src-tauri/target/release/${BIN_NAME}.exe"


### PR DESCRIPTION
## Summary
- The `uc-cli` crate's `[[bin]] name` was renamed from `uniclipboard-cli` to `uniclip` in 44a919ce, but `.github/workflows/build-cli.yml` still hard-coded the old name when locating the binary for codesign, notarization, and packaging, causing `tar: uniclipboard-cli: Cannot stat: No such file or directory` (run 25197832379).
- Updated the three `BIN_NAME` assignments to `uniclip` so they match cargo's actual output.
- Outer archive filename (`uniclipboard-cli-\${VERSION}-\${TARGET}.{tar.gz,zip}`) and the `upload-artifact` glob are intentionally preserved because `release.yml` and `scripts/generate-release-notes.js` filter on the `uniclipboard-cli-` prefix.

## Test plan
- [ ] Re-run the Build CLI workflow on this branch and confirm all four matrix targets produce signed/packaged archives.
- [ ] Confirm release.yml's CLI archive collection step still finds the artifacts.