### PR TITLE
fix(file-cache + sync): kill poison panic, plug GC, recover sync after daemon respawn

### DIFF
--- a/src-tauri/crates/uc-application/src/facade/app_paths.rs
+++ b/src-tauri/crates/uc-application/src/facade/app_paths.rs
@@ -38,7 +38,7 @@ impl AppPaths {
             settings_path: dirs.app_data_root.join("settings.json"),
             logs_dir: dirs.app_data_root.join("logs"),
             cache_dir: dirs.app_cache_root.clone(),
-            file_cache_dir: dirs.app_cache_root.join("file-cache"),
+            file_cache_dir: dirs.app_data_root.join("file-cache"),
             spool_dir: dirs.app_cache_root.join("spool"),
             app_data_root_dir: dirs.app_data_root.clone(),
         }

--- a/src-tauri/crates/uc-application/src/facade/clipboard_history/mod.rs
+++ b/src-tauri/crates/uc-application/src/facade/clipboard_history/mod.rs
@@ -5,6 +5,7 @@ use thiserror::Error;
 use uc_core::blob::ports::BlobReaderPort;
 use uc_core::clipboard::link_utils::extract_domain;
 use uc_core::ids::{EntryId, EventId, FormatId, RepresentationId};
+use uc_core::ports::blob::BlobTransferPort;
 use uc_core::ports::clipboard::{ClipboardPayloadResolverPort, ThumbnailRepositoryPort};
 use uc_core::ports::search::search_index::SearchIndexPort;
 use uc_core::ports::{
@@ -109,6 +110,11 @@ pub struct ClipboardHistoryFacadeDeps {
     pub file_transfer_repo: Arc<dyn FileTransferRepositoryPort>,
     pub search_index: Option<Arc<dyn SearchIndexPort>>,
     pub file_cache_dir: Option<PathBuf>,
+    /// 删除剪贴板条目时释放对应的 iroh-blobs tag。`None` 表示该装配场景
+    /// 不接入 blob 系统（例如某些纯文本 / mock 测试场景），此时 untag
+    /// 直接跳过；后台 GC 仍会按既定节奏处理脏 metadata（panic 防御不
+    /// 依赖此 port 的存在，仅依赖 cache 文件与 GUI/sqlite 状态一致）。
+    pub blob_transfer: Option<Arc<dyn BlobTransferPort>>,
     /// `seed_text_entry` 用：构造 `ClipboardEvent.source_device`。
     pub device_identity: Arc<dyn DeviceIdentityPort>,
     /// `seed_text_entry` 用：构造 `captured_at_ms` / `created_at_ms`。
@@ -142,6 +148,7 @@ impl ClipboardHistoryFacade {
             file_transfer_repo,
             search_index,
             file_cache_dir,
+            blob_transfer,
             device_identity,
             clock,
         } = deps;
@@ -194,6 +201,9 @@ impl ClipboardHistoryFacade {
         if let Some(idx) = search_index.clone() {
             delete_uc = delete_uc.with_search_index(idx);
         }
+        if let Some(bt) = blob_transfer.clone() {
+            delete_uc = delete_uc.with_blob_transfer(bt);
+        }
 
         let mut clear_uc = ClearClipboardHistoryUseCase::from_ports(
             entry_repo,
@@ -206,6 +216,9 @@ impl ClipboardHistoryFacade {
         }
         if let Some(idx) = search_index {
             clear_uc = clear_uc.with_search_index(idx);
+        }
+        if let Some(bt) = blob_transfer {
+            clear_uc = clear_uc.with_blob_transfer(bt);
         }
 
         Self {

--- a/src-tauri/crates/uc-application/src/facade/clipboard_history/mod.rs
+++ b/src-tauri/crates/uc-application/src/facade/clipboard_history/mod.rs
@@ -11,6 +11,7 @@ use uc_core::ports::search::search_index::SearchIndexPort;
 use uc_core::ports::{
     ClipboardEntryRepositoryPort, ClipboardEventWriterPort, ClipboardRepresentationRepositoryPort,
     ClipboardSelectionRepositoryPort, ClockPort, DeviceIdentityPort, FileTransferRepositoryPort,
+    SettingsPort,
 };
 use uc_core::{
     ClipboardEntry, ClipboardEvent, ClipboardSelection, ClipboardSelectionDecision, MimeType,
@@ -19,9 +20,10 @@ use uc_core::{
 };
 
 use crate::usecases::clipboard_history::{
-    compute_clipboard_stats, ClearClipboardHistoryUseCase, DeleteClipboardEntryUseCase,
-    EntryDetailResult, EntryProjectionDto, EntryResourceResult, GetEntryDetailUseCase,
-    GetEntryResourceUseCase, ListClipboardEntryProjectionsUseCase, ListProjectionsError,
+    compute_clipboard_stats, CleanupExpiredFilesUseCase, CleanupResult,
+    ClearClipboardHistoryUseCase, DeleteClipboardEntryUseCase, EntryDetailResult,
+    EntryProjectionDto, EntryResourceResult, GetEntryDetailUseCase, GetEntryResourceUseCase,
+    ListClipboardEntryProjectionsUseCase, ListProjectionsError,
     ToggleFavoriteClipboardEntryUseCase,
 };
 
@@ -84,6 +86,15 @@ pub struct ClearHistoryResultView {
     pub failed_entries: Vec<(String, String)>,
 }
 
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct CleanupResultView {
+    pub files_removed: u32,
+    pub bytes_reclaimed: u64,
+    pub entries_deleted: u32,
+    pub orphans_removed: u32,
+    pub errors: u32,
+}
+
 #[derive(Debug, Clone, Error, PartialEq, Eq)]
 pub enum ClipboardHistoryError {
     #[error("entry not found")]
@@ -115,6 +126,9 @@ pub struct ClipboardHistoryFacadeDeps {
     /// 直接跳过；后台 GC 仍会按既定节奏处理脏 metadata（panic 防御不
     /// 依赖此 port 的存在，仅依赖 cache 文件与 GUI/sqlite 状态一致）。
     pub blob_transfer: Option<Arc<dyn BlobTransferPort>>,
+    /// `cleanup_expired_files` 读取 `file_sync.file_auto_cleanup` 与
+    /// `file_sync.file_retention_hours`。
+    pub settings: Arc<dyn SettingsPort>,
     /// `seed_text_entry` 用：构造 `ClipboardEvent.source_device`。
     pub device_identity: Arc<dyn DeviceIdentityPort>,
     /// `seed_text_entry` 用：构造 `captured_at_ms` / `created_at_ms`。
@@ -128,6 +142,7 @@ pub struct ClipboardHistoryFacade {
     toggle_favorite_uc: ToggleFavoriteClipboardEntryUseCase,
     delete_uc: DeleteClipboardEntryUseCase,
     clear_uc: ClearClipboardHistoryUseCase,
+    cleanup_uc: Option<CleanupExpiredFilesUseCase>,
     /// debug seed 路径需要的额外 ports，常态业务不直接消费。
     seed_event_writer: Arc<dyn ClipboardEventWriterPort>,
     seed_entry_repo: Arc<dyn ClipboardEntryRepositoryPort>,
@@ -149,6 +164,7 @@ impl ClipboardHistoryFacade {
             search_index,
             file_cache_dir,
             blob_transfer,
+            settings,
             device_identity,
             clock,
         } = deps;
@@ -206,20 +222,40 @@ impl ClipboardHistoryFacade {
         }
 
         let mut clear_uc = ClearClipboardHistoryUseCase::from_ports(
-            entry_repo,
-            selection_repo,
-            event_writer,
-            representation_repo,
+            entry_repo.clone(),
+            selection_repo.clone(),
+            event_writer.clone(),
+            representation_repo.clone(),
         );
-        if let Some(dir) = file_cache_dir {
+        if let Some(dir) = file_cache_dir.clone() {
             clear_uc = clear_uc.with_file_cache_dir(dir);
         }
-        if let Some(idx) = search_index {
+        if let Some(idx) = search_index.clone() {
             clear_uc = clear_uc.with_search_index(idx);
         }
-        if let Some(bt) = blob_transfer {
+        if let Some(bt) = blob_transfer.clone() {
             clear_uc = clear_uc.with_blob_transfer(bt);
         }
+
+        // cleanup 只在装配方传入了 file_cache_dir 时有意义 —— 没有 cache
+        // 目录就没有需要扫描的文件，构造 use case 也没用。
+        let cleanup_uc = file_cache_dir.map(|dir| {
+            let mut uc = CleanupExpiredFilesUseCase::new(
+                settings,
+                dir,
+                entry_repo,
+                selection_repo,
+                event_writer,
+                representation_repo,
+            );
+            if let Some(idx) = search_index {
+                uc = uc.with_search_index(idx);
+            }
+            if let Some(bt) = blob_transfer {
+                uc = uc.with_blob_transfer(bt);
+            }
+            uc
+        });
 
         Self {
             list_uc,
@@ -228,6 +264,7 @@ impl ClipboardHistoryFacade {
             toggle_favorite_uc,
             delete_uc,
             clear_uc,
+            cleanup_uc,
             seed_event_writer,
             seed_entry_repo,
             seed_device_identity,
@@ -384,6 +421,25 @@ impl ClipboardHistoryFacade {
         Ok(resource_to_view(resource))
     }
 
+    /// Run a single sweep of the file-cache directory: every expired file
+    /// is routed through `delete_entry` (so iroh-blobs tags + sqlite rows
+    /// + cache files are cleaned together), or removed as an orphan if no
+    /// entry claims it.
+    ///
+    /// Returns `Ok(default())` when the facade was assembled without a
+    /// `file_cache_dir` (typical for headless test contexts) — there is no
+    /// cache to clean.
+    pub async fn cleanup_expired_files(&self) -> Result<CleanupResultView, ClipboardHistoryError> {
+        let Some(uc) = self.cleanup_uc.as_ref() else {
+            return Ok(CleanupResultView::default());
+        };
+        let result = uc
+            .execute()
+            .await
+            .map_err(|e| ClipboardHistoryError::Internal(e.to_string()))?;
+        Ok(cleanup_to_view(result))
+    }
+
     pub async fn clear_history(&self) -> Result<ClearHistoryResultView, ClipboardHistoryError> {
         let result = self
             .clear_uc
@@ -442,6 +498,16 @@ fn resource_to_view(resource: EntryResourceResult) -> EntryResourceView {
         size_bytes: resource.size_bytes,
         url: resource.url,
         inline_data: resource.inline_data,
+    }
+}
+
+fn cleanup_to_view(result: CleanupResult) -> CleanupResultView {
+    CleanupResultView {
+        files_removed: result.files_removed,
+        bytes_reclaimed: result.bytes_reclaimed,
+        entries_deleted: result.entries_deleted,
+        orphans_removed: result.orphans_removed,
+        errors: result.errors,
     }
 }
 

--- a/src-tauri/crates/uc-application/src/facade/mod.rs
+++ b/src-tauri/crates/uc-application/src/facade/mod.rs
@@ -47,6 +47,7 @@ pub use clipboard_capture::{
     ClipboardCapturePort,
 };
 pub use clipboard_history::{
+    CleanupResultView as ClipboardCleanupResultView,
     ClearHistoryResultView as ClipboardClearHistoryResultView, ClipboardHistoryError,
     ClipboardHistoryFacade, ClipboardHistoryFacadeDeps, ClipboardListInput, ClipboardStatsView,
     EntryDetailView, EntryProjectionView, EntryResourceView,

--- a/src-tauri/crates/uc-application/src/file_sync/cleanup.rs
+++ b/src-tauri/crates/uc-application/src/file_sync/cleanup.rs
@@ -1,215 +1,26 @@
-use std::path::{Path, PathBuf};
-use std::sync::Arc;
+//! `check_device_quota` is the only surviving artefact in this module.
+//! The expired-files cleanup use case moved to
+//! `usecases::clipboard_history::cleanup` so it can route through the
+//! entry-aware delete path.
+//!
+//! `check_device_quota` is currently uncalled — it computed a per-peer
+//! cache footprint based on a wrong path layout
+//! (`cache_dir/<source_device_id>` vs the real
+//! `cache_dir/iroh-blobs/<entry_id>`) and was never re-wired after the
+//! file-cache layout changed. Phase A made the layout question even
+//! more divergent (file_cache_dir moved to `~/Library/Application Support`).
+//! Kept here under `#[allow(dead_code)]` so an eventual quota feature
+//! has a starting point; remove if/when a follow-up rewrites it.
 
-use anyhow::Result;
-use tracing::{info, info_span, warn, Instrument};
+#![allow(dead_code)]
+
+use std::path::Path;
 
 use uc_core::ports::SettingsPort;
 
-/// Result of a cleanup operation, reporting counts and bytes reclaimed.
-#[derive(Debug, Default)]
-pub struct CleanupResult {
-    pub files_removed: u32,
-    pub bytes_reclaimed: u64,
-    pub errors: u32,
-}
-
-/// Use case: Clean up expired file cache entries.
-///
-/// Runs on app startup to:
-/// 1. Walk the file-cache directory tree
-/// 2. Remove files older than the configured retention period
-/// 3. Log summary: files removed, space reclaimed
-///
-/// This operates on the filesystem directly (no DB repository needed)
-/// since the file-cache directory structure is the source of truth
-/// for cached transfer files.
-pub struct CleanupExpiredFilesUseCase {
-    settings: Arc<dyn SettingsPort>,
-    file_cache_dir: PathBuf,
-}
-
-impl CleanupExpiredFilesUseCase {
-    pub fn new(settings: Arc<dyn SettingsPort>, file_cache_dir: PathBuf) -> Self {
-        Self {
-            settings,
-            file_cache_dir,
-        }
-    }
-
-    pub async fn execute(&self) -> Result<CleanupResult> {
-        let span = info_span!("usecase.cleanup_expired_files.execute");
-        async {
-            let settings = self.settings.load().await?;
-
-            if !settings.file_sync.file_auto_cleanup {
-                info!("File auto-cleanup disabled, skipping");
-                return Ok(CleanupResult::default());
-            }
-
-            let retention_hours = settings.file_sync.file_retention_hours;
-            let retention_secs = retention_hours as u64 * 3600;
-            let now = std::time::SystemTime::now();
-
-            if !self.file_cache_dir.exists() {
-                info!(
-                    path = %self.file_cache_dir.display(),
-                    "File cache directory does not exist, nothing to clean"
-                );
-                return Ok(CleanupResult::default());
-            }
-
-            // Collect files to remove (filesystem walk)
-            let expired_files = collect_expired_files(&self.file_cache_dir, now, retention_secs)?;
-
-            if expired_files.is_empty() {
-                info!("No expired cache files to clean up");
-                return Ok(CleanupResult::default());
-            }
-
-            let mut files_removed = 0u32;
-            let mut bytes_reclaimed = 0u64;
-            let mut errors = 0u32;
-
-            for (path, size) in &expired_files {
-                match tokio::fs::remove_file(path).await {
-                    Ok(()) => {
-                        files_removed += 1;
-                        bytes_reclaimed += size;
-                    }
-                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                        // File already gone, count as removed
-                        files_removed += 1;
-                    }
-                    Err(e) => {
-                        warn!(
-                            path = %path.display(),
-                            error = %e,
-                            "Failed to delete expired cache file"
-                        );
-                        errors += 1;
-                    }
-                }
-            }
-
-            // Clean up empty peer directories after file removal
-            cleanup_empty_dirs(&self.file_cache_dir).await;
-
-            let result = CleanupResult {
-                files_removed,
-                bytes_reclaimed,
-                errors,
-            };
-            info!(
-                files_removed = result.files_removed,
-                bytes_reclaimed_mb = result.bytes_reclaimed / (1024 * 1024),
-                errors = result.errors,
-                "File cache cleanup complete"
-            );
-
-            Ok(result)
-        }
-        .instrument(span)
-        .await
-    }
-}
-
-/// Collect files in the cache directory that are older than the retention period.
-///
-/// Returns a list of (path, file_size) tuples for expired files.
-fn collect_expired_files(
-    cache_dir: &Path,
-    now: std::time::SystemTime,
-    retention_secs: u64,
-) -> Result<Vec<(PathBuf, u64)>> {
-    let mut expired = Vec::new();
-    collect_expired_recursive(cache_dir, now, retention_secs, &mut expired)?;
-    Ok(expired)
-}
-
-fn collect_expired_recursive(
-    dir: &Path,
-    now: std::time::SystemTime,
-    retention_secs: u64,
-    out: &mut Vec<(PathBuf, u64)>,
-) -> Result<()> {
-    let entries = match std::fs::read_dir(dir) {
-        Ok(entries) => entries,
-        Err(e) => {
-            warn!(
-                path = %dir.display(),
-                error = %e,
-                "Failed to read cache directory"
-            );
-            return Ok(());
-        }
-    };
-
-    for entry in entries {
-        let entry = match entry {
-            Ok(e) => e,
-            Err(e) => {
-                warn!(error = %e, "Failed to read directory entry");
-                continue;
-            }
-        };
-
-        let meta = match entry.metadata() {
-            Ok(m) => m,
-            Err(e) => {
-                warn!(
-                    path = %entry.path().display(),
-                    error = %e,
-                    "Failed to read file metadata"
-                );
-                continue;
-            }
-        };
-
-        if meta.is_dir() {
-            collect_expired_recursive(&entry.path(), now, retention_secs, out)?;
-        } else if meta.is_file() {
-            let modified = meta.modified().unwrap_or(now);
-            let age = now.duration_since(modified).unwrap_or_default();
-            if age.as_secs() >= retention_secs {
-                out.push((entry.path(), meta.len()));
-            }
-        }
-    }
-
-    Ok(())
-}
-
-/// Remove empty directories within the cache dir after cleanup.
-async fn cleanup_empty_dirs(cache_dir: &Path) {
-    let entries = match std::fs::read_dir(cache_dir) {
-        Ok(e) => e,
-        Err(_) => return,
-    };
-
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if path.is_dir() {
-            // Only remove if empty
-            if let Ok(mut contents) = std::fs::read_dir(&path) {
-                if contents.next().is_none() {
-                    if let Err(e) = tokio::fs::remove_dir(&path).await {
-                        warn!(
-                            path = %path.display(),
-                            error = %e,
-                            "Failed to remove empty cache directory"
-                        );
-                    }
-                }
-            }
-        }
-    }
-}
-
 /// Check if accepting a file would exceed the per-device cache quota.
 ///
-/// Uses filesystem-based calculation of current cache usage for a peer.
-/// Returns Ok(()) if within quota, Err with quota details if exceeded.
+/// Currently dead — see module docs.
 pub async fn check_device_quota(
     settings: &dyn SettingsPort,
     cache_dir: &Path,
@@ -242,8 +53,7 @@ pub async fn check_device_quota(
     Ok(())
 }
 
-/// Calculate total size of files in a directory recursively.
-fn dir_size(path: &Path) -> Result<u64> {
+fn dir_size(path: &Path) -> anyhow::Result<u64> {
     let mut total = 0u64;
     if path.is_dir() {
         for entry in std::fs::read_dir(path)? {

--- a/src-tauri/crates/uc-application/src/file_sync/mod.rs
+++ b/src-tauri/crates/uc-application/src/file_sync/mod.rs
@@ -1,9 +1,6 @@
-//! File-sync use cases owned by the application layer.
-//!
-//! Slice 5 / D16-2 relocated `CleanupExpiredFilesUseCase` here from
-//! `uc-app::usecases::file_sync` so the file-cache cleanup task can be
-//! constructed without depending on the legacy `uc-app` crate.
+//! Holds residual file-sync helpers. The expired-cache cleanup use case
+//! moved to `crate::usecases::clipboard_history::cleanup` (it now routes
+//! every expired file through entry-aware deletion instead of bypassing
+//! iroh-blobs metadata).
 
 pub mod cleanup;
-
-pub use cleanup::CleanupExpiredFilesUseCase;

--- a/src-tauri/crates/uc-application/src/lib.rs
+++ b/src-tauri/crates/uc-application/src/lib.rs
@@ -7,13 +7,12 @@ pub mod facade;
 pub mod file_sync;
 pub mod sync_planner;
 
-// D16-2: deps + file_sync re-exports so composition roots (uc-bootstrap,
-// uc-tauri, uc-daemon) can depend on `uc_application::*` directly and
-// the legacy `uc_app::*` shims can be retired.
+// D16-2: deps re-exports so composition roots (uc-bootstrap, uc-tauri,
+// uc-daemon) can depend on `uc_application::*` directly and the legacy
+// `uc_app::*` shims can be retired.
 pub use deps::{
     AppDeps, ClipboardPorts, DevicePorts, SearchPorts, SecurityPorts, StoragePorts, SystemPorts,
 };
-pub use file_sync::CleanupExpiredFilesUseCase;
 
 // Slice 2 Phase 3 · T4 — public use case consumed directly by daemon
 // `InboundClipboardSyncWorker` (T8). Lives inside `usecases::clipboard_sync`

--- a/src-tauri/crates/uc-application/src/usecases/blob_transfer/mod.rs
+++ b/src-tauri/crates/uc-application/src/usecases/blob_transfer/mod.rs
@@ -110,8 +110,13 @@ mod tests {
 
         let entry_id = EntryId::new();
         let plaintext = Bytes::from_static(b"remote blob bytes");
+        // Phase F: publish 已携带原子 tag,seed 这里随意挂一个非冲突的 reason
+        // 即可 —— 真正被测试的是 use case 走 fetch 流程后再补一份业务 tag。
         let digest = transfer
-            .publish(plaintext.clone())
+            .publish(
+                plaintext.clone(),
+                TagReason::ClipboardEntry(EntryId::from("seed-fixture")),
+            )
             .await
             .expect("seed publish should succeed");
         let ticket = transfer
@@ -138,7 +143,11 @@ mod tests {
                 .expect("reference lookup should succeed"),
             Some(digest)
         );
-        assert_eq!(transfer.tag_count(), 1);
+        // Phase F 之后 publish 自身也算一次 tag(seed publish 时的
+        // `seed-fixture` reason),fetch use case 完成后再补一次 entry_id
+        // 的 tag,所以 fixture 里总共记录两条。这个断言锁定 fetch 路径
+        // 一定**有**业务 tag 调用,与 publish-时的 seed tag 区分开。
+        assert_eq!(transfer.tag_count(), 2);
     }
 
     #[derive(Default)]
@@ -172,24 +181,37 @@ mod tests {
 
     #[async_trait]
     impl BlobTransferPort for FakeBlobTransfer {
-        async fn publish(&self, plaintext: Bytes) -> Result<BlobDigest, BlobError> {
+        async fn publish(
+            &self,
+            plaintext: Bytes,
+            reason: TagReason,
+        ) -> Result<BlobDigest, BlobError> {
             *self.publish_count.lock().expect("lock publish count") += 1;
             let digest = digest_for(&plaintext);
             self.store
                 .lock()
                 .expect("lock store")
                 .insert(digest, plaintext);
+            // Phase F: publish atomically attaches the caller-supplied tag
+            // (mirrors `IrohBlobTransferAdapter::publish` going through
+            // `with_named_tag`). Tests asserting on `tag_count` see the
+            // publish-time tag plus any subsequent `tag(...)` calls.
+            self.tags.lock().expect("lock tags").push((digest, reason));
             Ok(digest)
         }
 
-        async fn publish_path(&self, path: &std::path::Path) -> Result<BlobDigest, BlobError> {
+        async fn publish_path(
+            &self,
+            path: &std::path::Path,
+            reason: TagReason,
+        ) -> Result<BlobDigest, BlobError> {
             // Fake-only: read into memory and delegate to publish() so
             // tests stay simple (small files) while still exercising the
             // path code-path through the use case + facade layers.
             let bytes = tokio::fs::read(path)
                 .await
                 .map_err(|e| BlobError::Internal(e.to_string()))?;
-            self.publish(Bytes::from(bytes)).await
+            self.publish(Bytes::from(bytes), reason).await
         }
 
         async fn issue_ticket(&self, digest: &BlobDigest) -> Result<BlobTicket, BlobError> {

--- a/src-tauri/crates/uc-application/src/usecases/blob_transfer/mod.rs
+++ b/src-tauri/crates/uc-application/src/usecases/blob_transfer/mod.rs
@@ -236,11 +236,11 @@ mod tests {
             Ok(())
         }
 
-        async fn untag(&self, digest: &BlobDigest, reason: TagReason) -> Result<(), BlobError> {
+        async fn untag(&self, reason: TagReason) -> Result<(), BlobError> {
             self.tags
                 .lock()
                 .expect("lock tags")
-                .retain(|(d, r)| d != digest || r != &reason);
+                .retain(|(_, r)| r != &reason);
             Ok(())
         }
 

--- a/src-tauri/crates/uc-application/src/usecases/blob_transfer/publish_blob.rs
+++ b/src-tauri/crates/uc-application/src/usecases/blob_transfer/publish_blob.rs
@@ -134,10 +134,17 @@ impl PublishBlobUseCase {
         // sensitive *metadata* (filenames, paths, mime, thumbnails) lives on
         // the clipboard event side and is encrypted there by
         // `EncryptingClipboardEventWriter`.
+        //
+        // Phase F: publish 携带业务 reason 一起原子入库。adapter 内部走
+        // `with_named_tag`,完成后 blob 已经直接挂在 ClipboardEntry tag 上,
+        // 不再产生 iroh-blobs 自动的 `auto-<ts>` 孤儿 tag。我们因此**也不再
+        // 单独调一次 `tag()`** —— 之前那次 tag() 是为了在 auto-tag 已经存在
+        // 的情况下额外打一层业务声明,Phase F 后语义等同于"重新 set 同一个
+        // 已存在的 tag",冗余。
         let publish_start = Instant::now();
         let digest = self
             .blob_transfer
-            .publish(plaintext)
+            .publish(plaintext, TagReason::ClipboardEntry(entry_id.clone()))
             .await
             .map_err(|e| PublishBlobError::Transfer(e.to_string()))?;
         let publish_ms = publish_start.elapsed().as_millis() as u64;
@@ -148,13 +155,6 @@ impl PublishBlobUseCase {
             .await
             .map_err(|e| PublishBlobError::Reference(e.to_string()))?;
         let save_ref_ms = save_ref_start.elapsed().as_millis() as u64;
-
-        let tag_start = Instant::now();
-        self.blob_transfer
-            .tag(&digest, TagReason::ClipboardEntry(entry_id.clone()))
-            .await
-            .map_err(|e| PublishBlobError::Transfer(e.to_string()))?;
-        let tag_ms = tag_start.elapsed().as_millis() as u64;
 
         let ticket_start = Instant::now();
         let ticket = self
@@ -172,7 +172,6 @@ impl PublishBlobUseCase {
             lookup_ms,
             publish_ms,
             save_ref_ms,
-            tag_ms,
             ticket_ms,
             "publish_blob: new blob added"
         );
@@ -202,10 +201,12 @@ impl PublishBlobUseCase {
         path: PathBuf,
         entry_id: EntryId,
     ) -> Result<PublishBlobOutcome, PublishBlobError> {
+        // Phase F: streaming publish 也走原子 tag 路径,理由与
+        // `execute_plaintext` 一致 —— 见上面 publish 注释。
         let publish_start = Instant::now();
         let digest = self
             .blob_transfer
-            .publish_path(&path)
+            .publish_path(&path, TagReason::ClipboardEntry(entry_id.clone()))
             .await
             .map_err(|e| PublishBlobError::Transfer(e.to_string()))?;
         let publish_ms = publish_start.elapsed().as_millis() as u64;
@@ -221,13 +222,6 @@ impl PublishBlobUseCase {
             .map_err(|e| PublishBlobError::Reference(e.to_string()))?;
         let save_ref_ms = save_ref_start.elapsed().as_millis() as u64;
 
-        let tag_start = Instant::now();
-        self.blob_transfer
-            .tag(&digest, TagReason::ClipboardEntry(entry_id.clone()))
-            .await
-            .map_err(|e| PublishBlobError::Transfer(e.to_string()))?;
-        let tag_ms = tag_start.elapsed().as_millis() as u64;
-
         let ticket_start = Instant::now();
         let ticket = self
             .blob_transfer
@@ -241,7 +235,6 @@ impl PublishBlobUseCase {
             path = %path.display(),
             publish_ms,
             save_ref_ms,
-            tag_ms,
             ticket_ms,
             "publish_blob: streamed from path"
         );

--- a/src-tauri/crates/uc-application/src/usecases/clipboard_history/cleanup.rs
+++ b/src-tauri/crates/uc-application/src/usecases/clipboard_history/cleanup.rs
@@ -1,0 +1,385 @@
+//! Entry-level cleanup of expired file-cache entries.
+//!
+//! Replaces the historical mtime-only `tokio::fs::remove_file` sweep that
+//! ran in `file_sync::cleanup`. The old behaviour deleted cache files
+//! without telling iroh-blobs, leaving `Complete{External([path], _)}`
+//! metadata pointing at vanished files — the precondition for the
+//! `Poisoned` panic at `bao_file.rs:410` once any code path tried to
+//! re-open the blob.
+//!
+//! The new flow walks the cache dir, builds an in-memory
+//! `path → entry_id` index from `text/uri-list` representations, and
+//! routes each expired file through the entry-aware delete path
+//! (`DeleteClipboardEntryUseCase`). Files with no owning entry are
+//! orphans and are removed directly — they would otherwise sit in the
+//! cache forever.
+//!
+//! The reverse index is built once per execution and lives only in
+//! memory; we deliberately avoid introducing a `path → entry_id` SQLite
+//! index because cleanup runs at most once per startup and the cost of
+//! decrypting representations on the order of a few thousand entries is
+//! fine. If cleanup frequency ever grows (e.g. per-hour sweep), revisit
+//! this trade-off.
+
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use anyhow::Result;
+use tracing::{info, info_span, warn, Instrument};
+
+use uc_core::ids::EntryId;
+use uc_core::ports::blob::BlobTransferPort;
+use uc_core::ports::search::search_index::SearchIndexPort;
+use uc_core::ports::{
+    ClipboardEntryRepositoryPort, ClipboardEventWriterPort, ClipboardRepresentationRepositoryPort,
+    ClipboardSelectionRepositoryPort, SettingsPort,
+};
+
+use super::delete_entry::DeleteClipboardEntryUseCase;
+
+/// Result of a cleanup pass.
+#[derive(Debug, Default, Clone)]
+pub struct CleanupResult {
+    /// Number of cache files reclaimed (entries deleted + orphans removed).
+    pub files_removed: u32,
+    /// Bytes reclaimed across all files removed.
+    pub bytes_reclaimed: u64,
+    /// Number of entries that were deleted via `delete_entry`.
+    pub entries_deleted: u32,
+    /// Number of orphan files removed without a matching entry.
+    pub orphans_removed: u32,
+    /// Number of failures (delete_entry failure or orphan remove_file failure).
+    pub errors: u32,
+}
+
+const ENTRY_LIST_BATCH_SIZE: usize = 1000;
+
+pub(crate) struct CleanupExpiredFilesUseCase {
+    settings: Arc<dyn SettingsPort>,
+    file_cache_dir: PathBuf,
+    entry_repo: Arc<dyn ClipboardEntryRepositoryPort>,
+    selection_repo: Arc<dyn ClipboardSelectionRepositoryPort>,
+    event_writer: Arc<dyn ClipboardEventWriterPort>,
+    representation_repo: Arc<dyn ClipboardRepresentationRepositoryPort>,
+    blob_transfer: Option<Arc<dyn BlobTransferPort>>,
+    search_index: Option<Arc<dyn SearchIndexPort>>,
+}
+
+impl CleanupExpiredFilesUseCase {
+    pub(crate) fn new(
+        settings: Arc<dyn SettingsPort>,
+        file_cache_dir: PathBuf,
+        entry_repo: Arc<dyn ClipboardEntryRepositoryPort>,
+        selection_repo: Arc<dyn ClipboardSelectionRepositoryPort>,
+        event_writer: Arc<dyn ClipboardEventWriterPort>,
+        representation_repo: Arc<dyn ClipboardRepresentationRepositoryPort>,
+    ) -> Self {
+        Self {
+            settings,
+            file_cache_dir,
+            entry_repo,
+            selection_repo,
+            event_writer,
+            representation_repo,
+            blob_transfer: None,
+            search_index: None,
+        }
+    }
+
+    pub(crate) fn with_blob_transfer(mut self, blob_transfer: Arc<dyn BlobTransferPort>) -> Self {
+        self.blob_transfer = Some(blob_transfer);
+        self
+    }
+
+    pub(crate) fn with_search_index(mut self, search_index: Arc<dyn SearchIndexPort>) -> Self {
+        self.search_index = Some(search_index);
+        self
+    }
+
+    #[tracing::instrument(name = "usecase.cleanup_expired_files.execute", skip(self))]
+    pub(crate) async fn execute(&self) -> Result<CleanupResult> {
+        let settings = self.settings.load().await?;
+
+        if !settings.file_sync.file_auto_cleanup {
+            info!("File auto-cleanup disabled, skipping");
+            return Ok(CleanupResult::default());
+        }
+
+        let retention_secs = settings.file_sync.file_retention_hours as u64 * 3600;
+        let now = std::time::SystemTime::now();
+
+        if !self.file_cache_dir.exists() {
+            info!(
+                path = %self.file_cache_dir.display(),
+                "File cache directory does not exist, nothing to clean"
+            );
+            return Ok(CleanupResult::default());
+        }
+
+        let expired_files = collect_expired_files(&self.file_cache_dir, now, retention_secs)?;
+        if expired_files.is_empty() {
+            info!("No expired cache files to clean up");
+            return Ok(CleanupResult::default());
+        }
+
+        let path_to_entry = self.build_reverse_index().await?;
+        info!(
+            expired_files = expired_files.len(),
+            indexed_paths = path_to_entry.len(),
+            "Reverse index built; routing expired files to entry-level delete or orphan removal"
+        );
+
+        let mut delete_uc = DeleteClipboardEntryUseCase::from_ports(
+            self.entry_repo.clone(),
+            self.selection_repo.clone(),
+            self.event_writer.clone(),
+            self.representation_repo.clone(),
+        )
+        .with_file_cache_dir(self.file_cache_dir.clone());
+        if let Some(idx) = self.search_index.clone() {
+            delete_uc = delete_uc.with_search_index(idx);
+        }
+        if let Some(bt) = self.blob_transfer.clone() {
+            delete_uc = delete_uc.with_blob_transfer(bt);
+        }
+
+        let mut result = CleanupResult::default();
+        // Multiple cache paths can map to the same entry_id (an entry with
+        // several files); only invoke delete_entry once per entry.
+        let mut handled_entries: HashSet<EntryId> = HashSet::new();
+
+        for (path, size) in &expired_files {
+            match path_to_entry.get(path) {
+                Some(entry_id) => {
+                    if !handled_entries.insert(entry_id.clone()) {
+                        // already deleted via a sibling expired file in this pass;
+                        // delete_entry already removed every cache file the entry
+                        // owned, so just account for the bytes we expected to free.
+                        result.files_removed += 1;
+                        result.bytes_reclaimed += size;
+                        continue;
+                    }
+                    match delete_uc.execute(entry_id).await {
+                        Ok(()) => {
+                            result.entries_deleted += 1;
+                            result.files_removed += 1;
+                            result.bytes_reclaimed += size;
+                        }
+                        Err(e) => {
+                            warn!(
+                                entry_id = %entry_id,
+                                path = %path.display(),
+                                error = %e,
+                                "delete_entry failed for expired cache file"
+                            );
+                            result.errors += 1;
+                        }
+                    }
+                }
+                None => match tokio::fs::remove_file(path).await {
+                    Ok(()) => {
+                        info!(
+                            path = %path.display(),
+                            "Removed orphan cache file (no owning entry in DB)"
+                        );
+                        result.orphans_removed += 1;
+                        result.files_removed += 1;
+                        result.bytes_reclaimed += size;
+                    }
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                        result.orphans_removed += 1;
+                        result.files_removed += 1;
+                    }
+                    Err(e) => {
+                        warn!(
+                            path = %path.display(),
+                            error = %e,
+                            "Failed to remove orphan cache file"
+                        );
+                        result.errors += 1;
+                    }
+                },
+            }
+        }
+
+        cleanup_empty_dirs(&self.file_cache_dir).await;
+
+        info!(
+            files_removed = result.files_removed,
+            entries_deleted = result.entries_deleted,
+            orphans_removed = result.orphans_removed,
+            errors = result.errors,
+            bytes_reclaimed_mb = result.bytes_reclaimed / (1024 * 1024),
+            "File cache cleanup complete"
+        );
+        Ok(result)
+    }
+
+    /// Walk every entry in the DB and build a `cache_path → entry_id`
+    /// index from `text/uri-list` representations. Plaintext URIs are
+    /// returned by the decrypting representation port — callers do not
+    /// need to think about encryption here.
+    async fn build_reverse_index(&self) -> Result<HashMap<PathBuf, EntryId>> {
+        let mut index: HashMap<PathBuf, EntryId> = HashMap::new();
+        let mut offset = 0usize;
+
+        loop {
+            let batch = self
+                .entry_repo
+                .list_entries(ENTRY_LIST_BATCH_SIZE, offset)
+                .instrument(info_span!(
+                    "list_entries_batch",
+                    batch_size = ENTRY_LIST_BATCH_SIZE,
+                    offset = offset
+                ))
+                .await
+                .map_err(|e| anyhow::anyhow!("list entries for cleanup index: {e}"))?;
+
+            if batch.is_empty() {
+                break;
+            }
+            let batch_len = batch.len();
+
+            for entry in &batch {
+                let representations = match self
+                    .representation_repo
+                    .get_representations_for_event(&entry.event_id)
+                    .await
+                {
+                    Ok(reps) => reps,
+                    Err(e) => {
+                        warn!(
+                            event_id = %entry.event_id,
+                            error = %e,
+                            "Failed to load representations while building reverse index — skipping entry"
+                        );
+                        continue;
+                    }
+                };
+
+                for rep in &representations {
+                    let mime = rep.mime_type.as_ref().map(|m| m.as_str()).unwrap_or("");
+                    if !mime.contains("uri-list") {
+                        continue;
+                    }
+                    let Some(inline) = rep.inline_data.as_ref() else {
+                        continue;
+                    };
+                    let uri_text = String::from_utf8_lossy(inline);
+                    for line in uri_text.lines() {
+                        let line = line.trim();
+                        if line.is_empty() || line.starts_with('#') {
+                            continue;
+                        }
+                        let path = if line.starts_with("file://") {
+                            url::Url::parse(line)
+                                .ok()
+                                .and_then(|u| u.to_file_path().ok())
+                        } else {
+                            Some(PathBuf::from(line))
+                        };
+                        let Some(path) = path else { continue };
+                        if path.starts_with(&self.file_cache_dir) {
+                            index.insert(path, entry.entry_id.clone());
+                        }
+                    }
+                }
+            }
+
+            offset += batch_len;
+            if batch_len < ENTRY_LIST_BATCH_SIZE {
+                break;
+            }
+        }
+
+        Ok(index)
+    }
+}
+
+fn collect_expired_files(
+    cache_dir: &Path,
+    now: std::time::SystemTime,
+    retention_secs: u64,
+) -> Result<Vec<(PathBuf, u64)>> {
+    let mut expired = Vec::new();
+    collect_expired_recursive(cache_dir, now, retention_secs, &mut expired)?;
+    Ok(expired)
+}
+
+fn collect_expired_recursive(
+    dir: &Path,
+    now: std::time::SystemTime,
+    retention_secs: u64,
+    out: &mut Vec<(PathBuf, u64)>,
+) -> Result<()> {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(e) => {
+            warn!(
+                path = %dir.display(),
+                error = %e,
+                "Failed to read cache directory"
+            );
+            return Ok(());
+        }
+    };
+
+    for entry in entries {
+        let entry = match entry {
+            Ok(e) => e,
+            Err(e) => {
+                warn!(error = %e, "Failed to read directory entry");
+                continue;
+            }
+        };
+
+        let meta = match entry.metadata() {
+            Ok(m) => m,
+            Err(e) => {
+                warn!(
+                    path = %entry.path().display(),
+                    error = %e,
+                    "Failed to read file metadata"
+                );
+                continue;
+            }
+        };
+
+        if meta.is_dir() {
+            collect_expired_recursive(&entry.path(), now, retention_secs, out)?;
+        } else if meta.is_file() {
+            let modified = meta.modified().unwrap_or(now);
+            let age = now.duration_since(modified).unwrap_or_default();
+            if age.as_secs() >= retention_secs {
+                out.push((entry.path(), meta.len()));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+async fn cleanup_empty_dirs(cache_dir: &Path) {
+    let entries = match std::fs::read_dir(cache_dir) {
+        Ok(e) => e,
+        Err(_) => return,
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            if let Ok(mut contents) = std::fs::read_dir(&path) {
+                if contents.next().is_none() {
+                    if let Err(e) = tokio::fs::remove_dir(&path).await {
+                        warn!(
+                            path = %path.display(),
+                            error = %e,
+                            "Failed to remove empty cache directory"
+                        );
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src-tauri/crates/uc-application/src/usecases/clipboard_history/clear_history.rs
+++ b/src-tauri/crates/uc-application/src/usecases/clipboard_history/clear_history.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tracing::{info, info_span, warn, Instrument};
+use uc_core::ports::blob::BlobTransferPort;
 use uc_core::ports::{
     ClipboardEntryRepositoryPort, ClipboardEventWriterPort, ClipboardRepresentationRepositoryPort,
     ClipboardSelectionRepositoryPort, SearchIndexPort,
@@ -24,6 +25,7 @@ pub(crate) struct ClearClipboardHistoryUseCase {
     representation_repo: Arc<dyn ClipboardRepresentationRepositoryPort>,
     file_cache_dir: Option<PathBuf>,
     search_index: Option<Arc<dyn SearchIndexPort>>,
+    blob_transfer: Option<Arc<dyn BlobTransferPort>>,
 }
 
 const BATCH_SIZE: usize = 1000;
@@ -42,6 +44,7 @@ impl ClearClipboardHistoryUseCase {
             representation_repo,
             file_cache_dir: None,
             search_index: None,
+            blob_transfer: None,
         }
     }
 
@@ -52,6 +55,11 @@ impl ClearClipboardHistoryUseCase {
 
     pub(crate) fn with_search_index(mut self, search_index: Arc<dyn SearchIndexPort>) -> Self {
         self.search_index = Some(search_index);
+        self
+    }
+
+    pub(crate) fn with_blob_transfer(mut self, blob_transfer: Arc<dyn BlobTransferPort>) -> Self {
+        self.blob_transfer = Some(blob_transfer);
         self
     }
 
@@ -86,6 +94,9 @@ impl ClearClipboardHistoryUseCase {
         }
         if let Some(search_index) = self.search_index.clone() {
             delete_uc = delete_uc.with_search_index(search_index);
+        }
+        if let Some(blob_transfer) = self.blob_transfer.clone() {
+            delete_uc = delete_uc.with_blob_transfer(blob_transfer);
         }
 
         for entry in &entries {

--- a/src-tauri/crates/uc-application/src/usecases/clipboard_history/delete_entry.rs
+++ b/src-tauri/crates/uc-application/src/usecases/clipboard_history/delete_entry.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use tracing::{info, info_span, warn, Instrument};
 use uc_core::ids::EntryId;
+use uc_core::ports::blob::{BlobTransferPort, TagReason};
 use uc_core::ports::{
     ClipboardEntryRepositoryPort, ClipboardEventWriterPort, ClipboardRepresentationRepositoryPort,
     ClipboardSelectionRepositoryPort, SearchIndexPort,
@@ -16,6 +17,7 @@ pub(crate) struct DeleteClipboardEntryUseCase {
     representation_repo: Arc<dyn ClipboardRepresentationRepositoryPort>,
     file_cache_dir: Option<PathBuf>,
     search_index: Option<Arc<dyn SearchIndexPort>>,
+    blob_transfer: Option<Arc<dyn BlobTransferPort>>,
 }
 
 impl DeleteClipboardEntryUseCase {
@@ -32,6 +34,7 @@ impl DeleteClipboardEntryUseCase {
             representation_repo,
             file_cache_dir: None,
             search_index: None,
+            blob_transfer: None,
         }
     }
 
@@ -42,6 +45,11 @@ impl DeleteClipboardEntryUseCase {
 
     pub(crate) fn with_search_index(mut self, search_index: Arc<dyn SearchIndexPort>) -> Self {
         self.search_index = Some(search_index);
+        self
+    }
+
+    pub(crate) fn with_blob_transfer(mut self, blob_transfer: Arc<dyn BlobTransferPort>) -> Self {
+        self.blob_transfer = Some(blob_transfer);
         self
     }
 
@@ -67,6 +75,23 @@ impl DeleteClipboardEntryUseCase {
         ))
         .await?;
         let event_id = entry.event_id.clone();
+
+        if let Some(blob_transfer) = self.blob_transfer.as_ref() {
+            async {
+                if let Err(e) = blob_transfer
+                    .untag(TagReason::ClipboardEntry(entry_id.clone()))
+                    .await
+                {
+                    warn!(
+                        entry_id = %entry_id,
+                        error = %e,
+                        "blob untag failed during entry delete; iroh-blobs GC will reclaim metadata on its next sweep"
+                    );
+                }
+            }
+            .instrument(info_span!("release_blob_tag", entry_id = %entry_id))
+            .await;
+        }
 
         async {
             let Some(ref cache_dir) = self.file_cache_dir else {

--- a/src-tauri/crates/uc-application/src/usecases/clipboard_history/mod.rs
+++ b/src-tauri/crates/uc-application/src/usecases/clipboard_history/mod.rs
@@ -5,6 +5,7 @@
 //! `uc-application/AGENTS.md` §11.4 every type here stays `pub(crate)` —
 //! external callers reach them exclusively through `ClipboardHistoryFacade`.
 
+pub(crate) mod cleanup;
 pub(crate) mod clear_history;
 pub(crate) mod delete_entry;
 pub(crate) mod get_entry_detail;
@@ -12,6 +13,7 @@ pub(crate) mod get_entry_resource;
 pub(crate) mod list_entry_projections;
 pub(crate) mod toggle_favorite;
 
+pub(crate) use cleanup::{CleanupExpiredFilesUseCase, CleanupResult};
 pub(crate) use clear_history::ClearClipboardHistoryUseCase;
 pub(crate) use delete_entry::DeleteClipboardEntryUseCase;
 pub(crate) use get_entry_detail::{EntryDetailResult, GetEntryDetailUseCase};

--- a/src-tauri/crates/uc-bootstrap/src/builders.rs
+++ b/src-tauri/crates/uc-bootstrap/src/builders.rs
@@ -82,6 +82,11 @@ fn build_core(
     // Idempotent -- safe to call multiple times
     crate::tracing::init_tracing_subscriber()?;
 
+    // 装 panic hook 把 panic 镜像到 jsonl(target = "panic")。必须在
+    // tracing init 之后,否则 hook 触发时 subscriber 还没接管 stderr,
+    // 等价于啥也没做。同样幂等,内部用 OnceLock 保证三个入口共用同一份。
+    crate::tracing::install_panic_logging_hook();
+
     let config = AppConfig::empty();
 
     let wired = wire_dependencies(&config)

--- a/src-tauri/crates/uc-bootstrap/src/non_gui_runtime.rs
+++ b/src-tauri/crates/uc-bootstrap/src/non_gui_runtime.rs
@@ -166,7 +166,7 @@ pub fn build_app_facade_from_deps(
             thumbnail_repo: deps.storage.thumbnail_repo.clone(),
             file_transfer_repo: deps.storage.file_transfer_repo.clone(),
             search_index: Some(deps.search.search_index.clone()),
-            file_cache_dir: Some(storage_paths.cache_dir.clone()),
+            file_cache_dir: Some(storage_paths.file_cache_dir.clone()),
             device_identity: deps.device.device_identity.clone(),
             clock: deps.system.clock.clone(),
         })),

--- a/src-tauri/crates/uc-bootstrap/src/non_gui_runtime.rs
+++ b/src-tauri/crates/uc-bootstrap/src/non_gui_runtime.rs
@@ -177,6 +177,7 @@ pub fn build_app_facade_from_deps(
             search_index: Some(deps.search.search_index.clone()),
             file_cache_dir: Some(storage_paths.file_cache_dir.clone()),
             blob_transfer: options.blob_transfer_port.clone(),
+            settings: deps.settings.clone(),
             device_identity: deps.device.device_identity.clone(),
             clock: deps.system.clock.clone(),
         })),

--- a/src-tauri/crates/uc-bootstrap/src/non_gui_runtime.rs
+++ b/src-tauri/crates/uc-bootstrap/src/non_gui_runtime.rs
@@ -114,6 +114,15 @@ pub struct AppFacadeAssemblyOptions {
     pub member_roster: Option<Arc<MemberRosterFacade>>,
     pub clipboard_sync: Option<Arc<ClipboardSyncFacade>>,
     pub blob_transfer: Option<Arc<BlobTransferFacade>>,
+    /// 底层 `BlobTransferPort`(`IrohBlobTransferAdapter`)直连引用,供
+    /// `ClipboardHistoryFacade` 在 `delete_entry` / `clear_history` 时
+    /// 调 `untag` 释放对应 entry 对 iroh-blobs 的引用。与 `blob_transfer`
+    /// 字段(承载发布/拉取 use case 的 facade)分开装配:facade 用于
+    /// "发布、拉取 blob"业务动作,这个 port 用于"释放 blob 引用"基础
+    /// 设施动作,两者共享同一个底层 adapter 实例。
+    /// `None` 表示该装配场景不接入 blob 系统(纯文本 / 测试场景),
+    /// 此时 untag 直接跳过。
+    pub blob_transfer_port: Option<Arc<dyn uc_core::ports::blob::BlobTransferPort>>,
     pub clipboard_restore: Option<ClipboardRestoreAssembly>,
     pub search_coordinator: Option<Arc<SearchCoordinator>>,
 }
@@ -167,6 +176,7 @@ pub fn build_app_facade_from_deps(
             file_transfer_repo: deps.storage.file_transfer_repo.clone(),
             search_index: Some(deps.search.search_index.clone()),
             file_cache_dir: Some(storage_paths.file_cache_dir.clone()),
+            blob_transfer: options.blob_transfer_port.clone(),
             device_identity: deps.device.device_identity.clone(),
             clock: deps.system.clock.clone(),
         })),
@@ -291,6 +301,7 @@ pub async fn build_cli_app_runtime(
             member_roster: Some(assembly.roster.clone()),
             clipboard_sync: Some(assembly.clipboard_sync.clone()),
             blob_transfer: Some(assembly.blob.clone()),
+            blob_transfer_port: Some(Arc::clone(&assembly.blob_transfer)),
             search_coordinator: Some(search_coordinator),
             ..Default::default()
         },

--- a/src-tauri/crates/uc-bootstrap/src/tracing.rs
+++ b/src-tauri/crates/uc-bootstrap/src/tracing.rs
@@ -46,6 +46,9 @@ static OTLP_GUARD: OnceLock<std::mem::ManuallyDrop<OtlpGuard>> = OnceLock::new()
 /// Guard that ensures tracing is initialized exactly once across all entry points.
 static TRACING_INITIALIZED: OnceLock<()> = OnceLock::new();
 
+/// Guard that ensures the panic logging hook is installed exactly once.
+static PANIC_HOOK_INSTALLED: OnceLock<()> = OnceLock::new();
+
 /// Read the `telemetry_enabled` setting from persisted settings.
 ///
 /// Uses the canonical settings repository read path so that defaults,
@@ -247,4 +250,77 @@ pub fn init_tracing_subscriber() -> anyhow::Result<()> {
     }
 
     Ok(())
+}
+
+/// 安装全局 panic hook,把 panic 信息镜像到 tracing。
+///
+/// 必须在 [`init_tracing_subscriber`] 之后调用 —— 这样 panic 才能进 jsonl。
+/// 调用幂等:重复调用静默返回。
+///
+/// # 行为
+///
+/// 1. 用 [`std::panic::take_hook`] 拿到当前 default hook 并保留。
+/// 2. 用 [`tracing::error!`] 记录 panic message + thread name + source
+///    location + 完整 backtrace,target 设为 `panic`,日志会按结构化字段进
+///    JSON 文件。
+/// 3. 末尾调用原 default hook,保持 stderr 输出和默认行为不变(测试输出、
+///    panic abort 等)。
+///
+/// # 为什么需要这个
+///
+/// 没有这个 hook,panic 只走 stderr,GUI / daemon 进程的 stderr 不进 jsonl。
+/// 当 iroh-blobs 一类的 silent-poison 设计把第一次 IO 错误 swallow 掉之
+/// 后,后续的 panic 还是能在 stderr 看到,但首因 panic 永远丢失。装上这个
+/// hook 后,所有 panic 都进 jsonl 的 `panic` target,可以离线追溯首因。
+///
+/// # 跨进程
+///
+/// 该函数在 `build_core` 中被三个入口共用(GUI / CLI / daemon),所以三种
+/// 运行模式下的 panic 都会被捕获到各自进程的 jsonl 中。
+pub fn install_panic_logging_hook() {
+    // 幂等保护:第一次调用拿走令牌、安装 hook;后续调用直接返回。
+    if PANIC_HOOK_INSTALLED.set(()).is_err() {
+        return;
+    }
+
+    let prev_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |panic_info| {
+        // 强制抓 backtrace,不依赖 RUST_BACKTRACE 环境变量 —— 用户在 dev
+        // 环境很少设这个变量,真正出现 panic 时 backtrace 是黄金信息。
+        let backtrace = std::backtrace::Backtrace::force_capture();
+
+        let location = panic_info
+            .location()
+            .map(|loc| format!("{}:{}:{}", loc.file(), loc.line(), loc.column()));
+
+        // panic payload 通常是 &str 或 String,其他类型用占位串避免再 panic。
+        let payload = panic_info.payload();
+        let message = if let Some(s) = payload.downcast_ref::<&'static str>() {
+            (*s).to_string()
+        } else if let Some(s) = payload.downcast_ref::<String>() {
+            s.clone()
+        } else {
+            "<non-string panic payload>".to_string()
+        };
+
+        let thread = std::thread::current()
+            .name()
+            .unwrap_or("<unnamed>")
+            .to_string();
+
+        ::tracing::error!(
+            target: "panic",
+            thread = %thread,
+            location = location.as_deref().unwrap_or("<unknown>"),
+            message = %message,
+            backtrace = %backtrace,
+            "thread panicked"
+        );
+
+        // 保留原 hook 的 stderr 输出 —— 终端用户、test runner、Sentry 旁路
+        // 都依赖这一行可见的 panic 文本。
+        prev_hook(panic_info);
+    }));
+
+    ::tracing::debug!("panic logging hook installed");
 }

--- a/src-tauri/crates/uc-core/src/ports/blob/transfer.rs
+++ b/src-tauri/crates/uc-core/src/ports/blob/transfer.rs
@@ -245,9 +245,12 @@ pub trait BlobTransferPort: Send + Sync {
     async fn tag(&self, digest: &BlobDigest, reason: TagReason) -> Result<(), BlobError>;
 
     /// Release a declaration previously made via [`tag`](Self::tag).
-    /// Idempotent: releasing a declaration that does not exist returns
-    /// `Ok(())`.
-    async fn untag(&self, digest: &BlobDigest, reason: TagReason) -> Result<(), BlobError>;
+    ///
+    /// `reason` carries the only identifier the adapter needs (the
+    /// declaration's tag scope) — no [`BlobDigest`] is required because
+    /// declarations are uniquely keyed by their reason. Idempotent:
+    /// releasing a declaration that does not exist returns `Ok(())`.
+    async fn untag(&self, reason: TagReason) -> Result<(), BlobError>;
 
     // ── Metadata ──
 

--- a/src-tauri/crates/uc-core/src/ports/blob/transfer.rs
+++ b/src-tauri/crates/uc-core/src/ports/blob/transfer.rs
@@ -174,23 +174,51 @@ pub trait BlobProgressSink: Send + Sync {
 pub trait BlobTransferPort: Send + Sync {
     // ── Producer side ──
 
-    /// Place a ciphertext into the local shareable store, return its
-    /// stable local identity. Idempotent: publishing the same bytes again
-    /// returns the same [`BlobDigest`].
-    async fn publish(&self, ciphertext: Bytes) -> Result<BlobDigest, BlobError>;
+    /// Place a ciphertext into the local shareable store and atomically
+    /// declare a tag for it, returning its stable local identity.
+    ///
+    /// Idempotent: publishing the same bytes again returns the same
+    /// [`BlobDigest`].
+    ///
+    /// `reason` is the tag declaration the adapter must attach to the
+    /// freshly-stored blob **as part of the same operation** that admits
+    /// it to the store. Adapters MUST NOT leave the blob in an unprotected
+    /// state between admission and tag attachment, even briefly — any
+    /// concurrent reclaim sweep that observes the blob without this tag
+    /// is allowed to delete it. Equivalent in protection guarantee to a
+    /// [`tag`](Self::tag) call performed at the moment of admission, but
+    /// without the gap that two separate operations would create.
+    ///
+    /// Rationale: the iroh-blobs backend's add-bytes path otherwise auto-
+    /// mints a per-publish `auto-<timestamp>` tag the caller cannot
+    /// address by reason. Folding the caller's [`TagReason`] into the
+    /// admission step is the only public surface that avoids creating
+    /// such a leaked tag — failing to attach it here would pin the blob
+    /// against [`untag`](Self::untag)-driven reclaim forever (Phase F of
+    /// the file-cache panic fix plan).
+    async fn publish(&self, ciphertext: Bytes, reason: TagReason) -> Result<BlobDigest, BlobError>;
 
-    /// Place the contents of a local file into the shareable store, return
-    /// its stable local identity. Adapters MAY stream the file from disk
-    /// rather than load it fully into memory; callers SHOULD prefer this
-    /// path for large payloads (clipboard files, oversized image reps that
-    /// already live on disk) so peak memory stays bounded regardless of
-    /// file size and the outbound dispatch path is not blocked while a
-    /// 1 GiB plaintext is materialised.
+    /// Place the contents of a local file into the shareable store and
+    /// atomically declare a tag for it, returning its stable local
+    /// identity. Adapters MAY stream the file from disk rather than load
+    /// it fully into memory; callers SHOULD prefer this path for large
+    /// payloads (clipboard files, oversized image reps that already live
+    /// on disk) so peak memory stays bounded regardless of file size and
+    /// the outbound dispatch path is not blocked while a 1 GiB plaintext
+    /// is materialised.
     ///
     /// Idempotent in the same sense as [`publish`](Self::publish):
     /// publishing the same byte content again returns the same
     /// [`BlobDigest`], regardless of which method was used.
-    async fn publish_path(&self, path: &std::path::Path) -> Result<BlobDigest, BlobError>;
+    ///
+    /// `reason` semantics are identical to [`publish`](Self::publish):
+    /// the tag declaration MUST be attached as part of the same admission
+    /// step, not as a follow-up call.
+    async fn publish_path(
+        &self,
+        path: &std::path::Path,
+        reason: TagReason,
+    ) -> Result<BlobDigest, BlobError>;
 
     /// Mint an out-of-band retrieval credential for a ciphertext the
     /// local store already holds, so other devices can pull from this

--- a/src-tauri/crates/uc-desktop/src/daemon/app_facade_assembly.rs
+++ b/src-tauri/crates/uc-desktop/src/daemon/app_facade_assembly.rs
@@ -13,6 +13,7 @@ use uc_bootstrap::{
     SpaceSetupAssembly,
 };
 use uc_core::clipboard::ClipboardIntegrationMode;
+use uc_core::ports::blob::BlobTransferPort;
 
 /// daemon AppFacade 装配结果。
 pub struct DaemonAppFacadeAssembly {
@@ -35,6 +36,8 @@ pub struct DaemonAppFacadeAssemblyInput<'a> {
 
 /// 构造 daemon 对外统一业务入口。
 pub fn build_daemon_app_facade(input: DaemonAppFacadeAssemblyInput<'_>) -> DaemonAppFacadeAssembly {
+    let blob_transfer_port: Arc<dyn BlobTransferPort> =
+        Arc::clone(&input.space_setup_assembly.blob_transfer);
     let app_facade = build_app_facade_from_deps(
         input.deps,
         input.storage_paths,
@@ -44,6 +47,7 @@ pub fn build_daemon_app_facade(input: DaemonAppFacadeAssemblyInput<'_>) -> Daemo
             member_roster: Some(input.space_setup_assembly.roster.clone()),
             clipboard_sync: Some(input.clipboard_sync),
             blob_transfer: Some(input.blob_transfer),
+            blob_transfer_port: Some(blob_transfer_port),
             clipboard_restore: Some(ClipboardRestoreAssembly {
                 write_coordinator: input.clipboard_write_coordinator,
                 integration_mode: input.clipboard_integration_mode,

--- a/src-tauri/crates/uc-infra/src/network/iroh/blobs.rs
+++ b/src-tauri/crates/uc-infra/src/network/iroh/blobs.rs
@@ -52,6 +52,24 @@ const BLOB_FETCH_BACKOFFS: [Duration; 3] = [
 
 pub const BLOBS_ALPN: &[u8] = iroh_blobs::ALPN;
 
+/// 1h between GC sweeps (Phase D1 decision Q1=A).
+///
+/// The sweep itself is cheap (redb scan + free list of any blob whose
+/// tags have all been released). Trade-off ratio: timely reclaim of
+/// ex-clipboard-entry blobs vs idle IO; 1h gives prompt cleanup without
+/// burning the disk on a daemon that never stops.
+///
+/// **Caveat — auto-tag leak (out of scope this PR).** `Blobs::add_bytes`
+/// / `add_path_with_opts` go through `AddProgress::with_tag` by default,
+/// minting a persistent random-named tag that pins every published blob
+/// against this same GC. So the sweep currently only reclaims blobs
+/// whose every tag has been released elsewhere — typically blobs
+/// fetched into the store and then explicitly untagged. Closing this
+/// leak requires teaching `BlobTransferPort::publish*` to attach the
+/// caller's `TagReason` atomically (no auto-tag), which is invasive
+/// enough to defer to a follow-up.
+pub const BLOBS_GC_INTERVAL: Duration = Duration::from_secs(3600);
+
 pub struct IrohBlobTransferAdapter {
     endpoint: Arc<Endpoint>,
     store: FsStore,
@@ -249,6 +267,22 @@ impl BlobTransferPort for IrohBlobTransferAdapter {
         progress: Option<&dyn BlobProgressSink>,
     ) -> Result<Bytes, BlobError> {
         let native = Self::parse_ticket(ticket)?;
+        // GC race window protection: hold a TempTag for the whole fetch
+        // method. iroh-blobs `Downloader::download(...).stream()` does not
+        // attach any protection to the freshly downloaded blob
+        // (`api/downloader.rs`, 0.100), so a concurrent GC sweep between
+        // download completion and the caller's `BlobTransferPort::tag(...)`
+        // call could reclaim the blob. Keeping `_temp_tag` alive through
+        // both `ensure_blob_in_store` and `get_bytes` closes the in-method
+        // window; the remaining microsecond window between this method
+        // returning and the use case's permanent `tag(...)` call is
+        // dominated by the GC interval (1h) and is theoretical only.
+        let _temp_tag = self
+            .store
+            .tags()
+            .temp_tag(HashAndFormat::raw(native.hash()))
+            .await
+            .map_err(|e| BlobError::Internal(format!("temp_tag for fetch: {e}")))?;
         self.ensure_blob_in_store(&native, progress).await?;
         self.store
             .blobs()
@@ -288,6 +322,17 @@ impl BlobTransferPort for IrohBlobTransferAdapter {
         let native = Self::parse_ticket(ticket)?;
         let digest = Self::core_digest(native.hash());
         let hash_prefix = hex_prefix(native.hash().as_bytes());
+
+        // GC race window protection — see `fetch` for the full rationale.
+        // Keeping `_temp_tag` alive through both `ensure_blob_in_store` and
+        // `export_with_opts` covers the in-method window; the caller's
+        // subsequent permanent `tag(...)` call closes it definitively.
+        let _temp_tag = self
+            .store
+            .tags()
+            .temp_tag(HashAndFormat::raw(native.hash()))
+            .await
+            .map_err(|e| BlobError::Internal(format!("temp_tag for fetch_to_path: {e}")))?;
 
         self.ensure_blob_in_store(&native, progress).await?;
 

--- a/src-tauri/crates/uc-infra/src/network/iroh/blobs.rs
+++ b/src-tauri/crates/uc-infra/src/network/iroh/blobs.rs
@@ -1113,4 +1113,66 @@ mod tests {
         fixture.shutdown().await?;
         Ok(())
     }
+
+    #[tokio::test]
+    async fn untag_keeps_blob_observable_for_subsequent_local_fetch() -> anyhow::Result<()> {
+        // Phase B 方案 X 的端到端回归。原 panic
+        // (`Poisoned storage should not be used` from `bao_file.rs:410`)
+        // 触发条件是 iroh-blobs metadata 还在、物理 data 文件被外部
+        // unlink —— 旧版 `delete_entry` 走的正是这条路径(直接 remove_file
+        // cache 而 metadata 留在 redb)。后续的 ObserveRequest 一进
+        // BaoFileStorage 就把 entry 标 Poisoned,任何对该 hash 的操作
+        // 都 panic。
+        //
+        // 修复后 `delete_entry` 改走 untag,不主动 unlink cache、不主动
+        // 删 metadata,GC 在 1h 内一致地回收 metadata + data。这个测试
+        // 复现"用户删 entry 后立即点旧历史"的场景:
+        //   1. publish + tag (业务侧持有声明)
+        //   2. untag (模拟 DeleteClipboardEntryUseCase)
+        //   3. has + issue_ticket + fetch_to_path (GUI 立即点旧历史)
+        //
+        // fetch_to_path 内部读 bao outboard,是原 panic 真正触发的代码
+        // 路径 —— 跑通即证明我们没有把 store 弄成 Poisoned 状态。
+        //
+        // 64 KiB 大于 iroh-blobs 默认 16 KiB inline 阈值,确保实际写出
+        // owned data 文件而非 inline,触达 bao_file 路径(否则小 payload
+        // 会走 inline 短路,绕过 panic 触发点,失去回归意义)。
+        let fixture = Fixture::bind().await?;
+        fixture.wait_for_direct_addr().await?;
+        let payload = vec![0xefu8; 64 * 1024];
+        let digest = fixture
+            .adapter
+            .publish(Bytes::from(payload.clone()))
+            .await?;
+        let reason = TagReason::ClipboardEntry(EntryId::from_str("entry-deleted"));
+        fixture.adapter.tag(&digest, reason.clone()).await?;
+
+        // 模拟 DeleteClipboardEntryUseCase:只释放业务声明,不动 store。
+        fixture.adapter.untag(reason).await?;
+
+        // GUI 立即重新点旧历史 —— 关键回归点。
+        assert!(
+            fixture.adapter.has(&digest).await?,
+            "untag must not remove metadata: blob should still be observable"
+        );
+        let ticket = fixture.adapter.issue_ticket(&digest).await?;
+
+        // local-hit fetch_to_path 走完整的 bao outboard 读取路径,
+        // 是原 panic 真正触发的代码点。
+        let dir = tempdir()?;
+        let target = dir.path().join("after_untag.bin");
+        let returned = fixture
+            .adapter
+            .fetch_to_path(&ticket, &target, None)
+            .await?;
+        assert_eq!(returned, digest);
+        let written = std::fs::read(&target)?;
+        assert_eq!(
+            written, payload,
+            "fetched bytes must match the original payload"
+        );
+
+        fixture.shutdown().await?;
+        Ok(())
+    }
 }

--- a/src-tauri/crates/uc-infra/src/network/iroh/blobs.rs
+++ b/src-tauri/crates/uc-infra/src/network/iroh/blobs.rs
@@ -59,15 +59,14 @@ pub const BLOBS_ALPN: &[u8] = iroh_blobs::ALPN;
 /// ex-clipboard-entry blobs vs idle IO; 1h gives prompt cleanup without
 /// burning the disk on a daemon that never stops.
 ///
-/// **Caveat — auto-tag leak (out of scope this PR).** `Blobs::add_bytes`
-/// / `add_path_with_opts` go through `AddProgress::with_tag` by default,
-/// minting a persistent random-named tag that pins every published blob
-/// against this same GC. So the sweep currently only reclaims blobs
-/// whose every tag has been released elsewhere — typically blobs
-/// fetched into the store and then explicitly untagged. Closing this
-/// leak requires teaching `BlobTransferPort::publish*` to attach the
-/// caller's `TagReason` atomically (no auto-tag), which is invasive
-/// enough to defer to a follow-up.
+/// Phase F closed the auto-tag leak that previously made this GC
+/// effectively a no-op for the publish path: `publish` / `publish_path`
+/// now route through `AddProgress::with_named_tag(reason)` instead of
+/// the default `with_tag` IntoFuture, so the only persistent tag a blob
+/// carries is the caller-supplied business reason.
+/// `BlobTransferPort::untag(reason)` therefore really drops the last
+/// reference, and the next sweep within `BLOBS_GC_INTERVAL` reclaims
+/// metadata + data atomically.
 pub const BLOBS_GC_INTERVAL: Duration = Duration::from_secs(3600);
 
 pub struct IrohBlobTransferAdapter {
@@ -179,29 +178,51 @@ fn preferred_import_mode() -> ImportMode {
 #[async_trait]
 impl BlobTransferPort for IrohBlobTransferAdapter {
     #[instrument(skip_all, fields(bytes = ciphertext.len()))]
-    async fn publish(&self, ciphertext: Bytes) -> Result<BlobDigest, BlobError> {
+    async fn publish(&self, ciphertext: Bytes, reason: TagReason) -> Result<BlobDigest, BlobError> {
         // GH#487: 大 blob 的 add_bytes 包含 BLAKE3 + BAO outboard 编码 +
         // 写盘,冷启动 / 慢盘场景下整段都可能阻塞十几秒。这里独立计时,让
         // 上游 publish_blob 的 publish_ms 能与本层 add_bytes_ms 对齐核对。
+        //
+        // Phase F: 用 `with_named_tag(reason_name)` 替代 `add_bytes(...).
+        // await` 默认走的 `with_tag` 路径。后者会自动给 blob 打一个
+        // `auto-<timestamp>` 持久 tag(`AddProgress::IntoFuture` 的默认行为),
+        // 我们没有任何渠道能在 untag 时一并清掉它 —— 结果就是即使业务侧
+        // 调了 `untag(ClipboardEntry)`,blob 仍被这个孤儿 auto-tag 钉死,
+        // GC(Phase D1)永远跑不掉它,cache 文件实际只能等下次 daemon 重启
+        // 让 Phase E1 的启动 sweep 清理。改用 `with_named_tag` 后,publish
+        // 时直接打业务 tag,untag 即真正释放,GC 1h 内就能回收。
+        //
+        // 内部行为(`api/blobs.rs:654-662`):
+        //   `with_named_tag = temp_tag().await? → tags.set(name, haf) → drop(tt)`
+        // TempTag 在 set 完成前一直保活,关闭了 admit ↔ tag 之间的 GC 窗口;
+        // set 是覆盖式,同一 reason 重复 publish 等价于覆盖到同一 hash,
+        // 语义上与 publish 自身的幂等性一致。
         let bytes = ciphertext.len() as u64;
         let started = Instant::now();
-        let tag = self
+        let tag_name = Self::tag_name(&reason);
+        let haf = self
             .store
             .blobs()
             .add_bytes(ciphertext)
+            .with_named_tag(tag_name.as_bytes())
             .await
             .map_err(|e| BlobError::Internal(e.to_string()))?;
         info!(
             bytes,
             add_bytes_ms = started.elapsed().as_millis() as u64,
-            blob_hash = %hex_prefix(tag.hash.as_bytes()),
+            blob_hash = %hex_prefix(haf.hash.as_bytes()),
+            tag = %tag_name,
             "iroh blob publish: add_bytes completed"
         );
-        Ok(Self::core_digest(tag.hash))
+        Ok(Self::core_digest(haf.hash))
     }
 
     #[instrument(skip_all, fields(path = %path.display()))]
-    async fn publish_path(&self, path: &std::path::Path) -> Result<BlobDigest, BlobError> {
+    async fn publish_path(
+        &self,
+        path: &std::path::Path,
+        reason: TagReason,
+    ) -> Result<BlobDigest, BlobError> {
         // GH#487 P1 streaming publish:走 iroh-blobs 的 add_path 入口,增量算
         // BAO outboard,整段过程内存峰值受 iroh chunk size 主导,与文件大小
         // 无关。旧路径(`tokio::fs::read → Bytes → add_bytes`)在 1GB 文件上
@@ -225,9 +246,12 @@ impl BlobTransferPort for IrohBlobTransferAdapter {
         // use)—— 覆盖了"不小心拖去回收站"这一最常见误操作。其他场景接受
         // 失败、由用户重新复制(对端报错而 sender 这一侧不感知,fallback
         // 到 Copy 重 import 的反向通知链路超出本次 step 范围)。
+        // Phase F: 与 `publish` 同理,改走 `with_named_tag`,避免 add_path
+        // 的 `IntoFuture` 默认 `with_tag` 路径产生孤儿 auto-tag。
         let started = Instant::now();
         let mode = preferred_import_mode();
-        let tag_info = self
+        let tag_name = Self::tag_name(&reason);
+        let haf = self
             .store
             .blobs()
             .add_path_with_opts(AddPathOptions {
@@ -235,15 +259,17 @@ impl BlobTransferPort for IrohBlobTransferAdapter {
                 format: BlobFormat::Raw,
                 mode,
             })
+            .with_named_tag(tag_name.as_bytes())
             .await
             .map_err(|e| BlobError::Internal(e.to_string()))?;
         info!(
             add_path_ms = started.elapsed().as_millis() as u64,
             mode = ?mode,
-            blob_hash = %hex_prefix(tag_info.hash.as_bytes()),
+            blob_hash = %hex_prefix(haf.hash.as_bytes()),
+            tag = %tag_name,
             "iroh blob publish: add_path completed (streaming)"
         );
-        Ok(Self::core_digest(tag_info.hash))
+        Ok(Self::core_digest(haf.hash))
     }
 
     #[instrument(skip_all)]
@@ -732,13 +758,27 @@ mod tests {
         BlobDigest::from_bytes([0x7f; 32])
     }
 
+    /// Phase F 之后 `publish` / `publish_path` 都强制要求 caller 传一个
+    /// `TagReason`(原子打 named tag,避免 auto-tag leak)。绝大多数测试只
+    /// 关心 publish 自身的语义,不在意打到哪个 reason 上,所以用一个针对
+    /// 测试名字的固定 EntryId 即可。同一测试内多次 publish 会共用一个
+    /// reason,语义上等价于"同一个业务实体反复刷新到同一个 hash",对测试
+    /// 断言无影响。
+    fn dummy_reason(name: &str) -> TagReason {
+        TagReason::ClipboardEntry(EntryId::from_str(name))
+    }
+
     #[tokio::test]
     async fn publish_same_bytes_returns_stable_digest() -> anyhow::Result<()> {
         let fixture = Fixture::bind().await?;
         let payload = Bytes::from_static(b"slice3-t4-stable");
+        let reason = dummy_reason("publish-stable");
 
-        let first = fixture.adapter.publish(payload.clone()).await?;
-        let second = fixture.adapter.publish(payload).await?;
+        let first = fixture
+            .adapter
+            .publish(payload.clone(), reason.clone())
+            .await?;
+        let second = fixture.adapter.publish(payload, reason).await?;
 
         assert_eq!(first, second);
         fixture.shutdown().await?;
@@ -756,7 +796,10 @@ mod tests {
         let payload = b"gh-487-fetch-to-path-local-hit".to_vec();
         let digest = fixture
             .adapter
-            .publish(Bytes::from(payload.clone()))
+            .publish(
+                Bytes::from(payload.clone()),
+                dummy_reason("fetch-local-hit"),
+            )
             .await?;
         let ticket = fixture.adapter.issue_ticket(&digest).await?;
 
@@ -788,7 +831,7 @@ mod tests {
         let payload = vec![0x5au8; 64 * 1024];
         let digest = fixture
             .adapter
-            .publish(Bytes::from(payload.clone()))
+            .publish(Bytes::from(payload.clone()), dummy_reason("fetch-try-ref"))
             .await?;
         let ticket = fixture.adapter.issue_ticket(&digest).await?;
 
@@ -820,7 +863,10 @@ mod tests {
         let payload = vec![0xa5u8; 64 * 1024];
         let digest = fixture
             .adapter
-            .publish(Bytes::from(payload.clone()))
+            .publish(
+                Bytes::from(payload.clone()),
+                dummy_reason("fetch-after-export"),
+            )
             .await?;
         let ticket = fixture.adapter.issue_ticket(&digest).await?;
 
@@ -865,9 +911,15 @@ mod tests {
 
         let bytes_digest = fixture
             .adapter
-            .publish(Bytes::from(payload.clone()))
+            .publish(
+                Bytes::from(payload.clone()),
+                dummy_reason("publish-eq-bytes"),
+            )
             .await?;
-        let path_digest = fixture.adapter.publish_path(&path).await?;
+        let path_digest = fixture
+            .adapter
+            .publish_path(&path, dummy_reason("publish-eq-path"))
+            .await?;
 
         assert_eq!(bytes_digest, path_digest);
         fixture.shutdown().await?;
@@ -978,7 +1030,10 @@ mod tests {
 
         let digest = fixture
             .adapter
-            .publish(Bytes::from_static(b"slice3-t4-has"))
+            .publish(
+                Bytes::from_static(b"slice3-t4-has"),
+                dummy_reason("has-test"),
+            )
             .await?;
 
         assert!(fixture.adapter.has(&digest).await?);
@@ -993,7 +1048,10 @@ mod tests {
         fixture.wait_for_direct_addr().await?;
         let digest = fixture
             .adapter
-            .publish(Bytes::from_static(b"slice3-t4-ticket"))
+            .publish(
+                Bytes::from_static(b"slice3-t4-ticket"),
+                dummy_reason("ticket-roundtrip"),
+            )
             .await?;
 
         let ticket = fixture.adapter.issue_ticket(&digest).await?;
@@ -1042,7 +1100,10 @@ mod tests {
         let fixture = Fixture::bind().await?;
         fixture.wait_for_direct_addr().await?;
         let payload = Bytes::from_static(b"slice3-t5-self-fetch");
-        let digest = fixture.adapter.publish(payload.clone()).await?;
+        let digest = fixture
+            .adapter
+            .publish(payload.clone(), dummy_reason("self-fetch"))
+            .await?;
         let ticket = fixture.adapter.issue_ticket(&digest).await?;
 
         let fetched = fixture.adapter.fetch(&ticket, None).await?;
@@ -1059,7 +1120,10 @@ mod tests {
         provider.wait_for_direct_addr().await?;
         receiver.wait_for_direct_addr().await?;
         let payload = Bytes::from_static(b"slice3-t5-remote-fetch");
-        let digest = provider.adapter.publish(payload.clone()).await?;
+        let digest = provider
+            .adapter
+            .publish(payload.clone(), dummy_reason("remote-fetch"))
+            .await?;
         let ticket = provider.adapter.issue_ticket(&digest).await?;
 
         let fetched = receiver.adapter.fetch(&ticket, None).await?;
@@ -1073,9 +1137,15 @@ mod tests {
     #[tokio::test]
     async fn tag_then_untag_is_idempotent() -> anyhow::Result<()> {
         let fixture = Fixture::bind().await?;
+        // Phase F 之后 publish 自带 named tag,这里再调一次 tag(reason) 是
+        // "已存在同名 tag 上 set 同一个 hash",iroh-blobs 视为 overwrite,所以
+        // tag/untag 的幂等契约依然成立 —— 这正是这个测试要锁定的语义。
         let digest = fixture
             .adapter
-            .publish(Bytes::from_static(b"slice3-t6-tag"))
+            .publish(
+                Bytes::from_static(b"slice3-t6-tag"),
+                dummy_reason("tag-publish"),
+            )
             .await?;
         let reason = TagReason::ClipboardEntry(EntryId::from_str("entry-a"));
 
@@ -1092,7 +1162,10 @@ mod tests {
         let fixture = Fixture::bind().await?;
         let digest = fixture
             .adapter
-            .publish(Bytes::from_static(b"slice3-t6-multi-tag"))
+            .publish(
+                Bytes::from_static(b"slice3-t6-multi-tag"),
+                dummy_reason("multi-tag-publish"),
+            )
             .await?;
         let first = TagReason::ClipboardEntry(EntryId::from_str("entry-a"));
         let second = TagReason::ClipboardEntry(EntryId::from_str("entry-b"));
@@ -1140,12 +1213,17 @@ mod tests {
         let fixture = Fixture::bind().await?;
         fixture.wait_for_direct_addr().await?;
         let payload = vec![0xefu8; 64 * 1024];
+        let reason = TagReason::ClipboardEntry(EntryId::from_str("entry-deleted"));
+        // Phase F: publish 已原子打业务 tag,无需再单独 tag()。这同时是
+        // Phase F 后语义对齐的关键 —— 1h GC interval 内 untag 后 store 立即
+        // **完全无 tag 保护**(没有 auto-tag 兜底了),仍要求 has /
+        // issue_ticket / fetch_to_path 在内存路径(尚未触发 GC)上不进入
+        // Poisoned 状态。如果未来有人在 publish/untag 路径里偷偷物理 unlink
+        // data 文件,这个测试同样会抓到。
         let digest = fixture
             .adapter
-            .publish(Bytes::from(payload.clone()))
+            .publish(Bytes::from(payload.clone()), reason.clone())
             .await?;
-        let reason = TagReason::ClipboardEntry(EntryId::from_str("entry-deleted"));
-        fixture.adapter.tag(&digest, reason.clone()).await?;
 
         // 模拟 DeleteClipboardEntryUseCase:只释放业务声明,不动 store。
         fixture.adapter.untag(reason).await?;

--- a/src-tauri/crates/uc-infra/src/network/iroh/blobs.rs
+++ b/src-tauri/crates/uc-infra/src/network/iroh/blobs.rs
@@ -337,7 +337,7 @@ impl BlobTransferPort for IrohBlobTransferAdapter {
     }
 
     #[instrument(skip_all)]
-    async fn untag(&self, _digest: &BlobDigest, reason: TagReason) -> Result<(), BlobError> {
+    async fn untag(&self, reason: TagReason) -> Result<(), BlobError> {
         let name = Self::tag_name(&reason);
         let removed = self
             .store
@@ -800,7 +800,7 @@ mod tests {
         // blobs to a ClipboardEntry and clean up on entry deletion.
         let reason = TagReason::ClipboardEntry(EntryId::from_str("entry-after-export"));
         fixture.adapter.tag(&digest, reason.clone()).await?;
-        fixture.adapter.untag(&digest, reason).await?;
+        fixture.adapter.untag(reason).await?;
 
         fixture.shutdown().await?;
         Ok(())
@@ -1035,8 +1035,8 @@ mod tests {
         let reason = TagReason::ClipboardEntry(EntryId::from_str("entry-a"));
 
         fixture.adapter.tag(&digest, reason.clone()).await?;
-        fixture.adapter.untag(&digest, reason.clone()).await?;
-        fixture.adapter.untag(&digest, reason).await?;
+        fixture.adapter.untag(reason.clone()).await?;
+        fixture.adapter.untag(reason).await?;
 
         fixture.shutdown().await?;
         Ok(())
@@ -1054,7 +1054,7 @@ mod tests {
 
         fixture.adapter.tag(&digest, first.clone()).await?;
         fixture.adapter.tag(&digest, second.clone()).await?;
-        fixture.adapter.untag(&digest, first.clone()).await?;
+        fixture.adapter.untag(first.clone()).await?;
 
         let second_tag = IrohBlobTransferAdapter::tag_name(&second);
         assert!(fixture
@@ -1064,7 +1064,7 @@ mod tests {
             .await?
             .is_some());
 
-        fixture.adapter.untag(&digest, second).await?;
+        fixture.adapter.untag(second).await?;
         fixture.shutdown().await?;
         Ok(())
     }

--- a/src-tauri/crates/uc-infra/src/network/iroh/node.rs
+++ b/src-tauri/crates/uc-infra/src/network/iroh/node.rs
@@ -590,12 +590,20 @@ impl IrohNodeBuilder {
         // `tokio::spawn`s `run_gc(store, config)` once at load time;
         // the loop lives until the store actor exits (i.e. effectively
         // the daemon's lifetime).
+        //
+        // `load_with_opts` 的第一个参数是 redb 数据库**文件**路径,不是 root
+        // 目录。`Options::new(root)` 才接 root,内部派生出 `root/data`、
+        // `root/temp`。直接传 `store_dir` 当 db_path 会让 redb 去把已经被
+        // `Options::new` 当作 root 的目录当文件打开,actor 启动会卡死(macOS
+        // 上 redb 在目录上的文件锁不会立即返回错误)。和 `FsStore::load`
+        // 内部一样用 `root/blobs.db` 作为 db 文件路径。
         let mut options = iroh_blobs::store::fs::options::Options::new(&store_dir);
         options.gc = Some(iroh_blobs::store::GcConfig {
             interval: crate::network::iroh::blobs::BLOBS_GC_INTERVAL,
             add_protected: None,
         });
-        let store = iroh_blobs::store::fs::FsStore::load_with_opts(store_dir.clone(), options)
+        let db_path = store_dir.join("blobs.db");
+        let store = iroh_blobs::store::fs::FsStore::load_with_opts(db_path, options)
             .await
             .map_err(|err| IrohNodeError::BlobStoreInit(err.to_string()))?;
         let protocol = iroh_blobs::BlobsProtocol::new(&store, None);

--- a/src-tauri/crates/uc-infra/src/network/iroh/node.rs
+++ b/src-tauri/crates/uc-infra/src/network/iroh/node.rs
@@ -607,23 +607,27 @@ impl IrohNodeBuilder {
             .await
             .map_err(|err| IrohNodeError::BlobStoreInit(err.to_string()))?;
 
-        // Phase E1: clean accumulated auto-* tags from prior sessions.
+        // Phase E1 (transitional): sweep `auto-*` tags left behind by
+        // pre-Phase-F daemons.
         //
-        // iroh-blobs `AddProgress::with_tag` (the `IntoFuture` default
-        // for every `add_bytes` / `add_path_with_opts` call) mints a
-        // persistent `auto-<timestamp>` tag protecting each newly-added
-        // blob from GC. Because nothing in our codebase ever cleans
-        // these auto-tags, they accumulate forever — and worse, they
-        // pin every blob the GC (Phase D1) would otherwise reclaim
-        // after the user deletes a clipboard entry.
+        // iroh-blobs `AddProgress::with_tag` (the `IntoFuture` default for
+        // `add_bytes` / `add_path_with_opts`) used to mint a persistent
+        // `auto-<timestamp>` tag protecting every newly-published blob
+        // from GC. Phase F (`IrohBlobTransferAdapter::publish*`) routes
+        // through `with_named_tag` instead, so freshly written blobs no
+        // longer carry an auto-tag. But upgrades from older builds inherit
+        // the leftover auto-tags, and those still pin every old blob
+        // against the Phase D1 GC even after the user deletes the owning
+        // entry — sweeping them once at startup is what lets cache reclaim
+        // recover for upgraded users.
         //
-        // Sweeping them at startup is safe because no `add_*` request
-        // can land between FsStore::load_with_opts returning and us
-        // re-acquiring the router (we are still single-threaded here).
-        // Future publishes will re-create their own auto-tag — which
-        // we'll sweep on the next start. Closing the leak permanently
-        // requires changing publish to attach the caller's TagReason
-        // atomically, which is invasive enough to defer to a follow-up.
+        // Sweeping is safe because no `add_*` request can land between
+        // `FsStore::load_with_opts` returning and us re-acquiring the
+        // router (single-threaded init). Phase F also means future
+        // publishes never re-create an auto-tag, so post-upgrade this
+        // sweep becomes a near-no-op (delete-prefix on an empty range);
+        // we keep it for one or two release cycles to cover stragglers
+        // and then can drop the call entirely.
         match store.tags().delete_prefix(b"auto-").await {
             Ok(removed) => {
                 if removed > 0 {
@@ -978,7 +982,12 @@ mod tests {
             .expect("install blobs");
 
         let digest = blob_transfer
-            .publish(bytes::Bytes::from_static(b"router-four-alpns"))
+            .publish(
+                bytes::Bytes::from_static(b"router-four-alpns"),
+                uc_core::ports::blob::TagReason::ClipboardEntry(uc_core::ids::EntryId::from_str(
+                    "router-blob-test",
+                )),
+            )
             .await
             .expect("publish through blob port");
         assert!(blob_transfer.has(&digest).await.expect("has digest"));

--- a/src-tauri/crates/uc-infra/src/network/iroh/node.rs
+++ b/src-tauri/crates/uc-infra/src/network/iroh/node.rs
@@ -583,7 +583,19 @@ impl IrohNodeBuilder {
         &mut self,
         store_dir: PathBuf,
     ) -> Result<BlobHandlers, IrohNodeError> {
-        let store = iroh_blobs::store::fs::FsStore::load(&store_dir)
+        // Phase D1: enable iroh-blobs internal GC at fixed interval.
+        // `FsStore::load_with_opts` is the only public entry that can
+        // wire `GcConfig` — `gc::run_gc` / `gc_run_once` themselves are
+        // crate-private in iroh-blobs 0.100. The store internally
+        // `tokio::spawn`s `run_gc(store, config)` once at load time;
+        // the loop lives until the store actor exits (i.e. effectively
+        // the daemon's lifetime).
+        let mut options = iroh_blobs::store::fs::options::Options::new(&store_dir);
+        options.gc = Some(iroh_blobs::store::GcConfig {
+            interval: crate::network::iroh::blobs::BLOBS_GC_INTERVAL,
+            add_protected: None,
+        });
+        let store = iroh_blobs::store::fs::FsStore::load_with_opts(store_dir.clone(), options)
             .await
             .map_err(|err| IrohNodeError::BlobStoreInit(err.to_string()))?;
         let protocol = iroh_blobs::BlobsProtocol::new(&store, None);
@@ -604,6 +616,7 @@ impl IrohNodeBuilder {
             store_dir = %store_dir.display(),
             alpn = %String::from_utf8_lossy(BLOBS_ALPN),
             endpoint_id = %self.endpoint.id().fmt_short(),
+            gc_interval_secs = crate::network::iroh::blobs::BLOBS_GC_INTERVAL.as_secs(),
             "iroh blobs acceptor installed"
         );
 

--- a/src-tauri/crates/uc-infra/src/network/iroh/node.rs
+++ b/src-tauri/crates/uc-infra/src/network/iroh/node.rs
@@ -27,7 +27,7 @@ use iroh::endpoint::{presets, QuicTransportConfig, VarInt};
 use iroh::protocol::{Router, RouterBuilder};
 use iroh::{Endpoint, RelayMode, TransportAddr};
 use noq_proto::congestion::BbrConfig;
-use tracing::{debug, info, instrument};
+use tracing::{debug, info, instrument, warn};
 
 use uc_core::file_transfer::OutboundProgressReporterPort;
 use uc_core::membership::MemberRepositoryPort;
@@ -606,6 +606,35 @@ impl IrohNodeBuilder {
         let store = iroh_blobs::store::fs::FsStore::load_with_opts(db_path, options)
             .await
             .map_err(|err| IrohNodeError::BlobStoreInit(err.to_string()))?;
+
+        // Phase E1: clean accumulated auto-* tags from prior sessions.
+        //
+        // iroh-blobs `AddProgress::with_tag` (the `IntoFuture` default
+        // for every `add_bytes` / `add_path_with_opts` call) mints a
+        // persistent `auto-<timestamp>` tag protecting each newly-added
+        // blob from GC. Because nothing in our codebase ever cleans
+        // these auto-tags, they accumulate forever — and worse, they
+        // pin every blob the GC (Phase D1) would otherwise reclaim
+        // after the user deletes a clipboard entry.
+        //
+        // Sweeping them at startup is safe because no `add_*` request
+        // can land between FsStore::load_with_opts returning and us
+        // re-acquiring the router (we are still single-threaded here).
+        // Future publishes will re-create their own auto-tag — which
+        // we'll sweep on the next start. Closing the leak permanently
+        // requires changing publish to attach the caller's TagReason
+        // atomically, which is invasive enough to defer to a follow-up.
+        match store.tags().delete_prefix(b"auto-").await {
+            Ok(removed) => {
+                if removed > 0 {
+                    info!(removed, "iroh blobs: swept stale auto-* tags");
+                }
+            }
+            Err(err) => {
+                warn!(error = %err, "iroh blobs: failed to sweep stale auto-* tags (non-fatal)");
+            }
+        }
+
         let protocol = iroh_blobs::BlobsProtocol::new(&store, None);
 
         let builder = self

--- a/src-tauri/crates/uc-tauri/src/bootstrap/run.rs
+++ b/src-tauri/crates/uc-tauri/src/bootstrap/run.rs
@@ -1,10 +1,12 @@
 use anyhow::Result;
 use std::time::Duration;
 
+use reqwest::header::AUTHORIZATION;
 use tauri::{AppHandle, Runtime};
 use tauri_plugin_shell::process::{CommandChild, CommandEvent};
 use tauri_plugin_shell::ShellExt;
 use tokio_util::sync::CancellationToken;
+use uc_daemon_client::http::{clear_session_token_cache, exchange_session_token};
 use uc_daemon_client::DaemonConnectionState;
 use uc_daemon_contract::api::auth::DaemonConnectionInfo;
 use uc_daemon_contract::api::types::HealthResponse;
@@ -177,6 +179,13 @@ pub async fn supervise_daemon<R: Runtime>(
                             Ok(info) => {
                                 state.set(info);
                                 tracing::info!("Daemon supervisor respawned daemon successfully");
+                                // Replay the GUI's one-shot `/lifecycle/ready` so the
+                                // new daemon exits its deferred state (clipboard
+                                // watcher + inbound clipboard sync). Without this,
+                                // the GUI's own ready latch never refires after a
+                                // respawn and sync stays silently dead until the
+                                // user restarts the GUI.
+                                replay_lifecycle_ready_after_respawn(state, &client).await;
                             }
                             Err(err) => {
                                 tracing::error!(error = %err, "Daemon supervisor respawned daemon but failed to load connection info");
@@ -201,6 +210,74 @@ pub async fn supervise_daemon<R: Runtime>(
                 }
                 respawn_backoff = (respawn_backoff * 2).min(SUPERVISOR_RESPAWN_BACKOFF_MAX);
             }
+        }
+    }
+}
+
+/// Re-issue `POST /lifecycle/ready` to a freshly respawned daemon so its
+/// deferred services (clipboard watcher, inbound clipboard sync, etc.) start.
+///
+/// The GUI signals `/lifecycle/ready` exactly once at boot and latches that
+/// success in a React ref, so it never reissues after a daemon respawn.
+/// Each respawned daemon process boots a fresh JWT secret, so we also clear
+/// the cached session token before exchanging a new one.
+///
+/// All errors are logged and swallowed — the supervisor's main loop must
+/// keep running even if this best-effort signal fails.
+async fn replay_lifecycle_ready_after_respawn(
+    state: &DaemonConnectionState,
+    client: &reqwest::Client,
+) {
+    clear_session_token_cache().await;
+
+    let pid = std::process::id();
+    let session_token = match exchange_session_token(client, state, pid, "gui").await {
+        Ok(token) => token,
+        Err(err) => {
+            tracing::warn!(
+                error = %err,
+                "Daemon supervisor failed to exchange session token after respawn; \
+                 deferred services will stay dormant until the GUI re-signals ready"
+            );
+            return;
+        }
+    };
+
+    let connection = match state.get() {
+        Some(c) => c,
+        None => {
+            tracing::warn!(
+                "Daemon supervisor missing connection info after respawn; \
+                 cannot replay /lifecycle/ready"
+            );
+            return;
+        }
+    };
+
+    let url = format!("{}/lifecycle/ready", connection.base_url);
+    match client
+        .post(&url)
+        .header(AUTHORIZATION, format!("Session {}", session_token))
+        .send()
+        .await
+    {
+        Ok(response) if response.status().is_success() => {
+            tracing::info!(
+                "Daemon supervisor replayed /lifecycle/ready after respawn; \
+                 deferred services should now start"
+            );
+        }
+        Ok(response) => {
+            tracing::warn!(
+                status = %response.status(),
+                "Daemon supervisor /lifecycle/ready replay returned non-success"
+            );
+        }
+        Err(err) => {
+            tracing::warn!(
+                error = %err,
+                "Daemon supervisor /lifecycle/ready replay failed"
+            );
         }
     }
 }

--- a/src-tauri/crates/uc-tauri/src/bootstrap/wiring.rs
+++ b/src-tauri/crates/uc-tauri/src/bootstrap/wiring.rs
@@ -38,7 +38,7 @@ use tauri::async_runtime;
 use tokio::time::{self, Duration};
 use tracing::{info, warn};
 
-use uc_application::CleanupExpiredFilesUseCase;
+use uc_application::facade::ClipboardHistoryFacade;
 use uc_bootstrap::TaskRegistry;
 use uc_daemon_client::{DaemonConnectionState, DaemonPairingClient};
 
@@ -55,22 +55,31 @@ const GUI_PAIRING_LEASE_TTL_MS: u64 = 300_000;
 const GUI_PAIRING_LEASE_REFRESH_INTERVAL: Duration = Duration::from_secs(120);
 
 /// Start the file cache cleanup task (runs once at startup, fire-and-forget).
+///
+/// Cleanup goes through `ClipboardHistoryFacade::cleanup_expired_files`,
+/// which routes every expired file through the entry-aware delete path
+/// (untag iroh-blobs reference + remove cache file + drop sqlite rows
+/// in one shot). Pre-Phase-C this called a standalone use case that
+/// `tokio::fs::remove_file`-d cache files directly, leaving iroh-blobs
+/// metadata pointing at vanished files (the precursor to the Poisoned
+/// BaoFileStorage panic at `bao_file.rs:410`).
 pub fn start_background_tasks(
-    settings: Arc<dyn uc_core::ports::SettingsPort>,
-    file_cache_dir: std::path::PathBuf,
+    history_facade: Arc<ClipboardHistoryFacade>,
     task_registry: &Arc<TaskRegistry>,
 ) {
     let registry = task_registry.clone();
     async_runtime::spawn(async move {
         registry
             .spawn("file_cache_cleanup", |_token| async move {
-                let uc = CleanupExpiredFilesUseCase::new(settings, file_cache_dir.clone());
-                match uc.execute().await {
+                match history_facade.cleanup_expired_files().await {
                     Ok(result) => {
                         if result.files_removed > 0 {
                             info!(
                                 files_removed = result.files_removed,
+                                entries_deleted = result.entries_deleted,
+                                orphans_removed = result.orphans_removed,
                                 bytes_reclaimed = result.bytes_reclaimed,
+                                errors = result.errors,
                                 "Startup file cache cleanup completed"
                             );
                         }

--- a/src-tauri/crates/uc-webserver/src/api/ws.rs
+++ b/src-tauri/crates/uc-webserver/src/api/ws.rs
@@ -315,6 +315,12 @@ async fn handle_connection(socket: WebSocket, state: DaemonApiState, claims: Ses
                             }
                         }
                     }
+                    // Both channels closed (typical at daemon shutdown when the
+                    // event broadcaster and heartbeat task drop their senders
+                    // around the same moment). Without this arm, tokio's
+                    // select! panics with "all branches are disabled and there
+                    // is no else branch".
+                    else => break,
                 }
             }
         });

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -275,8 +275,7 @@ fn run_app(ctx: GuiBootstrapContext) {
 
             // Start file cache cleanup task (runs once at startup)
             start_background_tasks(
-                runtime.settings_port(),
-                background.file_cache_dir.clone(),
+                runtime.app_facade().clipboard_history.clone(),
                 runtime.task_registry(),
             );
 


### PR DESCRIPTION
## Summary

- Rework the file-cache lifecycle so deleting a clipboard entry just untags the iroh-blobs reference instead of unlinking on-disk data — eliminates the `Poisoned storage` panic that fired when the user clicked an old history entry after a delete.
- Wire iroh-blobs GC, sweep stale `auto-*` tags at startup, and make `publish` atomically attach the caller's `TagReason` so cache files actually get reclaimed within the 1h GC window instead of leaking until restart.
- Fix `FsStore::load_with_opts` getting the `store_dir` as both root and db path (caused the test-suite hang), move the cache dir off `~/Library/Caches` to Application Support, route panics into the JSON log via a single bootstrap-level hook, and add an end-to-end regression test for the original delete→fetch panic.
- Fix the daemon-supervisor / GUI lifecycle desync: when the supervisor respawns the daemon, replay `/lifecycle/ready` (clearing the stale JWT first) so deferred services like clipboard watcher and inbound clipboard sync actually start instead of leaving sync silently dead in both directions.
- Harden the websocket send task's `tokio::select!` with an `else => break` so it stops panicking with `"all branches are disabled"` during daemon shutdown.

## Test plan

- [x] `cargo test --workspace --lib` (528+ pass including new untag→fetch regression)
- [x] `cargo fmt --check` / `cargo check` clean
- [ ] Manual: copy text + ~500KB image + ~10MB file across paired peers, delete an entry, immediately reopen old history — no panic, cache reclaimed within 1h
- [ ] Manual: kill the daemon while GUI is up; supervisor respawn should log `replayed /lifecycle/ready` and sync should resume both directions without restarting the GUI