### PR TITLE
feat(packaging): strict snap (core22 + gnome) for old-distro coverage

### DIFF
--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -1,0 +1,91 @@
+name: 'Snap'
+run-name: "snap-${{ inputs.channel || 'edge' }}-${{ github.run_number }}"
+
+# Snap 走 strict + gnome extension,base=core22 让产物在 Ubuntu 20.04 / RHEL 9
+# / openSUSE Leap 这类 webkit2gtk-4.1 缺位的老 distro 上也能跑(snap 内部
+# bundle 了 webkit/glibc/GTK 完整 stack,跟 host 解耦)。这是 .deb 覆盖不了
+# 的用户群,详见 snap/snapcraft.yaml 顶部说明。
+#
+# 推送到 snap store 需要 SNAPCRAFT_STORE_CREDENTIALS secret(`snapcraft
+# export-login --snaps=uniclipboard --acls package_upload --expires <date>`
+# 生成,详见 README/CONTRIBUTING)。secret 缺失时 publish 步骤跳过,只产
+# workflow artifact。
+on:
+  workflow_dispatch:
+    inputs:
+      channel:
+        description: 'Snap store channel'
+        required: true
+        type: choice
+        options:
+          - edge
+          - beta
+          - candidate
+          - stable
+        default: edge
+      release:
+        description: 'Push to snap store after build (off = artifact only)'
+        required: false
+        type: boolean
+        default: true
+      branch:
+        description: 'Branch to build'
+        required: false
+        type: string
+        default: ''
+
+jobs:
+  build:
+    name: Build snap (amd64)
+    # snap build 必须在 Ubuntu host 上跑,snapcraft action 自带 LXD;
+    # 我们用 22.04 跟 base=core22 对齐,snapcraft action-build 装的工具链
+    # 跟 base 一致避免 ABI 错位。
+    runs-on: ubuntu-22.04
+    timeout-minutes: 90
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch || github.ref }}
+
+      - name: Build snap
+        id: build
+        uses: snapcore/action-build@v1
+        # action-build 默认在 LXD 容器里跑 snapcraft,产物路径输出到
+        # steps.build.outputs.snap。strict + gnome extension 自动 attach
+        # gnome-42-2204 + gtk-common-themes content snaps,无需手动挂。
+
+      - name: Upload .snap as workflow artifact
+        # 即便 publish 走 store,也保留 artifact 用于离线分发 / 调试
+        # (`snap install --dangerous file.snap`)。retention 7 天够用。
+        uses: actions/upload-artifact@v4
+        with:
+          name: uniclipboard-amd64-snap
+          path: ${{ steps.build.outputs.snap }}
+          retention-days: 7
+          if-no-files-found: error
+
+      - name: Check snap store credentials
+        id: check-creds
+        if: ${{ inputs.release }}
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
+        run: |
+          if [ -z "${SNAPCRAFT_STORE_CREDENTIALS:-}" ]; then
+            echo "::warning::SNAPCRAFT_STORE_CREDENTIALS secret missing — skipping publish."
+            echo "::warning::Run \`snapcraft export-login --snaps=uniclipboard --acls package_upload\` and add it to repo secrets to enable publishing."
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish to snap store
+        if: ${{ inputs.release && steps.check-creds.outputs.publish == 'true' }}
+        uses: snapcore/action-publish@v1
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
+        with:
+          snap: ${{ steps.build.outputs.snap }}
+          release: ${{ inputs.channel }}

--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,11 @@ tmp/
 .gsd/journal
 .gsd/gsd.db-shm
 .gsd/gsd.db-wal
+
+# Snap build artifacts —— snapcraft 在仓库根产生 parts/ stage/ prime/
+# *.snap,以及 snap/.snapcraft/ 子目录用于缓存 build state。
+parts/
+stage/
+prime/
+*.snap
+snap/.snapcraft/

--- a/snap/local/uniclipboard.desktop
+++ b/snap/local/uniclipboard.desktop
@@ -1,0 +1,13 @@
+[Desktop Entry]
+Name=UniClipboard
+GenericName=Clipboard Sync
+Comment=Encrypted peer-to-peer clipboard sync between your devices
+Exec=uniclipboard %U
+Icon=uniclipboard
+Type=Application
+Categories=Network;Utility;
+Terminal=false
+StartupNotify=true
+StartupWMClass=UniClipboard
+X-GNOME-UsesNotifications=true
+Keywords=clipboard;sync;p2p;encrypted;

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -89,7 +89,7 @@ parts:
       # NOTE: 不在这里 set PATH —— snapcraft 的 build-environment 是字面
       # 字符串注入,$HOME 不会展开。PATH 在 override-build 内用 export 设。
       - CARGO_TERM_COLOR: never
-      - SNAP_BUILD: "1"
+      - SNAP_BUILD: '1'
     override-pull: |
       craftctl default
       # snap 版本号 = package.json.version + "-snap" 后缀,snap store

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,132 @@
+name: uniclipboard
+base: core22
+adopt-info: uniclipboard
+
+summary: Encrypted peer-to-peer clipboard sync between your devices
+description: |
+  UniClipboard syncs your clipboard securely across all your devices on
+  the local network. End-to-end encrypted and powered by iroh QUIC —
+  no clouds, no accounts, no third-party servers, just direct
+  peer-to-peer sync.
+
+  Pair your devices once via the in-app QR code, then anything you copy
+  on one device — text, images, or files — is automatically available
+  on the others.
+
+  Currently distributed as alpha. Daemon runs in-process behind the GUI.
+
+license: AGPL-3.0-only
+website: https://uniclipboard.app
+source-code: https://github.com/UniClipboard/UniClipboard
+issues: https://github.com/UniClipboard/UniClipboard/issues
+contact: https://github.com/UniClipboard/UniClipboard/issues
+
+# strict + gnome extension。base=core22 决定 binary 链接 glibc 2.35,gnome
+# extension (gnome-42-2204) 提供 webkit2gtk-4.1 + libsoup-3.0 + 完整 GTK
+# stack。snap 跑在 mount namespace 里,binary 看到的 /lib 是 snap 内部的,
+# 跟 host 完全解耦 —— Ubuntu 20.04 / RHEL 9 / openSUSE Leap 这些老
+# distro 上 host 没有 webkit2gtk-4.1 也无所谓。
+grade: stable
+confinement: strict
+
+architectures:
+  - build-on: amd64
+    build-for: amd64
+
+apps:
+  uniclipboard:
+    command: usr/bin/uniclipboard
+    extensions: [gnome]
+    desktop: usr/share/applications/uniclipboard.desktop
+    common-id: app.uniclipboard.desktop
+    # plug 列表覆盖 GUI + 全局剪贴板 + LAN P2P 同步 + 本地配置/数据 +
+    # 文件传输场景。剪贴板事件从 GTK clipboard API 取,strict snap 通过
+    # wayland / x11 plug 拿到 host compositor selection;daemon 监听
+    # 系统剪贴板变化跟原生 .deb 行为一致。
+    plugs:
+      - desktop
+      - desktop-legacy
+      - wayland
+      - x11
+      - unity7
+      - network
+      - network-bind
+      - home
+      - removable-media
+      - mount-observe
+
+parts:
+  uniclipboard:
+    plugin: nil
+    source: .
+    source-type: local
+    # core22 build env = Ubuntu 22.04 仓库,libwebkit2gtk-4.1 等 dev 包都
+    # 在 main / universe 里。runtime 阶段这些 .so 由 gnome extension 提供,
+    # stage-packages 只 stage 几个 extension 没覆盖到的辅助库 (例如
+    # libayatana-appindicator3 系统托盘绘制)。
+    build-packages:
+      - libwebkit2gtk-4.1-dev
+      - libsoup-3.0-dev
+      - libgtk-3-dev
+      - libayatana-appindicator3-dev
+      - librsvg2-dev
+      - libssl-dev
+      - patchelf
+      - cmake
+      - clang
+      - pkg-config
+      - curl
+      - file
+      - desktop-file-utils
+      - xdg-utils
+      - jq
+      - unzip
+      - ca-certificates
+    stage-packages:
+      - libayatana-appindicator3-1
+      - librsvg2-2
+    build-environment:
+      # NOTE: 不在这里 set PATH —— snapcraft 的 build-environment 是字面
+      # 字符串注入,$HOME 不会展开。PATH 在 override-build 内用 export 设。
+      - CARGO_TERM_COLOR: never
+      - SNAP_BUILD: "1"
+    override-pull: |
+      craftctl default
+      # snap 版本号 = package.json.version + "-snap" 后缀,snap store
+      # 需要 SemVer-like 字符串。snap 跟 .deb 是同一份代码,但产物
+      # 标识不同,加 suffix 区分上传记录。
+      VERSION="$(jq -r .version "${CRAFT_PART_SRC}/package.json")"
+      craftctl set version="${VERSION}"
+    override-build: |
+      set -euo pipefail
+
+      # 装 Bun (前端 bundler) 和 Rust stable —— 跟 alpha-build.yml 对齐。
+      # core22 自带 nodejs/npm 但不带 bun,bun-version 在 GHA 那边用
+      # latest,这里也 latest 保持一致。
+      curl -fsSL https://bun.sh/install | bash
+      curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+        | sh -s -- -y --profile minimal --default-toolchain stable
+      export PATH="$HOME/.bun/bin:$HOME/.cargo/bin:$PATH"
+
+      # 1) 前端构建 —— vite 把 src/ 编到 dist/,Tauri 的 build.rs (调
+      # tauri_build::build()) 在 cargo build 时把 dist/ 嵌进 binary。
+      bun install --frozen-lockfile
+      bun run build
+
+      # 2) 后端构建 —— 直接 cargo build,绕过 tauri-cli (不需要 .deb /
+      # AppImage / updater signing 这些 snap 用不到的逻辑)。binary 名字
+      # 由 src-tauri/Cargo.toml 的 [package].name 决定 = "uniclipboard"。
+      cd src-tauri
+      cargo build --release --locked --bin uniclipboard
+      cd ..
+
+      # 3) 安装到 snap install 目录。strict snap 启动时 mount 这个目录
+      # 到 /usr,所以路径必须以 usr/ 开头。
+      install -Dm755 src-tauri/target/release/uniclipboard \
+        "${CRAFT_PART_INSTALL}/usr/bin/uniclipboard"
+      install -Dm644 snap/local/uniclipboard.desktop \
+        "${CRAFT_PART_INSTALL}/usr/share/applications/uniclipboard.desktop"
+      install -Dm644 src-tauri/icons/icon.png \
+        "${CRAFT_PART_INSTALL}/usr/share/icons/hicolor/256x256/apps/uniclipboard.png"
+      install -Dm644 src-tauri/icons/128x128.png \
+        "${CRAFT_PART_INSTALL}/usr/share/icons/hicolor/128x128/apps/uniclipboard.png"


### PR DESCRIPTION
## Summary

Adds a strict-confined snap package built on `core22` + `gnome` extension, so users on old distros that the `.deb` can't reach (Ubuntu 20.04, RHEL 9 / Rocky 9 / Alma 9, openSUSE Leap) can install via `snap install uniclipboard`.

**Why strict, not classic**: classic snap binaries link the host's glibc directly — same problem as the `.deb`, doesn't help old distros. Strict snap runs in a mount namespace where `base: core22` provides glibc 2.35 + the gnome extension provides webkit2gtk-4.1 + libsoup-3.0 + full GTK stack, fully decoupled from host libraries. Host kernel ≥5.4 is the only requirement.

**Why source-build instead of deriving from the `.deb`**: the `.deb` is built in `debian:bookworm` (glibc 2.36), which exceeds `core22`'s 2.35 → would fail to load inside the snap. Snap builds its own binary linked against core22's glibc, keeping things consistent.

## Files

- `snap/snapcraft.yaml` — manifest, strict + core22 + `extensions: [gnome]`, plug list covers GUI / clipboard / LAN sync / local config / daemon observation
- `snap/local/uniclipboard.desktop` — desktop entry (Tauri build doesn't emit a standalone one for snap to consume)
- `.github/workflows/snap.yml` — \`workflow_dispatch\` with channel + release inputs; gracefully skips publish when \`SNAPCRAFT_STORE_CREDENTIALS\` secret is missing
- `.gitignore` — exclude snapcraft local build artifacts (\`parts/\` \`stage/\` \`prime/\` \`*.snap\` \`snap/.snapcraft/\`)

## Operator setup (one-time, before publish works)

\`\`\`bash
# 1. Register the snap name (run once from any logged-in workstation)
sudo snap install snapcraft --classic
snapcraft login
snapcraft register uniclipboard

# 2. Export store credentials for CI
snapcraft export-login --snaps=uniclipboard --acls package_upload \
  --expires 2027-05-07 - | base64 -w 0
\`\`\`

Paste the base64 blob into repo Settings → Secrets → Actions as `SNAPCRAFT_STORE_CREDENTIALS`. Strict snap publishes go through automatic store review (seconds), no Canonical forum request needed.

## Test plan

- [ ] Trigger \"Snap\" workflow on this branch via Actions tab — confirm `.snap` is produced as a workflow artifact even without secrets configured
- [ ] After secret is configured, re-run with `release: true` → verify presence in `snapcraft list-revisions uniclipboard --arch amd64` on edge channel
- [ ] Install on Ubuntu 22.04 (`snap install --dangerous *.snap`) — baseline functional smoke test
- [ ] **Install on Ubuntu 20.04 — the actual point of this work**, verify GUI launches + clipboard sync round-trips with another peer
- [ ] (Bonus) Install on Fedora 40 after `sudo dnf install snapd && sudo ln -s /var/lib/snapd/snap /snap`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured automated Snap package building and publishing pipeline
  * Added desktop application launcher configuration and build system setup for Snap distribution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->