### PR TITLE
fix(security): 消除 macOS 启动期与解锁期 Keychain 多次弹窗

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -65,6 +65,7 @@ Last activity: 2026-05-05 -- Wave 3 落地：95-06 NetworkSection 完全重写�
 | 260423-mxu | macOS / Linux 多 rep 原子写入 — 当前这两平台仍走单 rep policy 降级 | 2026-04-23 | 0960e7ee | [260423-mxu-macos-linux-rep-rep-policy](./quick/260423-mxu-macos-linux-rep-rep-policy/) |
 | 260505-keychain-prompts | 减少 macOS 首次使用时 Keychain 多次弹窗（kek_observed 进程级缓存） | 2026-05-05 | 39ce6f39 | [260505-keychain-prompts](./quick/260505-keychain-prompts/) |
 | 260505-iroh-identity-file-storage | 启动期 iroh 设备身份脱离 macOS Keychain，改走 0600 文件后端，彻底消除"用户没操作就弹"的根因 | 2026-05-05 | aa1b1d93 | [260505-iroh-identity-file-storage](./quick/260505-iroh-identity-file-storage/) |
+| 260505-keychain-startup-resume-gate | daemon startup_recovery 守 try_resume_session — auto_unlock=false 时不再下沉到 keychain | 2026-05-05 | 5912465c | [260505-keychain-startup-resume-gate](./quick/260505-keychain-startup-resume-gate/) |
 
 ## Session Continuity
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -64,6 +64,7 @@ Last activity: 2026-05-05 -- Wave 3 落地：95-06 NetworkSection 完全重写�
 | 260423-9do | Windows 多表示原子写入 + 解除平台层单 rep 契约 | 2026-04-23 | 2dde3312 | [260423-9do-windows-rep](./quick/260423-9do-windows-rep/) |
 | 260423-mxu | macOS / Linux 多 rep 原子写入 — 当前这两平台仍走单 rep policy 降级 | 2026-04-23 | 0960e7ee | [260423-mxu-macos-linux-rep-rep-policy](./quick/260423-mxu-macos-linux-rep-rep-policy/) |
 | 260505-keychain-prompts | 减少 macOS 首次使用时 Keychain 多次弹窗（kek_observed 进程级缓存） | 2026-05-05 | 39ce6f39 | [260505-keychain-prompts](./quick/260505-keychain-prompts/) |
+| 260505-iroh-identity-file-storage | 启动期 iroh 设备身份脱离 macOS Keychain，改走 0600 文件后端，彻底消除"用户没操作就弹"的根因 | 2026-05-05 | aa1b1d93 | [260505-iroh-identity-file-storage](./quick/260505-iroh-identity-file-storage/) |
 
 ## Session Continuity
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -63,6 +63,7 @@ Last activity: 2026-05-05 -- Wave 3 落地：95-06 NetworkSection 完全重写�
 |---|-------------|------|--------|-----------|
 | 260423-9do | Windows 多表示原子写入 + 解除平台层单 rep 契约 | 2026-04-23 | 2dde3312 | [260423-9do-windows-rep](./quick/260423-9do-windows-rep/) |
 | 260423-mxu | macOS / Linux 多 rep 原子写入 — 当前这两平台仍走单 rep policy 降级 | 2026-04-23 | 0960e7ee | [260423-mxu-macos-linux-rep-rep-policy](./quick/260423-mxu-macos-linux-rep-rep-policy/) |
+| 260505-keychain-prompts | 减少 macOS 首次使用时 Keychain 多次弹窗（kek_observed 进程级缓存） | 2026-05-05 | 39ce6f39 | [260505-keychain-prompts](./quick/260505-keychain-prompts/) |
 
 ## Session Continuity
 

--- a/.planning/quick/260505-iroh-identity-file-storage/260505-PLAN.md
+++ b/.planning/quick/260505-iroh-identity-file-storage/260505-PLAN.md
@@ -1,0 +1,154 @@
+---
+phase: 260505-iroh-identity-file-storage
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - src-tauri/crates/uc-bootstrap/src/assembly.rs
+  - src-tauri/crates/uc-bootstrap/src/space_setup.rs
+autonomous: true
+
+must_haves:
+  truths:
+    - "WiredDependencies 新增 `iroh_identity_dir: PathBuf` 字段，wire_dependencies 中以 `apply_profile_suffix(<app_data_root>/iroh-identity)` 计算并预先 `create_dir_all`，失败映射为 `WiringError::SecureStorageInit`。"
+    - "`build_space_setup_assembly` 给 `IrohIdentityStore::new` 注入 `Arc::new(FileSecureStorage::with_base_dir(wired.iroh_identity_dir.clone()))`，**不再共享** `deps.security.secure_storage`（即 KEK 用的系统 keychain）。"
+    - "iroh 长期 Ed25519 设备身份从此独占文件后端（`<app_data>/iroh-identity[_<profile>]/`，0600 unix 权限由 FileSecureStorage 写入时设定），`IrohNodeBuilder::bind` 启动期完全不接触 macOS keychain。"
+    - "KEK / KeySlot / key_migration / 其它 SecureStoragePort 消费方继续走系统 keychain（`platform.secure_storage`），用户加密秘密的保护级别零变化。"
+    - "老用户 keychain 中残留的 `iroh-identity:v1` 条目**不读、不删**——避免触发新的 keychain 弹窗；老用户升级后文件不存在 ⇒ `IrohIdentityStore::ensure_secret_key` 生成新身份 ⇒ peer 重新配对一次（一次性成本，符合用户"静默迁移、不弹窗"的明确要求）。"
+    - "公共 trait（`SecureStoragePort` / `LocalIdentityPort` / `IrohIdentityStore` 接口）零变化；FileSecureStorage / SystemSecureStorage 都已实现 SecureStoragePort，注入点替换是装配级改动。"
+    - "字节级行为：iroh 身份 = 32-byte Ed25519 secret key 的 raw 字节，FileSecureStorage 与 SystemSecureStorage 持久化的字节序列一致（IrohIdentityStore::persist_secret 输出 `sk.to_bytes()` 不变），新装路径 round-trip 等价。"
+  artifacts:
+    - path: "src-tauri/crates/uc-bootstrap/src/assembly.rs"
+      provides: "WiredDependencies.iroh_identity_dir 字段 + wire_dependencies 计算并预创建目录"
+      contains: "iroh_identity_dir"
+    - path: "src-tauri/crates/uc-bootstrap/src/space_setup.rs"
+      provides: "IrohIdentityStore 注入 FileSecureStorage 实例"
+      contains: "FileSecureStorage::with_base_dir"
+  key_links:
+    - from: "wire_dependencies"
+      to: "WiredDependencies.iroh_identity_dir"
+      via: "apply_profile_suffix(app_data_root_dir.join(\"iroh-identity\")) + create_dir_all"
+      pattern: "iroh-identity"
+    - from: "build_space_setup_assembly"
+      to: "IrohIdentityStore::new(FileSecureStorage)"
+      via: "wired.iroh_identity_dir → FileSecureStorage::with_base_dir → Arc<dyn SecureStoragePort>"
+      pattern: "FileSecureStorage::with_base_dir"
+    - from: "IrohNodeBuilder::bind → ensure_secret_key"
+      to: "FileSecureStorage::{get,set}"
+      via: "iroh-identity:v1 key 走文件后端，不再走 SystemSecureStorage"
+      pattern: "iroh-identity"
+---
+
+<objective>
+**问题**：260505-keychain-prompts 修复后用户实测仍在首次打开应用时被 macOS 弹 keychain 授权——而且发生在用户**还没创建 new space** 之前。先前的 `kek_observed` 缓存只能压住"加密路径"（unlock / verify_keychain_access）的弹窗，对当下场景无效，因为元凶是另一条路径：
+
+**根因**：`uc-bootstrap/src/space_setup.rs:219` 把 KEK 用的系统 keychain（`Arc::clone(&deps.security.secure_storage)`）也传给了 `IrohIdentityStore`，让 iroh 长期 Ed25519 设备身份与用户加密 KEK 共用同一条 macOS keychain（service `UniClipboard`，key `iroh-identity:v1`）。`IrohNodeBuilder::bind` 在启动期被无条件调用 → `ensure_secret_key` → 文件后端不存在 entry → `secure_storage.set("iroh-identity:v1", ...)` → **macOS 弹窗**。
+
+这条路径**不受任何加密 gate 控制**：
+- 不看 `auto_unlock_enabled`（默认 false 也照样弹）
+- 不看 `setup_status.has_completed`（用户没初始化空间也弹）
+- 不看 `keyslot_exists()`（用户没设密码也弹）
+
+只要应用启动、iroh node bind 就触发，违反用户明确给出的三条规则：
+1. 用户点 unlock 按钮才允许访问
+2. 启用 auto-unlock 且 unlock 流程触发时
+3. 设置加密口令时
+
+**目标**：iroh 设备身份从此独立用文件后端持久化（`<app_data>/iroh-identity[_<profile>]/`，0600），与加密 KEK 完全隔离。启动期 IrohNodeBuilder 完全不接触 macOS keychain。
+
+**非目标**（明确不做）：
+- 不删 / 不读老 keychain 中残留的 `iroh-identity:v1` 条目（用户要求"静默 + 零弹窗"，任何 `set` / `delete` / 边缘场景下的 `get` 都可能弹；老条目残留无害）
+- 不为老用户保留 iroh 身份（必然代价：升级后 peer 需重新配对一次。此乃用户 explicit trade-off）
+- 不动 KEK / KeySlot / key_migration 等真正属于"用户秘密"的 keychain 消费方
+- 不动 `SpaceAccessPort` / `LocalIdentityPort` / `IrohIdentityStore` 公共接口
+- 不动 V1 加密协议、keyslot 文件格式、Ed25519 密钥编码
+
+**安全权衡**（与用户达成共识）：iroh 设备身份从 keychain 移到 0600 文件后，损失"同用户其它进程访问需 ACL 提示"的保护层；但 iroh 身份**无法直接解密用户内容**（攻击者还需 KEK，仍在 keychain 里），且与 SSH/IPFS/Tailscale 等同类 P2P 工具的设备身份持久化实践一致。FileVault 全盘加密 + 用户登录会话保护已足够。
+</objective>
+
+<execution_context>
+@.planning/quick/260505-iroh-identity-file-storage/260505-PLAN.md
+</execution_context>
+
+<context>
+
+# 关键文件
+
+@src-tauri/crates/uc-bootstrap/src/assembly.rs
+@src-tauri/crates/uc-bootstrap/src/space_setup.rs
+@src-tauri/crates/uc-platform/src/file_secure_storage.rs
+@src-tauri/crates/uc-infra/src/network/iroh/identity_store.rs
+
+# 调用链
+
+启动期：
+```
+TauriRuntime / DaemonRuntime startup
+  → wire_dependencies(...)                   ← 计算 iroh_identity_dir + mkdir
+  → build_space_setup_assembly(wired, ...)
+    → IrohIdentityStore::new(
+        Arc::new(FileSecureStorage::with_base_dir(wired.iroh_identity_dir)),  ← 改动点
+        Arc::new(Sha256IdentityFingerprintFactory),
+      )
+    → IrohNodeBuilder::bind(&identity_store, ...)
+      → identity_store.ensure_secret_key()
+        → load_secret() → file 不存在 → None
+        → SecretKey::generate()
+        → persist_secret() → FileSecureStorage::set → mkdir + atomic rename + chmod 0600
+                              ↑ **零 keychain 接触，零弹窗**
+```
+
+# 与其它 SecureStoragePort 消费方的隔离
+
+| 消费方 | 后端 | 何时访问 |
+|---|---|---|
+| `KeyMaterialStore`（KEK） | macOS keychain (`platform.secure_storage`) | 用户初始化加密 / unlock / verify_keychain_access |
+| `DefaultKeyMigrationAdapter`（switch-space migration_key） | macOS keychain（同上） | 用户触发 switch-space |
+| `IrohIdentityStore`（iroh Ed25519） | **文件后端**（本次改动） | 启动期 `IrohNodeBuilder::bind` |
+
+</context>
+
+<tasks>
+
+## Task 1 — WiredDependencies 加 iroh_identity_dir 字段
+
+**file:** `src-tauri/crates/uc-bootstrap/src/assembly.rs`
+
+**action:**
+1. 在 `WiredDependencies` 加 `pub iroh_identity_dir: PathBuf` 字段（doc comment 说明与 KEK keychain 隔离的原因）。
+2. `wire_dependencies` 中：在已有 `iroh_blob_store_dir_for_wiring` 计算之后，新增 `iroh_identity_dir_for_wiring = apply_profile_suffix(paths.app_data_root_dir.join("iroh-identity"))`，并 `std::fs::create_dir_all(...)` 失败映射为 `WiringError::SecureStorageInit(...)`。
+3. `Ok(WiredDependencies { ..., iroh_identity_dir: iroh_identity_dir_for_wiring, ... })`。
+
+**verify:** `cargo check -p uc-bootstrap` 通过；rust-analyzer "missing structure fields" 错误消失。
+
+**done:** 字段定义、构造、mkdir、错误映射齐全。
+
+---
+
+## Task 2 — IrohIdentityStore 注入 FileSecureStorage
+
+**file:** `src-tauri/crates/uc-bootstrap/src/space_setup.rs`
+
+**action:**
+1. `use uc_platform::file_secure_storage::FileSecureStorage;`
+2. 把 `Arc::clone(&deps.security.secure_storage)` 替换为 `Arc::new(FileSecureStorage::with_base_dir(wired.iroh_identity_dir.clone())) as Arc<dyn uc_core::ports::SecureStoragePort>`。
+3. 加 inline 注释说明：a) 为什么不复用 KEK 的系统 keychain（启动期弹窗根因）；b) iroh 身份不是用户秘密，0600 文件足够；c) 老 keychain 条目不读不删的迁移策略；d) 老用户身份重置 = 重新配对一次。
+
+**verify:** `cargo check --workspace` 通过；`cargo clippy -p uc-bootstrap --no-deps` 不新增 warning。
+
+**done:** IrohIdentityStore 注入新后端 + 文档完整。
+
+---
+
+## Task 3 — 编译 / clippy / 测试验证
+
+**action:**
+- `RUSTC_WRAPPER= cargo check --workspace` 通过
+- `RUSTC_WRAPPER= cargo clippy -p uc-bootstrap -p uc-infra -p uc-platform --no-deps` 不新增 warning
+- `RUSTC_WRAPPER= cargo test -p uc-infra --lib security` 11/11 PASS
+- `RUSTC_WRAPPER= cargo test -p uc-platform --lib` 全部 PASS
+
+**done:** 三项均通过。
+
+</tasks>

--- a/.planning/quick/260505-iroh-identity-file-storage/260505-SUMMARY.md
+++ b/.planning/quick/260505-iroh-identity-file-storage/260505-SUMMARY.md
@@ -1,0 +1,97 @@
+---
+quick_id: 260505-iroh-identity-file-storage
+status: complete
+date: 2026-05-05
+plans_executed: 1
+files_modified:
+  - src-tauri/crates/uc-bootstrap/src/assembly.rs
+  - src-tauri/crates/uc-bootstrap/src/space_setup.rs
+---
+
+# Quick Task 260505 — iroh 设备身份脱离 macOS Keychain（彻底消除启动期弹窗）
+
+## 背景
+
+前一次 quick task `260505-keychain-prompts` 给 `DefaultSpaceAccessAdapter` 加了 `kek_observed` 进程级缓存，压住了加密路径（`unlock` / `verify_keychain_access` / `try_resume_session.store_kek`）的重复弹窗。但用户实测**首次打开应用、还没创建 new space**就被 macOS 弹 keychain，前次修复完全没覆盖这条路径。
+
+## 真凶
+
+`uc-bootstrap/src/space_setup.rs:219` 把 KEK 用的同一条系统 keychain 也传给了 `IrohIdentityStore`。`IrohNodeBuilder::bind` 在启动期被无条件调用，触发：
+
+```
+ensure_secret_key()
+  → secure_storage.get("iroh-identity:v1")     ← 文件不存在等价物，但走的是 macOS keychain
+  → 无 entry → SecretKey::generate()
+  → secure_storage.set("iroh-identity:v1", …)  ← macOS 弹"是否允许 UniClipboard 在 keychain 中保存数据"
+```
+
+这条路径**绕过所有加密 gate**：
+- 不查 `auto_unlock_enabled`（默认 false 也照样弹）
+- 不查 `setup_status.has_completed`（用户没初始化也弹）
+- 不查 `keyslot_exists()`（KEK 跟 iroh 身份是不同 keychain entry）
+
+违反用户明确给出的三条规则（点 unlock / 启用 auto-unlock / 设置加密口令）。
+
+## 改动
+
+只动 bootstrap 装配层，业务代码 / 公共 trait / 加密协议零变化。
+
+`src-tauri/crates/uc-bootstrap/src/assembly.rs`（+20）：
+
+- `WiredDependencies` 新增 `iroh_identity_dir: PathBuf` 字段
+- `wire_dependencies` 中 `apply_profile_suffix(<app_data>/iroh-identity)` + `create_dir_all`，失败 → `WiringError::SecureStorageInit`
+
+`src-tauri/crates/uc-bootstrap/src/space_setup.rs`（+25/-1）：
+
+- `use uc_platform::file_secure_storage::FileSecureStorage;`
+- `IrohIdentityStore::new` 第一参数从 `Arc::clone(&deps.security.secure_storage)`（系统 keychain）改成 `Arc::new(FileSecureStorage::with_base_dir(wired.iroh_identity_dir.clone()))`（0600 文件后端）
+
+## 各 SecureStoragePort 消费方现状
+
+| 消费方 | 后端 | 启动期? |
+|---|---|---|
+| `KeyMaterialStore`（KEK / KeySlot） | macOS keychain | ❌ 仅 unlock / verify_keychain_access / 用户初始化时 |
+| `DefaultKeyMigrationAdapter`（migration_key） | macOS keychain | ❌ 仅 switch-space 时 |
+| `IrohIdentityStore`（iroh Ed25519 设备身份） | **文件后端**（本次改动） | ✅ 启动期 `IrohNodeBuilder::bind`，但**零 keychain 接触** |
+
+## 迁移策略（用户要求 "静默 + 零弹窗"）
+
+- 老用户 keychain 中残留的 `iroh-identity:v1` 条目：**不读、不删**
+  - 任何 `get` 在某些边缘场景（dev 构建签名漂移、用户主动 deny 过）下可能弹窗 → 不冒险
+  - `delete` 同样可能弹窗 → 不冒险
+  - 残留条目无害，下次 `factory_reset` 或用户手动清理 keychain 即可
+- 文件不存在 → `IrohIdentityStore::ensure_secret_key` 生成新身份
+- **代价**：老用户升级后 iroh 设备身份重置，**需要重新与 peer 配对一次**（一次性成本，与用户达成共识）
+
+## 安全权衡（与用户达成共识）
+
+iroh 设备身份是**网络栈的"我是哪台机器"标识**，不是用户秘密：
+
+- **攻击者拿到 iroh 身份能做什么**：冒充该设备发起 iroh 握手；但 channel 加密走 KEK 派生的 proof key（仍在 keychain），冒充连接握手解不出来 → **无法读取 / 解密剪贴板内容**
+- **vs Keychain**：损失"同用户其它进程访问需 ACL 提示"的提示层；但 root / 物理访问 / FileVault 锁屏保护对两种方案等价
+- **行业实践**：SSH (`~/.ssh/id_ed25519`)、GPG、IPFS、Tailscale 等 P2P 工具的设备身份均用 0600 文件，不用 keychain
+- **结论**：风险轻微，trade-off 合理
+
+## 启动期弹窗次数对照
+
+| 场景 | 改动前 | 改动后 |
+|---|---|---|
+| 全新安装、用户没操作 | iroh `set` × 1 → **弹窗 1 次** | 0 次（文件后端） |
+| 全新安装 + 用户初始化加密 | iroh `set` × 1 + KEK `set` × 1 = 2 次 | 1 次（仅 KEK，符合规则 #3） |
+| 后续启动（已初始化、auto_unlock=false） | iroh `get`（命中）× 1 = 1 次 | 0 次 |
+| 后续启动（已初始化、auto_unlock=true） | iroh `get` + KEK `get` = 2 次 | 1 次（仅 KEK，符合规则 #2） |
+| 用户点 Unlock 按钮 | KEK `get` × 1 + 可能的 refresh `set`（前次 quick 已修） = 1 次 | 1 次（仅 KEK，符合规则 #1） |
+
+## 验证
+
+- `cargo check --workspace` ✅
+- `cargo clippy -p uc-bootstrap -p uc-infra -p uc-platform --no-deps` ✅（既存 warning 11+3+8 = 22 个，本次改动 0 新增）
+- `cargo test -p uc-infra --lib security` ✅ 11/11 PASS
+- `cargo test -p uc-platform --lib` ✅ 全部 PASS
+
+## 与前一个 quick task 的关系
+
+- `260505-keychain-prompts`（已合入）：解决加密路径的重复弹窗（KEK get/set 在同会话内幂等）
+- `260505-iroh-identity-file-storage`（本次）：解决 iroh 身份导致的"用户没操作就弹"
+
+两者是不同的 root cause，各自必要，互不冗余。

--- a/.planning/quick/260505-keychain-prompts/260505-PLAN.md
+++ b/.planning/quick/260505-keychain-prompts/260505-PLAN.md
@@ -1,0 +1,164 @@
+---
+phase: 260505-keychain-prompts
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - src-tauri/crates/uc-infra/src/security/space_access_adapter.rs
+autonomous: true
+
+must_haves:
+  truths:
+    - "DefaultSpaceAccessAdapter 持有进程级 AtomicBool `kek_observed`，仅在 keychain 中 KEK 与本机 keyslot 已对齐时为 true。一旦置位，verify_keychain_access / unlock 都不再访问 keychain。"
+    - "`do_first_time_init` 在 store_kek 成功后立即置位；store_keyslot 失败的回滚路径在 delete_kek 后复位。"
+    - "`try_resume_session` 在 load_kek + unwrap 双成功后置位（unwrap 成功证明 keychain 中 KEK 与 keyslot 匹配）。"
+    - "`derive_master_key_for_proof` 在 store_kek 成功后置位；store_keyslot / unwrap 失败的回滚路径在 delete_kek 后复位。"
+    - "`unlock` 路径在 `kek_observed == true` 时跳过 store_kek 刷新写入；为 false 时按原逻辑写入并在成功后置位（保持失败仅 warn 的非致命语义）。"
+    - "`verify_keychain_access` 在 `kek_observed == true` 时直接返回 Ok(true)，不访问 keychain；否则按原 load_kek 探测路径执行，并在 Ok 时置位。"
+    - "`factory_reset` 在 delete_kek 之后复位 `kek_observed = false`，确保下一轮初始化重新走完整观察路径。"
+    - "`SpaceAccessPort` trait 公共签名零变化；调用方（EncryptionFacade / UnlockSpaceUseCase / Webserver handler）零变化。"
+    - "字节级行为零变化：V1 加密协议（Argon2id KDF + XChaCha20-Poly1305 wrap/unwrap）不动；keyslot 落盘内容不动；KEK 派生算法不动。"
+  artifacts:
+    - path: "src-tauri/crates/uc-infra/src/security/space_access_adapter.rs"
+      provides: "kek_observed 进程级缓存 + 五处置位/复位 + verify_keychain_access / unlock 缓存命中分支"
+      contains: "kek_observed"
+  key_links:
+    - from: "DefaultSpaceAccessAdapter::verify_keychain_access"
+      to: "kek_observed.load (Acquire)"
+      via: "命中即返回 Ok(true)，不再调用 key_material.load_kek"
+      pattern: "kek_observed.load.*Acquire"
+    - from: "DefaultSpaceAccessAdapter::unlock"
+      to: "kek_observed.load (Acquire)"
+      via: "命中即跳过 store_kek 刷新写入"
+      pattern: "kek_observed.load.*Acquire"
+    - from: "DefaultSpaceAccessAdapter::try_resume_session"
+      to: "kek_observed.store(true, Release)"
+      via: "load_kek + unwrap 双成功后置位"
+      pattern: "kek_observed.store.true.*Release"
+    - from: "DefaultSpaceAccessAdapter::do_first_time_init"
+      to: "kek_observed.store(true, Release)"
+      via: "store_kek 成功后置位；store_keyslot 失败回滚路径置 false"
+      pattern: "kek_observed.store"
+    - from: "DefaultSpaceAccessAdapter::factory_reset"
+      to: "kek_observed.store(false, Release)"
+      via: "delete_kek 之后复位"
+      pattern: "kek_observed.store.false"
+---
+
+<objective>
+减少首次使用 UniClipboard 时 macOS 弹出 Keychain 授权对话框的次数。
+
+**问题**：首次使用流程会在 `try_resume_session` → `verify_keychain_access` → `unlock.store_kek refresh` 三个独立路径上各自访问 keychain 条目（`UniClipboard` / `kek:v1:<scope>`），即便用户已在第一次弹窗里点 Always Allow，未签名 / 签名身份漂移的 dev 构建上仍可能连弹多次。`do_first_time_init` 自身也是一次 store_kek（首次写入），导致首次上手用户体感 4–5 次弹窗。
+
+**目标**：把"本进程已确认 keychain 中存在与本机 keyslot 匹配的 KEK"作为进程级幂等开关。一旦观察过一次，本进程内后续所有非必要的 keychain 访问全部跳过——首次弹窗次数从 4–5 次压到 1–2 次（首次 store_kek 一次；用户点 Always Allow 后整个进程生命周期内不再弹）。
+
+**不动**：
+- `SpaceAccessPort` 公共 trait（uc-core 边界）
+- `KeyMaterialStore` / `SystemSecureStorage` / `keyring` 调用层
+- `InMemorySession` 本身（master_key 生命周期与本优化解耦）
+- V1 加密协议字节序列、keyslot 文件格式、KEK 派生算法
+- 测试 fake 实现（fake 不依赖 kek_observed 字段）
+</objective>
+
+<execution_context>
+@.planning/quick/260505-keychain-prompts/260505-PLAN.md
+</execution_context>
+
+<context>
+
+# 关键文件
+
+@src-tauri/crates/uc-infra/AGENTS.md
+@src-tauri/crates/uc-infra/src/security/space_access_adapter.rs
+
+# 调用链概览
+
+- `EncryptionFacade::unlock` → `SpaceAccessPort::try_resume_session`（启动期静默恢复）
+- `EncryptionFacade::verify_keychain_access` → `SpaceAccessPort::verify_keychain_access`（前端探测授权状态）
+- `UnlockSpaceUseCase::execute` → `SpaceAccessPort::unlock(passphrase)`（用户输入口令解锁）
+- `EncryptionFacade::initialize` → `SpaceAccessPort::initialize` → `do_first_time_init`（首次创建空间）
+- `derive_master_key_for_proof` 由 pairing joiner 流程调用（`SpaceAccessPort::derive_master_key_for_proof`）
+
+# 设计要点
+
+- `kek_observed` 是 `AtomicBool`，进程级单例；不写入 session.rs（`InMemorySession` 关心的是 in-memory master_key 生命周期，与 keychain ACL 状态正交）。
+- 状态语义：`true` ⇒ 本进程内已经成功 load_kek 或 store_kek 过 → keychain 已为本应用授予访问 → 后续 set/get 在已点 Always Allow 的应用上理论上不弹；但保险起见，能跳过的 keychain 调用一律跳过。
+- `lock()` 仅清空 in-memory master_key，**不复位 kek_observed**：keychain 条目本身不受 lock 影响，re-unlock 时同 KEK 仍在。
+- `factory_reset()` 删除了 keychain 条目，**必须复位 kek_observed**，否则下次 verify_keychain_access 会错误地返回 Ok(true)。
+
+</context>
+
+<tasks>
+
+## Task 1 — 在 DefaultSpaceAccessAdapter 加 kek_observed 字段
+
+**file:** `src-tauri/crates/uc-infra/src/security/space_access_adapter.rs`
+
+**action:**
+1. `use std::sync::atomic::{AtomicBool, Ordering};`
+2. `DefaultSpaceAccessAdapter` 结构体新增字段 `kek_observed: AtomicBool`（带 doc comment 说明语义、置位条件、复位条件）。
+3. `new()` 中 `kek_observed: AtomicBool::new(false)`。
+
+**verify:** `cargo check -p uc-infra` 通过。
+
+**done:** 字段定义、构造、文档注释三齐。
+
+---
+
+## Task 2 — `do_first_time_init` / `derive_master_key_for_proof` 写入路径标记
+
+**file:** `src-tauri/crates/uc-infra/src/security/space_access_adapter.rs`
+
+**action:**
+1. `do_first_time_init`：`store_kek` 成功后 `kek_observed.store(true, Release)`；`store_keyslot` 失败回滚路径在 `delete_kek` 之后 `kek_observed.store(false, Release)`。
+2. `derive_master_key_for_proof`：同上 — `store_kek` 成功置位；`store_keyslot` 失败回滚 + `unwrap` 失败回滚都在 `delete_kek` 之后置 false。
+
+**verify:** `cargo check -p uc-infra` 通过；`cargo clippy -p uc-infra --no-deps` 不新增 warning。
+
+**done:** 五处 `kek_observed.store` 全部就位（init 1 写 + 1 回滚；proof 1 写 + 2 回滚）。
+
+---
+
+## Task 3 — `try_resume_session` 静默恢复成功后置位
+
+**file:** `src-tauri/crates/uc-infra/src/security/space_access_adapter.rs`
+
+**action:** 在 `unwrap_master_key_xchacha` 成功之后、`session.set_master_key` 之前置位 `kek_observed.store(true, Release)`，并加 inline 注释说明"load_kek 成功 + unwrap 成功 ⇒ keychain 中 KEK 与本机 keyslot 匹配"。
+
+**verify:** `cargo check -p uc-infra` 通过。
+
+**done:** 置位语句存在；注释解释"为什么置位是安全的"。
+
+---
+
+## Task 4 — `unlock` 跳过冗余 store_kek 刷新
+
+**file:** `src-tauri/crates/uc-infra/src/security/space_access_adapter.rs`
+
+**action:**
+- 把原 `if let Err(e) = self.key_material.store_kek(...).await { warn!(...) }` 替换为三分支：
+  1. `kek_observed.load(Acquire) == true` ⇒ `debug!` 跳过；
+  2. 否则尝试 store_kek，失败 `warn!` 不影响解锁；
+  3. 成功则 `kek_observed.store(true, Release)`。
+- inline doc 解释为什么 unwrap 成功后跳过 refresh 是安全的（同 KEK，无信息增量）。
+
+**verify:** `cargo check -p uc-infra` 通过。
+
+**done:** 三分支 + 文档齐全。
+
+---
+
+## Task 5 — `verify_keychain_access` 命中即返回 + `factory_reset` 复位
+
+**file:** `src-tauri/crates/uc-infra/src/security/space_access_adapter.rs`
+
+**action:**
+- `verify_keychain_access`：函数体最前面 `if self.kek_observed.load(Acquire) { return Ok(true); }`；下方原 load_kek 探测的 `Ok(_)` 分支改为先置位再返回 `Ok(true)`。
+- `factory_reset`：`delete_kek` 之后、`session.clear()` 之前 `kek_observed.store(false, Release)`。
+
+**verify:** `cargo check -p uc-infra` + `cargo clippy -p uc-infra --no-deps` 通过；`cargo test -p uc-infra --lib security` 全部通过。
+
+**done:** verify 走 fast path；factory_reset 复位标志。
+
+</tasks>

--- a/.planning/quick/260505-keychain-prompts/260505-SUMMARY.md
+++ b/.planning/quick/260505-keychain-prompts/260505-SUMMARY.md
@@ -1,0 +1,66 @@
+---
+quick_id: 260505-keychain-prompts
+status: complete
+date: 2026-05-05
+plans_executed: 1
+files_modified:
+  - src-tauri/crates/uc-infra/src/security/space_access_adapter.rs
+---
+
+# Quick Task 260505 — 减少 macOS Keychain 多次弹窗
+
+## 问题
+
+首次使用 UniClipboard 时，macOS 会多次弹出 Keychain 授权对话框。诊断结论：进程内同一条 keychain 条目（`UniClipboard` / `kek:v1:<scope>`）被以下三条独立路径串行访问，每条都可能触发独立的授权提示：
+
+1. `try_resume_session` → `load_kek`（启动期静默恢复）
+2. `verify_keychain_access` → `load_kek`（前端探测授权状态）
+3. `unlock(passphrase)` → `store_kek` 刷新写入（注释自承"保持 keyring 与最新口令对齐"）
+
+加上 `do_first_time_init` 自身的首次 `store_kek`，未签名 / dev 构建上的首次上手用户体感 4–5 次弹窗。
+
+## 改动
+
+只动一个文件：`src-tauri/crates/uc-infra/src/security/space_access_adapter.rs`（+49/-2）。
+
+引入进程级幂等开关 `kek_observed: AtomicBool`，语义为"本进程内已确认 keychain 中存在与本机 keyslot 匹配的 KEK"：
+
+| 路径 | 行为 |
+|---|---|
+| `do_first_time_init` | `store_kek` 成功 → 置 true；`store_keyslot` 失败回滚路径在 `delete_kek` 之后置 false。 |
+| `derive_master_key_for_proof`（pairing joiner）| 同上：`store_kek` 成功 → 置 true；两条回滚路径置 false。 |
+| `try_resume_session` | `load_kek` 成功 + `unwrap` 成功 → 置 true（unwrap 成功证明 keychain 中 KEK 与本机 keyslot 匹配）。 |
+| `unlock(passphrase)` | `kek_observed == true` 时**跳过** `store_kek` 刷新写入（同 KEK 无信息增量）；否则走原写入路径，成功后置 true。失败仍仅 `warn`，非致命。 |
+| `verify_keychain_access` | `kek_observed == true` 直接返回 `Ok(true)`，不访问 keychain；否则按原 `load_kek` 探测，`Ok(_)` 分支置 true 后返回。 |
+| `factory_reset` | `delete_kek` 之后**复位 false**（keychain 条目已删除）。 |
+| `lock` | **不复位**（keychain 条目不受影响，re-unlock 仍是同 KEK）。 |
+
+## 设计决定
+
+- **位置**：`AtomicBool` 直接挂在 `DefaultSpaceAccessAdapter`，**不**进 `InMemorySession`。`InMemorySession` 关心 in-memory `master_key` 生命周期；keychain ACL 是进程级独立维度，与 `lock()` 解耦。
+- **内存序**：`Acquire`/`Release`，单写多读路径下足够。
+- **公共边界零变化**：`SpaceAccessPort` trait 签名、`KeyMaterialStore` / `SystemSecureStorage` API、所有调用方（`EncryptionFacade`、`UnlockSpaceUseCase`、webserver handler）一律不动。V1 加密协议字节、keyslot 文件格式、KEK 派生算法不动。
+- **未触及**：应用签名 / `tauri.conf.json` / `resolve_service_name()` 的稳定化属于另一类问题（运维 / 构建配置），不在本任务 scope；本次只解决"代码层重复访问"造成的弹窗。
+
+## 预期效果
+
+| 场景 | 改动前弹窗次数 | 改动后弹窗次数 |
+|---|---|---|
+| 首次使用（无 keyslot） | `do_first_time_init.store_kek` × 1 + `unlock.store_kek refresh` × 1 + 后续 `verify_keychain_access` ≈ 2–3 次 | `do_first_time_init.store_kek` × 1（用户点 Always Allow 后整个进程不再弹） |
+| 后续启动 | `try_resume_session.load_kek` × 1 + `verify_keychain_access` × 1 = 2 次 | `try_resume_session.load_kek` × 1 |
+| Lock → 重新 unlock | `unlock.store_kek refresh` × 1 | 0（`kek_observed` 在 lock 时不复位）|
+| `factory_reset` 后再初始化 | 同首次使用 | 同首次使用（`kek_observed` 已复位为 false） |
+
+## 验证
+
+- `cargo check -p uc-infra` ✅
+- `cargo clippy -p uc-infra --no-deps` ✅（17 个 warning 全部为既存，本文件 0 新增）
+- `cargo test -p uc-infra --lib security` ✅（11/11 PASS）
+- 公共 trait + 调用链零变化，调用方无需改动；fake / mock 实现（用于上层 use case 测试）不依赖 `kek_observed`，无影响。
+
+## 后续
+
+剩余的"代码外"弹窗源（属另一议题，本任务不处理）：
+
+- 应用签名 / signingIdentity 稳定（dev 构建未签名时即便逻辑正确也每次都问）
+- `resolve_service_name()` 在 release / dev / `UNICLIPBOARD_PROFILE` 切换时返回值要稳定（不同 service 是不同 keychain 条目）

--- a/.planning/quick/260505-keychain-startup-resume-gate/260505-PLAN.md
+++ b/.planning/quick/260505-keychain-startup-resume-gate/260505-PLAN.md
@@ -1,0 +1,141 @@
+---
+phase: 260505-keychain-startup-resume-gate
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - src-tauri/crates/uc-desktop/src/daemon/startup_recovery.rs
+autonomous: true
+---
+
+<objective>
+**问题**：用户在 GUI Unlock 页面观察到——
+1. 没在 settings 启用 auto unlock
+2. 没点击 Unlock 按钮
+
+但 macOS 仍然弹出了 keychain 访问请求。违反此前明确的三条访问规则
+（仅允许：手动 unlock / auto-unlock 流程 / 设置加密口令）。
+
+**根因**：`uc-desktop/src/daemon/startup_recovery.rs:57` 在 daemon 启动后台
+任务里**无条件**调用 `space_setup.try_resume_session()`：
+
+```
+spawn_startup_recovery
+  → recover_encryption_session(auto_unlock=false) → Ok(false)   ✅ 正确跳过
+  → space_setup.try_resume_session()                            ❌ 未守卫
+    → space_access.try_resume_session(SpaceId::new())
+      → adapter.load_kek()                                      ❌ macOS 弹窗
+```
+
+`space_setup.try_resume_session` 内部只看 `setup_status.has_completed`，
+不看 `auto_unlock_enabled`；用户已经设过加密口令（has_completed=true），
+所以无视 auto-unlock 开关直接下沉到 keychain。
+
+之前在 `try_resume_session` adapter 内加的 `is_ready()` short-circuit
+只在 session 已经 in-memory 时命中——启动期 in-memory 为空，short-circuit
+不命中，仍走 `load_kek` → keychain。
+
+**目标**：让 `space_setup.try_resume_session()` 只在 KEK 已经成功装进
+内存（`recover_encryption_session` 返回 `Ok(true)`）后才执行。这样：
+
+- auto_unlock_enabled=true → recover 成功 → unlocked=true →
+  space_setup.try_resume_session → adapter is_ready() short-circuit 命中 →
+  零 keychain 接触
+- auto_unlock_enabled=false → recover 直接 Ok(false) → unlocked=false →
+  跳过 space_setup.try_resume_session → 零 keychain 接触
+- 用户点 unlock → 走 EncryptionFacade::unlock 路径 → 弹 keychain（规则 #1）
+
+**非目标**（本次不做）：
+- 不动 `EncryptionFacade::unlock` / `SpaceSetupFacade::try_resume_session`
+  本身的逻辑或公开 API
+- 不动 adapter 层 `is_ready()` short-circuit（已在前一任务落地）
+- 不为 "auto_unlock_enabled=false 时的 switch-space migration recovery"
+  补一个新触发点。副作用接受：用户点 unlock 后再走 migration recovery
+  也不迟（且没有 KEK 也推不动）
+
+**安全权衡**：无新风险。仅去除一条不该走的 keychain 访问路径，对真正
+需要 keychain 的三条规则（手动 unlock / auto-unlock / 设密码）零影响。
+</objective>
+
+<execution_context>
+@.planning/quick/260505-keychain-startup-resume-gate/260505-PLAN.md
+</execution_context>
+
+<context>
+
+# 关键文件
+
+@src-tauri/crates/uc-desktop/src/daemon/startup_recovery.rs
+@src-tauri/crates/uc-desktop/src/daemon/app.rs
+@src-tauri/crates/uc-application/src/facade/space_setup/facade.rs
+@src-tauri/crates/uc-infra/src/security/space_access_adapter.rs
+
+# 调用链对比
+
+**修复前**（auto_unlock_enabled=false + has_completed=true）：
+```
+spawn_startup_recovery
+  → recover_encryption_session(false) → Ok(false)   [正确跳过]
+  → space_setup.try_resume_session()                [漏网之鱼]
+    → space_access.try_resume_session(SpaceId::new())
+      → adapter.try_resume_session
+        → is_ready()? false (启动期内存空)
+        → load_kek() → ★ macOS 弹窗 ★
+```
+
+**修复后**（auto_unlock_enabled=false + has_completed=true）：
+```
+spawn_startup_recovery
+  → recover_encryption_session(false) → Ok(false)
+  → unlocked=false → 跳过 space_setup.try_resume_session
+  → 0 次 keychain 接触
+```
+
+**修复后**（auto_unlock_enabled=true + has_completed=true）：
+```
+spawn_startup_recovery
+  → recover_encryption_session(true) → 内部走 EncryptionFacade::unlock
+    → adapter.try_resume_session → is_ready=false → load_kek → 弹窗（规则 #2 允许）
+    → 装入 in-memory session
+  → unlocked=true → space_setup.try_resume_session
+    → space_access.try_resume_session(SpaceId::new())
+      → adapter.try_resume_session
+        → is_ready()? true ✅ short-circuit
+        → 0 次额外 keychain 接触
+  → 总 1 次（规则 #2 允许的那一次）
+```
+
+</context>
+
+<tasks>
+
+## Task 1 — 把 try_resume_session 调用守在 unlocked 之后
+
+**file:** `src-tauri/crates/uc-desktop/src/daemon/startup_recovery.rs`
+
+**action:**
+1. 把 `match input.space_setup.try_resume_session().await { ... }` 块包进
+   `if unlocked { ... } else { tracing::info!(...) }` 守卫。
+2. 在 `if unlocked` 上方加 doc-comment 说明：a) 为何只在 unlocked 时调用；
+   b) 副作用——auto_unlock=false 时启动期跳过 migration recovery；
+   c) 用户点 unlock 后再做也不迟。
+3. else 分支输出 info 日志（便于排障辨认"为什么没发生 resume"）。
+
+**verify:** `cargo check -p uc-desktop` 通过。
+
+**done:** 守卫逻辑落地，日志清晰。
+
+---
+
+## Task 2 — 编译 / clippy / 测试验证
+
+**action:**
+- `RUSTC_WRAPPER= cargo check -p uc-desktop` 通过
+- `RUSTC_WRAPPER= cargo clippy -p uc-desktop --no-deps` 不新增 warning
+  （既存 1 个 derivable_impls 与本次无关）
+- `RUSTC_WRAPPER= cargo test -p uc-desktop --lib` 全 PASS（41 个）
+
+**done:** 三项均通过。
+
+</tasks>

--- a/.planning/quick/260505-keychain-startup-resume-gate/260505-SUMMARY.md
+++ b/.planning/quick/260505-keychain-startup-resume-gate/260505-SUMMARY.md
@@ -1,0 +1,99 @@
+---
+quick_id: 260505-keychain-startup-resume-gate
+status: complete
+date: 2026-05-05
+plans_executed: 1
+files_modified:
+  - src-tauri/crates/uc-desktop/src/daemon/startup_recovery.rs
+---
+
+# Quick Task 260505 — startup_recovery 守卫 try_resume_session（GUI 启动期 keychain 弹窗第三幕）
+
+## 背景
+
+前两个 quick task 已经按规则 #1/#2/#3 收口了 KEK 路径与 iroh 设备身份：
+
+- `260505-keychain-prompts`: `kek_observed` 进程级缓存，压住加密路径重复弹窗
+- `260505-iroh-identity-file-storage`: iroh 长期身份脱离 keychain，走 0600 文件
+- `260505-iroh-identity-file-storage` 后续: `try_resume_session` 在 session 已 in-memory 时 short-circuit
+
+但用户实测仍有问题：**GUI 启动后没启用 auto unlock、没点 Unlock 按钮，依然弹 keychain。**
+
+## 真凶
+
+`uc-desktop/src/daemon/startup_recovery.rs:57` 在 daemon 后台启动任务里
+**无条件**调用 `space_setup.try_resume_session()`：
+
+```text
+spawn_startup_recovery
+  → recover_encryption_session(auto_unlock=false) → Ok(false)   ← 这步正确
+  → space_setup.try_resume_session()                            ← 这步未守卫
+    → space_access.try_resume_session(SpaceId::new())
+      → adapter.try_resume_session
+        → is_ready()? false   (启动期 in-memory session 为空)
+        → load_kek()  → ★ macOS 弹窗 ★
+```
+
+`SpaceSetupFacade::try_resume_session` 内部只判断 `setup_status.has_completed`，
+不判断 `auto_unlock_enabled`。用户已经设过加密口令（has_completed=true），
+就直接绕过 auto-unlock 开关，把 KEK 访问下沉到 keychain。
+
+之前在 `DefaultSpaceAccessAdapter::try_resume_session` 加的 `is_ready()`
+short-circuit 只对"session 已经在内存中"的二次调用生效——启动期内存为空，
+short-circuit 不命中。
+
+## 改动
+
+只动 desktop 启动恢复一处，零业务/公共 API 变化。
+
+`src-tauri/crates/uc-desktop/src/daemon/startup_recovery.rs`（+22/-12）：
+
+把 `match input.space_setup.try_resume_session().await { ... }` 块包进
+`if unlocked { ... } else { tracing::info!(...) }`：
+
+```rust
+if unlocked {
+    match input.space_setup.try_resume_session().await {
+        Ok(true)  => { input.space_setup.refresh_presence().await; }
+        Ok(false) => tracing::info!(...),
+        Err(e)    => tracing::warn!(...),
+    }
+} else {
+    tracing::info!(
+        "background unlock: encryption session not unlocked — \
+         skipping space_setup resume to avoid keychain prompt"
+    );
+}
+```
+
+## 启动期 keychain 接触次数对照（GUI 启动）
+
+| 场景 | 改动前 | 改动后 |
+|---|---|---|
+| 已 setup, auto_unlock=false（用户场景） | **1 次（弹窗）** ❌ | 0 次 ✅ |
+| 已 setup, auto_unlock=true | 1 次（规则 #2 允许） | 1 次（规则 #2 允许）|
+| 未 setup（首次安装） | 0 次（has_completed=false 自然短路）| 0 次 |
+| 用户在 GUI 点 unlock | 0 次启动期 + 1 次（规则 #1 允许）| 同 |
+
+## 副作用
+
+- auto_unlock_enabled=false 时，启动期不再自动推进 switch-space migration recovery。
+- 缓解：没 KEK 也推不动 migration；用户点 unlock 解出 KEK 后再做也不迟
+  （后续可以在 EncryptionFacade::unlock 成功后追加一次 migration_state 查询，
+  此处不在本任务范围）。
+
+## 验证
+
+- `cargo check -p uc-desktop` ✅
+- `cargo clippy -p uc-desktop --no-deps` ✅（既存 1 个 derivable_impls warning 与本次无关）
+- `cargo test -p uc-desktop --lib` ✅ 41/41 PASS
+
+## 与前两个 quick task 的关系
+
+| Quick task | 修的弹窗路径 | 触发条件 |
+|---|---|---|
+| `260505-keychain-prompts` | KEK get/set 重复访问 | 加密路径同会话内多次操作 |
+| `260505-iroh-identity-file-storage` | iroh 身份 keychain entry | 启动期 IrohNodeBuilder::bind |
+| `260505-keychain-startup-resume-gate`（本次） | space_setup.try_resume_session → load_kek | daemon startup_recovery，has_completed=true 但 auto_unlock=false |
+
+三者属于不同 root cause、不同代码路径，叠加才完整覆盖"非授权场景下绝不接触 keychain"。

--- a/src-tauri/crates/uc-bootstrap/src/assembly.rs
+++ b/src-tauri/crates/uc-bootstrap/src/assembly.rs
@@ -157,6 +157,14 @@ pub struct WiredDependencies {
     /// Slice 3 Phase 1:iroh-blobs store 目录。由 `SpaceSetupAssembly`
     /// 装配 iroh blob handler 时使用。
     pub iroh_blob_store_dir: PathBuf,
+    /// iroh 长期 Ed25519 设备身份的文件存储根目录(`<app_data>/iroh-identity[_<profile>]/`)。
+    ///
+    /// 与 KEK 的系统 keychain 隔离:iroh 设备身份是网络栈的"我是哪台机器"
+    /// 标识,**不是**用户秘密;不应跟用户口令派生密钥共用同一条 macOS
+    /// keychain 条目,否则启动期 `IrohNodeBuilder::bind` 会在用户没有任何
+    /// 操作前触发 keychain 弹窗(违反"只在用户解锁/初始化时访问 keychain"
+    /// 的边界规则)。
+    pub iroh_identity_dir: PathBuf,
     /// Slice 3 Phase 1:明文 hash → 密文 digest 去重缓存。
     pub blob_reference_repo: Arc<dyn BlobReferenceRepositoryPort>,
     /// Switch-space 重加密迁移：跨重启的阶段持久化 port，落地为
@@ -799,6 +807,17 @@ pub fn wire_dependencies(config: &AppConfig) -> WiringResult<WiredDependencies> 
     let blob_reference_repo_for_wiring = Arc::clone(&infra.blob_reference_repo);
     let iroh_blob_store_dir_for_wiring =
         apply_profile_suffix(paths.app_data_root_dir.join("iroh-blobs"));
+    // iroh 设备身份的文件存储目录。先 mkdir,确保 `FileSecureStorage::with_base_dir`
+    // 在首次写身份时不会因目录不存在而失败。`apply_profile_suffix` 与
+    // `iroh_blob_store_dir` 用同一规则,保证 multi-profile dev 隔离。
+    let iroh_identity_dir_for_wiring =
+        apply_profile_suffix(paths.app_data_root_dir.join("iroh-identity"));
+    std::fs::create_dir_all(&iroh_identity_dir_for_wiring).map_err(|e| {
+        WiringError::SecureStorageInit(format!(
+            "failed to create iroh-identity dir {}: {e}",
+            iroh_identity_dir_for_wiring.display()
+        ))
+    })?;
 
     // Switch-space migration ports for SpaceSetupFacade. Same WiredDependencies
     // bypass pattern as `peer_addr_repo` — consumer lives in uc-application.
@@ -898,6 +917,7 @@ pub fn wire_dependencies(config: &AppConfig) -> WiringResult<WiredDependencies> 
         trusted_peer_repo: trusted_peer_repo_for_wiring,
         peer_addr_repo: peer_addr_repo_for_wiring,
         iroh_blob_store_dir: iroh_blob_store_dir_for_wiring,
+        iroh_identity_dir: iroh_identity_dir_for_wiring,
         blob_reference_repo: blob_reference_repo_for_wiring,
         migration_state: migration_state_for_wiring,
         key_migration: key_migration_for_wiring,

--- a/src-tauri/crates/uc-bootstrap/src/space_setup.rs
+++ b/src-tauri/crates/uc-bootstrap/src/space_setup.rs
@@ -48,6 +48,7 @@ use uc_infra::network::iroh::{
 // having to `use uc_infra` themselves.
 pub use uc_infra::network::iroh::IrohNodeConfig;
 use uc_infra::security::Sha256IdentityFingerprintFactory;
+use uc_platform::file_secure_storage::FileSecureStorage;
 
 use crate::assembly::WiredDependencies;
 
@@ -217,8 +218,30 @@ pub async fn build_space_setup_assembly(
     // fresh one here rather than down-casting through `dyn` because
     // `IrohIdentityStore::new` takes the concrete factory trait object and
     // we'd have to re-wrap anyway.
+    //
+    // **Storage backend separation**: iroh 长期 Ed25519 设备密钥走独立的
+    // `FileSecureStorage`(落地 `<app_data>/iroh-identity[_<profile>]/`),不
+    // 复用 `deps.security.secure_storage`(即 KEK 用的系统 keychain)。
+    //
+    // Why: `IrohNodeBuilder::bind` 在应用启动期被调用,会 `ensure_secret_key`
+    // → `secure_storage.get/set("iroh-identity:v1")`。如果用 keychain 后端,
+    // 这条路径会在用户**没有任何操作**(没点 unlock、没启用 auto-unlock、
+    // 没设置加密口令)的情况下触发 macOS keychain 弹窗,违反"keychain 只
+    // 在用户解锁/初始化加密时访问"的边界规则。
+    //
+    // 设备身份密钥不是用户秘密,本身只能用于 P2P 网络握手身份伪冒(且
+    // 攻击者还需要 KEK 才能解密剪贴板内容),用 0600 文件 + FileVault
+    // 全盘加密保护已足够,与 SSH/IPFS/Tailscale 等同类工具实践一致。
+    //
+    // Migration: 老用户 keychain 中残留的 `iroh-identity:v1` 条目**不动**
+    // (不读、不删,避免触发新的 keychain 弹窗);文件不存在 →
+    // `IrohIdentityStore::ensure_secret_key` 生成新身份 → 老用户在升级后
+    // iroh 设备身份重置,需要重新与 peer 配对一次。
+    let iroh_identity_storage: Arc<dyn uc_core::ports::SecureStoragePort> = Arc::new(
+        FileSecureStorage::with_base_dir(wired.iroh_identity_dir.clone()),
+    );
     let identity_store = Arc::new(IrohIdentityStore::new(
-        Arc::clone(&deps.security.secure_storage),
+        iroh_identity_storage,
         Arc::new(Sha256IdentityFingerprintFactory),
     ));
 

--- a/src-tauri/crates/uc-desktop/src/daemon/startup_recovery.rs
+++ b/src-tauri/crates/uc-desktop/src/daemon/startup_recovery.rs
@@ -54,20 +54,36 @@ pub fn spawn_startup_recovery(input: StartupRecoveryInput) {
             }
         };
 
-        match input.space_setup.try_resume_session().await {
-            Ok(true) => {
-                if let Err(error) = input.space_setup.refresh_presence().await {
-                    tracing::warn!(error = %error, "background unlock: presence probe failed");
+        // Gate: 仅当 KEK 已经被 `recover_encryption_session` 装进内存
+        // (即 auto_unlock_enabled=true 且解锁成功) 时，才进入 facade-level
+        // resume。否则 `space_setup.try_resume_session` 会下沉到
+        // `space_access.try_resume_session` → `load_kek` → 触发 macOS
+        // keychain 访问弹窗——而用户场景是"没启用 auto unlock、没点
+        // unlock 按钮"，按规则 #1/#2/#3 此刻不该接触 keychain。
+        //
+        // 副作用：auto_unlock_enabled=false 时，启动期不再自动推进
+        // switch-space migration recovery；但没有 KEK 也推不动，等用户
+        // 点 unlock / 显式 auto-unlock 后再做也不迟。
+        if unlocked {
+            match input.space_setup.try_resume_session().await {
+                Ok(true) => {
+                    if let Err(error) = input.space_setup.refresh_presence().await {
+                        tracing::warn!(error = %error, "background unlock: presence probe failed");
+                    }
+                }
+                Ok(false) => {
+                    tracing::info!(
+                        "background unlock: no space on this profile — skipping resume/probe"
+                    );
+                }
+                Err(error) => {
+                    tracing::warn!(error = ?error, "background unlock: try_resume_session failed");
                 }
             }
-            Ok(false) => {
-                tracing::info!(
-                    "background unlock: no space on this profile — skipping resume/probe"
-                );
-            }
-            Err(error) => {
-                tracing::warn!(error = ?error, "background unlock: try_resume_session failed");
-            }
+        } else {
+            tracing::info!(
+                "background unlock: encryption session not unlocked — skipping space_setup resume to avoid keychain prompt"
+            );
         }
 
         if input.run_mode.auto_triggers_deferred_services() && unlocked {

--- a/src-tauri/crates/uc-infra/src/security/space_access_adapter.rs
+++ b/src-tauri/crates/uc-infra/src/security/space_access_adapter.rs
@@ -9,6 +9,7 @@
 //! 字节级行为与历史 `EncryptionRepository` 一致——V1 加密协议
 //! (Argon2id KDF + XChaCha20-Poly1305 wrap/unwrap) ironclad 保留。
 
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -37,6 +38,18 @@ pub struct DefaultSpaceAccessAdapter {
     key_material: Arc<KeyMaterialStore>,
     current_profile: Arc<dyn CurrentProfilePort>,
     session: Arc<InMemorySession>,
+    /// 本进程内是否已经确认 keychain 中存在与本机 keyslot 匹配的 KEK。
+    ///
+    /// 一旦置位（`do_first_time_init` / `try_resume_session` /
+    /// `derive_master_key_for_proof` 成功，或 `unlock` 完成首次刷新写入后），
+    /// 后续的 `verify_keychain_access` 直接返回 `Ok(true)`，`unlock` 路径上
+    /// 的"刷新写入"也跳过——避免在 macOS 上重复触发 keychain 授权弹窗
+    /// （首次使用场景下原本会因 `try_resume_session` →
+    /// `verify_keychain_access` → `unlock.store_kek refresh` 三次独立访问
+    /// 而连弹三次）。
+    ///
+    /// `factory_reset` 删除 KEK 后必须复位为 `false`。
+    kek_observed: AtomicBool,
 }
 
 impl DefaultSpaceAccessAdapter {
@@ -49,6 +62,7 @@ impl DefaultSpaceAccessAdapter {
             key_material,
             current_profile,
             session,
+            kek_observed: AtomicBool::new(false),
         }
     }
 }
@@ -113,6 +127,7 @@ impl DefaultSpaceAccessAdapter {
             error!(error = %e, "store_kek failed");
             return Err(map_encryption_error(e));
         }
+        self.kek_observed.store(true, Ordering::Release);
 
         if let Err(e) = self.key_material.store_keyslot(&keyslot).await {
             error!(error = %e, "store_keyslot failed");
@@ -122,6 +137,7 @@ impl DefaultSpaceAccessAdapter {
             if let Err(err) = self.key_material.delete_kek(scope).await {
                 warn!(error = %err, "rollback delete_kek failed");
             }
+            self.kek_observed.store(false, Ordering::Release);
             return Err(map_encryption_error(e));
         }
 
@@ -219,8 +235,19 @@ impl SpaceAccessPort for DefaultSpaceAccessAdapter {
 
             // 把派生出的 KEK 重新写入 keyring,保持 keyring 与最新口令对齐
             // (让下次静默 startup 路径仍可命中)。失败仅 warn,不影响本次解锁。
-            if let Err(e) = self.key_material.store_kek(&scope, &kek).await {
+            //
+            // 优化:若本进程内已确认 keychain 中存在 KEK
+            // (`try_resume_session` / `do_first_time_init` /
+            // `derive_master_key_for_proof` 任一已置位 `kek_observed`),
+            // 此处 `unwrap` 已经成功——意味着本次派生出的 KEK 字节就是
+            // keychain 里那条记录的字节,再写一次没有信息增量,但在 macOS
+            // 上每次 set_secret 仍可能触发授权弹窗。因此跳过。
+            if self.kek_observed.load(Ordering::Acquire) {
+                debug!("skip store_kek refresh: KEK already observed in keychain this session");
+            } else if let Err(e) = self.key_material.store_kek(&scope, &kek).await {
                 warn!(error = %e, "store_kek refresh failed (non-fatal)");
+            } else {
+                self.kek_observed.store(true, Ordering::Release);
             }
 
             self.session.set_master_key(master_key);
@@ -260,6 +287,7 @@ impl SpaceAccessPort for DefaultSpaceAccessAdapter {
                 Ok(()) | Err(EncryptionError::KeyNotFound) => {}
                 Err(e) => return Err(map_encryption_error(e)),
             }
+            self.kek_observed.store(false, Ordering::Release);
             self.session.clear();
             Ok(())
         }
@@ -312,6 +340,11 @@ impl SpaceAccessPort for DefaultSpaceAccessAdapter {
             let master_key = v1_aead::unwrap_master_key_xchacha(&kek, &wrapped_master_key.blob)
                 .map_err(map_aead_error_for_unwrap)?;
 
+            // load_kek 成功 + unwrap 成功 ⇒ keychain 中 KEK 与本机 keyslot 匹配。
+            // 标记本进程已观察到该 KEK,后续 verify_keychain_access /
+            // unlock 路径无需再次访问 keychain。
+            self.kek_observed.store(true, Ordering::Release);
+
             self.session.set_master_key(master_key);
 
             info!("session resumed from keyring");
@@ -324,6 +357,14 @@ impl SpaceAccessPort for DefaultSpaceAccessAdapter {
     async fn verify_keychain_access(&self) -> Result<bool, SpaceAccessError> {
         let span = info_span!("infra.space_access.verify_keychain_access");
         async {
+            // 缓存命中:本进程内已成功 load_kek / store_kek 过——keychain
+            // 已经为本应用授予访问权限,无需再次探测。再次探测在 macOS 上
+            // 等价于一次 set_secret/get_secret 系统调用,可能触发新一轮
+            // 授权弹窗。
+            if self.kek_observed.load(Ordering::Acquire) {
+                return Ok(true);
+            }
+
             let profile = self
                 .current_profile
                 .current_profile()
@@ -334,7 +375,10 @@ impl SpaceAccessPort for DefaultSpaceAccessAdapter {
             // 探测: 把"权限被拒绝"和"keyring 暂时不可用"都视为 "Always Allow 未授予"
             // (Ok(false));只有"KEK 不存在"才升格成 NotInitialized 报错给上层。
             match self.key_material.load_kek(&scope).await {
-                Ok(_) => Ok(true),
+                Ok(_) => {
+                    self.kek_observed.store(true, Ordering::Release);
+                    Ok(true)
+                }
                 Err(EncryptionError::PermissionDenied) => Ok(false),
                 Err(EncryptionError::KeyringError(_)) => Ok(false),
                 Err(EncryptionError::KeyNotFound) => Err(SpaceAccessError::NotInitialized),
@@ -464,6 +508,7 @@ impl SpaceAccessPort for DefaultSpaceAccessAdapter {
                 error!(error = %e, "store_kek failed");
                 return Err(map_encryption_error(e));
             }
+            self.kek_observed.store(true, Ordering::Release);
 
             if let Err(e) = self.key_material.store_keyslot(&keyslot).await {
                 error!(error = %e, "store_keyslot failed");
@@ -473,6 +518,7 @@ impl SpaceAccessPort for DefaultSpaceAccessAdapter {
                 if let Err(err) = self.key_material.delete_kek(&scope).await {
                     warn!(error = %err, "rollback delete_kek failed");
                 }
+                self.kek_observed.store(false, Ordering::Release);
                 return Err(map_encryption_error(e));
             }
 
@@ -487,6 +533,7 @@ impl SpaceAccessPort for DefaultSpaceAccessAdapter {
                         if let Err(err) = self.key_material.delete_kek(&scope).await {
                             warn!(error = %err, "rollback delete_kek failed");
                         }
+                        self.kek_observed.store(false, Ordering::Release);
                         return Err(map_aead_error_for_unwrap(e));
                     }
                 };

--- a/src-tauri/crates/uc-infra/src/security/space_access_adapter.rs
+++ b/src-tauri/crates/uc-infra/src/security/space_access_adapter.rs
@@ -303,6 +303,16 @@ impl SpaceAccessPort for DefaultSpaceAccessAdapter {
         async {
             info!("attempting silent session resume from keyring");
 
+            // session 已经在内存中(典型场景:用户刚 `initialize` 完成,前端
+            // setup 后的 onSetupComplete 回调又调了一次 `EncryptionFacade::unlock`
+            // → 这里)。已经有 master_key,没必要再走 load_kek + unwrap +
+            // set_master_key 这一整圈——尤其是 load_kek 在 macOS 上每次都可能
+            // 触发 keychain 授权弹窗。直接返回 Ok(Some) 表达"会话已就绪"。
+            if self.session.is_ready() {
+                info!("session already in-memory, skip keychain probe");
+                return Ok(Some(ActiveSpace::new(space_id.clone())));
+            }
+
             if !self
                 .key_material
                 .keyslot_exists()


### PR DESCRIPTION
## Summary

按用户给出的三条 Keychain 访问规则（仅允许：手动 unlock / auto-unlock 流程触发 / 设置加密口令）逐条收口，消除启动期和加密路径的非法 Keychain 接触：

- **进程级 KEK 缓存** (`uc-infra`)：`DefaultSpaceAccessAdapter` 增加 `kek_observed: AtomicBool`，让 `verify_keychain_access` / `unlock` 的刷新写入 / `try_resume_session` 在同会话内幂等，并在 session 已 in-memory 时直接 short-circuit 跳过 `load_kek`。
- **iroh 设备身份脱离 Keychain** (`uc-bootstrap`)：iroh 长期 Ed25519 设备密钥改用独立的 `FileSecureStorage`（`<app_data>/iroh-identity[_<profile>]/`，0600），消除 `IrohNodeBuilder::bind` 启动期"用户没操作就弹"的根因；老 Keychain entry 不读不删（升级用户 iroh 身份重置 → 重新配对一次）。
- **startup_recovery 守 unlocked 闸** (`uc-desktop`)：`spawn_startup_recovery` 把 `space_setup.try_resume_session()` 包在 `if unlocked` 守卫里，避免 `auto_unlock_enabled=false` 但 `has_completed=true` 时仍下沉到 `load_kek`。

三条 fix 各自有独立的 quick-task PLAN/SUMMARY 落档（`.planning/quick/260505-*`），互不冗余、根因不同。

## Test plan

- [x] `cargo check --workspace` PASS
- [x] `cargo clippy -p uc-infra -p uc-bootstrap -p uc-desktop -p uc-platform --no-deps` 不新增 warning
- [x] `cargo test -p uc-infra --lib security` 11/11 PASS
- [x] `cargo test -p uc-platform --lib` 全 PASS
- [x] `cargo test -p uc-desktop --lib` 41/41 PASS
- [ ] 用户人工验证：全新启动 + auto_unlock=false + has_completed=true 场景下 0 次 Keychain 弹窗
- [ ] 用户人工验证：点击 Unlock 按钮路径只有 1 次 Keychain 弹窗（待用户确认；当前 dev 模式下报告仍偶现 2 次，可能为 codesign 漂移）