### PR TITLE
ci: 缓存与并行优化，缩短 PR 与 alpha 构建耗时

### DIFF
--- a/.github/workflows/alpha-build.yml
+++ b/.github/workflows/alpha-build.yml
@@ -77,7 +77,7 @@ jobs:
           node-version: lts/*
 
       - name: install Bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
 
@@ -85,6 +85,20 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "src-tauri -> target"
+          shared-key: ${{ matrix.target }}
+
+      - name: Cache Bun dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
 
       - name: install frontend dependencies
         run: bun install

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -3,7 +3,13 @@ name: Coverage
 on:
   push:
     branches: [main, develop]
+    paths:
+      - 'src-tauri/**'
+      - '.github/workflows/coverage.yml'
   pull_request:
+    paths:
+      - 'src-tauri/**'
+      - '.github/workflows/coverage.yml'
 
 jobs:
   coverage:

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -36,6 +36,14 @@ jobs:
         with:
           bun-version: latest
 
+      - name: Cache Bun dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
       - name: Install frontend dependencies
         run: bun install --frozen-lockfile
 

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -6,24 +6,58 @@ on:
     branches:
       - main
     types: [opened, synchronize, reopened]
+    paths:
+      - 'src/**'
+      - 'src-tauri/**'
+      - 'package.json'
+      - 'bun.lock'
+      - 'tsconfig*.json'
+      - 'vite.config.ts'
+      - 'tailwind.config.js'
+      - 'eslint.config.js'
+      - 'index.html'
+      - 'quick-panel.html'
+      - 'public/**'
+      - '.github/workflows/pr-check.yml'
 
+# 拆 frontend / rust 两个 job 并行：
+# - frontend: bun install + tsc + vite build (类型检查 + 产物构建)
+# - rust: cargo check --workspace --locked (不再带 --all-targets --all-features，
+#   PR 阶段不为 test/bench/全 feature 编译。test 在 coverage.yml 跑)
+# 完整的 tauri build / 签名 / 公证 仍只在 release 工作流跑。
 jobs:
-  check:
-    name: Code Check
+  frontend:
+    name: Frontend Type Check
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: lts/*
-
       - name: Install Bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
+
+      - name: Cache Bun dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
+      - name: Install frontend dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Type check & build frontend
+        run: bun run build
+
+  rust:
+    name: Rust Check
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
 
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
@@ -31,35 +65,15 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
-
-      - name: Cache Bun dependencies
-        uses: actions/cache@v4
-        with:
-          path: |
-            node_modules
-            ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lockb') }}
-          restore-keys: |
-            ${{ runner.os }}-bun-
+          sudo apt-get install -y --no-install-recommends \
+            libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
 
       - name: Cache Rust dependencies
-        uses: actions/cache@v4
+        uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            src-tauri/target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
+          workspaces: "src-tauri -> target"
+          shared-key: pr-check
 
-      - name: Install frontend dependencies
-        run: bun install
-
-      - name: Type check frontend
-        run: bun run build
-
-      - name: Check Rust code
+      - name: Check Rust workspace
         working-directory: src-tauri
-        run: cargo check --all-targets --all-features
+        run: cargo check --workspace --locked


### PR DESCRIPTION
## Summary

针对 PR / alpha 构建时长做缓存与触发优化（参考资料里的优先级 ① rust-cache + bun cache、② PR 不跑完整 tauri build、③ 并行、⑤ 前端依赖缓存、⑥ 减少无效触发）：

- **pr-check.yml**：拆 frontend / rust 两 job 并行；改用 `Swatinem/rust-cache@v2` 替代手写 `actions/cache`；`cargo check` 去掉 `--all-targets --all-features` 改用 `--workspace --locked`；加 `paths` 过滤跳过纯文档 PR。
- **alpha-build.yml**：补 `Swatinem/rust-cache@v2`（`shared-key` 对齐 `build.yml` 的 `${{ matrix.target }}` 直接复用其暖好的缓存）+ bun install cache；`setup-bun` v1 → v2。
- **coverage.yml**：`push` / `pull_request` 都加 `paths: src-tauri/**`，纯前端/docs PR 跳过 30 min `cargo llvm-cov`。
- **format.yml**：补 `~/.bun/install/cache`，避免每个 PR 全量重装前端依赖。

未引入 sccache（资料指出对 Rust/Tauri 项目收益不一定优于 rust-cache）。

## Test plan

- [ ] PR 触发 `pr-check` 后两 job 并行跑通
- [ ] 二次 PR 推送命中 rust-cache 与 bun cache（耗时显著下降）
- [ ] 仅改 docs/docs-site 的 PR 跳过 `pr-check` 与 `coverage`
- [ ] 触发 `alpha-build` 验证缓存命中