### PR TITLE
fix(ci): decouple homebrew tap update from release workflow

### DIFF
--- a/.github/workflows/homebrew-tap.yml
+++ b/.github/workflows/homebrew-tap.yml
@@ -1,0 +1,60 @@
+name: 'Homebrew Tap'
+run-name: >-
+  ${{ github.event_name == 'release'
+    && format('homebrew-tap-{0}', github.event.release.tag_name)
+    || format('homebrew-tap-manual-{0}', inputs.version) }}
+
+# Trigger the homebrew tap update only after a release transitions to
+# `published`. The Release workflow leaves stable releases in draft so a human
+# can review the generated notes; once they hit "Publish", this listener fires
+# and the asset URLs are guaranteed to be reachable (no draft 404 race).
+#
+# `workflow_dispatch` is exposed for debugging — handy when re-running against
+# an existing release without un-publishing it.
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: '版本号 (不带 v 前缀, e.g. 0.5.0)'
+        required: true
+        type: string
+
+jobs:
+  trigger:
+    name: Trigger tap update
+    # Skip prereleases on the auto path; manual dispatch always runs so we can
+    # debug against any version.
+    if: github.event_name == 'workflow_dispatch' || github.event.release.prerelease == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve version
+        id: resolve
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          TAG: ${{ github.event.release.tag_name }}
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            VERSION="${INPUT_VERSION#v}"
+          else
+            VERSION="${TAG#v}"
+          fi
+
+          if [ -z "$VERSION" ]; then
+            echo "Could not derive version (event=$EVENT_NAME tag=$TAG input=$INPUT_VERSION)" >&2
+            exit 1
+          fi
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Resolved version: $VERSION"
+
+      - name: Trigger tap update
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          VERSION: ${{ steps.resolve.outputs.version }}
+        run: |
+          gh workflow run update-tap.yml \
+            --repo UniClipboard/homebrew-tap \
+            --field version="$VERSION"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -381,17 +381,3 @@ jobs:
           REPO_OWNER=$(echo "${{ github.repository }}" | cut -d'/' -f1)
           REPO_NAME=$(echo "${{ github.repository }}" | cut -d'/' -f2)
           echo "https://${REPO_OWNER}.github.io/${REPO_NAME}/${{ needs.validate.outputs.channel }}.json" >> $GITHUB_STEP_SUMMARY
-
-  update-homebrew-tap:
-    name: Update Homebrew Tap
-    needs: [validate, create-release]
-    if: needs.validate.outputs.is_prerelease == 'false'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Trigger tap update
-        env:
-          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
-        run: |
-          gh workflow run update-tap.yml \
-            --repo UniClipboard/homebrew-uniclipboard \
-            --field version="${{ needs.validate.outputs.version }}"

--- a/README.md
+++ b/README.md
@@ -101,6 +101,29 @@ It enables seamless and secure syncing of text, images, and files across multipl
 
 Visit the [GitHub Releases](https://github.com/UniClipboard/UniClipboard/releases) page to download the installation package for your operating system.
 
+### Homebrew (macOS)
+
+On macOS, install via the official tap [`UniClipboard/homebrew-tap`](https://github.com/UniClipboard/homebrew-tap):
+
+```bash
+brew tap UniClipboard/tap
+
+# Desktop app (.app bundle)
+brew install --cask uniclipboard
+
+# CLI only — installs the `uniclip` command
+brew install uniclipboard
+```
+
+Or install in a single command without tapping first:
+
+```bash
+brew install --cask UniClipboard/tap/uniclipboard   # GUI
+brew install UniClipboard/tap/uniclipboard          # CLI
+```
+
+The cask and the formula can coexist — install both if you want the GUI plus the `uniclip` command.
+
 ### Build from Source
 
 ```bash

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -101,6 +101,29 @@ UniClipboard 是一款以**隐私优先**为核心理念的跨设备剪贴板同
 
 访问 [GitHub Releases](https://github.com/UniClipboard/UniClipboard/releases) 页面，下载适合您操作系统的安装包。
 
+### Homebrew（macOS）
+
+macOS 用户可以通过官方 tap [`UniClipboard/homebrew-tap`](https://github.com/UniClipboard/homebrew-tap) 安装：
+
+```bash
+brew tap UniClipboard/tap
+
+# 桌面应用（.app）
+brew install --cask uniclipboard
+
+# 仅安装 CLI，命令名为 `uniclip`
+brew install uniclipboard
+```
+
+也可以省去 `brew tap`，一行直装：
+
+```bash
+brew install --cask UniClipboard/tap/uniclipboard   # GUI
+brew install UniClipboard/tap/uniclipboard          # CLI
+```
+
+GUI 和 CLI 互不冲突，需要的话两个都装即可。
+
 ### 从源码构建
 
 ```bash


### PR DESCRIPTION
## Summary

- Stable releases (v0.4.0, v0.4.1, v0.5.0) all silently failed to update the Homebrew tap because the in-line `update-homebrew-tap` job ran while the GitHub release was still in draft, and draft assets return 404 on the public download URL.
- Replace the in-line job with a dedicated `Homebrew Tap` workflow that listens on `release: published`, so it only fires after a human publishes the draft and asset URLs are guaranteed reachable. A `workflow_dispatch` entry point is also exposed for manual debug runs.
- The dispatch target is also updated to the renamed `UniClipboard/homebrew-tap` repo.
- Add Homebrew install instructions (cask + formula) to both `README.md` and `README_ZH.md`.

## Test plan

- [ ] Manually trigger the new `Homebrew Tap` workflow against `0.5.0` from the Actions UI and confirm it kicks off `update-tap.yml` on `UniClipboard/homebrew-tap` successfully.
- [ ] Cut the next stable release end-to-end and verify the tap update runs automatically once the draft release is published.
- [ ] Render the README on GitHub and confirm the new "Homebrew (macOS)" section formats correctly in both EN and ZH versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * macOS Homebrew installation now available for both the desktop application and CLI tool.

* **Documentation**
  * Added Homebrew installation instructions in English and Chinese documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->