### PR TITLE
feat(keepalive): per-peer backoff + inbound-driven Online recovery

### DIFF
--- a/src-tauri/crates/uc-application/src/facade/app_facade.rs
+++ b/src-tauri/crates/uc-application/src/facade/app_facade.rs
@@ -47,7 +47,8 @@ use crate::facade::{
     SearchFacadeError, SearchPageView, SearchQueryInput, SearchRebuildAcceptedView,
     SearchStatusView, SettingsFacade, SettingsFacadeError, SpaceSetupFacade, StorageFacade,
 };
-use uc_core::ports::{PresenceEvent, ReachabilityState};
+use uc_core::ids::DeviceId;
+use uc_core::ports::{PresenceError, PresenceEvent, ReachabilityState};
 use uc_core::ClipboardChangeOrigin;
 use uc_core::SystemClipboardSnapshot;
 
@@ -141,6 +142,35 @@ impl AppFacade {
                 "space setup facade unavailable".to_string(),
             ))?
             .refresh_presence()
+            .await
+    }
+
+    /// 列出已配对 peer 的 `DeviceId`(本机已过滤)。供 desktop keepalive
+    /// 调度器用来发现新 peer / 收回已删除 peer。Thin wrapper over
+    /// [`SpaceSetupFacade::list_paired_peer_device_ids`].
+    pub async fn list_paired_peer_device_ids(
+        &self,
+    ) -> Result<Vec<DeviceId>, EnsureReachableAllError> {
+        self.space_setup
+            .as_ref()
+            .ok_or(EnsureReachableAllError::Repository(
+                "space setup facade unavailable".to_string(),
+            ))?
+            .list_paired_peer_device_ids()
+            .await
+    }
+
+    /// 对单个 peer 触发一次 `ensure_reachable`。供 desktop keepalive 调度
+    /// 器在退避到期时按需拨号。Thin wrapper over
+    /// [`SpaceSetupFacade::ensure_reachable_one`].
+    pub async fn ensure_reachable_one(
+        &self,
+        device: &DeviceId,
+    ) -> Result<ReachabilityState, PresenceError> {
+        self.space_setup
+            .as_ref()
+            .ok_or_else(|| PresenceError::Internal("space setup facade unavailable".to_string()))?
+            .ensure_reachable_one(device)
             .await
     }
 

--- a/src-tauri/crates/uc-application/src/facade/space_setup/facade.rs
+++ b/src-tauri/crates/uc-application/src/facade/space_setup/facade.rs
@@ -23,9 +23,12 @@ use tokio::sync::broadcast;
 use tokio::task::JoinHandle;
 use tracing::{info, instrument, warn};
 
-use uc_core::ids::SpaceId;
+use uc_core::ids::{DeviceId, SpaceId};
 use uc_core::ports::space::{SpaceAccessError, SpaceAccessPort};
-use uc_core::ports::{SettingsPort, SetupStatusPort};
+use uc_core::ports::{
+    PeerAddressRepositoryPort, PresenceError, PresencePort, ReachabilityState, SettingsPort,
+    SetupStatusPort,
+};
 use uc_core::setup::SetupStatus;
 
 use crate::facade::space_setup::commands::{
@@ -108,6 +111,17 @@ pub struct SpaceSetupFacade {
     /// 必须自己拿 port。
     migration_state: Arc<dyn MigrationStatePort>,
     blob_migration_repo: Arc<dyn BlobMigrationRepoPort>,
+    /// Held for the desktop keepalive scheduler — `list_paired_peer_device_ids`
+    /// reads `peer_addr_repo.list()` and `ensure_reachable_one` forwards to
+    /// `presence.ensure_reachable`. Both are thin wrappers driven by the
+    /// worker's per-peer backoff state machine; the underlying ports stay
+    /// owned by use cases as before.
+    peer_addr_repo: Arc<dyn PeerAddressRepositoryPort>,
+    presence: Arc<dyn PresencePort>,
+    /// `current_device_id()` snapshotted at facade-construction time so
+    /// `list_paired_peer_device_ids` can self-filter without grabbing the
+    /// `DeviceIdentityPort` lock on every call.
+    local_device_id: DeviceId,
 }
 
 impl SpaceSetupFacade {
@@ -175,6 +189,12 @@ impl SpaceSetupFacade {
         // T8 · F1 hook: construct ensure_reachable_all early so peer_addr_repo /
         // device_identity can still be Arc::clone'd here — both are moved into
         // downstream use cases below.
+        //
+        // Backoff scheduler (P-keepalive-backoff): the desktop keepalive
+        // worker reads `peer_addr_repo` and dials individual peers via the
+        // facade thin wrappers — clone before the use case ownership move.
+        let peer_addr_repo_for_facade = Arc::clone(&peer_addr_repo);
+        let presence_for_facade = Arc::clone(&presence);
         let ensure_reachable_all = Arc::new(EnsureReachableAllUseCase::new(
             Arc::clone(&peer_addr_repo),
             presence,
@@ -186,6 +206,9 @@ impl SpaceSetupFacade {
         // persistence is done by the already-existing use cases rather
         // than being duplicated here.
         let local_device_id = device_identity.current_device_id();
+        // Same id stashed for the keepalive scheduler's self-filter — the
+        // original is moved into the inbound orchestrator below.
+        let local_device_id_for_facade = local_device_id.clone();
         // Handshake TTL：sponsor 侧从 begin 到 confirm/reject 的 watchdog
         // （P7g），joiner 侧每次 recv 的 timeout（P7h）。60s 对齐 legacy
         // setup orchestrator 的默认值；足够覆盖一次人工口令输入 + 网络
@@ -279,6 +302,9 @@ impl SpaceSetupFacade {
             switch_space,
             migration_state: migration_state_for_facade,
             blob_migration_repo: blob_migration_repo_for_facade,
+            peer_addr_repo: peer_addr_repo_for_facade,
+            presence: presence_for_facade,
+            local_device_id: local_device_id_for_facade,
         }
     }
 
@@ -569,6 +595,48 @@ impl SpaceSetupFacade {
         &self,
     ) -> Result<EnsureReachableAllReport, EnsureReachableAllError> {
         self.ensure_reachable_all.execute().await
+    }
+
+    /// List `DeviceId`s of every paired peer (local device filtered out).
+    ///
+    /// Thin wrapper over `peer_addr_repo.list()` consumed by the desktop
+    /// keepalive scheduler so its per-peer backoff state can discover new
+    /// peers and prune removed ones each tick. Mirrors the iteration source
+    /// `EnsureReachableAllUseCase` uses internally — peers without an addr
+    /// blob are silently absent rather than surfaced as "no address"
+    /// errors. The local DeviceId is filtered defensively (the repo
+    /// shouldn't contain it; see the same guard in `EnsureReachableAllUseCase`).
+    pub async fn list_paired_peer_device_ids(
+        &self,
+    ) -> Result<Vec<DeviceId>, EnsureReachableAllError> {
+        let records = self.peer_addr_repo.list().await.map_err(|err| {
+            EnsureReachableAllError::Repository(format!("peer_addr_repo.list: {err}"))
+        })?;
+        Ok(records
+            .into_iter()
+            .filter_map(|r| {
+                if r.device_id == self.local_device_id {
+                    None
+                } else {
+                    Some(r.device_id)
+                }
+            })
+            .collect())
+    }
+
+    /// Ensure a single peer is reachable; thin wrapper over
+    /// `PresencePort::ensure_reachable`.
+    ///
+    /// The keepalive scheduler calls this only for peers whose backoff has
+    /// elapsed. `ensure_reachable` (not `verify_reachable`) is intentional:
+    /// when our outbound `peers` map already holds an alive connection the
+    /// fast-path returns Online without dialing — exactly what the
+    /// scheduler wants to avoid burning UDP probes on healthy peers.
+    pub async fn ensure_reachable_one(
+        &self,
+        device: &DeviceId,
+    ) -> Result<ReachabilityState, PresenceError> {
+        self.presence.ensure_reachable(device).await
     }
 
     /// F2 · Tear down facade-owned background work cleanly on app exit.

--- a/src-tauri/crates/uc-bootstrap/src/space_setup.rs
+++ b/src-tauri/crates/uc-bootstrap/src/space_setup.rs
@@ -279,6 +279,8 @@ pub async fn build_space_setup_assembly(
     // `EnsureReachableAllUseCase` 给 F1 hook 用。
     let presence: Arc<dyn PresencePort> = builder.install_presence(
         Arc::clone(&wired.peer_addr_repo),
+        Arc::clone(&deps.device.member_repo),
+        Arc::clone(&deps.security.fingerprint),
         Arc::clone(&deps.system.clock),
     );
     // Phase 96 INDIC-01:连接通道单一真相源。复用同一 endpoint +

--- a/src-tauri/crates/uc-bootstrap/tests/slice1_handshake_e2e.rs
+++ b/src-tauri/crates/uc-bootstrap/tests/slice1_handshake_e2e.rs
@@ -364,6 +364,8 @@ async fn build_side(name: &'static str, rendezvous_base_url: String) -> Side {
     // 一致。
     let presence: Arc<dyn uc_core::ports::PresencePort> = builder.install_presence(
         Arc::clone(&peer_addr_repo) as Arc<dyn uc_core::ports::PeerAddressRepositoryPort>,
+        Arc::clone(&member_repo) as Arc<dyn MemberRepositoryPort>,
+        Arc::new(Sha256IdentityFingerprintFactory),
         Arc::new(SystemClock) as Arc<dyn uc_core::ports::ClockPort>,
     );
     let iroh_node = builder.spawn();

--- a/src-tauri/crates/uc-bootstrap/tests/slice2_phase1_presence_e2e.rs
+++ b/src-tauri/crates/uc-bootstrap/tests/slice2_phase1_presence_e2e.rs
@@ -369,6 +369,8 @@ async fn build_side(name: &'static str, rendezvous_base_url: String) -> Side {
     );
     let presence: Arc<dyn PresencePort> = builder.install_presence(
         Arc::clone(&peer_addr_repo) as Arc<dyn uc_core::ports::PeerAddressRepositoryPort>,
+        Arc::clone(&member_repo) as Arc<dyn MemberRepositoryPort>,
+        Arc::new(Sha256IdentityFingerprintFactory),
         Arc::new(SystemClock) as Arc<dyn ClockPort>,
     );
     let iroh_node = builder.spawn();

--- a/src-tauri/crates/uc-bootstrap/tests/slice2_phase2_clipboard_e2e.rs
+++ b/src-tauri/crates/uc-bootstrap/tests/slice2_phase2_clipboard_e2e.rs
@@ -388,6 +388,8 @@ async fn build_side(name: &'static str, rendezvous_base_url: String) -> Side {
     );
     let presence: Arc<dyn PresencePort> = builder.install_presence(
         Arc::clone(&peer_addr_repo) as Arc<dyn uc_core::ports::PeerAddressRepositoryPort>,
+        Arc::clone(&member_repo) as Arc<dyn MemberRepositoryPort>,
+        Arc::new(Sha256IdentityFingerprintFactory),
         Arc::new(SystemClock),
     );
     let ClipboardHandlers {

--- a/src-tauri/crates/uc-desktop/src/daemon/workers/peer_keepalive.rs
+++ b/src-tauri/crates/uc-desktop/src/daemon/workers/peer_keepalive.rs
@@ -1,5 +1,6 @@
 //! Peer keepalive worker — periodically refresh presence so iroh's magicsock
-//! NAT binding and path cache never go idle.
+//! NAT binding and path cache never go idle, with per-peer exponential
+//! backoff so unreachable peers don't waste UDP probes every 25s.
 //!
 //! ## Why
 //!
@@ -7,47 +8,119 @@
 //! publisher every time a blob_ref comes in. When that peer hasn't been
 //! dialed for ~60s the iroh endpoint's cached path has expired and the
 //! connect attempt has to redo a full hole-punch + relay probe round. In
-//! practice that takes ~33s and often terminates with `blob unavailable`
-//! because the downloader's internal ConnectionPool also has a short
-//! connect_timeout. Users observed "first copy after a while always fails".
+//! practice that takes ~33s and often terminates with `blob unavailable`.
 //!
-//! Refreshing presence on a short cadence keeps a warm PRESENCE_ALPN
+//! Refreshing presence on a short cadence keeps a warm `PRESENCE_ALPN`
 //! connection alive per online peer, which in turn keeps the shared
-//! magicsock layer (NAT binding, learned direct addrs) warm so the BLOBS
-//! ALPN connection establishes on a hot path instead of cold-starting.
+//! magicsock layer warm so the BLOBS connection establishes on a hot path.
 //!
-//! ## Design
+//! ## Backoff design
 //!
-//! * Delegates to `SpaceSetupFacade::refresh_presence()`, which internally
-//!   runs `EnsureReachableAllUseCase` over every paired peer — reusing the
-//!   existing dial path instead of introducing a second one.
-//! * Worker only sees `Arc<AppFacade>`; `space_setup` is reached via
-//!   `app_facade.space_setup` to honor the single-entry rule documented in
-//!   `uc-application/src/facade/app_facade.rs`. CLI bundles where
-//!   `space_setup` is `None` make the keepalive tick a no-op (CLI has no
-//!   long-lived process to keep warm).
-//! * Ticker-only (no presence event subscription): the usecase is already
-//!   idempotent and handles both dialing new peers and re-dialing stale
-//!   connections. Subscribing would duplicate its scan.
-//! * `MissedTickBehavior::Delay` avoids bursty catch-up if the previous
-//!   refresh overran the interval (e.g. one peer's dial timing out).
+//! Without backoff every paired-but-offline peer eats a ~30s dial every
+//! 25s — for a daemon paired with five idle peers that's nontrivial
+//! cellular / battery cost. The scheduler maintains a per-peer
+//! [`BackoffState`] and only dials peers whose `next_dial_at` has elapsed.
+//! Ladder: 25s → 60s → 5min → 15min cap. Reset to 25s happens in two
+//! cases:
+//!
+//! 1. Successful dial (Online) — the peer is healthy.
+//! 2. **Inbound `Online` event** routed through `subscribe_peer_presence_events`.
+//!    `IrohPresenceHandler` flips a peer to Online when the *peer* dials
+//!    *us*, so a recovered offline peer's own keepalive announces them
+//!    well before our backoff would have us redial. Without this reset
+//!    the worst case for "peer comes back" is the cap (15min); with it,
+//!    the peer's own 25s keepalive bounds the window.
+//!
+//! ## Design (worker mechanics)
+//!
+//! * Drives off a 25s base ticker (`MissedTickBehavior::Delay`) and an
+//!   inbound `AppPresenceSubscription`. Both arms use `tokio::select!`
+//!   with `biased` so cancellation and presence resets land before a
+//!   ticker fires.
+//! * Each tick: `list_paired_peer_device_ids` from the facade, prune
+//!   removed peers from the backoff map, default-init new peers as ready,
+//!   then dispatch `JoinSet` of `ensure_reachable_one` calls only for
+//!   peers whose backoff has elapsed. Result of each dial updates that
+//!   peer's `BackoffState`.
+//! * `ensure_reachable_one` (vs `verify_reachable`): when our outbound
+//!   connection map already holds a live entry for a peer, the fast-path
+//!   returns `Online` without a fresh dial — exactly what the scheduler
+//!   wants for healthy peers, since burning UDP on a peer that just
+//!   answered would defeat the point of backoff.
 
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
+use tokio::task::JoinSet;
 use tokio::time::MissedTickBehavior;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 
-use uc_application::facade::AppFacade;
+use uc_application::facade::{
+    AppFacade, AppPresenceEvent, AppPresenceSubscription, AppPresenceSubscriptionError,
+};
+use uc_core::ids::DeviceId;
+use uc_core::ports::{PresenceError, ReachabilityState};
 
 use crate::daemon::service::{DaemonService, ServiceHealth};
 
-/// Refresh cadence. Must sit comfortably below iroh's default QUIC idle
-/// timeout (~60s) so the keepalive dial lands before the path is evicted.
-/// 25s gives ~2× safety margin without flooding the network with probes.
-const REFRESH_INTERVAL: Duration = Duration::from_secs(25);
+/// Base cadence — peers in good standing redial every 25s, comfortably
+/// below iroh's ~60s QUIC idle timeout so the path cache stays warm.
+const BASE_INTERVAL: Duration = Duration::from_secs(25);
+
+/// Backoff ladder indexed by `consecutive_failures`. Index 0 is the "no
+/// failures" base cadence. Failures escalate: 1×60s → 2×5min → 3+×15min.
+/// 15min cap balances "don't burn batteries on a long-offline peer" vs
+/// "still re-probe occasionally in case both inbound presence and our
+/// connection cache miss the recovery".
+const BACKOFF_LADDER: [Duration; 4] = [
+    BASE_INTERVAL,
+    Duration::from_secs(60),
+    Duration::from_secs(5 * 60),
+    Duration::from_secs(15 * 60),
+];
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct BackoffState {
+    consecutive_failures: u32,
+    next_dial_at: Instant,
+}
+
+impl BackoffState {
+    /// New peer — eligible immediately so the very next tick dials it.
+    fn ready_now(now: Instant) -> Self {
+        Self {
+            consecutive_failures: 0,
+            next_dial_at: now,
+        }
+    }
+
+    fn ready(&self, now: Instant) -> bool {
+        now >= self.next_dial_at
+    }
+
+    fn on_success(&mut self, now: Instant) {
+        self.consecutive_failures = 0;
+        self.next_dial_at = now + BACKOFF_LADDER[0];
+    }
+
+    fn on_failure(&mut self, now: Instant) {
+        self.consecutive_failures = self.consecutive_failures.saturating_add(1);
+        let idx = (self.consecutive_failures as usize).min(BACKOFF_LADDER.len() - 1);
+        self.next_dial_at = now + BACKOFF_LADDER[idx];
+    }
+
+    /// Reset triggered by an inbound `Online` event — equivalent to
+    /// `on_success` semantically (peer is reachable, clear failure count,
+    /// schedule next dial at base cadence) but called from a different
+    /// site so the log lines stay distinguishable.
+    fn reset(&mut self, now: Instant) {
+        self.consecutive_failures = 0;
+        self.next_dial_at = now + BACKOFF_LADDER[0];
+    }
+}
 
 pub struct PeerKeepAliveWorker {
     app_facade: Arc<AppFacade>,
@@ -56,6 +129,138 @@ pub struct PeerKeepAliveWorker {
 impl PeerKeepAliveWorker {
     pub fn new(app_facade: Arc<AppFacade>) -> Self {
         Self { app_facade }
+    }
+
+    /// Run one scheduling pass: discover peers, prune missing, dial only
+    /// peers whose backoff has elapsed, update each peer's state from its
+    /// dial result.
+    async fn dial_due_peers(&self, backoff: &mut HashMap<String, BackoffState>) {
+        let peers = match self.app_facade.list_paired_peer_device_ids().await {
+            Ok(ps) => ps,
+            Err(err) => {
+                warn!(error = %err, "list_paired_peer_device_ids failed; skipping keepalive tick");
+                return;
+            }
+        };
+
+        let now = Instant::now();
+        let active: HashSet<String> = peers.iter().map(|d| d.as_str().to_string()).collect();
+        backoff.retain(|k, _| active.contains(k));
+
+        let mut due: Vec<DeviceId> = Vec::new();
+        for device in peers {
+            let key = device.as_str().to_string();
+            let is_due = backoff
+                .entry(key)
+                .or_insert_with(|| BackoffState::ready_now(now))
+                .ready(now);
+            if is_due {
+                due.push(device);
+            }
+        }
+
+        if due.is_empty() {
+            debug!(
+                tracked = backoff.len(),
+                "keepalive tick: no peers due (all within backoff window)"
+            );
+            return;
+        }
+
+        let mut set: JoinSet<(DeviceId, Result<ReachabilityState, PresenceError>)> = JoinSet::new();
+        for device in due {
+            let app_facade = Arc::clone(&self.app_facade);
+            set.spawn(async move {
+                let result = app_facade.ensure_reachable_one(&device).await;
+                (device, result)
+            });
+        }
+
+        while let Some(joined) = set.join_next().await {
+            let observed_at = Instant::now();
+            match joined {
+                Ok((device, Ok(ReachabilityState::Online))) => {
+                    let key = device.as_str().to_string();
+                    if let Some(entry) = backoff.get_mut(&key) {
+                        entry.on_success(observed_at);
+                        debug!(device = %key, "keepalive dial → Online; backoff at base");
+                    }
+                }
+                Ok((device, Ok(_))) => {
+                    let key = device.as_str().to_string();
+                    if let Some(entry) = backoff.get_mut(&key) {
+                        entry.on_failure(observed_at);
+                        debug!(
+                            device = %key,
+                            fails = entry.consecutive_failures,
+                            "keepalive dial → Offline/Unknown; backoff escalated"
+                        );
+                    }
+                }
+                Ok((device, Err(err))) => {
+                    let key = device.as_str().to_string();
+                    if let Some(entry) = backoff.get_mut(&key) {
+                        entry.on_failure(observed_at);
+                        debug!(
+                            device = %key,
+                            error = %err,
+                            fails = entry.consecutive_failures,
+                            "keepalive dial errored; backoff escalated"
+                        );
+                    }
+                }
+                Err(err) => {
+                    warn!(error = %err, "keepalive dial task panicked or was cancelled");
+                }
+            }
+        }
+    }
+
+    /// Apply an inbound presence event to the backoff map. Online events
+    /// reset the relevant peer to base cadence; other states are ignored
+    /// (Offline is owned by the watchdog, Unknown is uninformative).
+    fn apply_presence_event(backoff: &mut HashMap<String, BackoffState>, event: AppPresenceEvent) {
+        if event.state != "online" {
+            return;
+        }
+        let now = Instant::now();
+        let entry = backoff
+            .entry(event.device_id.clone())
+            .or_insert_with(|| BackoffState::ready_now(now));
+        entry.reset(now);
+        debug!(
+            device = %event.device_id,
+            "inbound presence Online; backoff reset to base cadence",
+        );
+    }
+}
+
+/// Drain one item from the presence subscription. Pending forever when
+/// the subscription is unavailable so `tokio::select!` doesn't hot-loop.
+/// Closes the subscription (sets it to `None`) on `Closed` so subsequent
+/// calls fall into the pending branch instead of busy-looping.
+async fn next_presence_event(rx: &mut Option<AppPresenceSubscription>) -> Option<AppPresenceEvent> {
+    let r = match rx.as_mut() {
+        Some(r) => r,
+        None => {
+            std::future::pending::<()>().await;
+            unreachable!("pending future never resolves");
+        }
+    };
+    match r.recv().await {
+        Ok(event) => Some(event),
+        Err(AppPresenceSubscriptionError::Lagged(skipped)) => {
+            warn!(
+                skipped,
+                "presence subscription lagged; backoff state may briefly mis-bookkeep",
+            );
+            None
+        }
+        Err(AppPresenceSubscriptionError::Closed) => {
+            warn!("presence subscription closed; keepalive falling back to time-only mode");
+            *rx = None;
+            None
+        }
     }
 }
 
@@ -66,41 +271,48 @@ impl DaemonService for PeerKeepAliveWorker {
     }
 
     async fn start(&self, cancel: CancellationToken) -> anyhow::Result<()> {
-        let mut ticker = tokio::time::interval(REFRESH_INTERVAL);
+        let mut ticker = tokio::time::interval(BASE_INTERVAL);
         ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
-        // Skip the immediate first tick — `SpaceSetupFacade::auto_start_network`
-        // already fires one `ensure_reachable_all` right after network init, so
-        // there's nothing to keep alive for the first 25s anyway.
+        // Skip the immediate first tick — `auto_prime_presence` already
+        // ran one full pass right after `start_network`, so the first
+        // 25s sleep is the right cadence boundary.
         ticker.tick().await;
 
+        let mut presence_rx: Option<AppPresenceSubscription> =
+            match self.app_facade.subscribe_peer_presence_events() {
+                Ok(rx) => Some(rx),
+                Err(err) => {
+                    warn!(
+                        error = %err,
+                        "presence subscription unavailable; keepalive degraded to time-only mode",
+                    );
+                    None
+                }
+            };
+
+        let mut backoff: HashMap<String, BackoffState> = HashMap::new();
+
         info!(
-            interval_secs = REFRESH_INTERVAL.as_secs(),
-            "peer keepalive started"
+            base_interval_secs = BASE_INTERVAL.as_secs(),
+            backoff_cap_secs = BACKOFF_LADDER[BACKOFF_LADDER.len() - 1].as_secs(),
+            "peer keepalive started",
         );
 
         loop {
             tokio::select! {
+                biased;
                 _ = cancel.cancelled() => break,
-                _ = ticker.tick() => {
-                    let Some(space_setup) = self.app_facade.space_setup.as_ref() else {
-                        // No space_setup facade in this bundle (CLI). Nothing to keep warm.
-                        debug!("peer keepalive tick skipped: space_setup facade unavailable");
-                        continue;
-                    };
-                    match space_setup.refresh_presence().await {
-                        Ok(report) => {
-                            debug!(
-                                total = report.total,
-                                online = report.online,
-                                offline = report.offline,
-                                errors = report.errors.len(),
-                                "peer keepalive tick"
-                            );
-                        }
-                        Err(err) => {
-                            warn!(error = %err, "peer keepalive tick failed");
-                        }
+                event = next_presence_event(&mut presence_rx) => {
+                    if let Some(event) = event {
+                        Self::apply_presence_event(&mut backoff, event);
                     }
+                }
+                _ = ticker.tick() => {
+                    // CLI bundles without space_setup surface as
+                    // `EnsureReachableAllError::Repository("space setup
+                    // facade unavailable")` from the AppFacade thin
+                    // wrappers — `dial_due_peers` logs and skips.
+                    self.dial_due_peers(&mut backoff).await;
                 }
             }
         }
@@ -116,5 +328,143 @@ impl DaemonService for PeerKeepAliveWorker {
 
     fn health_check(&self) -> ServiceHealth {
         ServiceHealth::Healthy
+    }
+}
+
+// ============================================================================
+// Tests — pure-logic coverage for the BackoffState machine.
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn at(now: Instant, plus: Duration) -> Instant {
+        now + plus
+    }
+
+    #[test]
+    fn ready_now_dials_immediately() {
+        let now = Instant::now();
+        let s = BackoffState::ready_now(now);
+        assert!(s.ready(now));
+        assert!(s.ready(at(now, Duration::from_millis(1))));
+        assert_eq!(s.consecutive_failures, 0);
+    }
+
+    #[test]
+    fn on_success_resets_to_base_cadence() {
+        let now = Instant::now();
+        let mut s = BackoffState::ready_now(now);
+        s.consecutive_failures = 5;
+
+        s.on_success(now);
+
+        assert_eq!(s.consecutive_failures, 0);
+        assert!(!s.ready(now));
+        assert!(s.ready(at(now, BASE_INTERVAL)));
+    }
+
+    #[test]
+    fn on_failure_walks_the_ladder_and_caps() {
+        let now = Instant::now();
+        let mut s = BackoffState::ready_now(now);
+
+        // 1st failure → 60s window.
+        s.on_failure(now);
+        assert_eq!(s.consecutive_failures, 1);
+        assert!(s.ready(at(now, Duration::from_secs(60))));
+        assert!(!s.ready(at(now, Duration::from_secs(59))));
+
+        // 2nd failure → 5min window from `now`.
+        s.on_failure(now);
+        assert_eq!(s.consecutive_failures, 2);
+        assert!(s.ready(at(now, Duration::from_secs(5 * 60))));
+        assert!(!s.ready(at(now, Duration::from_secs(5 * 60 - 1))));
+
+        // 3rd failure → 15min cap.
+        s.on_failure(now);
+        assert_eq!(s.consecutive_failures, 3);
+        assert!(s.ready(at(now, Duration::from_secs(15 * 60))));
+
+        // 4th, 5th, … keep capping at 15min — counter still climbs (for
+        // observability) but the window does not.
+        s.on_failure(now);
+        s.on_failure(now);
+        assert_eq!(s.consecutive_failures, 5);
+        assert!(s.ready(at(now, Duration::from_secs(15 * 60))));
+        assert!(!s.ready(at(now, Duration::from_secs(15 * 60 - 1))));
+    }
+
+    #[test]
+    fn reset_clears_failure_count_and_returns_to_base() {
+        let now = Instant::now();
+        let mut s = BackoffState::ready_now(now);
+        s.on_failure(now);
+        s.on_failure(now);
+        s.on_failure(now);
+        assert_eq!(s.consecutive_failures, 3);
+
+        s.reset(now);
+
+        assert_eq!(s.consecutive_failures, 0);
+        // Even right after reset, we wait one base interval before the
+        // next dial — otherwise an inbound Online event would prompt an
+        // immediate redundant dial.
+        assert!(!s.ready(now));
+        assert!(s.ready(at(now, BASE_INTERVAL)));
+    }
+
+    #[test]
+    fn apply_presence_event_resets_existing_entry() {
+        let now = Instant::now();
+        let mut backoff: HashMap<String, BackoffState> = HashMap::new();
+        let mut s = BackoffState::ready_now(now);
+        s.on_failure(now);
+        s.on_failure(now);
+        backoff.insert("device-a".into(), s);
+
+        let event = AppPresenceEvent {
+            device_id: "device-a".into(),
+            state: "online".into(),
+            at_ms: 0,
+        };
+        PeerKeepAliveWorker::apply_presence_event(&mut backoff, event);
+
+        let entry = backoff.get("device-a").expect("entry retained");
+        assert_eq!(entry.consecutive_failures, 0);
+    }
+
+    #[test]
+    fn apply_presence_event_inserts_unknown_peer_for_later_pruning() {
+        // An Online event for a peer we've never dialed should still
+        // create an entry — the next tick's prune pass will drop it if
+        // the peer isn't actually paired.
+        let mut backoff: HashMap<String, BackoffState> = HashMap::new();
+        let event = AppPresenceEvent {
+            device_id: "ghost".into(),
+            state: "online".into(),
+            at_ms: 0,
+        };
+
+        PeerKeepAliveWorker::apply_presence_event(&mut backoff, event);
+        assert!(backoff.contains_key("ghost"));
+    }
+
+    #[test]
+    fn apply_presence_event_ignores_offline_and_unknown() {
+        let mut backoff: HashMap<String, BackoffState> = HashMap::new();
+        for state in ["offline", "unknown", "weird-future-variant"] {
+            let event = AppPresenceEvent {
+                device_id: "device-x".into(),
+                state: state.into(),
+                at_ms: 0,
+            };
+            PeerKeepAliveWorker::apply_presence_event(&mut backoff, event);
+        }
+        assert!(
+            backoff.is_empty(),
+            "non-online events must not pollute the backoff map",
+        );
     }
 }

--- a/src-tauri/crates/uc-infra/src/network/iroh/node.rs
+++ b/src-tauri/crates/uc-infra/src/network/iroh/node.rs
@@ -50,7 +50,7 @@ use super::clipboard_dispatch_adapter::{IrohClipboardDispatchAdapter, CLIPBOARD_
 use super::clipboard_receiver_adapter::IrohClipboardReceiverAdapter;
 use super::connection_channel_adapter::IrohConnectionChannelAdapter;
 use super::identity_store::IrohIdentityStore;
-use super::presence_adapter::{IrohPresenceAdapter, IrohPresenceHandler, PRESENCE_ALPN};
+use super::presence_adapter::{IrohPresenceAdapter, PRESENCE_ALPN};
 use super::transfer_progress_adapter::{
     InboundProgressEvent, IrohTransferProgressAdapter, TRANSFER_PROGRESS_ALPN,
 };
@@ -599,20 +599,31 @@ impl IrohNodeBuilder {
     pub fn install_presence(
         &mut self,
         peer_addr_repo: Arc<dyn PeerAddressRepositoryPort>,
+        member_repo: Arc<dyn MemberRepositoryPort>,
+        fingerprint_factory: Arc<dyn IdentityFingerprintFactoryPort>,
         clock: Arc<dyn ClockPort>,
     ) -> Arc<dyn PresencePort> {
+        // Build the adapter first so the handler shares its `last_state`
+        // and broadcast `Sender` — that's what makes inbound dials flip a
+        // recovered peer to Online without needing our own keepalive to
+        // dial them again.
+        let adapter = IrohPresenceAdapter::new(
+            Arc::clone(&self.endpoint),
+            peer_addr_repo,
+            member_repo,
+            fingerprint_factory,
+            clock,
+        );
+        let handler = adapter.handler();
+
         let builder = self
             .router_builder
             .take()
             .expect("router_builder missing — install_* called after spawn");
-        let builder = builder.accept(PRESENCE_ALPN, IrohPresenceHandler::new());
+        let builder = builder.accept(PRESENCE_ALPN, handler);
         self.router_builder = Some(builder);
 
-        Arc::new(IrohPresenceAdapter::new(
-            Arc::clone(&self.endpoint),
-            peer_addr_repo,
-            clock,
-        ))
+        Arc::new(adapter)
     }
 
     /// Build a [`ConnectionChannelPort`] (Phase 96 INDIC-01).
@@ -999,6 +1010,8 @@ mod tests {
 
         let presence: Arc<dyn PresencePort> = builder.install_presence(
             Arc::new(EmptyPeerAddressRepo),
+            Arc::new(EmptyMemberRepo),
+            Arc::new(crate::security::Sha256IdentityFingerprintFactory),
             Arc::new(FixedClock(1_700_000_000_000)),
         );
 
@@ -1061,6 +1074,8 @@ mod tests {
         let peer_addr_repo: Arc<dyn PeerAddressRepositoryPort> = Arc::new(EmptyPeerAddressRepo);
         let _presence = builder.install_presence(
             Arc::clone(&peer_addr_repo),
+            Arc::new(EmptyMemberRepo),
+            Arc::new(crate::security::Sha256IdentityFingerprintFactory),
             Arc::new(FixedClock(1_700_000_000_000)),
         );
 
@@ -1117,6 +1132,8 @@ mod tests {
         let peer_addr_repo: Arc<dyn PeerAddressRepositoryPort> = Arc::new(EmptyPeerAddressRepo);
         let _presence = builder.install_presence(
             Arc::clone(&peer_addr_repo),
+            Arc::new(EmptyMemberRepo),
+            Arc::new(crate::security::Sha256IdentityFingerprintFactory),
             Arc::new(FixedClock(1_700_000_000_000)),
         );
 

--- a/src-tauri/crates/uc-infra/src/network/iroh/presence_adapter.rs
+++ b/src-tauri/crates/uc-infra/src/network/iroh/presence_adapter.rs
@@ -31,6 +31,23 @@
 //! [`IrohPresenceHandler`], which holds each incoming connection open until
 //! the peer closes it — mirroring `spawn_hold_open_acceptor` in the probe.
 //! The dial side is invoked from [`IrohPresenceAdapter::ensure_reachable`].
+//!
+//! ## Inbound-driven Online flip
+//!
+//! Holding the connection open is necessary but not sufficient: a peer that
+//! recovers needs us to mark *it* Online without waiting for our next own
+//! dial. The handler therefore reverse-resolves `Connection::remote_id()`
+//! into a `DeviceId` (same `IdentityFingerprintFactoryPort` + `MemberRepo`
+//! lookup the clipboard receiver uses) and, on a Offline → Online
+//! transition, writes `last_state[device]=Online` and broadcasts a single
+//! `Online` event. Repeat inbound dials from the same peer (every keepalive
+//! tick) are idempotent — they don't re-broadcast.
+//!
+//! Offline detection is **not** mirrored here: the watchdog on our own
+//! outbound `Connection` remains the authoritative offline signal, so
+//! inbound `connection.closed()` only logs and returns. This keeps a single
+//! source of truth for Offline transitions and avoids state-write races
+//! between the watchdog and the inbound handler.
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -45,10 +62,13 @@ use tokio::task::JoinHandle;
 use tracing::{debug, info, instrument, warn};
 
 use uc_core::ids::DeviceId;
+use uc_core::membership::MemberRepositoryPort;
+use uc_core::ports::security::IdentityFingerprintFactoryPort;
 use uc_core::ports::{
     ClockPort, PeerAddressRepositoryPort, PresenceError, PresenceEvent, PresencePort,
     ReachabilityState,
 };
+use uc_core::security::IdentityFingerprint;
 
 use super::connect::connect_with_staggered_retry;
 
@@ -68,14 +88,86 @@ const EVENT_CHANNEL_CAPACITY: usize = 64;
 // ProtocolHandler (accept side)
 // ============================================================================
 
+/// Shared state between the dial-side adapter and the accept-side handler.
+///
+/// Both sides write `last_state` and emit `event_tx` events; sharing a
+/// single `Arc<Mutex<HashMap>>` for `last_state` is what makes the inbound
+/// Online flip race-safe with the outbound watchdog's Offline write — every
+/// state mutation goes through the same lock.
+struct HandlerState {
+    member_repo: Arc<dyn MemberRepositoryPort>,
+    fingerprint_factory: Arc<dyn IdentityFingerprintFactoryPort>,
+    last_state: Arc<Mutex<HashMap<String, ReachabilityState>>>,
+    event_tx: broadcast::Sender<PresenceEvent>,
+    clock: Arc<dyn ClockPort>,
+}
+
+impl HandlerState {
+    /// Resolve `remote_pubkey_bytes` (iroh `EndpointId` 32-byte public key)
+    /// back to a `SpaceMember.device_id` via the same fingerprint factory
+    /// the receiver adapter uses. `None` means "unknown peer" — handler
+    /// holds the connection open but does not mutate presence state.
+    ///
+    /// `member_repo.list()` is acceptable per the Slice 2 N ≤ 10 roster
+    /// assumption (see `clipboard_receiver_adapter.rs` for the same
+    /// rationale). A dedicated lookup-by-fingerprint index is a Phase 3
+    /// concern.
+    async fn resolve_device(&self, remote_pubkey_bytes: &[u8; 32]) -> Option<DeviceId> {
+        let derived = match self
+            .fingerprint_factory
+            .from_public_key(remote_pubkey_bytes)
+        {
+            Ok(fp) => fp,
+            Err(err) => {
+                warn!(
+                    error = %err,
+                    "presence accept: fingerprint derivation failed — cannot resolve peer",
+                );
+                return None;
+            }
+        };
+
+        let members = match self.member_repo.list().await {
+            Ok(ms) => ms,
+            Err(err) => {
+                warn!(
+                    error = %err,
+                    "presence accept: member_repo.list failed; treating peer as unknown",
+                );
+                return None;
+            }
+        };
+
+        members
+            .into_iter()
+            .find(|m| fingerprints_equal(&m.identity_fingerprint, &derived))
+            .map(|m| m.device_id)
+    }
+
+    fn now(&self) -> DateTime<Utc> {
+        let ms = self.clock.now_ms();
+        Utc.timestamp_millis_opt(ms).single().unwrap_or_else(|| {
+            warn!(
+                ms,
+                "ClockPort returned out-of-range epoch millis; falling back to Utc::now",
+            );
+            Utc::now()
+        })
+    }
+}
+
 /// Accept-side handler for [`PRESENCE_ALPN`].
 ///
-/// Holds each inbound connection open until the peer closes it. No frames
-/// are read — the whole point of the presence protocol is that the liveness
-/// signal is the QUIC connection itself, observed by the dial-side via
-/// [`Connection::closed`].
-#[derive(Clone, Default)]
-pub struct IrohPresenceHandler;
+/// Holds each inbound connection open until the peer closes it. Beyond
+/// holding (the original liveness contract), it also reverse-resolves the
+/// remote endpoint id to a `DeviceId` and flips
+/// `last_state[device] = Online` on the first inbound dial that wasn't
+/// already Online — the recovery path that makes peer-keepalive backoff
+/// safe to extend.
+#[derive(Clone)]
+pub struct IrohPresenceHandler {
+    state: Arc<HandlerState>,
+}
 
 impl std::fmt::Debug for IrohPresenceHandler {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -84,16 +176,50 @@ impl std::fmt::Debug for IrohPresenceHandler {
     }
 }
 
-impl IrohPresenceHandler {
-    pub fn new() -> Self {
-        Self
-    }
-}
-
 impl ProtocolHandler for IrohPresenceHandler {
     async fn accept(&self, connection: Connection) -> Result<(), AcceptError> {
         let remote = connection.remote_id();
         debug!(remote = %remote, "presence connection accepted; holding open until peer closes");
+
+        let remote_bytes: [u8; 32] = *remote.as_bytes();
+        if let Some(device_id) = self.state.resolve_device(&remote_bytes).await {
+            let key = device_id.as_str().to_string();
+            let now_at = self.state.now();
+
+            // Acquire `last_state` only long enough to insert and observe
+            // the previous value; broadcast and logging happen after the
+            // lock drops to avoid holding it across `.send`.
+            let prev = {
+                let mut last = self.state.last_state.lock().await;
+                last.insert(key, ReachabilityState::Online)
+            };
+
+            if prev != Some(ReachabilityState::Online) {
+                let _ = self.state.event_tx.send(PresenceEvent {
+                    device_id: device_id.clone(),
+                    state: ReachabilityState::Online,
+                    at: now_at,
+                });
+                info!(
+                    device = %device_id.as_str(),
+                    "inbound presence connection: peer marked Online",
+                );
+            } else {
+                debug!(
+                    device = %device_id.as_str(),
+                    "inbound presence connection: peer already Online (no event)",
+                );
+            }
+        } else {
+            // Unknown peer: hold the connection (matches the receiver
+            // adapter's tolerance for unresolved senders) but do not mutate
+            // any presence state and do not broadcast.
+            debug!(
+                remote = %remote,
+                "inbound presence connection from unresolved peer; holding without state change",
+            );
+        }
+
         let reason = connection.closed().await;
         debug!(
             remote = %remote,
@@ -102,6 +228,12 @@ impl ProtocolHandler for IrohPresenceHandler {
         );
         Ok(())
     }
+}
+
+/// `IdentityFingerprint` comparison surface — kept as a free function so
+/// future swaps to a normalised form land in one place.
+fn fingerprints_equal(a: &IdentityFingerprint, b: &IdentityFingerprint) -> bool {
+    a == b
 }
 
 // ============================================================================
@@ -122,9 +254,15 @@ pub struct IrohPresenceAdapter {
     /// Remember the last observed outcome for every device the adapter has
     /// ever probed. Distinct from `peers` because a failed dial should
     /// surface as `Offline` on `current_state` without leaving a live
-    /// connection entry behind.
+    /// connection entry behind. Shared with [`HandlerState`] so inbound
+    /// connections can flip a peer to Online under the same lock the
+    /// outbound watchdog uses to flip to Offline.
     last_state: Arc<Mutex<HashMap<String, ReachabilityState>>>,
     event_tx: broadcast::Sender<PresenceEvent>,
+    /// Cheap-clone state for [`IrohPresenceHandler`]. Constructed once in
+    /// [`IrohPresenceAdapter::new`] and handed out via
+    /// [`IrohPresenceAdapter::handler`].
+    handler_state: Arc<HandlerState>,
 }
 
 /// Per-device bookkeeping: the live connection we hold open, plus the
@@ -144,22 +282,48 @@ impl Drop for TrackedPeer {
 
 impl IrohPresenceAdapter {
     /// Construct an adapter wired to the given iroh endpoint, peer address
-    /// repository, and clock. Returns an owned value; the caller wraps it
-    /// in `Arc` before publishing it as `Arc<dyn PresencePort>` so shutdown
-    /// semantics match the rest of the iroh adapter family.
+    /// repository, member repository, fingerprint factory, and clock.
+    /// Returns an owned value; the caller wraps it in `Arc` before
+    /// publishing it as `Arc<dyn PresencePort>` so shutdown semantics match
+    /// the rest of the iroh adapter family.
+    ///
+    /// `member_repo` and `fingerprint_factory` are needed by the inbound
+    /// handler to reverse-resolve a remote `EndpointId` into a known
+    /// `DeviceId`; the same pair is consumed by `IrohClipboardReceiverAdapter`.
     pub fn new(
         endpoint: Arc<Endpoint>,
         peer_addr_repo: Arc<dyn PeerAddressRepositoryPort>,
+        member_repo: Arc<dyn MemberRepositoryPort>,
+        fingerprint_factory: Arc<dyn IdentityFingerprintFactoryPort>,
         clock: Arc<dyn ClockPort>,
     ) -> Self {
         let (event_tx, _) = broadcast::channel(EVENT_CHANNEL_CAPACITY);
+        let last_state = Arc::new(Mutex::new(HashMap::new()));
+        let handler_state = Arc::new(HandlerState {
+            member_repo,
+            fingerprint_factory,
+            last_state: Arc::clone(&last_state),
+            event_tx: event_tx.clone(),
+            clock: Arc::clone(&clock),
+        });
         Self {
             endpoint,
             peer_addr_repo,
             clock,
             peers: Arc::new(Mutex::new(HashMap::new())),
-            last_state: Arc::new(Mutex::new(HashMap::new())),
+            last_state,
             event_tx,
+            handler_state,
+        }
+    }
+
+    /// Cheap clone-able handle registered with iroh's `RouterBuilder`. Each
+    /// inbound connection runs [`IrohPresenceHandler::accept`], which
+    /// shares this adapter's `last_state` map and broadcast `Sender` via
+    /// `Arc<HandlerState>`.
+    pub fn handler(&self) -> IrohPresenceHandler {
+        IrohPresenceHandler {
+            state: Arc::clone(&self.handler_state),
         }
     }
 
@@ -494,7 +658,11 @@ mod tests {
     use tokio::time::timeout;
 
     use uc_core::ids::DeviceId;
+    use uc_core::membership::{MemberRepositoryPort, MembershipError, SpaceMember};
     use uc_core::ports::{PeerAddressError, PeerAddressRecord};
+    use uc_core::MemberSyncPreferences;
+
+    use crate::security::Sha256IdentityFingerprintFactory;
 
     const DIAL_BUDGET: Duration = Duration::from_secs(5);
     const OFFLINE_BUDGET: Duration = Duration::from_secs(10);
@@ -542,6 +710,49 @@ mod tests {
         }
     }
 
+    /// In-memory `MemberRepositoryPort` for handler-side identity
+    /// resolution. Tests that exercise dial-only paths leave it empty;
+    /// tests that exercise inbound `Online` flips seed it with a member
+    /// whose `identity_fingerphint` matches the dialing endpoint's pubkey.
+    #[derive(Default)]
+    struct MemMemberRepo {
+        inner: StdMutex<StdHashMap<String, SpaceMember>>,
+    }
+
+    impl MemMemberRepo {
+        fn seed(&self, member: SpaceMember) {
+            self.inner
+                .lock()
+                .unwrap()
+                .insert(member.device_id.as_str().to_string(), member);
+        }
+    }
+
+    #[async_trait]
+    impl MemberRepositoryPort for MemMemberRepo {
+        async fn get(&self, device: &DeviceId) -> Result<Option<SpaceMember>, MembershipError> {
+            Ok(self.inner.lock().unwrap().get(device.as_str()).cloned())
+        }
+        async fn list(&self) -> Result<Vec<SpaceMember>, MembershipError> {
+            Ok(self.inner.lock().unwrap().values().cloned().collect())
+        }
+        async fn save(&self, member: &SpaceMember) -> Result<(), MembershipError> {
+            self.inner
+                .lock()
+                .unwrap()
+                .insert(member.device_id.as_str().to_string(), member.clone());
+            Ok(())
+        }
+        async fn remove(&self, device_id: &DeviceId) -> Result<bool, MembershipError> {
+            Ok(self
+                .inner
+                .lock()
+                .unwrap()
+                .remove(device_id.as_str())
+                .is_some())
+        }
+    }
+
     struct FixedClock;
     impl ClockPort for FixedClock {
         fn now_ms(&self) -> i64 {
@@ -586,6 +797,12 @@ mod tests {
     /// `Router` registering [`IrohPresenceHandler`] on [`PRESENCE_ALPN`].
     /// Returns both endpoints, B's encoded blob for the repo, B's
     /// `DeviceId`, and B's `Router` so the test can shut it down later.
+    ///
+    /// The B-side adapter is a decoy used solely to produce a working
+    /// inbound handler — its `last_state` map is not observed by the
+    /// dial-side tests below. Tests that exercise the inbound Online flip
+    /// build their own adapter explicitly via
+    /// [`build_adapter_with_member_repo`].
     async fn setup_two_endpoints() -> (Arc<Endpoint>, Arc<Endpoint>, Vec<u8>, DeviceId, Router) {
         let endpoint_b = bound_endpoint().await;
         wait_for_direct_addrs(&endpoint_b).await;
@@ -593,8 +810,15 @@ mod tests {
         let b_blob = postcard::to_stdvec(&b_addr).expect("postcard encode EndpointAddr");
         let b_device_id = DeviceId::new(format!("endpoint-b-{}", endpoint_b.id().fmt_short()));
 
+        let decoy_adapter = IrohPresenceAdapter::new(
+            Arc::clone(&endpoint_b),
+            Arc::new(FakePeerAddressRepo::default()),
+            Arc::new(MemMemberRepo::default()),
+            Arc::new(Sha256IdentityFingerprintFactory),
+            Arc::new(FixedClock),
+        );
         let router_b = Router::builder((*endpoint_b).clone())
-            .accept(PRESENCE_ALPN, IrohPresenceHandler::new())
+            .accept(PRESENCE_ALPN, decoy_adapter.handler())
             .spawn();
 
         let endpoint_a = bound_endpoint().await;
@@ -611,11 +835,36 @@ mod tests {
         }
     }
 
+    /// Build an adapter for the dial-side tests. Inbound resolution is
+    /// not exercised here — the empty `MemMemberRepo` is enough to keep
+    /// the handler constructible.
     fn build_adapter(
         endpoint: Arc<Endpoint>,
         repo: Arc<dyn PeerAddressRepositoryPort>,
     ) -> IrohPresenceAdapter {
-        IrohPresenceAdapter::new(endpoint, repo, Arc::new(FixedClock))
+        IrohPresenceAdapter::new(
+            endpoint,
+            repo,
+            Arc::new(MemMemberRepo::default()),
+            Arc::new(Sha256IdentityFingerprintFactory),
+            Arc::new(FixedClock),
+        )
+    }
+
+    /// Build an adapter wired to a caller-supplied `MemberRepositoryPort`
+    /// so inbound-flip tests can seed the dialing endpoint's identity.
+    fn build_adapter_with_member_repo(
+        endpoint: Arc<Endpoint>,
+        repo: Arc<dyn PeerAddressRepositoryPort>,
+        member_repo: Arc<dyn MemberRepositoryPort>,
+    ) -> IrohPresenceAdapter {
+        IrohPresenceAdapter::new(
+            endpoint,
+            repo,
+            member_repo,
+            Arc::new(Sha256IdentityFingerprintFactory),
+            Arc::new(FixedClock),
+        )
     }
 
     // -- Tests ---------------------------------------------------------------
@@ -774,6 +1023,201 @@ mod tests {
         );
 
         router_b.shutdown().await.expect("router_b shutdown clean");
+        endpoint_a.close().await;
+    }
+
+    // -- Inbound-driven Online flip ------------------------------------------
+
+    /// Build a `SpaceMember` whose `identity_fingerprint` matches the
+    /// pubkey of `endpoint`, so the presence handler can reverse-resolve an
+    /// inbound `Connection::remote_id()` from that endpoint back to
+    /// `device_id`.
+    fn member_for_endpoint(endpoint: &Endpoint, device_id: &str) -> SpaceMember {
+        let factory = Sha256IdentityFingerprintFactory;
+        let fp = factory
+            .from_public_key(endpoint.id().as_bytes())
+            .expect("derive fingerprint from endpoint pubkey");
+        SpaceMember {
+            device_id: DeviceId::new(device_id),
+            device_name: device_id.to_string(),
+            identity_fingerprint: fp,
+            joined_at: Utc::now(),
+            sync_preferences: MemberSyncPreferences::default(),
+        }
+    }
+
+    /// Verdict — when an Offline (or Unknown) peer dials us at
+    /// `PRESENCE_ALPN`, the handler reverse-resolves the remote pubkey to
+    /// the seeded `DeviceId`, writes `last_state[device]=Online`, and
+    /// emits exactly one `Online` event.
+    #[tokio::test]
+    async fn accept_from_known_peer_flips_offline_to_online() {
+        let endpoint_a = bound_endpoint().await;
+        wait_for_direct_addrs(&endpoint_a).await;
+        let endpoint_b = bound_endpoint().await;
+        wait_for_direct_addrs(&endpoint_b).await;
+
+        let a_member = member_for_endpoint(&endpoint_a, "device-a");
+        let a_device_id = a_member.device_id.clone();
+        let b_member_repo = Arc::new(MemMemberRepo::default());
+        b_member_repo.seed(a_member);
+
+        let b_peer_addr_repo: Arc<dyn PeerAddressRepositoryPort> =
+            Arc::new(FakePeerAddressRepo::default());
+        let b_member_repo_dyn: Arc<dyn MemberRepositoryPort> = b_member_repo;
+        let b_adapter = build_adapter_with_member_repo(
+            Arc::clone(&endpoint_b),
+            b_peer_addr_repo,
+            b_member_repo_dyn,
+        );
+        let mut subscriber = b_adapter.subscribe();
+
+        // Before any inbound dial, B has no opinion on A's reachability.
+        assert_eq!(
+            b_adapter.current_state(&a_device_id).await,
+            ReachabilityState::Unknown,
+        );
+
+        let router_b = Router::builder((*endpoint_b).clone())
+            .accept(PRESENCE_ALPN, b_adapter.handler())
+            .spawn();
+
+        // A dials B directly — this exercises B's accept handler without
+        // pulling in A's own adapter. The connection is held open by the
+        // handler until the test drops it.
+        let b_addr = endpoint_b.addr();
+        let conn = timeout(DIAL_BUDGET, endpoint_a.connect(b_addr, PRESENCE_ALPN))
+            .await
+            .expect("connect within budget")
+            .expect("A dial B succeeds");
+
+        let event = timeout(Duration::from_secs(3), subscriber.recv())
+            .await
+            .expect("inbound Online event arrives within 3s")
+            .expect("event channel open");
+        assert_eq!(event.device_id, a_device_id);
+        assert_eq!(event.state, ReachabilityState::Online);
+
+        assert_eq!(
+            b_adapter.current_state(&a_device_id).await,
+            ReachabilityState::Online,
+        );
+
+        drop(conn);
+        router_b.shutdown().await.ok();
+        endpoint_a.close().await;
+    }
+
+    /// Verdict — repeated inbound dials from the same already-Online peer
+    /// must NOT re-broadcast. Each keepalive tick from a stable peer would
+    /// otherwise spam subscribers with duplicate events.
+    #[tokio::test]
+    async fn accept_already_online_does_not_rebroadcast() {
+        let endpoint_a = bound_endpoint().await;
+        wait_for_direct_addrs(&endpoint_a).await;
+        let endpoint_b = bound_endpoint().await;
+        wait_for_direct_addrs(&endpoint_b).await;
+
+        let a_member = member_for_endpoint(&endpoint_a, "device-a");
+        let b_member_repo = Arc::new(MemMemberRepo::default());
+        b_member_repo.seed(a_member);
+
+        let b_adapter = build_adapter_with_member_repo(
+            Arc::clone(&endpoint_b),
+            Arc::new(FakePeerAddressRepo::default()) as Arc<dyn PeerAddressRepositoryPort>,
+            b_member_repo as Arc<dyn MemberRepositoryPort>,
+        );
+        let mut subscriber = b_adapter.subscribe();
+
+        let router_b = Router::builder((*endpoint_b).clone())
+            .accept(PRESENCE_ALPN, b_adapter.handler())
+            .spawn();
+
+        let b_addr = endpoint_b.addr();
+        let conn1 = timeout(
+            DIAL_BUDGET,
+            endpoint_a.connect(b_addr.clone(), PRESENCE_ALPN),
+        )
+        .await
+        .expect("first connect within budget")
+        .expect("first dial succeeds");
+        let first = timeout(Duration::from_secs(3), subscriber.recv())
+            .await
+            .expect("first event arrives")
+            .expect("channel open");
+        assert_eq!(first.state, ReachabilityState::Online);
+
+        // Second dial — B's `last_state[A]` is already `Online`, so the
+        // handler must skip the broadcast.
+        let conn2 = timeout(DIAL_BUDGET, endpoint_a.connect(b_addr, PRESENCE_ALPN))
+            .await
+            .expect("second connect within budget")
+            .expect("second dial succeeds");
+
+        // Drain attempt with a tight deadline: any re-broadcast would
+        // arrive within milliseconds of the second connection landing.
+        let no_event = timeout(Duration::from_millis(500), subscriber.recv()).await;
+        assert!(
+            no_event.is_err(),
+            "expected no second event, got {:?}",
+            no_event.ok().map(|r| r.map(|e| (e.device_id, e.state))),
+        );
+
+        drop(conn1);
+        drop(conn2);
+        router_b.shutdown().await.ok();
+        endpoint_a.close().await;
+    }
+
+    /// Verdict — an inbound dial from a peer whose pubkey is NOT in
+    /// `member_repo` must hold the connection but leave presence state
+    /// untouched and emit no event. Mirrors the receiver adapter's
+    /// "unknown peer" tolerance.
+    #[tokio::test]
+    async fn accept_unknown_peer_does_not_touch_state() {
+        let endpoint_a = bound_endpoint().await;
+        wait_for_direct_addrs(&endpoint_a).await;
+        let endpoint_b = bound_endpoint().await;
+        wait_for_direct_addrs(&endpoint_b).await;
+
+        // member_repo deliberately empty — A's fingerprint will not
+        // resolve to any DeviceId.
+        let b_adapter = build_adapter_with_member_repo(
+            Arc::clone(&endpoint_b),
+            Arc::new(FakePeerAddressRepo::default()) as Arc<dyn PeerAddressRepositoryPort>,
+            Arc::new(MemMemberRepo::default()) as Arc<dyn MemberRepositoryPort>,
+        );
+        let mut subscriber = b_adapter.subscribe();
+
+        let router_b = Router::builder((*endpoint_b).clone())
+            .accept(PRESENCE_ALPN, b_adapter.handler())
+            .spawn();
+
+        let b_addr = endpoint_b.addr();
+        let conn = timeout(DIAL_BUDGET, endpoint_a.connect(b_addr, PRESENCE_ALPN))
+            .await
+            .expect("connect within budget")
+            .expect("dial succeeds");
+
+        // Give the handler time to run resolve_device, then assert no
+        // event landed.
+        let no_event = timeout(Duration::from_millis(500), subscriber.recv()).await;
+        assert!(
+            no_event.is_err(),
+            "unknown peer must not produce a presence event",
+        );
+
+        // No DeviceId was ever associated with A, so any current_state
+        // probe returns Unknown — the canonical "no opinion yet" verdict.
+        assert_eq!(
+            b_adapter
+                .current_state(&DeviceId::new("not-a-real-id"))
+                .await,
+            ReachabilityState::Unknown,
+        );
+
+        drop(conn);
+        router_b.shutdown().await.ok();
         endpoint_a.close().await;
     }
 }

--- a/src-tauri/crates/uc-observability/src/profile.rs
+++ b/src-tauri/crates/uc-observability/src/profile.rs
@@ -78,8 +78,36 @@ const NOISE_FILTERS: &[&str] = &[
     "swarm_discovery::socket=error",
     // hickory-dns resolver used by pkarr + relay URL resolution.
     "hickory=warn",
-    // Catch-all for libraries that emit through the `log` crate (forwarded
-    // into tracing). Without this they default to TRACE.
+    // === log-bridge noise ===
+    //
+    // Crates that emit through the `log` crate (forwarded via tracing-log).
+    // The catch-all `log=warn` is *not reliable* on its own: tracing-log 0.2
+    // dispatches each record in two steps —
+    //   1. `dispatch.enabled(filter_meta)` where `filter_meta.target()` is the
+    //      record's real target (e.g. `rustls::client::hs`)
+    //   2. `dispatch.event(Event::new(static_meta, ...))` where
+    //      `static_meta.target()` is the literal `"log"`
+    // EnvFilter caches Interest by static callsite. When the filter set has
+    // both a base level (`debug`) and a target rule (`log=warn`), the cached
+    // Interest collapses to `sometimes`, and the runtime check falls back on
+    // the dynamic `filter_meta` whose target is the real module path. At that
+    // point `log=warn` no longer matches and the base `debug` lets it through
+    // — which is why we measured ~23k DEBUG events leaking under target="log"
+    // (rustls handshake spam dominated).
+    //
+    // Fix: cap the actual log-bridged crates by their real prefix. These
+    // catch the high-volume offenders observed in production:
+    //   rustls::client::hs / tls13 / common_state  — TLS handshake DEBUG x10
+    //                                                 per iroh connect attempt
+    //   reqwest::connect                           — DEBUG per HTTP connect
+    //   igd_next::aio::tokio                       — UPnP/IGD discovery loop
+    "rustls=warn",
+    "reqwest=warn",
+    "igd_next=warn",
+    // Keep the literal-"log" catch-all as a backstop for any other log-only
+    // crate that slips in. It works for the subset of cases where EnvFilter's
+    // callsite Interest resolves statically (no `sometimes` fallback), and is
+    // harmless when it doesn't.
     "log=warn",
 ];
 


### PR DESCRIPTION
## Summary

- Replace the unconditional 25s keepalive scan in `peer_keepalive.rs` with a per-peer exponential backoff ladder (25s → 60s → 5min → 15min cap) so paired-but-offline peers don't burn a ~30s dial every tick.
- `IrohPresenceHandler` now reverse-resolves inbound `PRESENCE_ALPN` dials to a `DeviceId` (sharing `last_state` and broadcast `Sender` with the adapter) and flips that peer to Online on first contact, so recovery is bounded by the *peer's own* keepalive cadence rather than our 15min cap. The outbound watchdog stays the sole owner of Offline transitions.
- Adds two thin `AppFacade` wrappers (`list_paired_peer_device_ids`, `ensure_reachable_one`) for the worker, and threads `member_repo` + `fingerprint_factory` into `install_presence` so the handler can do the same identity lookup the clipboard receiver uses.

Note: PR diff also includes `uc-observability/src/profile.rs` from `19e57471` (already on `main`, not yet forward-merged to `dev`); not part of this work.

## Test plan

- [ ] `cargo test -p uc-desktop daemon::workers::peer_keepalive` (BackoffState ladder + presence-event handling unit tests)
- [ ] `cargo test -p uc-infra network::iroh::presence_adapter` (inbound Online flip integration tests)
- [ ] Manual: pair two devices, force-close peer, observe escalating backoff in logs; restart peer, confirm inbound presence event resets backoff to base