### PR TITLE
ci: alpha 自动发布、release 后自动触发 snap、format 直推 PR 分支

### DIFF
--- a/.github/workflows/alpha-build.yml
+++ b/.github/workflows/alpha-build.yml
@@ -104,7 +104,7 @@ jobs:
           tagName: v${{ inputs.version }}
           releaseName: UniClipboard Alpha v${{ inputs.version }}
           releaseBody: Alpha build for testing.
-          releaseDraft: true
+          releaseDraft: false
           prerelease: true
           uploadUpdaterJson: true
           args: ${{ matrix.args }}

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -66,54 +66,36 @@ jobs:
             fi
           fi
 
-      # ---------- Same-repo PR: create auto-fix branch + PR ----------
-      - name: Create fix branch and open PR (same-repo only)
+      # ---------- Same-repo PR: push fix directly to PR head branch ----------
+      - name: Auto-format and push to PR branch
+        id: push-fix
         if: |
           steps.diff.outputs.has_changes == 'true' &&
           steps.diff.outputs.has_workflow_changes != 'true' &&
           github.event.pull_request.head.repo.full_name == github.repository
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_HEAD_REF: ${{ github.head_ref }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          FIX_BRANCH="format-fix/pr-$PR_NUMBER"
-
-          git checkout -b "$FIX_BRANCH"
           git add -A
           git commit -m "style: auto-format code for PR #$PR_NUMBER"
-          git push origin "$FIX_BRANCH" --force
 
-          DIFF_STAT=$(git diff HEAD~1 --stat)
-
-          PR_BODY="Auto-generated format fix for #$PR_NUMBER.
-
-          Merge this PR first, then re-push the original branch to pass the format check.
-
-          **Changes:**
-          \`\`\`
-          $DIFF_STAT
-          \`\`\`"
-
-          # Check if a PR already exists for this fix branch.
-          EXISTING_PR_URL=$(gh pr list --head "$FIX_BRANCH" --json url --jq '.[0].url' 2>/dev/null)
-
-          if [ -n "$EXISTING_PR_URL" ]; then
-            echo "::notice::Format fix PR already exists: $EXISTING_PR_URL"
+          # GITHUB_TOKEN 推送的 commit 默认不会再触发任何 workflow(防递归),
+          # 所以本次 format check 仍以失败收尾,但 PR head 上已经带上了
+          # 格式化 commit。作者 git pull 之后再 push 一次(或在 GH UI 点
+          # re-run failed)checks 就会变绿。
+          if git push origin "HEAD:refs/heads/$PR_HEAD_REF"; then
+            echo "pushed=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::已自动提交格式化 commit 到 $PR_HEAD_REF。请 git pull 同步本地分支,然后重新 push 一次 / 或在 PR 页点 Re-run failed checks 让 CI 变绿。"
           else
-            NEW_PR_URL=$(gh pr create \
-              --title "style: auto-format for PR #$PR_NUMBER" \
-              --body "$PR_BODY" \
-              --base "$PR_HEAD_REF" \
-              --head "$FIX_BRANCH" 2>&1) && \
-            echo "::notice::Format fix PR created: $NEW_PR_URL" || \
-            echo "::warning::Could not auto-create PR (branch '$FIX_BRANCH' has been pushed). Please create a PR manually from '$FIX_BRANCH' → '$PR_HEAD_REF'. Error: $NEW_PR_URL"
+            echo "pushed=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::Auto-push 失败(可能远端在此期间有新 commit)。请本地运行 \`cd src-tauri && cargo fmt --all && cd .. && bun run format\` 并提交。"
           fi
 
-      # ---------- Fork PR: print diff for author to fix manually ----------
+      # ---------- Fork PR / workflow file changes: print diff for author ----------
       - name: Show diff when auto-push is unavailable
         if: |
           steps.diff.outputs.has_changes == 'true' &&
@@ -123,9 +105,9 @@ jobs:
           )
         run: |
           if [ "${{ steps.diff.outputs.has_workflow_changes }}" = "true" ]; then
-            echo "::warning::Format issues include .github/workflows files. GitHub Actions cannot auto-push workflow file changes with the default token."
+            echo "::warning::Format issues include .github/workflows files. GitHub Actions 默认 token 无权直推 workflow 文件,需要作者本地修复。"
           else
-            echo "::warning::Format issues found. Cannot auto-create fix PR for fork contributions."
+            echo "::warning::Format issues found. Fork PR 无法自动直推,请作者本地修复。"
           fi
           echo "Please run the following commands locally and push the changes:"
           echo ""
@@ -137,5 +119,9 @@ jobs:
       - name: Fail if format changes needed
         if: steps.diff.outputs.has_changes == 'true'
         run: |
-          echo "::error::Format issues found. See above for details."
+          if [ "${{ steps.push-fix.outputs.pushed }}" = "true" ]; then
+            echo "::error::Format 修复已自动推送到 PR 分支。请 pull 后 re-run checks 让本检查变绿。"
+          else
+            echo "::error::Format issues found. See above for details."
+          fi
           exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -285,7 +285,7 @@ jobs:
           tag_name: v${{ needs.validate.outputs.version }}
           name: v${{ needs.validate.outputs.version }}
           body_path: release-notes.md
-          draft: true
+          draft: ${{ needs.validate.outputs.channel != 'alpha' }}
           prerelease: ${{ needs.validate.outputs.is_prerelease == 'true' }}
           files: release-assets/*
         env:
@@ -374,11 +374,31 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Next Steps" >> $GITHUB_STEP_SUMMARY
           echo "1. Go to [Releases](https://github.com/${{ github.repository }}/releases)" >> $GITHUB_STEP_SUMMARY
-          echo "2. Review the generated draft release notes" >> $GITHUB_STEP_SUMMARY
-          echo "3. Publish the release when ready" >> $GITHUB_STEP_SUMMARY
+          if [ "${{ needs.validate.outputs.channel }}" = "alpha" ]; then
+            echo "2. Alpha release已自动发布，无需手动 publish" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "2. Review the generated draft release notes" >> $GITHUB_STEP_SUMMARY
+            echo "3. Publish the release when ready" >> $GITHUB_STEP_SUMMARY
+          fi
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Update Manifest" >> $GITHUB_STEP_SUMMARY
           echo "Channel manifest deployed to GitHub Pages:" >> $GITHUB_STEP_SUMMARY
           REPO_OWNER=$(echo "${{ github.repository }}" | cut -d'/' -f1)
           REPO_NAME=$(echo "${{ github.repository }}" | cut -d'/' -f2)
           echo "https://${REPO_OWNER}.github.io/${REPO_NAME}/${{ needs.validate.outputs.channel }}.json" >> $GITHUB_STEP_SUMMARY
+
+  snap:
+    # 主 release 完成后自动触发 snap 构建并推到对应 channel。
+    # 渠道映射：alpha→edge, beta→beta, rc→candidate, stable→stable。
+    # continue-on-error 让 snap 失败不会把整条 release 标红——GH release
+    # 此时已创建，snap 仅作 Linux 老 distro 覆盖的补充分发。
+    name: Build & publish snap
+    needs: [validate, create-release]
+    if: ${{ success() }}
+    continue-on-error: true
+    uses: ./.github/workflows/snap.yml
+    with:
+      channel: ${{ needs.validate.outputs.channel == 'alpha' && 'edge' || needs.validate.outputs.channel == 'rc' && 'candidate' || needs.validate.outputs.channel }}
+      release: true
+      branch: ${{ inputs.branch || '' }}
+    secrets: inherit

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -33,6 +33,27 @@ on:
         required: false
         type: string
         default: ''
+  workflow_call:
+    inputs:
+      channel:
+        description: 'Snap store channel'
+        required: false
+        type: string
+        default: edge
+      release:
+        description: 'Push to snap store after build (false = artifact only)'
+        required: false
+        type: boolean
+        default: true
+      branch:
+        description: 'Branch / ref to build'
+        required: false
+        type: string
+        default: ''
+    secrets:
+      SNAPCRAFT_STORE_CREDENTIALS:
+        description: 'snapcraft export-login token; missing = artifact-only'
+        required: false
 
 jobs:
   build:


### PR DESCRIPTION
## Summary

三处独立的 workflow 优化，合并到一条 PR：

- **alpha 自动发布**：`release.yml` 把 GitHub Release 的 `draft` 改成 `channel != 'alpha'` 条件式；`alpha-build.yml` 的 `releaseDraft` 同步改 false。alpha 走 prerelease 标记直接发布，stable/beta/rc 仍保留草稿评审。
- **release 完成后自动触发 snap**：`snap.yml` 加 `workflow_call` 入口（手动 dispatch 不变），`release.yml` 在 `create-release` 之后挂一个 reusable snap job；渠道映射 alpha→edge / rc→candidate / beta→beta / stable→stable，`continue-on-error: true` 让 snap 失败不影响主 release。
- **format 直推 PR 分支**：`format.yml` 移除原 fix-branch + 嵌套 PR 设计，改为同仓 PR 直接以 `github-actions[bot]` push 格式化 commit 到 PR head。fork PR / `.github/workflows/` 文件改动这两类不能直推的场景保留原 fallback。

## Test plan

- [ ] 手动触发 `Release` workflow（channel=alpha），验证：
  - [ ] GitHub Release 被直接发布而非 draft
  - [ ] `Build & publish snap` 子 job 自动启动并以 `edge` 渠道推送
  - [ ] snap job 失败不会让整条 release run 标红
- [ ] 手动触发 `Release` workflow（channel=stable），验证：
  - [ ] GitHub Release 仍以 draft 形态创建
  - [ ] snap 子 job 以 `stable` 渠道推送
- [ ] 提交一个含格式问题的同仓 PR，验证：
  - [ ] format check 失败
  - [ ] PR head 分支收到 `style: auto-format code for PR #N` 的 bot commit
  - [ ] 不再出现 `format-fix/pr-N` 分支或嵌套 PR
- [ ] fork PR 或改动 `.github/workflows/` 的 PR：format check 失败并打印 diff 与本地修复指引（保留原 fallback 行为）

## 备注

- GitHub `GITHUB_TOKEN` 推送的 commit 默认不会触发下游 workflow（防递归），所以 bot push 后 format check 不会自动重跑——作者需 `git pull` 后再 push 一次或在 PR 页 Re-run failed checks。文案里已写明。
- 想让 beta/rc 也自动发布的话，把 `release.yml:288` 的判断改为 `is_prerelease != 'true'` 即可。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Alpha releases are now published automatically upon completion.
  * Snap packages are now built and distributed automatically for release channels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->