### PR TITLE
chore(deps): prune unused crate deps + wire backend Sentry end-to-end

### DIFF
--- a/.github/workflows/alpha-build.yml
+++ b/.github/workflows/alpha-build.yml
@@ -86,6 +86,9 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
           VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}
+          # Backend Sentry DSN — independent Rust project DSN.
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+          APP_ENV: alpha
           VITE_OTEL_EXPORTER_OTLP_ENDPOINT: ${{ secrets.OTEL_EXPORTER_OTLP_ENDPOINT }}
           OTEL_EXPORTER_OTLP_ENDPOINT: ${{ secrets.OTEL_EXPORTER_OTLP_ENDPOINT }}
         with:
@@ -96,3 +99,30 @@ jobs:
           prerelease: true
           uploadUpdaterJson: true
           args: ${{ matrix.args }}
+
+      - name: Upload Sentry debug symbols
+        # 把 release 编译出的 .dSYM / .pdb / DWARF 上传给 Sentry,后续 panic
+        # 上报时 Sentry 用 build-id 把地址翻译回函数 + 文件 + 行号(配合
+        # --include-sources 还会嵌源码片段)。SENTRY_AUTH_TOKEN/SENTRY_PROJECT
+        # 缺失时整个 step 跳过,不阻断 alpha 构建。
+        shell: bash
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+        run: |
+          if [ -z "$SENTRY_AUTH_TOKEN" ] || [ -z "$SENTRY_PROJECT" ]; then
+            echo "::warning::SENTRY_AUTH_TOKEN/SENTRY_PROJECT not configured — skipping debug-files upload"
+            exit 0
+          fi
+          npm install -g @sentry/cli
+          if [ -d "src-tauri/target/${{ matrix.target }}/release" ]; then
+            TARGET_DIR="src-tauri/target/${{ matrix.target }}/release"
+          elif [ -d "src-tauri/target/release" ]; then
+            TARGET_DIR="src-tauri/target/release"
+          else
+            echo "::warning::No release directory found — skipping"
+            exit 0
+          fi
+          echo "Uploading debug files from $TARGET_DIR"
+          sentry-cli debug-files upload --include-sources "$TARGET_DIR"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,6 +119,13 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
           VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}
+          # Backend Sentry DSN — independent Rust project DSN, baked into the
+          # binary at compile time via option_env! in uc-bootstrap/src/tracing.rs.
+          # MUST be a separate Sentry project from VITE_SENTRY_DSN (front-end);
+          # see "阶段 2" decision in the dependency-prune branch discussion.
+          # Empty secret = backend Sentry disabled.
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+          APP_ENV: production
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
           APPLE_ID: ${{ secrets.APPLE_ID }}
@@ -138,6 +145,9 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
           VITE_APP_VERSION: ${{ steps.app-version.outputs.version }}
           VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}
+          # Backend Sentry DSN — independent Rust project DSN.
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+          APP_ENV: production
           VITE_OTEL_EXPORTER_OTLP_ENDPOINT: ${{ secrets.OTEL_EXPORTER_OTLP_ENDPOINT }}
           OTEL_EXPORTER_OTLP_ENDPOINT: ${{ secrets.OTEL_EXPORTER_OTLP_ENDPOINT }}
         run: |
@@ -146,6 +156,35 @@ jobs:
           else
             bun run tauri build ${{ matrix.args }}
           fi
+
+      - name: Upload Sentry debug symbols
+        # 把 release 编译出的 .dSYM (macOS) / .pdb (Windows) / DWARF (Linux)
+        # 上传给 Sentry,后续 panic 上报时 Sentry 用 build-id 把地址翻译回
+        # 函数名 + 文件 + 行号(配合 --include-sources 还会嵌源码片段)。
+        # 没配 SENTRY_AUTH_TOKEN / SENTRY_PROJECT 时整个 step 跳过,不阻断构建。
+        shell: bash
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+        run: |
+          if [ -z "$SENTRY_AUTH_TOKEN" ] || [ -z "$SENTRY_PROJECT" ]; then
+            echo "::warning::SENTRY_AUTH_TOKEN/SENTRY_PROJECT not configured — skipping debug-files upload"
+            exit 0
+          fi
+          npm install -g @sentry/cli
+          # macOS 用 --target,产物在 target/<triple>/release/;
+          # Linux/Windows args 为空,产物在 target/release/。
+          if [ -d "src-tauri/target/${{ matrix.target }}/release" ]; then
+            TARGET_DIR="src-tauri/target/${{ matrix.target }}/release"
+          elif [ -d "src-tauri/target/release" ]; then
+            TARGET_DIR="src-tauri/target/release"
+          else
+            echo "::warning::No release directory found — skipping"
+            exit 0
+          fi
+          echo "Uploading debug files from $TARGET_DIR"
+          sentry-cli debug-files upload --include-sources "$TARGET_DIR"
 
       - name: upload artifacts
         uses: actions/upload-artifact@v7

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -366,26 +366,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arboard"
-version = "3.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
-dependencies = [
- "clipboard-win",
- "image",
- "log",
- "objc2",
- "objc2-app-kit",
- "objc2-core-foundation",
- "objc2-core-graphics",
- "objc2-foundation",
- "parking_lot",
- "percent-encoding",
- "windows-sys 0.52.0",
- "x11rb",
-]
-
-[[package]]
 name = "arg_enum_proc_macro"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -743,7 +723,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
 dependencies = [
  "async-trait",
- "axum-core 0.4.5",
+ "axum-core",
  "base64 0.22.1",
  "bytes",
  "futures-util",
@@ -753,7 +733,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "itoa",
- "matchit 0.7.3",
+ "matchit",
  "memchr",
  "mime",
  "percent-encoding",
@@ -771,31 +751,6 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "axum"
-version = "0.8.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
-dependencies = [
- "axum-core 0.5.6",
- "bytes",
- "futures-util",
- "http 1.4.0",
- "http-body",
- "http-body-util",
- "itoa",
- "matchit 0.8.4",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "serde_core",
- "sync_wrapper",
- "tower",
- "tower-layer",
- "tower-service",
 ]
 
 [[package]]
@@ -817,24 +772,6 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
-dependencies = [
- "bytes",
- "futures-core",
- "http 1.4.0",
- "http-body",
- "http-body-util",
- "mime",
- "pin-project-lite",
- "sync_wrapper",
- "tower-layer",
- "tower-service",
 ]
 
 [[package]]
@@ -4913,12 +4850,6 @@ name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
-
-[[package]]
-name = "matchit"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "maybe-rayon"
@@ -9929,17 +9860,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "twox-hash"
-version = "1.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
-dependencies = [
- "cfg-if",
- "rand 0.8.5",
- "static_assertions",
-]
-
-[[package]]
 name = "typeid"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9964,19 +9884,15 @@ dependencies = [
  "hmac",
  "image",
  "libc",
- "log",
  "mockall 0.13.1",
- "rand 0.8.5",
  "semver",
  "serde",
- "serde_json",
  "sha2 0.10.9",
  "tempfile",
  "thiserror 2.0.17",
  "tokio",
  "tokio-util",
  "tracing",
- "tracing-opentelemetry",
  "tracing-subscriber",
  "uc-core",
  "uc-infra",
@@ -9992,16 +9908,12 @@ version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "base64 0.22.1",
- "blake3",
  "bytes",
  "chrono",
  "gethostname",
- "log",
  "mockall 0.13.1",
  "sentry",
  "sentry-tracing",
- "serde",
  "serde_json",
  "tempfile",
  "thiserror 2.0.17",
@@ -10015,7 +9927,6 @@ dependencies = [
  "uc-infra",
  "uc-observability",
  "uc-platform",
- "uuid",
  "wiremock",
 ]
 
@@ -10024,7 +9935,7 @@ name = "uc-cli"
 version = "0.6.0"
 dependencies = [
  "anyhow",
- "axum 0.7.9",
+ "axum",
  "base64 0.22.1",
  "bytes",
  "chrono",
@@ -10067,7 +9978,6 @@ version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "base32",
  "base64 0.22.1",
  "blake3",
  "bytes",
@@ -10076,7 +9986,6 @@ dependencies = [
  "mockall 0.14.0",
  "rand 0.9.2",
  "serde",
- "serde_bytes",
  "serde_json",
  "serde_with",
  "sha2 0.10.9",
@@ -10084,7 +9993,6 @@ dependencies = [
  "tokio",
  "toml 0.8.23",
  "tracing",
- "twox-hash",
  "url",
  "uuid",
  "zeroize",
@@ -10100,13 +10008,10 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
  "tokio",
  "tokio-tungstenite",
  "tokio-util",
  "tracing",
- "uc-application",
- "uc-core",
  "uc-daemon-contract",
  "uc-daemon-local",
  "url",
@@ -10116,12 +10021,11 @@ dependencies = [
 name = "uc-daemon-contract"
 version = "0.6.0"
 dependencies = [
- "base64 0.22.1",
  "serde",
  "serde_json",
  "serde_with",
  "uc-core",
- "utoipa 4.2.3",
+ "utoipa",
 ]
 
 [[package]]
@@ -10147,11 +10051,9 @@ version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "blake3",
  "chrono",
  "clipboard-rs",
  "diesel",
- "futures-util",
  "mockall 0.13.1",
  "reqwest 0.12.28",
  "serde",
@@ -10166,7 +10068,6 @@ dependencies = [
  "uc-daemon-client",
  "uc-daemon-contract",
  "uc-daemon-local",
- "uc-infra",
  "uc-observability",
  "uc-platform",
  "uc-webserver",
@@ -10189,7 +10090,6 @@ dependencies = [
  "config",
  "diesel",
  "diesel_migrations",
- "dirs 6.0.0",
  "futures-util",
  "hex",
  "hkdf",
@@ -10199,7 +10099,6 @@ dependencies = [
  "iroh-blobs",
  "iroh-tickets",
  "libsqlite3-sys",
- "log",
  "mockall 0.13.1",
  "noq-proto",
  "postcard",
@@ -10253,7 +10152,6 @@ name = "uc-platform"
 version = "0.6.0"
 dependencies = [
  "anyhow",
- "arboard",
  "async-trait",
  "base64 0.22.1",
  "blake3",
@@ -10272,7 +10170,6 @@ dependencies = [
  "objc2-app-kit",
  "objc2-foundation",
  "once_cell",
- "png 0.18.0",
  "rand 0.9.2",
  "serde",
  "serde_json",
@@ -10294,24 +10191,16 @@ name = "uc-tauri"
 version = "0.6.0"
 dependencies = [
  "anyhow",
- "async-trait",
- "base64 0.22.1",
  "chrono",
  "core-foundation 0.10.1",
  "core-graphics",
- "dirs 6.0.0",
- "futures-util",
- "gethostname",
  "log",
  "mockall 0.13.1",
  "objc2",
  "objc2-app-kit",
  "objc2-foundation",
- "reqwest 0.12.28",
  "sentry",
- "sentry-tracing",
  "serde",
- "serde_json",
  "tauri",
  "tauri-plugin-autostart",
  "tauri-plugin-global-shortcut",
@@ -10323,12 +10212,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.17",
  "tokio",
- "tokio-tungstenite",
- "tokio-util",
- "toml 0.8.23",
  "tracing",
- "tracing-log",
- "tracing-subscriber",
  "uc-application",
  "uc-bootstrap",
  "uc-core",
@@ -10337,10 +10221,8 @@ dependencies = [
  "uc-daemon-local",
  "uc-desktop",
  "uc-infra",
- "uc-observability",
  "uc-platform",
  "url",
- "uuid",
  "windows 0.61.3",
 ]
 
@@ -10350,7 +10232,7 @@ version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "axum 0.7.9",
+ "axum",
  "base64 0.22.1",
  "chrono",
  "futures-util",
@@ -10367,8 +10249,7 @@ dependencies = [
  "uc-daemon-contract",
  "uc-daemon-local",
  "url",
- "utoipa 4.2.3",
- "utoipa-axum",
+ "utoipa",
  "utoipa-swagger-ui",
 ]
 
@@ -10460,7 +10341,6 @@ dependencies = [
  "tauri-plugin-updater",
  "tempfile",
  "tokio",
- "uc-bootstrap",
  "uc-tauri",
 ]
 
@@ -10599,32 +10479,7 @@ dependencies = [
  "indexmap 2.12.1",
  "serde",
  "serde_json",
- "utoipa-gen 4.3.1",
-]
-
-[[package]]
-name = "utoipa"
-version = "5.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fcc29c80c21c31608227e0912b2d7fddba57ad76b606890627ba8ee7964e993"
-dependencies = [
- "indexmap 2.12.1",
- "serde",
- "serde_json",
- "utoipa-gen 5.4.0",
-]
-
-[[package]]
-name = "utoipa-axum"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c25bae5bccc842449ec0c5ddc5cbb6a3a1eaeac4503895dc105a1138f8234a0"
-dependencies = [
- "axum 0.8.8",
- "paste",
- "tower-layer",
- "tower-service",
- "utoipa 5.4.0",
+ "utoipa-gen",
 ]
 
 [[package]]
@@ -10642,23 +10497,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "utoipa-gen"
-version = "5.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d79d08d92ab8af4c5e8a6da20c47ae3f61a0f1dabc1997cdf2d082b757ca08b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.112",
-]
-
-[[package]]
 name = "utoipa-swagger-ui"
 version = "7.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "943e0ff606c6d57d410fd5663a4d7c074ab2c5f14ab903b9514565e59fa1189e"
 dependencies = [
- "axum 0.7.9",
+ "axum",
  "mime_guess",
  "regex",
  "reqwest 0.12.28",
@@ -10666,7 +10510,7 @@ dependencies = [
  "serde",
  "serde_json",
  "url",
- "utoipa 4.2.3",
+ "utoipa",
  "zip 1.1.4",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -44,11 +44,17 @@ cargo-clippy = []
 dev-profile = ["uc-tauri/dev-profile"]
 
 [profile.release]
-panic = "abort"   # Strip expensive panic clean-up logic
-codegen-units = 1 # Compile crates one after another so the compiler can optimize better
-lto = true        # Enables link to optimizations
-opt-level = "z"   # Optimize for binary size
-strip = true      # Remove debug symbols
+panic = "abort"                # Strip expensive panic clean-up logic
+codegen-units = 1              # Compile crates one after another so the compiler can optimize better
+lto = true                     # Enables link to optimizations
+opt-level = "z"                # Optimize for binary size
+# 关键:Sentry symbolication 需要 debug info。`line-tables-only` 只保留地址→
+# 文件/行号映射,不带变量名等更重的信息,体积成本最小;配合 split-debuginfo
+# 和 strip = "symbols",最终 binary 仍然干净,debug info 单独打包成
+# .dSYM/.dwp/.pdb,由 CI 上传给 Sentry 用作 stack trace 解析。
+debug = "line-tables-only"
+split-debuginfo = "packed"     # macOS → .dSYM bundle, Linux → .dwp;Windows MSVC 自带 .pdb
+strip = "symbols"              # binary 内嵌符号 strip 干净,独立 debug 文件保留
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-autostart = "2"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -19,11 +19,9 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-# Tauri shell entry — bin crate only constructs the bootstrap context and the
-# tauri::Context (the latter via the generate_context! macro that requires the
-# bin's tauri.conf.json), then hands control to uc-tauri which owns all the
-# Tauri-specific plumbing (commands, plugins, builder/setup, run loop).
-uc-bootstrap = { path = "crates/uc-bootstrap" }
+# Tauri shell entry — bin crate hands control to uc-tauri, which owns all
+# Tauri-specific plumbing (commands, plugins, builder/setup, run loop) and
+# pulls uc-bootstrap transitively for context construction.
 uc-tauri = { path = "crates/uc-tauri" }
 
 # Required for the tauri::generate_context!() macro the bin still calls.

--- a/src-tauri/crates/uc-application/Cargo.toml
+++ b/src-tauri/crates/uc-application/Cargo.toml
@@ -22,20 +22,14 @@ async-trait = "0.1"
 # Error handling
 anyhow = "1.0"
 
-# Logging
-log = "0.4"
-
 # Serialization
 serde = { version = "1", features = ["derive"] }
-serde_json = "1"
 
 # Time handling
 chrono = { version = "0.4", features = ["serde"] }
 thiserror = "2.0.17"
 futures = "0.3.31"
 tracing = "0.1.44"
-tracing-opentelemetry = "0.32"
-rand = "0.8"
 hmac = "0.12"
 sha2 = "0.10"
 blake3 = "1"

--- a/src-tauri/crates/uc-bootstrap/Cargo.toml
+++ b/src-tauri/crates/uc-bootstrap/Cargo.toml
@@ -22,20 +22,18 @@ sentry = { version = "0.46.1", features = ["tracing"] }
 sentry-tracing = "0.46.1"
 gethostname = "1.1"
 toml = "0.8"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
 chrono = { version = "0.4", features = ["serde"] }
-log = "0.4"
 async-trait = "0.1"
-uuid = { version = "1", features = ["v4", "fast-rng"] }
-blake3 = "1"
-base64 = "0.22"
 
 [dev-dependencies]
 tempfile = "3"
 tokio = { version = "1", features = ["full"] }
 mockall = "0.13"
 wiremock = "0.6"
+# tests/slice*_e2e.rs use serde_json::json! to build wiremock response bodies
+# and serde_json::from_slice to decode pairing request bodies. Production
+# composition root never serializes to JSON itself — keep this in dev only.
+serde_json = "1"
 # Slice 2 Phase 2 · T12 — clipboard e2e packs plaintext as `Bytes`
 # for `ClipboardSyncFacade::dispatch_entry`.
 bytes = "1.7"

--- a/src-tauri/crates/uc-bootstrap/src/tracing.rs
+++ b/src-tauri/crates/uc-bootstrap/src/tracing.rs
@@ -74,7 +74,11 @@ fn resolve_telemetry_enabled(settings_path: &Path) -> bool {
 ///
 /// 1. Resolves log directory from platform app-dirs
 /// 2. Selects [`LogProfile`] from `UC_LOG_PROFILE` env var (or build-type default)
-/// 3. Initializes Sentry if `SENTRY_DSN` is set
+/// 3. Initializes Sentry if a DSN is available — runtime `SENTRY_DSN` env takes
+///    priority, falling back to the compile-time `SENTRY_DSN` baked in by CI
+///    (mirrors the front-end `VITE_SENTRY_DSN` pattern). When the layer is
+///    installed it filters `target = "panic"` events so the sentry-panic
+///    integration owns panic-to-Sentry without duplicate issues.
 /// 4. Builds console + JSON layers via `uc_observability`
 /// 5. Composes all layers on a `Registry` and registers globally
 ///
@@ -106,13 +110,41 @@ pub fn init_tracing_subscriber() -> anyhow::Result<()> {
     // Step 2: Select log profile
     let profile = LogProfile::from_env();
 
-    // Step 3: Initialize Sentry (if SENTRY_DSN is set)
-    let sentry_layer = if let Ok(dsn) = std::env::var("SENTRY_DSN") {
+    // Step 3: Initialize Sentry (if a DSN is available).
+    //
+    // ## DSN 来源优先级
+    //
+    // 1. **运行时** `SENTRY_DSN` env —— 给 dev / 自部署用户运行时覆盖。
+    // 2. **编译期** `SENTRY_DSN` env —— CI 在 release build 时注入,等价前端
+    //    `VITE_SENTRY_DSN` 的处理方式。这是必需路径,否则用户机器上没人会
+    //    设这个 env,sentry 在终端用户那边永远不会启用。
+    //
+    // ## 防双重 panic 上报
+    //
+    // sentry crate 的默认 `default-integrations` 启用 `sentry-panic`,会自动
+    // 把 panic 捕获并上报为 Exception。同时 `install_panic_logging_hook` 把
+    // panic 写成 `tracing::error!(target: "panic", ...)` 进 jsonl
+    // (jsonl 是离线排障的关键,不能省)。这条 tracing event 默认会再被
+    // sentry-tracing layer 转成 sentry Event,导致同一个 panic 在 sentry 上
+    // 出现两条 issue。这里用 `event_filter` 让 sentry-tracing 主动忽略
+    // `target = "panic"` 的 event,把 panic→sentry 的职责完全交给
+    // sentry-panic integration,jsonl 一侧不受影响。
+    let runtime_dsn = std::env::var("SENTRY_DSN").ok().filter(|s| !s.is_empty());
+    let compile_time_dsn = option_env!("SENTRY_DSN").filter(|s| !s.is_empty());
+    let dsn = runtime_dsn.or_else(|| compile_time_dsn.map(String::from));
+
+    let sentry_layer = if let Some(dsn) = dsn {
         let guard = sentry::init((
             dsn,
             sentry::ClientOptions {
                 release: sentry::release_name!(),
-                traces_sample_rate: 1.0,
+                // CI 注入的环境标签,默认空 → sentry 显示 "production"。
+                environment: option_env!("APP_ENV")
+                    .filter(|s| !s.is_empty())
+                    .map(Into::into),
+                // ERROR / Exception 全采样;performance trace 降到 10% 控制 quota。
+                sample_rate: 1.0,
+                traces_sample_rate: 0.1,
                 ..Default::default()
             },
         ));
@@ -121,7 +153,20 @@ pub fn init_tracing_subscriber() -> anyhow::Result<()> {
             eprintln!("Sentry guard already initialized");
         }
 
-        Some(sentry_tracing::layer())
+        Some(sentry_tracing::layer().event_filter(|md| {
+            if md.target() == "panic" {
+                // panic 由 sentry-panic integration 上报,这里跳过避免重复。
+                sentry_tracing::EventFilter::Ignore
+            } else {
+                match *md.level() {
+                    ::tracing::Level::ERROR => sentry_tracing::EventFilter::Event,
+                    ::tracing::Level::WARN | ::tracing::Level::INFO => {
+                        sentry_tracing::EventFilter::Breadcrumb
+                    }
+                    _ => sentry_tracing::EventFilter::Ignore,
+                }
+            }
+        }))
     } else {
         // No eprintln here -- it pollutes CLI output. The absence of Sentry
         // is a normal condition and will be visible in the JSON log file via

--- a/src-tauri/crates/uc-core/Cargo.toml
+++ b/src-tauri/crates/uc-core/Cargo.toml
@@ -9,7 +9,6 @@ description = "Core domain models and business logic for UniClipboard"
 # Serialization
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde_bytes = "0.11"
 toml = "0.8"
 
 # Time handling
@@ -21,15 +20,11 @@ anyhow = "1.0"
 # Async traits
 async-trait = "0.1"
 
-# Hashing (for Payload)
-twox-hash = "1.6"
-
 # Cryptographic hashing
 sha2 = "0.10"
 
-# Base64/Base32 encoding
+# Base64 encoding
 base64 = "0.22"
-base32 = "0.5"
 
 # Bytes handling
 bytes = "1.7"

--- a/src-tauri/crates/uc-daemon-client/Cargo.toml
+++ b/src-tauri/crates/uc-daemon-client/Cargo.toml
@@ -11,8 +11,6 @@ path = "src/lib.rs"
 
 [dependencies]
 # Workspace crates
-uc-application = { path = "../uc-application" }
-uc-core = { path = "../uc-core" }
 uc-daemon-contract = { path = "../uc-daemon-contract" }
 uc-daemon-local = { path = "../uc-daemon-local" }
 
@@ -35,7 +33,6 @@ url = "2"
 
 # Error handling + logging
 anyhow = "1.0"
-thiserror = "2.0"
 tracing = "0.1"
 
 [dev-dependencies]

--- a/src-tauri/crates/uc-daemon-contract/Cargo.toml
+++ b/src-tauri/crates/uc-daemon-contract/Cargo.toml
@@ -11,7 +11,6 @@ path = "src/lib.rs"
 
 [dependencies]
 uc-core = { path = "../uc-core" }
-base64 = "0.22"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_with = "3.18.0"

--- a/src-tauri/crates/uc-desktop/Cargo.toml
+++ b/src-tauri/crates/uc-desktop/Cargo.toml
@@ -13,7 +13,6 @@ path = "src/lib.rs"
 uc-bootstrap = { path = "../uc-bootstrap" }
 uc-application = { path = "../uc-application" }
 uc-core = { path = "../uc-core" }
-uc-infra = { path = "../uc-infra" }
 uc-platform = { path = "../uc-platform", features = ["test-helpers"] }
 uc-observability = { path = "../uc-observability" }
 uc-daemon-contract = { path = "../uc-daemon-contract" }
@@ -28,9 +27,7 @@ serde_json = "1"
 anyhow = "1.0"
 async-trait = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
-blake3 = "1"
 tracing = "0.1"
-futures-util = "0.3"
 url = "2"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "rustls-tls-webpki-roots"] }
 

--- a/src-tauri/crates/uc-infra/Cargo.toml
+++ b/src-tauri/crates/uc-infra/Cargo.toml
@@ -47,9 +47,6 @@ diesel = { version = "2.3.5", features = [
 libsqlite3-sys = { version = "0.35", features = ["bundled"] }    # SQLite系统库绑定
 diesel_migrations = { version = "2.2.0", features = ["sqlite"] } # Diesel迁移工具
 
-# File system paths
-dirs = "6.0"
-
 # Async runtime (for mpsc channels in ports)
 tokio = { version = "1", features = [
     "sync",
@@ -60,7 +57,6 @@ tokio = { version = "1", features = [
     "io-util",
 ] }
 
-log = "0.4.29"
 tracing = "0.1"
 argon2 = "0.5.3"
 subtle = "2.5.0"

--- a/src-tauri/crates/uc-platform/Cargo.toml
+++ b/src-tauri/crates/uc-platform/Cargo.toml
@@ -44,11 +44,9 @@ subtle = "2.5"
 
 # Clipboard
 clipboard-rs = { version = "0.3.3", features = ["default"] }
-arboard = "3.4"
 
 # Image handling
 image = "0.25"
-png = "0.18"
 
 # File system
 dirs = "6.0"

--- a/src-tauri/crates/uc-tauri/Cargo.toml
+++ b/src-tauri/crates/uc-tauri/Cargo.toml
@@ -15,16 +15,11 @@ uc-core = { path = "../uc-core" }
 uc-application = { path = "../uc-application" }
 uc-infra = { path = "../uc-infra" }
 uc-platform = { path = "../uc-platform" }
-uc-observability = { path = "../uc-observability" }
 uc-bootstrap = { path = "../uc-bootstrap" }
 uc-desktop = { path = "../uc-desktop" }
 uc-daemon-contract = { path = "../uc-daemon-contract" }
 uc-daemon-local = { path = "../uc-daemon-local" }
 uc-daemon-client = { path = "../uc-daemon-client" }
-
-# System utilities
-gethostname = "1.1"
-uuid = { version = "1", features = ["v4", "fast-rng"] }
 
 # Tauri
 tauri = { workspace = true }
@@ -38,34 +33,21 @@ url = "2"
 
 # Async
 tokio = { version = "1", features = ["full"] }
-tokio-util = "0.7"
-tokio-tungstenite = "0.24"
-futures-util = "0.3"
-async-trait = "0.1"
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "rustls-tls-webpki-roots"] }
 
 # Serialization
 serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-toml = "0.8"
-base64 = "0.22"
 
 # Error handling
 anyhow = "1.0"
 thiserror = "2.0"
 
-# Logging
+# Logging — `log::*` macros consumed by `tauri-plugin-log` builder configuration.
 log = "0.4"
-dirs = "6.0.0"
 tauri-plugin-log = "2"
 chrono = { version = "0.4", features = ["serde"] }
 
 # Tracing support
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "registry"] }
-tracing-log = "0.2"
-sentry = { version = "0.46.1", features = ["tracing"] }
-sentry-tracing = "0.46.1"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows = { version = "0.61", features = [

--- a/src-tauri/crates/uc-webserver/Cargo.toml
+++ b/src-tauri/crates/uc-webserver/Cargo.toml
@@ -28,7 +28,6 @@ tokio-util = "0.7"
 tracing = "0.1"
 url = "2"
 utoipa = { version = "4", features = ["uuid", "chrono", "url"] }
-utoipa-axum = "0.2"
 utoipa-swagger-ui = { version = "7", features = ["axum"] }
 
 [dev-dependencies]


### PR DESCRIPTION
## Summary

Two atomic commits, both stand on their own:

1. **`chore(deps): prune unused crate dependencies across workspace`** — per-crate grep audit removed ~30 zero-reference declarations across 11 Cargo.toml files (e.g. `arboard`/`png` in uc-platform, `twox-hash`/`serde_bytes`/`base32` in uc-core, 14 deps in uc-tauri, etc.). `uc-bootstrap` keeps `serde_json` in `dev-dependencies` for `tests/slice*_e2e.rs` wiremock fixtures. Cargo.lock loses 8 orphan entries.

2. **`feat(sentry): wire backend with compile-time DSN baking and dSYM upload`** — backend Sentry was coded but unreachable in production because `SENTRY_DSN` was a runtime env nobody set. Fixed by reading runtime first, falling back to `option_env!()` at compile time (mirrors front-end `VITE_SENTRY_DSN`); release profile now emits `line-tables-only` debug info into split `.dSYM`/`.dwp`/`.pdb` while `strip = "symbols"` keeps the shipped binary clean; CI workflows inject `SENTRY_DSN`/`APP_ENV` and run `sentry-cli debug-files upload --include-sources` (no-op when secrets absent). Also fixes a latent double-reporting bug — `sentry-tracing` layer now `Ignore`s `target = \"panic\"` so the existing `sentry-panic` integration stays the sole panic→Exception path while `panic_logging_hook` keeps writing jsonl.

## Operator follow-up

Create a Rust Sentry project (separate from the front-end one) and add GitHub secrets: `SENTRY_DSN`, `SENTRY_PROJECT`, `SENTRY_AUTH_TOKEN` (org token, scopes: `project:write` + `project:releases` + `org:read`), optionally `SENTRY_ORG`.

## Test plan

- [x] `cargo check --workspace --all-targets` clean after commit 1
- [x] `cargo build --release --bin uniclipboard` clean after commit 2; verified `target/release/uniclipboard.dSYM` produced and binary stays at 27 MB
- [ ] After secrets are added: trigger `Build Alpha`, confirm dSYM appears in Sentry → Settings → Debug Files
- [ ] Install alpha bundle and trigger a panic; confirm Sentry issue carries fully symbolicated stack with source context