### PR TITLE
feat(settings): data-driven Experimental tag for unstable features

### DIFF
--- a/src/components/setting/ExperimentalBadge.tsx
+++ b/src/components/setting/ExperimentalBadge.tsx
@@ -1,0 +1,33 @@
+import { useTranslation } from 'react-i18next'
+import { Badge } from '@/components/ui/badge'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
+
+/**
+ * ExperimentalBadge — 标识某个设置项处于实验阶段。
+ *
+ * Hover/focus 时通过 Tooltip 显示完整说明，提示用户行为可能不稳定。
+ * 文案来自 i18n: `devices.settings.badges.experimental(Tooltip)`。
+ *
+ * 注意:Badge 是无 forwardRef 的 function component,直接 asChild 给 TooltipTrigger
+ * 会导致 Radix 拿不到 DOM ref → hover 不触发。这里用原生 span 作为 trigger,
+ * 内嵌 Badge 保留视觉样式(同 ConnectionChannelBadge 的处理方式)。
+ */
+export function ExperimentalBadge() {
+  const { t } = useTranslation()
+  const tooltip = t('devices.settings.badges.experimentalTooltip')
+
+  return (
+    <TooltipProvider delayDuration={200}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span tabIndex={0} aria-label={tooltip} className="inline-flex">
+            <Badge variant="secondary">{t('devices.settings.badges.experimental')}</Badge>
+          </span>
+        </TooltipTrigger>
+        <TooltipContent side="top">{tooltip}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  )
+}
+
+export default ExperimentalBadge

--- a/src/components/setting/NetworkSection.tsx
+++ b/src/components/setting/NetworkSection.tsx
@@ -165,6 +165,7 @@ const NetworkSection: React.FC = () => {
         label={t('settings.sections.network.lanOnly.label')}
         labelExtra={<LanOnlyDisclosure />}
         description={t('settings.sections.network.lanOnly.description')}
+        experimentalKey="network.lanOnly"
       >
         <Switch
           id="lan-only-switch"
@@ -178,6 +179,7 @@ const NetworkSection: React.FC = () => {
         label={t('settings.sections.network.allowOverlayAddrs.label')}
         labelExtra={<AllowOverlayAddrsDisclosure />}
         description={t('settings.sections.network.allowOverlayAddrs.description')}
+        experimentalKey="network.allowOverlayAddrs"
       >
         <Switch
           id="allow-overlay-addrs-switch"

--- a/src/components/setting/SettingRow.tsx
+++ b/src/components/setting/SettingRow.tsx
@@ -1,4 +1,6 @@
 import type { ReactNode } from 'react'
+import { isExperimentalFeature } from './experimental-features'
+import { ExperimentalBadge } from './ExperimentalBadge'
 import { cn } from '@/lib/utils'
 
 interface SettingRowProps {
@@ -7,6 +9,11 @@ interface SettingRowProps {
   description?: string
   children?: ReactNode
   className?: string
+  /**
+   * Data-driven experimental marker. When the key is registered in
+   * `experimental-features.ts`, an ExperimentalBadge is rendered next to the label.
+   */
+  experimentalKey?: string
 }
 
 export function SettingRow({
@@ -15,7 +22,10 @@ export function SettingRow({
   description,
   children,
   className,
+  experimentalKey,
 }: SettingRowProps) {
+  const showExperimental = isExperimentalFeature(experimentalKey)
+
   return (
     <div className={cn('flex items-center justify-between gap-4 px-4 py-3', className)}>
       {(label || description) && (
@@ -23,6 +33,7 @@ export function SettingRow({
           {label && (
             <div className="flex items-center gap-2">
               <h4 className="text-sm font-medium">{label}</h4>
+              {showExperimental && <ExperimentalBadge />}
               {labelExtra}
             </div>
           )}

--- a/src/components/setting/experimental-features.ts
+++ b/src/components/setting/experimental-features.ts
@@ -1,0 +1,17 @@
+/**
+ * Central registry of experimental setting keys.
+ *
+ * 数据驱动: 在此集中声明哪些设置项处于实验阶段。
+ * SettingRow 通过 `experimentalKey` prop 查询本表，命中则自动渲染 ExperimentalBadge。
+ *
+ * Key 命名约定: `<section>.<field>` (e.g. `network.lanOnly`).
+ */
+export const EXPERIMENTAL_FEATURE_KEYS = ['network.lanOnly', 'network.allowOverlayAddrs'] as const
+
+export type ExperimentalFeatureKey = (typeof EXPERIMENTAL_FEATURE_KEYS)[number]
+
+const EXPERIMENTAL_SET: ReadonlySet<string> = new Set(EXPERIMENTAL_FEATURE_KEYS)
+
+export function isExperimentalFeature(key: string | undefined): key is ExperimentalFeatureKey {
+  return key !== undefined && EXPERIMENTAL_SET.has(key)
+}

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -711,7 +711,9 @@
         "mvp": "MVP",
         "comingSoon": "Coming Soon",
         "notEditable": "Not Editable",
-        "globalFileSyncOff": "File sync off"
+        "globalFileSyncOff": "File sync off",
+        "experimental": "Experimental",
+        "experimentalTooltip": "This feature is experimental — its behavior may change or be unstable in future releases."
       },
       "sync": {
         "title": "Sync Settings",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -702,7 +702,9 @@
         "mvp": "MVP",
         "comingSoon": "即将推出",
         "notEditable": "不可变更",
-        "globalFileSyncOff": "文件同步已关闭"
+        "globalFileSyncOff": "文件同步已关闭",
+        "experimental": "实验性",
+        "experimentalTooltip": "该功能处于实验阶段，行为可能在后续版本中调整或不稳定。"
       },
       "sync": {
         "title": "同步设置",


### PR DESCRIPTION
## Summary
- 新增数据驱动的 `ExperimentalBadge` + 集中式 `experimental-features.ts` 注册表，未来标记新功能只需追加一个 key
- `SettingRow` 新增 `experimentalKey` prop，命中注册表则自动渲染 secondary 徽章 + hover/focus tooltip 警示
- 首批应用到 Network 设置的 LAN-only Mode 与 Allow Overlay Addrs 两个开关
- 中英双语文案落到 `devices.settings.badges.experimental` / `experimentalTooltip`

## Test plan
- [x] Settings → Network 看到两个开关旁出现 "Experimental / 实验性" 徽章
- [x] 鼠标悬停徽章显示 tooltip 警示文案
- [x] 切换语言后徽章与 tooltip 文案随之切换
- [x] `pnpm exec tsc --noEmit` / eslint / NetworkSection 单测均绿