### PR TITLE
fix(clipboard-restore): restore RTF/HTML via multi-rep + payload resolver

### DIFF
--- a/src-tauri/crates/uc-application/src/facade/clipboard_restore/mod.rs
+++ b/src-tauri/crates/uc-application/src/facade/clipboard_restore/mod.rs
@@ -5,8 +5,8 @@ use uc_core::blob::ports::BlobReaderPort;
 use uc_core::clipboard::ClipboardIntegrationMode;
 use uc_core::ids::EntryId;
 use uc_core::ports::{
-    ClipboardEntryRepositoryPort, ClipboardRepresentationRepositoryPort,
-    ClipboardSelectionRepositoryPort, ClockPort,
+    clipboard::ClipboardPayloadResolverPort, ClipboardEntryRepositoryPort,
+    ClipboardRepresentationRepositoryPort, ClipboardSelectionRepositoryPort, ClockPort,
 };
 
 use crate::clipboard_write::ClipboardWriteCoordinator;
@@ -29,6 +29,7 @@ pub struct ClipboardRestoreFacadeDeps {
     pub entry_repo: Arc<dyn ClipboardEntryRepositoryPort>,
     pub selection_repo: Arc<dyn ClipboardSelectionRepositoryPort>,
     pub representation_repo: Arc<dyn ClipboardRepresentationRepositoryPort>,
+    pub payload_resolver: Arc<dyn ClipboardPayloadResolverPort>,
     pub blob_store: Arc<dyn BlobReaderPort>,
     pub clock: Arc<dyn ClockPort>,
     pub write_coordinator: Arc<ClipboardWriteCoordinator>,
@@ -46,6 +47,7 @@ impl ClipboardRestoreFacade {
             entry_repo,
             selection_repo,
             representation_repo,
+            payload_resolver,
             blob_store,
             clock,
             write_coordinator,
@@ -57,6 +59,7 @@ impl ClipboardRestoreFacade {
             write_coordinator,
             selection_repo,
             representation_repo,
+            payload_resolver,
             blob_store,
             integration_mode,
         );

--- a/src-tauri/crates/uc-application/src/usecases/clipboard_restore/restore_selection.rs
+++ b/src-tauri/crates/uc-application/src/usecases/clipboard_restore/restore_selection.rs
@@ -1,10 +1,25 @@
-//! Reconstruct a system clipboard state from a historical entry, restoring
-//! the primary selected representation only.
+//! Reconstruct a system clipboard state from a historical entry. Files走单 rep
+//! 文件分支（CF_HDROP / NSPasteboardTypeFileURL），其它内容把所有非文件候选 rep
+//! （plain / html / rtf / image 等）一并打包到 `SystemClipboardSnapshot`，由平台
+//! 多 rep 写入路径决定哪些能落到系统剪贴板。
+//!
+//! 历史背景：
+//! - 早期实现只挑单一 rep（优先 plain text）写回，导致从 Word 这类富文本源恢复时
+//!   RTF / HTML 全部丢失（粘贴只剩纯文本）。
+//! - 之后改为多 rep 打包，但仍直接读 `rep.inline_data` 当作完整字节——这在 Staged
+//!   状态下取到的是 normalizer 留下的 500-char **预览截断版**，不是完整 RTF / HTML。
+//!   Word 等富文本目的地拿到的是被截断的 RTF 头，解析失败 → 粘出空文档。
+//!
+//! 当前实现：
+//! - 用 `ClipboardPayloadResolverPort` 解析每个 rep，由 resolver 根据 `payload_state`
+//!   正确路由（Inline 直读 / BlobReady 经 blob_store / Staged|Processing 走 cache+spool）。
+//! - paste_rep 解析失败 → 整体报错；secondary rep 解析失败 → 跳过 + warn，不影响其他 rep。
 
 use anyhow::{bail, Result};
+use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::Arc;
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 use uc_core::{
     blob::ports::BlobReaderPort,
@@ -12,8 +27,9 @@ use uc_core::{
         ClipboardIntegrationMode, ObservedClipboardRepresentation,
         PersistedClipboardRepresentation, SystemClipboardSnapshot,
     },
-    ids::{EntryId, EventId, RepresentationId},
+    ids::{EntryId, RepresentationId},
     ports::{
+        clipboard::{ClipboardPayloadResolverPort, ResolvedClipboardPayload},
         ClipboardEntryRepositoryPort, ClipboardRepresentationRepositoryPort,
         ClipboardSelectionRepositoryPort,
     },
@@ -28,6 +44,7 @@ pub(crate) struct RestoreClipboardSelectionUseCase {
     coordinator: Arc<ClipboardWriteCoordinator>,
     selection_repo: Arc<dyn ClipboardSelectionRepositoryPort>,
     representation_repo: Arc<dyn ClipboardRepresentationRepositoryPort>,
+    payload_resolver: Arc<dyn ClipboardPayloadResolverPort>,
     blob_store: Arc<dyn BlobReaderPort>,
     mode: ClipboardIntegrationMode,
 }
@@ -38,6 +55,7 @@ impl RestoreClipboardSelectionUseCase {
         coordinator: Arc<ClipboardWriteCoordinator>,
         selection_repo: Arc<dyn ClipboardSelectionRepositoryPort>,
         representation_repo: Arc<dyn ClipboardRepresentationRepositoryPort>,
+        payload_resolver: Arc<dyn ClipboardPayloadResolverPort>,
         blob_store: Arc<dyn BlobReaderPort>,
         mode: ClipboardIntegrationMode,
     ) -> Self {
@@ -46,6 +64,7 @@ impl RestoreClipboardSelectionUseCase {
             coordinator,
             selection_repo,
             representation_repo,
+            payload_resolver,
             blob_store,
             mode,
         }
@@ -65,13 +84,15 @@ impl RestoreClipboardSelectionUseCase {
             .await?
             .ok_or(anyhow::anyhow!("Selection not found"))?;
 
+        // 候选 rep 收集顺序：paste_rep 居首（保留"目标应用最优先粘贴"的语义），
+        // 然后是 primary / preview / secondary。整体去重后传给后续打包逻辑。
         let mut candidate_ids = Vec::new();
         candidate_ids.push(selection.selection.paste_rep_id.clone());
         candidate_ids.push(selection.selection.primary_rep_id.clone());
         candidate_ids.push(selection.selection.preview_rep_id.clone());
         candidate_ids.extend(selection.selection.secondary_rep_ids.clone());
 
-        let mut seen = std::collections::HashSet::new();
+        let mut seen = HashSet::new();
         candidate_ids.retain(|rep_id| seen.insert(rep_id.clone()));
 
         let mut candidates = Vec::new();
@@ -91,96 +112,145 @@ impl RestoreClipboardSelectionUseCase {
             }
         }
 
-        let restore_rep = Self::select_restore_representation(
-            &candidates,
-            &selection.selection.paste_rep_id,
-            &entry.event_id,
-        )?;
+        // 文件分支：paste_rep 是文件类型（CF_HDROP / NSPasteboardTypeFileURL）时，
+        // 走专用的 file snapshot 路径。文件 rep 的语义与文本/图像表示不可混写在
+        // 同一个 NSPasteboardItem / clipboard item 中，平台层目前也仅支持文件单独
+        // 写入；同时 build_file_snapshot 会校验本地文件存在性。
+        let paste_rep = candidates
+            .iter()
+            .find(|rep| rep.id == selection.selection.paste_rep_id)
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Paste representation {} not found for event {}",
+                    selection.selection.paste_rep_id,
+                    entry.event_id
+                )
+            })?;
 
-        if Self::is_file_representation(restore_rep) {
+        if Self::is_file_representation(paste_rep) {
             debug!(
                 entry_id = %entry_id,
-                restore_rep_id = %restore_rep.id,
+                paste_rep_id = %paste_rep.id,
                 "restore.build_snapshot: detected file entry, using file restore strategy"
             );
-            return self.build_file_snapshot(entry_id, restore_rep).await;
+            return self.build_file_snapshot(entry_id, paste_rep).await;
         }
 
-        let bytes = if let Some(inline_data) = &restore_rep.inline_data {
-            inline_data.clone()
-        } else if let Some(blob_id) = &restore_rep.blob_id {
-            self.blob_store.get(blob_id).await?
-        } else {
-            return Err(anyhow::anyhow!(
-                "Representation has no data: {}",
-                restore_rep.id
-            ));
-        };
+        // 非文件分支：把所有非文件候选 rep 都打包成多 rep snapshot，paste_rep 居首。
+        // 每条 rep 通过 `ClipboardPayloadResolverPort` 取字节，由 resolver 负责按
+        // payload_state 路由（Inline 直读已解密 inline_data / BlobReady 走 blob_store /
+        // Staged|Processing 走 cache+spool）。
+        //
+        // 注意不能直接读 `rep.inline_data`：当 rep 的明文体积超过 inline_threshold
+        // （默认 16KB）时，normalizer 会把它标成 Staged 并只在 inline_data 里留
+        // 500 字符的 UI preview，真实字节走 spool/blob 异步物化。直接读 inline_data
+        // 会拿到截断版，写到 NSPasteboard 上的 RTF / HTML 解析失败 → 粘出空。
+        //
+        // 平台多 rep 写入路径会原子地把所有支持的 rep 一并写入系统剪贴板：
+        // - macOS: NSPasteboard.writeObjects 提交一组 NSPasteboardItem
+        // - Windows: 单 OpenClipboard 会话内累加多个 CF_*
+        // - Linux: 当前降级为选最优单 rep（platform 层兜底）
+        // 平台层不认的 rep（私有格式等）会被静默跳过。
+        let mut representations = Vec::with_capacity(candidates.len());
+        let mut paste_first = true;
+        let mut packed_rep_ids: Vec<RepresentationId> = Vec::new();
+        for rep in &candidates {
+            if Self::is_file_representation(rep) {
+                debug!(
+                    entry_id = %entry_id,
+                    rep_id = %rep.id,
+                    format_id = %rep.format_id,
+                    "restore.build_snapshot: skipping file rep when paste_rep is non-file"
+                );
+                continue;
+            }
 
-        let representations = vec![ObservedClipboardRepresentation::new(
-            restore_rep.id.clone(),
-            restore_rep.format_id.clone(),
-            restore_rep.mime_type.clone(),
-            bytes,
-        )];
+            let is_paste_rep = rep.id == paste_rep.id;
+            let bytes = match self.payload_resolver.resolve(rep).await {
+                Ok(ResolvedClipboardPayload::Inline { bytes, .. }) => bytes,
+                Ok(ResolvedClipboardPayload::BlobRef { blob_id, .. }) => {
+                    match self.blob_store.get(&blob_id).await {
+                        Ok(plaintext) => plaintext,
+                        Err(err) if is_paste_rep => {
+                            return Err(anyhow::anyhow!(
+                                "Failed to fetch paste representation blob {}: {}",
+                                blob_id,
+                                err
+                            ));
+                        }
+                        Err(err) => {
+                            warn!(
+                                entry_id = %entry_id,
+                                rep_id = %rep.id,
+                                blob_id = %blob_id,
+                                error = %err,
+                                "restore.build_snapshot: skipping rep, blob fetch failed"
+                            );
+                            continue;
+                        }
+                    }
+                }
+                Err(err) if is_paste_rep => {
+                    return Err(anyhow::anyhow!(
+                        "Failed to resolve paste representation {} (state={:?}): {}",
+                        rep.id,
+                        rep.payload_state,
+                        err
+                    ));
+                }
+                Err(err) => {
+                    warn!(
+                        entry_id = %entry_id,
+                        rep_id = %rep.id,
+                        format_id = %rep.format_id,
+                        payload_state = ?rep.payload_state,
+                        error = %err,
+                        "restore.build_snapshot: skipping rep, resolver failed (likely Staged without cache/spool bytes)"
+                    );
+                    continue;
+                }
+            };
+
+            let observed = ObservedClipboardRepresentation::new(
+                rep.id.clone(),
+                rep.format_id.clone(),
+                rep.mime_type.clone(),
+                bytes,
+            );
+
+            packed_rep_ids.push(rep.id.clone());
+            if paste_first {
+                representations.insert(0, observed);
+                paste_first = false;
+            } else {
+                representations.push(observed);
+            }
+        }
+
+        if representations.is_empty() {
+            // 极端兜底：候选列表里所有 rep 都被跳过（没有 inline_data 也没有 blob_id）。
+            // 上面的循环已经把 paste_rep 缺数据的情况单独 bail 掉，所以走到这里基本
+            // 不会发生；但为了不交一个空 snapshot 给平台层，显式报错。
+            return Err(anyhow::anyhow!(
+                "No restorable representations after packing for entry {}",
+                entry_id
+            ));
+        }
 
         debug!(
             entry_id = %entry_id,
             event_id = %entry.event_id,
-            restore_rep_id = %restore_rep.id,
-            restore_format = %restore_rep.format_id,
-            restore_mime = ?restore_rep.mime_type.as_ref().map(|mime| mime.as_str()),
-            candidate_count = candidates.len(),
-            restore_size_bytes = representations[0].bytes.len(),
-            "restore.build_snapshot selected representation"
+            paste_rep_id = %paste_rep.id,
+            packed_rep_count = representations.len(),
+            packed_rep_ids = ?packed_rep_ids,
+            total_size_bytes = representations.iter().map(|r| r.bytes.len()).sum::<usize>(),
+            "restore.build_snapshot packed representations"
         );
 
         Ok(SystemClipboardSnapshot {
             ts_ms: chrono::Utc::now().timestamp_millis(),
             representations,
         })
-    }
-
-    fn select_restore_representation<'a>(
-        candidates: &'a [PersistedClipboardRepresentation],
-        paste_rep_id: &RepresentationId,
-        event_id: &EventId,
-    ) -> Result<&'a PersistedClipboardRepresentation> {
-        let paste_rep = candidates.iter().find(|rep| rep.id == *paste_rep_id);
-        if let Some(rep) = paste_rep {
-            if Self::is_file_representation(rep) {
-                return Ok(rep);
-            }
-        }
-
-        if let Some(rep) = candidates
-            .iter()
-            .find(|rep| Self::is_plain_text_representation(*rep))
-        {
-            return Ok(rep);
-        }
-
-        paste_rep.ok_or(anyhow::anyhow!(
-            "Representation {} not found for event {}",
-            paste_rep_id,
-            event_id
-        ))
-    }
-
-    fn is_plain_text_representation(rep: &PersistedClipboardRepresentation) -> bool {
-        if let Some(mime) = &rep.mime_type {
-            let mime_str = mime.as_str();
-            let mime_lower = mime_str.to_ascii_lowercase();
-            if mime_lower == "text/plain" || mime_lower.starts_with("text/plain;") {
-                return true;
-            }
-        }
-
-        let format_id = rep.format_id.as_ref();
-        format_id.eq_ignore_ascii_case("text")
-            || format_id.eq_ignore_ascii_case("public.utf8-plain-text")
-            || format_id.eq_ignore_ascii_case("public.text")
-            || format_id.eq_ignore_ascii_case("NSStringPboardType")
     }
 
     fn is_file_representation(rep: &PersistedClipboardRepresentation) -> bool {

--- a/src-tauri/crates/uc-application/src/usecases/clipboard_restore/restore_selection.rs
+++ b/src-tauri/crates/uc-application/src/usecases/clipboard_restore/restore_selection.rs
@@ -262,12 +262,33 @@ impl RestoreClipboardSelectionUseCase {
         entry_id: &EntryId,
         rep: &PersistedClipboardRepresentation,
     ) -> Result<SystemClipboardSnapshot> {
-        let bytes = if let Some(inline_data) = &rep.inline_data {
-            inline_data.clone()
-        } else if let Some(blob_id) = &rep.blob_id {
-            self.blob_store.get(blob_id).await?
-        } else {
-            bail!("File URI representation has no data for entry {}", entry_id);
+        // 与非文件分支同样走 payload_resolver：file URI list 在文件较多时同样会
+        // 触发 inline_threshold，rep.inline_data 只剩 500-char 预览截断版，直接
+        // clone 会拿到不完整的 URI 列表 → 文件路径解析丢失。resolver 会按
+        // payload_state 正确路由（Inline / BlobReady / Staged|Processing）。
+        let bytes = match self.payload_resolver.resolve(rep).await {
+            Ok(ResolvedClipboardPayload::Inline { bytes, .. }) => bytes,
+            Ok(ResolvedClipboardPayload::BlobRef { blob_id, .. }) => {
+                self.blob_store.get(&blob_id).await?
+            }
+            Err(resolver_err) => {
+                if let Some(blob_id) = &rep.blob_id {
+                    self.blob_store.get(blob_id).await.map_err(|blob_err| {
+                        anyhow::anyhow!(
+                            "File URI representation resolver failed ({}) and blob fallback failed for entry {}: {}",
+                            resolver_err,
+                            entry_id,
+                            blob_err
+                        )
+                    })?
+                } else {
+                    bail!(
+                        "File URI representation has no resolvable data for entry {}: {}",
+                        entry_id,
+                        resolver_err
+                    );
+                }
+            }
         };
 
         let uri_string = String::from_utf8(bytes)?;

--- a/src-tauri/crates/uc-bootstrap/src/non_gui_runtime.rs
+++ b/src-tauri/crates/uc-bootstrap/src/non_gui_runtime.rs
@@ -143,6 +143,7 @@ pub fn build_app_facade_from_deps(
             entry_repo: deps.clipboard.clipboard_entry_repo.clone(),
             selection_repo: deps.clipboard.selection_repo.clone(),
             representation_repo: deps.clipboard.representation_repo.clone(),
+            payload_resolver: deps.clipboard.payload_resolver.clone(),
             blob_store: deps.storage.blob_store.clone(),
             clock: deps.system.clock.clone(),
             write_coordinator: restore.write_coordinator,

--- a/src-tauri/crates/uc-platform/src/clipboard/platform/macos.rs
+++ b/src-tauri/crates/uc-platform/src/clipboard/platform/macos.rs
@@ -6,7 +6,8 @@ use objc2::rc::Retained;
 use objc2::runtime::ProtocolObject;
 use objc2_app_kit::{
     NSPasteboard, NSPasteboardItem, NSPasteboardTypeFileURL, NSPasteboardTypeHTML,
-    NSPasteboardTypePNG, NSPasteboardTypeString, NSPasteboardTypeTIFF, NSPasteboardWriting,
+    NSPasteboardTypePNG, NSPasteboardTypeRTF, NSPasteboardTypeString, NSPasteboardTypeTIFF,
+    NSPasteboardWriting,
 };
 use objc2_foundation::{NSArray, NSData};
 use std::sync::{Arc, Mutex};
@@ -75,6 +76,9 @@ fn resolve_multi_rep_mime(rep: &ObservedClipboardRepresentation) -> Option<&str>
                 Some("text/plain")
             }
             "public.html" | "Apple HTML pasteboard type" | "html" => Some("text/html"),
+            // RTF：从 Word / Pages 等富文本源复制时常与 plain text + html 同时出现；
+            // common.rs::read_snapshot 把它存为 format_id="rtf"，mime="text/rtf"。
+            "public.rtf" | "rtf" => Some("text/rtf"),
             // PixPin 截图 / Windows 端复制图片等场景 format_id 为 "image"，mime 通常为
             // "image/png"。`common.rs::read_snapshot` 已把图像统一标准化为 PNG，因此 jpeg /
             // webp / gif 不会出现在 envelope 中（与 windows.rs 保持同样取舍）。
@@ -162,9 +166,11 @@ fn make_nsdata(bytes: &[u8]) -> Retained<NSData> {
 /// - `text/uri-list` → 每个 URI 一个独立 `NSPasteboardItem`，承载 `NSPasteboardTypeFileURL`
 ///   （Apple 官方推荐的多文件写入形式）
 ///
-/// `image/jpeg` / `image/webp` / `image/gif` / RTF 等仍不支持：上游
-/// `common.rs::read_snapshot` 已把图像统一标准化为 PNG（与 windows.rs 同步取舍），
-/// envelope 不会出现这些 mime；RTF 等留待后续 phase 补齐 `NSPasteboardTypeRTF` 等。
+/// `text/rtf` → `NSPasteboardTypeRTF`（合并到 `text_item`，与 plain/html 共享同一
+///   NSPasteboardItem，让目的应用从同一个 item 看到一致的多格式表示）
+///
+/// `image/jpeg` / `image/webp` / `image/gif` 仍不支持：上游 `common.rs::read_snapshot`
+/// 已把图像统一标准化为 PNG（与 windows.rs 同步取舍），envelope 不会出现这些 mime。
 ///
 /// ## clearContents() 副作用防御
 ///
@@ -180,6 +186,7 @@ pub(crate) fn write_snapshot_multi_macos(snapshot: SystemClipboardSnapshot) -> R
             resolve_multi_rep_mime(rep),
             Some("text/plain")
                 | Some("text/html")
+                | Some("text/rtf")
                 | Some("text/uri-list")
                 | Some("image/png")
                 | Some("image/tiff")
@@ -198,8 +205,9 @@ pub(crate) fn write_snapshot_multi_macos(snapshot: SystemClipboardSnapshot) -> R
             "macOS 多 rep 写入：无可写 rep；未清空系统 pasteboard（防副作用兜底）"
         );
         anyhow::bail!(
-            "macOS 多 rep 写入：无可写 rep（支持 text/plain, text/html, text/uri-list, \
-             image/png, image/tiff）；未清空系统 pasteboard；跳过的 rep = {:?}",
+            "macOS 多 rep 写入：无可写 rep（支持 text/plain, text/html, text/rtf, \
+             text/uri-list, image/png, image/tiff）；未清空系统 pasteboard；\
+             跳过的 rep = {:?}",
             skipped
         );
     }
@@ -260,6 +268,25 @@ pub(crate) fn write_snapshot_multi_macos(snapshot: SystemClipboardSnapshot) -> R
                     warn!(
                         bytes = rep.bytes.len(),
                         "setData_forType(NSPasteboardTypeHTML) 返回 false"
+                    );
+                    skipped.push(rep.format_id.as_str().to_string());
+                }
+            }
+            Some("text/rtf") => {
+                // RTF 与 plain/html 同属"同一份内容的多种文本表示"，合并到 text_item。
+                // Word / Pages / 写字板等富文本目的地优先读 RTF；纯文本目的地（终端 /
+                // TextEdit 纯文本模式）继续用 NSPasteboardTypeString。原始 RTF 字节是
+                // ASCII 安全的（RTF 1.x 规范，非 ASCII 都做 \uN 转义），直接喂给 NSData。
+                // NSPasteboardTypeRTF 是 extern "C" 静态变量，访问需要 unsafe 块。
+                let data = make_nsdata(&rep.bytes);
+                let ok = unsafe { text_item.setData_forType(&data, NSPasteboardTypeRTF) };
+                if ok {
+                    debug!(bytes = rep.bytes.len(), "写入 NSPasteboardTypeRTF 成功");
+                    wrote_any = true;
+                } else {
+                    warn!(
+                        bytes = rep.bytes.len(),
+                        "setData_forType(NSPasteboardTypeRTF) 返回 false"
                     );
                     skipped.push(rep.format_id.as_str().to_string());
                 }
@@ -350,7 +377,7 @@ pub(crate) fn write_snapshot_multi_macos(snapshot: SystemClipboardSnapshot) -> R
                     format_id = %rep.format_id,
                     mime = ?other,
                     bytes = rep.bytes.len(),
-                    "macOS 多 rep 写入：跳过不支持的 rep（当前支持 text/plain, text/html, text/uri-list, image/png, image/tiff）"
+                    "macOS 多 rep 写入：跳过不支持的 rep（当前支持 text/plain, text/html, text/rtf, text/uri-list, image/png, image/tiff）"
                 );
                 skipped.push(rep.format_id.as_str().to_string());
             }
@@ -466,6 +493,24 @@ mod tests {
         // 显式 mime 优先于 format_id 推断（与 windows.rs 对称）。
         let r = rep("unknown-format-id", Some("image/png"));
         assert_eq!(resolve_multi_rep_mime(&r), Some("image/png"));
+    }
+
+    #[test]
+    fn resolves_text_rtf_from_format_id() {
+        // 与 common.rs::read_snapshot 写库时使用的 format_id="rtf" 对齐。
+        assert_eq!(resolve_multi_rep_mime(&rep("rtf", None)), Some("text/rtf"));
+        assert_eq!(
+            resolve_multi_rep_mime(&rep("public.rtf", None)),
+            Some("text/rtf")
+        );
+    }
+
+    #[test]
+    fn explicit_text_rtf_mime_takes_priority_over_format_id() {
+        // 上游（common.rs）总会给 RTF rep 显式打 mime="text/rtf"；显式 mime 必须优先
+        // 于 format_id 推断，避免被未来的 format_id 重命名意外打回 None。
+        let r = rep("unknown-format-id", Some("text/rtf"));
+        assert_eq!(resolve_multi_rep_mime(&r), Some("text/rtf"));
     }
 
     #[test]

--- a/src-tauri/crates/uc-platform/src/clipboard/platform/windows.rs
+++ b/src-tauri/crates/uc-platform/src/clipboard/platform/windows.rs
@@ -948,3 +948,38 @@ fn set_bytes(to: &mut [u8], from: &[u8], range: Range<usize>) {
         to[i] = from[from_idx];
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use uc_core::ids::{FormatId, RepresentationId};
+    use uc_core::MimeType;
+
+    fn rep(format: &str, mime: Option<&str>) -> ObservedClipboardRepresentation {
+        ObservedClipboardRepresentation::new(
+            RepresentationId::new(),
+            FormatId::from_str(format),
+            mime.map(|m| MimeType(m.to_string())),
+            Vec::new(),
+        )
+    }
+
+    #[test]
+    fn resolves_text_rtf_from_format_id() {
+        // 与 common.rs::read_snapshot 写库时使用的 format_id="rtf" 对齐；
+        // 与 macos.rs 同名测试镜像，保证两个平台的 multi-rep 派发结果一致。
+        assert_eq!(resolve_multi_rep_mime(&rep("rtf", None)), Some("text/rtf"));
+        assert_eq!(
+            resolve_multi_rep_mime(&rep("public.rtf", None)),
+            Some("text/rtf")
+        );
+    }
+
+    #[test]
+    fn explicit_text_rtf_mime_takes_priority_over_format_id() {
+        // 显式 mime 必须优先于 format_id 推断（与 macos.rs 对称），
+        // 避免被未来的 format_id 重命名意外打回 None。
+        let r = rep("unknown-format-id", Some("text/rtf"));
+        assert_eq!(resolve_multi_rep_mime(&r), Some("text/rtf"));
+    }
+}

--- a/src-tauri/crates/uc-platform/src/clipboard/platform/windows.rs
+++ b/src-tauri/crates/uc-platform/src/clipboard/platform/windows.rs
@@ -23,6 +23,11 @@ fn resolve_multi_rep_mime(rep: &ObservedClipboardRepresentation) -> Option<&str>
                 Some("text/plain")
             }
             "public.html" | "Apple HTML pasteboard type" | "html" => Some("text/html"),
+            // RTF：从 Word / Pages / 写字板等富文本源复制时常与 plain + html 一起出现；
+            // common.rs::read_snapshot 写库时使用 format_id="rtf", mime="text/rtf"。
+            // Windows 上对应 RegisterClipboardFormat("Rich Text Format") 注册的自定义
+            // format（CF_RTF 不是 Win32 预定义常量）。
+            "public.rtf" | "rtf" => Some("text/rtf"),
             // PixPin 截图等场景 format_id 为 "image"，mime 通常为 "image/png"。
             // `common.rs::read_snapshot` 把 macOS `public.png` / `public.tiff` 都转成 PNG。
             "public.png" | "image" => Some("image/png"),
@@ -225,9 +230,12 @@ const RETRY_BACKOFF_MS: [u64; MAX_WRITE_ATTEMPTS as usize] = [0, 20, 40];
 ///   与全部 PNG 元数据。CF_DIBV5 原生带 alpha 通道（`bV5AlphaMask = 0xFF000000`），
 ///   粘贴到 PowerPoint / Photoshop 时透明度不会被压平。
 ///
-/// `image/jpeg` / `image/tiff` / `image/webp` / `image/gif` 以及 RTF (CF_RTF) /
-/// files (CF_HDROP) 的多 rep 互操作性留到后续 phase 补齐（各自有独立编码 / format
-/// 注册 / 文件同步依赖）。遇到本路径不认的 rep 记 debug 日志并跳过。
+/// `text/rtf` → "Rich Text Format" 自定义 format（`register_format("Rich Text Format")`
+///   返回的 RegisterClipboardFormat 注册码；这是 Word / 写字板识别的标准 RTF 剪贴
+///   板 format 名）。RTF 字节直接 `set_without_clear` 累加到同一会话。
+///
+/// `image/jpeg` / `image/tiff` / `image/webp` / `image/gif` 仍未支持（各自需要独立的
+/// 编码 / format 注册）。遇到本路径不认的 rep 记 debug 日志并跳过。
 ///
 /// ### 调用方注意
 /// 此函数由 `common.rs::write_snapshot_multi` 在 `#[cfg(target_os = "windows")]`
@@ -259,7 +267,11 @@ pub(crate) fn write_snapshot_multi_windows(snapshot: SystemClipboardSnapshot) ->
     let has_writable = snapshot.representations.iter().any(|rep| {
         matches!(
             resolve_multi_rep_mime(rep),
-            Some("text/plain") | Some("text/html") | Some("image/png") | Some("text/uri-list")
+            Some("text/plain")
+                | Some("text/html")
+                | Some("text/rtf")
+                | Some("image/png")
+                | Some("text/uri-list")
         )
     });
 
@@ -275,8 +287,8 @@ pub(crate) fn write_snapshot_multi_windows(snapshot: SystemClipboardSnapshot) ->
             "Windows 多 rep 写入：无可写 rep；未清空 OS 剪贴板（防副作用兜底）"
         );
         anyhow::bail!(
-            "Windows 多 rep 写入：无可写 rep（支持 text/plain, text/html, image/png, text/uri-list）；\
-             未清空 OS 剪贴板；跳过的 rep = {:?}",
+            "Windows 多 rep 写入：无可写 rep（支持 text/plain, text/html, text/rtf, \
+             image/png, text/uri-list）；未清空 OS 剪贴板；跳过的 rep = {:?}",
             skipped
         );
     }
@@ -390,6 +402,12 @@ fn attempt_multi_write_inner(
     // RegisterClipboardFormat 对相同名称是幂等的，返回值在整个进程生命周期内固定。
     let html_fmt_opt: Option<u32> = HtmlFmt::new().map(|h| h.code());
 
+    // 提前注册 "Rich Text Format"——这是 Word / 写字板 / Outlook 等富文本应用约定的
+    // RTF 剪贴板 format 名（CF_RTF 不是 Win32 预定义常量）。同样靠 RegisterClipboardFormat
+    // 幂等性保证返回值在进程内稳定。失败时记 warn，主循环里跳过 RTF rep（不影响其他
+    // rep 的写入）。
+    let rtf_fmt_opt: Option<u32> = cb_raw::register_format("Rich Text Format").map(|nz| nz.get());
+
     let mut wrote_any = false;
     let mut skipped: Vec<String> = Vec::new();
 
@@ -421,6 +439,21 @@ fn attempt_multi_write_inner(
                 cb_raw::set_html(html_fmt, &html)
                     .map_err(|e| anyhow::anyhow!("set CF_HTML failed: {}", e))?;
                 debug!(bytes = rep.bytes.len(), "写入 CF_HTML 成功");
+                wrote_any = true;
+            }
+            Some("text/rtf") => {
+                // RTF 走 RegisterClipboardFormat("Rich Text Format")。RTF 1.x 规范要求
+                // 字节流是 ASCII 安全（非 ASCII 字符均通过 \uN 转义），因此可以直接以
+                // 原始字节写入 raw set_without_clear，不需要 UTF-8 / UTF-16 转换。
+                // set_without_clear 不调用 EmptyClipboard，保持累加语义。
+                let Some(rtf_fmt) = rtf_fmt_opt else {
+                    warn!("注册 Rich Text Format 失败，跳过 text/rtf rep");
+                    skipped.push(rep.format_id.as_str().to_string());
+                    continue;
+                };
+                cb_raw::set_without_clear(rtf_fmt, &rep.bytes)
+                    .map_err(|e| anyhow::anyhow!("set Rich Text Format failed: {}", e))?;
+                debug!(bytes = rep.bytes.len(), "写入 Rich Text Format 成功");
                 wrote_any = true;
             }
             Some("image/png") => {
@@ -510,14 +543,14 @@ fn attempt_multi_write_inner(
                 );
                 wrote_any = true;
             }
-            // image/jpeg / image/tiff / image/webp / image/gif / RTF 等均未支持，
+            // image/jpeg / image/tiff / image/webp / image/gif 等均未支持，
             // 未来在独立 phase 补齐（各自需要独立的编码转换 / format 注册）。
             other => {
                 info!(
                     format_id = %rep.format_id,
                     mime = ?other,
                     bytes = rep.bytes.len(),
-                    "Windows 多 rep 写入：跳过不支持的 rep（当前支持 text/plain, text/html, image/png, text/uri-list）"
+                    "Windows 多 rep 写入：跳过不支持的 rep（当前支持 text/plain, text/html, text/rtf, image/png, text/uri-list）"
                 );
                 skipped.push(rep.format_id.as_str().to_string());
             }
@@ -530,8 +563,8 @@ fn attempt_multi_write_inner(
         // 本函数返回 Err，由外层重试兜底；若所有 attempt 都落到这里，最终由
         // `write_snapshot_multi_windows` 的 `bail!` 报给调用方。
         anyhow::bail!(
-            "Windows 多 rep 写入：所有候选 rep 在写入阶段均失败（支持 text/plain, text/html, image/png）；\
-             跳过的 rep = {:?}",
+            "Windows 多 rep 写入：所有候选 rep 在写入阶段均失败（支持 text/plain, text/html, \
+             text/rtf, image/png, text/uri-list）；跳过的 rep = {:?}",
             skipped
         );
     }


### PR DESCRIPTION
## Summary

Restoring a clipboard entry copied from Word / Pages / browsers used to paste plain text only — RTF/HTML reps were being dropped or written as a 500-char preview-truncated stub that destination apps parsed as empty. Two root causes fixed:

1. **App layer**: `select_restore_representation` only kept one rep (preferring plain text). `build_snapshot` now packs every non-file candidate rep into the snapshot (paste_rep first), letting the platform multi-rep write path commit them atomically. Files keep the dedicated single-rep CF_HDROP / NSPasteboardTypeFileURL path.
2. **App layer**: For Staged reps (>16 KB plaintext), `rep.inline_data` is the normalizer's 500-char UI preview, not the full bytes — reading it directly produced a truncated RTF header that Word silently parsed as empty. Switched to `ClipboardPayloadResolverPort`, which routes Inline → inline_data, BlobReady → `blob_store.get(blob_id)`, and Staged/Processing → cache+spool with a clear error when bytes aren't yet materialized. paste_rep failures bail; secondary failures are logged and skipped.
3. **Platform layer**: Added `text/rtf` to the macOS and Windows multi-rep write paths (`NSPasteboardTypeRTF` merged into the same `text_item` as plain/html on macOS; `RegisterClipboardFormat("Rich Text Format")` + `set_without_clear` on Windows).

Closes #141, #503. Refs #482 (Win→Mac RTF Word for Mac path now reaches the pasteboard; any remaining issue would be RTF dialect compatibility, not transport).

## Test plan

- [ ] macOS: copy formatted text from Word → restore from history → paste back into Word with formatting preserved
- [ ] macOS: copy formatted text from Chrome / Safari → restore → paste into Word with formatting preserved
- [ ] macOS: large (>16 KB) RTF entry restores from spool/blob, no truncated paste
- [ ] Windows: copy formatted text from Word → restore → paste back into Word with formatting preserved
- [ ] Cross-device: Windows browser RTF → sync → restore on macOS → paste into Word for Mac
- [ ] Regression: file copy/paste (Finder/Explorer) still works via single-rep file path
- [ ] Regression: plain-text-only entries restore unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved clipboard restoration to reliably recover content from multiple representation types, reducing failed restores.
* **New Features**
  * Better handling of file-backed clipboard items so local files and referenced payloads restore more consistently.
  * Expanded RTF (Rich Text Format) support on Windows and macOS with improved detection and writing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->