### PR TITLE
fix(devices): show real online state and cut offline detection latency

### DIFF
--- a/src-tauri/crates/uc-application/src/usecases/presence/ensure_reachable_all.rs
+++ b/src-tauri/crates/uc-application/src/usecases/presence/ensure_reachable_all.rs
@@ -120,7 +120,13 @@ impl EnsureReachableAllUseCase {
             let presence = Arc::clone(&self.presence);
             let device_id = device_id.clone();
             set.spawn(async move {
-                let result = presence.ensure_reachable(&device_id).await;
+                // 用 verify_reachable 而非 ensure_reachable：probe 场景需要
+                // 绕过 IrohPresenceAdapter 的 fast-path，对已有 alive 连接
+                // 的 peer 也强制重新拨号。否则对端断网期间 fast-path 会持续
+                // 返回 Online，UI 要等 ~60s QUIC max_idle_timeout watchdog
+                // 才能切灰。F1 hook 路径下 peers map 为空，verify_reachable
+                // 与 ensure_reachable 行为等价。
+                let result = presence.verify_reachable(&device_id).await;
                 (device_id, result)
             });
         }

--- a/src-tauri/crates/uc-core/src/ports/presence.rs
+++ b/src-tauri/crates/uc-core/src/ports/presence.rs
@@ -56,6 +56,26 @@ pub trait PresencePort: Send + Sync {
     async fn ensure_reachable(&self, device: &DeviceId)
         -> Result<ReachabilityState, PresenceError>;
 
+    /// Force-revalidate reachability, bypassing any cached "alive connection"
+    /// fast-path inside the implementation.
+    ///
+    /// 用途：定期 probe 场景。`ensure_reachable` 在已有 alive 连接时即时返回
+    /// `Online`，这是业务路径（剪贴板传输前先确保连接可用）的合理优化；
+    /// 但当对端真断网时，QUIC `Connection::closed` watchdog 要等
+    /// `max_idle_timeout`（典型 60s）才能触发 Offline，期间
+    /// `ensure_reachable` 会持续撒谎说 Online。`verify_reachable` 强制重新
+    /// 拨号验证：拨号成功记 Online，拨号失败立即记 Offline 并清理 stale
+    /// 连接，把离线检测时延压到拨号失败时间（typically 5–15s）。
+    ///
+    /// Default impl 委托给 `ensure_reachable`，便于 mock / fake 复用而不必
+    /// 实现两份语义；带 fast-path 缓存的真实 adapter 应当 override。
+    async fn verify_reachable(
+        &self,
+        device: &DeviceId,
+    ) -> Result<ReachabilityState, PresenceError> {
+        self.ensure_reachable(device).await
+    }
+
     /// Read the current cached state without dialing.
     ///
     /// Returns `Unknown` if the device has never been probed in the current

--- a/src-tauri/crates/uc-daemon-contract/src/api/types.rs
+++ b/src-tauri/crates/uc-daemon-contract/src/api/types.rs
@@ -49,6 +49,21 @@ pub struct SpaceMemberDto {
     pub connected: bool,
 }
 
+/// Result of a `POST /presence/refresh` round.
+///
+/// 主动 probe 一轮 `ensure_reachable_all` 后的统计回执。UI 不靠这里直接判定
+/// 在线状态：probe 过程中各设备的 Online/Offline 变化会通过既有
+/// `peers.changed` WebSocket 链路推送，前端再走 `GET /paired-devices`
+/// 重拉。该响应只用于调用方显示进度或排障。
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PresenceRefreshResponse {
+    pub total: u32,
+    pub online: u32,
+    pub offline: u32,
+    pub errors: u32,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FileTransferProgressPayload {

--- a/src-tauri/crates/uc-infra/src/network/iroh/presence_adapter.rs
+++ b/src-tauri/crates/uc-infra/src/network/iroh/presence_adapter.rs
@@ -194,34 +194,23 @@ impl IrohPresenceAdapter {
     }
 }
 
-#[async_trait]
-impl PresencePort for IrohPresenceAdapter {
-    #[instrument(skip_all, fields(device = %device.as_str()))]
-    async fn ensure_reachable(
-        &self,
-        device: &DeviceId,
-    ) -> Result<ReachabilityState, PresenceError> {
+impl IrohPresenceAdapter {
+    /// 共享拨号路径：被 `ensure_reachable`（fast-path miss 后）和
+    /// `verify_reachable`（强制路径）复用。负责：
+    ///
+    /// 1. 从 `peer_addr_repo` 读地址 → 解码 `EndpointAddr`
+    /// 2. 通过 `connect_with_staggered_retry` 发起 iroh 拨号
+    /// 3. 成功：spawn watchdog、写 `peers` map、broadcast `Online`
+    ///    （若已存在 alive 条目则丢弃新拨连接，保留旧的——避免主动重连
+    ///    扰动同步链路）
+    /// 4. 失败：写 `last_state = Offline`、broadcast `Offline`
+    ///    （**不**清理已存在的 stale 条目——业务路径下拨号可能因临时网络
+    ///    抖动失败，旧连接其实还可用；`verify_reachable` 在外层补偿
+    ///    "把假装活着的旧连接 close 掉"的清理动作）
+    async fn dial_and_track(&self, device: &DeviceId) -> Result<ReachabilityState, PresenceError> {
         let key = device.as_str().to_string();
 
-        // Step 1: fast-path on an already-tracked live connection.
-        {
-            let mut peers = self.peers.lock().await;
-            if let Some(entry) = peers.get(&key) {
-                if entry.connection.close_reason().is_none() {
-                    debug!("ensure_reachable: already tracked and alive");
-                    return Ok(ReachabilityState::Online);
-                }
-                // Stale entry — the watchdog should already be in the
-                // process of cleaning up, but don't block on it. Remove
-                // here so the re-dial path below gets a clean slate.
-                if let Some(stale) = peers.remove(&key) {
-                    stale.watchdog.abort();
-                    debug!("ensure_reachable: evicted stale tracked entry before re-dial");
-                }
-            }
-        }
-
-        // Step 2: look up the stored transport address.
+        // Look up the stored transport address.
         let record = self
             .peer_addr_repo
             .get(device)
@@ -230,25 +219,25 @@ impl PresencePort for IrohPresenceAdapter {
         let record = match record {
             Some(r) => r,
             None => {
-                debug!("ensure_reachable: no address record; returning NoAddress");
+                debug!("dial_and_track: no address record; returning NoAddress");
                 return Err(PresenceError::NoAddress(device.clone()));
             }
         };
 
-        // Step 3: decode the opaque blob into the adapter-private
-        // `EndpointAddr`. Failure is a data-integrity issue (someone wrote
-        // junk into the repo) — surface it as `Internal` without leaking
-        // the postcard error type upward. The blob is guaranteed to have
-        // had its ephemeral `Ip(...)` direct addresses stripped at
-        // pairing-time write (see `persistable_addr::to_persistable_addr`),
-        // so what we decode here is `id + Relay(...)`. iroh's built-in
-        // pkarr discovery fills in fresh direct addrs at connect time.
+        // Decode the opaque blob into the adapter-private `EndpointAddr`.
+        // Failure is a data-integrity issue (someone wrote junk into the
+        // repo) — surface it as `Internal` without leaking the postcard
+        // error type upward. The blob is guaranteed to have had its
+        // ephemeral `Ip(...)` direct addresses stripped at pairing-time
+        // write (see `persistable_addr::to_persistable_addr`), so what we
+        // decode here is `id + Relay(...)`. iroh's built-in pkarr
+        // discovery fills in fresh direct addrs at connect time.
         let endpoint_addr: EndpointAddr =
             postcard::from_bytes(&record.addr_blob).map_err(|err| {
                 PresenceError::Internal(format!("postcard decode EndpointAddr: {err}"))
             })?;
 
-        // Step 4: dial.
+        // Dial.
         match connect_with_staggered_retry(
             Arc::clone(&self.endpoint),
             endpoint_addr,
@@ -277,19 +266,26 @@ impl PresencePort for IrohPresenceAdapter {
 
                 {
                     let mut peers = self.peers.lock().await;
-                    // If someone else raced us to insert, abort our own
-                    // watchdog and keep theirs — the winner gets to manage
-                    // the single connection slot per device. This is a
-                    // defensive branch; `ensure_reachable` should never be
-                    // concurrently called for the same device in Slice 2.
+                    // If an alive entry exists already (concurrent insert
+                    // raced, or `verify_reachable` redialed against a
+                    // tracked-but-stale-looking peer), abort our own
+                    // watchdog and keep theirs — single connection slot
+                    // per device.
                     if let Some(existing) = peers.get(&key) {
                         if existing.connection.close_reason().is_none() {
-                            warn!(
-                                "ensure_reachable: concurrent insert detected; \
+                            debug!(
+                                "dial_and_track: alive tracked entry exists; \
                                  discarding freshly dialed connection",
                             );
                             watchdog.abort();
                             drop(connection);
+
+                            // 仍旧 broadcast Online — verify_reachable 调用方
+                            // 期望"拨号成功 ⇒ Online 信号回传"。
+                            let mut last = self.last_state.lock().await;
+                            last.insert(key.clone(), ReachabilityState::Online);
+                            drop(last);
+                            self.broadcast(device.clone(), ReachabilityState::Online, now);
                             return Ok(ReachabilityState::Online);
                         }
                     }
@@ -306,16 +302,16 @@ impl PresencePort for IrohPresenceAdapter {
                     let mut last = self.last_state.lock().await;
                     last.insert(key.clone(), ReachabilityState::Online);
                 }
-                info!("ensure_reachable: dial succeeded, peer marked Online");
+                info!("dial_and_track: dial succeeded, peer marked Online");
                 self.broadcast(device.clone(), ReachabilityState::Online, now);
                 Ok(ReachabilityState::Online)
             }
             Err(err) => {
                 // No iroh error type leaks upward — per `uc-infra/AGENTS.md`
                 // §9.1 the failure is summarised into `last_state` + an
-                // event. The member stays in the repo; the next
-                // `ensure_reachable` retry is how recovery happens.
-                debug!(error = %err, "ensure_reachable: dial failed, peer marked Offline");
+                // event. The member stays in the repo; the next dial
+                // attempt is how recovery happens.
+                debug!(error = %err, "dial_and_track: dial failed, peer marked Offline");
                 let now = self.now();
                 {
                     let mut last = self.last_state.lock().await;
@@ -325,6 +321,70 @@ impl PresencePort for IrohPresenceAdapter {
                 Ok(ReachabilityState::Offline)
             }
         }
+    }
+}
+
+#[async_trait]
+impl PresencePort for IrohPresenceAdapter {
+    #[instrument(skip_all, fields(device = %device.as_str()))]
+    async fn ensure_reachable(
+        &self,
+        device: &DeviceId,
+    ) -> Result<ReachabilityState, PresenceError> {
+        let key = device.as_str().to_string();
+
+        // Step 1: fast-path on an already-tracked live connection.
+        {
+            let mut peers = self.peers.lock().await;
+            if let Some(entry) = peers.get(&key) {
+                if entry.connection.close_reason().is_none() {
+                    debug!("ensure_reachable: already tracked and alive");
+                    return Ok(ReachabilityState::Online);
+                }
+                // Stale entry — the watchdog should already be in the
+                // process of cleaning up, but don't block on it. Remove
+                // here so the re-dial path below gets a clean slate.
+                if let Some(stale) = peers.remove(&key) {
+                    stale.watchdog.abort();
+                    debug!("ensure_reachable: evicted stale tracked entry before re-dial");
+                }
+            }
+        }
+
+        // Step 2-4: dial via shared path.
+        self.dial_and_track(device).await
+    }
+
+    #[instrument(skip_all, fields(device = %device.as_str()))]
+    async fn verify_reachable(
+        &self,
+        device: &DeviceId,
+    ) -> Result<ReachabilityState, PresenceError> {
+        // 跳过 fast-path —— 即便已有 alive 连接也强制重拨验证可达性。
+        let result = self.dial_and_track(device).await?;
+
+        // 拨号失败 ⇒ 对端真不可达。把任何"看起来还活着"的 tracked 条目
+        // 从 peers map 移除并主动 close，避免下次 `ensure_reachable` 又
+        // 走 fast-path 撒谎说 Online。
+        //
+        // 不显式 abort watchdog：`Connection::close()` 让 watchdog 的
+        // `connection.closed().await` 立即 resolve 跑 cleanup（remove 已
+        // noop, last_state 已是 Offline, 再发一次冗余 Offline 事件幂等
+        // 无害）。当 `stale` 离作用域时 `TrackedPeer::drop` 兜底 abort，
+        // 此时 watchdog 多半已 fire 完毕，abort 也是 noop。这比"先 abort
+        // 后 close"避免 watchdog cleanup 半途被砍的 race。
+        if matches!(result, ReachabilityState::Offline) {
+            let stale = {
+                let mut peers = self.peers.lock().await;
+                peers.remove(device.as_str())
+            };
+            if let Some(stale) = stale {
+                stale.connection.close(0u32.into(), b"verify_failed");
+                debug!("verify_reachable: closed stale connection after dial failure");
+            }
+        }
+
+        Ok(result)
     }
 
     #[instrument(skip_all, fields(device = %device.as_str()))]

--- a/src-tauri/crates/uc-webserver/src/api/routes.rs
+++ b/src-tauri/crates/uc-webserver/src/api/routes.rs
@@ -87,6 +87,7 @@ pub fn router_l2_plus(state: DaemonApiState) -> Router<DaemonApiState> {
         .route("/status", get(status))
         .route("/peers", get(peers))
         .route("/paired-devices", get(paired_devices))
+        .route("/presence/refresh", post(refresh_presence))
         .merge(crate::api::lifecycle::router())
         .route(
             &format!("{}/:entry_id", http_route::CLIPBOARD_RESTORE),
@@ -169,6 +170,13 @@ async fn peers(State(state): State<DaemonApiState>) -> impl IntoResponse {
 
 async fn paired_devices(State(state): State<DaemonApiState>) -> impl IntoResponse {
     match state.paired_devices().await {
+        Ok(response) => Json(response).into_response(),
+        Err(error) => internal_error(error).into_response(),
+    }
+}
+
+async fn refresh_presence(State(state): State<DaemonApiState>) -> impl IntoResponse {
+    match state.refresh_presence().await {
         Ok(response) => Json(response).into_response(),
         Err(error) => internal_error(error).into_response(),
     }

--- a/src-tauri/crates/uc-webserver/src/api/server.rs
+++ b/src-tauri/crates/uc-webserver/src/api/server.rs
@@ -28,7 +28,8 @@ use crate::api::dto::error::ApiError;
 use crate::api::openapi::ApiDoc;
 use crate::api::routes;
 use crate::api::types::{
-    DaemonWsEvent, HealthResponse, PeerSnapshotDto, SpaceMemberDto, StatusResponse,
+    DaemonWsEvent, HealthResponse, PeerSnapshotDto, PresenceRefreshResponse, SpaceMemberDto,
+    StatusResponse,
 };
 use crate::api::ws;
 use crate::security::SecurityState;
@@ -110,16 +111,38 @@ impl DaemonApiState {
             .collect())
     }
 
+    /// 主动 probe 所有已配对 peer 的连接性。
+    ///
+    /// 用途：让"对端断网"场景下的离线检测从 ~60s（QUIC max_idle_timeout）
+    /// 缩短到 probe 间隔 + 拨号失败时间。`ensure_reachable_all` 内部对每个
+    /// peer 都重新发起一次 iroh 拨号——在线 peer 拨号成功后丢弃新连接保留
+    /// 旧的；离线 peer 拨号失败会立刻 `broadcast(Offline)`，进而触发
+    /// `peers.changed` 推送、前端重拉 `/paired-devices`、UI 切灰。
+    pub async fn refresh_presence(&self) -> anyhow::Result<PresenceRefreshResponse> {
+        let report = self.app_facade.refresh_presence().await?;
+        Ok(PresenceRefreshResponse {
+            total: report.total as u32,
+            online: report.online as u32,
+            offline: report.offline as u32,
+            errors: report.errors.len() as u32,
+        })
+    }
+
     pub async fn paired_devices(&self) -> anyhow::Result<Vec<SpaceMemberDto>> {
-        let members = self.app_facade.list_members().await?;
-        Ok(members
+        // 通过 list_peer_snapshots() 获取真实在线状态：
+        // 该方法走 list_with_presence()，会聚合 PresencePort.current_state()，
+        // 反映 IrohPresenceAdapter 中由 ensure_reachable / connection.closed()
+        // 维护的 last_state 缓存。list_members() 不查 PresencePort，所以
+        // 拿不到 connected。同时 list_peer_snapshots() 已过滤本机。
+        let snapshots = self.app_facade.list_peer_snapshots().await?;
+        Ok(snapshots
             .into_iter()
-            .map(|member| SpaceMemberDto {
-                peer_id: member.device_id,
-                device_name: member.device_name,
-                pairing_state: "Trusted".to_string(),
+            .map(|snapshot| SpaceMemberDto {
+                peer_id: snapshot.peer_id,
+                device_name: snapshot.device_name.unwrap_or_default(),
+                pairing_state: snapshot.pairing_state,
                 last_seen_at_ms: None,
-                connected: false,
+                connected: snapshot.connected,
             })
             .collect())
     }

--- a/src/api/daemon/index.ts
+++ b/src/api/daemon/index.ts
@@ -77,6 +77,8 @@ export {
   unpairDevice,
 } from './members'
 export type { LocalDeviceInfo, SpaceMember } from './members'
+export { refreshPresence } from './presence'
+export type { PresenceRefreshResult } from './presence'
 export { classifyPairingError } from './events'
 export type { PairingErrorKind } from './events'
 export { querySearch, getSearchStatus, triggerSearchRebuild } from './search'

--- a/src/api/daemon/members.ts
+++ b/src/api/daemon/members.ts
@@ -23,9 +23,9 @@ interface LocalDeviceInfoResponse {
 /**
  * Space member — matches `SpaceMemberDto` on the Rust side.
  *
- * `connected` is the runtime presence flag. After the libp2p adapter
- * was retired in Slice 4 P5a-1 it is hard-coded to `false` until the
- * iroh-side presence channel is wired in.
+ * `connected` 来自 `IrohPresenceAdapter.last_state`，由 ensure_reachable
+ * 拨号成功 / `connection.closed()` watchdog 维护；`/paired-devices` 通过
+ * `list_peer_snapshots` 聚合 `PresencePort.current_state()` 返回真实值。
  */
 export interface SpaceMember {
   peerId: string

--- a/src/api/daemon/presence.ts
+++ b/src/api/daemon/presence.ts
@@ -1,0 +1,32 @@
+/**
+ * Presence API — typed accessors for daemon presence endpoints.
+ *
+ * # Endpoints / 端点
+ * - `POST /presence/refresh` → 主动 probe 一轮所有已配对 peer 的连接性
+ *
+ * 用途：缩短"对端断网"场景下的离线检测时延。后端 watchdog 依赖 QUIC
+ * `max_idle_timeout = 60s` 才能感知断连；前端在 DevicesPage 可见时定期
+ * probe，可在 ~probe 间隔 + 拨号失败时间内反馈离线。probe 过程中真实的
+ * Online/Offline 变化会通过既有 `peers.changed` WebSocket 链路推到前端。
+ */
+
+import { daemonClient } from './client'
+
+export interface PresenceRefreshResult {
+  total: number
+  online: number
+  offline: number
+  errors: number
+}
+
+/**
+ * 触发一轮 ensure_reachable_all 探测。
+ *
+ * 后端会对所有已配对 peer 并发拨号；离线 peer 立即被标记 Offline，进而
+ * 推送 `peers.changed`，前端再走 fetchSpaceMembers 重拉刷新 UI。
+ */
+export async function refreshPresence(): Promise<PresenceRefreshResult> {
+  return daemonClient.request<PresenceRefreshResult>('/presence/refresh', {
+    method: 'POST',
+  })
+}

--- a/src/components/device/SpaceMembersPanel.tsx
+++ b/src/components/device/SpaceMembersPanel.tsx
@@ -13,12 +13,7 @@ import { useSetting } from '@/hooks/useSetting'
 import { daemonWs } from '@/lib/daemon-ws'
 import { createLogger } from '@/lib/logger'
 import { useAppDispatch, useAppSelector } from '@/store/hooks'
-import {
-  fetchSpaceMembers,
-  clearSpaceMembersError,
-  updatePeerConnectionStatus,
-  updatePeerDeviceName,
-} from '@/store/slices/devicesSlice'
+import { fetchSpaceMembers, clearSpaceMembersError } from '@/store/slices/devicesSlice'
 
 const log = createLogger('space-members-panel')
 
@@ -47,29 +42,15 @@ const SpaceMembersPanel: React.FC = () => {
   useEffect(() => {
     dispatch(fetchSpaceMembers())
 
+    // 后端 PresenceMonitor 仅广播 `peers.changed` 全量快照（见
+    // uc-desktop/src/daemon/peers/presence_monitor.rs 模块注释）。每次
+    // PresenceEvent（拨号成功 / connection.closed()）都会触发一次快照，
+    // 所以这里重新 HTTP 拉一遍即可同步在线状态与名单变化，
+    // 不需要单独处理 connectionChanged / nameUpdated 增量事件。
     const handler = (event: { topic: string; eventType: string; payload: unknown }) => {
       if (event.topic !== 'peers') return
       if (event.eventType === 'peers.changed') {
-        // 成员加入/离开 — 重新拉一遍以同步本地缓存
         dispatch(fetchSpaceMembers())
-      }
-      if (event.eventType === 'peers.connectionChanged') {
-        const p = event.payload as {
-          peerId: string
-          deviceName?: string | null
-          connected: boolean
-        }
-        dispatch(
-          updatePeerConnectionStatus({
-            peerId: p.peerId,
-            connected: p.connected,
-            deviceName: p.deviceName,
-          })
-        )
-      }
-      if (event.eventType === 'peers.nameUpdated') {
-        const p = event.payload as { peerId: string; deviceName: string }
-        dispatch(updatePeerDeviceName({ peerId: p.peerId, deviceName: p.deviceName }))
       }
     }
     const unsub = daemonWs.subscribe(['peers'], handler)

--- a/src/pages/DevicesPage.tsx
+++ b/src/pages/DevicesPage.tsx
@@ -1,8 +1,19 @@
 import React, { useEffect } from 'react'
+import { refreshPresence } from '@/api/daemon'
 import { SpaceMembersPanel, ThisDeviceCard } from '@/components'
 import { ScrollArea } from '@/components/ui/scroll-area'
+import { createLogger } from '@/lib/logger'
 import { useAppDispatch } from '@/store/hooks'
 import { fetchLocalDeviceInfo, fetchSpaceMembers } from '@/store/slices/devicesSlice'
+
+const log = createLogger('devices-page')
+
+// 主动 probe 间隔。QUIC `max_idle_timeout = 60s` 决定 watchdog 被动检测
+// 离线的上限；这里每 15s 主动跑一轮 ensure_reachable_all，离线 peer 拨号
+// 失败立即 broadcast(Offline) → peers.changed → UI 切灰，把"对端断网"
+// 的反馈时延压到 ~15s + 拨号失败时间。页面隐藏时浏览器会自动节流定时器
+// （后台 tab ≥ 1s），不再单独处理 visibility。
+const PRESENCE_REFRESH_INTERVAL_MS = 15_000
 
 const DevicesPage: React.FC = () => {
   const dispatch = useAppDispatch()
@@ -10,6 +21,17 @@ const DevicesPage: React.FC = () => {
   useEffect(() => {
     dispatch(fetchLocalDeviceInfo())
     dispatch(fetchSpaceMembers())
+
+    const probe = () => {
+      refreshPresence().catch(err => {
+        // setup 未完成 / daemon 未就绪时 refresh_presence 会 5xx；
+        // 不影响后续 tick，warn 即可。
+        log.warn({ err }, 'presence refresh failed')
+      })
+    }
+    probe()
+    const intervalId = setInterval(probe, PRESENCE_REFRESH_INTERVAL_MS)
+    return () => clearInterval(intervalId)
   }, [dispatch])
 
   return (

--- a/src/store/slices/devicesSlice.ts
+++ b/src/store/slices/devicesSlice.ts
@@ -99,24 +99,6 @@ const devicesSlice = createSlice({
     clearSpaceMembersError: state => {
       state.spaceMembersError = null
     },
-    updatePeerConnectionStatus: (
-      state,
-      action: { payload: { peerId: string; connected: boolean; deviceName?: string | null } }
-    ) => {
-      const peer = state.spaceMembers.find(d => d.peerId === action.payload.peerId)
-      if (peer) {
-        peer.connected = action.payload.connected
-        if (action.payload.deviceName) {
-          peer.deviceName = action.payload.deviceName
-        }
-      }
-    },
-    updatePeerDeviceName: (state, action: { payload: { peerId: string; deviceName: string } }) => {
-      const peer = state.spaceMembers.find(d => d.peerId === action.payload.peerId)
-      if (peer) {
-        peer.deviceName = action.payload.deviceName
-      }
-    },
   },
   extraReducers: builder => {
     // Local device info
@@ -183,10 +165,5 @@ const devicesSlice = createSlice({
   },
 })
 
-export const {
-  clearLocalDeviceError,
-  clearSpaceMembersError,
-  updatePeerConnectionStatus,
-  updatePeerDeviceName,
-} = devicesSlice.actions
+export const { clearLocalDeviceError, clearSpaceMembersError } = devicesSlice.actions
 export default devicesSlice.reducer


### PR DESCRIPTION
## Summary

- `paired_devices` was returning `connected=false` hard-coded, so other devices always rendered offline; switch the endpoint to `list_peer_snapshots` so the `PresencePort` value flows through.
- Add `PresencePort::verify_reachable` (default-implemented for mocks) so probe paths bypass `IrohPresenceAdapter`'s alive-connection fast-path; `EnsureReachableAllUseCase` now uses it and force-revalidates by re-dialing.
- Expose `POST /presence/refresh` and call it every 15s while `DevicesPage` is mounted, cutting perceived offline detection from ~60s (QUIC `max_idle_timeout`) to ~15-30s.
- Drop dead `peers.connectionChanged` / `peers.nameUpdated` frontend handlers — backend only emits `peers.changed` snapshots, so the working `peers.changed` → `fetchSpaceMembers` path is the single source of truth.

## Test plan

- [ ] Pair two peers; on Devices page, see the remote peer's status reflect actual online/offline (not always offline).
- [ ] Disconnect the remote peer (airplane mode / kill network); within ~30s of being on Devices page, the dot turns gray.
- [ ] Reconnect the remote peer; within ~15s the dot turns green again.
- [ ] `cargo test -p uc-infra --lib network::iroh::presence_adapter` and `cargo test -p uc-application --lib usecases::presence` still pass.