### PR TITLE
Linux build 基线重构: 容器化 + sentry rustls + CLI musl

### DIFF
--- a/.github/workflows/alpha-build.yml
+++ b/.github/workflows/alpha-build.yml
@@ -29,14 +29,16 @@ jobs:
       - name: Generate matrix
         id: set-matrix
         run: |
+          # Linux 构建走 debian:bookworm 容器 (glibc 2.36),其他 platform 在
+          # host runner 直接跑。详见 build.yml 同名 step 注释。
           if [ "${{ inputs.platform }}" == "all" ]; then
-            echo 'matrix=[{"platform":"macos-latest","target":"aarch64-apple-darwin","args":"--target aarch64-apple-darwin"},{"platform":"macos-latest","target":"x86_64-apple-darwin","args":"--target x86_64-apple-darwin"},{"platform":"ubuntu-22.04","target":"x86_64-unknown-linux-gnu","args":""},{"platform":"windows-latest","target":"x86_64-pc-windows-msvc","args":""}]' >> "$GITHUB_OUTPUT"
+            echo 'matrix=[{"platform":"macos-latest","target":"aarch64-apple-darwin","args":"--target aarch64-apple-darwin"},{"platform":"macos-latest","target":"x86_64-apple-darwin","args":"--target x86_64-apple-darwin"},{"platform":"ubuntu-22.04","target":"x86_64-unknown-linux-gnu","args":"","container":"debian:bookworm"},{"platform":"windows-latest","target":"x86_64-pc-windows-msvc","args":""}]' >> "$GITHUB_OUTPUT"
           elif [ "${{ inputs.platform }}" == "macos-aarch64" ]; then
             echo 'matrix=[{"platform":"macos-latest","target":"aarch64-apple-darwin","args":"--target aarch64-apple-darwin"}]' >> "$GITHUB_OUTPUT"
           elif [ "${{ inputs.platform }}" == "macos-x86_64" ]; then
             echo 'matrix=[{"platform":"macos-latest","target":"x86_64-apple-darwin","args":"--target x86_64-apple-darwin"}]' >> "$GITHUB_OUTPUT"
           elif [ "${{ inputs.platform }}" == "ubuntu-22.04" ]; then
-            echo 'matrix=[{"platform":"ubuntu-22.04","target":"x86_64-unknown-linux-gnu","args":""}]' >> "$GITHUB_OUTPUT"
+            echo 'matrix=[{"platform":"ubuntu-22.04","target":"x86_64-unknown-linux-gnu","args":"","container":"debian:bookworm"}]' >> "$GITHUB_OUTPUT"
           elif [ "${{ inputs.platform }}" == "windows-latest" ]; then
             echo 'matrix=[{"platform":"windows-latest","target":"x86_64-pc-windows-msvc","args":""}]' >> "$GITHUB_OUTPUT"
           fi
@@ -45,6 +47,7 @@ jobs:
     name: Build ${{ matrix.target }}
     needs: setup-matrix
     runs-on: ${{ matrix.platform }}
+    container: ${{ matrix.container || null }}
     permissions:
       contents: write
     strategy:
@@ -53,6 +56,18 @@ jobs:
         include: ${{ fromJSON(needs.setup-matrix.outputs.matrix) }}
 
     steps:
+      - name: Install container deps (Linux)
+        if: matrix.container != ''
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            git curl wget ca-certificates xz-utils unzip sudo \
+            build-essential pkg-config cmake clang \
+            libssl-dev \
+            libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf \
+            libgtk-3-dev libsoup-3.0-dev libjavascriptcoregtk-4.1-dev \
+            file desktop-file-utils
+
       - uses: actions/checkout@v4
 
       - name: setup node
@@ -69,12 +84,6 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
-
-      - name: install dependencies (ubuntu only)
-        if: matrix.platform == 'ubuntu-22.04'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
 
       - name: install frontend dependencies
         run: bun install

--- a/.github/workflows/alpha-build.yml
+++ b/.github/workflows/alpha-build.yml
@@ -66,7 +66,8 @@ jobs:
             libssl-dev \
             libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf \
             libgtk-3-dev libsoup-3.0-dev libjavascriptcoregtk-4.1-dev \
-            file desktop-file-utils
+            file desktop-file-utils \
+            xdg-utils
 
       - uses: actions/checkout@v4
 

--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -36,15 +36,17 @@ jobs:
       - name: Generate matrix
         id: set-matrix
         run: |
+          # CLI 体积小、不需要 webkit2gtk,但仍走 debian:bookworm 容器 (glibc 2.36)
+          # 与 tauri 主构建保持一致基线,避免 cli 二进制 glibc 要求高于 desktop 包。
           PLATFORM="${{ inputs.platform || 'all' }}"
           if [ "$PLATFORM" == "all" ]; then
-            echo 'matrix=[{"platform":"macos-latest","target":"aarch64-apple-darwin","args":"--target aarch64-apple-darwin"},{"platform":"macos-latest","target":"x86_64-apple-darwin","args":"--target x86_64-apple-darwin"},{"platform":"ubuntu-22.04","target":"x86_64-unknown-linux-gnu","args":""},{"platform":"windows-latest","target":"x86_64-pc-windows-msvc","args":""}]' >> "$GITHUB_OUTPUT"
+            echo 'matrix=[{"platform":"macos-latest","target":"aarch64-apple-darwin","args":"--target aarch64-apple-darwin"},{"platform":"macos-latest","target":"x86_64-apple-darwin","args":"--target x86_64-apple-darwin"},{"platform":"ubuntu-22.04","target":"x86_64-unknown-linux-gnu","args":"","container":"debian:bookworm"},{"platform":"windows-latest","target":"x86_64-pc-windows-msvc","args":""}]' >> "$GITHUB_OUTPUT"
           elif [ "$PLATFORM" == "macos-aarch64" ]; then
             echo 'matrix=[{"platform":"macos-latest","target":"aarch64-apple-darwin","args":"--target aarch64-apple-darwin"}]' >> "$GITHUB_OUTPUT"
           elif [ "$PLATFORM" == "macos-x86_64" ]; then
             echo 'matrix=[{"platform":"macos-latest","target":"x86_64-apple-darwin","args":"--target x86_64-apple-darwin"}]' >> "$GITHUB_OUTPUT"
           elif [ "$PLATFORM" == "ubuntu-22.04" ]; then
-            echo 'matrix=[{"platform":"ubuntu-22.04","target":"x86_64-unknown-linux-gnu","args":""}]' >> "$GITHUB_OUTPUT"
+            echo 'matrix=[{"platform":"ubuntu-22.04","target":"x86_64-unknown-linux-gnu","args":"","container":"debian:bookworm"}]' >> "$GITHUB_OUTPUT"
           elif [ "$PLATFORM" == "windows-latest" ]; then
             echo 'matrix=[{"platform":"windows-latest","target":"x86_64-pc-windows-msvc","args":""}]' >> "$GITHUB_OUTPUT"
           else
@@ -56,12 +58,23 @@ jobs:
     name: Build CLI ${{ matrix.target }}
     needs: setup-matrix
     runs-on: ${{ matrix.platform }}
+    container: ${{ matrix.container || null }}
     strategy:
       fail-fast: false
       matrix:
         include: ${{ fromJSON(needs.setup-matrix.outputs.matrix) }}
 
     steps:
+      # CLI 不依赖 webkit/appindicator,但同样需要 git/curl/cmake/clang 用于
+      # actions/checkout 与 aws-lc-sys (rustls) 的 C 工具链。
+      - name: Install container deps (Linux)
+        if: matrix.container != ''
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            git curl wget ca-certificates xz-utils unzip sudo \
+            build-essential pkg-config cmake clang libssl-dev
+
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.branch || github.ref }}
@@ -81,12 +94,6 @@ jobs:
         with:
           workspaces: "src-tauri -> target"
           shared-key: cli-${{ matrix.target }}
-
-      - name: install dependencies (ubuntu only)
-        if: matrix.platform == 'ubuntu-22.04'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
 
       - name: build CLI binary
         working-directory: src-tauri

--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -36,17 +36,20 @@ jobs:
       - name: Generate matrix
         id: set-matrix
         run: |
-          # CLI 体积小、不需要 webkit2gtk,但仍走 debian:bookworm 容器 (glibc 2.36)
-          # 与 tauri 主构建保持一致基线,避免 cli 二进制 glibc 要求高于 desktop 包。
+          # CLI Linux target 选 x86_64-unknown-linux-musl 静态编译:
+          # uc-cli 走 ring + rustls (无 aws-lc-sys / 无 openssl-sys),依赖图
+          # 里没有 C 库,musl 静态链可以一气呵成,glibc 完全无关。产物可直接
+          # 在任意 Linux (包括 Ubuntu 20.04 / Alpine / 老 RHEL) 上跑。
+          # 容器仍用 debian:bookworm 拿 musl-tools / cmake / clang 工具链。
           PLATFORM="${{ inputs.platform || 'all' }}"
           if [ "$PLATFORM" == "all" ]; then
-            echo 'matrix=[{"platform":"macos-latest","target":"aarch64-apple-darwin","args":"--target aarch64-apple-darwin"},{"platform":"macos-latest","target":"x86_64-apple-darwin","args":"--target x86_64-apple-darwin"},{"platform":"ubuntu-22.04","target":"x86_64-unknown-linux-gnu","args":"","container":"debian:bookworm"},{"platform":"windows-latest","target":"x86_64-pc-windows-msvc","args":""}]' >> "$GITHUB_OUTPUT"
+            echo 'matrix=[{"platform":"macos-latest","target":"aarch64-apple-darwin","args":"--target aarch64-apple-darwin"},{"platform":"macos-latest","target":"x86_64-apple-darwin","args":"--target x86_64-apple-darwin"},{"platform":"ubuntu-22.04","target":"x86_64-unknown-linux-musl","args":"--target x86_64-unknown-linux-musl","container":"debian:bookworm"},{"platform":"windows-latest","target":"x86_64-pc-windows-msvc","args":""}]' >> "$GITHUB_OUTPUT"
           elif [ "$PLATFORM" == "macos-aarch64" ]; then
             echo 'matrix=[{"platform":"macos-latest","target":"aarch64-apple-darwin","args":"--target aarch64-apple-darwin"}]' >> "$GITHUB_OUTPUT"
           elif [ "$PLATFORM" == "macos-x86_64" ]; then
             echo 'matrix=[{"platform":"macos-latest","target":"x86_64-apple-darwin","args":"--target x86_64-apple-darwin"}]' >> "$GITHUB_OUTPUT"
           elif [ "$PLATFORM" == "ubuntu-22.04" ]; then
-            echo 'matrix=[{"platform":"ubuntu-22.04","target":"x86_64-unknown-linux-gnu","args":"","container":"debian:bookworm"}]' >> "$GITHUB_OUTPUT"
+            echo 'matrix=[{"platform":"ubuntu-22.04","target":"x86_64-unknown-linux-musl","args":"--target x86_64-unknown-linux-musl","container":"debian:bookworm"}]' >> "$GITHUB_OUTPUT"
           elif [ "$PLATFORM" == "windows-latest" ]; then
             echo 'matrix=[{"platform":"windows-latest","target":"x86_64-pc-windows-msvc","args":""}]' >> "$GITHUB_OUTPUT"
           else
@@ -65,15 +68,16 @@ jobs:
         include: ${{ fromJSON(needs.setup-matrix.outputs.matrix) }}
 
     steps:
-      # CLI 不依赖 webkit/appindicator,但同样需要 git/curl/cmake/clang 用于
-      # actions/checkout 与 aws-lc-sys (rustls) 的 C 工具链。
+      # CLI 不依赖 webkit/appindicator;musl-tools 提供 musl-gcc 作为 musl
+      # target 的 linker;ring (rustls 默认 crypto) 在 musl 上需要 cc/clang。
       - name: Install container deps (Linux)
         if: matrix.container != ''
         run: |
           apt-get update
           apt-get install -y --no-install-recommends \
             git curl wget ca-certificates xz-utils unzip sudo \
-            build-essential pkg-config cmake clang libssl-dev
+            build-essential pkg-config cmake clang \
+            musl-tools
 
       - uses: actions/checkout@v4
         with:
@@ -87,7 +91,9 @@ jobs:
       - name: install Rust stable
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
+          # Linux 走 musl,需要 rustup 装 x86_64-unknown-linux-musl target;
+          # macOS 装两个 darwin target;Windows host=msvc 装 noop。
+          targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || matrix.target }}
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
@@ -97,6 +103,11 @@ jobs:
 
       - name: build CLI binary
         working-directory: src-tauri
+        # musl 链接器 + ring/cc-rs 的 C 编译器都指到 musl-gcc,产物完全静态,
+        # 不再链 host glibc。其他 platform 这两个 env 是 noop。
+        env:
+          CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER: musl-gcc
+          CC_x86_64_unknown_linux_musl: musl-gcc
         run: cargo build --release -p uc-cli ${{ matrix.args }}
 
       - name: import Apple certificate (macOS only)

--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -105,9 +105,19 @@ jobs:
         working-directory: src-tauri
         # musl 链接器 + ring/cc-rs 的 C 编译器都指到 musl-gcc,产物完全静态,
         # 不再链 host glibc。其他 platform 这两个 env 是 noop。
+        #
+        # `-C relocation-model=static` 禁用 PIE。Rust 1.71+ 的
+        # x86_64-unknown-linux-musl target 默认 position-independent-executables=true,
+        # 即使全静态链 (ldd 报 "statically linked",无 DT_NEEDED) 仍会写入
+        # PT_INTERP=/lib/ld-musl-x86_64.so.1。glibc 主机上没有该 loader,
+        # execve 直接 ENOENT,shell 报 "no such file or directory" (但报的是
+        # 二进制本身,因为内核没法把 errno 区分成 "interpreter 找不到")。
+        # 关掉 PIE 后产物变成无 PT_INTERP 的经典 static ELF,任意 Linux x86_64
+        # (glibc / musl) 都能直接 exec。这才符合 ace8685f 切 musl 的初衷。
         env:
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER: musl-gcc
           CC_x86_64_unknown_linux_musl: musl-gcc
+          CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_RUSTFLAGS: "-C relocation-model=static"
         run: cargo build --release -p uc-cli ${{ matrix.args }}
 
       - name: import Apple certificate (macOS only)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,15 +51,17 @@ jobs:
       - name: Generate matrix
         id: set-matrix
         run: |
+          # Linux 构建在 host=ubuntu-22.04 上启容器跑 (debian:bookworm, glibc 2.36),
+          # 其他 platform (macOS/Windows) 不带 container 字段 → 直接在 host runner 跑。
           PLATFORM="${{ inputs.platform || 'all' }}"
           if [ "$PLATFORM" == "all" ]; then
-            echo 'matrix=[{"platform":"macos-latest","target":"aarch64-apple-darwin","args":"--target aarch64-apple-darwin"},{"platform":"macos-latest","target":"x86_64-apple-darwin","args":"--target x86_64-apple-darwin"},{"platform":"ubuntu-22.04","target":"x86_64-unknown-linux-gnu","args":""},{"platform":"windows-latest","target":"x86_64-pc-windows-msvc","args":""}]' >> "$GITHUB_OUTPUT"
+            echo 'matrix=[{"platform":"macos-latest","target":"aarch64-apple-darwin","args":"--target aarch64-apple-darwin"},{"platform":"macos-latest","target":"x86_64-apple-darwin","args":"--target x86_64-apple-darwin"},{"platform":"ubuntu-22.04","target":"x86_64-unknown-linux-gnu","args":"","container":"debian:bookworm"},{"platform":"windows-latest","target":"x86_64-pc-windows-msvc","args":""}]' >> "$GITHUB_OUTPUT"
           elif [ "$PLATFORM" == "macos-aarch64" ]; then
             echo 'matrix=[{"platform":"macos-latest","target":"aarch64-apple-darwin","args":"--target aarch64-apple-darwin"}]' >> "$GITHUB_OUTPUT"
           elif [ "$PLATFORM" == "macos-x86_64" ]; then
             echo 'matrix=[{"platform":"macos-latest","target":"x86_64-apple-darwin","args":"--target x86_64-apple-darwin"}]' >> "$GITHUB_OUTPUT"
           elif [ "$PLATFORM" == "ubuntu-22.04" ]; then
-            echo 'matrix=[{"platform":"ubuntu-22.04","target":"x86_64-unknown-linux-gnu","args":""}]' >> "$GITHUB_OUTPUT"
+            echo 'matrix=[{"platform":"ubuntu-22.04","target":"x86_64-unknown-linux-gnu","args":"","container":"debian:bookworm"}]' >> "$GITHUB_OUTPUT"
           elif [ "$PLATFORM" == "windows-latest" ]; then
             echo 'matrix=[{"platform":"windows-latest","target":"x86_64-pc-windows-msvc","args":""}]' >> "$GITHUB_OUTPUT"
           else
@@ -71,12 +73,30 @@ jobs:
     name: Build ${{ matrix.target }}
     needs: setup-matrix
     runs-on: ${{ matrix.platform }}
+    # matrix.container 仅 Linux 条目设置,其他 platform 该字段缺失 → null →
+    # GitHub Actions 跳过容器,直接在 host runner 上执行。
+    container: ${{ matrix.container || null }}
     strategy:
       fail-fast: false
       matrix:
         include: ${{ fromJSON(needs.setup-matrix.outputs.matrix) }}
 
     steps:
+      # bookworm 容器是 minimal,actions/checkout 需要 git;后续 step 还要
+      # curl/ca-certificates 用于装 rustup/bun/node。一次装齐 Tauri Linux
+      # 所需的全部 dev 包,glibc 基线 = bookworm 的 2.36。
+      - name: Install container deps (Linux)
+        if: matrix.container != ''
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            git curl wget ca-certificates xz-utils unzip sudo \
+            build-essential pkg-config cmake clang \
+            libssl-dev \
+            libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf \
+            libgtk-3-dev libsoup-3.0-dev libjavascriptcoregtk-4.1-dev \
+            file desktop-file-utils
+
       - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.branch || github.ref }}
@@ -109,12 +129,6 @@ jobs:
           key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
           restore-keys: |
             ${{ runner.os }}-bun-
-
-      - name: install dependencies (ubuntu only)
-        if: matrix.platform == 'ubuntu-22.04'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
 
       - name: install frontend dependencies
         run: bun install

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,7 +95,8 @@ jobs:
             libssl-dev \
             libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf \
             libgtk-3-dev libsoup-3.0-dev libjavascriptcoregtk-4.1-dev \
-            file desktop-file-utils
+            file desktop-file-utils \
+            xdg-utils
 
       - uses: actions/checkout@v6
         with:

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4646,6 +4646,7 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
 dependencies = [
+ "cc",
  "pkg-config",
 ]
 
@@ -9883,6 +9884,7 @@ dependencies = [
  "image",
  "keyring",
  "libc",
+ "libdbus-sys",
  "log",
  "mockall 0.13.1",
  "objc2",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -717,6 +717,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa7e52a4c5c547c741610a2c6f123f3881e409b714cd27e6798ef020c514f0a"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "axum"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1331,6 +1353,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "cmov"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1526,7 +1557,7 @@ dependencies = [
  "bitflags 2.10.0",
  "core-foundation 0.10.1",
  "core-graphics-types",
- "foreign-types 0.5.0",
+ "foreign-types",
  "libc",
 ]
 
@@ -2722,21 +2753,12 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared 0.1.1",
-]
-
-[[package]]
-name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared 0.3.1",
+ "foreign-types-shared",
 ]
 
 [[package]]
@@ -2749,12 +2771,6 @@ dependencies = [
  "quote",
  "syn 2.0.112",
 ]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign-types-shared"
@@ -2776,6 +2792,12 @@ name = "fragile"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "funty"
@@ -3694,22 +3716,6 @@ dependencies = [
  "tokio-rustls",
  "tower-service",
  "webpki-roots",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
 ]
 
 [[package]]
@@ -5094,23 +5100,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe 0.1.6",
- "openssl-sys",
- "schannel",
- "security-framework 2.11.1",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "ndk"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5859,54 +5848,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "openssl"
-version = "0.10.75"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
-dependencies = [
- "bitflags 2.10.0",
- "cfg-if",
- "foreign-types 0.3.2",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.112",
-]
-
-[[package]]
-name = "openssl-probe"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
-
-[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.111"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "option-ext"
@@ -6818,6 +6763,7 @@ version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -7299,13 +7245,12 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier 0.7.0",
@@ -7313,7 +7258,6 @@ dependencies = [
  "serde_json",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
  "tower",
@@ -7534,6 +7478,7 @@ version = "0.23.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "533f54bc6a7d4f647e46ad909549eda97bf5afc1585190ef692b4286b198bd8f"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -7549,7 +7494,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
 dependencies = [
- "openssl-probe 0.2.1",
+ "openssl-probe",
  "rustls-pki-types",
  "schannel",
  "security-framework 3.5.1",
@@ -7619,6 +7564,7 @@ version = "0.103.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -7840,8 +7786,8 @@ checksum = "b93b3e19f45495ddd41d8222a152c48c84f6ba45abe9c69e2527e9cdea29bb5b"
 dependencies = [
  "cfg_aliases",
  "httpdate",
- "native-tls",
  "reqwest 0.13.3",
+ "rustls",
  "sentry-actix",
  "sentry-backtrace",
  "sentry-contexts",
@@ -7850,7 +7796,6 @@ dependencies = [
  "sentry-log",
  "sentry-panic",
  "sentry-tracing",
- "tokio",
  "ureq",
 ]
 
@@ -9279,16 +9224,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
 name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10185,14 +10120,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d39cb1dbab692d82a977c0392ffac19e188bd9186a9f32806f0aaa859d75585a"
 dependencies = [
  "base64 0.22.1",
- "der 0.7.10",
  "log",
- "native-tls",
  "percent-encoding",
+ "rustls",
  "rustls-pki-types",
  "ureq-proto",
  "utf-8",
- "webpki-root-certs",
+ "webpki-roots",
 ]
 
 [[package]]

--- a/src-tauri/crates/uc-bootstrap/Cargo.toml
+++ b/src-tauri/crates/uc-bootstrap/Cargo.toml
@@ -18,7 +18,23 @@ anyhow = "1.0"
 thiserror = "2.0"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "registry"] }
-sentry = { version = "0.48.1", features = ["tracing", "logs"] }
+sentry = { version = "0.48.1", default-features = false, features = [
+    "backtrace",
+    "contexts",
+    "debug-images",
+    "panic",
+    "release-health",
+    # transport=ureq 而非 reqwest:reqwest 0.13 的 rustls feature 硬绑定
+    # aws-lc-rs (C 库,CMake 编译,musl cross 不友好);ureq 3.x 的 rustls
+    # feature 只走 ring,与 workspace 其他 rustls 用户对齐。这样 uc-cli 走
+    # musl 静态编译时依赖图里没有任何 C 工具链强依赖。sentry 的 HTTP 上报
+    # 本就 fire-and-forget,同步 ureq 在独立 worker 线程跑,不阻塞主程序
+    # async 调度。
+    "ureq",
+    "rustls",
+    "tracing",
+    "logs",
+] }
 gethostname = "1.1"
 toml = "0.8"
 chrono = { version = "0.4", features = ["serde"] }

--- a/src-tauri/crates/uc-platform/Cargo.toml
+++ b/src-tauri/crates/uc-platform/Cargo.toml
@@ -83,6 +83,24 @@ tempfile = "3"
 mockall = "0.13"
 tracing-subscriber = { version = "0.3", features = ["registry"] }
 
+# Linux 上 keyring → dbus-secret-service → dbus → libdbus-sys。默认 libdbus-sys
+# 走 pkg-config 找系统 libdbus-1-dev,musl 静态交叉编译没有 sysroot 走不通
+# (见 ace8685f 启用 musl 后 CI 报的 "pkg-config has not been configured to
+# support cross-compilation")。这里只在 musl target 上对 libdbus-sys 启用
+# vendored,build.rs 改走 cc-rs 编 dbus 1.14.4 的源码 (crate 内置 vendor/dbus/),
+# 配合容器里已有的 CC_x86_64_unknown_linux_musl=musl-gcc 直接静态链 libdbus.a
+# 进二进制。Cargo feature unification 保证 dbus-secret-service 用的也是同一个
+# 开了 vendored 的 libdbus-sys 实例。
+#
+# 用 target_env="musl" 收口的原因:linux-gnu (本地 dev / 桌面端 CI) 仍走系统
+# libdbus,避免每个本地 Linux 构建都重新编一份 dbus 1.14.4 source。
+#
+# 注意:静态链只解决构建期的依赖,运行期仍需要目标机器有 dbus 会话总线 +
+# secret-service backend (gnome-keyring/kwallet),否则 keyring 调用会在
+# 运行期失败 (Alpine / 极简 distro 是这个状态)。
+[target.'cfg(all(target_os = "linux", target_env = "musl"))'.dependencies]
+libdbus-sys = { version = "0.2", features = ["vendored"] }
+
 [target.'cfg(windows)'.dependencies]
 clipboard-win = { version = "5.4" }
 

--- a/src-tauri/crates/uc-tauri/Cargo.toml
+++ b/src-tauri/crates/uc-tauri/Cargo.toml
@@ -66,7 +66,7 @@ objc2-foundation = { version = "0.3", features = ["NSGeometry", "objc2-core-foun
 
 [dev-dependencies]
 uc-platform = { path = "../uc-platform", features = ["test-helpers"] }
-sentry = { version = "0.48.1", features = ["test"] }
+sentry = { version = "0.48.1", default-features = false, features = ["test"] }
 tauri = { workspace = true, features = ["test"] }
 tempfile = "3"
 mockall = "0.13"


### PR DESCRIPTION
## 三件事一起搞,围绕同一主题: Linux build 基线稳定 + 兼容性收敛

> 此 PR 吃掉原 PR #552 的内容,#552 已关闭。

### 1. `ci(linux)`: Linux build 在 `debian:bookworm` 容器内跑

之前 `ubuntu-22.04` runner glibc=2.35,GitHub-hosted image deprecation 后会再向上漂(2.39 / 2.41),release binary 最低运行环境随之收紧,**用户兼容性随 GitHub runner 调度变化**,可控性差。

切到 `debian:bookworm` 容器后:
- glibc 基线 = **2.36**,受 Debian 12 release 节奏锁定。
- webkit2gtk-4.1 / libappindicator3 / libsoup-3.0 / libjavascriptcoregtk-4.1 全部从容器内 apt 仓库装,不依赖 host runner image。
- macOS / Windows 矩阵不带 `container` 字段,GHA 跳过容器,行为不变。

### 2. `chore(deps)`: sentry 走 ureq + rustls + ring,彻底干掉 OpenSSL 与 aws-lc

sentry 0.48 默认 features 中的 `transport=["reqwest","native-tls"]` 把 `openssl/openssl-sys/native-tls/hyper-tls/tokio-native-tls` 一路拉进 workspace。

直觉上把 sentry 切成 `reqwest+rustls` 即可,**但 reqwest 0.13 的 `rustls` feature 硬绑定 `aws-lc-rs`**(C 库,CMake + bindgen,musl cross 不友好),无 ring 变体。改用 sentry `ureq` transport,ureq 3.x 的 rustls feature 显式只走 ring,与 workspace 其他 rustls 用户对齐:

```
cargo tree -i openssl    → not found
cargo tree -i native-tls → not found
cargo tree -i aws-lc-sys → not found (含 --target all)
cargo tree -i aws-lc-rs  → not found (含 --target all)
cargo tree -i ring 仍命中 (workspace 唯一 crypto provider)
```

sentry 上报本就 fire-and-forget,同步 ureq 由 sentry 自己包装在独立 worker 线程跑,不阻塞主程序 async 调度。

### 3. `ci(cli)`: CLI 静态 musl 编译

uc-cli 依赖图里无 C 工具链(见 ②),musl 静态编译一气呵成。产物完全脱离 host glibc,可在任意 Linux 发行版直接跑(Alpine / 老 Ubuntu / 老 RHEL),不再受构建机 image 升级影响。

- target = `x86_64-unknown-linux-musl`
- `musl-tools` 提供 `musl-gcc` 作为链接器
- `CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc` + `CC_x86_64_unknown_linux_musl=musl-gcc`,让 ring 内部 cc-rs 走 musl-gcc 编汇编
- archive 命名: `uniclipboard-cli-X.Y.Z-x86_64-unknown-linux-musl.tar.gz`(target triple 自然变化)

## ⚠️ Desktop 仍未支持 Ubuntu 20.04

bookworm glibc 2.36 仍 > Ubuntu 20.04 的 2.31。Tauri 2 强制 webkit2gtk-4.1,而 20.04 / Debian 11 默认仓库都没该包。要支持 Ubuntu 20.04 desktop 需要自编 webkit / AppImage bundle libwebkit,工程量大,**不在本 PR 范围**。

CLI musl 二进制不受此限制,在 Ubuntu 20.04 等老系统上能直接跑。

## Test plan

- [ ] dispatch `Build Tauri App` (platform=ubuntu-22.04) 走 PR 分支
  - [ ] container 拉起,apt install 全部成功
  - [ ] tauri build 完成,产物 .deb / .AppImage 在 artifacts 里
  - [ ] `objdump -T` 确认 desktop binary glibc 符号 ≤ `GLIBC_2.36`
- [ ] dispatch `Build CLI` (platform=ubuntu-22.04) 走 PR 分支
  - [ ] cargo build --target x86_64-unknown-linux-musl 成功
  - [ ] `file uniclip` 显示 `statically linked`
  - [ ] `ldd uniclip` 报 `not a dynamic executable`
  - [ ] 产物在 Alpine / Ubuntu 20.04 / Ubuntu 24.04 上分别能跑通 `uniclip --help`
- [ ] dispatch macOS / Windows 路径,确认两个非 Linux 矩阵未受影响
- [ ] 跑一次 release dry-run 走 release.yml 验证 reusable-workflow 整链 OK
- [ ] 启动 desktop app,触发一次 Sentry 上报(panic 或显式 capture),确认 ureq transport 真的把数据送上去


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build infrastructure to use containerized Linux environments for improved consistency and reproducibility.
  * Linux binaries now built with static linking for enhanced portability across systems.
  * Optimized error tracking configuration for more reliable crash reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->