### PR TITLE
feat(docs-site): 启用 Orama 搜索引擎并修复 i18n middleware 拦截

### DIFF
--- a/docs-site/bun.lock
+++ b/docs-site/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "docs-site",
       "dependencies": {
+        "@orama/tokenizers": "^3.1.18",
         "fumadocs-core": "16.8.7",
         "fumadocs-mdx": "14.3.2",
         "fumadocs-ui": "16.8.7",
@@ -248,6 +249,8 @@
     "@nolyfill/is-core-module": ["@nolyfill/is-core-module@1.0.39", "", {}, "sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA=="],
 
     "@orama/orama": ["@orama/orama@3.1.18", "", {}, "sha512-a61ljmRVVyG5MC/698C8/FfFDw5a8LOIvyOLW5fztgUXqUpc1jOfQzOitSCbge657OgXXThmY3Tk8fpiDb4UcA=="],
+
+    "@orama/tokenizers": ["@orama/tokenizers@3.1.18", "", { "dependencies": { "@orama/orama": "3.1.18" } }, "sha512-Ra4dFddWZ7hCGPAehnd/6QZjlzQvczYSt1y1Fq4HteJqRu2yvfR6fXvxiUnKi+HIgJYPxKhebJEjvJdF8LYQWg=="],
 
     "@radix-ui/number": ["@radix-ui/number@1.1.1", "", {}, "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g=="],
 

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -12,6 +12,7 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@orama/tokenizers": "^3.1.18",
     "fumadocs-core": "16.8.7",
     "fumadocs-mdx": "14.3.2",
     "fumadocs-ui": "16.8.7",

--- a/docs-site/src/app/[lang]/layout.tsx
+++ b/docs-site/src/app/[lang]/layout.tsx
@@ -1,6 +1,6 @@
-import { RootProvider } from 'fumadocs-ui/provider/next'
 import '../global.css'
 import { Manrope } from 'next/font/google'
+import { DocsProviders } from '@/components/docs-providers'
 import { i18nUI } from '@/lib/layout.shared'
 
 const manrope = Manrope({
@@ -13,7 +13,7 @@ export default async function Layout({ params, children }: LayoutProps<'/[lang]'
   return (
     <html lang={lang} className={manrope.className} suppressHydrationWarning>
       <body className="flex flex-col min-h-screen">
-        <RootProvider i18n={i18nUI.provider(lang)}>{children}</RootProvider>
+        <DocsProviders i18n={i18nUI.provider(lang)}>{children}</DocsProviders>
       </body>
     </html>
   )

--- a/docs-site/src/app/api/search/route.ts
+++ b/docs-site/src/app/api/search/route.ts
@@ -1,11 +1,22 @@
+import { createTokenizer } from '@orama/tokenizers/mandarin'
 import { createFromSource } from 'fumadocs-core/search/server'
 import { source } from '@/lib/source'
 
 export const { GET } = createFromSource(source, {
   // Map fumadocs locale codes to Orama language settings.
-  // https://docs.orama.com/docs/orama-js/supported-languages
+  // Mandarin requires a dedicated tokenizer — `language: 'mandarin'` alone
+  // does not split CJK text into searchable tokens.
+  // https://docs.orama.com/docs/orama-js/supported-languages/using-chinese-with-orama
   localeMap: {
     en: { language: 'english' },
-    zh: { language: 'mandarin' },
+    zh: {
+      components: {
+        tokenizer: createTokenizer(),
+      },
+      search: {
+        threshold: 0,
+        tolerance: 0,
+      },
+    },
   },
 })

--- a/docs-site/src/components/docs-providers.tsx
+++ b/docs-site/src/components/docs-providers.tsx
@@ -1,0 +1,19 @@
+'use client'
+
+import { RootProvider } from 'fumadocs-ui/provider/next'
+import type { ReactNode } from 'react'
+import { docsBasePath } from '@/lib/shared'
+
+// fetch() in the search client doesn't honor Next.js `basePath`, so we must
+// pin the API URL to the prefixed route registered by `app/api/search/route.ts`.
+const SEARCH_API = `${docsBasePath}/api/search`
+
+type I18nProp = Parameters<typeof RootProvider>[0]['i18n']
+
+export function DocsProviders({ i18n, children }: { i18n: I18nProp; children: ReactNode }) {
+  return (
+    <RootProvider i18n={i18n} search={{ options: { api: SEARCH_API } }}>
+      {children}
+    </RootProvider>
+  )
+}

--- a/docs-site/src/proxy.ts
+++ b/docs-site/src/proxy.ts
@@ -48,8 +48,10 @@ export default function proxy(request: NextRequest, event: NextFetchEvent) {
 }
 
 export const config = {
-  // Match every request except Next.js internals and files with extensions.
+  // Match every request except Next.js internals, API routes, and files
+  // with extensions. API routes (e.g. `/api/search`) must not run through
+  // the i18n middleware — it would try to redirect them under a locale.
   // Listing root `/` separately because the negative-lookahead pattern below
   // doesn't reliably match an empty path with path-to-regexp.
-  matcher: ['/', '/((?!_next|favicon.ico|.*\\..*).*)'],
+  matcher: ['/', '/((?!_next|api/|favicon.ico|.*\\..*).*)'],
 }


### PR DESCRIPTION
## Summary

- 接入 fumadocs Orama 搜索：英文默认 + 中文 mandarin 分词器（`@orama/tokenizers`）
- 新增 `DocsProviders` client wrapper，把 `SEARCH_API` 显式指向 `/docs/api/search`，绕开 fumadocs 客户端 `fetch()` 不带 Next.js `basePath` 的限制
- `proxy.ts` matcher 排除 `/api/`，避免 i18n middleware 把 `/docs/api/search` 改写到 locale 路径导致 404

## Test plan

- [ ] `bun run types:check` 通过
- [ ] `bun run build` 成功，路由清单包含 `ƒ /api/search`
- [ ] `bun run dev` 后访问 `/docs/en`，DevTools Network 中搜索请求 URL 为 `http://localhost:3000/docs/api/search?...` 并返回 200
- [ ] `/docs/zh` 中文检索（如「设备」「快捷面板」）能命中结果