### PR TITLE
fix(security): zeroize MasterKey and Kek on drop (#547)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -9912,6 +9912,7 @@ dependencies = [
  "url",
  "uuid",
  "wiremock",
+ "zeroize",
  "zstd",
 ]
 

--- a/src-tauri/crates/uc-infra/Cargo.toml
+++ b/src-tauri/crates/uc-infra/Cargo.toml
@@ -62,6 +62,9 @@ argon2 = "0.5.3"
 subtle = "2.5.0"
 chacha20poly1305 = "0.10.1"
 rand = "0.9.2"
+# Memory hygiene: zero out MasterKey / Kek bytes when dropped so residual key
+# material does not linger in heap/stack pages after lock/clear/refresh paths.
+zeroize = { version = "1.8.2", features = ["derive"] }
 blake3 = "1.8.2"
 hex = "0.4.3"
 hkdf = "0.12"

--- a/src-tauri/crates/uc-infra/src/security/key_material.rs
+++ b/src-tauri/crates/uc-infra/src/security/key_material.rs
@@ -60,7 +60,7 @@ impl KeyMaterialStore {
     pub async fn store_kek(&self, scope: &KeyScope, kek: &Kek) -> Result<(), EncryptionError> {
         let key = kek_key(scope);
         self.secure_storage
-            .set(&key, &kek.0)
+            .set(&key, kek.as_bytes())
             .map_err(map_storage_error)
     }
 

--- a/src-tauri/crates/uc-infra/src/security/secrets.rs
+++ b/src-tauri/crates/uc-infra/src/security/secrets.rs
@@ -9,18 +9,23 @@
 //!   包装/解包 `MasterKey`,使用后立即丢弃。
 //!
 //! 注:两种类型均不实现 `Serialize` / `Deserialize`,防止不小心序列化到磁盘。
+//!
+//! 内存卫生:两种类型都派生 `ZeroizeOnDrop`,被 drop 时(包括 `session.clear()`、
+//! `set_master_key` 替换旧值、短生命周期克隆/派生 KEK 用完丢弃等路径)32 字节
+//! 密钥就地清零,降低进程内存快照 / crash dump / swap 残留中残留密钥物料的概率。
 
 use rand::{rngs::OsRng, TryRngCore};
 use std::fmt;
 use uc_core::crypto::model::EncryptionError;
+use zeroize::{Zeroize, ZeroizeOnDrop};
 
 /// The data-encryption key (DEK) used to encrypt clipboard blobs.
 ///
 /// - 32 bytes is suitable for XChaCha20-Poly1305 / AES-256-GCM keys.
 /// - Do NOT implement Serialize/Deserialize.
-/// - Consider adding `zeroize` to wipe on drop in adapters.
-#[derive(Clone, PartialEq, Eq)]
-pub struct MasterKey(pub [u8; 32]);
+/// - Drops zero out the inner bytes via `ZeroizeOnDrop`.
+#[derive(Clone, PartialEq, Eq, Zeroize, ZeroizeOnDrop)]
+pub struct MasterKey([u8; 32]);
 
 impl fmt::Debug for MasterKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -55,14 +60,23 @@ impl MasterKey {
         mk_bytes.copy_from_slice(bytes);
         Ok(MasterKey(mk_bytes))
     }
+
+    /// 消费 self 取出原始字节,只在必须移交所有权(如把字节交给 `ProofDerivedKey`
+    /// 这种已经自身负责 zeroize 的目标类型)的极少数路径上使用。
+    pub(crate) fn into_bytes(self) -> [u8; 32] {
+        // 拷贝出去后 self 仍会被 drop,届时 self.0 会被自身 ZeroizeOnDrop 清零;
+        // 调用方持有的副本由调用方负责保护。
+        self.0
+    }
 }
 
 /// The key-encryption key (KEK) derived from passphrase via KDF.
 /// KEK is used ONLY to wrap/unwrap the MasterKey.
 ///
-/// Keep KEK ephemeral (avoid long-lived storage).
-#[derive(Clone, PartialEq, Eq)]
-pub struct Kek(pub [u8; 32]);
+/// Keep KEK ephemeral (avoid long-lived storage). Drops zero out the inner
+/// bytes via `ZeroizeOnDrop`.
+#[derive(Clone, PartialEq, Eq, Zeroize, ZeroizeOnDrop)]
+pub struct Kek([u8; 32]);
 
 impl fmt::Debug for Kek {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src-tauri/crates/uc-infra/src/security/session.rs
+++ b/src-tauri/crates/uc-infra/src/security/session.rs
@@ -18,7 +18,12 @@ struct State {
     master_key: Option<MasterKey>,
 }
 
-/// In-memory master-key 容器,线程安全 + drop 时由 MasterKey 自身的 Drop 清零。
+/// In-memory master-key 容器,线程安全。
+///
+/// `MasterKey` 派生 `ZeroizeOnDrop`(见 `super::secrets`),所以
+/// `set_master_key` 替换旧值、`clear` 把 `Option` 置空、整个 `InMemorySession`
+/// 被 drop 等路径都会就地把 32 字节密钥清零——会话生命周期结束后,残留密钥
+/// 物料就不会停留在堆/栈/swap 页面里。
 #[derive(Clone)]
 pub struct InMemorySession {
     state: Arc<Mutex<State>>,
@@ -52,7 +57,7 @@ impl InMemorySession {
     pub fn set_master_key(&self, master_key: MasterKey) {
         let span = debug_span!("infra.session.set_master_key");
         span.in_scope(|| {
-            // 替换旧密钥——MasterKey 被 drop 时由其 Drop impl 清零。
+            // 替换旧密钥——旧 MasterKey 被 drop 时由 ZeroizeOnDrop 清零。
             self.state.lock().expect("session lock").master_key = Some(master_key);
             debug!("master key set");
         });

--- a/src-tauri/crates/uc-infra/src/security/space_access_adapter.rs
+++ b/src-tauri/crates/uc-infra/src/security/space_access_adapter.rs
@@ -423,7 +423,7 @@ impl SpaceAccessPort for DefaultSpaceAccessAdapter {
             .session
             .get_master_key()
             .map_err(map_encryption_error)?;
-        Ok(Some(ProofDerivedKey::from_bytes(master_key.0)))
+        Ok(Some(ProofDerivedKey::from_bytes(master_key.into_bytes())))
     }
 
     async fn prepare_join_offer(
@@ -556,7 +556,7 @@ impl SpaceAccessPort for DefaultSpaceAccessAdapter {
             // Phase C 起不再写 `.initialized_encryption` marker 文件;
             // "本机已初始化" 的真相由磁盘 keyslot 文件存在性回答。
             self.session.set_master_key(master_key.clone());
-            let derived = ProofDerivedKey::from_bytes(master_key.0);
+            let derived = ProofDerivedKey::from_bytes(master_key.into_bytes());
 
             info!("master key derivation completed");
             Ok(derived)


### PR DESCRIPTION
## Summary

Fixes #547. `MasterKey` 和 `Kek` 之前是裸 `[u8; 32]` newtype，`session.rs` 注释声称替换/清空时清零，但其实没有 `Drop` 实现——密钥字节会以原文形式残留在堆/栈页面、进程内存快照、crash dump、swap/hibernation 文件中。

- `MasterKey` / `Kek` 派生 `Zeroize` + `ZeroizeOnDrop`，drop 时就地清零；元组字段从 `pub` 收为私有，新增 `MasterKey::into_bytes(self)` 仅在必须移交所有权（如交付给同样 zeroize 的 `ProofDerivedKey`）的路径上使用。
- `key_material.rs` 改用 `kek.as_bytes()`、`space_access_adapter.rs` 两处改用 `master_key.into_bytes()`，不再越过 newtype 直接读字段。
- `session.rs` 注释改为真实描述实施后的不变量。
- 无磁盘 / wire 格式变更；运行时成本仅为 drop 时清零 32 字节。

## Test plan

- [x] `cargo check --workspace` 通过
- [x] `cargo test -p uc-infra --lib` 全部 178 个测试通过
- [ ] 后续可考虑给 `v1_aead.rs::okm` 等 Argon2 中间缓冲区、`ProofDerivedKey` 再做一轮收敛（issue 中列为 follow-up）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal cryptographic key handling with enhanced memory management practices.

* **Chores**
  * Added memory safety dependency for infrastructure updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->