### PR TITLE
fix(security): 自动迁移 iroh device identity,免去 0.6→0.7 升级重新配对

### DIFF
--- a/src-tauri/crates/uc-bootstrap/src/space_setup.rs
+++ b/src-tauri/crates/uc-bootstrap/src/space_setup.rs
@@ -42,13 +42,14 @@ use uc_core::ports::{
 use uc_infra::network::iroh::transfer_progress_adapter::InboundProgressEvent;
 use uc_infra::network::iroh::{
     BlobHandlers, ClipboardHandlers, IrohIdentityStore, IrohNode, IrohNodeBuilder, IrohNodeError,
-    TransferProgressHandlers,
+    TransferProgressHandlers, IDENTITY_STORE_KEY,
 };
 // Re-exported so external callers can parametrise the assembly without
 // having to `use uc_infra` themselves.
 pub use uc_infra::network::iroh::IrohNodeConfig;
 use uc_infra::security::Sha256IdentityFingerprintFactory;
 use uc_platform::file_secure_storage::FileSecureStorage;
+use uc_platform::migrating_secure_storage::MigratingSecureStorage;
 
 use crate::assembly::WiredDependencies;
 
@@ -233,13 +234,31 @@ pub async fn build_space_setup_assembly(
     // 攻击者还需要 KEK 才能解密剪贴板内容),用 0600 文件 + FileVault
     // 全盘加密保护已足够,与 SSH/IPFS/Tailscale 等同类工具实践一致。
     //
-    // Migration: 老用户 keychain 中残留的 `iroh-identity:v1` 条目**不动**
-    // (不读、不删,避免触发新的 keychain 弹窗);文件不存在 →
-    // `IrohIdentityStore::ensure_secret_key` 生成新身份 → 老用户在升级后
-    // iroh 设备身份重置,需要重新与 peer 配对一次。
-    let iroh_identity_storage: Arc<dyn uc_core::ports::SecureStoragePort> = Arc::new(
+    // Migration (0.6.x → 0.7+): 0.6.x 把 `iroh-identity:v1` 写在系统 keychain
+    // (与 KEK 同 service "UniClipboard")。直接换 file backend 会让升级用户
+    // 的 iroh 设备身份重置 → 对端 `trusted_peer.peer_fingerprint` 不再匹配
+    // → 必须重新走完整 pairing 流程。这里用 `MigratingSecureStorage` 做
+    // 一次性迁移装饰:`get` 优先 file,miss 时 fallback 查 keychain,命中
+    // 后写 file 并 best-effort 删 keychain。后续 `set` / `delete` 只走 file。
+    //
+    // 迁移仅作用于 `IDENTITY_STORE_KEY` 白名单——其他 key 的访问永远不会
+    // 触碰 keychain,因此 fresh 安装零额外 keychain 调用(平台 NoEntry 不
+    // 弹窗);只有"keychain 里恰好有 iroh-identity:v1 条目"的升级路径会
+    // 读一次 keychain。在生产签名稳定的 build 上,同应用同 service 的读取
+    // 命中已有 ACL 白名单 → 不弹 prompt;最坏情况(codesign drift)弹一次
+    // 也比让用户重新配对友好得多。
+    //
+    // 迁移代码保留至 1.0:确保跳版本升级 (e.g. 0.6.x → 0.7.5 跳过中间版本)
+    // 仍能拾起残留的 keychain 条目;清理时机与 0.6.x EOL 对齐。
+    let file_backend: Arc<dyn uc_core::ports::SecureStoragePort> = Arc::new(
         FileSecureStorage::with_base_dir(wired.iroh_identity_dir.clone()),
     );
+    let iroh_identity_storage: Arc<dyn uc_core::ports::SecureStoragePort> =
+        Arc::new(MigratingSecureStorage::new(
+            file_backend,
+            Arc::clone(&deps.security.secure_storage),
+            vec![IDENTITY_STORE_KEY.to_string()],
+        ));
     let identity_store = Arc::new(IrohIdentityStore::new(
         iroh_identity_storage,
         Arc::new(Sha256IdentityFingerprintFactory),

--- a/src-tauri/crates/uc-platform/src/lib.rs
+++ b/src-tauri/crates/uc-platform/src/lib.rs
@@ -59,6 +59,7 @@ pub mod bootstrap;
 pub mod capability;
 pub mod clipboard;
 pub mod file_secure_storage;
+pub mod migrating_secure_storage;
 pub mod ports;
 pub mod secure_storage;
 pub mod system_secure_storage;

--- a/src-tauri/crates/uc-platform/src/migrating_secure_storage.rs
+++ b/src-tauri/crates/uc-platform/src/migrating_secure_storage.rs
@@ -1,0 +1,371 @@
+//! `MigratingSecureStorage` —— 一次性把指定 key 从 legacy 后端搬到 primary 后端的装饰器。
+//!
+//! ## 适用场景
+//!
+//! 当某个 secret 的存储后端发生迁移（例如 0.6.0 把 iroh device identity 从
+//! macOS Keychain 搬到 `<app_data>/iroh-identity/` 的文件存储），需要让升级
+//! 上来的老用户**自动**沿用旧值，而不是因为新后端为空就生成全新的 secret。
+//!
+//! ## 行为契约
+//!
+//! * `get(k)`：先查 `primary`；命中返回。否则若 `k ∈ migration_keys` 则查
+//!   `legacy_fallback`：legacy 命中时**先写 primary，再 best-effort 删
+//!   legacy**，返回 legacy 值；legacy 也 miss 则返回 `Ok(None)`。`k` 不在
+//!   `migration_keys` 时**永远不查** legacy（避免给非迁移路径无谓增加访问）。
+//! * `set(k, v)` / `delete(k)`：只走 `primary`。迁移装饰器对外只看见
+//!   primary 的状态，永远不会回写或扩散到 legacy。
+//!
+//! ## 失败语义
+//!
+//! * `primary.set` 失败：迁移整体失败，向上抛 `SecureStorageError`，**不动**
+//!   legacy。这样下次启动还能再试，避免数据丢失。
+//! * `legacy.delete` 失败：仅 `warn!` log，不影响业务结果。重复迁移幂等
+//!   ——下次启动 primary 已命中，根本不进入 legacy 分支。
+//!
+//! ## 跨平台 prompt 影响
+//!
+//! 在 macOS 上读取已存在但 ACL 不匹配当前 codesign 的 keychain item 会触发
+//! 系统授权弹窗。但：
+//! 1. 旧 keychain 里**没有**该 key 时（fresh install），平台返回 `NoEntry`
+//!    不弹窗，所以新装用户零额外 prompt。
+//! 2. 老用户升级时即便 prompt 一次，相比"必须重新走完整 pairing 流程"
+//!    （输 passphrase + 找 PIN + 等握手）体验显著更好；而且实际场景下用户
+//!    通常已经为同 service 的 KEK item 选过 "Always Allow"，同应用读其他 item
+//!    在生产签名稳定的 build 上不再 prompt。
+//!
+//! Windows / Linux 平台的 secret store 没有 per-item ACL prompt 行为，迁移
+//! 完全无感。
+
+use std::sync::Arc;
+
+use tracing::{debug, info, warn};
+use uc_core::ports::{SecureStorageError, SecureStoragePort};
+
+/// 把 `legacy_fallback` 中白名单 key 一次性搬到 `primary` 的装饰器。
+///
+/// 详见 module doc。
+pub struct MigratingSecureStorage {
+    primary: Arc<dyn SecureStoragePort>,
+    legacy_fallback: Arc<dyn SecureStoragePort>,
+    migration_keys: Vec<String>,
+}
+
+impl MigratingSecureStorage {
+    /// 构造装饰器。`migration_keys` 是允许从 `legacy_fallback` 迁移的 key
+    /// 白名单——只有列在白名单里的 key 才会触发 legacy 查询。
+    pub fn new(
+        primary: Arc<dyn SecureStoragePort>,
+        legacy_fallback: Arc<dyn SecureStoragePort>,
+        migration_keys: Vec<String>,
+    ) -> Self {
+        Self {
+            primary,
+            legacy_fallback,
+            migration_keys,
+        }
+    }
+
+    fn is_migratable(&self, key: &str) -> bool {
+        self.migration_keys.iter().any(|k| k == key)
+    }
+}
+
+impl SecureStoragePort for MigratingSecureStorage {
+    fn get(&self, key: &str) -> Result<Option<Vec<u8>>, SecureStorageError> {
+        if let Some(value) = self.primary.get(key)? {
+            return Ok(Some(value));
+        }
+        if !self.is_migratable(key) {
+            return Ok(None);
+        }
+        match self.legacy_fallback.get(key)? {
+            Some(value) => {
+                // 先把 legacy 值落地到 primary，再删 legacy。任一步顺序错都会
+                // 导致升级路径不幂等：先删后写而中间崩溃 → 数据永久丢失。
+                self.primary.set(key, &value)?;
+                match self.legacy_fallback.delete(key) {
+                    Ok(()) => {
+                        info!(
+                            key = %key,
+                            "migrated secret from legacy secure storage to primary"
+                        );
+                    }
+                    Err(err) => {
+                        // 删除失败不影响业务：下次启动 primary 命中后根本不
+                        // 走 legacy 分支，残留条目不会引起任何冲突；用户主动
+                        // factory_reset 时再统一清理。
+                        warn!(
+                            key = %key,
+                            error = %err,
+                            "migrated secret to primary, but legacy delete failed; \
+                             residual entry will be ignored on next boot"
+                        );
+                    }
+                }
+                Ok(Some(value))
+            }
+            None => {
+                debug!(
+                    key = %key,
+                    "no legacy secret found; primary remains empty"
+                );
+                Ok(None)
+            }
+        }
+    }
+
+    fn set(&self, key: &str, value: &[u8]) -> Result<(), SecureStorageError> {
+        self.primary.set(key, value)
+    }
+
+    fn delete(&self, key: &str) -> Result<(), SecureStorageError> {
+        self.primary.delete(key)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+
+    /// In-memory `SecureStoragePort` 用于测试。配合 `Mutex<Counters>` 暴露
+    /// 调用次数，让测试断言"legacy 在不应被访问时一次都没被调过"。
+    #[derive(Default)]
+    struct InMemoryStore {
+        map: Mutex<HashMap<String, Vec<u8>>>,
+        counters: Mutex<Counters>,
+        fail_set: Mutex<bool>,
+        fail_delete: Mutex<bool>,
+    }
+
+    #[derive(Default, Debug, Clone)]
+    struct Counters {
+        gets: usize,
+        sets: usize,
+        deletes: usize,
+    }
+
+    impl InMemoryStore {
+        fn new() -> Arc<Self> {
+            Arc::new(Self::default())
+        }
+
+        fn with_entry(key: &str, value: &[u8]) -> Arc<Self> {
+            let store = Self::default();
+            store
+                .map
+                .lock()
+                .unwrap()
+                .insert(key.to_string(), value.to_vec());
+            Arc::new(store)
+        }
+
+        fn counters(&self) -> Counters {
+            self.counters.lock().unwrap().clone()
+        }
+
+        fn has(&self, key: &str) -> bool {
+            self.map.lock().unwrap().contains_key(key)
+        }
+
+        fn get_value(&self, key: &str) -> Option<Vec<u8>> {
+            self.map.lock().unwrap().get(key).cloned()
+        }
+
+        fn arm_set_failure(&self) {
+            *self.fail_set.lock().unwrap() = true;
+        }
+
+        fn arm_delete_failure(&self) {
+            *self.fail_delete.lock().unwrap() = true;
+        }
+    }
+
+    impl SecureStoragePort for InMemoryStore {
+        fn get(&self, key: &str) -> Result<Option<Vec<u8>>, SecureStorageError> {
+            self.counters.lock().unwrap().gets += 1;
+            Ok(self.map.lock().unwrap().get(key).cloned())
+        }
+
+        fn set(&self, key: &str, value: &[u8]) -> Result<(), SecureStorageError> {
+            self.counters.lock().unwrap().sets += 1;
+            if *self.fail_set.lock().unwrap() {
+                return Err(SecureStorageError::Other("test: set failed".into()));
+            }
+            self.map
+                .lock()
+                .unwrap()
+                .insert(key.to_string(), value.to_vec());
+            Ok(())
+        }
+
+        fn delete(&self, key: &str) -> Result<(), SecureStorageError> {
+            self.counters.lock().unwrap().deletes += 1;
+            if *self.fail_delete.lock().unwrap() {
+                return Err(SecureStorageError::Other("test: delete failed".into()));
+            }
+            self.map.lock().unwrap().remove(key);
+            Ok(())
+        }
+    }
+
+    const KEY: &str = "iroh-identity:v1";
+    const OTHER_KEY: &str = "kek:default";
+
+    fn build(
+        primary: Arc<InMemoryStore>,
+        legacy: Arc<InMemoryStore>,
+        whitelist: &[&str],
+    ) -> MigratingSecureStorage {
+        MigratingSecureStorage::new(
+            primary,
+            legacy,
+            whitelist.iter().map(|s| s.to_string()).collect(),
+        )
+    }
+
+    #[test]
+    fn primary_hit_skips_legacy() {
+        let primary = InMemoryStore::with_entry(KEY, b"primary-value");
+        let legacy = InMemoryStore::with_entry(KEY, b"legacy-value");
+        let store = build(Arc::clone(&primary), Arc::clone(&legacy), &[KEY]);
+
+        let got = store.get(KEY).unwrap();
+
+        assert_eq!(got.as_deref(), Some(&b"primary-value"[..]));
+        assert_eq!(legacy.counters().gets, 0, "legacy must not be queried");
+    }
+
+    #[test]
+    fn legacy_hit_migrates_then_deletes_legacy() {
+        let primary = InMemoryStore::new();
+        let legacy = InMemoryStore::with_entry(KEY, b"legacy-value");
+        let store = build(Arc::clone(&primary), Arc::clone(&legacy), &[KEY]);
+
+        let got = store.get(KEY).unwrap();
+
+        assert_eq!(got.as_deref(), Some(&b"legacy-value"[..]));
+        assert_eq!(
+            primary.get_value(KEY).as_deref(),
+            Some(&b"legacy-value"[..]),
+            "value must be persisted into primary"
+        );
+        assert!(
+            !legacy.has(KEY),
+            "legacy entry must be deleted after migration"
+        );
+        let legacy_counters = legacy.counters();
+        assert_eq!(legacy_counters.gets, 1);
+        assert_eq!(legacy_counters.deletes, 1);
+    }
+
+    #[test]
+    fn second_get_after_migration_does_not_touch_legacy() {
+        let primary = InMemoryStore::new();
+        let legacy = InMemoryStore::with_entry(KEY, b"legacy-value");
+        let store = build(Arc::clone(&primary), Arc::clone(&legacy), &[KEY]);
+
+        let _ = store.get(KEY).unwrap();
+        let before = legacy.counters();
+        let _ = store.get(KEY).unwrap();
+        let after = legacy.counters();
+
+        assert_eq!(
+            before.gets, after.gets,
+            "legacy must not be re-queried once primary is populated"
+        );
+    }
+
+    #[test]
+    fn both_miss_returns_none_without_writing_primary() {
+        let primary = InMemoryStore::new();
+        let legacy = InMemoryStore::new();
+        let store = build(Arc::clone(&primary), Arc::clone(&legacy), &[KEY]);
+
+        let got = store.get(KEY).unwrap();
+
+        assert!(got.is_none());
+        assert_eq!(primary.counters().sets, 0);
+        assert!(!primary.has(KEY));
+    }
+
+    #[test]
+    fn non_whitelisted_key_never_consults_legacy() {
+        let primary = InMemoryStore::new();
+        let legacy = InMemoryStore::with_entry(OTHER_KEY, b"sensitive-kek");
+        let store = build(Arc::clone(&primary), Arc::clone(&legacy), &[KEY]);
+
+        let got = store.get(OTHER_KEY).unwrap();
+
+        assert!(got.is_none());
+        assert_eq!(
+            legacy.counters().gets,
+            0,
+            "non-migratable key must not trigger legacy access"
+        );
+    }
+
+    #[test]
+    fn primary_set_failure_keeps_legacy_intact() {
+        let primary = InMemoryStore::new();
+        primary.arm_set_failure();
+        let legacy = InMemoryStore::with_entry(KEY, b"legacy-value");
+        let store = build(Arc::clone(&primary), Arc::clone(&legacy), &[KEY]);
+
+        let result = store.get(KEY);
+
+        assert!(result.is_err(), "primary write failure must propagate");
+        assert!(
+            legacy.has(KEY),
+            "legacy entry must remain so next boot can retry"
+        );
+        assert_eq!(legacy.counters().deletes, 0);
+    }
+
+    #[test]
+    fn legacy_delete_failure_still_returns_migrated_value() {
+        let primary = InMemoryStore::new();
+        let legacy = InMemoryStore::with_entry(KEY, b"legacy-value");
+        legacy.arm_delete_failure();
+        let store = build(Arc::clone(&primary), Arc::clone(&legacy), &[KEY]);
+
+        let got = store.get(KEY).unwrap();
+
+        assert_eq!(got.as_deref(), Some(&b"legacy-value"[..]));
+        assert_eq!(
+            primary.get_value(KEY).as_deref(),
+            Some(&b"legacy-value"[..]),
+            "primary must still be populated even if legacy delete fails"
+        );
+    }
+
+    #[test]
+    fn set_writes_only_to_primary() {
+        let primary = InMemoryStore::new();
+        let legacy = InMemoryStore::new();
+        let store = build(Arc::clone(&primary), Arc::clone(&legacy), &[KEY]);
+
+        store.set(KEY, b"new-value").unwrap();
+
+        assert!(primary.has(KEY));
+        assert!(!legacy.has(KEY));
+        assert_eq!(legacy.counters().sets, 0);
+    }
+
+    #[test]
+    fn delete_removes_only_from_primary() {
+        let primary = InMemoryStore::with_entry(KEY, b"primary-value");
+        let legacy = InMemoryStore::with_entry(KEY, b"legacy-value");
+        let store = build(Arc::clone(&primary), Arc::clone(&legacy), &[KEY]);
+
+        store.delete(KEY).unwrap();
+
+        assert!(!primary.has(KEY));
+        assert!(
+            legacy.has(KEY),
+            "delete must not propagate to legacy fallback"
+        );
+        assert_eq!(legacy.counters().deletes, 0);
+    }
+}


### PR DESCRIPTION
## 背景

PR #529 把 iroh Ed25519 设备密钥从 macOS Keychain 搬到 \`<app_data>/iroh-identity/\` 文件存储以消除启动期 keychain 弹窗,但其 commit 直接放弃了对 0.6.x 老条目的迁移("legacy entries are neither read nor deleted ... existing peers will need to re-pair once"),导致 0.6.x → 0.7.x 升级双端 iroh PeerId 全部重置、\`trusted_peer.peer_fingerprint\` 不再匹配,**用户必须重新走完整 pairing 流程**才能继续同步——本次双端 prod 日志诊断确认了这一点。

## 改动

引入 \`MigratingSecureStorage\` 装饰器在 \`space_setup\` 装配处包一层透明迁移:\`get\` 优先 file backend,miss 时若 key 在白名单(目前仅 \`IDENTITY_STORE_KEY\`)则 fallback 查 keychain,命中即写 file、best-effort 删 keychain;\`set\` / \`delete\` 只走 file。

## 行为保证

- **Fresh 0.7.x 安装**:keychain NoEntry 不弹窗 → 0 次 prompt
- **0.6.x 升级**:keychain 命中 → 文件落地 → PeerId 不变 → **配对自动恢复**;生产签名 build 上同应用读 ACL 已存在 → 不弹 prompt
- **0.7.x 第二次启动**:primary 命中 → 不进 legacy 分支(幂等)
- 失败语义:\`primary.set\` 失败时不动 keychain(下次再试);\`legacy.delete\` 失败仅 warn(不影响业务)

## 测试

\`cargo test -p uc-platform --lib\` 19 passed(含 9 个 \`MigratingSecureStorage\` 单测);\`cargo test -p uc-bootstrap --lib\` 12 passed;两个 crate \`cargo check\` 干净通过。预存在的 2 个 doctest failure 与本改动无关。

## Test plan

- [ ] 双端 0.6.x → 此 PR 构建出的 nightly 升级,验证不需要重新配对、剪贴板继续同步
- [ ] Fresh 0.7.x 安装路径验证(无 \`iroh-identity:v1\` keychain 残留时)0 次 keychain 调用
- [ ] 验证升级后 keychain 旧条目被清理(\`security find-generic-password\` 返回 NoEntry)
- [ ] Windows 端验证迁移路径(无 prompt 行为差异)