### PR TITLE
fix(devices): keep invite dialog mounted across spaceMembers transition

### DIFF
--- a/src/components/device/AddDeviceDialog.tsx
+++ b/src/components/device/AddDeviceDialog.tsx
@@ -70,6 +70,9 @@ export default function AddDeviceDialog({ open, onOpenChange }: AddDeviceDialogP
   // ref 镜像 step / loading，供 ws 回调判断且避免 effect 因依赖变更重订阅
   const stepRef = useRef<Step>('invitation')
   const loadingRef = useRef(false)
+  // 标记本次 open 是否已经初始化过邀请。effect 因 t 引用变化、Strict Mode
+  // 双跑或父组件结构切换重挂载等原因被重跑时，不要重复 issue 新邀请。
+  const initializedRef = useRef(false)
   useEffect(() => {
     stepRef.current = step
   }, [step])
@@ -88,6 +91,12 @@ export default function AddDeviceDialog({ open, onOpenChange }: AddDeviceDialogP
   // 后端约束"同一时刻一个邀请"，关闭对话框不取消邀请，重开会拿回同一个
   useEffect(() => {
     if (!open) return
+    // 防止 effect 重跑导致重复申请邀请。例如：配对成功后父组件因 spaceMembers
+    // 变化重渲染，又或者 i18n 资源 reload 让 t 引用变化 — 这些都不应该触发
+    // 第二次 issuePairingInvitation()，否则 step='success' 还没显示完就被新
+    // 邀请码覆盖了。重置在 line 184 的关闭副作用里完成。
+    if (initializedRef.current) return
+    initializedRef.current = true
     let cancelled = false
     void (async () => {
       setLoading(true)
@@ -180,6 +189,7 @@ export default function AddDeviceDialog({ open, onOpenChange }: AddDeviceDialogP
       setCopied(false)
       setStep('invitation')
       setFailureReason(null)
+      initializedRef.current = false
     }
   }, [open])
 

--- a/src/components/device/SpaceMembersPanel.tsx
+++ b/src/components/device/SpaceMembersPanel.tsx
@@ -107,8 +107,14 @@ const SpaceMembersPanel: React.FC = () => {
   const selectedDevice = spaceMembers.find(d => d.peerId === selectedDeviceId)
   const unpairTargetDevice = spaceMembers.find(d => d.peerId === unpairTargetId)
 
+  // 注意：所有 dialog（AddDeviceDialog / DeviceSettingsSheet / UnpairAlertDialog）
+  // 在文件末尾统一根级渲染，不要放进下面任何一个条件分支里 —— 配对成功时
+  // spaceMembers 从 0 变 1 会让分支切换，分支内的 dialog 会被 React 视作不同
+  // 位置卸载并重建，AddDeviceDialog 的 step='success' 状态会丢失，
+  // 重建后的实例又会再次拉取新邀请码。
+  let body: React.ReactNode
   if (spaceMembersError) {
-    return (
+    body = (
       <div className="space-y-2">
         <h3 className="text-xs font-medium text-muted-foreground px-1 uppercase tracking-wider">
           {t('devices.pairedDevices.title')}
@@ -130,122 +136,123 @@ const SpaceMembersPanel: React.FC = () => {
         </div>
       </div>
     )
-  }
-
-  if (spaceMembers.length === 0) {
-    return (
+  } else if (spaceMembers.length === 0) {
+    body = (
+      <div className="space-y-2">
+        <h3 className="text-xs font-medium text-muted-foreground px-1 uppercase tracking-wider">
+          {t('devices.pairedDevices.title')}
+        </h3>
+        <div className="flex flex-col items-center rounded-xl border border-dashed border-border/80 py-10 px-6 text-center">
+          <div className="mb-4 rounded-full bg-muted/50 p-4 ring-1 ring-border/50">
+            <Monitor className="h-8 w-8 text-muted-foreground/70" />
+          </div>
+          <h3 className="mb-1.5 text-sm font-medium text-foreground">
+            {t('devices.list.empty.title')}
+          </h3>
+          <p className="mb-4 max-w-xs text-xs text-muted-foreground">
+            {t('devices.list.empty.description')}
+          </p>
+          <Button variant="outline" size="sm" onClick={() => setAddDialogOpen(true)}>
+            <Plus className="h-3.5 w-3.5" />
+            {t('devices.list.actions.addDevice')}
+          </Button>
+        </div>
+      </div>
+    )
+  } else {
+    body = (
       <>
+        {globalAutoSyncOff && (
+          <Alert className="border-amber-500/20 bg-amber-500/10">
+            <AlertTriangle className="h-4 w-4 text-amber-500" />
+            <AlertDescription className="text-amber-700 dark:text-amber-400">
+              {t('devices.syncPaused.message')}{' '}
+              <button
+                type="button"
+                onClick={() => navigate('/settings', { state: { category: 'sync' } })}
+                className="font-medium underline hover:no-underline"
+              >
+                {t('devices.syncPaused.goToSettings')}
+              </button>
+            </AlertDescription>
+          </Alert>
+        )}
+
         <div className="space-y-2">
           <h3 className="text-xs font-medium text-muted-foreground px-1 uppercase tracking-wider">
             {t('devices.pairedDevices.title')}
           </h3>
-          <div className="flex flex-col items-center rounded-xl border border-dashed border-border/80 py-10 px-6 text-center">
-            <div className="mb-4 rounded-full bg-muted/50 p-4 ring-1 ring-border/50">
-              <Monitor className="h-8 w-8 text-muted-foreground/70" />
-            </div>
-            <h3 className="mb-1.5 text-sm font-medium text-foreground">
-              {t('devices.list.empty.title')}
-            </h3>
-            <p className="mb-4 max-w-xs text-xs text-muted-foreground">
-              {t('devices.list.empty.description')}
-            </p>
-            <Button variant="outline" size="sm" onClick={() => setAddDialogOpen(true)}>
-              <Plus className="h-3.5 w-3.5" />
-              {t('devices.list.actions.addDevice')}
-            </Button>
+          <div className="grid grid-cols-2 gap-3">
+            {spaceMembers.map((device, index) => {
+              const Icon = getDeviceIcon(device.deviceName)
+              const iconColor = getIconColor(index)
+
+              return (
+                <button
+                  key={device.peerId}
+                  type="button"
+                  onClick={() => openSheet(device.peerId)}
+                  className="group relative flex flex-col items-center rounded-2xl bg-card p-5 pt-6 pb-4 text-center shadow-sm ring-1 ring-border/40 transition-all hover:shadow-md hover:ring-border/60 cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                >
+                  {/* Icon with status indicator */}
+                  <div className="relative mb-3">
+                    <div
+                      className={`h-14 w-14 rounded-2xl flex items-center justify-center shadow-sm ${iconColor}`}
+                    >
+                      <Icon className="h-7 w-7" />
+                    </div>
+                    {/* Online/offline dot */}
+                    <span
+                      className={`absolute -bottom-0.5 -right-0.5 h-3.5 w-3.5 rounded-full ring-2 ring-card ${
+                        device.connected ? 'bg-emerald-500' : 'bg-muted-foreground/30'
+                      }`}
+                    />
+                  </div>
+
+                  {/* Device name */}
+                  <span className="truncate w-full font-medium text-foreground text-sm leading-tight">
+                    {device.deviceName || t('devices.list.labels.unknownDevice')}
+                  </span>
+
+                  {/* Status text */}
+                  <span
+                    className={`mt-1 text-xs ${
+                      device.connected
+                        ? 'text-emerald-600 dark:text-emerald-400'
+                        : 'text-muted-foreground'
+                    }`}
+                  >
+                    {device.connected
+                      ? t('devices.list.status.online')
+                      : t('devices.list.status.offline')}
+                  </span>
+                </button>
+              )
+            })}
+
+            {/* Add device card */}
+            <button
+              type="button"
+              onClick={() => setAddDialogOpen(true)}
+              className="group flex flex-col items-center justify-center rounded-2xl border-2 border-dashed border-border/60 p-5 pt-6 pb-4 text-center transition-all hover:border-border hover:bg-muted/30 cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              <div className="mb-3 h-14 w-14 rounded-2xl flex items-center justify-center bg-muted/50 transition-colors group-hover:bg-muted">
+                <Plus className="h-7 w-7 text-muted-foreground/70 group-hover:text-foreground" />
+              </div>
+              <span className="text-sm font-medium text-muted-foreground group-hover:text-foreground">
+                {t('devices.list.actions.addDevice')}
+              </span>
+            </button>
           </div>
         </div>
-        <AddDeviceDialog open={addDialogOpen} onOpenChange={setAddDialogOpen} />
       </>
     )
   }
 
   return (
     <>
-      {globalAutoSyncOff && (
-        <Alert className="border-amber-500/20 bg-amber-500/10">
-          <AlertTriangle className="h-4 w-4 text-amber-500" />
-          <AlertDescription className="text-amber-700 dark:text-amber-400">
-            {t('devices.syncPaused.message')}{' '}
-            <button
-              type="button"
-              onClick={() => navigate('/settings', { state: { category: 'sync' } })}
-              className="font-medium underline hover:no-underline"
-            >
-              {t('devices.syncPaused.goToSettings')}
-            </button>
-          </AlertDescription>
-        </Alert>
-      )}
-
-      <div className="space-y-2">
-        <h3 className="text-xs font-medium text-muted-foreground px-1 uppercase tracking-wider">
-          {t('devices.pairedDevices.title')}
-        </h3>
-        <div className="grid grid-cols-2 gap-3">
-          {spaceMembers.map((device, index) => {
-            const Icon = getDeviceIcon(device.deviceName)
-            const iconColor = getIconColor(index)
-
-            return (
-              <button
-                key={device.peerId}
-                type="button"
-                onClick={() => openSheet(device.peerId)}
-                className="group relative flex flex-col items-center rounded-2xl bg-card p-5 pt-6 pb-4 text-center shadow-sm ring-1 ring-border/40 transition-all hover:shadow-md hover:ring-border/60 cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-ring"
-              >
-                {/* Icon with status indicator */}
-                <div className="relative mb-3">
-                  <div
-                    className={`h-14 w-14 rounded-2xl flex items-center justify-center shadow-sm ${iconColor}`}
-                  >
-                    <Icon className="h-7 w-7" />
-                  </div>
-                  {/* Online/offline dot */}
-                  <span
-                    className={`absolute -bottom-0.5 -right-0.5 h-3.5 w-3.5 rounded-full ring-2 ring-card ${
-                      device.connected ? 'bg-emerald-500' : 'bg-muted-foreground/30'
-                    }`}
-                  />
-                </div>
-
-                {/* Device name */}
-                <span className="truncate w-full font-medium text-foreground text-sm leading-tight">
-                  {device.deviceName || t('devices.list.labels.unknownDevice')}
-                </span>
-
-                {/* Status text */}
-                <span
-                  className={`mt-1 text-xs ${
-                    device.connected
-                      ? 'text-emerald-600 dark:text-emerald-400'
-                      : 'text-muted-foreground'
-                  }`}
-                >
-                  {device.connected
-                    ? t('devices.list.status.online')
-                    : t('devices.list.status.offline')}
-                </span>
-              </button>
-            )
-          })}
-
-          {/* Add device card */}
-          <button
-            type="button"
-            onClick={() => setAddDialogOpen(true)}
-            className="group flex flex-col items-center justify-center rounded-2xl border-2 border-dashed border-border/60 p-5 pt-6 pb-4 text-center transition-all hover:border-border hover:bg-muted/30 cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-ring"
-          >
-            <div className="mb-3 h-14 w-14 rounded-2xl flex items-center justify-center bg-muted/50 transition-colors group-hover:bg-muted">
-              <Plus className="h-7 w-7 text-muted-foreground/70 group-hover:text-foreground" />
-            </div>
-            <span className="text-sm font-medium text-muted-foreground group-hover:text-foreground">
-              {t('devices.list.actions.addDevice')}
-            </span>
-          </button>
-        </div>
-      </div>
-
+      {body}
+      <AddDeviceDialog open={addDialogOpen} onOpenChange={setAddDialogOpen} />
       <DeviceSettingsSheet
         open={sheetOpen}
         onOpenChange={setSheetOpen}
@@ -255,15 +262,12 @@ const SpaceMembersPanel: React.FC = () => {
         globalFileSyncOff={globalFileSyncOff}
         onUnpair={handleUnpairRequest}
       />
-
       <UnpairAlertDialog
         open={unpairDialogOpen}
         onOpenChange={setUnpairDialogOpen}
         deviceName={unpairTargetDevice?.deviceName || t('devices.list.labels.unknownDevice')}
         onConfirm={handleUnpairConfirm}
       />
-
-      <AddDeviceDialog open={addDialogOpen} onOpenChange={setAddDialogOpen} />
     </>
   )
 }


### PR DESCRIPTION
## Summary
- 邀请方在对方完成配对后，modal 期望切换到"设备已加入"成功态，但实际却又拉取了一个新邀请码。根因是 `SpaceMembersPanel` 在两个不同的条件分支里分别渲染了 `<AddDeviceDialog />`：当 `dispatch(fetchSpaceMembers())` 把成员数从 0 刷新到 1 时，父组件分支切换，React 把这两处视为不同位置的元素，**卸载旧实例、挂载新实例**。新实例 `step` 重置为 `'invitation'`、`useEffect` 重新跑、`getSetupState()` 返回 `currentInvitation=null`（已被对方消费），于是再次调用 `issuePairingInvitation()` 拿到新码。
- 把 `AddDeviceDialog`（连同 `DeviceSettingsSheet`、`UnpairAlertDialog`）从条件分支里抽出，统一放到根级 `return` 中渲染 —— 配对成功不再使其卸载，`step='success'` 能稳定保留 `SUCCESS_AUTO_CLOSE_MS` (2s) 后自动关闭。
- 在 `AddDeviceDialog` 增加 `initializedRef` 守卫，使 init effect 在同一次 open 期间只跑一次，挡住 `t` 引用变化、Strict Mode 双跑、父组件结构变更等场景下的重复 `issuePairingInvitation()`。`open=false` 时清空 ref，下次重开仍能正常初始化。

## Test plan
- [x] `bunx tsc --noEmit` 通过
- [x] `bunx eslint` 改动文件 通过
- [x] `bunx vitest run` —— 59 test files / 324 tests 全部通过
- [x] 手动 dual-side 验证：邀请方设备列表为空 → 发起邀请 → 加入方完成验证 → 邀请方 modal 显示"设备已加入"并 2 秒后自动关闭，**不再出现新邀请码刷出**
- [x] 手动验证关闭 dialog 再重开能正常拿回当前邀请码（后端持有 `currentInvitation` 时复用，无 invitation 时新申请一次）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where device pairing invitation requests could be issued multiple times when opening the pairing dialog, potentially causing duplicate entries
  * Improved stability of device management dialogs to prevent unexpected state resets when the space members list changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->