### PR TITLE
feat(docs-site): polish tab titles and default-open sidebar

### DIFF
--- a/docs-site/content/docs/en/getting-started/meta.json
+++ b/docs-site/content/docs/en/getting-started/meta.json
@@ -1,5 +1,6 @@
 {
   "title": "Getting Started",
   "icon": "Rocket",
+  "defaultOpen": true,
   "pages": ["install", "quick-start"]
 }

--- a/docs-site/content/docs/en/guides/meta.json
+++ b/docs-site/content/docs/en/guides/meta.json
@@ -1,5 +1,6 @@
 {
   "title": "Guides",
   "icon": "BookOpen",
+  "defaultOpen": true,
   "pages": ["pairing", "sync", "quick-panel", "search", "devices", "settings", "troubleshooting"]
 }

--- a/docs-site/content/docs/en/index.mdx
+++ b/docs-site/content/docs/en/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Welcome
+metaTitle: Documentation
 description: A privacy-first, end-to-end encrypted clipboard that follows you across devices and networks.
 ---
 

--- a/docs-site/content/docs/en/reference/meta.json
+++ b/docs-site/content/docs/en/reference/meta.json
@@ -1,5 +1,6 @@
 {
   "title": "Reference",
   "icon": "Wrench",
+  "defaultOpen": true,
   "pages": ["cli"]
 }

--- a/docs-site/content/docs/zh/getting-started/meta.json
+++ b/docs-site/content/docs/zh/getting-started/meta.json
@@ -1,5 +1,6 @@
 {
   "title": "上手",
   "icon": "Rocket",
+  "defaultOpen": true,
   "pages": ["install", "quick-start"]
 }

--- a/docs-site/content/docs/zh/guides/meta.json
+++ b/docs-site/content/docs/zh/guides/meta.json
@@ -1,5 +1,6 @@
 {
   "title": "指南",
   "icon": "BookOpen",
+  "defaultOpen": true,
   "pages": ["pairing", "sync", "quick-panel", "search", "devices", "settings", "troubleshooting"]
 }

--- a/docs-site/content/docs/zh/index.mdx
+++ b/docs-site/content/docs/zh/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: 欢迎
+metaTitle: 文档
 description: 隐私优先、端到端加密、跨设备跨网络的剪贴板。
 ---
 

--- a/docs-site/content/docs/zh/reference/meta.json
+++ b/docs-site/content/docs/zh/reference/meta.json
@@ -1,5 +1,6 @@
 {
   "title": "参考",
   "icon": "Wrench",
+  "defaultOpen": true,
   "pages": ["cli"]
 }

--- a/docs-site/source.config.ts
+++ b/docs-site/source.config.ts
@@ -1,12 +1,15 @@
 import { metaSchema, pageSchema } from 'fumadocs-core/source/schema'
 import { defineConfig, defineDocs } from 'fumadocs-mdx/config'
+import { z } from 'zod'
 
 // You can customize Zod schemas for frontmatter and `meta.json` here
 // see https://fumadocs.dev/docs/mdx/collections
 export const docs = defineDocs({
   dir: 'content/docs',
   docs: {
-    schema: pageSchema,
+    schema: pageSchema.extend({
+      metaTitle: z.string().optional(),
+    }),
     postprocess: {
       includeProcessedMarkdown: true,
     },

--- a/docs-site/src/app/[lang]/(docs)/[[...slug]]/page.tsx
+++ b/docs-site/src/app/[lang]/(docs)/[[...slug]]/page.tsx
@@ -53,7 +53,7 @@ export async function generateMetadata(props: PageProps<'/[lang]/[[...slug]]'>):
   if (!page) notFound()
 
   return {
-    title: page.data.title,
+    title: page.data.metaTitle ?? page.data.title,
     description: page.data.description,
     openGraph: {
       images: getPageImage(page).url,

--- a/docs-site/src/app/[lang]/layout.tsx
+++ b/docs-site/src/app/[lang]/layout.tsx
@@ -1,12 +1,21 @@
 import '../global.css'
+import type { Metadata } from 'next'
 import { Manrope } from 'next/font/google'
 import { DocsProviders } from '@/components/docs-providers'
 import { i18nUI } from '@/lib/layout.shared'
+import { appName } from '@/lib/shared'
 
 const manrope = Manrope({
   subsets: ['latin'],
   variable: '--font-manrope',
 })
+
+export const metadata: Metadata = {
+  title: {
+    template: `%s - ${appName}`,
+    default: appName,
+  },
+}
 
 export default async function Layout({ params, children }: LayoutProps<'/[lang]'>) {
   const { lang } = await params


### PR DESCRIPTION
## Summary

- Add `title.template` (`%s - UniClipboard`) at the `[lang]` layout so every docs page has a meaningful browser tab title instead of the bare frontmatter title.
- Extend the page frontmatter schema with optional `metaTitle` that overrides the tab title without changing the page H1 — used on `/docs` and `/zh/docs` so the H1 stays `Welcome` / `欢迎` while the tab reads `Documentation - UniClipboard` / `文档 - UniClipboard`.
- Set `defaultOpen: true` on all category `meta.json` files (en + zh: getting-started, guides, reference) so the sidebar lands fully expanded.

## Test plan

- [ ] `pnpm --filter docs-site dev`, visit `/docs` and `/zh/docs` — confirm tab title is `Documentation - UniClipboard` / `文档 - UniClipboard` and H1 is still `Welcome` / `欢迎`.
- [ ] Visit a non-index page (e.g. `/docs/getting-started/install`) — tab title should fall back to `<page title> - UniClipboard`.
- [ ] On first load, sidebar Getting Started / Guides / Reference (上手 / 指南 / 参考) groups are expanded.