### PR TITLE
fix(unpair): cascade revoke_member to peer_addr & trusted_peer + boot reconcile

### DIFF
--- a/src-tauri/crates/uc-application/src/facade/roster/errors.rs
+++ b/src-tauri/crates/uc-application/src/facade/roster/errors.rs
@@ -21,6 +21,13 @@ pub enum RosterError {
     #[error("failed to read local identity: {0}")]
     LocalIdentity(String),
 
+    /// `PeerAddressRepositoryPort` 故障。`revoke_member` 在删除成员后
+    /// 还需要清理同设备的 peer 地址条目,否则 dispatch / presence 仍会
+    /// 把已撤销设备当作目标(见 `dispatch_entry.rs` module doc 关于
+    /// "peer_addr_repo 是 paired members 权威集合" 的不变量)。
+    #[error("failed to remove peer address: {0}")]
+    PeerAddressRepository(String),
+
     /// 目标成员不存在。
     #[error("member `{0}` not found")]
     NotFound(String),

--- a/src-tauri/crates/uc-application/src/facade/roster/errors.rs
+++ b/src-tauri/crates/uc-application/src/facade/roster/errors.rs
@@ -28,6 +28,13 @@ pub enum RosterError {
     #[error("failed to remove peer address: {0}")]
     PeerAddressRepository(String),
 
+    /// `TrustedPeerRepositoryPort` 故障。`revoke_member` 在删除成员后
+    /// 还要清掉对应的 trust 记录,否则同一设备重新配对时会被
+    /// `TrustPeerUseCase` 的 `AlreadyTrusted` 检查直接挡死
+    /// (见 `trust_peer.rs` 注释关于"先 Distrust 再 Trust" 的显式流程)。
+    #[error("failed to remove trusted peer: {0}")]
+    TrustedPeerRepository(String),
+
     /// 目标成员不存在。
     #[error("member `{0}` not found")]
     NotFound(String),

--- a/src-tauri/crates/uc-application/src/facade/roster/facade.rs
+++ b/src-tauri/crates/uc-application/src/facade/roster/facade.rs
@@ -20,6 +20,7 @@ use tokio::sync::broadcast;
 use tracing::instrument;
 
 use uc_core::membership::MemberRepositoryPort;
+use uc_core::ports::peer_address::PeerAddressRepositoryPort;
 use uc_core::ports::{LocalIdentityPort, PresenceEvent, PresencePort};
 use uc_core::DeviceId;
 
@@ -33,6 +34,7 @@ use crate::facade::roster::errors::RosterError;
 /// 的风格,便于 bootstrap 分步 construct 各 facade。
 pub struct MemberRosterDeps {
     pub member_repo: Arc<dyn MemberRepositoryPort>,
+    pub peer_addr_repo: Arc<dyn PeerAddressRepositoryPort>,
     pub local_identity: Arc<dyn LocalIdentityPort>,
     pub presence: Arc<dyn PresencePort>,
 }
@@ -40,6 +42,7 @@ pub struct MemberRosterDeps {
 /// Roster 查询门面 —— 见模块文档。
 pub struct MemberRosterFacade {
     member_repo: Arc<dyn MemberRepositoryPort>,
+    peer_addr_repo: Arc<dyn PeerAddressRepositoryPort>,
     local_identity: Arc<dyn LocalIdentityPort>,
     presence: Arc<dyn PresencePort>,
 }
@@ -48,6 +51,7 @@ impl MemberRosterFacade {
     pub fn new(deps: MemberRosterDeps) -> Self {
         Self {
             member_repo: deps.member_repo,
+            peer_addr_repo: deps.peer_addr_repo,
             local_identity: deps.local_identity,
             presence: deps.presence,
         }
@@ -182,6 +186,12 @@ impl MemberRosterFacade {
     }
 
     /// 撤销成员。撤销语义由 application 层表达,daemon 不直接调用 use case。
+    ///
+    /// 不只删 `member_repo` —— 还要把同设备的 `peer_addr_repo` 条目一并清掉,
+    /// 否则 `dispatch_entry` / `ensure_reachable_all` 仍会把它当作目标继续拨号
+    /// 与同步剪贴板。`peer_addr_repo` 在文档语义上是"已配对成员的权威集合"
+    /// (见 `dispatch_entry.rs` module doc:"avoids iterating ghost entries in
+    /// `member_repo` that never completed pairing"),unpair 必须维护这条不变量。
     #[instrument(skip_all, fields(device_id = %device_id))]
     pub async fn revoke_member(&self, device_id: &str) -> Result<(), RosterError> {
         let device_id = DeviceId::new(device_id);
@@ -190,11 +200,19 @@ impl MemberRosterFacade {
             .remove(&device_id)
             .await
             .map_err(|err| RosterError::MemberRepository(err.to_string()))?;
-        if removed {
-            Ok(())
-        } else {
-            Err(RosterError::NotFound(device_id.as_str().to_string()))
+        if !removed {
+            return Err(RosterError::NotFound(device_id.as_str().to_string()));
         }
+
+        // peer_addr_repo.remove 是 idempotent 的(port doc),所以即使条目不
+        // 存在也会成功;失败仅在底层存储真正出错时发生。member_repo 已经删
+        // 了无法回滚——把错误抛给上层比静默吞错更好,启动期 reconcile 会兜底。
+        self.peer_addr_repo
+            .remove(&device_id)
+            .await
+            .map_err(|err| RosterError::PeerAddressRepository(err.to_string()))?;
+
+        Ok(())
     }
 
     /// `PresencePort::subscribe` 的 thin 转发。
@@ -230,6 +248,7 @@ mod tests {
     use crate::facade::roster::{ContentTypesPatch, MemberSyncPreferencesPatch};
     use uc_core::ids::DeviceId;
     use uc_core::membership::{MemberSyncPreferences, MembershipError, SpaceMember};
+    use uc_core::ports::peer_address::{PeerAddressError, PeerAddressRecord};
     use uc_core::ports::{LocalIdentityError, PresenceError, PresenceEvent, ReachabilityState};
     use uc_core::security::IdentityFingerprint;
 
@@ -244,6 +263,20 @@ mod tests {
             async fn list(&self) -> Result<Vec<SpaceMember>, MembershipError>;
             async fn save(&self, member: &SpaceMember) -> Result<(), MembershipError>;
             async fn remove(&self, device_id: &DeviceId) -> Result<bool, MembershipError>;
+        }
+    }
+
+    // ── mockall: peer_addr_repo ─────────────────────────────────────────
+
+    mockall::mock! {
+        pub PeerAddrRepo {}
+
+        #[async_trait]
+        impl PeerAddressRepositoryPort for PeerAddrRepo {
+            async fn get(&self, device: &DeviceId) -> Result<Option<PeerAddressRecord>, PeerAddressError>;
+            async fn upsert(&self, record: &PeerAddressRecord) -> Result<(), PeerAddressError>;
+            async fn list(&self) -> Result<Vec<PeerAddressRecord>, PeerAddressError>;
+            async fn remove(&self, device: &DeviceId) -> Result<(), PeerAddressError>;
         }
     }
 
@@ -341,8 +374,26 @@ mod tests {
         local_identity: MockLocalIdentity,
         presence: Arc<FakePresence>,
     ) -> MemberRosterFacade {
+        // 多数测试不走 revoke_member 路径,默认给一个不设 expectation 的
+        // peer_addr mock —— mockall 严格模式下若意外被调用会 panic,
+        // 等价于 "断言 peer_addr 在该测试中不应被触发"。
+        build_facade_with_peer_addr(
+            member_repo,
+            MockPeerAddrRepo::new(),
+            local_identity,
+            presence,
+        )
+    }
+
+    fn build_facade_with_peer_addr(
+        member_repo: MockMemberRepo,
+        peer_addr_repo: MockPeerAddrRepo,
+        local_identity: MockLocalIdentity,
+        presence: Arc<FakePresence>,
+    ) -> MemberRosterFacade {
         MemberRosterFacade::new(MemberRosterDeps {
             member_repo: Arc::new(member_repo),
+            peer_addr_repo: Arc::new(peer_addr_repo),
             local_identity: Arc::new(local_identity),
             presence,
         })
@@ -509,6 +560,7 @@ mod tests {
 
         let facade = MemberRosterFacade::new(MemberRosterDeps {
             member_repo: Arc::new(repo),
+            peer_addr_repo: Arc::new(MockPeerAddrRepo::new()),
             local_identity: Arc::new(id),
             presence: Arc::clone(&presence) as Arc<dyn PresencePort>,
         });
@@ -538,6 +590,7 @@ mod tests {
         let presence = Arc::new(FakePresence::new(vec![]));
         let facade = MemberRosterFacade::new(MemberRosterDeps {
             member_repo: Arc::new(repo),
+            peer_addr_repo: Arc::new(MockPeerAddrRepo::new()),
             local_identity: Arc::new(id),
             presence: Arc::clone(&presence) as Arc<dyn PresencePort>,
         });
@@ -638,16 +691,64 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn revoke_member_accepts_application_device_id() {
+    async fn revoke_member_clears_member_repo_and_peer_addr_repo() {
+        // 修复点验收:revoke_member 必须同时清两表,否则 dispatch_entry /
+        // ensure_reachable_all 仍会把已撤销设备当作目标继续 fan-out。
         let mut repo = MockMemberRepo::new();
         repo.expect_remove()
             .times(1)
             .withf(|device_id| device_id == &DeviceId::new("dev-1"))
             .returning(|_| Ok(true));
+        let mut peer_addr = MockPeerAddrRepo::new();
+        peer_addr
+            .expect_remove()
+            .times(1)
+            .withf(|device_id| device_id == &DeviceId::new("dev-1"))
+            .returning(|_| Ok(()));
         let id = MockLocalIdentity::new();
         let presence = Arc::new(FakePresence::new(vec![]));
-        let facade = build_facade(repo, id, presence);
+        let facade = build_facade_with_peer_addr(repo, peer_addr, id, presence);
 
         facade.revoke_member("dev-1").await.expect("ok");
+    }
+
+    #[tokio::test]
+    async fn revoke_member_skips_peer_addr_cleanup_when_member_not_found() {
+        // member_repo.remove 返回 false 表示成员不存在 —— 此时 facade 直接
+        // 返回 NotFound,不应再去碰 peer_addr_repo。peer_addr mock 不设
+        // expect_remove,被调用即 panic。
+        let mut repo = MockMemberRepo::new();
+        repo.expect_remove().times(1).returning(|_| Ok(false));
+        let peer_addr = MockPeerAddrRepo::new();
+        let id = MockLocalIdentity::new();
+        let presence = Arc::new(FakePresence::new(vec![]));
+        let facade = build_facade_with_peer_addr(repo, peer_addr, id, presence);
+
+        let err = facade.revoke_member("ghost").await.unwrap_err();
+        assert!(matches!(err, RosterError::NotFound(d) if d == "ghost"));
+    }
+
+    #[tokio::test]
+    async fn revoke_member_propagates_peer_addr_repo_failure() {
+        // member 已经删了无法回滚 —— 但 peer_addr_repo 失败仍然要冒泡,
+        // UI 才能感知到清理不完整,启动期 reconcile 会在下次 boot 兜底。
+        let mut repo = MockMemberRepo::new();
+        repo.expect_remove().times(1).returning(|_| Ok(true));
+        let mut peer_addr = MockPeerAddrRepo::new();
+        peer_addr
+            .expect_remove()
+            .times(1)
+            .returning(|_| Err(PeerAddressError::Internal("disk full".into())));
+        let id = MockLocalIdentity::new();
+        let presence = Arc::new(FakePresence::new(vec![]));
+        let facade = build_facade_with_peer_addr(repo, peer_addr, id, presence);
+
+        let err = facade.revoke_member("dev-1").await.unwrap_err();
+        match err {
+            RosterError::PeerAddressRepository(msg) => {
+                assert!(msg.contains("disk full"), "msg = {msg}");
+            }
+            other => panic!("expected PeerAddressRepository, got {other:?}"),
+        }
     }
 }

--- a/src-tauri/crates/uc-application/src/facade/roster/facade.rs
+++ b/src-tauri/crates/uc-application/src/facade/roster/facade.rs
@@ -22,6 +22,7 @@ use tracing::instrument;
 use uc_core::membership::MemberRepositoryPort;
 use uc_core::ports::peer_address::PeerAddressRepositoryPort;
 use uc_core::ports::{LocalIdentityPort, PresenceEvent, PresencePort};
+use uc_core::trusted_peer::TrustedPeerRepositoryPort;
 use uc_core::DeviceId;
 
 use crate::facade::roster::commands::{
@@ -35,6 +36,7 @@ use crate::facade::roster::errors::RosterError;
 pub struct MemberRosterDeps {
     pub member_repo: Arc<dyn MemberRepositoryPort>,
     pub peer_addr_repo: Arc<dyn PeerAddressRepositoryPort>,
+    pub trusted_peer_repo: Arc<dyn TrustedPeerRepositoryPort>,
     pub local_identity: Arc<dyn LocalIdentityPort>,
     pub presence: Arc<dyn PresencePort>,
 }
@@ -43,6 +45,7 @@ pub struct MemberRosterDeps {
 pub struct MemberRosterFacade {
     member_repo: Arc<dyn MemberRepositoryPort>,
     peer_addr_repo: Arc<dyn PeerAddressRepositoryPort>,
+    trusted_peer_repo: Arc<dyn TrustedPeerRepositoryPort>,
     local_identity: Arc<dyn LocalIdentityPort>,
     presence: Arc<dyn PresencePort>,
 }
@@ -52,6 +55,7 @@ impl MemberRosterFacade {
         Self {
             member_repo: deps.member_repo,
             peer_addr_repo: deps.peer_addr_repo,
+            trusted_peer_repo: deps.trusted_peer_repo,
             local_identity: deps.local_identity,
             presence: deps.presence,
         }
@@ -187,11 +191,24 @@ impl MemberRosterFacade {
 
     /// 撤销成员。撤销语义由 application 层表达,daemon 不直接调用 use case。
     ///
-    /// 不只删 `member_repo` —— 还要把同设备的 `peer_addr_repo` 条目一并清掉,
-    /// 否则 `dispatch_entry` / `ensure_reachable_all` 仍会把它当作目标继续拨号
-    /// 与同步剪贴板。`peer_addr_repo` 在文档语义上是"已配对成员的权威集合"
-    /// (见 `dispatch_entry.rs` module doc:"avoids iterating ghost entries in
-    /// `member_repo` that never completed pairing"),unpair 必须维护这条不变量。
+    /// Facade 级联清理三张表,以维持设计意图的不变量
+    /// `trusted_peer ⊆ member` 与 `peer_addr ⊆ member`:
+    ///
+    /// 1. `member_repo` —— 主体记录,先删;返回 `Ok(false)` 表示成员不存在
+    ///    (`NotFound`),后续两步跳过。
+    /// 2. `peer_addr_repo` —— 不删会让 `dispatch_entry` /
+    ///    `ensure_reachable_all` 仍把已撤销设备当目标(见
+    ///    `dispatch_entry.rs` module doc 关于 "avoids iterating ghost entries
+    ///    in `member_repo` that never completed pairing" 的不变量)。
+    /// 3. `trusted_peer_repo` —— 不删会让同设备**重新配对失败**:
+    ///    `TrustPeerUseCase::execute` 检查到行已存在直接返回
+    ///    `AlreadyTrusted`(见 `trust_peer.rs` 注释:"先 Distrust 再 Trust" 的
+    ///    显式流程)。`distrust_peer.rs` 注释里讲 "UI 的'解除配对'由 Facade
+    ///    级联调用",这里就是那个级联。
+    ///
+    /// 失败处理:`member_repo.remove` 已成功后没法回滚,后续两步任一失败
+    /// 都把错误抛给调用方,启动期 `reconcile_*` 会在下次 boot 兜底。两个
+    /// remove port 都是 idempotent,缺行不会算 error。
     #[instrument(skip_all, fields(device_id = %device_id))]
     pub async fn revoke_member(&self, device_id: &str) -> Result<(), RosterError> {
         let device_id = DeviceId::new(device_id);
@@ -205,12 +222,19 @@ impl MemberRosterFacade {
         }
 
         // peer_addr_repo.remove 是 idempotent 的(port doc),所以即使条目不
-        // 存在也会成功;失败仅在底层存储真正出错时发生。member_repo 已经删
-        // 了无法回滚——把错误抛给上层比静默吞错更好,启动期 reconcile 会兜底。
+        // 存在也会成功;失败仅在底层存储真正出错时发生。
         self.peer_addr_repo
             .remove(&device_id)
             .await
             .map_err(|err| RosterError::PeerAddressRepository(err.to_string()))?;
+
+        // trusted_peer_repo.remove 返回 bool: true=删除一行,false=本来就没有
+        // (peer 还没建立 trust 就被踢)。两种都属正常;只有底层存储故障
+        // 时才报错。
+        self.trusted_peer_repo
+            .remove(&device_id)
+            .await
+            .map_err(|err| RosterError::TrustedPeerRepository(err.to_string()))?;
 
         Ok(())
     }
@@ -251,6 +275,7 @@ mod tests {
     use uc_core::ports::peer_address::{PeerAddressError, PeerAddressRecord};
     use uc_core::ports::{LocalIdentityError, PresenceError, PresenceEvent, ReachabilityState};
     use uc_core::security::IdentityFingerprint;
+    use uc_core::trusted_peer::{TrustedPeer, TrustedPeerError};
 
     // ── mockall: member_repo ────────────────────────────────────────────
 
@@ -277,6 +302,20 @@ mod tests {
             async fn upsert(&self, record: &PeerAddressRecord) -> Result<(), PeerAddressError>;
             async fn list(&self) -> Result<Vec<PeerAddressRecord>, PeerAddressError>;
             async fn remove(&self, device: &DeviceId) -> Result<(), PeerAddressError>;
+        }
+    }
+
+    // ── mockall: trusted_peer_repo ──────────────────────────────────────
+
+    mockall::mock! {
+        pub TrustedPeerRepo {}
+
+        #[async_trait]
+        impl TrustedPeerRepositoryPort for TrustedPeerRepo {
+            async fn get(&self, peer_device_id: &DeviceId) -> Result<Option<TrustedPeer>, TrustedPeerError>;
+            async fn list(&self) -> Result<Vec<TrustedPeer>, TrustedPeerError>;
+            async fn save(&self, trusted_peer: &TrustedPeer) -> Result<(), TrustedPeerError>;
+            async fn remove(&self, peer_device_id: &DeviceId) -> Result<bool, TrustedPeerError>;
         }
     }
 
@@ -374,26 +413,29 @@ mod tests {
         local_identity: MockLocalIdentity,
         presence: Arc<FakePresence>,
     ) -> MemberRosterFacade {
-        // 多数测试不走 revoke_member 路径,默认给一个不设 expectation 的
-        // peer_addr mock —— mockall 严格模式下若意外被调用会 panic,
-        // 等价于 "断言 peer_addr 在该测试中不应被触发"。
-        build_facade_with_peer_addr(
+        // 多数测试不走 revoke_member 路径,默认给两个不设 expectation 的
+        // mock —— mockall 严格模式下若意外被调用会 panic,等价于
+        // "断言这两个 repo 在该测试中不应被触发"。
+        build_facade_with_unpair_repos(
             member_repo,
             MockPeerAddrRepo::new(),
+            MockTrustedPeerRepo::new(),
             local_identity,
             presence,
         )
     }
 
-    fn build_facade_with_peer_addr(
+    fn build_facade_with_unpair_repos(
         member_repo: MockMemberRepo,
         peer_addr_repo: MockPeerAddrRepo,
+        trusted_peer_repo: MockTrustedPeerRepo,
         local_identity: MockLocalIdentity,
         presence: Arc<FakePresence>,
     ) -> MemberRosterFacade {
         MemberRosterFacade::new(MemberRosterDeps {
             member_repo: Arc::new(member_repo),
             peer_addr_repo: Arc::new(peer_addr_repo),
+            trusted_peer_repo: Arc::new(trusted_peer_repo),
             local_identity: Arc::new(local_identity),
             presence,
         })
@@ -561,6 +603,7 @@ mod tests {
         let facade = MemberRosterFacade::new(MemberRosterDeps {
             member_repo: Arc::new(repo),
             peer_addr_repo: Arc::new(MockPeerAddrRepo::new()),
+            trusted_peer_repo: Arc::new(MockTrustedPeerRepo::new()),
             local_identity: Arc::new(id),
             presence: Arc::clone(&presence) as Arc<dyn PresencePort>,
         });
@@ -591,6 +634,7 @@ mod tests {
         let facade = MemberRosterFacade::new(MemberRosterDeps {
             member_repo: Arc::new(repo),
             peer_addr_repo: Arc::new(MockPeerAddrRepo::new()),
+            trusted_peer_repo: Arc::new(MockTrustedPeerRepo::new()),
             local_identity: Arc::new(id),
             presence: Arc::clone(&presence) as Arc<dyn PresencePort>,
         });
@@ -691,9 +735,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn revoke_member_clears_member_repo_and_peer_addr_repo() {
-        // 修复点验收:revoke_member 必须同时清两表,否则 dispatch_entry /
-        // ensure_reachable_all 仍会把已撤销设备当作目标继续 fan-out。
+    async fn revoke_member_clears_all_three_repos() {
+        // 修复点验收:revoke_member 必须级联清三张表,否则:
+        //   - peer_addr 残留 → dispatch / presence 仍把已撤销设备当目标
+        //   - trusted_peer 残留 → 同设备重新配对会被 AlreadyTrusted 阻塞
         let mut repo = MockMemberRepo::new();
         repo.expect_remove()
             .times(1)
@@ -705,24 +750,49 @@ mod tests {
             .times(1)
             .withf(|device_id| device_id == &DeviceId::new("dev-1"))
             .returning(|_| Ok(()));
+        let mut trusted = MockTrustedPeerRepo::new();
+        trusted
+            .expect_remove()
+            .times(1)
+            .withf(|device_id| device_id == &DeviceId::new("dev-1"))
+            .returning(|_| Ok(true));
         let id = MockLocalIdentity::new();
         let presence = Arc::new(FakePresence::new(vec![]));
-        let facade = build_facade_with_peer_addr(repo, peer_addr, id, presence);
+        let facade = build_facade_with_unpair_repos(repo, peer_addr, trusted, id, presence);
 
         facade.revoke_member("dev-1").await.expect("ok");
     }
 
     #[tokio::test]
-    async fn revoke_member_skips_peer_addr_cleanup_when_member_not_found() {
-        // member_repo.remove 返回 false 表示成员不存在 —— 此时 facade 直接
-        // 返回 NotFound,不应再去碰 peer_addr_repo。peer_addr mock 不设
-        // expect_remove,被调用即 panic。
+    async fn revoke_member_tolerates_missing_trusted_peer_row() {
+        // peer 配对完成前/中途断流时,member_repo 已经写但 trusted_peer 还没
+        // 写——unpair 时 trusted_peer.remove 返回 Ok(false)(不存在),应当
+        // 视为正常完成,不应抛错。
+        let mut repo = MockMemberRepo::new();
+        repo.expect_remove().times(1).returning(|_| Ok(true));
+        let mut peer_addr = MockPeerAddrRepo::new();
+        peer_addr.expect_remove().times(1).returning(|_| Ok(()));
+        let mut trusted = MockTrustedPeerRepo::new();
+        trusted.expect_remove().times(1).returning(|_| Ok(false));
+        let id = MockLocalIdentity::new();
+        let presence = Arc::new(FakePresence::new(vec![]));
+        let facade = build_facade_with_unpair_repos(repo, peer_addr, trusted, id, presence);
+
+        facade.revoke_member("dev-1").await.expect("ok");
+    }
+
+    #[tokio::test]
+    async fn revoke_member_skips_cleanup_when_member_not_found() {
+        // member_repo.remove 返回 false 表示成员不存在 —— facade 直接返回
+        // NotFound,不应再去碰 peer_addr_repo / trusted_peer_repo。两个 mock
+        // 都不设 expect_remove,被调用即 panic。
         let mut repo = MockMemberRepo::new();
         repo.expect_remove().times(1).returning(|_| Ok(false));
         let peer_addr = MockPeerAddrRepo::new();
+        let trusted = MockTrustedPeerRepo::new();
         let id = MockLocalIdentity::new();
         let presence = Arc::new(FakePresence::new(vec![]));
-        let facade = build_facade_with_peer_addr(repo, peer_addr, id, presence);
+        let facade = build_facade_with_unpair_repos(repo, peer_addr, trusted, id, presence);
 
         let err = facade.revoke_member("ghost").await.unwrap_err();
         assert!(matches!(err, RosterError::NotFound(d) if d == "ghost"));
@@ -730,8 +800,8 @@ mod tests {
 
     #[tokio::test]
     async fn revoke_member_propagates_peer_addr_repo_failure() {
-        // member 已经删了无法回滚 —— 但 peer_addr_repo 失败仍然要冒泡,
-        // UI 才能感知到清理不完整,启动期 reconcile 会在下次 boot 兜底。
+        // member 已经删了无法回滚 —— peer_addr 失败短路返回错误,
+        // trusted_peer 也不应再被调用(短路,mock 不设 expect_remove)。
         let mut repo = MockMemberRepo::new();
         repo.expect_remove().times(1).returning(|_| Ok(true));
         let mut peer_addr = MockPeerAddrRepo::new();
@@ -739,9 +809,10 @@ mod tests {
             .expect_remove()
             .times(1)
             .returning(|_| Err(PeerAddressError::Internal("disk full".into())));
+        let trusted = MockTrustedPeerRepo::new();
         let id = MockLocalIdentity::new();
         let presence = Arc::new(FakePresence::new(vec![]));
-        let facade = build_facade_with_peer_addr(repo, peer_addr, id, presence);
+        let facade = build_facade_with_unpair_repos(repo, peer_addr, trusted, id, presence);
 
         let err = facade.revoke_member("dev-1").await.unwrap_err();
         match err {
@@ -749,6 +820,33 @@ mod tests {
                 assert!(msg.contains("disk full"), "msg = {msg}");
             }
             other => panic!("expected PeerAddressRepository, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn revoke_member_propagates_trusted_peer_repo_failure() {
+        // member + peer_addr 都成功后,trusted_peer 失败要冒泡 ——
+        // UI 才能感知"trust 没清,重新配对仍可能 AlreadyTrusted",
+        // 启动期 reconcile_trusted_peers 会在下次 boot 兜底。
+        let mut repo = MockMemberRepo::new();
+        repo.expect_remove().times(1).returning(|_| Ok(true));
+        let mut peer_addr = MockPeerAddrRepo::new();
+        peer_addr.expect_remove().times(1).returning(|_| Ok(()));
+        let mut trusted = MockTrustedPeerRepo::new();
+        trusted
+            .expect_remove()
+            .times(1)
+            .returning(|_| Err(TrustedPeerError::Repository("io error".into())));
+        let id = MockLocalIdentity::new();
+        let presence = Arc::new(FakePresence::new(vec![]));
+        let facade = build_facade_with_unpair_repos(repo, peer_addr, trusted, id, presence);
+
+        let err = facade.revoke_member("dev-1").await.unwrap_err();
+        match err {
+            RosterError::TrustedPeerRepository(msg) => {
+                assert!(msg.contains("io error"), "msg = {msg}");
+            }
+            other => panic!("expected TrustedPeerRepository, got {other:?}"),
         }
     }
 }

--- a/src-tauri/crates/uc-bootstrap/src/builders.rs
+++ b/src-tauri/crates/uc-bootstrap/src/builders.rs
@@ -163,11 +163,14 @@ pub async fn build_daemon_app() -> anyhow::Result<DaemonBootstrapContext> {
     let (config, wired) = build_core(None)?;
     let storage_paths = get_storage_paths(&config)?;
 
-    // 启动期 reconcile:删除 peer_addr_repo 中所有 member_repo 已不再持有的
-    // 设备条目,恢复"peer_addr_repo 是 paired members 权威集合" 的不变量
-    // (见 `dispatch_entry.rs` module doc / `init.rs::reconcile_peer_addresses`)。
-    // 在 `build_space_setup_assembly` 之前执行,确保 dispatch / presence 一上线
-    // 看到的就是干净状态。失败只 log 不阻断启动 —— reconcile 是治理性的。
+    // 启动期 reconcile:把 peer_addr_repo / trusted_peer_repo 中
+    // member_repo 已不再持有的孤儿条目清掉,恢复设计意图的不变量
+    // `peer_addr ⊆ member`、`trusted_peer ⊆ member`(见
+    // `dispatch_entry.rs` module doc 关于 paired-members 权威集合,
+    // `trust_peer.rs` 关于"先 Distrust 再 Trust" 的显式流程,以及
+    // `init.rs::reconcile_*`)。两者都在 `build_space_setup_assembly` 之前
+    // 执行,确保 dispatch / presence / 重新配对路径一上线就是干净状态。
+    // 失败只 log 不阻断启动 —— reconcile 是治理性的。
     if let Err(err) = crate::init::reconcile_peer_addresses(
         Arc::clone(&wired.deps.device.member_repo),
         Arc::clone(&wired.peer_addr_repo),
@@ -177,6 +180,17 @@ pub async fn build_daemon_app() -> anyhow::Result<DaemonBootstrapContext> {
         tracing::warn!(
             error = %err,
             "peer_addr reconcile failed at boot; daemon continues with whatever orphans remain"
+        );
+    }
+    if let Err(err) = crate::init::reconcile_trusted_peers(
+        Arc::clone(&wired.deps.device.member_repo),
+        Arc::clone(&wired.trusted_peer_repo),
+    )
+    .await
+    {
+        tracing::warn!(
+            error = %err,
+            "trusted_peer reconcile failed at boot; daemon continues with whatever orphans remain"
         );
     }
 

--- a/src-tauri/crates/uc-bootstrap/src/builders.rs
+++ b/src-tauri/crates/uc-bootstrap/src/builders.rs
@@ -163,6 +163,23 @@ pub async fn build_daemon_app() -> anyhow::Result<DaemonBootstrapContext> {
     let (config, wired) = build_core(None)?;
     let storage_paths = get_storage_paths(&config)?;
 
+    // 启动期 reconcile:删除 peer_addr_repo 中所有 member_repo 已不再持有的
+    // 设备条目,恢复"peer_addr_repo 是 paired members 权威集合" 的不变量
+    // (见 `dispatch_entry.rs` module doc / `init.rs::reconcile_peer_addresses`)。
+    // 在 `build_space_setup_assembly` 之前执行,确保 dispatch / presence 一上线
+    // 看到的就是干净状态。失败只 log 不阻断启动 —— reconcile 是治理性的。
+    if let Err(err) = crate::init::reconcile_peer_addresses(
+        Arc::clone(&wired.deps.device.member_repo),
+        Arc::clone(&wired.peer_addr_repo),
+    )
+    .await
+    {
+        tracing::warn!(
+            error = %err,
+            "peer_addr reconcile failed at boot; daemon continues with whatever orphans remain"
+        );
+    }
+
     // Build the iroh-stack assembly on the caller's runtime. Must NOT spin up
     // a throwaway current-thread rt here: `Endpoint::bind` spawns magicsock /
     // relay / STUN actors via `tokio::spawn`, which attach to whatever runtime

--- a/src-tauri/crates/uc-bootstrap/src/init.rs
+++ b/src-tauri/crates/uc-bootstrap/src/init.rs
@@ -10,6 +10,7 @@ use uc_core::ids::DeviceId;
 use uc_core::membership::MemberRepositoryPort;
 use uc_core::ports::peer_address::PeerAddressRepositoryPort;
 use uc_core::ports::{SettingsPort, SetupStatusPort};
+use uc_core::trusted_peer::TrustedPeerRepositoryPort;
 use uc_infra::FileSetupStatusRepository;
 
 use crate::assembly::{get_default_app_dirs, get_storage_paths};
@@ -179,6 +180,75 @@ pub async fn reconcile_peer_addresses(
     Ok(())
 }
 
+/// 启动期清理:删除所有"在 `trusted_peer_repo` 但不在 `member_repo`"的孤儿
+/// 条目。
+///
+/// 配套 `MemberRosterFacade::revoke_member` 的级联清理:撤销成员时若 trust
+/// 删失败,或老版本 unpair 路径根本没碰过 trust 表,残留行会导致**同设备
+/// 重新配对**被 `TrustPeerUseCase::execute` 的 `AlreadyTrusted` 检查直接挡死
+/// (见 `trust_peer.rs:42`)。reconcile 把不变量 `trusted_peer ⊆ member_repo`
+/// 重新拉齐,让重新配对路径不再被历史遗留卡住。
+///
+/// 跟 `reconcile_peer_addresses` 同样的失败策略:单条 / 整体失败都只 log,
+/// 不阻断 daemon 启动。
+pub async fn reconcile_trusted_peers(
+    member_repo: Arc<dyn MemberRepositoryPort>,
+    trusted_peer_repo: Arc<dyn TrustedPeerRepositoryPort>,
+) -> anyhow::Result<()> {
+    let members = member_repo
+        .list()
+        .await
+        .map_err(|e| anyhow::anyhow!("list members: {e}"))?;
+    let member_ids: Vec<DeviceId> = members.into_iter().map(|m| m.device_id).collect();
+
+    let trusted = trusted_peer_repo
+        .list()
+        .await
+        .map_err(|e| anyhow::anyhow!("list trusted peers: {e}"))?;
+
+    let orphans: Vec<DeviceId> = trusted
+        .into_iter()
+        .filter_map(|peer| {
+            if member_ids.contains(&peer.peer_device_id) {
+                None
+            } else {
+                Some(peer.peer_device_id)
+            }
+        })
+        .collect();
+
+    if orphans.is_empty() {
+        tracing::debug!("trusted_peer reconcile: no orphans");
+        return Ok(());
+    }
+
+    tracing::info!(
+        orphan_count = orphans.len(),
+        "trusted_peer reconcile: removing orphan entries (in trusted_peer_repo but not in member_repo)"
+    );
+
+    for device_id in &orphans {
+        match trusted_peer_repo.remove(device_id).await {
+            Ok(removed) => {
+                tracing::info!(
+                    device_id = %device_id.as_str(),
+                    removed,
+                    "trusted_peer reconcile: removed orphan"
+                );
+            }
+            Err(err) => {
+                tracing::warn!(
+                    device_id = %device_id.as_str(),
+                    error = %err,
+                    "trusted_peer reconcile: failed to remove orphan; will retry next boot"
+                );
+            }
+        }
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -188,6 +258,7 @@ mod tests {
     use uc_core::membership::{MemberSyncPreferences, MembershipError, SpaceMember};
     use uc_core::ports::peer_address::{PeerAddressError, PeerAddressRecord};
     use uc_core::security::IdentityFingerprint;
+    use uc_core::trusted_peer::{TrustedPeer, TrustedPeerError};
 
     struct FakeMemberRepo {
         members: Vec<SpaceMember>,
@@ -331,6 +402,117 @@ mod tests {
 
         // ghost-b 仍被尝试删除并成功
         let removed = peer_addr_repo.removed.lock().unwrap().clone();
+        assert_eq!(removed, vec![DeviceId::new("ghost-b")]);
+    }
+
+    // ── trusted_peer reconcile ──────────────────────────────────────────
+
+    struct RecordingTrustedPeerRepo {
+        rows: StdMutex<Vec<TrustedPeer>>,
+        removed: StdMutex<Vec<DeviceId>>,
+        fail_remove_for: Option<DeviceId>,
+    }
+
+    #[async_trait]
+    impl TrustedPeerRepositoryPort for RecordingTrustedPeerRepo {
+        async fn get(
+            &self,
+            _peer_device_id: &DeviceId,
+        ) -> Result<Option<TrustedPeer>, TrustedPeerError> {
+            unreachable!("reconcile only calls list + remove")
+        }
+        async fn list(&self) -> Result<Vec<TrustedPeer>, TrustedPeerError> {
+            Ok(self.rows.lock().unwrap().clone())
+        }
+        async fn save(&self, _trusted_peer: &TrustedPeer) -> Result<(), TrustedPeerError> {
+            unreachable!("reconcile only calls list + remove")
+        }
+        async fn remove(&self, peer_device_id: &DeviceId) -> Result<bool, TrustedPeerError> {
+            if self
+                .fail_remove_for
+                .as_ref()
+                .is_some_and(|fail| fail == peer_device_id)
+            {
+                return Err(TrustedPeerError::Repository("io error".into()));
+            }
+            let mut rows = self.rows.lock().unwrap();
+            let before = rows.len();
+            rows.retain(|p| &p.peer_device_id != peer_device_id);
+            let removed = rows.len() < before;
+            self.removed.lock().unwrap().push(peer_device_id.clone());
+            Ok(removed)
+        }
+    }
+
+    fn trusted(device: &str) -> TrustedPeer {
+        TrustedPeer {
+            local_device_id: DeviceId::new("local"),
+            peer_device_id: DeviceId::new(device),
+            peer_fingerprint: fp(),
+            trusted_at: Utc::now(),
+        }
+    }
+
+    #[tokio::test]
+    async fn reconcile_trusted_peers_removes_only_orphans() {
+        let member_repo = Arc::new(FakeMemberRepo {
+            members: vec![member("active")],
+        });
+        let trusted_repo = Arc::new(RecordingTrustedPeerRepo {
+            rows: StdMutex::new(vec![
+                trusted("active"),
+                trusted("ghost-a"),
+                trusted("ghost-b"),
+            ]),
+            removed: StdMutex::new(vec![]),
+            fail_remove_for: None,
+        });
+
+        reconcile_trusted_peers(member_repo, trusted_repo.clone() as _)
+            .await
+            .expect("reconcile ok");
+
+        let removed = trusted_repo.removed.lock().unwrap().clone();
+        assert_eq!(removed.len(), 2);
+        assert!(removed.contains(&DeviceId::new("ghost-a")));
+        assert!(removed.contains(&DeviceId::new("ghost-b")));
+        let surviving = trusted_repo.rows.lock().unwrap();
+        assert_eq!(surviving.len(), 1);
+        assert_eq!(surviving[0].peer_device_id, DeviceId::new("active"));
+    }
+
+    #[tokio::test]
+    async fn reconcile_trusted_peers_no_op_when_aligned() {
+        let member_repo = Arc::new(FakeMemberRepo {
+            members: vec![member("a"), member("b")],
+        });
+        let trusted_repo = Arc::new(RecordingTrustedPeerRepo {
+            rows: StdMutex::new(vec![trusted("a"), trusted("b")]),
+            removed: StdMutex::new(vec![]),
+            fail_remove_for: None,
+        });
+
+        reconcile_trusted_peers(member_repo, trusted_repo.clone() as _)
+            .await
+            .expect("reconcile ok");
+
+        assert!(trusted_repo.removed.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn reconcile_trusted_peers_continues_after_individual_remove_failure() {
+        let member_repo = Arc::new(FakeMemberRepo { members: vec![] });
+        let trusted_repo = Arc::new(RecordingTrustedPeerRepo {
+            rows: StdMutex::new(vec![trusted("ghost-a"), trusted("ghost-b")]),
+            removed: StdMutex::new(vec![]),
+            fail_remove_for: Some(DeviceId::new("ghost-a")),
+        });
+
+        reconcile_trusted_peers(member_repo, trusted_repo.clone() as _)
+            .await
+            .expect("reconcile returns Ok even if a single remove fails");
+
+        let removed = trusted_repo.removed.lock().unwrap().clone();
         assert_eq!(removed, vec![DeviceId::new("ghost-b")]);
     }
 }

--- a/src-tauri/crates/uc-bootstrap/src/init.rs
+++ b/src-tauri/crates/uc-bootstrap/src/init.rs
@@ -6,6 +6,9 @@ use std::sync::Arc;
 use uc_application::facade::AppPaths;
 use uc_application::facade::SetupStatusFacade;
 use uc_core::config::AppConfig;
+use uc_core::ids::DeviceId;
+use uc_core::membership::MemberRepositoryPort;
+use uc_core::ports::peer_address::PeerAddressRepositoryPort;
 use uc_core::ports::{SettingsPort, SetupStatusPort};
 use uc_infra::FileSetupStatusRepository;
 
@@ -101,4 +104,233 @@ pub async fn ensure_default_device_name(
     }
 
     Ok(())
+}
+
+/// 启动期清理:删除所有"在 `peer_addr_repo` 但不在 `member_repo`"的孤儿
+/// 条目。
+///
+/// `peer_addr_repo` 在文档语义上是"已配对成员的权威集合"(见
+/// `dispatch_entry.rs` module doc),`dispatch_entry` 与
+/// `ensure_reachable_all` 都直接遍历它来决定 fan-out 目标。Slice 4 P5a-1
+/// 之前 unpair 只删 `member_repo`,残留的 peer_addr 条目就成了"已撤销
+/// 设备仍被当目标"的根因。Commit A 修了 unpair 路径,但 unpair 时遇到
+/// 异常或老版本写入的孤儿,需要这一次启动期 reconcile 兜底清掉。
+///
+/// 设计取舍:reconcile 失败不会阻断 daemon 启动 —— 失败只 log warn,因为
+/// 干净的不变量是"nice to have",运行时即便残留几个孤儿,影响仍然只是
+/// "对 unpaired peer 多发几次失败 envelope",不会导致数据损坏。
+pub async fn reconcile_peer_addresses(
+    member_repo: Arc<dyn MemberRepositoryPort>,
+    peer_addr_repo: Arc<dyn PeerAddressRepositoryPort>,
+) -> anyhow::Result<()> {
+    let members = member_repo
+        .list()
+        .await
+        .map_err(|e| anyhow::anyhow!("list members: {e}"))?;
+    // 成员数通常 1–10 量级,linear search 比引入 HashSet 更直接
+    // (`DeviceId` 也未实现 Hash)。
+    let member_ids: Vec<DeviceId> = members.into_iter().map(|m| m.device_id).collect();
+
+    let peer_addrs = peer_addr_repo
+        .list()
+        .await
+        .map_err(|e| anyhow::anyhow!("list peer addresses: {e}"))?;
+
+    let orphans: Vec<DeviceId> = peer_addrs
+        .into_iter()
+        .filter_map(|record| {
+            if member_ids.contains(&record.device_id) {
+                None
+            } else {
+                Some(record.device_id)
+            }
+        })
+        .collect();
+
+    if orphans.is_empty() {
+        tracing::debug!("peer_addr reconcile: no orphans");
+        return Ok(());
+    }
+
+    tracing::info!(
+        orphan_count = orphans.len(),
+        "peer_addr reconcile: removing orphan entries (in peer_addr_repo but not in member_repo)"
+    );
+
+    for device_id in &orphans {
+        match peer_addr_repo.remove(device_id).await {
+            Ok(()) => {
+                tracing::info!(
+                    device_id = %device_id.as_str(),
+                    "peer_addr reconcile: removed orphan"
+                );
+            }
+            Err(err) => {
+                // 单条失败不阻断其余清理,reconcile 是治理性,不是关键路径。
+                tracing::warn!(
+                    device_id = %device_id.as_str(),
+                    error = %err,
+                    "peer_addr reconcile: failed to remove orphan; will retry next boot"
+                );
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use chrono::Utc;
+    use std::sync::Mutex as StdMutex;
+    use uc_core::membership::{MemberSyncPreferences, MembershipError, SpaceMember};
+    use uc_core::ports::peer_address::{PeerAddressError, PeerAddressRecord};
+    use uc_core::security::IdentityFingerprint;
+
+    struct FakeMemberRepo {
+        members: Vec<SpaceMember>,
+    }
+
+    #[async_trait]
+    impl MemberRepositoryPort for FakeMemberRepo {
+        async fn get(&self, _device_id: &DeviceId) -> Result<Option<SpaceMember>, MembershipError> {
+            unreachable!("reconcile only calls list")
+        }
+        async fn list(&self) -> Result<Vec<SpaceMember>, MembershipError> {
+            Ok(self.members.clone())
+        }
+        async fn save(&self, _member: &SpaceMember) -> Result<(), MembershipError> {
+            unreachable!("reconcile only calls list")
+        }
+        async fn remove(&self, _device_id: &DeviceId) -> Result<bool, MembershipError> {
+            unreachable!("reconcile only calls list")
+        }
+    }
+
+    struct RecordingPeerAddrRepo {
+        records: StdMutex<Vec<PeerAddressRecord>>,
+        removed: StdMutex<Vec<DeviceId>>,
+        fail_remove_for: Option<DeviceId>,
+    }
+
+    #[async_trait]
+    impl PeerAddressRepositoryPort for RecordingPeerAddrRepo {
+        async fn get(
+            &self,
+            _device: &DeviceId,
+        ) -> Result<Option<PeerAddressRecord>, PeerAddressError> {
+            unreachable!("reconcile only calls list + remove")
+        }
+        async fn upsert(&self, _record: &PeerAddressRecord) -> Result<(), PeerAddressError> {
+            unreachable!("reconcile only calls list + remove")
+        }
+        async fn list(&self) -> Result<Vec<PeerAddressRecord>, PeerAddressError> {
+            Ok(self.records.lock().unwrap().clone())
+        }
+        async fn remove(&self, device: &DeviceId) -> Result<(), PeerAddressError> {
+            if self
+                .fail_remove_for
+                .as_ref()
+                .is_some_and(|fail| fail == device)
+            {
+                return Err(PeerAddressError::Internal("disk full".into()));
+            }
+            self.records
+                .lock()
+                .unwrap()
+                .retain(|r| &r.device_id != device);
+            self.removed.lock().unwrap().push(device.clone());
+            Ok(())
+        }
+    }
+
+    fn fp() -> IdentityFingerprint {
+        IdentityFingerprint::from_raw_string("ABCDEFGHIJKLMNOP").expect("16-char fingerprint")
+    }
+
+    fn member(device: &str) -> SpaceMember {
+        SpaceMember {
+            device_id: DeviceId::new(device),
+            device_name: format!("dev-{device}"),
+            identity_fingerprint: fp(),
+            joined_at: Utc::now(),
+            sync_preferences: MemberSyncPreferences::default(),
+        }
+    }
+
+    fn peer_record(device: &str) -> PeerAddressRecord {
+        PeerAddressRecord {
+            device_id: DeviceId::new(device),
+            addr_blob: vec![1, 2, 3],
+            observed_at: Utc::now(),
+        }
+    }
+
+    #[tokio::test]
+    async fn reconcile_removes_only_orphans() {
+        let member_repo = Arc::new(FakeMemberRepo {
+            members: vec![member("dev-current")],
+        });
+        let peer_addr_repo = Arc::new(RecordingPeerAddrRepo {
+            records: StdMutex::new(vec![
+                peer_record("dev-current"),
+                peer_record("ebbbd64f-orphan"),
+                peer_record("another-ghost"),
+            ]),
+            removed: StdMutex::new(vec![]),
+            fail_remove_for: None,
+        });
+
+        reconcile_peer_addresses(member_repo, peer_addr_repo.clone() as _)
+            .await
+            .expect("reconcile ok");
+
+        let removed = peer_addr_repo.removed.lock().unwrap().clone();
+        assert_eq!(removed.len(), 2);
+        assert!(removed.contains(&DeviceId::new("ebbbd64f-orphan")));
+        assert!(removed.contains(&DeviceId::new("another-ghost")));
+        // 当前成员不能被误删
+        let surviving = peer_addr_repo.records.lock().unwrap();
+        assert_eq!(surviving.len(), 1);
+        assert_eq!(surviving[0].device_id, DeviceId::new("dev-current"));
+    }
+
+    #[tokio::test]
+    async fn reconcile_no_op_when_aligned() {
+        let member_repo = Arc::new(FakeMemberRepo {
+            members: vec![member("a"), member("b")],
+        });
+        let peer_addr_repo = Arc::new(RecordingPeerAddrRepo {
+            records: StdMutex::new(vec![peer_record("a"), peer_record("b")]),
+            removed: StdMutex::new(vec![]),
+            fail_remove_for: None,
+        });
+
+        reconcile_peer_addresses(member_repo, peer_addr_repo.clone() as _)
+            .await
+            .expect("reconcile ok");
+
+        assert!(peer_addr_repo.removed.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn reconcile_continues_after_individual_remove_failure() {
+        // 一条 remove 失败不应阻断后续清理。
+        let member_repo = Arc::new(FakeMemberRepo { members: vec![] });
+        let peer_addr_repo = Arc::new(RecordingPeerAddrRepo {
+            records: StdMutex::new(vec![peer_record("ghost-a"), peer_record("ghost-b")]),
+            removed: StdMutex::new(vec![]),
+            fail_remove_for: Some(DeviceId::new("ghost-a")),
+        });
+
+        reconcile_peer_addresses(member_repo, peer_addr_repo.clone() as _)
+            .await
+            .expect("reconcile returns Ok even if a single remove fails");
+
+        // ghost-b 仍被尝试删除并成功
+        let removed = peer_addr_repo.removed.lock().unwrap().clone();
+        assert_eq!(removed, vec![DeviceId::new("ghost-b")]);
+    }
 }

--- a/src-tauri/crates/uc-bootstrap/src/lib.rs
+++ b/src-tauri/crates/uc-bootstrap/src/lib.rs
@@ -29,7 +29,7 @@ pub use builders::{
     build_slice1_cli_context, CliBootstrapContext, DaemonBootstrapContext, GuiBootstrapContext,
 };
 pub use config::load_config;
-pub use init::{ensure_default_device_name, is_setup_complete};
+pub use init::{ensure_default_device_name, is_setup_complete, reconcile_peer_addresses};
 pub use non_gui_runtime::{
     build_app_facade_from_deps, build_cli_app_facade, build_cli_app_runtime, build_non_gui_bundle,
     resolve_clipboard_integration_mode, AppFacadeAssemblyOptions, CliAppRuntime,

--- a/src-tauri/crates/uc-bootstrap/src/lib.rs
+++ b/src-tauri/crates/uc-bootstrap/src/lib.rs
@@ -29,7 +29,10 @@ pub use builders::{
     build_slice1_cli_context, CliBootstrapContext, DaemonBootstrapContext, GuiBootstrapContext,
 };
 pub use config::load_config;
-pub use init::{ensure_default_device_name, is_setup_complete, reconcile_peer_addresses};
+pub use init::{
+    ensure_default_device_name, is_setup_complete, reconcile_peer_addresses,
+    reconcile_trusted_peers,
+};
 pub use non_gui_runtime::{
     build_app_facade_from_deps, build_cli_app_facade, build_cli_app_runtime, build_non_gui_bundle,
     resolve_clipboard_integration_mode, AppFacadeAssemblyOptions, CliAppRuntime,

--- a/src-tauri/crates/uc-bootstrap/src/space_setup.rs
+++ b/src-tauri/crates/uc-bootstrap/src/space_setup.rs
@@ -322,6 +322,7 @@ pub async fn build_space_setup_assembly(
     // 能直接读到。Facade 本身是纯 thin wrapper,构造非常便宜。
     let roster = Arc::new(MemberRosterFacade::new(MemberRosterDeps {
         member_repo: Arc::clone(&deps.device.member_repo),
+        peer_addr_repo: Arc::clone(&wired.peer_addr_repo),
         local_identity: Arc::clone(&local_identity),
         presence: Arc::clone(&presence),
     }));

--- a/src-tauri/crates/uc-bootstrap/src/space_setup.rs
+++ b/src-tauri/crates/uc-bootstrap/src/space_setup.rs
@@ -323,6 +323,7 @@ pub async fn build_space_setup_assembly(
     let roster = Arc::new(MemberRosterFacade::new(MemberRosterDeps {
         member_repo: Arc::clone(&deps.device.member_repo),
         peer_addr_repo: Arc::clone(&wired.peer_addr_repo),
+        trusted_peer_repo: Arc::clone(&wired.trusted_peer_repo),
         local_identity: Arc::clone(&local_identity),
         presence: Arc::clone(&presence),
     }));

--- a/src-tauri/crates/uc-bootstrap/tests/slice2_phase1_presence_e2e.rs
+++ b/src-tauri/crates/uc-bootstrap/tests/slice2_phase1_presence_e2e.rs
@@ -412,6 +412,7 @@ async fn build_side(name: &'static str, rendezvous_base_url: String) -> Side {
         member_repo: Arc::clone(&member_repo) as Arc<dyn MemberRepositoryPort>,
         peer_addr_repo: Arc::clone(&peer_addr_repo)
             as Arc<dyn uc_core::ports::PeerAddressRepositoryPort>,
+        trusted_peer_repo: Arc::clone(&trusted_peer_repo) as Arc<dyn TrustedPeerRepositoryPort>,
         local_identity: local_identity_for_roster,
         presence: presence_for_roster,
     }));

--- a/src-tauri/crates/uc-bootstrap/tests/slice2_phase1_presence_e2e.rs
+++ b/src-tauri/crates/uc-bootstrap/tests/slice2_phase1_presence_e2e.rs
@@ -410,6 +410,8 @@ async fn build_side(name: &'static str, rendezvous_base_url: String) -> Side {
 
     let roster = Arc::new(MemberRosterFacade::new(MemberRosterDeps {
         member_repo: Arc::clone(&member_repo) as Arc<dyn MemberRepositoryPort>,
+        peer_addr_repo: Arc::clone(&peer_addr_repo)
+            as Arc<dyn uc_core::ports::PeerAddressRepositoryPort>,
         local_identity: local_identity_for_roster,
         presence: presence_for_roster,
     }));

--- a/src-tauri/crates/uc-bootstrap/tests/slice2_phase2_clipboard_e2e.rs
+++ b/src-tauri/crates/uc-bootstrap/tests/slice2_phase2_clipboard_e2e.rs
@@ -444,6 +444,7 @@ async fn build_side(name: &'static str, rendezvous_base_url: String) -> Side {
         member_repo: Arc::clone(&member_repo) as Arc<dyn MemberRepositoryPort>,
         peer_addr_repo: Arc::clone(&peer_addr_repo)
             as Arc<dyn uc_core::ports::PeerAddressRepositoryPort>,
+        trusted_peer_repo: Arc::clone(&trusted_peer_repo) as Arc<dyn TrustedPeerRepositoryPort>,
         local_identity: local_identity_for_roster,
         presence: presence_for_roster,
     }));

--- a/src-tauri/crates/uc-bootstrap/tests/slice2_phase2_clipboard_e2e.rs
+++ b/src-tauri/crates/uc-bootstrap/tests/slice2_phase2_clipboard_e2e.rs
@@ -442,6 +442,8 @@ async fn build_side(name: &'static str, rendezvous_base_url: String) -> Side {
 
     let roster = Arc::new(MemberRosterFacade::new(MemberRosterDeps {
         member_repo: Arc::clone(&member_repo) as Arc<dyn MemberRepositoryPort>,
+        peer_addr_repo: Arc::clone(&peer_addr_repo)
+            as Arc<dyn uc_core::ports::PeerAddressRepositoryPort>,
         local_identity: local_identity_for_roster,
         presence: presence_for_roster,
     }));

--- a/src-tauri/crates/uc-cli/src/commands/devices.rs
+++ b/src-tauri/crates/uc-cli/src/commands/devices.rs
@@ -74,6 +74,9 @@ fn render_roster_error(err: &RosterError) -> String {
     match err {
         RosterError::MemberRepository(message) => format!("list devices failed: {message}"),
         RosterError::LocalIdentity(message) => format!("local identity read failed: {message}"),
+        RosterError::PeerAddressRepository(message) => {
+            format!("peer address cleanup failed: {message}")
+        }
         RosterError::NotFound(message) => format!("member not found: {message}"),
         RosterError::Unavailable => "member roster unavailable".to_string(),
     }

--- a/src-tauri/crates/uc-cli/src/commands/devices.rs
+++ b/src-tauri/crates/uc-cli/src/commands/devices.rs
@@ -77,6 +77,9 @@ fn render_roster_error(err: &RosterError) -> String {
         RosterError::PeerAddressRepository(message) => {
             format!("peer address cleanup failed: {message}")
         }
+        RosterError::TrustedPeerRepository(message) => {
+            format!("trusted peer cleanup failed: {message}")
+        }
         RosterError::NotFound(message) => format!("member not found: {message}"),
         RosterError::Unavailable => "member roster unavailable".to_string(),
     }

--- a/src-tauri/crates/uc-cli/src/commands/members.rs
+++ b/src-tauri/crates/uc-cli/src/commands/members.rs
@@ -112,6 +112,9 @@ pub async fn run(json: bool, verbose: bool) -> i32 {
             let msg = match &err {
                 RosterError::MemberRepository(m) => format!("list members failed: {m}"),
                 RosterError::LocalIdentity(m) => format!("local identity read failed: {m}"),
+                RosterError::PeerAddressRepository(m) => {
+                    format!("peer address cleanup failed: {m}")
+                }
                 RosterError::NotFound(m) => format!("member not found: {m}"),
                 RosterError::Unavailable => "member roster unavailable".to_string(),
             };

--- a/src-tauri/crates/uc-cli/src/commands/members.rs
+++ b/src-tauri/crates/uc-cli/src/commands/members.rs
@@ -115,6 +115,9 @@ pub async fn run(json: bool, verbose: bool) -> i32 {
                 RosterError::PeerAddressRepository(m) => {
                     format!("peer address cleanup failed: {m}")
                 }
+                RosterError::TrustedPeerRepository(m) => {
+                    format!("trusted peer cleanup failed: {m}")
+                }
                 RosterError::NotFound(m) => format!("member not found: {m}"),
                 RosterError::Unavailable => "member roster unavailable".to_string(),
             };


### PR DESCRIPTION
## Summary

Unpair previously only deleted from `member_repo`, leaving stale rows in `peer_addr_repo` (which `dispatch_entry` / `ensure_reachable_all` iterate as the authoritative paired-members roster) and `trusted_peer` (which `TrustPeerUseCase::execute` checks via `AlreadyTrusted` and would block a fresh re-pair). `MemberRosterFacade::revoke_member` now cascades through all three repos in `member → peer_addr → trusted_peer` order, restoring the `peer_addr ⊆ member` and `trusted_peer ⊆ member` invariants. Two new `reconcile_peer_addresses` / `reconcile_trusted_peers` janitor passes run at the top of `build_daemon_app` to clean orphans already on disk from older builds. New `RosterError::PeerAddressRepository` / `TrustedPeerRepository` variants surface failures distinctly so the next-boot reconcile can act as a safety net without silently swallowing.

## Test plan

- [x] `cargo test -p uc-application --lib facade::roster` (15/15, including 5 revoke_member cases: three-table cascade, missing-trust tolerance, not-found short-circuit, peer_addr failure, trusted_peer failure)
- [x] `cargo test -p uc-bootstrap --lib init::` (6/6: peer_addr & trusted_peer reconcile each cover only-orphans, aligned no-op, single-failure resilience)
- [x] `cargo check --workspace --tests`
- [ ] Manual: unpair a paired peer, confirm dispatch + presence stop targeting it; rebuild + restart daemon, confirm logs show 0 reconcile orphans on a clean session