### PR TITLE
fix(macos): restore main window on Dock icon reopen

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -433,6 +433,17 @@ fn run_app(ctx: GuiBootstrapContext) {
                 tauri::RunEvent::Exit => {
                     info!("Application exiting");
                 }
+                #[cfg(target_os = "macos")]
+                tauri::RunEvent::Reopen {
+                    has_visible_windows,
+                    ..
+                } => {
+                    // macOS: 点击 Dock 图标时，若没有可见窗口则恢复主窗口
+                    if !has_visible_windows {
+                        info!("Dock reopen with no visible windows, showing main window");
+                        uc_tauri::tray::show_main_window(app_handle);
+                    }
+                }
                 _ => {}
             }
         });


### PR DESCRIPTION
## Summary
- The Tauri `.run()` handler in `src-tauri/src/main.rs` only matched `ExitRequested` and `Exit`, so `RunEvent::Reopen` (NSApplicationDelegate's `applicationShouldHandleReopen:hasVisibleWindows:`) was silently dropped.
- Symptom: after closing the main window to tray, clicking the macOS Dock icon did nothing — only the menu-bar tray icon could bring the window back.
- Fix: handle `Reopen` on macOS and call `show_main_window` when `has_visible_windows == false`, which already restores Dock visibility, unminimizes, shows, and focuses the window.

## Test plan
- [ ] Build the app, close the main window to tray, then click the Dock icon — main window should reappear.
- [ ] Click the menu-bar tray icon — should still work as before.
- [ ] Quit via tray menu — exit cleanup should still run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * macOS: The main window now properly restores when reopening the app from the Dock if no windows were previously visible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->