### PR TITLE
docs: add CONTRIBUTING guides (en + zh) and link from READMEs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,316 @@
+# Contributing to UniClipboard
+
+Thanks for your interest in contributing to UniClipboard! This document explains how to set up the project, the workflow we follow, and the conventions we expect contributions to respect.
+
+> A Chinese version is welcome — open a PR adding `CONTRIBUTING_ZH.md` if you'd like to mirror this guide.
+
+## Table of Contents
+
+- [Code of Conduct](#code-of-conduct)
+- [Ways to Contribute](#ways-to-contribute)
+- [Reporting Bugs](#reporting-bugs)
+- [Suggesting Features](#suggesting-features)
+- [Reporting Security Issues](#reporting-security-issues)
+- [Development Setup](#development-setup)
+- [Project Structure](#project-structure)
+- [Development Workflow](#development-workflow)
+- [Branching Strategy](#branching-strategy)
+- [Commit Conventions](#commit-conventions)
+- [Code Style and Quality](#code-style-and-quality)
+- [Testing](#testing)
+- [Documentation](#documentation)
+- [Pull Requests](#pull-requests)
+- [Release Process](#release-process)
+- [License](#license)
+
+## Code of Conduct
+
+Be respectful, constructive, and patient. We expect everyone interacting in issues, pull requests, and discussions to follow basic open-source etiquette: assume good intent, focus on the technical question, and keep conversations welcoming to newcomers.
+
+## Ways to Contribute
+
+There are many ways to help, no matter your experience level:
+
+- **Report bugs** with clear reproduction steps.
+- **Suggest features** that fit the project's privacy-first, cross-device focus.
+- **Fix bugs** — start with issues labeled `good first issue` or `help wanted`.
+- **Improve documentation** — typos, unclear sections, missing setup steps.
+- **Add tests** — both Rust and TypeScript test coverage are always welcome.
+- **Translate UI strings** — the app uses `i18next`; new locales are appreciated.
+- **Review pull requests** — a thoughtful second pair of eyes is valuable.
+
+## Reporting Bugs
+
+Before opening a new issue, please:
+
+1. Search [existing issues](https://github.com/UniClipboard/UniClipboard/issues) to avoid duplicates.
+2. Confirm you can reproduce the bug on the latest release.
+
+When filing a bug, include:
+
+- **Environment** — OS and version, UniClipboard version, install method (DMG, AppImage, MSI, Homebrew, source build).
+- **Steps to reproduce** — short, deterministic, numbered.
+- **Expected vs actual behavior**.
+- **Logs** — relevant excerpts from the log directory:
+  - macOS: `~/Library/Application Support/app.uniclipboard.desktop[-<profile>]/logs/`
+  - Linux: `~/.local/share/app.uniclipboard.desktop[-<profile>]/logs/`
+  - Windows: `%LOCALAPPDATA%\app.uniclipboard.desktop[-<profile>]\logs\`
+- **Screenshots or recordings** for UI issues.
+
+Strip personal data from logs and clipboard payloads before posting.
+
+## Suggesting Features
+
+Open a GitHub issue describing:
+
+- The user-facing problem you're trying to solve (not the implementation).
+- Why existing functionality is insufficient.
+- Whether the feature aligns with the project's principles: privacy-first, end-to-end encrypted, no mandatory cloud account.
+
+Proposals that compromise the security model (for example, server-side plaintext access) will not be accepted.
+
+## Reporting Security Issues
+
+**Do not** report security vulnerabilities through public GitHub issues.
+
+See [`SECURITY.md`](./SECURITY.md) for the disclosure process. We take cryptographic and privacy-related reports seriously and will coordinate a fix and release timeline with you.
+
+## Development Setup
+
+### Prerequisites
+
+- **Rust** — stable toolchain (`rustup` recommended). The version is pinned via `rust-toolchain.toml` if present.
+- **Bun** — JavaScript package manager and runtime. Install from [bun.sh](https://bun.sh).
+- **Tauri prerequisites** — see the official [Tauri prerequisites guide](https://tauri.app/start/prerequisites/) for OS-specific build dependencies (WebView2 on Windows, `webkit2gtk` and friends on Linux, Xcode CLT on macOS).
+
+Optional but useful:
+
+- `cargo-llvm-cov` for Rust coverage reports.
+- `cargo sweep` to keep `target/` directories small during development.
+
+### Clone and Install
+
+```bash
+git clone https://github.com/UniClipboard/UniClipboard.git
+cd UniClipboard
+bun install
+```
+
+`bun install` triggers Husky hook installation via the `prepare` script. Pre-commit lint-staged checks will run automatically on `git commit`.
+
+### Run the Desktop App in Development Mode
+
+```bash
+# Single instance, dev profile (data lives under app.uniclipboard.desktop-dev)
+bun tauri:dev
+```
+
+To debug peer-to-peer sync locally, two isolated instances can run side by side on the same machine:
+
+```bash
+# Run two peers concurrently — peerA in full clipboard mode, peerB passive
+bun tauri:dev:dual
+
+# Or start them individually if you need to attach a debugger
+bun tauri:dev:peerA
+bun tauri:dev:peerB
+```
+
+Each peer uses a different `UC_PROFILE` so their data, vault, and logs do not collide.
+
+### Build a Release Bundle
+
+```bash
+bun tauri build
+```
+
+Bundles land in `src-tauri/target/release/bundle/`.
+
+## Project Structure
+
+```text
+.
+├── src/                # React + TypeScript frontend (Tauri webview)
+├── src-tauri/          # Rust workspace (daemon, app shell, core, infra, platform crates)
+├── workers/            # Cloudflare Worker for the encrypted relay
+├── docs/               # Architecture, agent rules, release workflow, UAT, etc.
+├── scripts/            # Dev/release scripts (e.g. bump-version.js)
+├── public/             # Static assets served by Vite
+├── assets/             # Marketing/icon assets
+├── AGENTS.md           # Root navigation index for repository instructions
+└── README.md           # User-facing project introduction
+```
+
+`AGENTS.md` is the canonical entry point for repository conventions. When working on a specific area, read the focused document it links to (frontend, Rust/Tauri, architecture, workflow, or project memory) instead of skimming everything.
+
+## Development Workflow
+
+The project enforces a structured approach for non-trivial changes. Read [`docs/agent/workflow-rules.md`](./docs/agent/workflow-rules.md) for the full rules; the highlights are:
+
+- **Fix root causes, not symptoms.** No "temporary compromise" patches that hide structural issues.
+- **Preserve a single source of truth.** Do not duplicate the same business rule across modules.
+- **No parallel old/new logic** without an explicit removal plan.
+- **Architecture matters.** The Rust workspace follows a hexagonal layering rule: `uc-app → uc-core ← uc-infra / uc-platform`. `uc-core` must not depend on infra or platform crates. See [`docs/agent/architecture-rules.md`](./docs/agent/architecture-rules.md) and [`docs/architecture/ports.md`](./docs/architecture/ports.md).
+
+If you are unsure whether a change is a localized bug fix or a structural one, default to opening an issue or draft PR for discussion before investing time in a refactor.
+
+## Branching Strategy
+
+The project uses a **release-branch workflow** anchored on `main`:
+
+- **`main`** — always reflects the most recently shipped release. Direct merges from `dev` are not allowed.
+- **`dev`** — the integration branch where day-to-day work lands.
+- **`release/vX.Y.Z[-channel.N]`** — cut from `main` when preparing a release. Once published, the release branch is merged back into both `main` and `dev`.
+- **Feature branches** — branch from `dev`, name them descriptively (e.g. `feat/quick-panel-search`, `fix/devices-online-state`).
+
+When opening a PR, target the `dev` branch unless the maintainers explicitly ask you to target a release branch.
+
+## Commit Conventions
+
+Every commit must represent **exactly one engineering intent**. See [`docs/agent/architecture-rules.md`](./docs/agent/architecture-rules.md#atomic-commit-rule) for the full rule set.
+
+### Allowed Commit Types
+
+| Type        | Use For                                                              |
+| ----------- | -------------------------------------------------------------------- |
+| `feat:`     | New user-facing capability                                           |
+| `impl:`     | Concrete implementation step of a previously planned feature         |
+| `fix:`      | Bug fix                                                              |
+| `hotfix:`   | Urgent production fix                                                |
+| `refactor:` | Structural change without behavior change                            |
+| `arch:`     | Architecture or boundary change (e.g. introducing a new port)        |
+| `chore:`    | Tooling, build, dependency, scripts                                  |
+| `infra:`    | Deployment or environment config                                     |
+| `test:`     | Add or adjust tests                                                  |
+| `perf:`     | Performance optimization (benchmarks expected)                       |
+| `docs:`     | Documentation only                                                   |
+
+### Format
+
+```text
+<type>(<optional scope>): <single intent summary>
+
+[optional body explaining why, not what]
+```
+
+Examples drawn from the project's history:
+
+```text
+fix(storage): isolate cache_dir from data root on Windows
+fix(devices): show real online state and cut offline detection latency
+chore(observability): silence swarm_discovery::socket EHOSTUNREACH spam
+```
+
+### What to Avoid
+
+- Mixing a feature change with formatting cleanup in the same commit.
+- Commits whose message needs `and`, `also`, `plus`, or `misc` to summarize them — split them.
+- Commits that modify both a port definition and its adapter — split them so the port lands first.
+- Commits that build successfully only because a follow-up commit "completes" them.
+
+If you accumulate many local changes, the [`atomic-commits`](https://docs.anthropic.com/) workflow encourages re-organizing them into clean, single-intent commits before pushing.
+
+## Code Style and Quality
+
+### Linters and Formatters
+
+JavaScript/TypeScript:
+
+```bash
+bun run lint        # eslint
+bun run lint:fix    # eslint --fix
+bun run format      # prettier --write .
+```
+
+Rust (run inside `src-tauri/`):
+
+```bash
+cargo fmt --all
+cargo clippy --workspace --all-targets -- -D warnings
+```
+
+Pre-commit hooks (via Husky and lint-staged) automatically run `eslint`, `prettier`, and `cargo fmt` on staged files. Do not bypass hooks (`--no-verify`) without a documented reason.
+
+### Style Guidelines
+
+- **Comments and project documentation are written in Chinese**, per `AGENTS.md`. Identifiers, commit messages, and PR titles/descriptions remain English so tooling and external collaborators stay aligned.
+- **No machine-specific absolute paths** in tracked files. Use repo-relative paths in docs and configuration.
+- **Markdown fenced code blocks must include a language identifier** (`bash`, `rust`, `ts`, `text`, etc.).
+- **Frontend code** follows the rules in [`docs/agent/frontend-ui-rules.md`](./docs/agent/frontend-ui-rules.md).
+- **Rust/Tauri code** follows the rules in [`docs/agent/rust-tauri-rules.md`](./docs/agent/rust-tauri-rules.md).
+
+## Testing
+
+### Frontend
+
+```bash
+bun test           # vitest, watch mode
+bun test --run     # single run, useful in CI
+```
+
+Tests use Vitest with `@testing-library/react`. Place colocated tests next to the code they cover (e.g. `Component.test.tsx`).
+
+### Rust
+
+```bash
+cd src-tauri
+cargo test --workspace
+```
+
+For coverage reports:
+
+```bash
+bun run test:coverage   # produces an HTML report under src-tauri/target/llvm-cov
+```
+
+### Manual / UAT Verification
+
+Some changes require UI verification or multi-device sync testing. The project keeps UAT notes under `docs/uat/`. For UI work, please describe in the PR what you exercised manually (golden path + at least one edge case).
+
+When a fix is hard to cover with automated tests, add a regression note under `docs/fixes/` describing the failure mode and how it is now prevented.
+
+## Documentation
+
+- User-facing changes that alter behavior should update `README.md` and `README_ZH.md` together.
+- Internal architectural decisions belong under `docs/architecture/`.
+- Agent/contributor instructions belong under `docs/agent/` and are linked from `AGENTS.md`.
+- Release-related guidance lives in [`docs/release-workflow.md`](./docs/release-workflow.md) and [`docs/CHANGELOG_TEMPLATE.md`](./docs/CHANGELOG_TEMPLATE.md).
+
+If you add a new top-level doc, add a pointer to it from `AGENTS.md` so future contributors can discover it.
+
+## Pull Requests
+
+### Before You Open a PR
+
+- Rebase onto the latest `dev`.
+- Make sure `bun run lint`, `bun run format`, `bun test`, and `cargo test` (where relevant) all pass locally.
+- Keep the diff focused. Open separate PRs for unrelated changes.
+
+### PR Description
+
+Include:
+
+- **What** changed and **why** (link to the issue if applicable).
+- **How** you verified the change — automated tests, manual steps, dual-peer scenarios, etc.
+- **Screenshots or short clips** for UI changes.
+- **Risk assessment** for changes that touch storage, encryption, networking, or daemon lifecycle.
+
+### Review Process
+
+- A maintainer will review and may request changes.
+- Automated review bots may post suggestions. Treat them as **inputs, not commands** — verify each item against the codebase, then accept or reject with a short technical justification. See the "AI Review Intake" section in [`docs/agent/workflow-rules.md`](./docs/agent/workflow-rules.md).
+- CI must be green before merging. PRs use squash merge by default; the squashed message should follow the commit conventions above.
+
+## Release Process
+
+Releases are driven by maintainers via the GitHub Actions `Release` workflow. End-to-end version bump rules, channel definitions (`stable` / `alpha` / `beta` / `rc`), and packaging details are documented in [`docs/release-workflow.md`](./docs/release-workflow.md). Contributors generally do not need to bump versions manually — the workflow handles it.
+
+If your change should appear in the user-facing changelog, mention it in your PR description so the release notes can pick it up. The format follows [`docs/CHANGELOG_TEMPLATE.md`](./docs/CHANGELOG_TEMPLATE.md): only user-perceivable changes, one line each, no internal jargon.
+
+## License
+
+By contributing to UniClipboard, you agree that your contributions will be licensed under the [AGPL-3.0](./LICENSE) license, the same license that covers the rest of the project. If you incorporate third-party code, ensure its license is compatible and document the source in the PR.
+
+---
+
+Thanks again for helping make UniClipboard better. If anything in this guide is unclear or out of date, open an issue or PR — improving the contributor experience is itself a valuable contribution.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thanks for your interest in contributing to UniClipboard! This document explains how to set up the project, the workflow we follow, and the conventions we expect contributions to respect.
 
-> A Chinese version is welcome — open a PR adding `CONTRIBUTING_ZH.md` if you'd like to mirror this guide.
+> A Chinese version is available — see [`CONTRIBUTING_ZH.md`](./CONTRIBUTING_ZH.md).
 
 ## Table of Contents
 

--- a/CONTRIBUTING_ZH.md
+++ b/CONTRIBUTING_ZH.md
@@ -1,0 +1,318 @@
+# UniClipboard 贡献指南
+
+[English](./CONTRIBUTING.md) | 简体中文
+
+感谢你愿意为 UniClipboard 做贡献！本文档说明如何搭建开发环境、我们遵循的工作流，以及对贡献内容的约定。
+
+## 目录
+
+- [行为准则](#行为准则)
+- [贡献方式](#贡献方式)
+- [报告 Bug](#报告-bug)
+- [建议新功能](#建议新功能)
+- [报告安全问题](#报告安全问题)
+- [开发环境搭建](#开发环境搭建)
+- [项目结构](#项目结构)
+- [开发流程](#开发流程)
+- [分支策略](#分支策略)
+- [Commit 规范](#commit-规范)
+- [代码风格与质量](#代码风格与质量)
+- [测试](#测试)
+- [文档](#文档)
+- [Pull Request](#pull-request)
+- [发布流程](#发布流程)
+- [许可证](#许可证)
+
+## 行为准则
+
+请保持尊重、建设性与耐心。我们希望所有在 issue、PR、讨论中互动的人都遵守开源社区的基本礼仪：默认对方善意，聚焦在技术问题上，让新人感到被欢迎。
+
+## 贡献方式
+
+无论经验深浅，都有很多参与方式：
+
+- **报告 Bug**：附带清晰的复现步骤。
+- **提出功能建议**：与项目"隐私优先、跨设备"的方向契合即可。
+- **修复 Bug**：可以从带有 `good first issue` 或 `help wanted` 标签的 issue 入手。
+- **改进文档**：错别字、表述不清、缺失的搭建步骤都欢迎修正。
+- **补充测试**：Rust 与 TypeScript 两侧的测试覆盖率提升都很受欢迎。
+- **翻译界面**：项目使用 `i18next`，欢迎补充新语种。
+- **审阅 PR**：一个用心的第二双眼睛非常有价值。
+
+## 报告 Bug
+
+提 issue 之前请先：
+
+1. 在 [现有 issue](https://github.com/UniClipboard/UniClipboard/issues) 中搜索，避免重复。
+2. 确认该 Bug 在最新发布版本上仍能复现。
+
+提 Bug 时请附带：
+
+- **环境信息**：操作系统及版本、UniClipboard 版本、安装方式（DMG、AppImage、MSI、Homebrew、源码构建）。
+- **复现步骤**：简短、确定性、按编号列出。
+- **预期行为 vs 实际行为**。
+- **日志**：从下列日志目录摘取相关片段：
+  - macOS：`~/Library/Application Support/app.uniclipboard.desktop[-<profile>]/logs/`
+  - Linux：`~/.local/share/app.uniclipboard.desktop[-<profile>]/logs/`
+  - Windows：`%LOCALAPPDATA%\app.uniclipboard.desktop[-<profile>]\logs\`
+- **截图或录屏**：UI 问题尤其需要。
+
+发布前请清除日志和剪贴板内容中的个人数据。
+
+## 建议新功能
+
+提 issue 时请说明：
+
+- 你想解决的**用户层面**问题（不是实现细节）。
+- 现有功能为什么不够。
+- 该功能是否与项目原则一致：隐私优先、端到端加密、不强制依赖云账户。
+
+破坏安全模型的提案（例如允许服务器获取明文）不会被接受。
+
+## 报告安全问题
+
+**请勿**通过公开 GitHub issue 报告安全漏洞。
+
+请按照 [`SECURITY.md`](./SECURITY.md) 中的披露流程联系我们。我们会认真对待与加密、隐私相关的报告，并与你一起协调修复与发布的时间线。
+
+## 开发环境搭建
+
+### 前置依赖
+
+- **Rust**：稳定版工具链（推荐使用 `rustup`）。如果仓库中存在 `rust-toolchain.toml`，会以其为准。
+- **Bun**：JavaScript 包管理器与运行时。可从 [bun.sh](https://bun.sh) 下载。
+- **Tauri 构建依赖**：参考 Tauri 官方 [前置依赖文档](https://tauri.app/start/prerequisites/)，按系统准备好相应组件（Windows 的 WebView2、Linux 的 `webkit2gtk` 等、macOS 的 Xcode CLT）。
+
+可选但有用：
+
+- `cargo-llvm-cov`：用于生成 Rust 覆盖率报告。
+- `cargo sweep`：开发期间清理 `target/` 目录。
+
+### 克隆与安装
+
+```bash
+git clone https://github.com/UniClipboard/UniClipboard.git
+cd UniClipboard
+bun install
+```
+
+`bun install` 会通过 `prepare` 脚本自动安装 Husky 钩子，`git commit` 时会自动跑 lint-staged 检查。
+
+### 以开发模式运行桌面端
+
+```bash
+# 单实例，dev profile（数据目录在 app.uniclipboard.desktop-dev 下）
+bun tauri:dev
+```
+
+如果要在本机调试 P2P 同步，可以同时运行两个相互隔离的实例：
+
+```bash
+# 并行运行两个 peer，peerA 是完整剪贴板模式，peerB 是被动模式
+bun tauri:dev:dual
+
+# 或者分别启动，便于挂调试器
+bun tauri:dev:peerA
+bun tauri:dev:peerB
+```
+
+两个 peer 使用不同的 `UC_PROFILE`，所以它们的数据、密钥库、日志互不冲突。
+
+### 构建发行包
+
+```bash
+bun tauri build
+```
+
+产物会出现在 `src-tauri/target/release/bundle/`。
+
+## 项目结构
+
+```text
+.
+├── src/                # React + TypeScript 前端（Tauri webview）
+├── src-tauri/          # Rust 工作区（daemon、app、core、infra、platform 等 crate）
+├── workers/            # Cloudflare Worker，加密中继
+├── docs/               # 架构、agent 规则、发布流程、UAT 等
+├── scripts/            # 开发/发布脚本（如 bump-version.js）
+├── public/             # Vite 提供的静态资源
+├── assets/             # 营销/图标素材
+├── AGENTS.md           # 仓库说明的根导航索引
+└── README.md           # 面向用户的项目介绍
+```
+
+`AGENTS.md` 是仓库约定的入口文档。在某个具体方向工作时，按它的指引读对应的专题文档（前端、Rust/Tauri、架构、工作流、项目记忆），不要把所有文档一次性全读一遍。
+
+## 开发流程
+
+非简单改动需要遵循结构化的处理方式。完整规则见 [`docs/agent/workflow-rules.md`](./docs/agent/workflow-rules.md)，要点是：
+
+- **修复根因，而不是症状**。不允许"先这样处理一下"式的临时补丁掩盖结构问题。
+- **保持单一事实来源**。同一业务规则不在多个模块重复实现。
+- **不允许新旧逻辑长期并存**，必须有明确的迁移/删除计划。
+- **遵守架构边界**。Rust 工作区采用六边形分层：`uc-app → uc-core ← uc-infra / uc-platform`。`uc-core` 不得依赖 infra 或 platform crate。详见 [`docs/agent/architecture-rules.md`](./docs/agent/architecture-rules.md) 与 [`docs/architecture/ports.md`](./docs/architecture/ports.md)。
+
+如果你不确定某个变更是局部修复还是需要做结构调整，建议先开 issue 或 draft PR 与维护者讨论，再投入大块时间重构。
+
+## 分支策略
+
+项目使用以 `main` 为锚的 **release-branch 工作流**：
+
+- **`main`**：始终对应最近一次发布的版本。**不允许**直接从 `dev` 合并。
+- **`dev`**：日常开发的集成分支。
+- **`release/vX.Y.Z[-channel.N]`**：准备发布时从 `main` 切出的分支。发布完成后再反向合并回 `main` 与 `dev`。
+- **功能分支**：从 `dev` 切出，命名要有描述性（如 `feat/quick-panel-search`、`fix/devices-online-state`）。
+
+提 PR 时默认目标分支是 `dev`，除非维护者明确要求你目标到某个 release 分支。
+
+## Commit 规范
+
+每个 commit 必须只表达**一个**工程意图。完整规则见 [`docs/agent/architecture-rules.md`](./docs/agent/architecture-rules.md#atomic-commit-rule)。
+
+### 允许的 commit 类型
+
+| 类型        | 适用场景                                        |
+| ----------- | ---------------------------------------------- |
+| `feat:`     | 新增的用户可见能力                              |
+| `impl:`     | 已规划功能的具体实现步骤                        |
+| `fix:`      | Bug 修复                                       |
+| `hotfix:`   | 紧急的生产环境修复                              |
+| `refactor:` | 不改变行为的结构调整                            |
+| `arch:`     | 架构或边界变更（如新增一个 port）              |
+| `chore:`    | 工具、构建、依赖、脚本                          |
+| `infra:`    | 部署或环境配置                                  |
+| `test:`     | 新增或调整测试                                  |
+| `perf:`     | 性能优化（需附带 benchmark）                    |
+| `docs:`     | 仅文档变更                                      |
+
+### 格式
+
+```text
+<type>(<可选 scope>): <单一意图概述>
+
+[可选正文：解释"为什么"，而不是"做了什么"]
+```
+
+来自项目历史的真实示例：
+
+```text
+fix(storage): isolate cache_dir from data root on Windows
+fix(devices): show real online state and cut offline detection latency
+chore(observability): silence swarm_discovery::socket EHOSTUNREACH spam
+```
+
+> commit 信息、PR 标题与描述使用英文，确保工具链与外部协作者通用。代码注释和项目内文档使用中文。
+
+### 应避免的写法
+
+- 把功能改动和格式化清理混在同一个 commit 里。
+- commit 信息需要用 `and`、`also`、`plus`、`misc` 才能概括 —— 这种就要拆分。
+- 同一个 commit 中既改了 port 定义又改了 adapter 实现 —— 拆开，让 port 先落地。
+- 仅靠后续 commit 才能"补全"的 commit。每个 commit 应单独可构建、可运行。
+
+如果你本地积累了较多变更，可以借助 `atomic-commits` 之类的工作流把它们重新整理成单一意图的干净 commit 后再推送。
+
+## 代码风格与质量
+
+### Lint 与格式化
+
+JavaScript / TypeScript：
+
+```bash
+bun run lint        # eslint
+bun run lint:fix    # eslint --fix
+bun run format      # prettier --write .
+```
+
+Rust（在 `src-tauri/` 目录下执行）：
+
+```bash
+cargo fmt --all
+cargo clippy --workspace --all-targets -- -D warnings
+```
+
+通过 Husky 与 lint-staged 配置的 pre-commit 钩子，会在暂存文件上自动跑 `eslint`、`prettier`、`cargo fmt`。**不要随意使用 `--no-verify` 跳过钩子**，除非有清晰的理由并写进 PR 说明。
+
+### 风格约定
+
+- **代码注释和项目文档使用中文**（依据 `AGENTS.md`）。代码标识符、commit message、PR 标题与描述保持英文，便于工具链与外部协作。
+- 仓库内文件**不得包含机器特定的绝对路径**，统一使用相对仓库根的路径。
+- Markdown 代码围栏**必须带语言标识**（`bash`、`rust`、`ts`、`text` 等）。
+- **前端代码**遵循 [`docs/agent/frontend-ui-rules.md`](./docs/agent/frontend-ui-rules.md)。
+- **Rust/Tauri 代码**遵循 [`docs/agent/rust-tauri-rules.md`](./docs/agent/rust-tauri-rules.md)。
+
+## 测试
+
+### 前端
+
+```bash
+bun test           # vitest，watch 模式
+bun test --run     # 单次运行，CI 中适用
+```
+
+测试基于 Vitest 与 `@testing-library/react`。请把测试与被测代码放在同一目录（如 `Component.test.tsx`）。
+
+### Rust
+
+```bash
+cd src-tauri
+cargo test --workspace
+```
+
+覆盖率报告：
+
+```bash
+bun run test:coverage   # 在 src-tauri/target/llvm-cov 下生成 HTML 报告
+```
+
+### 手动 / UAT 验证
+
+部分变更需要手动跑 UI 或多设备同步场景。项目把 UAT 记录放在 `docs/uat/`。涉及 UI 的 PR，请在描述中说明你手动验证了哪些路径（黄金路径 + 至少一个边界场景）。
+
+如果某个修复难以用自动化测试覆盖，请在 `docs/fixes/` 下添加一份回归说明，描述失效形式以及现在如何防止它再次发生。
+
+## 文档
+
+- 改动影响用户行为时，`README.md` 与 `README_ZH.md` 应同步更新。
+- 内部架构决策放在 `docs/architecture/` 下。
+- 面向 agent / 贡献者的说明放在 `docs/agent/` 下，并通过 `AGENTS.md` 索引。
+- 发布相关说明在 [`docs/release-workflow.md`](./docs/release-workflow.md) 与 [`docs/CHANGELOG_TEMPLATE.md`](./docs/CHANGELOG_TEMPLATE.md)。
+
+新增顶层文档时，请在 `AGENTS.md` 中加一条指引，便于后续贡献者发现。
+
+## Pull Request
+
+### 提 PR 之前
+
+- 先 rebase 到最新的 `dev`。
+- 本地确认 `bun run lint`、`bun run format`、`bun test`、`cargo test`（涉及时）都能通过。
+- 保持 diff 聚焦。互不相关的改动请拆成独立 PR。
+
+### PR 描述
+
+应包含：
+
+- 改动**做了什么**以及**为什么**（如对应了 issue 请关联）。
+- **如何验证**：自动化测试、手动步骤、双 peer 场景等。
+- UI 改动请附**截图或短视频**。
+- 涉及存储、加密、网络、daemon 生命周期的改动，请说明**风险评估**。
+
+### 评审流程
+
+- 维护者会进行 review，可能要求修改。
+- 自动化 review bot 提出的建议视为**输入而非命令**：每条都需要结合代码现状判断后再决定接受或拒绝，并附简短的技术理由。详见 [`docs/agent/workflow-rules.md`](./docs/agent/workflow-rules.md) 中的 "AI Review Intake" 章节。
+- CI 必须全绿才能合并。默认使用 squash merge，squash 后的 commit 信息也要遵守上述 commit 规范。
+
+## 发布流程
+
+发布由维护者通过 GitHub Actions 的 `Release` 工作流触发。版本升级规则、发布渠道（`stable` / `alpha` / `beta` / `rc`）以及打包细节详见 [`docs/release-workflow.md`](./docs/release-workflow.md)。一般情况下贡献者无需手动 bump 版本号，由发布工作流统一处理。
+
+如果你的改动应当出现在用户可见的 changelog 中，请在 PR 描述中提一下，便于发布说明引用。格式参考 [`docs/CHANGELOG_TEMPLATE.md`](./docs/CHANGELOG_TEMPLATE.md)：只写用户可感知的变化，每条一行，避免内部术语。
+
+## 许可证
+
+提交贡献即表示你同意你的贡献以 [AGPL-3.0](./LICENSE) 协议授权，与项目其余部分一致。如果你引入了第三方代码，请确保许可证兼容并在 PR 中注明来源。
+
+---
+
+再次感谢你帮 UniClipboard 变得更好。如果本指南有任何不清楚或过时的地方，欢迎开 issue 或 PR —— 改进贡献者体验本身也是一种宝贵的贡献。

--- a/README.md
+++ b/README.md
@@ -230,13 +230,15 @@ The 0.6 release replaced the underlying networking stack. Existing pairings from
 
 ## Contributing
 
-Contributions of all kinds are welcome! If you're interested in improving UniClipboard:
+Contributions of all kinds are welcome! Please read [CONTRIBUTING.md](./CONTRIBUTING.md) for the full development setup, branching strategy, commit conventions, and PR process.
+
+Quick start:
 
 1. Fork this repository
 2. Create your feature branch (`git checkout -b feature/amazing-feature`)
-3. Commit your changes (`git commit -m 'Add some amazing feature'`)
+3. Commit your changes following the project's [commit conventions](./CONTRIBUTING.md#commit-conventions)
 4. Push to the branch (`git push origin feature/amazing-feature`)
-5. Create a Pull Request
+5. Open a Pull Request against the `dev` branch
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ It enables seamless and secure syncing of text, images, and files across multipl
 
 ![Image](https://github.com/user-attachments/assets/8d339467-5bbe-4afa-9235-1d26cbff82c9)
 
+<p align="center">
+  <video src="https://github.com/user-attachments/assets/2775e733-c92b-41e5-b842-8173c206ad61" controls muted playsinline width="800"></video>
+</p>
+
 <div align="center">
   <br/>
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -230,13 +230,15 @@ uniclip status / start / stop   # 守护进程生命周期
 
 ## 参与贡献
 
-非常欢迎各种形式的贡献！如果您对改进 UniClipboard 感兴趣，请：
+非常欢迎各种形式的贡献！开发环境搭建、分支策略、commit 规范、PR 流程的完整说明请参阅 [CONTRIBUTING_ZH.md](./CONTRIBUTING_ZH.md)（[English](./CONTRIBUTING.md)）。
+
+快速上手：
 
 1. Fork 本仓库
 2. 创建您的特性分支 (`git checkout -b feature/amazing-feature`)
-3. 提交您的更改 (`git commit -m 'Add some amazing feature'`)
+3. 按照项目的 [commit 规范](./CONTRIBUTING_ZH.md#commit-规范) 提交更改
 4. 推送到分支 (`git push origin feature/amazing-feature`)
-5. 创建一个 Pull Request
+5. 向 `dev` 分支提交 Pull Request
 
 ## 许可证
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -12,6 +12,10 @@ UniClipboard 是一款以**隐私优先**为核心理念的跨设备剪贴板同
 
 ![Image](https://github.com/user-attachments/assets/8d339467-5bbe-4afa-9235-1d26cbff82c9)
 
+<p align="center">
+  <video src="https://github.com/user-attachments/assets/2775e733-c92b-41e5-b842-8173c206ad61" controls muted playsinline width="800"></video>
+</p>
+
 <div align="center">
 
   <br/>


### PR DESCRIPTION
## Summary

- Add `CONTRIBUTING.md` and `CONTRIBUTING_ZH.md` covering dev setup, project structure, branching strategy, atomic commit conventions, code style, testing, documentation, PR review, and release process — all anchored to the existing rules in `AGENTS.md` and `docs/agent/*`.
- Update `README.md` and `README_ZH.md` Contributing sections to point at the new guides, link to the commit-conventions section, and direct PRs at the `dev` branch instead of the previous generic 5-step boilerplate.

## Test plan

- [x] `bun run format` (ran via lint-staged on commit)
- [ ] Visual review of rendered Markdown on GitHub
- [ ] Verify cross-links between `README.md` ↔ `CONTRIBUTING.md` ↔ `CONTRIBUTING_ZH.md` ↔ `README_ZH.md` resolve

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive contribution guidelines detailing development environment setup, branching strategy, commit conventions, and pull request workflows
  * Added Chinese language contribution documentation to support international community contributors
  * Embedded product demo video in project README files (English and Chinese versions)
  * Updated README sections to direct contributors to detailed guidelines and instructions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->