### PR TITLE
fix(webserver): allow PATCH in CORS so device sync toggle works + add request tracing

### DIFF
--- a/src-tauri/crates/uc-webserver/src/api/member.rs
+++ b/src-tauri/crates/uc-webserver/src/api/member.rs
@@ -6,6 +6,7 @@
 use axum::extract::{Path, State};
 use axum::routing::{get, patch};
 use axum::{Json, Router};
+use tracing::{info, instrument, warn};
 
 use uc_application::facade::{
     ContentTypesPatch, MemberSyncPreferencesPatch, MemberSyncPreferencesView, RosterError,
@@ -45,10 +46,17 @@ pub fn router() -> Router<DaemonApiState> {
         (status = 500, description = "Internal server error", body = crate::api::dto::error::ApiErrorResponse)
     )
 )]
+#[instrument(
+    name = "api.member.get_sync_preferences",
+    level = "info",
+    skip(state),
+    fields(device_id = %device_id)
+)]
 pub async fn get_member_sync_preferences_handler(
     State(state): State<DaemonApiState>,
     Path(device_id): Path<String>,
 ) -> Result<Json<GetMemberSyncPreferencesResponse>, ApiError> {
+    info!("get member sync preferences request received");
     let app = state.app_facade_or_error()?;
     let roster = app
         .member_roster
@@ -59,6 +67,11 @@ pub async fn get_member_sync_preferences_handler(
         .await
         .map_err(|e| map_member_error(&device_id, "get_member_sync_preferences", e))?;
 
+    info!(
+        send_enabled = prefs.send_enabled,
+        receive_enabled = prefs.receive_enabled,
+        "get member sync preferences succeeded"
+    );
     Ok(Json(GetMemberSyncPreferencesResponse {
         data: member_sync_preferences_to_dto(prefs),
         ts: chrono::Utc::now().timestamp_millis(),
@@ -84,11 +97,24 @@ pub async fn get_member_sync_preferences_handler(
         (status = 500, description = "Internal server error", body = crate::api::dto::error::ApiErrorResponse)
     )
 )]
+#[instrument(
+    name = "api.member.update_sync_preferences",
+    level = "info",
+    skip(state, payload),
+    fields(
+        device_id = %device_id,
+        patch_send_enabled = ?payload.send_enabled,
+        patch_receive_enabled = ?payload.receive_enabled,
+        patch_send_content_types = payload.send_content_types.is_some(),
+        patch_receive_content_types = payload.receive_content_types.is_some(),
+    )
+)]
 pub async fn update_member_sync_preferences_handler(
     State(state): State<DaemonApiState>,
     Path(device_id): Path<String>,
     Json(payload): Json<MemberSyncPreferencesPatchDto>,
 ) -> Result<Json<UpdateMemberSyncPreferencesResponse>, ApiError> {
+    info!("update member sync preferences request received");
     let app = state.app_facade_or_error()?;
     let roster = app
         .member_roster
@@ -99,6 +125,11 @@ pub async fn update_member_sync_preferences_handler(
         .await
         .map_err(|e| map_member_error(&device_id, "update_member_sync_preferences", e))?;
 
+    info!(
+        send_enabled = updated.send_enabled,
+        receive_enabled = updated.receive_enabled,
+        "update member sync preferences succeeded"
+    );
     Ok(Json(UpdateMemberSyncPreferencesResponse {
         success: true,
         data: member_sync_preferences_to_dto(updated),
@@ -163,10 +194,23 @@ fn member_sync_preferences_to_dto(
 /// "not found" 文案（见 `GetMemberSyncPreferences::execute`），这里做字符串匹配
 /// 把它提升为 404；其余视为 500。
 fn map_member_error(device_id: &str, context: &str, err: RosterError) -> ApiError {
-    tracing::error!(error = %err, device_id = %device_id, context = context, "member handler failed");
     if matches!(err, RosterError::NotFound(_)) {
+        warn!(
+            error = %err,
+            device_id = %device_id,
+            context = context,
+            error_kind = "member_not_found",
+            "member handler rejected request: member not found"
+        );
         ApiError::not_found(format!("member `{device_id}` not found"))
     } else {
+        tracing::error!(
+            error = %err,
+            device_id = %device_id,
+            context = context,
+            error_kind = "roster_internal",
+            "member handler failed"
+        );
         ApiError::internal(err.to_string())
     }
 }

--- a/src-tauri/crates/uc-webserver/src/api/server.rs
+++ b/src-tauri/crates/uc-webserver/src/api/server.rs
@@ -191,7 +191,114 @@ pub fn build_router(state: DaemonApiState) -> Router {
         .merge(crate::security::connect::router())
         .merge(ws::router())
         .layer(middleware::from_fn(cors_middleware))
+        // request_tracing wraps cors so we observe every request — including
+        // CORS-rejected, auth-rejected, rate-limited, and 404s — at one place.
+        // Layer ordering: in axum the LAST `.layer()` is OUTERMOST (runs first
+        // on the request, last on the response). Adding tracing after cors
+        // makes it the outer ring around everything.
+        .layer(middleware::from_fn(request_tracing_middleware))
         .with_state(state)
+}
+
+/// Global HTTP request tracing — logs entry, status, and elapsed for every
+/// route. Auth query param is redacted so session tokens never appear in logs.
+pub(crate) async fn request_tracing_middleware(request: Request<Body>, next: Next) -> Response {
+    let method = request.method().clone();
+    let path = request.uri().path().to_string();
+    let query_redacted = redact_query_secrets(request.uri().query());
+    let request_id = format!("{:016x}", rand::random::<u64>());
+    let start = Instant::now();
+
+    if method == Method::OPTIONS {
+        tracing::debug!(
+            request_id = %request_id,
+            method = %method,
+            path = %path,
+            query = %query_redacted,
+            "daemon http preflight received"
+        );
+    } else {
+        tracing::info!(
+            request_id = %request_id,
+            method = %method,
+            path = %path,
+            query = %query_redacted,
+            "daemon http request received"
+        );
+    }
+
+    let response = next.run(request).await;
+    let status = response.status();
+    let elapsed_ms = start.elapsed().as_millis() as u64;
+
+    let level_action = if status.is_server_error() {
+        "server_error"
+    } else if status.is_client_error() {
+        "client_error"
+    } else {
+        "ok"
+    };
+
+    match level_action {
+        "server_error" => tracing::error!(
+            request_id = %request_id,
+            method = %method,
+            path = %path,
+            status = status.as_u16(),
+            elapsed_ms,
+            "daemon http request failed (server error)"
+        ),
+        "client_error" => tracing::warn!(
+            request_id = %request_id,
+            method = %method,
+            path = %path,
+            status = status.as_u16(),
+            elapsed_ms,
+            "daemon http request rejected (client error)"
+        ),
+        _ => {
+            if method == Method::OPTIONS {
+                tracing::debug!(
+                    request_id = %request_id,
+                    method = %method,
+                    path = %path,
+                    status = status.as_u16(),
+                    elapsed_ms,
+                    "daemon http preflight completed"
+                );
+            } else {
+                tracing::info!(
+                    request_id = %request_id,
+                    method = %method,
+                    path = %path,
+                    status = status.as_u16(),
+                    elapsed_ms,
+                    "daemon http request completed"
+                );
+            }
+        }
+    }
+
+    response
+}
+
+/// Redact secrets from a query string before logging. `auth=...` carries
+/// session tokens via query (used by `<img src>` blob loads); we replace its
+/// value with `<redacted>` so it never reaches log files.
+fn redact_query_secrets(query: Option<&str>) -> String {
+    let Some(q) = query else {
+        return String::new();
+    };
+    url::form_urlencoded::parse(q.as_bytes())
+        .map(|(k, v)| {
+            if k == "auth" || k == "token" || k == "session" {
+                format!("{k}=<redacted>")
+            } else {
+                format!("{k}={v}")
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("&")
 }
 
 pub(crate) async fn cors_middleware(request: Request<Body>, next: Next) -> Response {

--- a/src-tauri/crates/uc-webserver/src/api/server.rs
+++ b/src-tauri/crates/uc-webserver/src/api/server.rs
@@ -238,7 +238,10 @@ fn apply_cors_headers(headers: &mut HeaderMap, origin: Option<&str>) {
 
     headers.insert(
         ACCESS_CONTROL_ALLOW_METHODS,
-        HeaderValue::from_static("GET, POST, PUT, DELETE, OPTIONS"),
+        // PATCH 必须列在这里：`/member/:device_id/sync-preferences` 走 PATCH，
+        // 浏览器/webview 在 preflight 响应里看不到 PATCH 就会拦截真请求 ——
+        // 现象是 DeviceSettingsSheet 上的发送开关切了又弹回、永远改不动。
+        HeaderValue::from_static("GET, POST, PUT, PATCH, DELETE, OPTIONS"),
     );
     headers.insert(
         ACCESS_CONTROL_ALLOW_HEADERS,

--- a/src-tauri/crates/uc-webserver/src/api/settings.rs
+++ b/src-tauri/crates/uc-webserver/src/api/settings.rs
@@ -8,6 +8,7 @@
 use axum::extract::State;
 use axum::routing::{get, put};
 use axum::{Json, Router};
+use tracing::{info, instrument};
 use uc_application::facade::settings as app_settings;
 use utoipa;
 
@@ -37,12 +38,15 @@ pub fn router() -> Router<DaemonApiState> {
         (status = 500, description = "Internal server error", body = crate::api::dto::error::ApiErrorResponse)
     )
 )]
+#[instrument(name = "api.settings.get", level = "info", skip(state))]
 async fn get_settings_handler(
     State(state): State<DaemonApiState>,
 ) -> Result<Json<GetSettingsResponse>, ApiError> {
+    info!("get settings request received");
     let app = state.app_facade_or_error()?;
     let settings = app.settings.get().await.map_err(settings_error_to_api)?;
 
+    info!("get settings succeeded");
     Ok(Json(GetSettingsResponse {
         data: settings_view_to_dto(settings),
         ts: chrono::Utc::now().timestamp_millis(),
@@ -66,10 +70,26 @@ async fn get_settings_handler(
         (status = 500, description = "Internal server error", body = crate::api::dto::error::ApiErrorResponse)
     )
 )]
+#[instrument(
+    name = "api.settings.update",
+    level = "info",
+    skip(state, payload),
+    fields(
+        has_general = payload.general.is_some(),
+        has_sync = payload.sync.is_some(),
+        has_security = payload.security.is_some(),
+        has_pairing = payload.pairing.is_some(),
+        has_file_sync = payload.file_sync.is_some(),
+        has_network = payload.network.is_some(),
+        has_retention_policy = payload.retention_policy.is_some(),
+        has_keyboard_shortcuts = payload.keyboard_shortcuts.is_some(),
+    )
+)]
 async fn update_settings_handler(
     State(state): State<DaemonApiState>,
     Json(payload): Json<SettingsPatchDto>,
 ) -> Result<Json<UpdateSettingsResponse>, ApiError> {
+    info!("update settings request received");
     let app = state.app_facade_or_error()?;
 
     // D-D1：`network` 段非空（任何字段变更）触发 restart_required = true。
@@ -97,6 +117,7 @@ async fn update_settings_handler(
         uc_observability::set_telemetry_enabled(enabled);
     }
 
+    info!(restart_required, "update settings succeeded");
     Ok(Json(UpdateSettingsResponse {
         success: true,
         data: settings_view_to_dto(updated),


### PR DESCRIPTION
## Summary

- **Bug fix**: `apply_cors_headers` 写死的 `Access-Control-Allow-Methods` 漏了 `PATCH`，导致 webview 拦截 `/member/:id/sync-preferences` 的预检后真请求 —— 用户表现为 DeviceSettingsSheet 上的发送/内容类型开关切了即弹回、永远改不动。全项目唯一走 PATCH 的就是这一条路由,所以症状精准命中"已配对设备同步设置"，其它接口未受影响。
- **诊断基建**: 新增全局 `request_tracing_middleware`，自动记录每条 HTTP 请求的 method / path / status / elapsed_ms / request_id；OPTIONS 走 DEBUG, 4xx 走 WARN, 5xx 走 ERROR, 2xx 走 INFO。`auth` / `token` / `session` 这几个 query 参数在写入日志前 redact，避免 session token 泄到磁盘。
- **handler 业务字段**: `member` 与 `settings` 的 handler 补上 `#[instrument]` + 关键业务字段（`device_id`、`patch_send_enabled`、`has_general` 等），`member_not_found` 从 ERROR 降到 WARN（4xx 客户端错误不应该污染 ERROR 噪音）。

## Test plan

- [x] `cargo check -p uc-webserver` 通过（`cargo fmt` 钩子已自动跑）
- [ ] 重启 daemon/Tauri，进入 设备 → 选已配对设备 → 切"启用发送"开关。预期：开关稳定切到目标状态、redux 拿到 `MemberSyncPreferencesDto`，后端日志能看到一对 INFO `daemon http preflight completed` (OPTIONS 204) + INFO `daemon http request completed` (PATCH 200)，外加 `update member sync preferences succeeded`。
- [ ] 触发一次 `/settings` PUT，确认全局 tracing 中间件输出 `restart_required` 字段。
- [ ] 抓任一接口 4xx（如随便造个不存在的 device_id 触发 404），确认日志走 WARN 而不是 ERROR。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling and logging for member synchronization operations

* **Chores**
  * Enhanced API reliability with expanded request tracing
  * Expanded API support with additional HTTP request method capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->