### PR TITLE
fix(quick-panel): wrap webview entry in redux Provider

### DIFF
--- a/src/quick-panel/main.tsx
+++ b/src/quick-panel/main.tsx
@@ -1,14 +1,18 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
+import { Provider } from 'react-redux'
 import QuickPanelApp from './QuickPanelApp'
 import '@/i18n'
 import { initializeWindowUi } from '@/lib/window-ui'
+import { store } from '@/store'
 import '@/styles/globals.css'
 
 initializeWindowUi()
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
-    <QuickPanelApp />
+    <Provider store={store}>
+      <QuickPanelApp />
+    </Provider>
   </React.StrictMode>
 )


### PR DESCRIPTION
## Summary

- `useClipboardEventStream` started calling `useAppDispatch` in 07fcb220 (inbound placeholder cards), but the quick-panel webview entry (`src/quick-panel/main.tsx`) never mounted react-redux's `Provider`.
- Hook threw "could not find react-redux context value" on mount, crashing the panel's React tree — toggling the global shortcut showed a blank window.
- Wrap `QuickPanelApp` in `<Provider store={store}>` mirroring the main window entry to restore the panel.

## Test plan

- [ ] Verify quick panel opens and renders history when triggered via global shortcut on macOS
- [ ] Verify on Windows
- [x] `pnpm exec tsc --noEmit`
- [x] `pnpm exec vitest run src/quick-panel`