### PR TITLE
Runtime-gate telemetry exports

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,8 +3,8 @@ gsd_state_version: 1.0
 milestone: v0.7.0
 milestone_name: LAN-only Mode
 status: Phase 95 verifier=gaps_found (16/17 must-haves); 1 gap blocking closing-loop — dev-mode `app.restart()` respawn 不可达。next: `/gsd-plan-phase 95 --gaps`
-last_updated: "2026-05-05T00:40:00.000Z"
-last_activity: 2026-05-05 -- Phase 95 verifier 16/17 PASS（自动化 54/54、所有 fence 0 命中、5/6 UAT PASS）。唯一 gap：Tauri 2 + bun + macOS 组合下 `tauri:dev` 不 respawn binary 导致 NETSET-05 closing-loop 半生效。VERIFICATION.md 已 commit。
+last_updated: "2026-05-05T16:45:00.000Z"
+last_activity: 2026-05-05 -- Completed quick task 260505-17q: telemetry_enabled 设置控制 Sentry 上报（前后端）+ 修复前端 OTLP 接线
 progress:
   total_phases: 4
   completed_phases: 1
@@ -66,6 +66,7 @@ Last activity: 2026-05-05 -- Wave 3 落地：95-06 NetworkSection 完全重写�
 | 260505-keychain-prompts | 减少 macOS 首次使用时 Keychain 多次弹窗（kek_observed 进程级缓存） | 2026-05-05 | 39ce6f39 | [260505-keychain-prompts](./quick/260505-keychain-prompts/) |
 | 260505-iroh-identity-file-storage | 启动期 iroh 设备身份脱离 macOS Keychain，改走 0600 文件后端，彻底消除"用户没操作就弹"的根因 | 2026-05-05 | aa1b1d93 | [260505-iroh-identity-file-storage](./quick/260505-iroh-identity-file-storage/) |
 | 260505-keychain-startup-resume-gate | daemon startup_recovery 守 try_resume_session — auto_unlock=false 时不再下沉到 keychain | 2026-05-05 | 5912465c | [260505-keychain-startup-resume-gate](./quick/260505-keychain-startup-resume-gate/) |
+| 260505-17q | telemetry_enabled 设置控制 Sentry 上报（前后端）+ 修复前端 OTLP 接线 bug | 2026-05-05 | a0fe00d0 | [260505-17q-sentry-respect-telemetry-flag](./quick/260505-17q-sentry-respect-telemetry-flag/) |
 
 ## Session Continuity
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,8 +3,8 @@ gsd_state_version: 1.0
 milestone: v0.7.0
 milestone_name: LAN-only Mode
 status: Phase 95 verifier=gaps_found (16/17 must-haves); 1 gap blocking closing-loop — dev-mode `app.restart()` respawn 不可达。next: `/gsd-plan-phase 95 --gaps`
-last_updated: "2026-05-05T16:45:00.000Z"
-last_activity: 2026-05-05 -- Completed quick task 260505-17q: telemetry_enabled 设置控制 Sentry 上报（前后端）+ 修复前端 OTLP 接线
+last_updated: "2026-05-05T17:30:00.000Z"
+last_activity: 2026-05-05 -- Completed quick task 260505-1np: 后端 Sentry/OTLP 改成 runtime gate（telemetry toggle 立即生效，撤回 restart_required）
 progress:
   total_phases: 4
   completed_phases: 1
@@ -67,6 +67,7 @@ Last activity: 2026-05-05 -- Wave 3 落地：95-06 NetworkSection 完全重写�
 | 260505-iroh-identity-file-storage | 启动期 iroh 设备身份脱离 macOS Keychain，改走 0600 文件后端，彻底消除"用户没操作就弹"的根因 | 2026-05-05 | aa1b1d93 | [260505-iroh-identity-file-storage](./quick/260505-iroh-identity-file-storage/) |
 | 260505-keychain-startup-resume-gate | daemon startup_recovery 守 try_resume_session — auto_unlock=false 时不再下沉到 keychain | 2026-05-05 | 5912465c | [260505-keychain-startup-resume-gate](./quick/260505-keychain-startup-resume-gate/) |
 | 260505-17q | telemetry_enabled 设置控制 Sentry 上报（前后端）+ 修复前端 OTLP 接线 bug | 2026-05-05 | a0fe00d0 | [260505-17q-sentry-respect-telemetry-flag](./quick/260505-17q-sentry-respect-telemetry-flag/) |
+| 260505-1np | 后端 Sentry/OTLP 改成 runtime gate（telemetry toggle 立即生效，撤回 restart_required） | 2026-05-05 | 626ef96a | [260505-1np-telemetry-runtime-gate](./quick/260505-1np-telemetry-runtime-gate/) |
 
 ## Session Continuity
 

--- a/.planning/quick/260505-17q-sentry-respect-telemetry-flag/260505-17q-PLAN.md
+++ b/.planning/quick/260505-17q-sentry-respect-telemetry-flag/260505-17q-PLAN.md
@@ -1,0 +1,124 @@
+---
+id: 260505-17q
+slug: sentry-respect-telemetry-flag
+description: 让 telemetry_enabled 设置控制 Sentry 上报（前后端）并修复前端 OTLP 接线
+created: 2026-05-05
+mode: quick
+---
+
+# 260505-17q: Sentry 受 telemetry_enabled 控制 + 前端 OTLP 接线
+
+## 背景
+
+`General › Telemetry` 这个用户开关当前只覆盖了**后端 OTLP（→ Seq）**。Sentry 在前后端都没有受这个开关约束。前端 OTLP 因为 `initFrontendOtlp()` 和 `setFrontendTelemetryEnabled()` 在生产代码从未被调用，实际上一直处于"永远关闭"的状态——这是 pre-existing bug，借本次顺手修。
+
+## 目标（must_haves）
+
+- T1：后端 `sentry::init()` 仅当 DSN 可用 **且** `telemetry_enabled = true` 才执行；与现有 OTLP 行为一致（init-time gate，需重启切换）。
+- T2：后端 `PUT /settings` 在 `general.telemetry_enabled` 变更时返回 `restart_required = true`（与 `network` 走相同的提示路径）。
+- T3：前端 `Sentry` 在 `beforeSend` / `beforeBreadcrumb` / `beforeSendLog` 三处都通过模块级 enabled flag 进行 runtime gate；提供 `setFrontendSentryEnabled(boolean)` setter。
+- T4：前端 `initFrontendOtlp()` 在 `main.tsx` 启动期被调用；`SettingContext` 在 settings 加载/变更时调用 `setFrontendTelemetryEnabled` 与 `setFrontendSentryEnabled`，用 `setting.general.telemetryEnabled` 同步两端。
+- T5：`cargo check --workspace --all-targets` 与 `pnpm typecheck` 通过；新增/修改逻辑覆盖最小测试。
+
+## 任务清单
+
+### Task 1 — 后端 Sentry init 受 telemetry_enabled 控制
+
+**files:**
+- `src-tauri/crates/uc-bootstrap/src/tracing.rs`
+
+**action:**
+- 在 sentry init 块前加判断：仅当 `telemetry_enabled` 为 true 时才走 `sentry::init`。
+  - 需要把 `resolve_telemetry_enabled(&paths.settings_path)` 调用提前到 sentry init 之前（当前在 OTLP 块里）。
+- 当 telemetry 关掉但 DSN 存在时，写一行 `info!` 注明 sentry 被用户禁用，避免静默差异。
+- `Tracing initialized ...` 那行 info 加 `sentry_enabled` 字段，方便排查。
+
+**verify:**
+- 关掉 telemetry → Sentry 不 init（无 SENTRY_GUARD 写入）
+- 开启 telemetry + 有 DSN → Sentry init 正常
+
+**done:** `cargo check -p uc-bootstrap` 通过
+
+### Task 2 — 后端 settings handler restart_required
+
+**files:**
+- `src-tauri/crates/uc-webserver/src/api/settings.rs`
+
+**action:**
+- `update_settings_handler` 当前只在 `payload.network.is_some()` 时设 restart。补上：当 `payload.general.as_ref().and_then(|g| g.telemetry_enabled).is_some()` 也设 restart_required。
+- 注释里说明：因为 telemetry 走 init-time gate（与 OTLP 一致），改了必须重启才能生效。
+
+**verify:**
+- 单测：构造一个仅 patch.general.telemetry_enabled 的请求，断言响应 restart_required = true
+- 同时验证 patch.general.theme 等无关字段不会触发 restart_required
+
+**done:** `cargo check -p uc-webserver` 通过；新单测通过
+
+### Task 3 — 前端 Sentry runtime gate
+
+**files:**
+- `src/observability/sentry.ts`
+
+**action:**
+- 模块级 `let sentryRuntimeEnabled = true`（默认 true 以捕获启动期错误，避免 settings 加载完成前漏报）
+- `beforeSend`：`if (!sentryRuntimeEnabled) return null` 在最前面
+- `beforeBreadcrumb`：同样 `if (!sentryRuntimeEnabled) return null`
+- `beforeSendLog`：同样 `if (!sentryRuntimeEnabled) return null`
+- 导出 `setFrontendSentryEnabled(enabled: boolean): void` setter
+- 现有 `sentryEnabled` 编译期常量保留作为 DSN 存在性的标记（不变）
+
+**verify:**
+- 单测：默认 true → events 通过；置 false → beforeSend/beforeBreadcrumb/beforeSendLog 返回 null
+- ResizeObserver 已有 drop 逻辑要继续生效（不能被新 gate 改变）
+
+**done:** `pnpm typecheck` 通过；sentry.test.ts 通过
+
+### Task 4 — 前端 OTLP 接线 + SettingContext 同步
+
+**files:**
+- `src/main.tsx`
+- `src/contexts/SettingContext.tsx`
+
+**action:**
+- `main.tsx`：在 `initSentry()` 之后追加 `initFrontendOtlp()`（pre-existing bug 修复）
+- `SettingContext.tsx`：
+  - 增加 `useEffect`，依赖 `setting?.general.telemetryEnabled`
+  - 当 setting 加载完成（不为 null）时，调用 `setFrontendTelemetryEnabled(setting.general.telemetryEnabled)` 和 `setFrontendSentryEnabled(setting.general.telemetryEnabled)`
+  - 这样 toggle 变更走 `updateGeneralSetting` → `setSetting` → effect 触发，前端两端同步无需重启
+
+**verify:**
+- 启动后 settings 加载完成时，sentry/otlp 的 enabled flag 与 setting 一致
+- toggle 改变后，前端立即反映（前端不需要重启）
+
+**done:** `pnpm typecheck` 通过
+
+### Task 5 — 验证 + SUMMARY + STATE
+
+**files:**
+- `.planning/quick/260505-17q-sentry-respect-telemetry-flag/260505-17q-SUMMARY.md`
+- `.planning/STATE.md`
+
+**action:**
+- 跑 `cargo check --workspace --all-targets`
+- 跑 `pnpm typecheck`
+- 跑相关单测：`pnpm test src/observability` 与 `cargo test -p uc-webserver settings`
+- 写 SUMMARY.md（status: complete）
+- 更新 STATE.md 的 Quick Tasks Completed 表
+
+**done:** 所有检查通过；SUMMARY 写好；STATE 更新
+
+## 不在范围
+
+- 改后端 Sentry 为 runtime gate（用 `before_send` 闭包 + 原子布尔）—— 与现有 OTLP 行为不一致，本次保持 init-time gate
+- 删除 sentry 相关依赖或 feature-gate 化
+- 修改 telemetry_enabled 的默认值或文案
+
+## 关键路径与行号
+
+- `src-tauri/crates/uc-bootstrap/src/tracing.rs:91-298`（init_tracing_subscriber）
+- `src-tauri/crates/uc-bootstrap/src/tracing.rs:132-175`（sentry init 块）
+- `src-tauri/crates/uc-webserver/src/api/settings.rs:79`（restart_required 计算）
+- `src/observability/sentry.ts:13-93`
+- `src/observability/otlp.ts:30-31, 195-226`（initFrontendOtlp + setFrontendTelemetryEnabled）
+- `src/contexts/SettingContext.tsx:22-85`
+- `src/main.tsx:9-11`

--- a/.planning/quick/260505-17q-sentry-respect-telemetry-flag/260505-17q-SUMMARY.md
+++ b/.planning/quick/260505-17q-sentry-respect-telemetry-flag/260505-17q-SUMMARY.md
@@ -1,0 +1,91 @@
+---
+id: 260505-17q
+slug: sentry-respect-telemetry-flag
+description: telemetry_enabled 设置控制 Sentry 上报（前后端）+ 修复前端 OTLP 接线 bug
+status: complete
+created: 2026-05-05
+completed: 2026-05-05
+---
+
+# 260505-17q SUMMARY
+
+## 问题
+
+`General › Telemetry` 这个用户开关此前只覆盖了**后端 OTLP（→ Seq）**：
+
+| 维度 | 此前 |
+|---|---|
+| 后端 OTLP（→ Seq） | ✅ 受 `telemetry_enabled` 控制（init-time gate） |
+| 后端 Sentry | ❌ 只看 DSN，不读 setting |
+| 前端 Sentry | ❌ `Sentry.init()` 之后无任何 gate |
+| 前端 OTLP（→ Seq） | ❌ pre-existing bug：`initFrontendOtlp()` 与 `setFrontendTelemetryEnabled()` 在生产代码从未被调用 |
+
+## 改动
+
+### 1. 后端 Sentry init-time gate — `d331e60f`
+`src-tauri/crates/uc-bootstrap/src/tracing.rs`
+- `telemetry_enabled` 解析提前到 sentry init 之前，与 OTLP 共用同一信号源。
+- `sentry::init()` 仅当 DSN 可用 **且** `telemetry_enabled = true` 才执行。
+- `Tracing initialized ...` info 增加 `sentry_enabled` 字段。
+
+### 2. PUT /settings 触发 restart_required — `06db0d79`
+`src-tauri/crates/uc-webserver/src/api/settings.rs`
+- handler 在 `payload.general.telemetry_enabled.is_some()` 时也设 `restart_required = true`。
+- 测试 fixture（`tests/settings_network_smoke.rs`）的 `simulate_put` 同步更新，与 handler 同源。
+- 新增 `telemetry_toggle_signals_restart` 单测，覆盖：
+  - `telemetryEnabled=false` → restart=true
+  - `telemetryEnabled=true` → restart=true（重新启用同样要重启）
+  - `general.deviceName` 单独变更 → restart=false（防 `general.is_some()` 误判）
+
+### 3. 前端 Sentry runtime gate — `5fabd3fa`
+`src/observability/sentry.ts` + `src/observability/__tests__/sentry.test.ts`
+- 模块级 `sentryRuntimeEnabled = true`（默认开，避免漏掉启动期错误）。
+- 三个 callback 都加 gate：`beforeSend` / `beforeBreadcrumb` / `beforeSendLog` 在 false 时返回 `null` 丢弃 event。
+- 导出 `setFrontendSentryEnabled(enabled: boolean)` setter。
+- 新增两个单测：disabled 时三 callback 全部 drop；re-enabled 时恢复转发并保留原有 redaction。
+
+### 4. 前端 OTLP bootstrap + SettingContext 同步 — `a0fe00d0`
+- `src/main.tsx`：在 `initSentry()` 后追加 `initFrontendOtlp()` 调用（修复 pre-existing bug——之前 frontend OTLP 永远静默）。
+- `src/contexts/SettingContext.tsx`：新 `useEffect` 依赖 `setting?.general?.telemetryEnabled`，在变更时同时调用 `setFrontendTelemetryEnabled()` 与 `setFrontendSentryEnabled()`，让前端无需重启就能切换。
+
+## 验证
+
+| 检查 | 结果 |
+|---|---|
+| `cargo check --workspace --all-targets` | ✅ Finished |
+| `cargo test -p uc-webserver --test settings_network_smoke` | ✅ 4 passed (含新加的 `telemetry_toggle_signals_restart`) |
+| `pnpm vitest run src/observability` | ✅ 18 passed (含 sentry runtime-gate 新增 2 例) |
+| `pnpm vitest run src/contexts/__tests__/SettingContext` | ✅ 11 passed |
+| `npx tsc --noEmit` | ✅ no errors |
+
+## 结果对照表
+
+| 维度 | 之前 | 之后 |
+|---|---|---|
+| 后端 OTLP | init-time gate | 不变 |
+| 后端 Sentry | 始终启用（有 DSN） | init-time gate（与 OTLP 一致），改了发 `restart_required = true` |
+| 前端 Sentry | 始终启用（有 DSN） | runtime gate via `beforeSend/Breadcrumb/SendLog`，无需重启 |
+| 前端 OTLP | 永远静默（bootstrap 漏调） | 正常 init + 受同一 telemetry 开关控制 |
+
+## 用户视角行为
+
+- **关掉 Telemetry**：
+  - 前端 Sentry 立即停止上报（runtime gate）
+  - 前端 OTLP 立即停止上报（runtime gate）
+  - 后端 Sentry / OTLP **下次启动后**停止（init-time gate；UI 通过 restart_required 字段提醒）
+- **开启 Telemetry**：
+  - 前端两端立即恢复
+  - 后端两端 **下次启动后**恢复
+
+## 不在范围
+
+- 后端 Sentry 改 runtime gate（用 `before_send` + 原子布尔）。本次保持与 OTLP 行为一致（init-time gate）。
+- Sentry 相关 crate 的 feature-gate 化或依赖删除。
+- `telemetry_enabled` 默认值 / UI 文案修改。
+
+## 关联 commits
+
+- `d331e60f` feat(sentry): gate backend init on telemetry_enabled toggle
+- `06db0d79` feat(api): signal restart_required when telemetry_enabled changes
+- `5fabd3fa` feat(sentry): runtime-gate frontend Sentry on telemetry toggle
+- `a0fe00d0` feat(observability): wire frontend OTLP and sync telemetry toggle

--- a/.planning/quick/260505-1np-telemetry-runtime-gate/260505-1np-PLAN.md
+++ b/.planning/quick/260505-1np-telemetry-runtime-gate/260505-1np-PLAN.md
@@ -1,0 +1,66 @@
+---
+id: 260505-1np
+slug: telemetry-runtime-gate
+description: 后端 Sentry/OTLP 改成 runtime gate，撤回 telemetry 触发 restart_required
+created: 2026-05-05
+mode: quick
+supersedes: 260505-17q（部分）
+---
+
+# 260505-1np: 后端 telemetry 改 runtime gate
+
+## 背景
+
+`260505-17q` 把后端 Sentry / OTLP 都做成 init-time gate，与现有 OTLP 行为一致。
+但用户视角看，"开关 telemetry 应该立即生效"才是合理预期 —— 这是上一轮折中决定，不是技术约束。本轮把后端两端都改成 runtime gate，对齐前端行为。
+
+## 目标
+
+| 维度 | 之前（17q 后） | 本轮 |
+|---|---|---|
+| 前端 Sentry | runtime gate | 不变 |
+| 前端 OTLP | runtime gate | 不变 |
+| 后端 Sentry | init-time gate（需重启） | **runtime gate** |
+| 后端 OTLP | init-time gate（需重启） | **runtime gate** |
+| `PUT /settings` `restart_required` | telemetry 变更触发 | **撤回**（telemetry 不再需要重启） |
+
+## 任务清单
+
+### Task 1 — 新增 `uc-observability::telemetry_gate`
+- `static AtomicBool TELEMETRY_ENABLED`，默认 `true`（防启动期事件被吃）
+- 公开 `is_telemetry_enabled()` / `set_telemetry_enabled(bool)`
+- `lib.rs` re-export
+
+### Task 2 — OTLP 层运行时 gate
+- 改 `otlp/layer.rs` + `otlp/logs_layer.rs`：在已有 `EnvFilter` 之上叠 `FilterFn`
+  检查 `is_telemetry_enabled()`，关掉时丢弃所有 span/event
+- 改 `otlp/provider.rs`：去掉 `telemetry_enabled` 参数对 init 的影响
+  （endpoint 配置好就 init provider；运行时 gate 在 layer 层）
+- 公共 API 保持兼容（参数仍接收但语义变成"启动期初始值"）
+
+### Task 3 — Sentry 改 runtime gate
+- `uc-bootstrap/src/tracing.rs`：sentry init 不再读 `telemetry_enabled`
+  （只看 DSN 即 init）
+- `ClientOptions.before_send` / `before_breadcrumb` 闭包检查
+  `is_telemetry_enabled()`，关掉时返回 `None`
+- 启动期把磁盘上的 `telemetry_enabled` 写入 atomic（`set_telemetry_enabled`）
+
+### Task 4 — webserver settings handler
+- 增加 `uc-webserver` 对 `uc-observability` 的依赖（如还没有）
+- handler 在 `payload.general.telemetry_enabled.is_some()` 时调
+  `uc_observability::set_telemetry_enabled(value)`
+- `restart_required` 撤回 telemetry 那一支，回到只看 `network`
+- 删除 `telemetry_toggle_signals_restart` 测试（行为变了），新增覆盖
+  setter 被正确调用的测试
+
+### Task 5 — 编译/测试 + SUMMARY + STATE
+- `cargo check --workspace --all-targets`
+- `cargo test -p uc-observability telemetry_gate`
+- `cargo test -p uc-webserver --test settings_network_smoke`
+- 写 SUMMARY；更新 STATE
+
+## 不在范围
+
+- 前端任何改动（前端已经是 runtime gate）
+- 改 `telemetry_enabled` 默认值或 UI 文案
+- `sentry::init` 的 panic integration 行为（panic event 仍然过 before_send，所以 gate 生效）

--- a/.planning/quick/260505-1np-telemetry-runtime-gate/260505-1np-SUMMARY.md
+++ b/.planning/quick/260505-1np-telemetry-runtime-gate/260505-1np-SUMMARY.md
@@ -1,0 +1,90 @@
+---
+id: 260505-1np
+slug: telemetry-runtime-gate
+description: 后端 Sentry/OTLP 改成 runtime gate，撤回 telemetry 触发 restart_required
+status: complete
+created: 2026-05-05
+completed: 2026-05-05
+supersedes: 260505-17q（部分 — 后端 init-time gate 那部分）
+---
+
+# 260505-1np SUMMARY
+
+## 背景
+
+`260505-17q` 把后端 Sentry / OTLP 都做成 init-time gate，与已有 OTLP 行为一致。
+但用户视角看，"开关 telemetry 应该立即生效"才是合理预期。本轮把后端两端都改成 runtime gate，对齐前端，撤回 `restart_required` 信号。
+
+## 改动
+
+### 1. uc-observability 暴露 telemetry runtime gate — `9da05fb6`
+- 新增 `telemetry_gate.rs`：`static AtomicBool TELEMETRY_ENABLED`（默认 `true`，避免启动期事件被吃）
+- 公开 `is_telemetry_enabled()` / `set_telemetry_enabled(bool)`
+- `lib.rs` re-export
+
+### 2. OTLP 层 runtime gate via FilterFn — `4414e587`
+- `otlp/layer.rs` 与 `otlp/logs_layer.rs` 在已有 `EnvFilter` 之上叠 `FilterFn`，
+  关掉时丢弃 span / log event
+- `otlp/provider.rs` 不再需要 `telemetry_enabled` 参数 — endpoint 配置就 init provider
+- 公共 API（`init_otlp_provider` / `init_otlp_pipeline*`）签名变了：去掉了
+  `telemetry_enabled` 参数。所有 caller 一并更新
+
+### 3. Sentry runtime gate + webserver 接线 — `626ef96a`
+- `uc-bootstrap/src/tracing.rs`：sentry 只看 DSN 即 init；
+  `ClientOptions.before_send` 与 `before_breadcrumb` 闭包检查
+  `is_telemetry_enabled()`，关掉时返回 `None` —— 包括 sentry-panic integration
+  发出的 panic Exception 也走同一过滤路径
+- 启动期把 disk 上的 `telemetry_enabled` 推入 atomic（防遗漏初始状态）
+- `uc-webserver` 增加 `uc-observability` dep；handler 写盘成功后调
+  `set_telemetry_enabled(value)`；`restart_required` 撤回到只看 `network`
+- 测试 `telemetry_toggle_signals_restart` 重写为 `telemetry_toggle_runtime_gate_no_restart`，
+  锁定两件事：toggle 不再触发 restart + atomic 被正确推进
+
+## 验证
+
+| 检查 | 结果 |
+|---|---|
+| `cargo check --workspace --all-targets` | ✅ Finished |
+| `cargo test -p uc-observability telemetry_gate` | ✅ 2/2 |
+| `cargo test -p uc-webserver --test settings_network_smoke` | ✅ 4/4 (含新 `telemetry_toggle_runtime_gate_no_restart`) |
+
+## 结果对照
+
+| 维度 | 17q 完成后 | 本轮 1np 后 |
+|---|---|---|
+| 前端 Sentry | runtime | 不变 |
+| 前端 OTLP | runtime | 不变 |
+| 后端 Sentry | **init-time** | **runtime** ✓ |
+| 后端 OTLP | **init-time** | **runtime** ✓ |
+| `PUT /settings restart_required` | telemetry 变更触发 | **不再触发**（仅 network） |
+
+## 用户视角行为
+
+- **关掉 Telemetry**：前后端 Sentry / OTLP **立即**停止上报，无需任何重启
+- **开启 Telemetry**：同样立即恢复
+
+## 实现关键点
+
+1. **FilterFn 类型签名 trick**：`FilterFn::new` 默认 `F = fn(&Metadata<'_>) -> bool`。
+   闭包会改变 generic 让公共 type alias 变形 → 改用顶层 `fn` 项 + 显式
+   `type TelemetryGateFn = fn(&Metadata<'_>) -> bool` 局部 binding，把 fn item
+   coerce 成 fn pointer 再传入。
+
+2. **panic 双重上报防御保留**：`sentry-tracing` layer 仍然 `event_filter` 跳过
+   `target = "panic"`；panic event 由 sentry-panic integration 单独上报，
+   它的 event 也会过 `before_send` 被运行时 gate 拦下，不会泄露。
+
+3. **写盘 → atomic 顺序**：handler 在 `facade.update().await` 成功后才调
+   `set_telemetry_enabled` —— 持久化失败时 atomic 不被污染。
+
+## 不在范围
+
+- 前端任何改动（17q 已经把前端做成 runtime）
+- `telemetry_enabled` 默认值或 UI 文案
+- Sentry / OpenTelemetry crate 的 feature-gate 化或依赖删除
+
+## 关联 commits
+
+- `9da05fb6` feat(observability): add process-wide telemetry runtime gate
+- `4414e587` feat(otlp): runtime-gate trace and logs layers via FilterFn
+- `626ef96a` feat(sentry): runtime-gate backend Sentry and wire toggle without restart

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -10248,6 +10248,7 @@ dependencies = [
  "uc-core",
  "uc-daemon-contract",
  "uc-daemon-local",
+ "uc-observability",
  "url",
  "utoipa",
  "utoipa-swagger-ui",

--- a/src-tauri/crates/uc-bootstrap/src/tracing.rs
+++ b/src-tauri/crates/uc-bootstrap/src/tracing.rs
@@ -110,14 +110,24 @@ pub fn init_tracing_subscriber() -> anyhow::Result<()> {
     // Step 2: Select log profile
     let profile = LogProfile::from_env();
 
-    // Step 2b: Resolve `telemetry_enabled` from persisted settings.
+    // Step 2b: Resolve `telemetry_enabled` from persisted settings and push it
+    // into the process-wide runtime gate exposed by `uc-observability`.
     //
-    // 必须在 sentry / OTLP 任何一处 init 前读出来 —— 这两条上报通道都受
-    // 同一个用户开关 (`General › Telemetry`) 控制,且都走 init-time gate
-    // (改了要重启才生效),所以一次性读、两处共用。
+    // Both Sentry and OTLP consult that gate at event time (Sentry via the
+    // `before_send` / `before_breadcrumb` hooks installed below; OTLP via the
+    // `FilterFn` wrapper around its trace and logs layers). This means the
+    // user-facing `General › Telemetry` switch takes effect immediately —
+    // `uc-webserver`'s PUT /settings handler calls `set_telemetry_enabled`
+    // when the field changes, and the next emitted event already honors it.
+    //
+    // Reading the persisted value here is what makes the *initial* state
+    // correct: until the daemon side serves any settings update, the gate
+    // would otherwise carry its `true` default and ignore a user who had
+    // turned telemetry off in a previous session.
     let telemetry_enabled = resolve_telemetry_enabled(&paths.settings_path);
+    uc_observability::set_telemetry_enabled(telemetry_enabled);
 
-    // Step 3: Initialize Sentry (if a DSN is available **and** telemetry is enabled).
+    // Step 3: Initialize Sentry whenever a DSN is available.
     //
     // ## DSN 来源优先级
     //
@@ -128,9 +138,13 @@ pub fn init_tracing_subscriber() -> anyhow::Result<()> {
     //
     // ## 与 telemetry_enabled 的关系
     //
-    // `telemetry_enabled = false` 时即使 DSN 存在也不 init —— 等价于关掉
-    // 整条 sentry 上报链路,不会留 Hub / panic integration 钩子。这与 OTLP
-    // 一致:用户开关 OFF 就完全静默。改了开关需要重启才生效(init-time gate)。
+    // Sentry is initialized unconditionally when a DSN exists, but every
+    // outgoing event (incl. the panic Exception emitted by the bundled
+    // `sentry-panic` integration) is funneled through the `before_send`
+    // closure below, and every breadcrumb through `before_breadcrumb`. Both
+    // closures consult `uc_observability::is_telemetry_enabled()` and drop
+    // the payload when the user has telemetry off. Net effect: the user
+    // toggle takes effect immediately without a process restart.
     //
     // ## 防双重 panic 上报
     //
@@ -146,9 +160,9 @@ pub fn init_tracing_subscriber() -> anyhow::Result<()> {
     let compile_time_dsn = option_env!("SENTRY_DSN").filter(|s| !s.is_empty());
     let dsn = runtime_dsn.or_else(|| compile_time_dsn.map(String::from));
 
-    let sentry_enabled = dsn.is_some() && telemetry_enabled;
+    let sentry_dsn_present = dsn.is_some();
 
-    let sentry_layer = if let Some(dsn) = dsn.filter(|_| telemetry_enabled) {
+    let sentry_layer = if let Some(dsn) = dsn {
         let guard = sentry::init((
             dsn,
             sentry::ClientOptions {
@@ -160,6 +174,26 @@ pub fn init_tracing_subscriber() -> anyhow::Result<()> {
                 // ERROR / Exception 全采样;performance trace 降到 10% 控制 quota。
                 sample_rate: 1.0,
                 traces_sample_rate: 0.1,
+                // Runtime telemetry gate. Drops every outgoing event (incl.
+                // panics from the sentry-panic integration) when the user has
+                // telemetry off, without un-installing any global hook.
+                before_send: Some(std::sync::Arc::new(|event| {
+                    if uc_observability::is_telemetry_enabled() {
+                        Some(event)
+                    } else {
+                        None
+                    }
+                })),
+                // Same gate for the breadcrumb trail — when telemetry is off
+                // we drop them at capture time so re-enabling telemetry mid-
+                // session doesn't leak the previous quiet period's context.
+                before_breadcrumb: Some(std::sync::Arc::new(|breadcrumb| {
+                    if uc_observability::is_telemetry_enabled() {
+                        Some(breadcrumb)
+                    } else {
+                        None
+                    }
+                })),
                 ..Default::default()
             },
         ));
@@ -183,10 +217,9 @@ pub fn init_tracing_subscriber() -> anyhow::Result<()> {
             }
         }))
     } else {
-        // No eprintln here -- it pollutes CLI output. The absence of Sentry
-        // is a normal condition (no DSN, or user disabled telemetry) and
-        // will be visible in the JSON log file via the tracing::info! at the
-        // end of initialization (`sentry_enabled` field).
+        // No eprintln here -- it pollutes CLI output. Absence of a DSN is a
+        // normal condition; the closing tracing::info! reports it via the
+        // `sentry_dsn_present` field.
         None
     };
 
@@ -212,18 +245,18 @@ pub fn init_tracing_subscriber() -> anyhow::Result<()> {
     // (determined by the full `.with()` composition in Step 5, not at
     // provider-init time). `SdkTracerProvider::clone()` uses Arc semantics.
     //
-    // `telemetry_enabled` is resolved once in Step 2b above and shared with
-    // the sentry init block — both honor the same user-facing toggle.
+    // The `telemetry_enabled` flag was already pushed into
+    // `uc_observability`'s runtime gate in Step 2b. The provider is now
+    // initialized whenever an OTLP endpoint is configured; whether spans /
+    // logs actually flow is decided per-event by the FilterFn wrapped
+    // around the trace and logs layers, so a user toggle takes effect
+    // immediately.
 
-    // Note: OTLP enablement and any compile-time config backfill are handled
-    // inside init_otlp_provider. The exporter itself still resolves the final
+    // Note: any compile-time OTLP endpoint backfill is handled inside
+    // init_otlp_provider. The exporter itself still resolves the final
     // endpoint using OpenTelemetry's standard env-var rules.
     let otlp_providers = {
-        match uc_observability::otlp::init_otlp_provider(
-            &profile,
-            device_id.as_deref(),
-            telemetry_enabled,
-        ) {
+        match uc_observability::otlp::init_otlp_provider(&profile, device_id.as_deref()) {
             Ok(Some((providers, guard))) => {
                 // Wrap the guard in ManuallyDrop before handing it to the
                 // OnceLock. If `set` ever fails (it shouldn't — idempotency
@@ -291,15 +324,20 @@ pub fn init_tracing_subscriber() -> anyhow::Result<()> {
 
     let _ = TRACING_INITIALIZED.set(());
 
+    // `otlp_initialized` / `sentry_dsn_present` describe whether the export
+    // pipelines were *constructed*; `telemetry_enabled` is the runtime gate
+    // that decides whether events actually flow through them. A pipeline can
+    // be initialized but currently silent (telemetry off) and become live the
+    // instant the user toggles it on, with no restart.
     ::tracing::info!(
         profile = %profile,
         logs_dir = %paths.logs_dir.display(),
-        otlp_enabled = otlp_enabled,
-        sentry_enabled = sentry_enabled,
+        otlp_initialized = otlp_enabled,
+        sentry_dsn_present = sentry_dsn_present,
         telemetry_enabled = telemetry_enabled,
         "Tracing initialized with dual output (console + JSON{}{})",
         if otlp_enabled { " + OTLP" } else { "" },
-        if sentry_enabled { " + Sentry" } else { "" }
+        if sentry_dsn_present { " + Sentry" } else { "" }
     );
 
     // Legacy env var migration warning (D-14, REQ-87-10).

--- a/src-tauri/crates/uc-bootstrap/src/tracing.rs
+++ b/src-tauri/crates/uc-bootstrap/src/tracing.rs
@@ -110,7 +110,14 @@ pub fn init_tracing_subscriber() -> anyhow::Result<()> {
     // Step 2: Select log profile
     let profile = LogProfile::from_env();
 
-    // Step 3: Initialize Sentry (if a DSN is available).
+    // Step 2b: Resolve `telemetry_enabled` from persisted settings.
+    //
+    // 必须在 sentry / OTLP 任何一处 init 前读出来 —— 这两条上报通道都受
+    // 同一个用户开关 (`General › Telemetry`) 控制,且都走 init-time gate
+    // (改了要重启才生效),所以一次性读、两处共用。
+    let telemetry_enabled = resolve_telemetry_enabled(&paths.settings_path);
+
+    // Step 3: Initialize Sentry (if a DSN is available **and** telemetry is enabled).
     //
     // ## DSN 来源优先级
     //
@@ -118,6 +125,12 @@ pub fn init_tracing_subscriber() -> anyhow::Result<()> {
     // 2. **编译期** `SENTRY_DSN` env —— CI 在 release build 时注入,等价前端
     //    `VITE_SENTRY_DSN` 的处理方式。这是必需路径,否则用户机器上没人会
     //    设这个 env,sentry 在终端用户那边永远不会启用。
+    //
+    // ## 与 telemetry_enabled 的关系
+    //
+    // `telemetry_enabled = false` 时即使 DSN 存在也不 init —— 等价于关掉
+    // 整条 sentry 上报链路,不会留 Hub / panic integration 钩子。这与 OTLP
+    // 一致:用户开关 OFF 就完全静默。改了开关需要重启才生效(init-time gate)。
     //
     // ## 防双重 panic 上报
     //
@@ -133,7 +146,9 @@ pub fn init_tracing_subscriber() -> anyhow::Result<()> {
     let compile_time_dsn = option_env!("SENTRY_DSN").filter(|s| !s.is_empty());
     let dsn = runtime_dsn.or_else(|| compile_time_dsn.map(String::from));
 
-    let sentry_layer = if let Some(dsn) = dsn {
+    let sentry_enabled = dsn.is_some() && telemetry_enabled;
+
+    let sentry_layer = if let Some(dsn) = dsn.filter(|_| telemetry_enabled) {
         let guard = sentry::init((
             dsn,
             sentry::ClientOptions {
@@ -169,8 +184,9 @@ pub fn init_tracing_subscriber() -> anyhow::Result<()> {
         }))
     } else {
         // No eprintln here -- it pollutes CLI output. The absence of Sentry
-        // is a normal condition and will be visible in the JSON log file via
-        // the tracing::info! at the end of initialization.
+        // is a normal condition (no DSN, or user disabled telemetry) and
+        // will be visible in the JSON log file via the tracing::info! at the
+        // end of initialization (`sentry_enabled` field).
         None
     };
 
@@ -195,10 +211,9 @@ pub fn init_tracing_subscriber() -> anyhow::Result<()> {
     // layer can be built with the correct generic subscriber type `S`
     // (determined by the full `.with()` composition in Step 5, not at
     // provider-init time). `SdkTracerProvider::clone()` uses Arc semantics.
-    // Step 4c: Read telemetry_enabled from persisted settings.
-    // This is a lightweight file read — the full settings are loaded later by
-    // the app runtime. We only need the boolean gate here.
-    let telemetry_enabled = resolve_telemetry_enabled(&paths.settings_path);
+    //
+    // `telemetry_enabled` is resolved once in Step 2b above and shared with
+    // the sentry init block — both honor the same user-facing toggle.
 
     // Note: OTLP enablement and any compile-time config backfill are handled
     // inside init_otlp_provider. The exporter itself still resolves the final
@@ -280,9 +295,11 @@ pub fn init_tracing_subscriber() -> anyhow::Result<()> {
         profile = %profile,
         logs_dir = %paths.logs_dir.display(),
         otlp_enabled = otlp_enabled,
+        sentry_enabled = sentry_enabled,
         telemetry_enabled = telemetry_enabled,
-        "Tracing initialized with dual output (console + JSON{})",
-        if otlp_enabled { " + OTLP" } else { "" }
+        "Tracing initialized with dual output (console + JSON{}{})",
+        if otlp_enabled { " + OTLP" } else { "" },
+        if sentry_enabled { " + Sentry" } else { "" }
     );
 
     // Legacy env var migration warning (D-14, REQ-87-10).

--- a/src-tauri/crates/uc-observability/src/lib.rs
+++ b/src-tauri/crates/uc-observability/src/lib.rs
@@ -51,9 +51,11 @@ pub mod otlp;
 pub mod profile;
 pub(crate) mod span_fields;
 pub mod stages;
+pub mod telemetry_gate;
 
 pub use context::{global_device_id, set_global_device_id};
 pub use flow::FlowId;
 pub use init::{build_console_layer, build_json_layer, init_tracing_subscriber};
 pub use profile::LogProfile;
+pub use telemetry_gate::{is_telemetry_enabled, set_telemetry_enabled};
 pub use tracing_appender::non_blocking::WorkerGuard;

--- a/src-tauri/crates/uc-observability/src/otlp/layer.rs
+++ b/src-tauri/crates/uc-observability/src/otlp/layer.rs
@@ -2,21 +2,30 @@ use opentelemetry::trace::TracerProvider as _;
 use opentelemetry_sdk::trace::{SdkTracer, SdkTracerProvider};
 use tracing::Subscriber;
 use tracing_opentelemetry::OpenTelemetryLayer;
-use tracing_subscriber::{filter::Filtered, registry::LookupSpan, EnvFilter, Layer};
+use tracing_subscriber::{
+    filter::{FilterFn, Filtered},
+    registry::LookupSpan,
+    EnvFilter, Layer,
+};
 
 use crate::profile::LogProfile;
+use crate::telemetry_gate;
 
 /// Concrete OTLP layer type returned by `build_otlp_layer`.
 ///
-/// `OpenTelemetryLayer<S, T>` is generic over the subscriber type `S` and
-/// tracer type `T`. Returning a concrete type (rather than `impl Layer<S>`)
-/// allows callers to bind the return value to a typed `Option<...>` variable,
-/// letting Rust infer `S` from the downstream `.with()` composition context
-/// rather than fixing it at the call site.
+/// Two filters stacked over `OpenTelemetryLayer<S, SdkTracer>`:
 ///
-/// `S` is the subscriber type (e.g., `Layered<..., Registry>`),
-/// `SdkTracer` is the concrete OTel tracer implementation.
-pub type OtlpConcreteLayer<S> = Filtered<OpenTelemetryLayer<S, SdkTracer>, EnvFilter, S>;
+/// 1. **Inner `EnvFilter`** (`profile.otlp_filter()`) — static profile-based
+///    level/target filter applied at subscriber construction.
+/// 2. **Outer `FilterFn`** (telemetry runtime gate) — checks the global
+///    `telemetry_enabled` AtomicBool on every metadata callback so the user
+///    can toggle telemetry in Settings without restarting the process.
+///
+/// Returning a concrete type (rather than `impl Layer<S>`) preserves the
+/// pattern the bootstrap uses: bind to `Option<OtlpConcreteLayer<_>>` and
+/// let Rust infer `S` from the downstream `.with()` composition.
+pub type OtlpConcreteLayer<S> =
+    Filtered<Filtered<OpenTelemetryLayer<S, SdkTracer>, EnvFilter, S>, FilterFn, S>;
 
 pub fn build_otlp_layer<S>(
     provider: &SdkTracerProvider,
@@ -26,5 +35,20 @@ where
     S: Subscriber + for<'a> LookupSpan<'a> + Send + Sync,
 {
     let tracer = provider.tracer("uc-observability");
-    OpenTelemetryLayer::new(tracer).with_filter(profile.otlp_filter())
+    // Bind the fn item to a typed fn-pointer local so `FilterFn::new`
+    // resolves its `F` to the default `fn(&Metadata<'_>) -> bool` and the
+    // resulting layer matches `OtlpConcreteLayer<S>` exactly.
+    let gate: TelemetryGateFn = telemetry_gate_filter;
+    OpenTelemetryLayer::new(tracer)
+        .with_filter(profile.otlp_filter())
+        .with_filter(FilterFn::new(gate))
+}
+
+type TelemetryGateFn = fn(&tracing::Metadata<'_>) -> bool;
+
+/// Free function so `FilterFn` can use the default `fn(&Metadata) -> bool`
+/// generic parameter (closure types would force a different generic and
+/// blow up the public type alias).
+fn telemetry_gate_filter(_meta: &tracing::Metadata<'_>) -> bool {
+    telemetry_gate::is_telemetry_enabled()
 }

--- a/src-tauri/crates/uc-observability/src/otlp/logs_layer.rs
+++ b/src-tauri/crates/uc-observability/src/otlp/logs_layer.rs
@@ -1,17 +1,29 @@
 use opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge;
 use opentelemetry_sdk::logs::{SdkLogger, SdkLoggerProvider};
 use tracing::Subscriber;
-use tracing_subscriber::{filter::Filtered, registry::LookupSpan, EnvFilter, Layer};
+use tracing_subscriber::{
+    filter::{FilterFn, Filtered},
+    registry::LookupSpan,
+    EnvFilter, Layer,
+};
 
 use crate::profile::LogProfile;
+use crate::telemetry_gate;
 
 /// Concrete OTLP logs layer type returned by `build_otlp_logs_layer`.
 ///
-/// `OpenTelemetryTracingBridge` converts tracing events into OTLP log records.
-/// The `Filtered` wrapper applies the profile-based `EnvFilter` so only INFO+
-/// events are exported.
-pub type OtlpLogsConcreteLayer<S> =
-    Filtered<OpenTelemetryTracingBridge<SdkLoggerProvider, SdkLogger>, EnvFilter, S>;
+/// Two filters stacked over `OpenTelemetryTracingBridge`:
+///
+/// 1. **Inner `EnvFilter`** (`profile.otlp_filter()`) — profile-based level
+///    filter so only INFO+ events are exported.
+/// 2. **Outer `FilterFn`** — runtime telemetry gate; toggling
+///    `general.telemetry_enabled` flips the AtomicBool checked here so
+///    log records stop flowing without a process restart.
+pub type OtlpLogsConcreteLayer<S> = Filtered<
+    Filtered<OpenTelemetryTracingBridge<SdkLoggerProvider, SdkLogger>, EnvFilter, S>,
+    FilterFn,
+    S,
+>;
 
 pub fn build_otlp_logs_layer<S>(
     provider: &SdkLoggerProvider,
@@ -21,5 +33,16 @@ where
     S: Subscriber + for<'a> LookupSpan<'a> + Send + Sync,
 {
     let bridge = OpenTelemetryTracingBridge::new(provider);
-    bridge.with_filter(profile.otlp_filter())
+    let gate: TelemetryGateFn = telemetry_gate_filter;
+    bridge
+        .with_filter(profile.otlp_filter())
+        .with_filter(FilterFn::new(gate))
+}
+
+type TelemetryGateFn = fn(&tracing::Metadata<'_>) -> bool;
+
+/// Free function so `FilterFn` matches its default `fn(&Metadata) -> bool`
+/// generic parameter (mirrors `layer.rs`).
+fn telemetry_gate_filter(_meta: &tracing::Metadata<'_>) -> bool {
+    telemetry_gate::is_telemetry_enabled()
 }

--- a/src-tauri/crates/uc-observability/src/otlp/mod.rs
+++ b/src-tauri/crates/uc-observability/src/otlp/mod.rs
@@ -52,16 +52,20 @@ pub struct OtlpProviders {
 ///    `logs_layer::build_otlp_logs_layer::<S>()` once the subscriber type `S`
 ///    is determined by the composition context.
 ///
-/// Returns `Ok(None)` when OTLP is disabled (missing endpoint, or Prod
-/// profile with `telemetry_enabled = false`).
-/// The W3C propagator is always installed globally regardless.
+/// Returns `Ok(None)` only when no OTLP endpoint is configured. The provider
+/// is no longer gated on `telemetry_enabled` — the user-facing toggle is now
+/// honored at event time by `FilterFn` wrappers in `layer.rs` /
+/// `logs_layer.rs`, so callers should always init the provider when an
+/// endpoint exists and let the runtime gate decide whether events flow.
+///
+/// The W3C propagator is always installed globally regardless of init
+/// outcome.
 pub fn init_otlp_provider(
     profile: &LogProfile,
     device_id: Option<&str>,
-    telemetry_enabled: bool,
 ) -> anyhow::Result<Option<(OtlpProviders, OtlpGuard)>> {
     let Some((tracer_provider, logger_provider, guard)) =
-        provider::init_provider_and_guard(profile, device_id, telemetry_enabled)?
+        provider::init_provider_and_guard(profile, device_id)?
     else {
         return Ok(None);
     };
@@ -81,13 +85,11 @@ pub fn init_otlp_provider(
 pub fn init_otlp_pipeline_generic<S>(
     profile: &LogProfile,
     device_id: Option<&str>,
-    telemetry_enabled: bool,
 ) -> anyhow::Result<Option<(impl Layer<S> + Send + Sync + 'static, OtlpGuard)>>
 where
     S: tracing::Subscriber + for<'a> LookupSpan<'a> + Send + Sync,
 {
-    let Some((providers, guard)) = init_otlp_provider(profile, device_id, telemetry_enabled)?
-    else {
+    let Some((providers, guard)) = init_otlp_provider(profile, device_id)? else {
         return Ok(None);
     };
 
@@ -98,27 +100,28 @@ where
 
 /// Initialize the OTLP tracing pipeline.
 ///
-/// Returns `Ok(None)` when:
-/// - `OTEL_EXPORTER_OTLP_ENDPOINT` env var is not set, OR
-/// - The profile is `LogProfile::Prod` (OTLP is dev-only).
+/// Returns `Ok(None)` when `OTEL_EXPORTER_OTLP_ENDPOINT` env var is not set
+/// (and no compile-time endpoint baked in). Whether events actually flow is
+/// controlled at runtime by the telemetry gate
+/// (`uc_observability::set_telemetry_enabled`).
 ///
-/// Returns `Ok(Some((layer, guard)))` when the env var is set and profile is Dev/DebugClipboard/Cli.
-/// The caller must store the guard for the lifetime of the process; dropping it flushes spans.
+/// Returns `Ok(Some((layer, guard)))` when the endpoint is configured. The
+/// caller must store the guard for the lifetime of the process; dropping it
+/// flushes spans.
 ///
-/// The W3C TraceContextPropagator is always installed globally, even when the exporter
-/// is disabled, so cross-device traceparent headers remain populated.
+/// The W3C TraceContextPropagator is always installed globally, even when
+/// the exporter is disabled, so cross-device traceparent headers remain
+/// populated.
 ///
 /// Returns a boxed `OtlpLayer` (i.e., `Box<dyn Layer<Registry>>`) to avoid
-/// type inference issues at call sites (tests, bootstrap) where the subscriber type
-/// parameter `S` cannot always be inferred. For composition with a specific `S`,
-/// use `init_otlp_pipeline_generic`.
+/// type inference issues at call sites (tests, bootstrap) where the
+/// subscriber type parameter `S` cannot always be inferred. For composition
+/// with a specific `S`, use `init_otlp_pipeline_generic`.
 pub fn init_otlp_pipeline(
     profile: &LogProfile,
     device_id: Option<&str>,
-    telemetry_enabled: bool,
 ) -> anyhow::Result<Option<(OtlpLayer, OtlpGuard)>> {
-    let Some((providers, guard)) = init_otlp_provider(profile, device_id, telemetry_enabled)?
-    else {
+    let Some((providers, guard)) = init_otlp_provider(profile, device_id)? else {
         return Ok(None);
     };
 

--- a/src-tauri/crates/uc-observability/src/otlp/provider.rs
+++ b/src-tauri/crates/uc-observability/src/otlp/provider.rs
@@ -55,19 +55,6 @@ fn build_span_exporter_from_env() -> anyhow::Result<SpanExporter> {
         .map_err(|e| anyhow::anyhow!("build OTLP span exporter: {e}"))
 }
 
-/// Check whether the OTLP pipeline should be activated for the given profile
-/// and user telemetry preference.
-///
-/// Activation rules:
-/// - Dev / DebugClipboard / Cli: always allowed (developer-controlled)
-/// - Prod: only when `telemetry_enabled` is `true`
-fn otlp_is_enabled(profile: &LogProfile, telemetry_enabled: bool) -> bool {
-    match profile {
-        LogProfile::Prod => telemetry_enabled,
-        _ => true,
-    }
-}
-
 fn build_log_exporter_from_env() -> anyhow::Result<opentelemetry_otlp::LogExporter> {
     opentelemetry_otlp::LogExporter::builder()
         .with_http()
@@ -86,18 +73,27 @@ fn build_otlp_guard(
     }
 }
 
-/// Initialize the OTLP provider with dual-layer gating:
-/// 1. Endpoint must be configured (env var or baked-in)
-/// 2. Profile + `telemetry_enabled` must allow it
+/// Initialize the OTLP provider when an endpoint is configured.
+///
+/// Returns `Ok(None)` when no endpoint is set (env var or baked-in). Provider
+/// init is no longer gated on `telemetry_enabled`: that switch is consulted
+/// at event time by `layer.rs` / `logs_layer.rs` via the runtime telemetry
+/// gate, so toggling the user preference takes effect without restart.
+///
+/// The W3C propagator is always installed regardless of init outcome so
+/// cross-process trace headers stay populated for daemon ↔ GUI plumbing.
+///
+/// `_profile` is retained in the signature for forward compatibility (the
+/// previous version branched on it for activation; now it would only matter
+/// if a future profile wanted to skip provider construction entirely).
 pub(super) fn init_provider_and_guard(
-    profile: &LogProfile,
+    _profile: &LogProfile,
     device_id: Option<&str>,
-    telemetry_enabled: bool,
 ) -> anyhow::Result<Option<(SdkTracerProvider, SdkLoggerProvider, OtlpGuard)>> {
     // Always install the W3C propagator.
     global::set_text_map_propagator(TraceContextPropagator::new());
 
-    if !otlp_is_enabled(profile, telemetry_enabled) || !config::otlp_endpoint_is_configured() {
+    if !config::otlp_endpoint_is_configured() {
         return Ok(None);
     }
 

--- a/src-tauri/crates/uc-observability/src/telemetry_gate.rs
+++ b/src-tauri/crates/uc-observability/src/telemetry_gate.rs
@@ -1,0 +1,62 @@
+//! Process-wide runtime gate for the user-facing telemetry switch.
+//!
+//! Both Sentry and OTLP read this gate at event time so toggling
+//! `general.telemetry_enabled` in the UI takes effect without a restart.
+//!
+//! - Frontend has its own gate (`setFrontendSentryEnabled` /
+//!   `setFrontendTelemetryEnabled`) since the gate must live in the JS runtime.
+//! - This module is the equivalent for the Rust side: `uc-bootstrap` consults
+//!   it from Sentry's `before_send` / `before_breadcrumb` hooks; the OTLP
+//!   trace and logs layers consult it via `tracing_subscriber::FilterFn`.
+//!
+//! ## Default
+//!
+//! Defaults to `true` so events emitted between process start and the first
+//! settings load are NOT silently dropped — `uc-bootstrap` reads the
+//! persisted preference from disk during init and overrides the default
+//! before any user-visible event would normally be processed.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+
+static TELEMETRY_ENABLED: AtomicBool = AtomicBool::new(true);
+
+/// Returns whether the user-facing telemetry switch is currently on.
+///
+/// Hot path — called once per emitted event/span. `Ordering::Relaxed` is
+/// sufficient because there is no other state we synchronize with: the
+/// worst case is that an event emitted concurrently with a setter call is
+/// classified by the pre-toggle value, which is acceptable.
+#[inline]
+pub fn is_telemetry_enabled() -> bool {
+    TELEMETRY_ENABLED.load(Ordering::Relaxed)
+}
+
+/// Update the runtime gate.
+///
+/// Called from two paths:
+/// - `uc-bootstrap` once at init time after reading persisted settings.
+/// - `uc-webserver` PUT /settings handler whenever `telemetry_enabled`
+///   changes, so the new value takes effect immediately.
+pub fn set_telemetry_enabled(enabled: bool) {
+    TELEMETRY_ENABLED.store(enabled, Ordering::Relaxed);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_is_true_to_avoid_dropping_pre_init_events() {
+        // Reset to default in case prior test mutated; then assert.
+        set_telemetry_enabled(true);
+        assert!(is_telemetry_enabled());
+    }
+
+    #[test]
+    fn setter_round_trip() {
+        set_telemetry_enabled(false);
+        assert!(!is_telemetry_enabled());
+        set_telemetry_enabled(true);
+        assert!(is_telemetry_enabled());
+    }
+}

--- a/src-tauri/crates/uc-webserver/Cargo.toml
+++ b/src-tauri/crates/uc-webserver/Cargo.toml
@@ -14,6 +14,7 @@ uc-application = { path = "../uc-application" }
 uc-core = { path = "../uc-core" }
 uc-daemon-contract = { path = "../uc-daemon-contract" }
 uc-daemon-local = { path = "../uc-daemon-local" }
+uc-observability = { path = "../uc-observability" }
 anyhow = "1.0"
 axum = { version = "0.7", features = ["ws", "tokio", "http1", "http2"] }
 base64 = "0.22"

--- a/src-tauri/crates/uc-webserver/src/api/settings.rs
+++ b/src-tauri/crates/uc-webserver/src/api/settings.rs
@@ -72,26 +72,30 @@ async fn update_settings_handler(
 ) -> Result<Json<UpdateSettingsResponse>, ApiError> {
     let app = state.app_facade_or_error()?;
 
-    // D-D1：以下两类 patch 触发 restart_required = true：
-    //   1. `network` 段非空（任何字段变更）—— 现有行为，Phase 95 引入。
-    //   2. `general.telemetry_enabled` 显式给值 —— 后端 Sentry 与 OTLP
-    //      都走 init-time gate（uc-bootstrap/src/tracing.rs），运行中改这
-    //      个开关不会影响已注册的全局 subscriber / sentry Hub。前端能
-    //      runtime 切换（SettingContext → setFrontendSentryEnabled），
-    //      但要让后端两条上报通道也对齐用户意图，必须重启。
-    // Pitfall 3 防御：调用方（前端）必须显式承担"还没真正生效"。
-    let telemetry_changed = payload
-        .general
-        .as_ref()
-        .and_then(|g| g.telemetry_enabled)
-        .is_some();
-    let restart_required = payload.network.is_some() || telemetry_changed;
+    // D-D1：`network` 段非空（任何字段变更）触发 restart_required = true。
+    // 当前 NetworkSettings 仅含 allow_relay_fallback；后续若加字段，仍走 is_some()
+    // 兜底。其它字段（general / sync 等）不影响该信号 — 它们不需要重启。
+    //
+    // `general.telemetry_enabled` 历史曾通过这里触发 restart（260505-17q），后于
+    // 260505-1np 改成运行时 gate（见 uc-observability::set_telemetry_enabled），
+    // 不再需要重启 — 下面在 facade 写盘成功后直接把新值推进 atomic 即可立即生效。
+    // Pitfall 3 防御：调用方（前端 Phase 95）必须显式承担"还没真正生效"。
+    let restart_required = payload.network.is_some();
+
+    // 取出可能存在的 telemetry 新值，再传 patch 给 facade 写盘 — 写盘成功后再
+    // 把 atomic 推进新值，保证持久化与运行时状态保持单调一致（如果写盘失败，
+    // 也不会污染运行时 gate）。
+    let telemetry_update = payload.general.as_ref().and_then(|g| g.telemetry_enabled);
 
     let updated = app
         .settings
         .update(settings_patch_from_dto(payload))
         .await
         .map_err(settings_error_to_api)?;
+
+    if let Some(enabled) = telemetry_update {
+        uc_observability::set_telemetry_enabled(enabled);
+    }
 
     Ok(Json(UpdateSettingsResponse {
         success: true,

--- a/src-tauri/crates/uc-webserver/src/api/settings.rs
+++ b/src-tauri/crates/uc-webserver/src/api/settings.rs
@@ -72,11 +72,20 @@ async fn update_settings_handler(
 ) -> Result<Json<UpdateSettingsResponse>, ApiError> {
     let app = state.app_facade_or_error()?;
 
-    // D-D1：patch 中 `network` 段非空（任何字段变更）时 restart_required = true。
-    // 当前 NetworkSettings 仅含 allow_relay_fallback；后续若加字段，仍走 is_some()
-    // 兜底。其它字段（general / sync 等）不影响该信号 — 它们不需要重启。
-    // Pitfall 3 防御：调用方（前端 Phase 95）必须显式承担"还没真正生效"。
-    let restart_required = payload.network.is_some();
+    // D-D1：以下两类 patch 触发 restart_required = true：
+    //   1. `network` 段非空（任何字段变更）—— 现有行为，Phase 95 引入。
+    //   2. `general.telemetry_enabled` 显式给值 —— 后端 Sentry 与 OTLP
+    //      都走 init-time gate（uc-bootstrap/src/tracing.rs），运行中改这
+    //      个开关不会影响已注册的全局 subscriber / sentry Hub。前端能
+    //      runtime 切换（SettingContext → setFrontendSentryEnabled），
+    //      但要让后端两条上报通道也对齐用户意图，必须重启。
+    // Pitfall 3 防御：调用方（前端）必须显式承担"还没真正生效"。
+    let telemetry_changed = payload
+        .general
+        .as_ref()
+        .and_then(|g| g.telemetry_enabled)
+        .is_some();
+    let restart_required = payload.network.is_some() || telemetry_changed;
 
     let updated = app
         .settings

--- a/src-tauri/crates/uc-webserver/tests/settings_network_smoke.rs
+++ b/src-tauri/crates/uc-webserver/tests/settings_network_smoke.rs
@@ -74,24 +74,25 @@ async fn simulate_put(facade: &SettingsFacade, body_json: &str) -> Value {
     // 1. 反序列化 wire body → DTO
     let payload: SettingsPatchDto = serde_json::from_str(body_json).expect("parse PUT body");
 
-    // 2. handler 内联计算 restart_required（Phase 94 plan 04 task 1 + 260505-17q）
+    // 2. handler 内联计算 restart_required（Phase 94 plan 04 task 1）
     //    必须与 src/api/settings.rs::update_settings_handler 同源。
-    //    触发条件：
-    //      - 任何 network 段变更（D-D1 原条款）
-    //      - general.telemetry_enabled 显式给值（260505-17q：后端 Sentry/OTLP
-    //        都走 init-time gate，改了要重启才生效）
-    let telemetry_changed = payload
-        .general
-        .as_ref()
-        .and_then(|g| g.telemetry_enabled)
-        .is_some();
-    let restart_required = payload.network.is_some() || telemetry_changed;
+    //    触发条件：任何 network 段变更（D-D1）。
+    //    260505-1np：telemetry_enabled 改成运行时 gate，不再触发重启。
+    let restart_required = payload.network.is_some();
 
-    // 3. DTO → View patch → SettingsFacade::update → View
+    // 3. handler 在 facade 写盘成功后会把新 telemetry 值推进
+    //    `uc_observability::set_telemetry_enabled` atomic — 这里复刻同一行为。
+    let telemetry_update = payload.general.as_ref().and_then(|g| g.telemetry_enabled);
+
+    // 4. DTO → View patch → SettingsFacade::update → View
     let view = facade
         .update(settings_patch_from_dto(payload))
         .await
         .expect("settings update");
+
+    if let Some(enabled) = telemetry_update {
+        uc_observability::set_telemetry_enabled(enabled);
+    }
 
     // 4. View → DTO，组装 UpdateSettingsResponse
     let resp = UpdateSettingsResponse {
@@ -280,16 +281,22 @@ async fn restart_required_truth_table() {
     );
 }
 
-/// Test 4（260505-17q — telemetry_enabled 触发 restart_required）：
-/// 后端 Sentry / OTLP 走 init-time gate，运行中改 telemetry 开关只能影响
-/// 前端（runtime gate via SettingContext）；要让后端两条上报通道也对齐
-/// 用户意图，必须重启。handler 因此把 telemetry_enabled 显式给值视为
-/// restart-triggering，与 network 段同语义。
+/// Test 4（260505-1np — telemetry_enabled 走运行时 gate）：
+/// 后端 Sentry / OTLP 现在通过 `uc_observability::is_telemetry_enabled()`
+/// 在 event 时检查 atomic 决定丢弃与否，PUT /settings 不再返回
+/// restart_required。这条用例锁定两件事：
+///   1. 任何 telemetry 变更都不触发 restart（与 17q 行为相反）；
+///   2. handler 写盘成功后把新值推进 `set_telemetry_enabled` atomic，
+///      下次 `is_telemetry_enabled()` 反映该值。
 #[tokio::test]
-async fn telemetry_toggle_signals_restart() {
+async fn telemetry_toggle_runtime_gate_no_restart() {
     let facade = build_facade();
 
-    // Case A：telemetryEnabled=false → restartRequired=true
+    // 锚定起点：默认 true。
+    uc_observability::set_telemetry_enabled(true);
+    assert!(uc_observability::is_telemetry_enabled());
+
+    // Case A：telemetryEnabled=false → restartRequired=false + atomic flipped。
     let off_resp = simulate_put(
         &facade,
         &json!({"general": {"telemetryEnabled": false}}).to_string(),
@@ -297,37 +304,45 @@ async fn telemetry_toggle_signals_restart() {
     .await;
     assert_eq!(
         off_resp["restartRequired"],
-        Value::Bool(true),
-        "telemetryEnabled=false must signal restart (backend init-time gate)"
+        Value::Bool(false),
+        "telemetry toggle must NOT signal restart (260505-1np runtime gate)"
     );
     assert_eq!(
         off_resp["data"]["general"]["telemetryEnabled"],
         Value::Bool(false),
         "PUT response must reflect written telemetry value"
     );
+    assert!(
+        !uc_observability::is_telemetry_enabled(),
+        "handler must push new telemetry value into the runtime gate atomic"
+    );
 
-    // Case B：telemetryEnabled=true → restartRequired=true（向另一方向切换同样要重启）
+    // Case B：telemetryEnabled=true → atomic flips back, still no restart.
     let on_resp = simulate_put(
         &facade,
         &json!({"general": {"telemetryEnabled": true}}).to_string(),
     )
     .await;
-    assert_eq!(
-        on_resp["restartRequired"],
-        Value::Bool(true),
-        "telemetryEnabled=true must also signal restart (re-enable path)"
+    assert_eq!(on_resp["restartRequired"], Value::Bool(false));
+    assert!(
+        uc_observability::is_telemetry_enabled(),
+        "re-enable path must flip atomic back to true"
     );
 
-    // Case C：general 段存在但 telemetryEnabled=None → 不触发 restart
-    // 防御 `payload.general.is_some()` 误用 — 必须只看 telemetry_enabled 字段本身。
+    // Case C：general 段不带 telemetryEnabled → atomic 不被触碰
+    // 防御 `payload.general.is_some()` 误用。
+    uc_observability::set_telemetry_enabled(false);
     let unrelated_resp = simulate_put(
         &facade,
         &json!({"general": {"deviceName": "ws-1"}}).to_string(),
     )
     .await;
-    assert_eq!(
-        unrelated_resp["restartRequired"],
-        Value::Bool(false),
-        "general patch without telemetryEnabled must NOT signal restart"
+    assert_eq!(unrelated_resp["restartRequired"], Value::Bool(false));
+    assert!(
+        !uc_observability::is_telemetry_enabled(),
+        "patches without telemetry_enabled must leave the atomic untouched"
     );
+
+    // 收尾恢复默认值，避免污染同进程其它测试。
+    uc_observability::set_telemetry_enabled(true);
 }

--- a/src-tauri/crates/uc-webserver/tests/settings_network_smoke.rs
+++ b/src-tauri/crates/uc-webserver/tests/settings_network_smoke.rs
@@ -74,8 +74,18 @@ async fn simulate_put(facade: &SettingsFacade, body_json: &str) -> Value {
     // 1. 反序列化 wire body → DTO
     let payload: SettingsPatchDto = serde_json::from_str(body_json).expect("parse PUT body");
 
-    // 2. handler 内联计算 restart_required（Phase 94 plan 04 task 1 改造 — D-D1）
-    let restart_required = payload.network.is_some();
+    // 2. handler 内联计算 restart_required（Phase 94 plan 04 task 1 + 260505-17q）
+    //    必须与 src/api/settings.rs::update_settings_handler 同源。
+    //    触发条件：
+    //      - 任何 network 段变更（D-D1 原条款）
+    //      - general.telemetry_enabled 显式给值（260505-17q：后端 Sentry/OTLP
+    //        都走 init-time gate，改了要重启才生效）
+    let telemetry_changed = payload
+        .general
+        .as_ref()
+        .and_then(|g| g.telemetry_enabled)
+        .is_some();
+    let restart_required = payload.network.is_some() || telemetry_changed;
 
     // 3. DTO → View patch → SettingsFacade::update → View
     let view = facade
@@ -267,5 +277,57 @@ async fn restart_required_truth_table() {
         case5_resp["restartRequired"],
         Value::Bool(false),
         "wire case 5: legacy general-only payload → restartRequired=false"
+    );
+}
+
+/// Test 4（260505-17q — telemetry_enabled 触发 restart_required）：
+/// 后端 Sentry / OTLP 走 init-time gate，运行中改 telemetry 开关只能影响
+/// 前端（runtime gate via SettingContext）；要让后端两条上报通道也对齐
+/// 用户意图，必须重启。handler 因此把 telemetry_enabled 显式给值视为
+/// restart-triggering，与 network 段同语义。
+#[tokio::test]
+async fn telemetry_toggle_signals_restart() {
+    let facade = build_facade();
+
+    // Case A：telemetryEnabled=false → restartRequired=true
+    let off_resp = simulate_put(
+        &facade,
+        &json!({"general": {"telemetryEnabled": false}}).to_string(),
+    )
+    .await;
+    assert_eq!(
+        off_resp["restartRequired"],
+        Value::Bool(true),
+        "telemetryEnabled=false must signal restart (backend init-time gate)"
+    );
+    assert_eq!(
+        off_resp["data"]["general"]["telemetryEnabled"],
+        Value::Bool(false),
+        "PUT response must reflect written telemetry value"
+    );
+
+    // Case B：telemetryEnabled=true → restartRequired=true（向另一方向切换同样要重启）
+    let on_resp = simulate_put(
+        &facade,
+        &json!({"general": {"telemetryEnabled": true}}).to_string(),
+    )
+    .await;
+    assert_eq!(
+        on_resp["restartRequired"],
+        Value::Bool(true),
+        "telemetryEnabled=true must also signal restart (re-enable path)"
+    );
+
+    // Case C：general 段存在但 telemetryEnabled=None → 不触发 restart
+    // 防御 `payload.general.is_some()` 误用 — 必须只看 telemetry_enabled 字段本身。
+    let unrelated_resp = simulate_put(
+        &facade,
+        &json!({"general": {"deviceName": "ws-1"}}).to_string(),
+    )
+    .await;
+    assert_eq!(
+        unrelated_resp["restartRequired"],
+        Value::Bool(false),
+        "general patch without telemetryEnabled must NOT signal restart"
     );
 }

--- a/src/contexts/SettingContext.tsx
+++ b/src/contexts/SettingContext.tsx
@@ -9,6 +9,8 @@ import { emitSettingsChanged } from '@/lib/settings-events'
 import { invokeWithTrace } from '@/lib/tauri-command'
 import { applyThemePreset } from '@/lib/theme-engine'
 import { startThemeTransition } from '@/lib/theme-transition'
+import { setFrontendTelemetryEnabled } from '@/observability/otlp'
+import { setFrontendSentryEnabled } from '@/observability/sentry'
 import type { SettingContextType, Settings } from '@/types/setting'
 
 const log = createLogger('setting-context')
@@ -258,6 +260,18 @@ export const SettingProvider: React.FC<SettingProviderProps> = ({ children }) =>
       log.error({ err }, 'Failed to sync tray language')
     })
   }, [setting?.general?.language])
+
+  // Push the user-facing telemetry toggle into both frontend observability sinks.
+  // Runs on initial settings load and on every subsequent change so toggling the
+  // switch in Settings → General takes effect without a frontend restart.
+  // Backend Sentry/OTLP use init-time gates and require a process restart —
+  // signaled separately via the PUT /settings restart_required field.
+  useEffect(() => {
+    const enabled = setting?.general?.telemetryEnabled
+    if (typeof enabled !== 'boolean') return
+    setFrontendTelemetryEnabled(enabled)
+    setFrontendSentryEnabled(enabled)
+  }, [setting?.general?.telemetryEnabled])
 
   const value: SettingContextType = {
     setting,

--- a/src/contexts/SettingContext.tsx
+++ b/src/contexts/SettingContext.tsx
@@ -261,11 +261,8 @@ export const SettingProvider: React.FC<SettingProviderProps> = ({ children }) =>
     })
   }, [setting?.general?.language])
 
-  // Push the user-facing telemetry toggle into both frontend observability sinks.
-  // Runs on initial settings load and on every subsequent change so toggling the
-  // switch in Settings → General takes effect without a frontend restart.
-  // Backend Sentry/OTLP use init-time gates and require a process restart —
-  // signaled separately via the PUT /settings restart_required field.
+  // 将用户侧遥测开关同步到前端观测出口；初次加载设置和后续变更都会立即生效。
+  // 后端 Sentry/OTLP 通过 uc-observability 的运行时 gate 同步，不需要重启。
   useEffect(() => {
     const enabled = setting?.general?.telemetryEnabled
     if (typeof enabled !== 'boolean') return

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,9 +6,15 @@ import App from './App'
 import './i18n'
 import { store } from './store'
 import { connectDaemonWs, registerDaemonShutdownListener } from '@/lib/daemon-ws-bootstrap'
+import { initFrontendOtlp } from '@/observability/otlp'
 import { initSentry, Sentry } from '@/observability/sentry'
 
 initSentry()
+// OTLP buffer/endpoint setup. Whether records actually flush is gated by
+// `setFrontendTelemetryEnabled`, wired from SettingContext once the daemon
+// returns settings — so events queued before that point are dropped silently
+// (consistent with telemetry-off as the conservative startup default).
+initFrontendOtlp()
 
 const startupTimingOrigin = Date.now()
 const logStartupTiming = (label: string) => {

--- a/src/observability/__tests__/sentry.test.ts
+++ b/src/observability/__tests__/sentry.test.ts
@@ -17,8 +17,8 @@ vi.mock('@sentry/react', async importOriginal => {
 describe('initSentry', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    // Reset runtime gate so each test starts from "enabled".
-    setFrontendSentryEnabled(true)
+    // 重置到启动默认值，避免设置加载前误发。
+    setFrontendSentryEnabled(false)
   })
 
   it('initializes Sentry with correct configuration', () => {
@@ -36,6 +36,7 @@ describe('initSentry', () => {
   })
 
   it('scrubs sensitive data from breadcrumbs', () => {
+    setFrontendSentryEnabled(true)
     initSentry()
     const initCall = vi.mocked(Sentry.init).mock.calls[0][0]
     const beforeBreadcrumb = initCall.beforeBreadcrumb!
@@ -57,6 +58,7 @@ describe('initSentry', () => {
   })
 
   it('scrubs sensitive data from event extra', async () => {
+    setFrontendSentryEnabled(true)
     initSentry()
     const initCall = vi.mocked(Sentry.init).mock.calls[0][0]
     const beforeSend = initCall.beforeSend!
@@ -77,6 +79,7 @@ describe('initSentry', () => {
   })
 
   it('preserves existing ResizeObserver filter in beforeSend', async () => {
+    setFrontendSentryEnabled(true)
     initSentry()
     const initCall = vi.mocked(Sentry.init).mock.calls[0][0]
     const beforeSend = initCall.beforeSend!
@@ -110,6 +113,15 @@ describe('initSentry', () => {
     expect(await Promise.resolve(beforeSend(event, {}))).toBeNull()
     expect(beforeBreadcrumb(breadcrumb, {})).toBeNull()
     expect(beforeSendLog(log)).toBeNull()
+  })
+
+  it('starts with the runtime gate disabled until settings enable it', async () => {
+    initSentry()
+    const initCall = vi.mocked(Sentry.init).mock.calls[0][0]
+    const beforeSend = initCall.beforeSend!
+
+    const event = { extra: { early: 'startup' } } as unknown as ErrorEvent
+    expect(await Promise.resolve(beforeSend(event, {}))).toBeNull()
   })
 
   it('passes events through when telemetry runtime gate is re-enabled', async () => {

--- a/src/observability/__tests__/sentry.test.ts
+++ b/src/observability/__tests__/sentry.test.ts
@@ -1,7 +1,7 @@
 import type { ErrorEvent } from '@sentry/core'
 import * as Sentry from '@sentry/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { initSentry, setFrontendSentryEnabled } from '../sentry'
+import { initSentry, setFrontendSentryEnabled } from '@/observability/sentry'
 
 // Mock Sentry
 vi.mock('@sentry/react', async importOriginal => {

--- a/src/observability/__tests__/sentry.test.ts
+++ b/src/observability/__tests__/sentry.test.ts
@@ -1,7 +1,7 @@
 import type { ErrorEvent } from '@sentry/core'
 import * as Sentry from '@sentry/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { initSentry } from '../sentry'
+import { initSentry, setFrontendSentryEnabled } from '../sentry'
 
 // Mock Sentry
 vi.mock('@sentry/react', async importOriginal => {
@@ -17,6 +17,8 @@ vi.mock('@sentry/react', async importOriginal => {
 describe('initSentry', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    // Reset runtime gate so each test starts from "enabled".
+    setFrontendSentryEnabled(true)
   })
 
   it('initializes Sentry with correct configuration', () => {
@@ -88,5 +90,40 @@ describe('initSentry', () => {
     const result = await Promise.resolve(beforeSend(resizeEvent, {}))
 
     expect(result).toBeNull()
+  })
+
+  it('drops events when telemetry runtime gate is disabled', async () => {
+    initSentry()
+    const initCall = vi.mocked(Sentry.init).mock.calls[0][0]
+    const beforeSend = initCall.beforeSend!
+    const beforeBreadcrumb = initCall.beforeBreadcrumb!
+    const beforeSendLog = initCall.beforeSendLog!
+
+    setFrontendSentryEnabled(false)
+
+    const event = { extra: { foo: 'bar' } } as unknown as ErrorEvent
+    const breadcrumb: Sentry.Breadcrumb = { message: 'click' }
+    const log = { body: 'hello', attributes: { x: 1 } } as unknown as Parameters<
+      NonNullable<typeof beforeSendLog>
+    >[0]
+
+    expect(await Promise.resolve(beforeSend(event, {}))).toBeNull()
+    expect(beforeBreadcrumb(breadcrumb, {})).toBeNull()
+    expect(beforeSendLog(log)).toBeNull()
+  })
+
+  it('passes events through when telemetry runtime gate is re-enabled', async () => {
+    initSentry()
+    const initCall = vi.mocked(Sentry.init).mock.calls[0][0]
+    const beforeSend = initCall.beforeSend!
+
+    setFrontendSentryEnabled(false)
+    setFrontendSentryEnabled(true)
+
+    const event = { extra: { safe: 'data' } } as unknown as ErrorEvent
+    const result = await Promise.resolve(beforeSend(event, {}))
+
+    expect(result).not.toBeNull()
+    expect(result?.extra).toEqual({ safe: 'data' })
   })
 })

--- a/src/observability/sentry.ts
+++ b/src/observability/sentry.ts
@@ -13,19 +13,15 @@ import { redactSensitiveArgs } from '@/observability/redaction'
 const sentryEnabled = Boolean(import.meta.env.VITE_SENTRY_DSN)
 
 /**
- * Runtime telemetry gate, mirrors `general.telemetryEnabled`.
+ * 运行时遥测开关，镜像 `general.telemetryEnabled`。
  *
- * Default `true` so events emitted before settings finish loading still flow
- * to Sentry — losing the first few hundred ms of startup errors would defeat
- * the point of frontend error tracking. SettingContext flips this to the
- * persisted user preference as soon as the daemon returns settings, and on
- * every subsequent update.
+ * 默认 `false`，避免设置加载完成前的事件在尚未确认用户持久化偏好时离开进程。
+ * SettingContext 会在 daemon 返回设置后立即把它切到持久化值，之后每次更新也会同步。
  *
- * Backend equivalent: `tracing_subscriber::init` reads telemetry_enabled
- * from disk and gates Sentry/OTLP at init time (requires restart). The
- * frontend can do better — runtime toggle via beforeSend hooks below.
+ * 后端等价开关在 `uc_observability::telemetry_gate`，前端用下面的 beforeSend
+ * 系列 hook 做运行时过滤。
  */
-let sentryRuntimeEnabled = true
+let sentryRuntimeEnabled = false
 
 export function setFrontendSentryEnabled(enabled: boolean): void {
   sentryRuntimeEnabled = enabled

--- a/src/observability/sentry.ts
+++ b/src/observability/sentry.ts
@@ -12,6 +12,25 @@ import { redactSensitiveArgs } from '@/observability/redaction'
 
 const sentryEnabled = Boolean(import.meta.env.VITE_SENTRY_DSN)
 
+/**
+ * Runtime telemetry gate, mirrors `general.telemetryEnabled`.
+ *
+ * Default `true` so events emitted before settings finish loading still flow
+ * to Sentry — losing the first few hundred ms of startup errors would defeat
+ * the point of frontend error tracking. SettingContext flips this to the
+ * persisted user preference as soon as the daemon returns settings, and on
+ * every subsequent update.
+ *
+ * Backend equivalent: `tracing_subscriber::init` reads telemetry_enabled
+ * from disk and gates Sentry/OTLP at init time (requires restart). The
+ * frontend can do better — runtime toggle via beforeSend hooks below.
+ */
+let sentryRuntimeEnabled = true
+
+export function setFrontendSentryEnabled(enabled: boolean): void {
+  sentryRuntimeEnabled = enabled
+}
+
 const getTauriPlatform = (): string => {
   if (typeof window === 'undefined' || !('__TAURI__' in window)) {
     return 'unknown'
@@ -30,6 +49,9 @@ export function initSentry(): void {
   }
 
   const beforeSend: (event: ErrorEvent, hint: EventHint) => ErrorEvent | null = (event, _hint) => {
+    if (!sentryRuntimeEnabled) {
+      return null
+    }
     const type = event.exception?.values?.[0]?.type
     if (type === 'ResizeObserver loop limit exceeded') {
       return null
@@ -41,6 +63,9 @@ export function initSentry(): void {
   }
 
   const beforeBreadcrumb = (breadcrumb: Sentry.Breadcrumb): Sentry.Breadcrumb | null => {
+    if (!sentryRuntimeEnabled) {
+      return null
+    }
     if (breadcrumb.data) {
       breadcrumb.data = redactSensitiveArgs(breadcrumb.data) as Record<string, unknown>
     }
@@ -71,6 +96,9 @@ export function initSentry(): void {
     beforeSend,
     beforeBreadcrumb,
     beforeSendLog: log => {
+      if (!sentryRuntimeEnabled) {
+        return null
+      }
       if (log.attributes) {
         log.attributes = redactSensitiveArgs(log.attributes) as Record<string, unknown>
       }


### PR DESCRIPTION
## Summary

Runtime-gates frontend and backend telemetry so Sentry and OTLP respect the user telemetry setting without requiring a restart.
Adds a shared backend telemetry gate, wires settings updates into it, and keeps restart-required limited to network changes.
Bootstraps frontend OTLP and syncs frontend Sentry/OTLP gates from settings.
Includes planning summaries and tests for the telemetry toggle behavior.

## Verification

- npx vitest run src/observability/__tests__/sentry.test.ts src/observability/__tests__/otlp.test.ts src/contexts/__tests__/SettingContext.network.test.tsx src/api/daemon/__tests__/settings.test.ts
- cargo test -p uc-observability --manifest-path Cargo.toml
- cargo test -p uc-webserver --test settings_network_smoke --manifest-path Cargo.toml
- cargo check -p uc-bootstrap -p uc-webserver -p uc-observability --manifest-path Cargo.toml
- bun run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Telemetry toggle now applies immediately without requiring an app restart.
  * Frontend telemetry settings are synchronized with backend in real-time.

* **Bug Fixes**
  * Fixed telemetry preferences not consistently applying across all telemetry services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->