### PR TITLE
feat(network): allow_overlay_network_addrs toggle + Tailscale IPv6 ULA filter

### DIFF
--- a/docs/p2p/2026-05-05-iroh-virtual-nic-filter.md
+++ b/docs/p2p/2026-05-05-iroh-virtual-nic-filter.md
@@ -1,0 +1,722 @@
+# iroh 虚拟网卡地址过滤设计与实现
+
+> 落地时间：2026-05-05
+> 涉及版本：iroh 0.98.2、uniclipboard `0.6.x` 起
+> Issue 关联：UniClipboard#486
+> 主要 commits：`50477a17` / `800a508a` / `ae39f432`
+
+## 1. 背景与动机
+
+UniClipboard 通过 iroh 建立设备之间的直连。iroh 在协商 NAT
+穿透时会把本机所有可达的网络地址（"direct addresses"）发布到
+pkarr/mDNS/DHT，让对端的 magicsock 拿到候选列表后逐个尝试连接。
+
+问题在于：现代用户机器上常有**虚拟网卡**，它们的 IP 看起来像普通
+LAN 地址，但跨主机不可达：
+
+| 网段 | 来源 | 跨主机可达性 |
+|---|---|---|
+| `198.18.0.0/15` | Clash 默认 fake-ip 池 | 不可达（本机回环） |
+| `100.64.0.0/10` | CGNAT / Tailscale 默认 IPv4 段 | 仅在同一 tailnet 内可达 |
+| `fd7a:115c:a1e0::/48` | Tailscale IPv6 ULA | 仅在同一 tailnet 内可达 |
+| `169.254.0.0/16` | IPv4 link-local autoconf | 仅本机有意义 |
+
+如果这些地址被作为直连候选发布出去：
+
+1. **死候选阻塞**：peer 的 magicsock 会逐个尝试 path validation。
+   每条死路径都要消耗 PathId 预算（默认 13；项目里因为 multipath
+   并发已经把上限提到 64，见 `uc-infra/src/network/iroh/node.rs`
+   的 `build_transport_config`），并拉长 RTT 探测窗口。
+2. **假赢风险**：本机 TUN 接口的 ACK 比真实 LAN 快，path-race 中
+   虚拟路径可能临时胜出，但实际报文回不来；最终连接挂死或被踢回
+   relay。Issue #486 在 Clash fake-ip 案例上观察到这一现象。
+
+`uc-observability/src/profile.rs` 也已记录到部分用户出现 `EHOSTUNREACH`
+错误，源头正是 VPN/Clash TUN 接口被 iroh 当作直连候选。
+
+## 2. 设计反复讨论的关键决策
+
+### 2.1 不是所有"虚拟 IP"都该一刀切过滤
+
+设计上把这四段拆成两类：
+
+| 类别 | 网段 | 处理 |
+|---|---|---|
+| **always-filtered** | `198.18.0.0/15`、`169.254.0.0/16` | 永远过滤，无 escape hatch |
+| **overlay 类** | `100.64.0.0/10`、`fd7a:115c:a1e0::/48` | 默认过滤，专业用户可 opt-in 放行 |
+
+**为什么不让用户也能关掉 Clash fake-ip 过滤？**
+198.18.x 没有任何合法跨主机用例 —— 暴露给用户只会增加误用面，没有收益。
+
+**为什么 Tailscale 段需要 opt-in？**
+如果两台设备**都在同一个 tailnet** 中，且真实 LAN/公网直连不通，那
+Tailscale 100.x / fd7a:: 是合法可达路径，过滤反而让用户损失一条
+路径。这是少数派但真实场景。
+
+### 2.2 反向命名 vs 正向命名
+
+- `allow_relay_fallback`（已存在）业务正向语义，但 UI 文案是 "LAN-only Mode"，
+  导致 UI checked === ON === LAN-only === `allow_relay_fallback = false`。
+  存在唯一一处取反点，由 `uc-bootstrap/src/network_policy.rs` 集中收口。
+- `allow_overlay_network_addrs`（本次新增）**正向同名传递，不取反**：
+  UI checked === `allow_overlay_network_addrs`。不参与反向命名铁律。
+
+这避免了两个语义反转字段叠加在一起带来的认知负担。
+
+### 2.3 默认值 = `false`（保持现行行为）
+
+Issue #486 已经在生产用户的 telemetry 里观察到死候选问题，过滤是
+**已被验证有效的修复**。新字段的默认值与既有 v0.6.x 行为完全一致，
+属于纯粹的"专业用户调优"开关，不影响多数派。
+
+### 2.4 配置粒度 = 单一布尔
+
+候选过的方案：
+
+- ❌ **整体开关**（`filter_virtual_nics`）：误把 Clash 与 Tailscale
+  绑在一起，开了之后用户不知不觉踩到 Clash 假赢。
+- ❌ **三档枚举**（`Strict | Permissive | Off`）：心智负担过高，
+  且 Permissive 与 Strict 之间的语义边界没有真实需求驱动。
+- ❌ **CIDR 黑名单**（用户填段）：要求懂 CIDR；过早抽象。
+- ✅ **单一布尔，仅控制 overlay 类**：简单、语义直接、未来扩展段
+  时不需要改字段名。
+
+### 2.5 修改后必须重启
+
+iroh 的 `Endpoint::builder().addr_filter(...)` 在 `bind` 时被冻结
+为 endpoint 常量，没有运行时可改的接口。叠加项目里 `BIND_LOCK`
+（`uc-infra/src/network/iroh/node.rs:409` 附近）的"进程级单次 bind"
+约束，运行时热切换被显式排除（Pitfall 3 防御）。
+
+UI 上沿用既有 `RestartBanner` 组件——任何 `NetworkSettings` 字段
+变更都共享同一个重启提示，因为它们的根因相同。
+
+## 3. 整体架构与改动范围
+
+```
+                 ┌─────────────────────────────────────────────┐
+                 │ Settings JSON (settings.json)               │
+                 │  network: {                                 │
+                 │    allow_relay_fallback: bool               │
+                 │    allow_overlay_network_addrs: bool  ← 新  │
+                 │  }                                          │
+                 └────────────────┬────────────────────────────┘
+                                  │  serde
+                 ┌────────────────▼────────────────────────────┐
+                 │ uc-core::settings::model::NetworkSettings   │
+                 └────────────────┬────────────────────────────┘
+                                  │  From<core>
+            ┌─────────────────────┼─────────────────────┐
+            ▼                     ▼                     ▼
+    ┌───────────────┐    ┌─────────────────┐   ┌──────────────────┐
+    │ application   │    │ daemon-contract │   │ bootstrap        │
+    │ View / Patch  │    │ DTO (camelCase) │   │ network_policy   │
+    └───────┬───────┘    └────────┬────────┘   └────────┬─────────┘
+            │                     │                     │
+            ▼                     ▼                     ▼
+    ┌───────────────┐    ┌─────────────────┐   ┌──────────────────┐
+    │ webserver     │    │ Frontend        │   │ uc-infra         │
+    │ PUT /settings │    │ NetworkSection  │   │ IrohNodeConfig   │
+    │ + smoke test  │    │ + Disclosure    │   │ + AddrFilter     │
+    └───────────────┘    └─────────────────┘   └──────────────────┘
+```
+
+涉及的 crate：`uc-core`、`uc-application`、`uc-daemon-contract`、
+`uc-bootstrap`、`uc-infra`、`uc-webserver`、前端。
+
+## 4. 各层实现
+
+### 4.1 `uc-core`：领域字段
+
+`uc-core/src/settings/model.rs`：
+
+```/Users/mark/conductor/workspaces/uniclipboard/edinburgh/src-tauri/crates/uc-core/src/settings/model.rs#L189-219
+pub struct NetworkSettings {
+    #[serde(default = "default_allow_relay_fallback")]
+    pub allow_relay_fallback: bool,
+
+    /// 是否允许把 VPN / overlay 类虚拟网卡地址（CGNAT 100.64.0.0/10、
+    /// Tailscale ULA fd7a:115c:a1e0::/48）作为 iroh 直连候选。
+    /// 默认 false（过滤）。
+    #[serde(default = "default_allow_overlay_network_addrs")]
+    pub allow_overlay_network_addrs: bool,
+}
+
+fn default_allow_overlay_network_addrs() -> bool {
+    false
+}
+```
+
+要点：
+
+- `#[serde(default = ...)]` 让旧 `settings.json`（没这个字段）反序列化
+  时自动回填 `false`，向后兼容。
+- `Default` impl 在 `uc-core/src/settings/defaults.rs`，与 serde 默认
+  函数保持一致（同一份业务规则不允许两处不一致）。
+
+测试覆盖：默认值、旧 JSON 反序列化、显式 true/false JSON 反序列化
+（见 `defaults.rs` 的 `network_settings_default_filters_overlay_addrs`
+等用例）。
+
+### 4.2 `uc-application`：View / Patch
+
+`uc-application/src/facade/settings/models.rs` 加镜像字段：
+
+- `NetworkSettingsView`：读路径用，包含完整字段
+- `NetworkSettingsPatch`：写路径用，每字段是 `Option<bool>`，
+  `None` = 不修改
+
+`apply_settings_patch` 中显式判断 `Some(v)` 才写入，保证 patch 层面
+的"缺字段不抹掉"语义。
+
+测试覆盖：
+
+- patch 缺字段保留已存在值
+- patch 显式 Some(true) / Some(false) 双向覆盖
+- View 透明搬运业务正向语义（不取反）
+
+### 4.3 `uc-daemon-contract`：wire DTO
+
+`uc-daemon-contract/src/api/dto/settings.rs` 中 `NetworkSettingsDto`
+和 `NetworkSettingsPatchDto` 加 `allow_overlay_network_addrs` 字段。
+wire 字段名经 `#[serde(rename_all = "camelCase")]` 自动转为
+`allowOverlayNetworkAddrs`。
+
+新增字段的 wire 设计有一个细节：
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct NetworkSettingsDto {
+    pub allow_relay_fallback: bool,
+    #[serde(default)]
+    pub allow_overlay_network_addrs: bool,  // 旧 wire 兼容
+}
+```
+
+`#[serde(default)]` 保证旧前端发来的 wire（不含 `allowOverlayNetworkAddrs`）
+仍然可以反序列化，回填 `false`。这一兼容性由
+`dto_deserializes_legacy_wire_without_overlay_field` 测试钉死。
+
+### 4.4 `uc-bootstrap`：翻译层
+
+`uc-bootstrap/src/network_policy.rs` 是项目里**唯一允许进行业务语义
+↔ infra 语义反转**的地方（Pitfall 1 铁律）。
+
+```/Users/mark/conductor/workspaces/uniclipboard/edinburgh/src-tauri/crates/uc-bootstrap/src/network_policy.rs#L37-50
+pub(crate) fn relay_policy_to_iroh_config(
+    allow_relay_fallback: bool,
+    allow_overlay_network_addrs: bool,
+    rendezvous_base_url: Option<String>,
+) -> IrohNodeConfig {
+    IrohNodeConfig {
+        // ↓ 全工程**唯一**取反点 — Pitfall 1 防御铁律。
+        disable_relays: !allow_relay_fallback,
+        // ↓ 正向同名字段，直接搬运不取反。
+        allow_overlay_network_addrs,
+        rendezvous_base_url,
+    }
+}
+```
+
+调用点（`builders.rs` 与 `non_gui_runtime.rs`）从 `SettingsPort` 加载
+后透传到 `IrohNodeConfig`，并在 `tracing::info!(target: "settings.network", ...)`
+中暴露字段值供排障。
+
+### 4.5 `uc-infra`：iroh 接入与过滤实现
+
+`uc-infra/src/network/iroh/node.rs` 是核心实现所在。
+
+#### 4.5.1 `IrohNodeConfig` 加字段
+
+```rust
+pub struct IrohNodeConfig {
+    pub rendezvous_base_url: Option<String>,
+    pub disable_relays: bool,
+    pub allow_overlay_network_addrs: bool,
+}
+```
+
+#### 4.5.2 `is_virtual_nic_ip` 双类拆分
+
+```/Users/mark/conductor/workspaces/uniclipboard/edinburgh/src-tauri/crates/uc-infra/src/network/iroh/node.rs#L302-336
+fn is_virtual_nic_ip(ip: IpAddr, allow_overlay: bool) -> bool {
+    match ip {
+        IpAddr::V4(v4) => {
+            let o = v4.octets();
+            // Always-filtered classes:
+            if (o[0] == 198 && (o[1] & 0xfe) == 18)        // 198.18.0.0/15
+                || (o[0] == 169 && o[1] == 254)             // 169.254.0.0/16
+            {
+                return true;
+            }
+            // Overlay class (CGNAT / Tailscale 100.64.0.0/10):
+            if !allow_overlay && o[0] == 100 && (o[1] & 0xc0) == 64 {
+                return true;
+            }
+            false
+        }
+        IpAddr::V6(v6) => {
+            // Tailscale IPv6 ULA fd7a:115c:a1e0::/48
+            let segs = v6.segments();
+            if !allow_overlay && segs[0] == 0xfd7a
+                && segs[1] == 0x115c && segs[2] == 0xa1e0
+            {
+                return true;
+            }
+            false
+        }
+    }
+}
+```
+
+要点：
+
+- IPv4 段用位运算判 CIDR：`(o[1] & 0xfe) == 18` 等价于
+  `o[1] in [18, 19]`（覆盖 `198.18.x.x` + `198.19.x.x` 即 /15）。
+  `(o[1] & 0xc0) == 64` 等价于 `o[1] in [64, 65, ..., 127]`，
+  覆盖 100.64.0.0/10。
+- IPv6 ULA 用前 48 位（前 3 个 16-bit segment）判定。
+- **本次同步补上历史漏过的 Tailscale IPv6 ULA `fd7a:115c:a1e0::/48`**。
+  原版只过滤 IPv4，导致 IPv6-preferred 网络下行为不对称。
+
+#### 4.5.3 `apply_addr_filter` 抽出可测的纯函数
+
+`AddrFilter` 是 iroh 暴露的不透明 wrapper，外部不能直接 invoke
+其内部闭包做单测。所以把过滤逻辑抽成：
+
+```rust
+fn apply_addr_filter<'a>(
+    addrs: &'a Vec<TransportAddr>,
+    allow_overlay: bool,
+) -> Cow<'a, Vec<TransportAddr>> {
+    // 任一虚拟 IP 都不存在 → 直接返回 Borrowed（零拷贝快路径）
+    let any_virtual = addrs.iter().any(|a| match a {
+        TransportAddr::Ip(s) => is_virtual_nic_ip(s.ip(), allow_overlay),
+        _ => false,
+    });
+    if !any_virtual {
+        return Cow::Borrowed(addrs);
+    }
+    // 否则构造过滤后的 Owned 集合 + 打 debug 日志
+    let kept: Vec<TransportAddr> = ...
+    let dropped: Vec<String> = ...
+    debug!(
+        target: "iroh.addr_filter",
+        allow_overlay,
+        dropped_count = dropped.len(),
+        dropped = ?dropped,
+        "filtered virtual-NIC addresses from candidate set",
+    );
+    Cow::Owned(kept)
+}
+
+fn build_addr_filter(allow_overlay: bool) -> AddrFilter {
+    AddrFilter::new(move |addrs: &Vec<TransportAddr>|
+        apply_addr_filter(addrs, allow_overlay)
+    )
+}
+```
+
+`Cow` 的设计避免了"无虚拟 IP"快路径的不必要拷贝（最常见情况）。
+
+#### 4.5.4 `bind` 时的可观测日志
+
+```rust
+let allow_overlay = config.allow_overlay_network_addrs;
+info!(
+    target: "iroh.addr_filter",
+    allow_overlay,
+    "addr filter configured: overlay-network addresses {} ...",
+    if allow_overlay { "ALLOWED" } else { "BLOCKED" },
+);
+let endpoint = Endpoint::builder(presets::N0)
+    ...
+    .addr_filter(build_addr_filter(allow_overlay))
+    ...;
+```
+
+每次 daemon 启动留一行 INFO，便于 support 反查"用户当前是不是把
+开关打开了"。
+
+#### 4.5.5 测试覆盖
+
+`apply_addr_filter` 与 `is_virtual_nic_ip` 各 4 段地址 × 2 状态
+共 7 个单测用例，覆盖：
+
+- 始终过滤类（Clash / link-local）忽略 overlay flag
+- CGNAT v4 / Tailscale v6 ULA 跟随 overlay flag
+- 真实 LAN / 公网 / 边界值（如 `100.63.255.255` 与 `100.128.0.0`
+  分别在 `100.64.0.0/10` 之外）从不被过滤
+- `apply_addr_filter` 对完整候选集的端到端行为
+
+### 4.6 前端：UI、i18n、Disclosure
+
+#### 4.6.1 UI 组件
+
+`src/components/setting/NetworkSection.tsx` 是 Phase 95 已有的网络
+设置组件，本次新增第二个 SettingRow：
+
+- 复用既有 `RestartBanner` 组件（任一开关切换后共享 banner，因为
+  根因都是"需要重启 daemon"）
+- 复用 `useDebounce(value, 500)` 模式：本地乐观切换 → 500ms
+  debounce 后 PUT；多次连击合并为一次请求
+- 失败时回滚到 persisted 值 + 显示 inline `saveError`
+- 给两个 Switch 都加 `aria-label`，便于 testing-library 在 DOM
+  里区分 / 屏幕阅读器友好
+
+新增独立的 `AllowOverlayAddrsDisclosure.tsx`，与 `LanOnlyDisclosure`
+同模式（click-only Popover），但内容针对 overlay 语义，4 段说明：
+
+- 影响范围（哪些段、哪些不在范围）
+- 默认关闭原因（死候选阻塞）
+- 何时开启（同 tailnet + 真实 LAN 不通）
+- 权衡（开错了只是连接慢，不会断 — relay 仍然兜底）
+
+#### 4.6.2 类型同步
+
+前端有两处 `NetworkSettings` 类型：
+
+- `src/api/daemon/settings.ts` — wire 边界类型（与 daemon HTTP API 对齐）
+- `src/types/setting.ts` — 应用内类型（与 `uc-core::Settings` 对齐）
+
+两处都加 `allowOverlayNetworkAddrs: boolean` 字段，由人工 cross-review
+保持同步（项目无 ts-rs / bindgen 自动生成）。
+
+#### 4.6.3 i18n 文案
+
+`src/i18n/locales/en-US.json` / `zh-CN.json` 在
+`settings.sections.network.allowOverlayAddrs` 下新增完整 key 树：
+
+```
+allowOverlayAddrs:
+  label
+  description
+  infoIconAriaLabel
+  saveError
+  disclosure:
+    title
+    intro
+    covered: { title, description }
+    whyOff:  { title, description }
+    whenOn:  { title, description }
+    tradeoff:{ title, description }
+```
+
+#### 4.6.4 toSettingsPatchRequest 的 spread 改造
+
+`src/api/daemon/settings.ts` 中 patch 构造改为 spread：
+
+```typescript
+if (settings.network) {
+  patch.network = { ...settings.network }
+}
+```
+
+理由：测试和 `SettingContext.updateNetworkSetting` 经常传
+`Partial<NetworkSettings>`，如果在 patch 里显式列字段会输出
+`undefined` 值，违背 wire patch "缺字段=不修改" 的语义。spread
+天然只镜像 input 中实际存在的字段。
+
+## 5. iroh AddrFilter 工作机制（基于源码）
+
+这是本次实现的关键技术点，查清后才敢宣称"过滤生效"。
+
+### 5.1 调用位置
+
+iroh `0.98.2` 的 `Endpoint::builder().addr_filter(filter)` 把
+`AddrFilter` 存到 endpoint 内部，bind 时传给
+`AddressLookupServices`：
+
+```/Users/mark/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/iroh-0.98.2/src/endpoint.rs#L277-278
+if let Some(filter) = self.addr_filter {
+    address_lookup.set_addr_filter(filter);
+}
+```
+
+### 5.2 publish 路径中的过滤
+
+`AddressLookupServices::publish()` 是过滤真正生效的地方：
+
+```/Users/mark/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/iroh-0.98.2/src/address_lookup.rs#L549-563
+pub(crate) fn publish(&self, data: &EndpointData) {
+    let data = match &*self.addr_filter.read().expect("poisoned") {
+        Some(filter) => data.apply_filter(filter),  // ← 过滤
+        None => Cow::Borrowed(data),
+    };
+    let services = self.services.read().expect("poisoned");
+    for service in &*services {
+        service.publish(&data);  // ← 过滤后的 data 才送给 pkarr / mDNS / DHT
+    }
+    ...
+}
+```
+
+**因此**：
+
+- 我们注册的 `AddrFilter` 在每次 publish endpoint addressing
+  数据给下游 lookup service 之前都会运行一次。
+- pkarr 公网 DHT、mDNS LAN 广播、可能的 DNS publisher 都拿到的是
+  **过滤后的子集**。
+- peer 通过任何 lookup 渠道查询本机时，得到的候选地址列表里
+  **不会包含**我们丢弃的虚拟网卡 IP。
+
+### 5.3 publish snapshot ≠ publish 给 peer 的内容
+
+代码里的 `log_publish_addrs()` 函数打 INFO 日志：
+
+```rust
+let addr = endpoint.addr();
+let ip_addrs: Vec<String> = addr.addrs.iter().filter_map(...).collect();
+info!(
+    stage,
+    ip_addrs = ?ip_addrs,
+    "iroh endpoint publish snapshot (refs UniClipboard#486)"
+);
+```
+
+`endpoint.addr()` 返回的是 **magicsock 内部知道的本机所有 socket 地址**
+（由 OS 接口枚举得出），是 `AddressLookupServices::publish()` **之前**
+的 raw 集合。它会包含所有虚拟网卡 IP，**这是预期的、不参与过滤**。
+
+排障时不要把这个 snapshot 当成"对端能看到的列表"。**真正决定对端
+看到什么的，是 `apply_addr_filter` 的 dropped 日志**（5.5 节）。
+
+### 5.4 lookup 路径中的过滤
+
+`AddrFilter` 同样作用于 lookup 返回结果：本机通过 pkarr/mDNS/DHT
+查询某个对端 NodeId 时，返回的候选地址列表也过这个 filter。即使
+对端发来的列表里包含 `100.x`（比如对端用的是旧版本没装这个
+filter），本机的 magicsock **也不会去拨**这些地址。
+
+这就是为什么"两边都升级"虽然是最干净的，但单边升级也仍然有
+保护效果——本机至少不会被坏候选拖累。
+
+### 5.5 dropped 日志解读
+
+每次 filter 把虚拟 IP 从输入候选集中剔除，都打一条 DEBUG 日志：
+
+```
+target=iroh.addr_filter
+message="filtered virtual-NIC addresses from candidate set"
+allow_overlay=<bool>
+dropped_count=<N>
+dropped=["100.79.191.42:60781", "198.18.0.1:60781"]
+```
+
+注意：`dropped` 显示的是**那次 filter 调用的输入候选集中被丢掉的
+IPs**。iroh 的 publish 是**事件驱动**的，magicsock 每发现新地址
+就触发一次 `AddressLookupServices::publish()`，每次的输入
+`EndpointData` 不一定包含全部本机地址。
+
+所以排障时看到 `dropped=["198.18.0.1:..."]` 只丢了 1 个不要慌——
+那次 publish 可能就只携带了 198.18，100.x 是另一次 publish 的
+事件。把同一个 endpoint port（如 `60781`）的所有 dropped 日志
+聚合起来看才是完整图景。
+
+## 6. 配置项使用
+
+### 6.1 用户视角（UI）
+
+进入 `Settings → 网络`：
+
+- **LAN-only Mode**（既有）— 默认 OFF。打开后禁用 iroh relay 回落，
+  仅同局域网直连。
+- **允许虚拟网络地址**（本次新增）— 默认 OFF。开启后允许 Tailscale 等
+  overlay 网络地址作为直连候选。
+
+每个开关右侧的 ⓘ 图标点开有详细说明。开关切换后会显示重启 banner，
+点"立即重启"或下次启动时生效。
+
+### 6.2 文件视角（settings.json）
+
+dev profile 路径（macOS）：
+
+```
+~/Library/Application Support/app.uniclipboard.desktop-dev/settings.json
+```
+
+production 路径：
+
+```
+~/Library/Application Support/uniclipboard/settings.json
+```
+
+字段在 `network` 段下：
+
+```json
+{
+  "network": {
+    "allow_relay_fallback": true,
+    "allow_overlay_network_addrs": false
+  }
+}
+```
+
+直接编辑文件后**必须重启 daemon** 才能生效。
+
+### 6.3 何时建议开启 `allow_overlay_network_addrs`
+
+仅在以下条件**同时**满足时考虑开启：
+
+1. 两台设备**都**安装了 Tailscale（或其他相同的 overlay 网络）
+   并加入同一个 tailnet
+2. 真实 LAN / 公网 NAT 穿透**不通**（连接持续走 relay 或失败）
+3. 在 Tailscale 客户端里能 `ping` / `ssh` 通对端，证明 overlay 路径
+   本身可用
+
+不满足任一条件，开启后只会让连接变慢（多消耗 path-validation
+预算去试不通的 100.x），不会带来任何收益。**默认保持关闭**就好。
+
+## 7. 日志与可观测性
+
+### 7.1 启动时
+
+每次 daemon 启动留两行 INFO：
+
+```
+target=settings.network
+message="applying network settings: allow_relay_fallback=... → disable_relays=..., allow_overlay_network_addrs=..."
+
+target=iroh.addr_filter
+message="addr filter configured: overlay-network addresses {ALLOWED|BLOCKED} (Tailscale 100.64/10 + fd7a:115c:a1e0::/48)"
+```
+
+第一行来自 `bootstrap`（settings 加载点），第二行来自 `uc-infra`
+（`bind` 时）。两行都包含 `device_id`，便于跨实例排障。
+
+### 7.2 运行时
+
+publish 事件触发的 filter 执行：
+
+```
+DEBUG target=iroh.addr_filter
+message="filtered virtual-NIC addresses from candidate set"
+allow_overlay=<bool>
+dropped_count=<N>
+dropped=[<list of "ip:port">]
+```
+
+只有当输入候选集**确实**包含被过滤段的 IP 时才打印（`apply_addr_filter`
+对干净候选走 `Cow::Borrowed` 快路径不打日志）。
+
+### 7.3 排障 grep 命令
+
+```bash
+LOG="$HOME/Library/Application Support/app.uniclipboard.desktop-dev/logs/uniclipboard.json.<DATE>"
+
+# 当前开关状态
+grep '"target":"settings.network"' "$LOG" | tail -3
+grep "addr filter configured" "$LOG" | tail -3
+
+# 过滤行为
+grep "filtered virtual-NIC" "$LOG" | jq -r '.dropped' | sort | uniq -c
+
+# magicsock 内部 raw 全集（参考用，不等于发给 peer 的内容）
+grep "iroh endpoint publish snapshot" "$LOG" | tail -3
+```
+
+## 8. 真机验证流程
+
+按"成本 / 价值"分三级，建议至少跑 Level 1。
+
+### 8.1 Level 1 — 基础回归（不需要 Tailscale）
+
+1. **启动 daemon**：`pnpm tauri:dev` 或 `tauri:dev:peerA`
+2. **看启动日志**：grep `target=settings.network` 与
+   `addr filter configured`，确认 `allow_overlay_network_addrs=false`
+   + `BLOCKED`。
+3. **UI 验证**：
+   - 进 Settings → 网络，看到两个开关
+   - ⓘ 图标点开有 disclosure popover
+   - 切换新开关 → RestartBanner 立即出现
+   - 关闭设置面板再打开 → banner 消失（in-memory pending 不跨 session）
+4. **持久化**：`cat .../settings.json | jq .network` 确认字段值。
+5. **重启后**：再 grep `addr filter configured`，确认状态从 `BLOCKED`
+   翻到 `ALLOWED`。
+6. **dropped 日志**（如果本机装了 Clash 或 Tailscale）：
+   `grep "filtered virtual-NIC" "$LOG"` 看是否有过滤事件。
+
+### 8.2 Level 2 — Tailscale 真过滤（需要 tailnet）
+
+1. **关闭开关 + 重启**，确认 BLOCKED 状态下：
+   - `dropped` 日志中包含本机的 `100.x:port`（Tailscale IPv4）
+   - 如果本机有 Tailscale IPv6 ULA，也应被丢弃
+2. **打开开关 + 重启**，确认 ALLOWED 状态下：
+   - `dropped` 日志中**不再**包含 `100.x`
+   - 仍然丢弃 `198.18.x`、`169.254.x`（始终过滤类）
+
+### 8.3 Level 3 — 跨设备连通性（需要两台设备）
+
+如果两端都装了 UniClipboard：
+
+1. 默认配置下复制粘贴正常 → 默认行为没坏
+2. 两端都打开新开关 → 复制粘贴仍然正常 → overlay 路径不会比 LAN/relay 差
+3. （可选）造一个对称 NAT + Tailscale 通的环境，验 OFF/ON 的连接成功率
+   差异
+
+## 9. Pitfall 防御与铁律
+
+### 9.1 反向命名铁律（Pitfall 1）
+
+- `allow_relay_fallback` 业务正向 ↔ infra `disable_relays` 反向 → 唯一
+  取反点位于 `uc-bootstrap/src/network_policy.rs`
+- `allow_overlay_network_addrs` 全链路正向同名传递 → 不参与铁律
+- 任何在 DTO / View / 前端 store 维护反向布尔镜像字段都视为回归
+- 既有审计测试在 `src/api/daemon/__tests__/settings.test.ts` 的
+  `反向命名审计 (Pitfall 1 fence)` describe 块里钉死
+
+### 9.2 BIND_LOCK 进程级单次（Pitfall 3）
+
+- `IrohNodeBuilder::bind` 在 production 路径下用
+  `OnceLock` 守护，第二次调用 panic
+- 含义：运行时热切换 `allow_overlay_network_addrs` 不可能，必须
+  重启 daemon
+- 这与 UI 的 RestartBanner 设计是同一根因
+
+### 9.3 IPv6 ULA 一致性
+
+- 历史欠账：原本只过滤 IPv4 100.64/10，IPv6 ULA `fd7a:115c:a1e0::/48`
+  漏过
+- 本次修补：开关同时控制两段；测试覆盖两段对称
+- 任何后续加新 overlay 段的 PR 必须 v4/v6 同时实现，不允许只实现一边
+
+### 9.4 occasional dropped_count=1 不是 bug
+
+见 5.5。不要看到一条只丢 1 个就以为过滤漏了——iroh publish 是事件
+驱动的增量更新。
+
+## 10. 已知边界与未来扩展
+
+### 10.1 不在本期范围
+
+- **运行时热切换**：必须重启 daemon。`BIND_LOCK` 是结构性约束，
+  解决需要独立 phase（"endpoint 重建" 工程量与风险都更大）
+- **UI 中"过滤动作可见性"**：当前只有日志，没有给用户面板上
+  显示"今天过滤了 N 个虚拟 IP"。如有 telemetry 信号显示用户需要，
+  可以加
+- **细粒度网段开关**：不拆 Clash / Tailscale / 其他独立开关。
+  YAGNI，单一布尔够用
+- **CIDR 用户自定义黑名单**：同上
+
+### 10.2 未来可能扩展
+
+- 加新的虚拟网卡段（如 ZeroTier、Hyper-V 默认段）：
+  - 始终过滤类直接加进 `is_virtual_nic_ip` 的 always-filter 块
+  - overlay 类（条件可达）加进 `if !allow_overlay { ... }` 块
+- 给 `apply_addr_filter` 加 metric counter（dropped 总数、按段分类
+  count），导到 OTLP，便于宏观观察用户群中的虚拟网卡分布
+- 双协议栈对称增强：如果未来 IPv6 链路 prefer 度更高，把 IPv4
+  link-local 的 IPv6 等价（fe80::/10 link-local）也加进 always-filter
+
+## 11. 参考资料
+
+- Issue：UniClipboard#486
+- iroh `AddrFilter` 文档：`iroh-0.98.2/src/address_lookup.rs` 顶部
+  module doc
+- iroh PR：iroh#3960、iroh#4010（`AddrFilter` 引入与 publish 路径过滤）
+- 相关 phase 工件：`.planning/phases/094-backend-network-allow-relay-fallback/`、
+  `.planning/phases/095-networksection-ux/`
+- 项目分层规范：`src-tauri/crates/uc-core/AGENTS.md`、
+  `src-tauri/crates/uc-application/AGENTS.md`、
+  `src-tauri/crates/uc-infra/AGENTS.md`

--- a/src-tauri/crates/uc-application/src/facade/settings/models.rs
+++ b/src-tauri/crates/uc-application/src/facade/settings/models.rs
@@ -136,6 +136,7 @@ pub struct FileSyncSettingsView {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NetworkSettingsView {
     pub allow_relay_fallback: bool,
+    pub allow_overlay_network_addrs: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -227,6 +228,7 @@ pub struct FileSyncSettingsPatch {
 #[derive(Debug, Clone, Default)]
 pub struct NetworkSettingsPatch {
     pub allow_relay_fallback: Option<bool>,
+    pub allow_overlay_network_addrs: Option<bool>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -457,6 +459,7 @@ impl From<core::Settings> for SettingsView {
             },
             network: NetworkSettingsView {
                 allow_relay_fallback: value.network.allow_relay_fallback,
+                allow_overlay_network_addrs: value.network.allow_overlay_network_addrs,
             },
         }
     }
@@ -585,6 +588,9 @@ pub(crate) fn apply_settings_patch(
         if let Some(v) = network.allow_relay_fallback {
             existing.network.allow_relay_fallback = v;
         }
+        if let Some(v) = network.allow_overlay_network_addrs {
+            existing.network.allow_overlay_network_addrs = v;
+        }
     }
 
     existing
@@ -620,6 +626,16 @@ mod network_settings_apply_patch_tests {
         let mut s = Settings::default();
         s.network = NetworkSettings {
             allow_relay_fallback: allow,
+            allow_overlay_network_addrs: false,
+        };
+        s
+    }
+
+    fn baseline_with_overlay(allow_overlay: bool) -> Settings {
+        let mut s = Settings::default();
+        s.network = NetworkSettings {
+            allow_relay_fallback: true,
+            allow_overlay_network_addrs: allow_overlay,
         };
         s
     }
@@ -642,9 +658,7 @@ mod network_settings_apply_patch_tests {
     fn apply_patch_with_empty_network_section_keeps_existing() {
         let existing = baseline_with_network(true);
         let patch = SettingsPatch {
-            network: Some(NetworkSettingsPatch {
-                allow_relay_fallback: None,
-            }),
+            network: Some(NetworkSettingsPatch::default()),
             ..Default::default()
         };
         let result = apply_settings_patch(existing, patch);
@@ -661,6 +675,7 @@ mod network_settings_apply_patch_tests {
         let patch = SettingsPatch {
             network: Some(NetworkSettingsPatch {
                 allow_relay_fallback: Some(false),
+                ..Default::default()
             }),
             ..Default::default()
         };
@@ -675,6 +690,7 @@ mod network_settings_apply_patch_tests {
         let patch = SettingsPatch {
             network: Some(NetworkSettingsPatch {
                 allow_relay_fallback: Some(true),
+                ..Default::default()
             }),
             ..Default::default()
         };
@@ -692,5 +708,59 @@ mod network_settings_apply_patch_tests {
             !view.network.allow_relay_fallback,
             "view 必须保留业务正向语义，不取反"
         );
+    }
+
+    /// allow_overlay_network_addrs：patch 缺字段时不抹掉已存在值。
+    #[test]
+    fn apply_patch_with_no_overlay_field_keeps_existing() {
+        let existing = baseline_with_overlay(true);
+        let patch = SettingsPatch {
+            network: Some(NetworkSettingsPatch::default()),
+            ..Default::default()
+        };
+        let result = apply_settings_patch(existing, patch);
+        assert!(
+            result.network.allow_overlay_network_addrs,
+            "inner None must keep existing true"
+        );
+    }
+
+    /// allow_overlay_network_addrs：显式 Some(true) 写入生效。
+    #[test]
+    fn apply_patch_with_overlay_explicit_true_writes_through() {
+        let existing = baseline_with_overlay(false);
+        let patch = SettingsPatch {
+            network: Some(NetworkSettingsPatch {
+                allow_overlay_network_addrs: Some(true),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let result = apply_settings_patch(existing, patch);
+        assert!(result.network.allow_overlay_network_addrs);
+    }
+
+    /// allow_overlay_network_addrs：显式 Some(false) 双向覆盖。
+    #[test]
+    fn apply_patch_with_overlay_explicit_false_writes_through() {
+        let existing = baseline_with_overlay(true);
+        let patch = SettingsPatch {
+            network: Some(NetworkSettingsPatch {
+                allow_overlay_network_addrs: Some(false),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let result = apply_settings_patch(existing, patch);
+        assert!(!result.network.allow_overlay_network_addrs);
+    }
+
+    /// View 透明搬运 allow_overlay_network_addrs。
+    #[test]
+    fn from_core_settings_passes_through_overlay_field() {
+        let mut s = Settings::default();
+        s.network.allow_overlay_network_addrs = true;
+        let view: SettingsView = s.into();
+        assert!(view.network.allow_overlay_network_addrs);
     }
 }

--- a/src-tauri/crates/uc-bootstrap/src/builders.rs
+++ b/src-tauri/crates/uc-bootstrap/src/builders.rs
@@ -191,6 +191,7 @@ pub async fn build_daemon_app() -> anyhow::Result<DaemonBootstrapContext> {
         .await
         .map_err(|err| anyhow::anyhow!("settings load failed at startup: {err}"))?;
     let allow_relay_fallback = settings.network.allow_relay_fallback;
+    let allow_overlay_network_addrs = settings.network.allow_overlay_network_addrs;
 
     // 【checker BLOCKER 4 — 单一取反点铁律】
     // `disable_relays` 的值**只能**通过 `relay_policy_to_iroh_config` 取得，
@@ -199,6 +200,7 @@ pub async fn build_daemon_app() -> anyhow::Result<DaemonBootstrapContext> {
     // `iroh_config.disable_relays` 读取。
     let iroh_config = crate::network_policy::relay_policy_to_iroh_config(
         allow_relay_fallback,
+        allow_overlay_network_addrs,
         None, // production 不 override rendezvous，使用默认 RENDEZVOUS_BASE_URL
     );
 
@@ -210,9 +212,11 @@ pub async fn build_daemon_app() -> anyhow::Result<DaemonBootstrapContext> {
         target: "settings.network",
         allow_relay_fallback,
         disable_relays = iroh_config.disable_relays,
-        "applying network.allow_relay_fallback={} → disable_relays={}",
+        allow_overlay_network_addrs = iroh_config.allow_overlay_network_addrs,
+        "applying network settings: allow_relay_fallback={} → disable_relays={}, allow_overlay_network_addrs={}",
         allow_relay_fallback,
         iroh_config.disable_relays,
+        iroh_config.allow_overlay_network_addrs,
     );
 
     let space_setup_assembly = build_space_setup_assembly(&wired, iroh_config)

--- a/src-tauri/crates/uc-bootstrap/src/network_policy.rs
+++ b/src-tauri/crates/uc-bootstrap/src/network_policy.rs
@@ -22,7 +22,7 @@
 
 use crate::space_setup::IrohNodeConfig;
 
-/// 把业务侧 `network.allow_relay_fallback` 翻译为 infra 侧 `IrohNodeConfig`。
+/// 把业务侧 `Settings.network` 翻译为 infra 侧 `IrohNodeConfig`。
 ///
 /// 语义反转点（**唯一**）：
 /// - `allow_relay_fallback = true`  → `disable_relays = false`（允许 fallback，
@@ -30,17 +30,24 @@ use crate::space_setup::IrohNodeConfig;
 /// - `allow_relay_fallback = false` → `disable_relays = true`（LAN-only，跨
 ///   网段设备会失联）
 ///
+/// `allow_overlay_network_addrs` 为正向同名字段，直接传递不取反。
+///
 /// 参数：
 /// - `allow_relay_fallback`：业务正向语义，由 `uc-core::Settings.network` 透传
+/// - `allow_overlay_network_addrs`：业务正向语义，由 `uc-core::Settings.network`
+///   透传；专业用户开关，控制是否把 VPN/overlay 类虚拟网卡 IP 作为 iroh 直连候选
 /// - `rendezvous_base_url`：`None` 走 `RENDEZVOUS_BASE_URL` 默认；production 调
 ///   用方传 `None`；集成测试覆盖 override
 pub(crate) fn relay_policy_to_iroh_config(
     allow_relay_fallback: bool,
+    allow_overlay_network_addrs: bool,
     rendezvous_base_url: Option<String>,
 ) -> IrohNodeConfig {
     IrohNodeConfig {
         // ↓ 全工程**唯一**取反点 — Pitfall 1 防御铁律。
         disable_relays: !allow_relay_fallback,
+        // ↓ 正向同名字段，直接搬运不取反。
+        allow_overlay_network_addrs,
         rendezvous_base_url,
     }
 }
@@ -54,7 +61,7 @@ mod tests {
     /// 单方向断言无法捕捉"代码错把恒等当取反"或"反向写漏"两类 bug。
     #[test]
     fn allow_true_means_disable_false() {
-        let cfg = relay_policy_to_iroh_config(true, None);
+        let cfg = relay_policy_to_iroh_config(true, false, None);
         assert!(!cfg.disable_relays, "allow=true MUST produce disable=false");
         assert!(cfg.rendezvous_base_url.is_none());
     }
@@ -62,7 +69,7 @@ mod tests {
     /// Pitfall 1 防御 truth-table（反向）：allow=false 必须导致 disable=true。
     #[test]
     fn allow_false_means_disable_true() {
-        let cfg = relay_policy_to_iroh_config(false, None);
+        let cfg = relay_policy_to_iroh_config(false, false, None);
         assert!(cfg.disable_relays, "allow=false MUST produce disable=true");
         assert!(cfg.rendezvous_base_url.is_none());
     }
@@ -70,7 +77,30 @@ mod tests {
     /// rendezvous override 透明传递（产线 None；集成测试 Some(url)）。
     #[test]
     fn rendezvous_override_passes_through() {
-        let cfg = relay_policy_to_iroh_config(true, Some("http://test".into()));
+        let cfg = relay_policy_to_iroh_config(true, false, Some("http://test".into()));
         assert_eq!(cfg.rendezvous_base_url, Some("http://test".into()));
+    }
+
+    /// allow_overlay_network_addrs 正向同名搬运（不取反）。
+    #[test]
+    fn overlay_addrs_true_passes_through() {
+        let cfg = relay_policy_to_iroh_config(true, true, None);
+        assert!(cfg.allow_overlay_network_addrs);
+    }
+
+    /// allow_overlay_network_addrs=false 默认搬运。
+    #[test]
+    fn overlay_addrs_false_passes_through() {
+        let cfg = relay_policy_to_iroh_config(true, false, None);
+        assert!(!cfg.allow_overlay_network_addrs);
+    }
+
+    /// 两个开关相互独立（正交）：disable_relays 由 allow_relay_fallback 决定，
+    /// 与 allow_overlay_network_addrs 无关。
+    #[test]
+    fn switches_are_independent() {
+        let cfg = relay_policy_to_iroh_config(false, true, None);
+        assert!(cfg.disable_relays, "LAN-only on, overlay on");
+        assert!(cfg.allow_overlay_network_addrs);
     }
 }

--- a/src-tauri/crates/uc-bootstrap/src/non_gui_runtime.rs
+++ b/src-tauri/crates/uc-bootstrap/src/non_gui_runtime.rs
@@ -287,19 +287,25 @@ pub async fn build_cli_app_runtime(
         .await
         .map_err(|err| anyhow::anyhow!("settings load failed at startup: {err}"))?;
     let allow_relay_fallback = settings.network.allow_relay_fallback;
+    let allow_overlay_network_addrs = settings.network.allow_overlay_network_addrs;
 
     // 【checker BLOCKER 4 — 单一取反点铁律】见 builders.rs 同处注释。
     // 不在此处内联 `let disable_relays = !allow_relay_fallback;`。
-    let iroh_config =
-        crate::network_policy::relay_policy_to_iroh_config(allow_relay_fallback, None);
+    let iroh_config = crate::network_policy::relay_policy_to_iroh_config(
+        allow_relay_fallback,
+        allow_overlay_network_addrs,
+        None,
+    );
 
     tracing::info!(
         target: "settings.network",
         allow_relay_fallback,
         disable_relays = iroh_config.disable_relays,
-        "applying network.allow_relay_fallback={} → disable_relays={}",
+        allow_overlay_network_addrs = iroh_config.allow_overlay_network_addrs,
+        "applying network settings: allow_relay_fallback={} → disable_relays={}, allow_overlay_network_addrs={}",
         allow_relay_fallback,
         iroh_config.disable_relays,
+        iroh_config.allow_overlay_network_addrs,
     );
 
     let assembly = build_space_setup_assembly(&wired, iroh_config)

--- a/src-tauri/crates/uc-bootstrap/tests/slice1_handshake_e2e.rs
+++ b/src-tauri/crates/uc-bootstrap/tests/slice1_handshake_e2e.rs
@@ -344,6 +344,7 @@ async fn build_side(name: &'static str, rendezvous_base_url: String) -> Side {
         IrohNodeConfig {
             rendezvous_base_url: Some(rendezvous_base_url),
             disable_relays: true,
+            allow_overlay_network_addrs: false,
         },
     )
     .await

--- a/src-tauri/crates/uc-bootstrap/tests/slice2_phase1_presence_e2e.rs
+++ b/src-tauri/crates/uc-bootstrap/tests/slice2_phase1_presence_e2e.rs
@@ -354,6 +354,7 @@ async fn build_side(name: &'static str, rendezvous_base_url: String) -> Side {
         IrohNodeConfig {
             rendezvous_base_url: Some(rendezvous_base_url),
             disable_relays: true,
+            allow_overlay_network_addrs: false,
         },
     )
     .await

--- a/src-tauri/crates/uc-bootstrap/tests/slice2_phase2_clipboard_e2e.rs
+++ b/src-tauri/crates/uc-bootstrap/tests/slice2_phase2_clipboard_e2e.rs
@@ -373,6 +373,7 @@ async fn build_side(name: &'static str, rendezvous_base_url: String) -> Side {
         IrohNodeConfig {
             rendezvous_base_url: Some(rendezvous_base_url),
             disable_relays: true,
+            allow_overlay_network_addrs: false,
         },
     )
     .await

--- a/src-tauri/crates/uc-core/src/settings/defaults.rs
+++ b/src-tauri/crates/uc-core/src/settings/defaults.rs
@@ -230,6 +230,7 @@ impl Default for NetworkSettings {
     ///
     /// Defaults:
     /// - `allow_relay_fallback`: true
+    /// - `allow_overlay_network_addrs`: false
     ///
     // 默认 true = 允许 fallback。
     // 改成 false 会让所有跨网段老用户突然离线，属于 breaking change。
@@ -237,6 +238,7 @@ impl Default for NetworkSettings {
     fn default() -> Self {
         Self {
             allow_relay_fallback: true,
+            allow_overlay_network_addrs: false,
         }
     }
 }
@@ -336,5 +338,42 @@ mod tests {
         let json = r#"{ "network": { "allow_relay_fallback": true } }"#;
         let s: Settings = serde_json::from_str(json).expect("parse explicit true");
         assert!(s.network.allow_relay_fallback);
+    }
+
+    /// 默认值：默认过滤 overlay 网络地址，保持 v0.6.x 起的现行行为。
+    #[test]
+    fn network_settings_default_filters_overlay_addrs() {
+        let n = NetworkSettings::default();
+        assert!(
+            !n.allow_overlay_network_addrs,
+            "NetworkSettings::default().allow_overlay_network_addrs MUST be false"
+        );
+    }
+
+    /// 老 settings.json 缺 `allow_overlay_network_addrs` 字段时回填默认 false。
+    #[test]
+    fn old_settings_json_without_overlay_field_falls_back_to_default() {
+        let json = r#"{ "network": { "allow_relay_fallback": true } }"#;
+        let s: Settings = serde_json::from_str(json).expect("parse old network section");
+        assert!(
+            !s.network.allow_overlay_network_addrs,
+            "missing allow_overlay_network_addrs MUST default to false"
+        );
+    }
+
+    /// 显式 true 必须保留（专业用户主动开启）。
+    #[test]
+    fn explicit_allow_overlay_network_addrs_true_is_preserved() {
+        let json = r#"{ "network": { "allow_relay_fallback": true, "allow_overlay_network_addrs": true } }"#;
+        let s: Settings = serde_json::from_str(json).expect("parse explicit overlay true");
+        assert!(s.network.allow_overlay_network_addrs);
+    }
+
+    /// 显式 false 必须保留（双向覆盖）。
+    #[test]
+    fn explicit_allow_overlay_network_addrs_false_is_preserved() {
+        let json = r#"{ "network": { "allow_relay_fallback": true, "allow_overlay_network_addrs": false } }"#;
+        let s: Settings = serde_json::from_str(json).expect("parse explicit overlay false");
+        assert!(!s.network.allow_overlay_network_addrs);
     }
 }

--- a/src-tauri/crates/uc-core/src/settings/model.rs
+++ b/src-tauri/crates/uc-core/src/settings/model.rs
@@ -195,6 +195,20 @@ pub struct NetworkSettings {
     /// 业务正向语义：UI "LAN-only Mode = ON" → 此字段 = `false`。
     #[serde(default = "default_allow_relay_fallback")]
     pub allow_relay_fallback: bool,
+
+    /// 是否允许把 VPN / overlay 类虚拟网卡地址（CGNAT 100.64.0.0/10、
+    /// Tailscale ULA fd7a:115c:a1e0::/48）作为 iroh 直连候选。
+    ///
+    /// 默认 `false`：默认过滤，避免对端不在同一 tailnet 时把死候选发给 peer，
+    /// 拖慢 path-validation、占用 PathId 预算。两端确实都接入同一 VPN
+    /// （如 Tailscale）希望让 iroh 借用该 overlay 网络互联时改为 `true`。
+    ///
+    /// 注意：`198.18.0.0/15`（Clash fake-ip）、`169.254.0.0/16`（IPv4 link-local）
+    /// 与本字段无关，永远过滤。
+    ///
+    /// 修改后需重启 daemon 生效（iroh endpoint bind-time 常量）。
+    #[serde(default = "default_allow_overlay_network_addrs")]
+    pub allow_overlay_network_addrs: bool,
 }
 
 // 默认 true = 允许 fallback。
@@ -202,6 +216,13 @@ pub struct NetworkSettings {
 // 修改默认值前请先 grep `LAN-only Mode` 文档与 changelog。
 fn default_allow_relay_fallback() -> bool {
     true
+}
+
+// 默认 false = 过滤虚拟网卡候选（保持 v0.6.x 起的现行行为）。
+// 改成 true 会让 100.64/10 + fd7a:115c:a1e0::/48 重新出现在
+// peer 候选列表里，可能引入对端不可达的死候选拖慢 path-race。
+fn default_allow_overlay_network_addrs() -> bool {
+    false
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src-tauri/crates/uc-daemon-contract/src/api/dto/settings.rs
+++ b/src-tauri/crates/uc-daemon-contract/src/api/dto/settings.rs
@@ -203,10 +203,16 @@ pub struct FileSyncSettingsDto {
 /// 反向命名规则（Pitfall 1）：业务正向语义 `allow_relay_fallback`，
 /// 不在此层重命名为 `lan_only` 或类似镜像。wire 字段 = `allowRelayFallback`
 /// （camelCase 自动转换）。取反唯一发生在 `uc-bootstrap/src/network_policy.rs`。
+///
+/// `allow_overlay_network_addrs` 控制是否把 VPN/overlay 类虚拟网卡 IP（CGNAT
+/// 100.64.0.0/10、Tailscale ULA fd7a:115c:a1e0::/48）作为 iroh 直连候选发布
+/// 给对端。默认 `false`（过滤）。专业用户在两端都接入同一 VPN 时可开启。
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct NetworkSettingsDto {
     pub allow_relay_fallback: bool,
+    #[serde(default)]
+    pub allow_overlay_network_addrs: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
@@ -317,6 +323,7 @@ pub struct FileSyncSettingsPatchDto {
 #[serde(rename_all = "camelCase")]
 pub struct NetworkSettingsPatchDto {
     pub allow_relay_fallback: Option<bool>,
+    pub allow_overlay_network_addrs: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -496,6 +503,7 @@ impl From<core::NetworkSettings> for NetworkSettingsDto {
     fn from(value: core::NetworkSettings) -> Self {
         Self {
             allow_relay_fallback: value.allow_relay_fallback,
+            allow_overlay_network_addrs: value.allow_overlay_network_addrs,
         }
     }
 }
@@ -593,28 +601,44 @@ mod network_dto_tests {
     fn dto_serializes_camel_case_wire() {
         let dto = NetworkSettingsDto {
             allow_relay_fallback: true,
+            allow_overlay_network_addrs: false,
         };
         let json = serde_json::to_string(&dto).expect("serialize");
-        assert_eq!(json, r#"{"allowRelayFallback":true}"#);
+        assert_eq!(
+            json,
+            r#"{"allowRelayFallback":true,"allowOverlayNetworkAddrs":false}"#
+        );
     }
 
     #[test]
     fn dto_deserializes_camel_case_wire() {
-        let json = r#"{"allowRelayFallback":false}"#;
+        let json = r#"{"allowRelayFallback":false,"allowOverlayNetworkAddrs":true}"#;
         let dto: NetworkSettingsDto = serde_json::from_str(json).expect("deserialize");
         assert!(!dto.allow_relay_fallback);
+        assert!(dto.allow_overlay_network_addrs);
+    }
+
+    /// 旧 wire（无 allowOverlayNetworkAddrs 字段）仍可反序列化，回填 false。
+    #[test]
+    fn dto_deserializes_legacy_wire_without_overlay_field() {
+        let json = r#"{"allowRelayFallback":true}"#;
+        let dto: NetworkSettingsDto = serde_json::from_str(json).expect("deserialize legacy");
+        assert!(dto.allow_relay_fallback);
+        assert!(!dto.allow_overlay_network_addrs);
     }
 
     #[test]
     fn from_core_passes_through_business_semantics() {
         let core_value = core::NetworkSettings {
             allow_relay_fallback: false,
+            allow_overlay_network_addrs: true,
         };
         let dto: NetworkSettingsDto = core_value.into();
         assert!(
             !dto.allow_relay_fallback,
             "DTO MUST NOT invert semantics (Pitfall 1)"
         );
+        assert!(dto.allow_overlay_network_addrs);
     }
 
     #[test]

--- a/src-tauri/crates/uc-infra/src/network/iroh/node.rs
+++ b/src-tauri/crates/uc-infra/src/network/iroh/node.rs
@@ -161,6 +161,16 @@ pub struct IrohNodeConfig {
     /// iroh can fall back to the public relay mesh when NAT blocks direct
     /// UDP.
     pub disable_relays: bool,
+    /// If true, allow VPN / overlay-network virtual NIC addresses (CGNAT
+    /// `100.64.0.0/10`, Tailscale ULA `fd7a:115c:a1e0::/48`) to flow through
+    /// the address filter as direct-connection candidates. Default `false`
+    /// (drop them). Power users set this when both peers share an overlay
+    /// network and want iroh to leverage that path.
+    ///
+    /// Clash fake-ip (`198.18.0.0/15`) and IPv4 link-local (`169.254.0.0/16`)
+    /// are unconditionally filtered regardless of this flag — they have no
+    /// legitimate cross-host use case.
+    pub allow_overlay_network_addrs: bool,
 }
 
 /// Snapshot the candidate set this endpoint is currently advertising and
@@ -286,32 +296,96 @@ fn build_transport_config() -> QuicTransportConfig {
 }
 
 /// IP-range predicate that flags well-known *virtual* NIC addresses we don't
-/// want propagated as direct-address candidates. Treats the address as
-/// virtual when it falls into a range that no real LAN would ever use:
+/// want propagated as direct-address candidates.
 ///
+/// Two filter classes:
+///
+/// **Always filtered (no escape hatch — `allow_overlay = true` does NOT keep these):**
 /// * `198.18.0.0/15` — the default Clash fake-ip pool. Observed concretely
 ///   on this user's macOS box where Clash assigns `198.18.0.1` to its TUN
 ///   interface; iroh's magicsock then publishes that to the peer, the peer
 ///   races it against the real LAN candidate, and the TUN path occasionally
-///   wins because its local stack ACKs faster than the real LAN.
-/// * `100.64.0.0/10` — CGNAT / Tailscale default range. Same shape of bug:
-///   Tailscale advertises a 100.x address that's only routable inside the
-///   tailnet, but iroh can't tell that from a normal LAN IP.
+///   wins because its local stack ACKs faster than the real LAN. No legitimate
+///   cross-host use case.
 /// * `169.254.0.0/16` — IPv4 link-local autoconf. Only meaningful on the
 ///   originating host; useless as a candidate for a remote peer.
-fn is_virtual_nic_ip(ip: IpAddr) -> bool {
+///
+/// **Overlay-network class (filtered only when `allow_overlay = false`):**
+/// * `100.64.0.0/10` — CGNAT / Tailscale default IPv4 range. Tailscale
+///   advertises a 100.x address that's only routable inside the same tailnet;
+///   when peers are not in the same tailnet, this is a dead candidate that
+///   wastes path-validation budget. Power users running both peers inside one
+///   tailnet may opt in via `Settings.network.allow_overlay_network_addrs`.
+/// * `fd7a:115c:a1e0::/48` — Tailscale IPv6 ULA. Same shape of bug as the
+///   IPv4 100.x case; same opt-in semantics.
+fn is_virtual_nic_ip(ip: IpAddr, allow_overlay: bool) -> bool {
     match ip {
         IpAddr::V4(v4) => {
             let o = v4.octets();
-            (o[0] == 198 && (o[1] & 0xfe) == 18) // 198.18.0.0/15 (Clash fake-ip)
-                || (o[0] == 100 && (o[1] & 0xc0) == 64) // 100.64.0.0/10 (CGNAT/Tailscale)
-                || (o[0] == 169 && o[1] == 254) // 169.254.0.0/16 (link-local)
+            // Always-filtered classes:
+            if (o[0] == 198 && (o[1] & 0xfe) == 18) // 198.18.0.0/15 (Clash fake-ip)
+                || (o[0] == 169 && o[1] == 254)
+            // 169.254.0.0/16 (IPv4 link-local)
+            {
+                return true;
+            }
+            // Overlay class (CGNAT / Tailscale 100.64.0.0/10):
+            if !allow_overlay && o[0] == 100 && (o[1] & 0xc0) == 64 {
+                return true;
+            }
+            false
         }
-        // v1 only filters IPv4. IPv6 ULA / link-local can be added once we
-        // have telemetry showing iroh actually publishing them on real
-        // user setups.
-        IpAddr::V6(_) => false,
+        IpAddr::V6(v6) => {
+            // Tailscale IPv6 ULA `fd7a:115c:a1e0::/48` — overlay class.
+            // Match on the first three 16-bit segments (high 48 bits).
+            let segs = v6.segments();
+            if !allow_overlay && segs[0] == 0xfd7a && segs[1] == 0x115c && segs[2] == 0xa1e0 {
+                return true;
+            }
+            false
+        }
     }
+}
+
+/// Pure filter logic — given a candidate set, return what to publish.
+///
+/// Extracted from [`build_addr_filter`] so it is unit-testable without
+/// reaching into the iroh `AddrFilter` wrapper (the wrapper is opaque from
+/// outside the crate and offers no introspection).
+fn apply_addr_filter<'a>(
+    addrs: &'a Vec<TransportAddr>,
+    allow_overlay: bool,
+) -> Cow<'a, Vec<TransportAddr>> {
+    let any_virtual = addrs.iter().any(|a| match a {
+        TransportAddr::Ip(s) => is_virtual_nic_ip(s.ip(), allow_overlay),
+        _ => false,
+    });
+    if !any_virtual {
+        return Cow::Borrowed(addrs);
+    }
+    let kept: Vec<TransportAddr> = addrs
+        .iter()
+        .filter(|a| match a {
+            TransportAddr::Ip(s) => !is_virtual_nic_ip(s.ip(), allow_overlay),
+            _ => true,
+        })
+        .cloned()
+        .collect();
+    let dropped: Vec<String> = addrs
+        .iter()
+        .filter_map(|a| match a {
+            TransportAddr::Ip(s) if is_virtual_nic_ip(s.ip(), allow_overlay) => Some(s.to_string()),
+            _ => None,
+        })
+        .collect();
+    debug!(
+        target: "iroh.addr_filter",
+        allow_overlay,
+        dropped_count = dropped.len(),
+        dropped = ?dropped,
+        "filtered virtual-NIC addresses from candidate set",
+    );
+    Cow::Owned(kept)
 }
 
 /// Build the `AddrFilter` we hand to `Endpoint::builder().addr_filter(...)`.
@@ -320,25 +394,14 @@ fn is_virtual_nic_ip(ip: IpAddr) -> bool {
 /// single registration covers pkarr / mdns / static / DHT lookups in one
 /// place — that's what makes this a viable replacement for "fork iroh and
 /// patch magicsock" (issue #486 §三 A).
-fn build_addr_filter() -> AddrFilter {
-    AddrFilter::new(|addrs: &Vec<TransportAddr>| {
-        let any_virtual = addrs.iter().any(|a| match a {
-            TransportAddr::Ip(s) => is_virtual_nic_ip(s.ip()),
-            _ => false,
-        });
-        if !any_virtual {
-            return Cow::Borrowed(addrs);
-        }
-        let kept: Vec<TransportAddr> = addrs
-            .iter()
-            .filter(|a| match a {
-                TransportAddr::Ip(s) => !is_virtual_nic_ip(s.ip()),
-                _ => true,
-            })
-            .cloned()
-            .collect();
-        Cow::Owned(kept)
-    })
+///
+/// `allow_overlay` is captured by the closure so the predicate behaviour is
+/// fixed at endpoint bind time — the iroh `Endpoint` does not support
+/// runtime mutation of address filters; toggling
+/// `Settings.network.allow_overlay_network_addrs` requires a daemon restart
+/// (the same constraint as `disable_relays`).
+fn build_addr_filter(allow_overlay: bool) -> AddrFilter {
+    AddrFilter::new(move |addrs: &Vec<TransportAddr>| apply_addr_filter(addrs, allow_overlay))
 }
 
 /// Pitfall 3 结构性防御：进程级单次 bind 守护（**production-only**）。
@@ -416,6 +479,14 @@ impl IrohNodeBuilder {
         } else {
             RelayMode::Default
         };
+        // Snapshot the overlay flag before consuming `config` into `Self`.
+        let allow_overlay = config.allow_overlay_network_addrs;
+        info!(
+            target: "iroh.addr_filter",
+            allow_overlay,
+            "addr filter configured: overlay-network addresses {} (Tailscale 100.64/10 + fd7a:115c:a1e0::/48)",
+            if allow_overlay { "ALLOWED" } else { "BLOCKED" },
+        );
         let endpoint = Endpoint::builder(presets::N0)
             .secret_key(secret)
             // Only PAIRING is declared at bind time; additional ALPNs are
@@ -425,10 +496,10 @@ impl IrohNodeBuilder {
             .alpns(vec![PAIRING_ALPN.to_vec()])
             .relay_mode(relay_mode)
             .transport_config(build_transport_config())
-            // UniClipboard#486: drop Clash TUN / CGNAT / link-local IPs from
-            // every address-lookup service in one shot. See
-            // `build_addr_filter` for the predicate.
-            .addr_filter(build_addr_filter())
+            // UniClipboard#486: drop Clash TUN / link-local IPs from every
+            // address-lookup service in one shot, and drop CGNAT/Tailscale
+            // overlay IPs unless the user opts in. See `build_addr_filter`.
+            .addr_filter(build_addr_filter(allow_overlay))
             // UniClipboard#486 §三 B: enable mDNS LAN discovery in addition
             // to the n0 preset's pkarr DHT lookup. Two peers on the same
             // Wi-Fi advertise their LAN IPs to each other through swarm-
@@ -445,6 +516,7 @@ impl IrohNodeBuilder {
         debug!(
             endpoint_id = %endpoint.id().fmt_short(),
             disable_relays = config.disable_relays,
+            allow_overlay_network_addrs = config.allow_overlay_network_addrs,
             rendezvous_override = config.rendezvous_base_url.is_some(),
             "iroh node bound; ready to install transport handlers"
         );
@@ -1051,5 +1123,190 @@ mod tests {
 
         let node = builder.spawn();
         node.shutdown().await;
+    }
+
+    // ──────────────────────────────────────────────────────────────────
+    // is_virtual_nic_ip / build_addr_filter unit tests
+    // ──────────────────────────────────────────────────────────────────
+
+    use std::net::{Ipv4Addr, Ipv6Addr};
+    use std::net::{SocketAddr, SocketAddrV4, SocketAddrV6};
+
+    fn v4(ip: &str) -> IpAddr {
+        IpAddr::V4(ip.parse::<Ipv4Addr>().unwrap())
+    }
+    fn v6(ip: &str) -> IpAddr {
+        IpAddr::V6(ip.parse::<Ipv6Addr>().unwrap())
+    }
+
+    /// Always-filtered classes are filtered regardless of the overlay flag.
+    #[test]
+    fn always_filtered_classes_ignore_overlay_flag() {
+        for &allow in &[false, true] {
+            // 198.18.0.0/15 — Clash fake-ip
+            assert!(
+                is_virtual_nic_ip(v4("198.18.0.1"), allow),
+                "198.18.0.1 must be filtered (allow_overlay={allow})"
+            );
+            assert!(
+                is_virtual_nic_ip(v4("198.19.255.255"), allow),
+                "198.19.255.255 must be filtered (allow_overlay={allow})"
+            );
+            // 169.254.0.0/16 — IPv4 link-local
+            assert!(
+                is_virtual_nic_ip(v4("169.254.1.1"), allow),
+                "169.254.1.1 must be filtered (allow_overlay={allow})"
+            );
+        }
+    }
+
+    /// CGNAT/Tailscale 100.64/10 is filtered when overlay is denied,
+    /// allowed when overlay is permitted.
+    #[test]
+    fn cgnat_v4_respects_overlay_flag() {
+        // allow_overlay = false → filtered
+        assert!(is_virtual_nic_ip(v4("100.64.0.1"), false));
+        assert!(is_virtual_nic_ip(v4("100.100.100.100"), false));
+        assert!(is_virtual_nic_ip(v4("100.127.255.255"), false));
+
+        // allow_overlay = true → allowed (predicate returns false)
+        assert!(!is_virtual_nic_ip(v4("100.64.0.1"), true));
+        assert!(!is_virtual_nic_ip(v4("100.100.100.100"), true));
+        assert!(!is_virtual_nic_ip(v4("100.127.255.255"), true));
+    }
+
+    /// Tailscale IPv6 ULA fd7a:115c:a1e0::/48 mirrors the CGNAT v4 case.
+    #[test]
+    fn tailscale_ula_v6_respects_overlay_flag() {
+        // First three 16-bit segments must match: fd7a:115c:a1e0
+        assert!(is_virtual_nic_ip(v6("fd7a:115c:a1e0::1"), false));
+        assert!(is_virtual_nic_ip(v6("fd7a:115c:a1e0:ab12:cd34::"), false));
+        assert!(!is_virtual_nic_ip(v6("fd7a:115c:a1e0::1"), true));
+        assert!(!is_virtual_nic_ip(v6("fd7a:115c:a1e0:ab12:cd34::"), true));
+    }
+
+    /// Real-world LAN/WAN IPs are never filtered, regardless of flag.
+    #[test]
+    fn real_world_addresses_pass_through() {
+        for &allow in &[false, true] {
+            for ip in [
+                v4("10.0.0.1"),
+                v4("192.168.1.42"),
+                v4("172.16.0.5"),
+                v4("8.8.8.8"),
+                v4("100.63.255.255"), // just below 100.64/10
+                v4("100.128.0.0"),    // just above 100.64/10
+                v4("198.17.255.255"), // just below 198.18/15
+                v4("198.20.0.0"),     // just above 198.18/15
+                v4("169.253.255.255"),
+                v4("169.255.0.0"),
+                v6("2001:db8::1"),
+                v6("fe80::1"),
+                v6("fd7a:115c:a1e1::1"), // off-by-one outside Tailscale ULA
+                v6("fc00::1"),           // generic ULA, not Tailscale
+            ] {
+                assert!(
+                    !is_virtual_nic_ip(ip, allow),
+                    "{ip} must NOT be filtered (allow_overlay={allow})"
+                );
+            }
+        }
+    }
+
+    /// apply_addr_filter: no virtual addresses present → returns Borrowed
+    /// (untouched).
+    #[test]
+    fn addr_filter_passes_through_clean_set() {
+        let addrs = vec![
+            TransportAddr::Ip(SocketAddr::V4(SocketAddrV4::new(
+                "192.168.1.1".parse().unwrap(),
+                4242,
+            ))),
+            TransportAddr::Ip(SocketAddr::V4(SocketAddrV4::new(
+                "10.0.0.5".parse().unwrap(),
+                4242,
+            ))),
+        ];
+        let kept = apply_addr_filter(&addrs, false);
+        assert_eq!(
+            kept.len(),
+            addrs.len(),
+            "clean set must be passed through unchanged"
+        );
+    }
+
+    /// apply_addr_filter: drops virtual NIC addrs when allow_overlay=false.
+    #[test]
+    fn addr_filter_drops_overlay_when_disallowed() {
+        let addrs = vec![
+            TransportAddr::Ip(SocketAddr::V4(SocketAddrV4::new(
+                "192.168.1.1".parse().unwrap(),
+                4242,
+            ))),
+            TransportAddr::Ip(SocketAddr::V4(SocketAddrV4::new(
+                "100.64.0.7".parse().unwrap(),
+                4242,
+            ))), // Tailscale 100.x — must be dropped
+            TransportAddr::Ip(SocketAddr::V6(SocketAddrV6::new(
+                "fd7a:115c:a1e0::1".parse().unwrap(),
+                4242,
+                0,
+                0,
+            ))), // Tailscale ULA — must be dropped
+            TransportAddr::Ip(SocketAddr::V4(SocketAddrV4::new(
+                "198.18.0.1".parse().unwrap(),
+                4242,
+            ))), // Clash — always dropped
+        ];
+        let kept: Vec<TransportAddr> = apply_addr_filter(&addrs, false).into_owned();
+        assert_eq!(kept.len(), 1, "only the real LAN IP should survive");
+        match &kept[0] {
+            TransportAddr::Ip(s) => assert_eq!(s.ip().to_string(), "192.168.1.1"),
+            _ => panic!("expected Ip variant"),
+        }
+    }
+
+    /// apply_addr_filter: keeps overlay addrs when allow_overlay=true,
+    /// but still drops always-filtered classes.
+    #[test]
+    fn addr_filter_keeps_overlay_when_allowed_but_still_drops_clash() {
+        let addrs = vec![
+            TransportAddr::Ip(SocketAddr::V4(SocketAddrV4::new(
+                "192.168.1.1".parse().unwrap(),
+                4242,
+            ))),
+            TransportAddr::Ip(SocketAddr::V4(SocketAddrV4::new(
+                "100.64.0.7".parse().unwrap(),
+                4242,
+            ))), // overlay — kept now
+            TransportAddr::Ip(SocketAddr::V6(SocketAddrV6::new(
+                "fd7a:115c:a1e0::1".parse().unwrap(),
+                4242,
+                0,
+                0,
+            ))), // overlay — kept now
+            TransportAddr::Ip(SocketAddr::V4(SocketAddrV4::new(
+                "198.18.0.1".parse().unwrap(),
+                4242,
+            ))), // Clash — always dropped
+            TransportAddr::Ip(SocketAddr::V4(SocketAddrV4::new(
+                "169.254.0.5".parse().unwrap(),
+                4242,
+            ))), // link-local — always dropped
+        ];
+        let kept: Vec<TransportAddr> = apply_addr_filter(&addrs, true).into_owned();
+        assert_eq!(kept.len(), 3, "real LAN + 2 overlay candidates kept");
+        let ips: Vec<String> = kept
+            .iter()
+            .filter_map(|a| match a {
+                TransportAddr::Ip(s) => Some(s.ip().to_string()),
+                _ => None,
+            })
+            .collect();
+        assert!(ips.contains(&"192.168.1.1".to_string()));
+        assert!(ips.contains(&"100.64.0.7".to_string()));
+        assert!(ips.iter().any(|s| s == "fd7a:115c:a1e0::1"));
+        assert!(!ips.iter().any(|s| s == "198.18.0.1"));
+        assert!(!ips.iter().any(|s| s == "169.254.0.5"));
     }
 }

--- a/src-tauri/crates/uc-webserver/src/api/settings.rs
+++ b/src-tauri/crates/uc-webserver/src/api/settings.rs
@@ -169,6 +169,7 @@ pub fn settings_patch_from_dto(patch: SettingsPatchDto) -> app_settings::Setting
             .network
             .map(|network| app_settings::NetworkSettingsPatch {
                 allow_relay_fallback: network.allow_relay_fallback,
+                allow_overlay_network_addrs: network.allow_overlay_network_addrs,
             }),
     }
 }
@@ -231,6 +232,7 @@ pub fn settings_view_to_dto(value: app_settings::SettingsView) -> SettingsDto {
         },
         network: NetworkSettingsDto {
             allow_relay_fallback: value.network.allow_relay_fallback,
+            allow_overlay_network_addrs: value.network.allow_overlay_network_addrs,
         },
     }
 }

--- a/src-tauri/crates/uc-webserver/tests/settings_network_smoke.rs
+++ b/src-tauri/crates/uc-webserver/tests/settings_network_smoke.rs
@@ -199,6 +199,7 @@ async fn restart_required_truth_table() {
     let payload_some_false = SettingsPatchDto {
         network: Some(NetworkSettingsPatchDto {
             allow_relay_fallback: Some(false),
+            ..Default::default()
         }),
         ..Default::default()
     };
@@ -211,6 +212,7 @@ async fn restart_required_truth_table() {
     let payload_some_true = SettingsPatchDto {
         network: Some(NetworkSettingsPatchDto {
             allow_relay_fallback: Some(true),
+            ..Default::default()
         }),
         ..Default::default()
     };

--- a/src/__tests__/api/daemon/_test-helpers.ts
+++ b/src/__tests__/api/daemon/_test-helpers.ts
@@ -208,6 +208,7 @@ export function makeSettingsDto(overrides: Partial<Settings> = {}): Settings {
     },
     network: {
       allowRelayFallback: true,
+      allowOverlayNetworkAddrs: false,
     },
     ...overrides,
   }

--- a/src/api/daemon/__tests__/settings.test.ts
+++ b/src/api/daemon/__tests__/settings.test.ts
@@ -144,7 +144,10 @@ describe('settings api — updateSettings restartRequired signal', () => {
  */
 describe('反向命名审计 (Pitfall 1 fence)', () => {
   it('Settings.network 字段名是 allowRelayFallback 不是反向布尔镜像', () => {
-    const sample: Settings['network'] = { allowRelayFallback: true }
+    const sample: Settings['network'] = {
+      allowRelayFallback: true,
+      allowOverlayNetworkAddrs: false,
+    }
     const keys = Object.keys(sample)
     expect(keys).toContain('allowRelayFallback')
     // 任何反向布尔镜像字段出现都视为回归 — 字段名通过 join 拼接以避免被

--- a/src/api/daemon/settings.ts
+++ b/src/api/daemon/settings.ts
@@ -91,13 +91,18 @@ export interface FileSyncSettings {
 }
 
 /**
- * Network settings — wire field `allowRelayFallback` (camelCase 与 daemon serde 对齐).
+ * Network settings — wire fields camelCase aligned with daemon serde.
  *
- * 网络设置 — wire 字段 allowRelayFallback。前端只允许在 NetworkSection.tsx
- * 一处取反；不要在前端维护反向布尔镜像字段（反向命名铁律）。
+ * 网络设置 — 前端只允许在 NetworkSection.tsx 一处对 `allowRelayFallback` 取反；
+ * 不要在前端维护反向布尔镜像字段（反向命名铁律）。
+ *
+ * `allowOverlayNetworkAddrs` 控制是否把 VPN/overlay 类虚拟网卡 IP（CGNAT
+ * 100.64.0.0/10、Tailscale ULA fd7a:115c:a1e0::/48）作为 iroh 直连候选。
+ * 默认 `false`。专业用户在两端都接入同一 VPN 时可开启。
  */
 export interface NetworkSettings {
   allowRelayFallback: boolean
+  allowOverlayNetworkAddrs: boolean
 }
 
 /**
@@ -326,7 +331,11 @@ function toSettingsPatchRequest(settings: Partial<Settings>): SettingsPatchReque
   }
 
   if (settings.network) {
-    patch.network = { allowRelayFallback: settings.network.allowRelayFallback }
+    // Spread to only mirror fields actually present on the input — both
+    // existing tests and SettingContext sometimes pass `Partial<NetworkSettings>`
+    // (e.g. just `{ allowRelayFallback: ... }`); we must not emit undefined
+    // fields, since the wire patch interprets `null/undefined` as "no change".
+    patch.network = { ...settings.network }
   }
 
   return patch

--- a/src/components/layout/__tests__/SidebarUpdateIndicator.test.tsx
+++ b/src/components/layout/__tests__/SidebarUpdateIndicator.test.tsx
@@ -50,6 +50,7 @@ const baseSetting: Settings = {
   },
   network: {
     allowRelayFallback: true,
+    allowOverlayNetworkAddrs: false,
   },
 }
 

--- a/src/components/setting/AllowOverlayAddrsDisclosure.tsx
+++ b/src/components/setting/AllowOverlayAddrsDisclosure.tsx
@@ -1,0 +1,60 @@
+import { Info } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { Popover, PopoverTrigger, PopoverContent } from '@/components/ui/popover'
+
+/**
+ * AllowOverlayAddrsDisclosure — info icon click-only Popover, 解释什么是虚拟网络
+ * 地址、为什么默认关闭、什么时候应该开启。
+ *
+ * 与 LanOnlyDisclosure 同模式：click-only（hover 容纳量不够 + 内容不可复制）。
+ */
+const DISCLOSURE_KEYS = ['covered', 'whyOff', 'whenOn', 'tradeoff'] as const
+
+export function AllowOverlayAddrsDisclosure() {
+  const { t } = useTranslation()
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          aria-label={t('settings.sections.network.allowOverlayAddrs.infoIconAriaLabel')}
+          aria-haspopup="dialog"
+          className="inline-flex items-center justify-center rounded-md p-1 text-muted-foreground hover:text-foreground hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+        >
+          <Info className="size-3.5" aria-hidden="true" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        sideOffset={8}
+        aria-labelledby="allow-overlay-addrs-disclosure-title"
+      >
+        <div className="space-y-3">
+          <div>
+            <p id="allow-overlay-addrs-disclosure-title" className="text-sm font-medium">
+              {t('settings.sections.network.allowOverlayAddrs.disclosure.title')}
+            </p>
+            <p className="text-xs text-muted-foreground mt-1">
+              {t('settings.sections.network.allowOverlayAddrs.disclosure.intro')}
+            </p>
+          </div>
+          <div className="space-y-2">
+            {DISCLOSURE_KEYS.map(key => (
+              <div key={key} className="space-y-1">
+                <p className="text-sm font-medium">
+                  {t(`settings.sections.network.allowOverlayAddrs.disclosure.${key}.title`)}
+                </p>
+                <p className="text-xs text-muted-foreground leading-snug">
+                  {t(`settings.sections.network.allowOverlayAddrs.disclosure.${key}.description`)}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}
+
+export default AllowOverlayAddrsDisclosure

--- a/src/components/setting/NetworkSection.tsx
+++ b/src/components/setting/NetworkSection.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { AllowOverlayAddrsDisclosure } from './AllowOverlayAddrsDisclosure'
 import { LanOnlyDisclosure } from './LanOnlyDisclosure'
@@ -56,13 +56,18 @@ const NetworkSection: React.FC = () => {
   const [restartError, setRestartError] = useState<string | null>(null)
   const [saveError, setSaveError] = useState<string | null>(null)
 
-  // 防止 useEffect 在 mount 时立即触发 PUT（每个开关独立 pristine flag）
-  const isPristineRelayRef = useRef(true)
-  const isPristineOverlayRef = useRef(true)
+  // 防止 useEffect 在 mount 时立即触发 PUT（网络设置整体只跳过一次）
+  const isPristineRef = useRef(true)
 
   // debounced 写盘值（D-D3：500ms after last user change）
-  const debouncedAllowRelay = useDebounce(allowRelayFallback, 500)
-  const debouncedAllowOverlay = useDebounce(allowOverlayNetworkAddrs, 500)
+  const networkDraft = useMemo(
+    () => ({
+      allowRelayFallback,
+      allowOverlayNetworkAddrs,
+    }),
+    [allowRelayFallback, allowOverlayNetworkAddrs]
+  )
+  const debouncedNetwork = useDebounce(networkDraft, 500)
 
   // ── Effect 1: setting 加载后同步本地 state baseline ─────────────
   useEffect(() => {
@@ -72,65 +77,39 @@ const NetworkSection: React.FC = () => {
     }
   }, [setting])
 
-  // ── Effect 2: debounced PUT for allowRelayFallback ──────────────
+  // ── Effect 2: debounced PUT for the network settings group ──────
   useEffect(() => {
-    if (isPristineRelayRef.current) {
-      isPristineRelayRef.current = false
+    if (isPristineRef.current) {
+      isPristineRef.current = false
       return
     }
     if (!setting) return
-    if (debouncedAllowRelay === persistedAllowRelay) return
+    const relayChanged = debouncedNetwork.allowRelayFallback !== persistedAllowRelay
+    const overlayChanged = debouncedNetwork.allowOverlayNetworkAddrs !== persistedAllowOverlay
+    if (!relayChanged && !overlayChanged) return
 
     void (async () => {
       try {
-        const result = await updateNetworkSetting({
-          allowRelayFallback: debouncedAllowRelay,
-        })
+        const result = await updateNetworkSetting(debouncedNetwork)
         if (result.restartRequired) {
           setPending(true)
         } else {
           setPending(false)
         }
       } catch (err) {
-        log.error({ err }, '保存 LAN-only 设置失败')
+        log.error({ err }, '保存网络设置失败')
         setAllowRelayFallback(persistedAllowRelay)
-        setPending(false)
-        const message = err instanceof Error ? err.message : String(err)
-        setSaveError(t('settings.sections.network.lanOnly.saveError', { message }))
-        window.setTimeout(() => setSaveError(null), 5000)
-      }
-    })()
-  }, [debouncedAllowRelay])
-
-  // ── Effect 3: debounced PUT for allowOverlayNetworkAddrs ────────
-  useEffect(() => {
-    if (isPristineOverlayRef.current) {
-      isPristineOverlayRef.current = false
-      return
-    }
-    if (!setting) return
-    if (debouncedAllowOverlay === persistedAllowOverlay) return
-
-    void (async () => {
-      try {
-        const result = await updateNetworkSetting({
-          allowOverlayNetworkAddrs: debouncedAllowOverlay,
-        })
-        if (result.restartRequired) {
-          setPending(true)
-        } else {
-          setPending(false)
-        }
-      } catch (err) {
-        log.error({ err }, '保存 Allow Overlay Network Addrs 设置失败')
         setAllowOverlayNetworkAddrs(persistedAllowOverlay)
         setPending(false)
         const message = err instanceof Error ? err.message : String(err)
-        setSaveError(t('settings.sections.network.allowOverlayAddrs.saveError', { message }))
+        const errorKey = relayChanged
+          ? 'settings.sections.network.lanOnly.saveError'
+          : 'settings.sections.network.allowOverlayAddrs.saveError'
+        setSaveError(t(errorKey, { message }))
         window.setTimeout(() => setSaveError(null), 5000)
       }
     })()
-  }, [debouncedAllowOverlay])
+  }, [debouncedNetwork])
 
   // ── Switch 切换 handler（LAN-only — 反向命名唯一取反点） ────────
   const handleLanOnlySwitchChange = (checked: boolean) => {

--- a/src/components/setting/NetworkSection.tsx
+++ b/src/components/setting/NetworkSection.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { AllowOverlayAddrsDisclosure } from './AllowOverlayAddrsDisclosure'
 import { LanOnlyDisclosure } from './LanOnlyDisclosure'
 import { RestartBanner } from './RestartBanner'
 import { SettingGroup } from './SettingGroup'
@@ -24,12 +25,18 @@ const log = createLogger('network-section')
  * - **Pitfall 1（反向命名）**：UI checked === ON === LAN-only === allowRelayFallback === false。
  *   本组件含**唯一一处**前端取反点（line marker `// FENCE: 反向命名唯一取反点` 标注两处）。
  *   全工程 grep `!allowRelayFallback` 仅命中 NetworkSection.tsx 与本组件单元测试 — 其它文件 0 匹配。
+ *   `allowOverlayNetworkAddrs` 为正向同名字段（UI checked === 字段值），不参与取反铁律。
  * - **Pitfall 5（边界透明）**：禁词清单 `fully offline / 完全离线 / 绝对私有 / no internet /
  *   private mode / encrypted-and-local` 全工程 0 匹配；4 类外网请求由 LanOnlyDisclosure 显式披露。
  * - **Pitfall 10（重启 UX 半生效）**：使用持久 inline RestartBanner（不是 toast 也不是 sonner）；
  *   debounce 500ms 防 disk I/O 爆；切换瞬间 setPending(true) 乐观显示，不等 PUT 返回。
  * - **Pitfall 11（占位组件残留）**：旧 `Network settings are not yet available` /
  *   `网络设置功能在新架构中尚未实现` / `settings.sections.network.placeholder` 全部清零。
+ *
+ * # 共享 RestartBanner
+ *   两个开关（LAN-only / Allow Overlay Addrs）任一改动后都使 daemon 需要重启
+ *   （iroh endpoint bind-time 常量 + BIND_LOCK 进程级单次 bind）。pending 状态合并，
+ *   一个 banner 服务两个开关。
  */
 const NetworkSection: React.FC = () => {
   const { t } = useTranslation()
@@ -37,9 +44,11 @@ const NetworkSection: React.FC = () => {
 
   // 当前持久值（来自 SettingContext，作为 baseline）
   const persistedAllowRelay = setting?.network?.allowRelayFallback ?? true
+  const persistedAllowOverlay = setting?.network?.allowOverlayNetworkAddrs ?? false
 
   // 本地乐观 state（D-D2：切换后立即更新，不等 PUT 返回）
   const [allowRelayFallback, setAllowRelayFallback] = useState(persistedAllowRelay)
+  const [allowOverlayNetworkAddrs, setAllowOverlayNetworkAddrs] = useState(persistedAllowOverlay)
 
   // pending 状态（来自两个源：用户切换 / PUT 后 restartRequired；不跨 session）
   const [pending, setPending] = useState(false)
@@ -47,27 +56,29 @@ const NetworkSection: React.FC = () => {
   const [restartError, setRestartError] = useState<string | null>(null)
   const [saveError, setSaveError] = useState<string | null>(null)
 
-  // 防止 useEffect 在 mount 时立即触发 PUT（pristine flag）
-  const isPristineRef = useRef(true)
+  // 防止 useEffect 在 mount 时立即触发 PUT（每个开关独立 pristine flag）
+  const isPristineRelayRef = useRef(true)
+  const isPristineOverlayRef = useRef(true)
 
   // debounced 写盘值（D-D3：500ms after last user change）
   const debouncedAllowRelay = useDebounce(allowRelayFallback, 500)
+  const debouncedAllowOverlay = useDebounce(allowOverlayNetworkAddrs, 500)
 
   // ── Effect 1: setting 加载后同步本地 state baseline ─────────────
   useEffect(() => {
     if (setting?.network) {
       setAllowRelayFallback(setting.network.allowRelayFallback)
+      setAllowOverlayNetworkAddrs(setting.network.allowOverlayNetworkAddrs)
     }
   }, [setting])
 
-  // ── Effect 2: debounced PUT /settings ───────────────────────────
+  // ── Effect 2: debounced PUT for allowRelayFallback ──────────────
   useEffect(() => {
-    if (isPristineRef.current) {
-      isPristineRef.current = false
+    if (isPristineRelayRef.current) {
+      isPristineRelayRef.current = false
       return
     }
     if (!setting) return
-    // 用户实际改变了值才发 PUT
     if (debouncedAllowRelay === persistedAllowRelay) return
 
     void (async () => {
@@ -82,22 +93,58 @@ const NetworkSection: React.FC = () => {
         }
       } catch (err) {
         log.error({ err }, '保存 LAN-only 设置失败')
-        // PUT 失败回滚 Switch 视觉到 persisted 值 + 显示 inline saveError
         setAllowRelayFallback(persistedAllowRelay)
         setPending(false)
         const message = err instanceof Error ? err.message : String(err)
         setSaveError(t('settings.sections.network.lanOnly.saveError', { message }))
-        // 5s 后自动清除 saveError（per UI-SPEC interaction contract）
         window.setTimeout(() => setSaveError(null), 5000)
       }
     })()
   }, [debouncedAllowRelay])
 
-  // ── Switch 切换 handler（反向命名唯一取反点） ──────────────────
-  const handleSwitchChange = (checked: boolean) => {
+  // ── Effect 3: debounced PUT for allowOverlayNetworkAddrs ────────
+  useEffect(() => {
+    if (isPristineOverlayRef.current) {
+      isPristineOverlayRef.current = false
+      return
+    }
+    if (!setting) return
+    if (debouncedAllowOverlay === persistedAllowOverlay) return
+
+    void (async () => {
+      try {
+        const result = await updateNetworkSetting({
+          allowOverlayNetworkAddrs: debouncedAllowOverlay,
+        })
+        if (result.restartRequired) {
+          setPending(true)
+        } else {
+          setPending(false)
+        }
+      } catch (err) {
+        log.error({ err }, '保存 Allow Overlay Network Addrs 设置失败')
+        setAllowOverlayNetworkAddrs(persistedAllowOverlay)
+        setPending(false)
+        const message = err instanceof Error ? err.message : String(err)
+        setSaveError(t('settings.sections.network.allowOverlayAddrs.saveError', { message }))
+        window.setTimeout(() => setSaveError(null), 5000)
+      }
+    })()
+  }, [debouncedAllowOverlay])
+
+  // ── Switch 切换 handler（LAN-only — 反向命名唯一取反点） ────────
+  const handleLanOnlySwitchChange = (checked: boolean) => {
     // FENCE: 反向命名唯一取反点（Pitfall 1 — UI checked = LAN-only ON = allowRelay false）
     const newAllowRelay = !checked
     setAllowRelayFallback(newAllowRelay)
+    setPending(true)
+    setSaveError(null)
+    setRestartError(null)
+  }
+
+  // ── Switch 切换 handler（Allow Overlay — 正向同名，不取反） ─────
+  const handleAllowOverlaySwitchChange = (checked: boolean) => {
+    setAllowOverlayNetworkAddrs(checked)
     setPending(true)
     setSaveError(null)
     setRestartError(null)
@@ -142,9 +189,22 @@ const NetworkSection: React.FC = () => {
       >
         <Switch
           id="lan-only-switch"
+          aria-label={t('settings.sections.network.lanOnly.label')}
           // FENCE: 反向命名唯一取反点（Pitfall 1 — checked=ON ⇔ allowRelayFallback=false）
           checked={!allowRelayFallback}
-          onCheckedChange={handleSwitchChange}
+          onCheckedChange={handleLanOnlySwitchChange}
+        />
+      </SettingRow>
+      <SettingRow
+        label={t('settings.sections.network.allowOverlayAddrs.label')}
+        labelExtra={<AllowOverlayAddrsDisclosure />}
+        description={t('settings.sections.network.allowOverlayAddrs.description')}
+      >
+        <Switch
+          id="allow-overlay-addrs-switch"
+          aria-label={t('settings.sections.network.allowOverlayAddrs.label')}
+          checked={allowOverlayNetworkAddrs}
+          onCheckedChange={handleAllowOverlaySwitchChange}
         />
       </SettingRow>
       {saveError && (

--- a/src/components/setting/__tests__/AboutSection.test.tsx
+++ b/src/components/setting/__tests__/AboutSection.test.tsx
@@ -63,6 +63,7 @@ const baseSetting: Settings = {
   },
   network: {
     allowRelayFallback: true,
+    allowOverlayNetworkAddrs: false,
   },
 }
 

--- a/src/components/setting/__tests__/NetworkSection.test.tsx
+++ b/src/components/setting/__tests__/NetworkSection.test.tsx
@@ -196,7 +196,10 @@ describe('NetworkSection — Phase 95 集成', () => {
       vi.advanceTimersByTime(500)
     })
     expect(mockUpdate).toHaveBeenCalledTimes(1)
-    expect(mockUpdate).toHaveBeenCalledWith({ allowRelayFallback: false })
+    expect(mockUpdate).toHaveBeenCalledWith({
+      allowRelayFallback: false,
+      allowOverlayNetworkAddrs: false,
+    })
   })
 
   it('Test 5: 连击 Switch 只 PUT 一次（debounce 合并）', async () => {
@@ -225,7 +228,10 @@ describe('NetworkSection — Phase 95 集成', () => {
     })
     expect(mockUpdate).toHaveBeenCalledTimes(1)
     // 起始 allowRelay=true（OFF）→ click1=false → click2=true → click3=false
-    expect(mockUpdate).toHaveBeenLastCalledWith({ allowRelayFallback: false })
+    expect(mockUpdate).toHaveBeenLastCalledWith({
+      allowRelayFallback: false,
+      allowOverlayNetworkAddrs: false,
+    })
   })
 
   it('Test 6: 点击「立即重启」调 invokeWithTrace("restart_app")', async () => {
@@ -372,10 +378,40 @@ describe('NetworkSection — Phase 95 集成', () => {
       vi.advanceTimersByTime(600)
     })
     expect(mockUpdate).toHaveBeenCalledTimes(1)
-    expect(mockUpdate).toHaveBeenCalledWith({ allowOverlayNetworkAddrs: true })
+    expect(mockUpdate).toHaveBeenCalledWith({
+      allowRelayFallback: true,
+      allowOverlayNetworkAddrs: true,
+    })
   })
 
-  it('Test 17: AllowOverlayAddrsDisclosure trigger 在 SettingRow 内可见', async () => {
+  it('Test 17: 快速切换两个网络开关 — debounce 后保存同一组最终值', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    const mockUpdate = vi.fn().mockResolvedValue({ restartRequired: true })
+    setupSetting({ updateNetworkSetting: mockUpdate })
+
+    render(<NetworkSection />)
+    const lanOnlySw = await screen.findByRole('switch', { name: /LAN-only/ })
+    const overlaySw = await screen.findByRole('switch', { name: /虚拟网络地址|overlay/i })
+
+    await user.click(lanOnlySw)
+    await act(async () => {
+      vi.advanceTimersByTime(100)
+    })
+    await user.click(overlaySw)
+
+    await act(async () => {
+      vi.advanceTimersByTime(600)
+    })
+
+    expect(mockUpdate).toHaveBeenCalledTimes(1)
+    expect(mockUpdate).toHaveBeenCalledWith({
+      allowRelayFallback: false,
+      allowOverlayNetworkAddrs: true,
+    })
+  })
+
+  it('Test 18: AllowOverlayAddrsDisclosure trigger 在 SettingRow 内可见', async () => {
     renderWithOverrides({ allowRelayFallback: true })
     expect(
       await screen.findByRole('button', {

--- a/src/components/setting/__tests__/NetworkSection.test.tsx
+++ b/src/components/setting/__tests__/NetworkSection.test.tsx
@@ -78,6 +78,7 @@ const baseSetting: Settings = {
   },
   network: {
     allowRelayFallback: true,
+    allowOverlayNetworkAddrs: false,
   },
 }
 
@@ -144,7 +145,7 @@ afterEach(() => {
 describe('NetworkSection — Phase 95 集成', () => {
   it('Test 1: applied OFF 默认态 — Switch=OFF + RestartBanner 不可见', async () => {
     renderWithOverrides({ allowRelayFallback: true })
-    const sw = await screen.findByRole('switch')
+    const sw = await screen.findByRole('switch', { name: /LAN-only/ })
     expect(sw).toHaveAttribute('aria-checked', 'false')
     // RestartBanner 不挂 — role=status 不应出现
     await waitFor(() => {
@@ -154,7 +155,7 @@ describe('NetworkSection — Phase 95 集成', () => {
 
   it('Test 2: applied ON 默认态 — Switch=ON + RestartBanner 不可见', async () => {
     renderWithOverrides({ allowRelayFallback: false })
-    const sw = await screen.findByRole('switch')
+    const sw = await screen.findByRole('switch', { name: /LAN-only/ })
     expect(sw).toHaveAttribute('aria-checked', 'true')
     await waitFor(() => {
       expect(screen.queryByRole('status')).toBeNull()
@@ -164,7 +165,7 @@ describe('NetworkSection — Phase 95 集成', () => {
   it('Test 3: 用户点 Switch — Switch 立即翻 + RestartBanner 立即可见（乐观 pending D-D2）', async () => {
     const user = userEvent.setup()
     renderWithOverrides({ allowRelayFallback: true })
-    const sw = await screen.findByRole('switch')
+    const sw = await screen.findByRole('switch', { name: /LAN-only/ })
     expect(sw).toHaveAttribute('aria-checked', 'false')
 
     await user.click(sw)
@@ -181,7 +182,7 @@ describe('NetworkSection — Phase 95 集成', () => {
     setupSetting({ updateNetworkSetting: mockUpdate })
 
     render(<NetworkSection />)
-    const sw = await screen.findByRole('switch')
+    const sw = await screen.findByRole('switch', { name: /LAN-only/ })
     await user.click(sw)
 
     // 100ms 内不应触发
@@ -205,7 +206,7 @@ describe('NetworkSection — Phase 95 集成', () => {
     setupSetting({ updateNetworkSetting: mockUpdate })
 
     render(<NetworkSection />)
-    const sw = await screen.findByRole('switch')
+    const sw = await screen.findByRole('switch', { name: /LAN-only/ })
 
     // 100ms 内连点 3 次
     await user.click(sw)
@@ -230,7 +231,7 @@ describe('NetworkSection — Phase 95 集成', () => {
   it('Test 6: 点击「立即重启」调 invokeWithTrace("restart_app")', async () => {
     const user = userEvent.setup()
     renderWithOverrides({ allowRelayFallback: true })
-    const sw = await screen.findByRole('switch')
+    const sw = await screen.findByRole('switch', { name: /LAN-only/ })
     await user.click(sw)
 
     // Banner 立即可见
@@ -251,7 +252,7 @@ describe('NetworkSection — Phase 95 集成', () => {
       return undefined
     })
     renderWithOverrides({ allowRelayFallback: true })
-    const sw = await screen.findByRole('switch')
+    const sw = await screen.findByRole('switch', { name: /LAN-only/ })
     await user.click(sw)
 
     const restartBtn = await screen.findByRole('button', { name: /立即重启|Restart now/ })
@@ -271,7 +272,7 @@ describe('NetworkSection — Phase 95 集成', () => {
     setupSetting({ updateNetworkSetting: mockUpdate })
 
     render(<NetworkSection />)
-    const sw = await screen.findByRole('switch')
+    const sw = await screen.findByRole('switch', { name: /LAN-only/ })
     await user.click(sw) // OFF → ON
     expect(sw).toHaveAttribute('aria-checked', 'true')
 
@@ -329,7 +330,7 @@ describe('NetworkSection — Phase 95 集成', () => {
 
   it('Test 13: 占位组件残留 fence — 不渲染 placeholder 文本（Pitfall 11）', async () => {
     const { container } = renderWithOverrides({ allowRelayFallback: true })
-    await screen.findByRole('switch')
+    await screen.findByRole('switch', { name: /LAN-only/ })
     expect(container.textContent).not.toMatch(/Network settings are not yet available/)
     expect(container.textContent).not.toMatch(/网络设置功能在新架构中尚未实现/)
   })
@@ -337,8 +338,50 @@ describe('NetworkSection — Phase 95 集成', () => {
   it('Test 14: 反向命名 fence — checked = !allowRelayFallback', async () => {
     // allowRelay=false（即 LAN-only ON）⇒ Switch checked=true
     renderWithOverrides({ allowRelayFallback: false })
-    const sw = await screen.findByRole('switch')
+    const sw = await screen.findByRole('switch', { name: /LAN-only/ })
     expect(sw).toHaveAttribute('aria-checked', 'true')
+  })
+
+  it('Test 15: allowOverlayNetworkAddrs 正向命名 — checked === allowOverlayNetworkAddrs', async () => {
+    // 默认 false ⇒ Switch checked=false
+    renderWithOverrides({ allowOverlayNetworkAddrs: false })
+    const offSw = await screen.findByRole('switch', { name: /虚拟网络地址|overlay/i })
+    expect(offSw).toHaveAttribute('aria-checked', 'false')
+    cleanup()
+
+    // true ⇒ Switch checked=true（无取反）
+    renderWithOverrides({ allowOverlayNetworkAddrs: true })
+    const onSw = await screen.findByRole('switch', { name: /虚拟网络地址|overlay/i })
+    expect(onSw).toHaveAttribute('aria-checked', 'true')
+  })
+
+  it('Test 16: 切换 overlay switch — debounce 500ms 后调 updateNetworkSetting', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    const mockUpdate = vi.fn().mockResolvedValue({ restartRequired: true })
+    setupSetting({ updateNetworkSetting: mockUpdate })
+
+    render(<NetworkSection />)
+    const sw = await screen.findByRole('switch', { name: /虚拟网络地址|overlay/i })
+    await user.click(sw)
+
+    expect(sw).toHaveAttribute('aria-checked', 'true')
+    expect(screen.getByRole('status')).toBeInTheDocument()
+
+    await act(async () => {
+      vi.advanceTimersByTime(600)
+    })
+    expect(mockUpdate).toHaveBeenCalledTimes(1)
+    expect(mockUpdate).toHaveBeenCalledWith({ allowOverlayNetworkAddrs: true })
+  })
+
+  it('Test 17: AllowOverlayAddrsDisclosure trigger 在 SettingRow 内可见', async () => {
+    renderWithOverrides({ allowRelayFallback: true })
+    expect(
+      await screen.findByRole('button', {
+        name: /了解什么是虚拟网络地址|Learn what overlay network addresses/,
+      })
+    ).toBeInTheDocument()
   })
 })
 
@@ -352,7 +395,7 @@ describe('Phase 95 ROADMAP fence — 4 验收 + 3 Pitfall 防御', () => {
 
   it('Pitfall 11 — 占位组件残留全清', async () => {
     const { container } = renderWithOverrides({ allowRelayFallback: true })
-    await screen.findByRole('switch')
+    await screen.findByRole('switch', { name: /LAN-only/ })
     expect(container.textContent).not.toMatch(/Network settings are not yet available/)
     expect(container.textContent).not.toMatch(/网络设置功能在新架构中尚未实现/)
   })
@@ -360,7 +403,7 @@ describe('Phase 95 ROADMAP fence — 4 验收 + 3 Pitfall 防御', () => {
   it('Pitfall 10 — RestartBanner 是持久 inline 不是 toast（pending 时 role=status 存在）', async () => {
     const user = userEvent.setup()
     renderWithOverrides({ allowRelayFallback: true })
-    const sw = await screen.findByRole('switch')
+    const sw = await screen.findByRole('switch', { name: /LAN-only/ })
     await user.click(sw)
 
     const banner = screen.getByRole('status')

--- a/src/contexts/__tests__/SettingContext.cross-window.test.tsx
+++ b/src/contexts/__tests__/SettingContext.cross-window.test.tsx
@@ -94,6 +94,7 @@ const baseSetting: Settings = {
   },
   network: {
     allowRelayFallback: true,
+    allowOverlayNetworkAddrs: false,
   },
 }
 

--- a/src/contexts/__tests__/SettingContext.network.test.tsx
+++ b/src/contexts/__tests__/SettingContext.network.test.tsx
@@ -94,6 +94,7 @@ const baseSetting: Settings = {
   },
   network: {
     allowRelayFallback: true,
+    allowOverlayNetworkAddrs: false,
   },
 }
 
@@ -152,7 +153,7 @@ describe('SettingContext network — updateNetworkSetting + saveSetting restartR
 
     expect(mockUpdateSettings).toHaveBeenCalledWith(
       expect.objectContaining({
-        network: { allowRelayFallback: false },
+        network: expect.objectContaining({ allowRelayFallback: false }),
       })
     )
     // 关键 fence：updateNetworkSetting 不应越界改其它段，验证 general/sync 段保持原状

--- a/src/contexts/__tests__/SettingContext.theme.test.tsx
+++ b/src/contexts/__tests__/SettingContext.theme.test.tsx
@@ -88,6 +88,7 @@ const baseSetting: Settings = {
   },
   network: {
     allowRelayFallback: true,
+    allowOverlayNetworkAddrs: false,
   },
 }
 

--- a/src/contexts/__tests__/UpdateContext.test.tsx
+++ b/src/contexts/__tests__/UpdateContext.test.tsx
@@ -60,6 +60,7 @@ const baseSetting: Settings = {
   },
   network: {
     allowRelayFallback: true,
+    allowOverlayNetworkAddrs: false,
   },
 }
 

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -226,6 +226,32 @@
             }
           }
         },
+        "allowOverlayAddrs": {
+          "label": "Allow overlay network addresses",
+          "description": "Off by default. Enable when both peers share the same VPN (e.g. Tailscale) so connections can use that overlay network. Takes effect after restart.",
+          "infoIconAriaLabel": "Learn what overlay network addresses are and when to enable this option",
+          "saveError": "Save failed: {{message}}. Reverted to the previous setting.",
+          "disclosure": {
+            "title": "About overlay network addresses",
+            "intro": "When establishing direct connections, your machine has multiple IP addresses (real LAN, VPN tunnels, etc.). \"Overlay network addresses\" refers to virtual NIC IPs created by VPN software:",
+            "covered": {
+              "title": "What this affects",
+              "description": "Specifically the CGNAT range 100.64.0.0/10 (Tailscale's default IPv4) and the Tailscale IPv6 ULA fd7a:115c:a1e0::/48. Clash fake-ip (198.18.0.0/15) and link-local (169.254.0.0/16) are always filtered regardless of this setting."
+            },
+            "whyOff": {
+              "title": "Why off by default",
+              "description": "When two peers are not in the same VPN, publishing virtual-NIC IPs as connection candidates wastes path-validation budget on dead candidates and slows the real direct connection."
+            },
+            "whenOn": {
+              "title": "When to turn on",
+              "description": "Turn on if both peers are in the same Tailscale tailnet (or another shared overlay) and direct LAN/Internet paths are blocked, but the overlay route works. iroh will then use the overlay path as a connection candidate."
+            },
+            "tradeoff": {
+              "title": "Trade-off",
+              "description": "If only one peer has the VPN — or peers are in different tailnets — turning this on makes connections slower but doesn't outright break them (relay fallback still works). If unsure, leave it off."
+            }
+          }
+        },
         "restartBanner": {
           "message": "Restart the app to apply the LAN-only Mode change.",
           "restartButton": "Restart now",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -217,6 +217,32 @@
             }
           }
         },
+        "allowOverlayAddrs": {
+          "label": "允许虚拟网络地址",
+          "description": "默认关闭。当两端都接入同一个 VPN（如 Tailscale）时打开，让连接借用该虚拟网络。重启后生效。",
+          "infoIconAriaLabel": "了解什么是虚拟网络地址，以及何时应该开启",
+          "saveError": "保存失败：{{message}}。已恢复到上一次的设置。",
+          "disclosure": {
+            "title": "关于虚拟网络地址",
+            "intro": "建立直连时，本机会同时拥有多个 IP（真实局域网、VPN 隧道等）。「虚拟网络地址」指 VPN 软件建立的虚拟网卡 IP：",
+            "covered": {
+              "title": "本开关影响的范围",
+              "description": "具体是 CGNAT 段 100.64.0.0/10（Tailscale 默认 IPv4）和 Tailscale IPv6 ULA fd7a:115c:a1e0::/48。Clash fake-ip（198.18.0.0/15）和链路本地（169.254.0.0/16）始终被过滤，不受此开关影响。"
+            },
+            "whyOff": {
+              "title": "为什么默认关闭",
+              "description": "如果两端不在同一个 VPN 中，把虚拟网卡地址作为连接候选会让对端浪费 path-validation 预算去试一条死路，反而拖慢真正的直连建立速度。"
+            },
+            "whenOn": {
+              "title": "什么时候开启",
+              "description": "如果两端确实都在同一个 Tailscale tailnet（或其他相同的 overlay 网络）中，且真实局域网 / 公网直连不通、但 overlay 通，开启后 iroh 会把 overlay 路径作为可选直连候选。"
+            },
+            "tradeoff": {
+              "title": "权衡说明",
+              "description": "如果只有一端装了 VPN——或两端在不同的 tailnet 中——开启后只是连接更慢，并不会彻底连不上（中继回落仍然有效）。不确定就保持关闭。"
+            }
+          }
+        },
         "restartBanner": {
           "message": "需要重启应用以使 LAN-only 模式更改生效。",
           "restartButton": "立即重启",

--- a/src/types/setting.ts
+++ b/src/types/setting.ts
@@ -125,9 +125,13 @@ export interface FileSyncSettings {
  * UI checked = "LAN-only Mode = ON" 等价于 allowRelayFallback 取反值。
  * 前端只允许在 NetworkSection.tsx 一处用取反表达式；
  * 永远不要在前端 store 维护反向布尔镜像字段。
+ *
+ * `allowOverlayNetworkAddrs` 为正向同名字段（UI checked === 字段值），
+ * 控制是否把 VPN/overlay 类虚拟网卡 IP 作为 iroh 直连候选。
  */
 export interface NetworkSettings {
   allowRelayFallback: boolean
+  allowOverlayNetworkAddrs: boolean
 }
 
 /**


### PR DESCRIPTION
## Summary
- 新增 `Settings.network.allow_overlay_network_addrs` 开关（默认 `false`），让专业用户在两端都接入同一 VPN（如 Tailscale）时可放行 CGNAT `100.64.0.0/10` 与 Tailscale ULA `fd7a:115c:a1e0::/48` 作为 iroh 直连候选。
- 同时补上历史欠账：iroh `AddrFilter` 原本只过滤 IPv4 段，本次同步过滤 Tailscale IPv6 ULA，IPv4/IPv6 行为对称。
- Clash fake-ip `198.18.0.0/15` 与 IPv4 link-local `169.254.0.0/16` 仍永远过滤（无 escape hatch），它们没有合法跨主机用例。
- 全链路落地：core/application/contract DTO + bootstrap 单一翻译点 + uc-infra `is_virtual_nic_ip` 拆 always-filtered / overlay 双类 + 前端 NetworkSection 第二个开关 + AllowOverlayAddrsDisclosure popover（中英 i18n）+ 启动 INFO 日志 / 过滤 DEBUG 日志可观测。
- 设计与实现细节、Pitfall 防御、真机验证流程见 `docs/p2p/2026-05-05-iroh-virtual-nic-filter.md`。

## Test plan
- [x] `cargo test --workspace --lib` 全绿（含 7 个新 infra 单测覆盖 4 段地址 × 2 开关状态）
- [x] `cargo test -p uc-webserver --test settings_network_smoke` 3/3
- [x] `pnpm test --run` 372/372（含 3 个新 NetworkSection 用例）
- [x] `pnpm tsc --noEmit` 干净
- [x] 真机 dev 日志验证：`BLOCKED ↔ ALLOWED` 翻转、`dropped` 日志同时含 `100.x` 和 `198.18.x`、settings.json 持久化正确
- [ ] 跨设备 / Tailscale 真过滤 Level 2 验证（可选）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new network setting to control whether overlay network addresses (VPN/virtual interface addresses) can be used as direct connection candidates, with an informational disclosure panel explaining when and why to enable this option.

* **Documentation**
  * Added detailed documentation on the virtual network interface filtering strategy and the corresponding architecture implementation across the application stack.

* **Internationalization**
  * Added English and Chinese translations for the new overlay network address setting, help text, and disclosure information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->