### PR TITLE
fix(observability): Sentry/OTLP environment 跟随 release channel,alpha 不再误标 production

### DIFF
--- a/.github/workflows/alpha-build.yml
+++ b/.github/workflows/alpha-build.yml
@@ -86,6 +86,7 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
           VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}
+          VITE_APP_ENV: alpha
           # Backend Sentry DSN — independent Rust project DSN.
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           APP_ENV: alpha

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,16 @@ on:
           - 'windows-latest'
           - 'all'
         default: 'all'
+      channel:
+        description: '发布渠道(决定 Sentry/OTLP environment 标签)'
+        required: false
+        type: choice
+        options:
+          - 'stable'
+          - 'alpha'
+          - 'beta'
+          - 'rc'
+        default: 'stable'
   workflow_call:
     inputs:
       platform:
@@ -26,6 +36,11 @@ on:
         required: false
         type: string
         default: ''
+      channel:
+        description: '发布渠道,决定 APP_ENV/VITE_APP_ENV 注入值(stable→production,其他→channel 原样)'
+        required: false
+        type: string
+        default: 'stable'
 
 jobs:
   setup-matrix:
@@ -111,6 +126,27 @@ jobs:
           version="$(node -p "require('./package.json').version")"
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
+      - name: resolve APP_ENV from channel
+        # Sentry/OTLP environment 标签来源:
+        #   stable  → "production" (Sentry 默认值,符合大多数 dashboard 习惯)
+        #   alpha/beta/rc → 同名,作为独立 environment
+        # 该值同时注入给 Rust 后端 (APP_ENV, option_env! 编译期读取) 和前端
+        # (VITE_APP_ENV, Vite 在 build 时内联),保证前后端 environment 一致。
+        id: resolve-env
+        shell: bash
+        run: |
+          CHANNEL="${{ inputs.channel || 'stable' }}"
+          case "$CHANNEL" in
+            stable) APP_ENV="production" ;;
+            alpha|beta|rc) APP_ENV="$CHANNEL" ;;
+            *)
+              echo "::warning::未知 channel '$CHANNEL',回退为 production"
+              APP_ENV="production"
+              ;;
+          esac
+          echo "app_env=$APP_ENV" >> "$GITHUB_OUTPUT"
+          echo "Resolved APP_ENV=$APP_ENV (from channel=$CHANNEL)"
+
       - name: build Tauri app (macOS signed)
         if: matrix.platform == 'macos-latest'
         uses: tauri-apps/tauri-action@v0
@@ -119,13 +155,14 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
           VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}
+          VITE_APP_ENV: ${{ steps.resolve-env.outputs.app_env }}
           # Backend Sentry DSN — independent Rust project DSN, baked into the
           # binary at compile time via option_env! in uc-bootstrap/src/tracing.rs.
           # MUST be a separate Sentry project from VITE_SENTRY_DSN (front-end);
           # see "阶段 2" decision in the dependency-prune branch discussion.
           # Empty secret = backend Sentry disabled.
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
-          APP_ENV: production
+          APP_ENV: ${{ steps.resolve-env.outputs.app_env }}
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
           APPLE_ID: ${{ secrets.APPLE_ID }}
@@ -145,9 +182,10 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
           VITE_APP_VERSION: ${{ steps.app-version.outputs.version }}
           VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}
+          VITE_APP_ENV: ${{ steps.resolve-env.outputs.app_env }}
           # Backend Sentry DSN — independent Rust project DSN.
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
-          APP_ENV: production
+          APP_ENV: ${{ steps.resolve-env.outputs.app_env }}
           VITE_OTEL_EXPORTER_OTLP_ENDPOINT: ${{ secrets.OTEL_EXPORTER_OTLP_ENDPOINT }}
           OTEL_EXPORTER_OTLP_ENDPOINT: ${{ secrets.OTEL_EXPORTER_OTLP_ENDPOINT }}
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,6 +155,7 @@ jobs:
     with:
       platform: ${{ inputs.platform || 'all' }}
       branch: ${{ inputs.branch || '' }}
+      channel: ${{ needs.validate.outputs.channel }}
     secrets: inherit
 
   build-cli:

--- a/src-tauri/crates/uc-observability/src/otlp/resource.rs
+++ b/src-tauri/crates/uc-observability/src/otlp/resource.rs
@@ -9,13 +9,22 @@ pub fn build_resource(device_id: Option<&str>) -> Resource {
         // TODO: use semconv::OS_TYPE when `semconv_experimental` feature is stable in 0.31.x
         KeyValue::new("os.type", std::env::consts::OS),
         // TODO: semconv const when stabilized in opentelemetry-semantic-conventions 0.31
+        //
+        // 优先读编译期 `APP_ENV`(CI 在 build.yml/alpha-build.yml 注入,与后端
+        // Sentry tracing.rs 共用同一个变量来源),保证 channel 区分:
+        //   - stable release → "production"
+        //   - alpha/beta/rc release → 同名 channel
+        // CI 没注入(本地 cargo run / cargo test)时退回旧行为:debug build 标
+        // "development",release build 标 "production"。
         KeyValue::new(
             "deployment.environment.name",
-            if cfg!(debug_assertions) {
-                "development"
-            } else {
-                "production"
-            },
+            option_env!("APP_ENV")
+                .filter(|s| !s.is_empty())
+                .unwrap_or(if cfg!(debug_assertions) {
+                    "development"
+                } else {
+                    "production"
+                }),
         ),
     ];
     let resolved = device_id

--- a/src/observability/otlp.ts
+++ b/src/observability/otlp.ts
@@ -61,7 +61,10 @@ function resolveFrontendOtlpEndpoint(): string {
 function buildResourceAttributes(): OtlpKeyValue[] {
   const attrs: OtlpKeyValue[] = [
     { key: 'service.name', value: { stringValue: SERVICE_NAME } },
-    { key: 'deployment.environment', value: { stringValue: import.meta.env.MODE } },
+    {
+      key: 'deployment.environment',
+      value: { stringValue: import.meta.env.VITE_APP_ENV ?? import.meta.env.MODE },
+    },
   ]
 
   if (frontendDeviceId) {

--- a/src/observability/sentry.ts
+++ b/src/observability/sentry.ts
@@ -52,7 +52,7 @@ export function initSentry(): void {
     tracesSampleRate: import.meta.env.DEV ? 1.0 : 0.1,
     replaysSessionSampleRate: import.meta.env.DEV ? 1.0 : 0.1,
     replaysOnErrorSampleRate: 1.0,
-    environment: import.meta.env.MODE,
+    environment: import.meta.env.VITE_APP_ENV ?? import.meta.env.MODE,
     release: import.meta.env.VITE_APP_VERSION,
     sendDefaultPii: true,
     enableLogs: true,

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -3,6 +3,7 @@
 interface ImportMetaEnv {
   readonly VITE_SENTRY_DSN?: string
   readonly VITE_APP_VERSION?: string
+  readonly VITE_APP_ENV?: string
   readonly VITE_OTEL_EXPORTER_OTLP_ENDPOINT?: string
   readonly VITE_SEQ_URL?: string
 }


### PR DESCRIPTION
## Summary

修复 alpha 等预发布版本在 Sentry/OTLP 上 `environment` 一律显示 `production` 的问题。`release.yml` 之前没把 `channel` 透传到 `build.yml`，加上 `build.yml` 把 `APP_ENV` 硬编码为 `production`、后端 OTLP `resource.rs` 用 `cfg!(debug_assertions)` 二选一，导致 v0.7.0-alpha.1 等版本上报到 Sentry/OTLP 时 environment 全部错标 `production`，污染告警和 release health 指标。

本次让 channel 信号一路从 `release.yml validate` → `build.yml` → CI 编译期 (`APP_ENV` for Rust `option_env!` / `VITE_APP_ENV` for Vite)，覆盖前后端 Sentry 和前后端 OTLP 四处 environment 字段；本地 dev 行为通过 fallback 保留不变（前端回退到 `import.meta.env.MODE`，后端回退到 `cfg!(debug_assertions)`）。映射规则：`stable→production`，`alpha/beta/rc→` 同名 channel。

## Test plan

- [x] `tsc --noEmit` 通过
- [x] `vitest run src/observability/__tests__/sentry.test.ts` 4/4 通过
- [x] `cargo check -p uc-observability` 通过
- [ ] 下次手动触发 alpha release，验证 Sentry/OTLP 上 environment 字段显示为 `alpha`
- [ ] 下次 stable release，验证 environment 显示 `production`，本地 `vite dev` / `cargo run` 行为不变