### PR TITLE
docs: embed demo video in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ It enables seamless and secure syncing of text, images, and files across multipl
 
 ![Image](https://github.com/user-attachments/assets/8d339467-5bbe-4afa-9235-1d26cbff82c9)
 
+<p align="center">
+  <video src="https://github.com/user-attachments/assets/2775e733-c92b-41e5-b842-8173c206ad61" controls muted playsinline width="800"></video>
+</p>
+
 <div align="center">
   <br/>
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -12,6 +12,10 @@ UniClipboard 是一款以**隐私优先**为核心理念的跨设备剪贴板同
 
 ![Image](https://github.com/user-attachments/assets/8d339467-5bbe-4afa-9235-1d26cbff82c9)
 
+<p align="center">
+  <video src="https://github.com/user-attachments/assets/2775e733-c92b-41e5-b842-8173c206ad61" controls muted playsinline width="800"></video>
+</p>
+
 <div align="center">
 
   <br/>


### PR DESCRIPTION
## Summary
- Add inline `<video>` block under the existing screenshot in both `README.md` and `README_ZH.md`, sourced from a GitHub user-attachments URL so the demo plays inline on github.com.

## Test plan
- [ ] Open the PR's Files Changed view and confirm the video player renders inline (not a broken link).