### PR TITLE
fix(mobile-sync): recover image mime + clear placeholder card on inbound apply

### DIFF
--- a/src-tauri/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/tests.rs
+++ b/src-tauri/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/tests.rs
@@ -1,9 +1,13 @@
-use std::sync::Arc;
+use std::sync::{Arc, Mutex, RwLock};
 
 use anyhow::Result;
 use async_trait::async_trait;
 use bytes::Bytes;
 use mockall::predicate::*;
+
+use crate::facade::host_event::{
+    ClipboardHostEvent, ClipboardOriginKind, EmitError, HostEvent, HostEventEmitterPort,
+};
 
 use uc_core::ids::{DeviceId, EntryId, FormatId, RepresentationId};
 use uc_core::ports::blob::{BlobDigest, BlobTicket, PlaintextHash};
@@ -130,6 +134,43 @@ fn build_with_blob_materializer(
 }
 
 // ── verdicts ────────────────────────────────────────────────────────
+
+// ── host-event recording fake ───────────────────────────────────────
+
+/// 录制 emitter:把 emit() 收到的所有 HostEvent 按时间顺序追加到 Vec,
+/// 让测试断言事件序列(尤其是 IncomingPending → NewContent 的顺序与
+/// 内容)而不是依赖外部 broadcast / WS 链路。
+#[derive(Default)]
+struct RecordingEmitter {
+    events: Mutex<Vec<HostEvent>>,
+}
+
+impl RecordingEmitter {
+    fn snapshot(&self) -> Vec<HostEvent> {
+        self.events.lock().unwrap().clone()
+    }
+}
+
+impl HostEventEmitterPort for RecordingEmitter {
+    fn emit(&self, event: HostEvent) -> Result<(), EmitError> {
+        self.events.lock().unwrap().push(event);
+        Ok(())
+    }
+}
+
+fn build_with_recording_emitter(
+    repo: MockEntryRepo,
+    capture: MockCapture,
+    write: MockWrite,
+) -> (ApplyInboundClipboardUseCase, Arc<RecordingEmitter>) {
+    let recorder = Arc::new(RecordingEmitter::default());
+    let cell: crate::facade::blob_transfer::SharedHostEventEmitter = Arc::new(RwLock::new(
+        Arc::clone(&recorder) as Arc<dyn HostEventEmitterPort>,
+    ));
+    let uc = ApplyInboundClipboardUseCase::new(Arc::new(repo), Arc::new(capture), Arc::new(write))
+        .with_host_event_emitter(cell);
+    (uc, recorder)
+}
 
 /// Verdict 1 — happy path: dedup miss → decode → capture → write →
 /// `Applied { entry_id }`. mockall asserts: dedup query once with
@@ -590,4 +631,80 @@ async fn file_cache_blob_materializer_rejects_out_of_bounds_representation_index
         err.to_string().contains("out of bounds"),
         "error must mention out-of-bounds context: {err}"
     );
+}
+
+/// 回归 pin —— 2026-05-08 移动端图片回归暴露:apply_inbound 流程入口 emit
+/// `IncomingPending` 后,**末尾必须 emit `NewContent`**,否则前端
+/// `useClipboardEventStream.ts:122` 的 `removePendingEntry()` 永远收不到
+/// 信号,"正在接收"占位卡片永驻直到用户 reload。
+///
+/// 检查两件事:
+///   1. emitter 收到的事件序列是 [IncomingPending, NewContent](顺序固定)。
+///   2. 两条事件 entry_id 相同 —— 前端靠 entry_id 把占位卡片下线、用真实
+///      entry 替换;两边 id 不一致就等于占位卡片没被清。
+#[tokio::test]
+async fn happy_path_emits_incoming_pending_then_new_content() {
+    let (input, hash) = fixture_input("regress: placeholder must be cleared");
+
+    let mut repo = MockEntryRepo::new();
+    repo.expect_find_entry_id_by_snapshot_hash()
+        .with(eq(hash))
+        .times(1)
+        .returning(|_| Ok(None));
+
+    // capture 把流程入口预生成的 receiver_entry_id 原样回填 —— 这是真实
+    // capture 路径的契约(materializer / capture 都共享同一 entry_id)。
+    let mut capture = MockCapture::new();
+    capture
+        .expect_capture()
+        .times(1)
+        .returning(|preset, _| Ok(Some(preset)));
+
+    let mut write = MockWrite::new();
+    write.expect_write().times(1).returning(|_| Ok(()));
+
+    let (uc, recorder) = build_with_recording_emitter(repo, capture, write);
+    let outcome = uc.execute(input).await.expect("happy path");
+
+    let applied_entry_id = match outcome {
+        ApplyOutcome::Applied { entry_id } => entry_id,
+        other => panic!("expected Applied, got {other:?}"),
+    };
+
+    let events = recorder.snapshot();
+    assert_eq!(
+        events.len(),
+        2,
+        "happy path must emit exactly 2 host events (IncomingPending + NewContent), got {} events: {:?}",
+        events.len(),
+        events
+    );
+
+    match &events[0] {
+        HostEvent::Clipboard(ClipboardHostEvent::IncomingPending { entry_id, .. }) => {
+            assert_eq!(
+                entry_id,
+                applied_entry_id.as_ref(),
+                "IncomingPending entry_id must match the eventual Applied entry_id"
+            );
+        }
+        other => panic!("event[0] must be IncomingPending, got {other:?}"),
+    }
+
+    match &events[1] {
+        HostEvent::Clipboard(ClipboardHostEvent::NewContent {
+            entry_id, origin, ..
+        }) => {
+            assert_eq!(
+                entry_id,
+                applied_entry_id.as_ref(),
+                "NewContent entry_id must match — front end keys placeholder eviction by entry_id"
+            );
+            assert!(
+                matches!(origin, ClipboardOriginKind::Remote),
+                "inbound NewContent must carry origin=Remote, got {origin:?}"
+            );
+        }
+        other => panic!("event[1] must be NewContent, got {other:?}"),
+    }
 }

--- a/src-tauri/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/usecase.rs
+++ b/src-tauri/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/usecase.rs
@@ -9,7 +9,9 @@ use uc_core::ports::ClipboardEntryRepositoryPort;
 use uc_core::SystemClipboardSnapshot;
 
 use crate::facade::blob_transfer::SharedHostEventEmitter;
-use crate::facade::host_event::{ClipboardHostEvent, HostEvent, TransferHostEvent};
+use crate::facade::host_event::{
+    ClipboardHostEvent, ClipboardOriginKind, HostEvent, TransferHostEvent,
+};
 use crate::usecases::clipboard_sync::payload_codec::decode_v3_bytes_to_snapshot_and_blob_refs;
 
 use super::materializer::InboundBlobMaterializer;
@@ -224,6 +226,38 @@ impl ApplyInboundClipboardUseCase {
         })?;
 
         info!(entry_id = %entry_id, "inbound clipboard applied");
+
+        // 关键:发出 `clipboard.new_content`,让前端 placeholder 卡片下线。
+        //
+        // 单点修复链路如下:
+        //   1. 流程入口(line 136)我们 emit 了 `IncomingPending`,前端
+        //      `useClipboardEventStream.ts:82` 据此 `addPendingEntry()` 显示
+        //      "正在接收"占位卡片。
+        //   2. apply_inbound 写完 OS clipboard 后,clipboard_watcher 会收到
+        //      回声,但因 origin == RemotePush 在 watcher 入口短路返回(避免
+        //      重复 capture),那条短路把 watcher 原本会 emit 的 new_content
+        //      也吃掉了。
+        //   3. 历史上从来没有任何点 emit 过 `ClipboardHostEvent::NewContent`
+        //      给入站路径,导致前端 `removePendingEntry()` 永远收不到信号。
+        //      用户看到"正在接收"卡死,只能 reload 才能看到真实 entry。
+        //      2026-05-08 移动端图片回归把这条慢流量(数 MB JPEG)放大成可见
+        //      bug —— 文本同步因为太快、列表常常被别的原因刷新而蒙混过关。
+        //
+        // 在此处 emit `NewContent { origin: Remote }`,前端
+        // `useClipboardEventStream.ts:114-122` 收到后:
+        //   * `removePendingEntry(entry_id)` 清掉占位卡片
+        //   * 走 remote 分支 `onRemoteInvalidate()` 节流刷新列表 —— 真实 entry
+        //     接替占位卡片,UI 状态收敛。
+        //
+        // preview 字段:与 watcher 路径(`clipboard_watcher.rs:163`)保持一致用
+        // 占位串。前端只把它打日志,不渲染;真实 preview 由列表刷新时从 daemon
+        // 列表 API 拿到的 `ClipboardItemResponse` 提供。
+        self.emit_host_event(HostEvent::Clipboard(ClipboardHostEvent::NewContent {
+            entry_id: entry_id.as_ref().to_string(),
+            preview: "New clipboard content".to_string(),
+            origin: ClipboardOriginKind::Remote,
+        }));
+
         Ok(ApplyOutcome::Applied { entry_id })
     }
 }

--- a/src-tauri/crates/uc-desktop/src/daemon/workers/clipboard_watcher.rs
+++ b/src-tauri/crates/uc-desktop/src/daemon/workers/clipboard_watcher.rs
@@ -127,12 +127,13 @@ impl ClipboardChangeHandler for DaemonClipboardChangeHandler {
         );
 
         // RemotePush 是 apply_inbound 写入 OS 剪切板后 watcher 收到的回声。
-        // entry / event / search 索引 / WS clipboard.new_content 已由
-        // apply_inbound 完整发出过；这里若再跑一次 capture pipeline 会产生
-        // 第二条 entry，用户层表现为同一份内容出现两份。直接短路返回，
-        // 与 LocalRestore 在功能效果上对称（LocalRestore 在 usecase 内部
-        // 短路，RemotePush 因 apply_inbound 也走同一 usecase 入口，必须
-        // 在 watcher 层短路才不会破坏入站落库路径）。
+        // entry 落库 / search 索引 / `clipboard.new_content` WS 事件均由
+        // `ApplyInboundClipboardUseCase` 自己发出（流程入口的 `IncomingPending`
+        // 和成功收尾时的 `NewContent`，详见 `apply_inbound/usecase.rs`）；
+        // 这里若再跑一次 capture pipeline 会产生第二条 entry，用户层表现为
+        // 同一份内容出现两份。直接短路返回，与 LocalRestore 在功能效果上对称
+        // （LocalRestore 在 usecase 内部短路，RemotePush 因 apply_inbound 也
+        // 走同一 usecase 入口，必须在 watcher 层短路才不会破坏入站落库路径）。
         if origin == ClipboardChangeOrigin::RemotePush {
             debug!(
                 origin_guard_key = %origin_guard_key,

--- a/src-tauri/crates/uc-platform/src/clipboard/common.rs
+++ b/src-tauri/crates/uc-platform/src/clipboard/common.rs
@@ -4,6 +4,30 @@ use tracing::{debug, info, warn};
 use uc_core::clipboard::{MimeType, ObservedClipboardRepresentation, SystemClipboardSnapshot};
 use uc_core::ids::RepresentationId;
 
+/// 文件头魔数嗅探,返回桌面剪贴板能消费的 `image/*` mime 字符串。
+/// 无法识别返回 None。只读前 12 字节,无内存分配。
+pub(crate) fn sniff_image_magic(body: &[u8]) -> Option<&'static str> {
+    if body.starts_with(&[0xFF, 0xD8, 0xFF]) {
+        return Some("image/jpeg");
+    }
+    if body.starts_with(&[0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]) {
+        return Some("image/png");
+    }
+    if body.starts_with(b"GIF87a") || body.starts_with(b"GIF89a") {
+        return Some("image/gif");
+    }
+    if body.len() >= 12 && body.starts_with(b"RIFF") && &body[8..12] == b"WEBP" {
+        return Some("image/webp");
+    }
+    if body.starts_with(&[0x42, 0x4D]) {
+        return Some("image/bmp");
+    }
+    if body.starts_with(&[0x49, 0x49, 0x2A, 0x00]) || body.starts_with(&[0x4D, 0x4D, 0x00, 0x2A]) {
+        return Some("image/tiff");
+    }
+    None
+}
+
 /// Known TIFF UTI aliases on macOS pasteboard.
 /// When the image has already been captured via the fast raw-TIFF path,
 /// these formats must be skipped in the raw fallback loop to avoid
@@ -649,23 +673,46 @@ impl CommonClipboardImpl {
         // 单 rep 快路径：走既有 clipboard-rs 高层 API（行为与改动前完全一致）。
         let rep = &snapshot.representations[0];
 
-        // Use explicit MIME if present, otherwise infer from macOS/cross-platform format_id.
-        let effective_mime =
-            rep.mime
-                .as_ref()
-                .map(|m| m.as_str())
-                .or_else(|| match rep.format_id.as_str() {
-                    "public.utf8-plain-text" | "public.text" | "NSStringPboardType" | "text" => {
-                        Some("text/plain")
-                    }
-                    "public.html" | "Apple HTML pasteboard type" | "html" => Some("text/html"),
-                    "public.rtf" | "rtf" => Some("text/rtf"),
-                    "public.png" | "image" => Some("image/png"),
-                    "public.tiff" => Some("image/tiff"),
-                    "public.jpeg" => Some("image/jpeg"),
-                    "public.file-url" | "NSFilenamesPboardType" => Some("text/uri-list"),
-                    _ => None,
-                });
+        // 先按 format_id 推断默认 mime。
+        let format_default = match rep.format_id.as_str() {
+            "public.utf8-plain-text" | "public.text" | "NSStringPboardType" | "text" => {
+                Some("text/plain")
+            }
+            "public.html" | "Apple HTML pasteboard type" | "html" => Some("text/html"),
+            "public.rtf" | "rtf" => Some("text/rtf"),
+            "public.png" | "image" => Some("image/png"),
+            "public.tiff" => Some("image/tiff"),
+            "public.jpeg" => Some("image/jpeg"),
+            "public.file-url" | "NSFilenamesPboardType" => Some("text/uri-list"),
+            _ => None,
+        };
+
+        // 决定 effective_mime:
+        //   情况 A —— image-like format_id 但显式 mime 不是 image/*:几乎一定是客户端
+        //     误标(典型:iOS / SyncClipboard 兼容客户端 PUT /file 时不设 Content-Type
+        //     → 服务端默认 application/octet-stream → 这里 mime=Some("application/octet-stream"))。
+        //     先字节嗅探拿真实图片 mime,失败再回退到 format_id 默认。**绝不**让 image rep
+        //     携带 application/octet-stream 流到下游 set_image / set_buffer:
+        //     2026-05-08 真机回归(IMG_20260508_200644.jpg)就是这条路径把 JPEG 字节
+        //     用非法 NSPasteboard type 写进了系统剪贴板。
+        //   情况 B —— 显式 mime 存在 → 沿用。
+        //   情况 C —— 没有显式 mime → 回退 format_id 默认。
+        let effective_mime: Option<&str> = match (rep.mime.as_deref(), format_default) {
+            (Some(m), Some(default))
+                if default.starts_with("image/") && !m.starts_with("image/") =>
+            {
+                let recovered = sniff_image_magic(&rep.bytes).unwrap_or(default);
+                warn!(
+                    format_id = %rep.format_id,
+                    wire_mime = m,
+                    recovered_mime = recovered,
+                    "write_snapshot: image rep declared non-image mime; recovered via byte sniff/format_id default"
+                );
+                Some(recovered)
+            }
+            (Some(m), _) => Some(m),
+            (None, default) => default,
+        };
 
         match effective_mime {
             Some("text/plain") => {
@@ -752,6 +799,38 @@ impl CommonClipboardImpl {
                 );
             }
             _ => {
+                // 兜底分支:effective_mime 没命中任何已支持类型。这条路径之前会
+                // 静默 set_buffer(format_id, bytes) —— 历史教训(2026-05-08
+                // IMG_20260508_200644.jpg 真机回归):image rep + mime
+                // application/octet-stream 落到这里,把 JPEG 字节用非法
+                // pasteboard type "image" 写进了系统剪贴板,既无法以图像形式
+                // 粘贴,又把原始 EXIF 字节当文本暴露给用户。违反
+                // `uc-platform/AGENTS.md` §11.2「不允许静默降级」。
+                //
+                // 现在:
+                //   * image-like format_id 在 effective_mime 决策阶段已被字节
+                //     嗅探纠正,不会再到达这里;若到达说明前置守卫失效 —— bail。
+                //   * 其它未识别 mime 的 rep 仍走 set_buffer,但必须先 WARN,让
+                //     "OS 剪贴板里写了非标准 type"这件事可观测。
+                let format_default_image_like = matches!(
+                    rep.format_id.as_str(),
+                    "image" | "public.png" | "public.tiff" | "public.jpeg" | "public.gif"
+                );
+                if format_default_image_like {
+                    anyhow::bail!(
+                        "write_snapshot: image-like format_id {:?} reached fallback branch \
+                         with mime {:?} — image-mime recovery should have run upstream; \
+                         refusing to set_buffer with a non-UTI pasteboard type",
+                        rep.format_id,
+                        rep.mime
+                    );
+                }
+                warn!(
+                    format_id = %rep.format_id,
+                    mime = ?rep.mime,
+                    bytes = rep.bytes.len(),
+                    "write_snapshot: writing rep via raw set_buffer fallback (no recognized mime mapping)"
+                );
                 map_clipboard_err(ctx.set_buffer(&rep.format_id, rep.bytes.clone()))?;
             }
         }
@@ -953,5 +1032,77 @@ mod tests {
             false,
             false
         ));
+    }
+
+    // ─── sniff_image_magic ──────────────────────────────────────────────
+    //
+    // 守住 2026-05-08 IMG_20260508_200644.jpg 真机回归:image rep 携带
+    // application/octet-stream 时,write_snapshot 必须能从字节嗅出真实
+    // image/* mime,而不是把原始 JPEG 字节用非法 UTI 写进 NSPasteboard。
+
+    #[test]
+    fn sniff_image_magic_recognizes_jpeg() {
+        // JPEG SOI + APP0 marker (real JFIF header)
+        let bytes = [0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, b'J', b'F', b'I', b'F'];
+        assert_eq!(sniff_image_magic(&bytes), Some("image/jpeg"));
+    }
+
+    #[test]
+    fn sniff_image_magic_recognizes_jpeg_with_exif_marker() {
+        // 真机回归 case:Xiaomi 14 拍的 JPEG,SOI 后第二段是 APP1 (Exif)
+        let bytes = [0xFF, 0xD8, 0xFF, 0xE1, 0x00, 0x18, b'E', b'x', b'i', b'f'];
+        assert_eq!(sniff_image_magic(&bytes), Some("image/jpeg"));
+    }
+
+    #[test]
+    fn sniff_image_magic_recognizes_png() {
+        let bytes = [
+            0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D,
+        ];
+        assert_eq!(sniff_image_magic(&bytes), Some("image/png"));
+    }
+
+    #[test]
+    fn sniff_image_magic_recognizes_gif() {
+        assert_eq!(sniff_image_magic(b"GIF87a..."), Some("image/gif"));
+        assert_eq!(sniff_image_magic(b"GIF89a..."), Some("image/gif"));
+    }
+
+    #[test]
+    fn sniff_image_magic_recognizes_webp() {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(b"RIFF");
+        bytes.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]);
+        bytes.extend_from_slice(b"WEBP");
+        assert_eq!(sniff_image_magic(&bytes), Some("image/webp"));
+    }
+
+    #[test]
+    fn sniff_image_magic_recognizes_bmp() {
+        assert_eq!(sniff_image_magic(&[0x42, 0x4D, 0x00]), Some("image/bmp"));
+    }
+
+    #[test]
+    fn sniff_image_magic_recognizes_tiff_both_endians() {
+        assert_eq!(
+            sniff_image_magic(&[0x49, 0x49, 0x2A, 0x00, 0x00]),
+            Some("image/tiff")
+        );
+        assert_eq!(
+            sniff_image_magic(&[0x4D, 0x4D, 0x00, 0x2A, 0x00]),
+            Some("image/tiff")
+        );
+    }
+
+    #[test]
+    fn sniff_image_magic_returns_none_for_text_or_short_input() {
+        assert_eq!(sniff_image_magic(b"hello world"), None);
+        assert_eq!(sniff_image_magic(&[]), None);
+        // RIFF without WEBP suffix (e.g. WAV) must not be misclassified.
+        let mut riff_wav = Vec::new();
+        riff_wav.extend_from_slice(b"RIFF");
+        riff_wav.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]);
+        riff_wav.extend_from_slice(b"WAVE");
+        assert_eq!(sniff_image_magic(&riff_wav), None);
     }
 }

--- a/src-tauri/crates/uc-platform/src/clipboard/platform/macos.rs
+++ b/src-tauri/crates/uc-platform/src/clipboard/platform/macos.rs
@@ -67,29 +67,45 @@ impl SystemClipboardPort for MacOSClipboard {
 ///
 /// 与 `common.rs` 单 rep 快路径、`windows.rs::resolve_multi_rep_mime` 保持一致的
 /// 推断表：显式 mime → 使用；否则 format_id 映射。
+///
+/// 例外:image-like format_id 但显式 mime 不是 `image/*` 时,先做字节魔数嗅探,
+/// 失败回退到 format_id 默认。原因见 `common.rs::write_snapshot` 同位置注释。
 fn resolve_multi_rep_mime(rep: &ObservedClipboardRepresentation) -> Option<&str> {
-    rep.mime
-        .as_ref()
-        .map(|m| m.as_str())
-        .or_else(|| match rep.format_id.as_str() {
-            "public.utf8-plain-text" | "public.text" | "NSStringPboardType" | "text" => {
-                Some("text/plain")
-            }
-            "public.html" | "Apple HTML pasteboard type" | "html" => Some("text/html"),
-            // RTF：从 Word / Pages 等富文本源复制时常与 plain text + html 同时出现；
-            // common.rs::read_snapshot 把它存为 format_id="rtf"，mime="text/rtf"。
-            "public.rtf" | "rtf" => Some("text/rtf"),
-            // PixPin 截图 / Windows 端复制图片等场景 format_id 为 "image"，mime 通常为
-            // "image/png"。`common.rs::read_snapshot` 已把图像统一标准化为 PNG，因此 jpeg /
-            // webp / gif 不会出现在 envelope 中（与 windows.rs 保持同样取舍）。
-            "public.png" | "image" => Some("image/png"),
-            "public.tiff" => Some("image/tiff"),
-            // file-list 表示：接收端 materializer 会把 rep.bytes 改写为本机 file:// URI
-            // 列表（每行一条），写入时为每个 URI 生成一个独立 NSPasteboardItem 承载
-            // NSPasteboardTypeFileURL —— Finder / NSDocumentController 识别的规范形式。
-            "public.file-url" | "NSFilenamesPboardType" | "files" => Some("text/uri-list"),
-            _ => None,
-        })
+    let format_default = match rep.format_id.as_str() {
+        "public.utf8-plain-text" | "public.text" | "NSStringPboardType" | "text" => {
+            Some("text/plain")
+        }
+        "public.html" | "Apple HTML pasteboard type" | "html" => Some("text/html"),
+        // RTF：从 Word / Pages 等富文本源复制时常与 plain text + html 同时出现；
+        // common.rs::read_snapshot 把它存为 format_id="rtf"，mime="text/rtf"。
+        "public.rtf" | "rtf" => Some("text/rtf"),
+        // PixPin 截图 / Windows 端复制图片等场景 format_id 为 "image"，mime 通常为
+        // "image/png"。`common.rs::read_snapshot` 已把图像统一标准化为 PNG，因此 jpeg /
+        // webp / gif 不会出现在 envelope 中（与 windows.rs 保持同样取舍）。
+        "public.png" | "image" => Some("image/png"),
+        "public.tiff" => Some("image/tiff"),
+        // file-list 表示：接收端 materializer 会把 rep.bytes 改写为本机 file:// URI
+        // 列表（每行一条），写入时为每个 URI 生成一个独立 NSPasteboardItem 承载
+        // NSPasteboardTypeFileURL —— Finder / NSDocumentController 识别的规范形式。
+        "public.file-url" | "NSFilenamesPboardType" | "files" => Some("text/uri-list"),
+        _ => None,
+    };
+
+    match (rep.mime.as_deref(), format_default) {
+        (Some(m), Some(default)) if default.starts_with("image/") && !m.starts_with("image/") => {
+            let recovered =
+                crate::clipboard::common::sniff_image_magic(&rep.bytes).unwrap_or(default);
+            tracing::warn!(
+                format_id = %rep.format_id,
+                wire_mime = m,
+                recovered_mime = recovered,
+                "macOS multi-rep: image rep declared non-image mime; recovered via byte sniff/format_id default"
+            );
+            Some(recovered)
+        }
+        (Some(m), _) => Some(m),
+        (None, default) => default,
+    }
 }
 
 /// 把 text/uri-list rep 的字节解析为每行一条 URI 字符串。

--- a/src-tauri/crates/uc-platform/src/clipboard/platform/windows.rs
+++ b/src-tauri/crates/uc-platform/src/clipboard/platform/windows.rs
@@ -15,28 +15,42 @@ use uc_core::ports::SystemClipboardPort;
 /// 既用于前置 "有无可写 rep" 扫描，也用于主循环分派，避免两处逻辑漂移。
 /// 与 `common.rs` 单 rep 快路径的 format_id → mime 推断表对齐。
 fn resolve_multi_rep_mime(rep: &ObservedClipboardRepresentation) -> Option<&str> {
-    rep.mime
-        .as_ref()
-        .map(|m| m.as_str())
-        .or_else(|| match rep.format_id.as_str() {
-            "public.utf8-plain-text" | "public.text" | "NSStringPboardType" | "text" => {
-                Some("text/plain")
-            }
-            "public.html" | "Apple HTML pasteboard type" | "html" => Some("text/html"),
-            // RTF：从 Word / Pages / 写字板等富文本源复制时常与 plain + html 一起出现；
-            // common.rs::read_snapshot 写库时使用 format_id="rtf", mime="text/rtf"。
-            // Windows 上对应 RegisterClipboardFormat("Rich Text Format") 注册的自定义
-            // format（CF_RTF 不是 Win32 预定义常量）。
-            "public.rtf" | "rtf" => Some("text/rtf"),
-            // PixPin 截图等场景 format_id 为 "image"，mime 通常为 "image/png"。
-            // `common.rs::read_snapshot` 把 macOS `public.png` / `public.tiff` 都转成 PNG。
-            "public.png" | "image" => Some("image/png"),
-            // file-list 表示：接收端 materializer 会把 rep.bytes 改写为本机 file:// URI
-            // 列表（每行一条），写入时解析为原生路径后通过 CF_HDROP 提交，Explorer /
-            // 资源管理器识别的规范形式。
-            "public.file-url" | "NSFilenamesPboardType" | "files" => Some("text/uri-list"),
-            _ => None,
-        })
+    let format_default = match rep.format_id.as_str() {
+        "public.utf8-plain-text" | "public.text" | "NSStringPboardType" | "text" => {
+            Some("text/plain")
+        }
+        "public.html" | "Apple HTML pasteboard type" | "html" => Some("text/html"),
+        // RTF：从 Word / Pages / 写字板等富文本源复制时常与 plain + html 一起出现；
+        // common.rs::read_snapshot 写库时使用 format_id="rtf", mime="text/rtf"。
+        // Windows 上对应 RegisterClipboardFormat("Rich Text Format") 注册的自定义
+        // format（CF_RTF 不是 Win32 预定义常量）。
+        "public.rtf" | "rtf" => Some("text/rtf"),
+        // PixPin 截图等场景 format_id 为 "image"，mime 通常为 "image/png"。
+        // `common.rs::read_snapshot` 把 macOS `public.png` / `public.tiff` 都转成 PNG。
+        "public.png" | "image" => Some("image/png"),
+        // file-list 表示：接收端 materializer 会把 rep.bytes 改写为本机 file:// URI
+        // 列表（每行一条），写入时解析为原生路径后通过 CF_HDROP 提交，Explorer /
+        // 资源管理器识别的规范形式。
+        "public.file-url" | "NSFilenamesPboardType" | "files" => Some("text/uri-list"),
+        _ => None,
+    };
+
+    // image-like format_id 但显式 mime 非 image/*:见 `common.rs::write_snapshot` 同位置注释。
+    match (rep.mime.as_deref(), format_default) {
+        (Some(m), Some(default)) if default.starts_with("image/") && !m.starts_with("image/") => {
+            let recovered =
+                crate::clipboard::common::sniff_image_magic(&rep.bytes).unwrap_or(default);
+            tracing::warn!(
+                format_id = %rep.format_id,
+                wire_mime = m,
+                recovered_mime = recovered,
+                "Windows multi-rep: image rep declared non-image mime; recovered via byte sniff/format_id default"
+            );
+            Some(recovered)
+        }
+        (Some(m), _) => Some(m),
+        (None, default) => default,
+    }
 }
 
 /// 把 text/uri-list rep 的字节解析为本机路径列表（`Vec<PathBuf>`）。

--- a/src-tauri/crates/uc-webserver/src/mobile_lan/routes.rs
+++ b/src-tauri/crates/uc-webserver/src/mobile_lan/routes.rs
@@ -276,7 +276,7 @@ async fn put_clipboard_file(
 ) -> Result<StatusCode, Response> {
     // mime 走 Content-Type 头;客户端不带就回退 application/octet-stream
     // (与 SyncClipboard shortcut 上传 PNG / RTF 等场景一致)。
-    let mime = request
+    let raw_mime = request
         .headers()
         .get(header::CONTENT_TYPE)
         .and_then(|v| v.to_str().ok())
@@ -291,12 +291,36 @@ async fn put_clipboard_file(
         })?
         .to_vec();
 
+    // mime 兜底:某些移动端(iOS Shortcut / 第三方 SyncClipboard 兼容客户端)
+    // 上传 .jpg/.png 时不带 Content-Type 或带 application/octet-stream。如果
+    // 让 octet-stream 一路下沉到剪贴板写入层,会让 image rep 携带非 image/*
+    // mime 落到 macOS NSPasteboard 上,系统识别不出 image type、用户读到的
+    // 是原始 JPEG 字节(2026-05-08 真机回归 IMG_20260508_200644.jpg 复现)。
+    // 这里在最外层基于 data_name 扩展名 + 文件头魔数嗅探,把 image 类的
+    // mime 修正回正确的 image/* 形态;无法识别时保持原 mime 不动。
+    let effective_mime = if mime_is_unspecific(&raw_mime) {
+        match infer_image_mime(&data_name, &body_bytes) {
+            Some(sniffed) => {
+                tracing::info!(
+                    data_name = %data_name,
+                    raw_mime = %raw_mime,
+                    sniffed_mime = sniffed,
+                    "PUT /file: overrode unspecific Content-Type with sniffed image mime"
+                );
+                sniffed.to_string()
+            }
+            None => raw_mime.clone(),
+        }
+    } else {
+        raw_mime.clone()
+    };
+
     let bytes_len = body_bytes.len();
     let log_data_name = data_name.clone();
-    let log_mime = mime.clone();
+    let log_mime = effective_mime.clone();
     let device_id = authed.device.device_id.clone();
     match facade
-        .put_clipboard_file(data_name, mime, body_bytes, device_id)
+        .put_clipboard_file(data_name, effective_mime, body_bytes, device_id)
         .await
     {
         Ok(outcome) => {
@@ -311,6 +335,75 @@ async fn put_clipboard_file(
         }
         Err(err) => Err(map_apply_error(err, "PUT /file")),
     }
+}
+
+/// 判断客户端给的 Content-Type 是否"没说人话",也就是值得进一步嗅探。
+///
+/// 命中条件:空、application/octet-stream、binary/octet-stream、application/binary,
+/// 或纯 `application/*` 而无更具体的子类型(部分客户端会发 `application/`)。
+fn mime_is_unspecific(mime: &str) -> bool {
+    let trimmed = mime.split(';').next().unwrap_or("").trim();
+    matches!(
+        trimmed,
+        "" | "application/octet-stream"
+            | "binary/octet-stream"
+            | "application/binary"
+            | "application/"
+    )
+}
+
+/// 嗅探图片 mime:**优先文件头魔数**(防止 .jpg 改名为 .png 等),魔数无法
+/// 识别时回退扩展名。返回值是 `image/*` 中桌面端剪贴板能消费的形式。
+///
+/// 字节嗅探只看前 12 字节,无所有权拷贝。
+fn infer_image_mime(data_name: &str, body: &[u8]) -> Option<&'static str> {
+    if let Some(by_magic) = sniff_image_magic(body) {
+        return Some(by_magic);
+    }
+    let lower = data_name.to_ascii_lowercase();
+    let ext = std::path::Path::new(&lower)
+        .extension()
+        .and_then(|e| e.to_str())?;
+    match ext {
+        "jpg" | "jpeg" | "jpe" => Some("image/jpeg"),
+        "png" => Some("image/png"),
+        "gif" => Some("image/gif"),
+        "webp" => Some("image/webp"),
+        "bmp" => Some("image/bmp"),
+        "tif" | "tiff" => Some("image/tiff"),
+        "heic" | "heif" => Some("image/heic"),
+        _ => None,
+    }
+}
+
+/// 文件头魔数嗅探。覆盖桌面剪贴板真实会遇到的 6 种格式;其余返回 None 让
+/// 调用方决定是否回退扩展名。
+fn sniff_image_magic(body: &[u8]) -> Option<&'static str> {
+    // JPEG: FF D8 FF (SOI + 第一段 marker 高字节)
+    if body.starts_with(&[0xFF, 0xD8, 0xFF]) {
+        return Some("image/jpeg");
+    }
+    // PNG: 89 50 4E 47 0D 0A 1A 0A
+    if body.starts_with(&[0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]) {
+        return Some("image/png");
+    }
+    // GIF87a / GIF89a
+    if body.starts_with(b"GIF87a") || body.starts_with(b"GIF89a") {
+        return Some("image/gif");
+    }
+    // WEBP: RIFF....WEBP
+    if body.len() >= 12 && body.starts_with(b"RIFF") && &body[8..12] == b"WEBP" {
+        return Some("image/webp");
+    }
+    // BMP: 42 4D
+    if body.starts_with(&[0x42, 0x4D]) {
+        return Some("image/bmp");
+    }
+    // TIFF little-endian (II*\0) / big-endian (MM\0*)
+    if body.starts_with(&[0x49, 0x49, 0x2A, 0x00]) || body.starts_with(&[0x4D, 0x4D, 0x00, 0x2A]) {
+        return Some("image/tiff");
+    }
+    None
 }
 
 // ─── helpers ────────────────────────────────────────────────────────────
@@ -494,6 +587,91 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn put_file_with_octet_stream_jpeg_returns_200() {
+        // 2026-05-08 IMG_20260508_200644.jpg 真机回归 pin:某些移动客户端
+        // 上传 .jpg 时 Content-Type 发成 application/octet-stream(或不发)。
+        // 路由层应吃下,不能 400/500。mime 兜底逻辑 (sniff/扩展名) 会在
+        // 内部把 mime 修正为 image/jpeg —— 这条 test 只跨过路由层,确保
+        // 接口契约稳定;深层 mime 修正语义靠 `infer_image_mime_*` 单测覆盖。
+        let facade = build_facade_with_seeded_device("mobile_alice", "wonderland").await;
+        let app = build_app(facade);
+
+        // 真实 JPEG 头(SOI + APP1/Exif marker), 模拟 Xiaomi 14 拍的照片头几字节
+        let jpeg_head = vec![0xFF, 0xD8, 0xFF, 0xE1, 0x00, 0x18, b'E', b'x', b'i', b'f'];
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/file/IMG_20260508_200644.jpg")
+                    .header("Authorization", auth_header("mobile_alice", "wonderland"))
+                    .header("Content-Type", "application/octet-stream")
+                    .body(Body::from(jpeg_head))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    // ─── mime 兜底纯函数单测 ────────────────────────────────────────────
+
+    #[test]
+    fn mime_is_unspecific_recognizes_known_unspecific_values() {
+        assert!(mime_is_unspecific(""));
+        assert!(mime_is_unspecific("application/octet-stream"));
+        assert!(mime_is_unspecific(
+            "application/octet-stream; charset=binary"
+        ));
+        assert!(mime_is_unspecific("binary/octet-stream"));
+        assert!(mime_is_unspecific("application/binary"));
+        assert!(mime_is_unspecific("application/"));
+    }
+
+    #[test]
+    fn mime_is_unspecific_rejects_specific_values() {
+        assert!(!mime_is_unspecific("image/jpeg"));
+        assert!(!mime_is_unspecific("image/png"));
+        assert!(!mime_is_unspecific("text/plain"));
+        assert!(!mime_is_unspecific("application/pdf"));
+    }
+
+    #[test]
+    fn infer_image_mime_prefers_byte_magic_over_extension() {
+        // 文件名说 .png 但实际是 JPEG 字节 → 嗅探优先,以字节为准。
+        let jpeg = [0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10];
+        assert_eq!(infer_image_mime("liar.png", &jpeg), Some("image/jpeg"));
+    }
+
+    #[test]
+    fn infer_image_mime_falls_back_to_extension_when_magic_misses() {
+        // 字节嗅不出来(空 / 非图片头),按扩展名兜底。
+        assert_eq!(infer_image_mime("photo.jpg", &[]), Some("image/jpeg"));
+        assert_eq!(infer_image_mime("photo.JPEG", &[]), Some("image/jpeg"));
+        assert_eq!(infer_image_mime("snap.png", b"junk"), Some("image/png"));
+        assert_eq!(infer_image_mime("anim.gif", &[]), Some("image/gif"));
+        assert_eq!(infer_image_mime("photo.heic", &[]), Some("image/heic"));
+    }
+
+    #[test]
+    fn infer_image_mime_returns_none_for_non_image_extension() {
+        // 文件不是图片,且字节也嗅不出来 → 不要瞎猜。
+        assert_eq!(infer_image_mime("doc.pdf", b"%PDF-1.7"), None);
+        assert_eq!(infer_image_mime("noext", &[]), None);
+        assert_eq!(infer_image_mime("script.sh", b"#!/bin/sh"), None);
+    }
+
+    #[test]
+    fn infer_image_mime_xiaomi_jpeg_real_world_case() {
+        // 2026-05-08 真机回归:文件名 IMG_20260508_200644.jpg + JPEG 头,
+        // 客户端发 application/octet-stream → 路由层应嗅到 image/jpeg。
+        let bytes = [0xFF, 0xD8, 0xFF, 0xE1, 0x00, 0x18, b'E', b'x', b'i', b'f'];
+        assert_eq!(
+            infer_image_mime("IMG_20260508_200644.jpg", &bytes),
+            Some("image/jpeg")
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Two related bugs surfaced by the 2026-05-08 mobile image sync regression (`IMG_20260508_200644.jpg` from a Xiaomi 14):

1. **Image bytes shown as garbled text in clipboard** — Mobile clients (iOS Shortcut / 第三方 SyncClipboard 兼容) sometimes PUT `/file/foo.jpg` without `Content-Type: image/jpeg`, defaulting to `application/octet-stream`. The bad mime rode through `ApplyInbound` to the clipboard writer, where `rep.mime` took precedence over the `format_id="image"` fallback; the fallback `_` arm then silently called `set_buffer("image", jpeg_bytes)` — an illegal NSPasteboard type — leaving raw JPEG bytes (FF D8 FF + EXIF + Xiaomi marker) readable as text but never recognized as an image.

2. **"正在接收" placeholder card stuck until reload** — `ApplyInbound` emitted `IncomingPending` to show the card but **nothing** ever emitted `ClipboardHostEvent::NewContent` for inbound entries (the watcher's `RemotePush` short-circuit skips it; no other site constructed it). Frontend's `removePendingEntry()` therefore never fired, leaving the card permanent until manual reload. Multi-MB JPEG transfers made it visible; text sync had the same bug masked by unrelated list refreshes.

## Fixes (defense in depth for #1, single-point for #2)

- **Server boundary** (`mobile_lan/routes.rs`): when `Content-Type` is unspecific, sniff body magic + filename extension and rewrite mime to `image/*` before handing to facade.
- **`effective_mime` decision** (`common.rs`, `platform/macos.rs`, `platform/windows.rs`): image-like `format_id` with non-image declared mime → byte-sniff first, fall back to `format_id` default; never let `application/octet-stream` reach `set_image` / `set_buffer`.
- **`write_snapshot` fallback arm** (`common.rs`): image-like `format_id` reaching the unmatched `_` branch now bails (was silent `set_buffer` with bogus type); other unrecognized mimes log WARN before set_buffer (§11.2 "no silent degradation").
- **`apply_inbound::execute` success exit** (`apply_inbound/usecase.rs`): emits `ClipboardHostEvent::NewContent { entry_id, origin: Remote }` so the frontend's placeholder is cleared and a throttled list reload picks up the real entry. Also corrects misleading watcher comment that claimed this was already happening.

## Tests

- 8 `sniff_image_magic` cases covering JPEG/PNG/GIF/WEBP/BMP/TIFF (incl. real Xiaomi EXIF JPEG header).
- 6 `mime_is_unspecific` / `infer_image_mime` unit tests in routes.
- End-to-end PUT `/file/IMG_20260508_200644.jpg` with `application/octet-stream` + JPEG bytes returns 200.
- `happy_path_emits_incoming_pending_then_new_content` regression pin: asserts `[IncomingPending, NewContent]` event sequence with matching `entry_id` and `origin=Remote`.

## Test plan

- [x] `cargo test -p uc-platform --lib clipboard::common::tests` (14 passed)
- [x] `cargo test -p uc-webserver --lib mobile_lan::routes` (14 passed)
- [x] `cargo test -p uc-application --lib clipboard_sync::apply_inbound` (11 passed)
- [ ] Manual: send a Xiaomi JPEG from mobile → desktop logs show `overrode unspecific Content-Type with sniffed image mime`, envelope `rep_formats` becomes `image@image/jpeg`, macOS clipboard pastes as image
- [ ] Manual: same upload → "正在接收" card disappears within ~300ms after `inbound clipboard applied`, no page reload required

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic image format detection for clipboard content across all platforms, improving compatibility for image sharing.
  * Enhanced clipboard sync with proper event notifications when content is updated from remote sources.

* **Bug Fixes**
  * Improved handling of generic MIME types by intelligently detecting actual image formats from file headers.
  * Fixed mobile file upload to correctly identify image formats even when sent with generic content types.

* **Tests**
  * Added comprehensive tests for clipboard event sequencing and image format detection across multiple formats (JPEG, PNG, GIF, WEBP, BMP, TIFF).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->