### PR TITLE
chore(observability): silence swarm_discovery::socket EHOSTUNREACH spam

### DIFF
--- a/src-tauri/crates/uc-observability/src/profile.rs
+++ b/src-tauri/crates/uc-observability/src/profile.rs
@@ -55,6 +55,12 @@ const NOISE_FILTERS: &[&str] = &[
     // swarm-discovery is the mDNS backend pulled in by the
     // `address-lookup-mdns` feature; very chatty at INFO/DEBUG.
     "swarm_discovery=warn",
+    // The socket actor logs `error sending mDNS: No route to host` on every
+    // tick when a bound interface (VPN/Clash TUN, stale virtual NIC, Wi-Fi
+    // mid-reassoc) returns EHOSTUNREACH. The condition is harmless — peer
+    // discovery still works on the other interfaces — but the actor's send
+    // cadence is fixed inside the crate, so we suppress the per-tick WARN.
+    "swarm_discovery::socket=error",
     // hickory-dns resolver used by pkarr + relay URL resolution.
     "hickory=warn",
     // Catch-all for libraries that emit through the `log` crate (forwarded


### PR DESCRIPTION
## Summary

The `swarm_discovery::socket` sender actor logs a WARN on every tick when a bound interface returns `EHOSTUNREACH (os error 65)` — typically caused by VPN/Clash TUN, stale virtual NICs, or Wi-Fi mid-reassoc. Discovery still succeeds on the other interfaces, but the actor's send cadence is fixed inside the crate, so the noise is unavoidable from our side.

This PR adds a single `tracing` directive `swarm_discovery::socket=error` to `NOISE_FILTERS`, capping just that submodule while leaving the rest of `swarm_discovery` at WARN for genuine signals.

## Test plan
- [x] `cargo check -p uc-observability` passes
- [ ] Run the app on a host with Clash/VPN active and confirm the per-tick `error sending mDNS` WARN no longer appears

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced log noise from repeated network connectivity messages during normal operation, improving log readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->