### PR TITLE
docs(docs-site): integrate mobile LAN API reference via fumadocs-openapi

### DIFF
--- a/docs-site/bun.lock
+++ b/docs-site/bun.lock
@@ -8,11 +8,13 @@
         "@orama/tokenizers": "^3.1.18",
         "fumadocs-core": "16.8.7",
         "fumadocs-mdx": "14.3.2",
+        "fumadocs-openapi": "^10.8.1",
         "fumadocs-ui": "16.8.7",
         "lucide-react": "^1.14.0",
         "next": "16.2.4",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
+        "shiki": "^4.0.2",
         "tailwind-merge": "^3.5.0",
       },
       "devDependencies": {
@@ -145,6 +147,10 @@
     "@floating-ui/utils": ["@floating-ui/utils@0.2.11", "", {}, "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg=="],
 
     "@fumadocs/tailwind": ["@fumadocs/tailwind@0.0.5", "", { "peerDependencies": { "@tailwindcss/oxide": "^4.0.0", "tailwindcss": "^4.0.0" }, "optionalPeers": ["@tailwindcss/oxide", "tailwindcss"] }, "sha512-ENKPWUDRmriccsrUDE4bDBq3FNr/ms3BP2rWlsAEMV1yP23pcCaan+ceGfeBUsAQjw7sj9Q3R4Kl3g/TCStPzQ=="],
+
+    "@fumari/json-schema-ts": ["@fumari/json-schema-ts@0.0.2", "", { "dependencies": { "esrap": "^2.2.3" }, "peerDependencies": { "json-schema-typed": "^8.0.2" }, "optionalPeers": ["json-schema-typed"] }, "sha512-A2x8nj45r8Kc3Gqa+HpWRF9uzIMc9dySB6L2R2kiyjLHXWBsZUX99Atj5+Yup/iRQXQ9s8AX+uAPwPze7Xn05A=="],
+
+    "@fumari/stf": ["@fumari/stf@1.0.5", "", { "peerDependencies": { "@types/react": "*", "react": "^19.2.0", "react-dom": "^19.2.0" }, "optionalPeers": ["@types/react"] }, "sha512-O9UQIbV15ePV5vUgceCcaMDuBRYfrSuogDEY5E//CmrbIiWJ1Ji5VgGHHH0L0HQuRr5riUJuAEr9lYIvJl9OyQ=="],
 
     "@humanfs/core": ["@humanfs/core@0.19.2", "", { "dependencies": { "@humanfs/types": "^0.15.0" } }, "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA=="],
 
@@ -295,6 +301,8 @@
     "@radix-ui/react-roving-focus": ["@radix-ui/react-roving-focus@1.1.11", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-collection": "1.1.7", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-direction": "1.1.1", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-controllable-state": "1.2.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA=="],
 
     "@radix-ui/react-scroll-area": ["@radix-ui/react-scroll-area@1.2.10", "", { "dependencies": { "@radix-ui/number": "1.1.1", "@radix-ui/primitive": "1.1.3", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-direction": "1.1.1", "@radix-ui/react-presence": "1.1.5", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-tAXIa1g3sM5CGpVT0uIbUx/U3Gs5N8T52IICuCtObaos1S8fzsrPXG5WObkQN3S6NVl6wKgPhAIiBGbWnvc97A=="],
+
+    "@radix-ui/react-select": ["@radix-ui/react-select@2.2.6", "", { "dependencies": { "@radix-ui/number": "1.1.1", "@radix-ui/primitive": "1.1.3", "@radix-ui/react-collection": "1.1.7", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-direction": "1.1.1", "@radix-ui/react-dismissable-layer": "1.1.11", "@radix-ui/react-focus-guards": "1.1.3", "@radix-ui/react-focus-scope": "1.1.7", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-popper": "1.2.8", "@radix-ui/react-portal": "1.1.9", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-slot": "1.2.3", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-controllable-state": "1.2.2", "@radix-ui/react-use-layout-effect": "1.1.1", "@radix-ui/react-use-previous": "1.1.1", "@radix-ui/react-visually-hidden": "1.2.3", "aria-hidden": "^1.2.4", "react-remove-scroll": "^2.6.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-I30RydO+bnn2PQztvo25tswPH+wFBjehVGtmagkU78yMdwTwVf12wnAOF+AeP8S2N8xD+5UPbGhkUfPyvT+mwQ=="],
 
     "@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.4", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA=="],
 
@@ -644,6 +652,8 @@
 
     "esquery": ["esquery@1.7.0", "", { "dependencies": { "estraverse": "^5.1.0" } }, "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g=="],
 
+    "esrap": ["esrap@2.2.6", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.4.15" }, "peerDependencies": { "@typescript-eslint/types": "^8.2.0" }, "optionalPeers": ["@typescript-eslint/types"] }, "sha512-WN0clHt0a4mzC780UBVVBpsj4vSSjOFNRd2WjYtduB9HeKxm1sjHMNUwLEHVjI3FdCQD/Hurgz9ftbKEzP79Ow=="],
+
     "esrecurse": ["esrecurse@4.3.0", "", { "dependencies": { "estraverse": "^5.2.0" } }, "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag=="],
 
     "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
@@ -676,6 +686,8 @@
 
     "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
 
+    "fast-uri": ["fast-uri@3.1.2", "", {}, "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ=="],
+
     "fastq": ["fastq@1.20.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
@@ -697,6 +709,8 @@
     "fumadocs-core": ["fumadocs-core@16.8.7", "", { "dependencies": { "@orama/orama": "^3.1.18", "estree-util-value-to-estree": "^3.5.0", "github-slugger": "^2.0.0", "hast-util-to-estree": "^3.1.3", "hast-util-to-jsx-runtime": "^2.3.6", "js-yaml": "^4.1.1", "mdast-util-mdx": "^3.0.0", "mdast-util-to-markdown": "^2.1.2", "remark": "^15.0.1", "remark-gfm": "^4.0.1", "remark-rehype": "^11.1.2", "scroll-into-view-if-needed": "^3.1.0", "shiki": "^4.0.2", "tinyglobby": "^0.2.16", "unified": "^11.0.5", "unist-util-visit": "^5.1.0", "vfile": "^6.0.3" }, "peerDependencies": { "@mdx-js/mdx": "*", "@mixedbread/sdk": "0.x.x", "@orama/core": "1.x.x", "@oramacloud/client": "2.x.x", "@tanstack/react-router": "1.x.x", "@types/estree-jsx": "*", "@types/hast": "*", "@types/mdast": "*", "@types/react": "*", "algoliasearch": "5.x.x", "flexsearch": "*", "lucide-react": "*", "next": "16.x.x", "react": "^19.2.0", "react-dom": "^19.2.0", "react-router": "7.x.x", "waku": "^0.26.0 || ^0.27.0 || ^1.0.0", "zod": "4.x.x" }, "optionalPeers": ["@mdx-js/mdx", "@mixedbread/sdk", "@orama/core", "@oramacloud/client", "@tanstack/react-router", "@types/estree-jsx", "@types/hast", "@types/mdast", "@types/react", "algoliasearch", "flexsearch", "lucide-react", "next", "react", "react-dom", "react-router", "waku", "zod"] }, "sha512-y7awKyp4PwA2fGCsa/9z7a6/SlhAIABV9B/kmUAy9NlM+eo1Lm3P0A+Bcs7R36YsVsJd9tqiVuExbpLQ7n01Jw=="],
 
     "fumadocs-mdx": ["fumadocs-mdx@14.3.2", "", { "dependencies": { "@mdx-js/mdx": "^3.1.1", "@standard-schema/spec": "^1.1.0", "chokidar": "^5.0.0", "esbuild": "^0.28.0", "estree-util-value-to-estree": "^3.5.0", "js-yaml": "^4.1.1", "mdast-util-mdx": "^3.0.0", "mdast-util-to-markdown": "^2.1.2", "picocolors": "^1.1.1", "picomatch": "^4.0.4", "tinyexec": "^1.1.1", "tinyglobby": "^0.2.16", "unified": "^11.0.5", "unist-util-remove-position": "^5.0.0", "unist-util-visit": "^5.1.0", "vfile": "^6.0.3", "zod": "^4.3.6" }, "peerDependencies": { "@types/mdast": "*", "@types/mdx": "*", "@types/react": "*", "fumadocs-core": "^15.0.0 || ^16.0.0", "mdast-util-directive": "*", "next": "^15.3.0 || ^16.0.0", "react": "^19.2.0", "vite": "6.x.x || 7.x.x || 8.x.x" }, "optionalPeers": ["@types/mdast", "@types/mdx", "@types/react", "mdast-util-directive", "next", "react", "vite"], "bin": { "fumadocs-mdx": "dist/bin.js" } }, "sha512-73SoZkbUuqnD91G/0zBcaQdM1TMnYw5JJzKgkGvQTiZbtLQFuWTt8/uRqnzFMuNIUu/WY9Lo9d1iZ8G+jOVieA=="],
+
+    "fumadocs-openapi": ["fumadocs-openapi@10.8.1", "", { "dependencies": { "@fumari/json-schema-ts": "^0.0.2", "@fumari/stf": "1.0.5", "@radix-ui/react-accordion": "^1.2.12", "@radix-ui/react-dialog": "^1.1.15", "@radix-ui/react-select": "^2.2.6", "@radix-ui/react-slot": "^1.2.4", "ajv": "^8.20.0", "chokidar": "^5.0.0", "class-variance-authority": "^0.7.1", "github-slugger": "^2.0.0", "hast-util-to-jsx-runtime": "^2.3.6", "js-yaml": "^4.1.1", "lucide-react": "^1.11.0", "remark": "^15.0.1", "remark-rehype": "^11.1.2", "shiki": "^4.0.2", "tailwind-merge": "^3.5.0", "xml-js": "^1.6.11" }, "peerDependencies": { "@scalar/api-client-react": "2.0.1", "@types/react": "*", "fumadocs-core": "^16.7.15", "fumadocs-ui": "^16.7.15", "json-schema-typed": "*", "react": "^19.2.0", "react-dom": "^19.2.0" }, "optionalPeers": ["@scalar/api-client-react", "@types/react", "json-schema-typed"] }, "sha512-pImxrxlqTqalD6tfDs2qEtngyM9W1zs0n+xpZ8rKw02pe0unVY8nHlFDGqlW54db8fxlNUC7y0tTa7IbB6gcKQ=="],
 
     "fumadocs-ui": ["fumadocs-ui@16.8.7", "", { "dependencies": { "@fumadocs/tailwind": "0.0.5", "@radix-ui/react-accordion": "^1.2.12", "@radix-ui/react-collapsible": "^1.1.12", "@radix-ui/react-dialog": "^1.1.15", "@radix-ui/react-direction": "^1.1.1", "@radix-ui/react-navigation-menu": "^1.2.14", "@radix-ui/react-popover": "^1.1.15", "@radix-ui/react-presence": "^1.1.5", "@radix-ui/react-scroll-area": "^1.2.10", "@radix-ui/react-slot": "^1.2.4", "@radix-ui/react-tabs": "^1.1.13", "class-variance-authority": "^0.7.1", "lucide-react": "^1.14.0", "motion": "^12.38.0", "next-themes": "^0.4.6", "react-remove-scroll": "^2.7.2", "rehype-raw": "^7.0.0", "scroll-into-view-if-needed": "^3.1.0", "shiki": "^4.0.2", "tailwind-merge": "^3.5.0", "unist-util-visit": "^5.1.0" }, "peerDependencies": { "@takumi-rs/image-response": "*", "@types/mdx": "*", "@types/react": "*", "fumadocs-core": "16.8.7", "next": "16.x.x", "react": "^19.2.0", "react-dom": "^19.2.0" }, "optionalPeers": ["@takumi-rs/image-response", "@types/mdx", "@types/react", "next"] }, "sha512-ICTA2y+R++f8UKF3RL6mT3jCk6l7F5wpfuPV5dc7VRWNGxeFeiEwHdqo6Zb51HTjt1jDc7PQ1/T8I+gwPniU8g=="],
 
@@ -1148,6 +1162,8 @@
 
     "remark-stringify": ["remark-stringify@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-to-markdown": "^2.0.0", "unified": "^11.0.0" } }, "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw=="],
 
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
     "resolve": ["resolve@2.0.0-next.6", "", { "dependencies": { "es-errors": "^1.3.0", "is-core-module": "^2.16.1", "node-exports-info": "^1.6.0", "object-keys": "^1.1.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA=="],
 
     "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
@@ -1161,6 +1177,8 @@
     "safe-push-apply": ["safe-push-apply@1.0.0", "", { "dependencies": { "es-errors": "^1.3.0", "isarray": "^2.0.5" } }, "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA=="],
 
     "safe-regex-test": ["safe-regex-test@1.1.0", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "is-regex": "^1.2.1" } }, "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw=="],
+
+    "sax": ["sax@1.6.0", "", {}, "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA=="],
 
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
@@ -1310,6 +1328,8 @@
 
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
+    "xml-js": ["xml-js@1.6.11", "", { "dependencies": { "sax": "^1.2.4" }, "bin": { "xml-js": "./bin/cli.js" } }, "sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g=="],
+
     "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
@@ -1331,6 +1351,8 @@
     "@radix-ui/react-popover/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
     "@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
+
+    "@radix-ui/react-select/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" }, "bundled": true }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
 
@@ -1362,6 +1384,8 @@
 
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
+    "fumadocs-openapi/ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
+
     "is-bun-module/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "mdast-util-find-and-replace/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
@@ -1379,6 +1403,8 @@
     "eslint-plugin-jsx-a11y/minimatch/brace-expansion": ["brace-expansion@1.1.14", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g=="],
 
     "eslint-plugin-react/minimatch/brace-expansion": ["brace-expansion@1.1.14", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g=="],
+
+    "fumadocs-openapi/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "eslint-plugin-import/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 

--- a/docs-site/content/docs/en/reference/meta.json
+++ b/docs-site/content/docs/en/reference/meta.json
@@ -2,5 +2,5 @@
   "title": "Reference",
   "icon": "Wrench",
   "defaultOpen": true,
-  "pages": ["cli"]
+  "pages": ["cli", "mobile-api"]
 }

--- a/docs-site/content/docs/en/reference/mobile-api.mdx
+++ b/docs-site/content/docs/en/reference/mobile-api.mdx
@@ -1,0 +1,28 @@
+---
+title: Mobile LAN API
+description: SyncClipboard-compatible HTTP endpoints exposed by the desktop daemon for mobile clients.
+---
+
+The desktop daemon exposes a small SyncClipboard-compatible HTTP service on the
+LAN so a paired mobile device — iOS Shortcuts, Android, or any third-party
+SyncClipboard client — can read and push clipboard items.
+
+All endpoints are mounted at the **root path** (`/SyncClipboard.json`,
+`/file/{dataName}`) and require **HTTP Basic Authentication**. Credentials are
+minted on the desktop side during pairing and are bound to a single registered
+device.
+
+For setup, see [Pairing](../guides/pairing) and the SyncClipboard tab in the
+mobile clients section.
+
+<APIPage
+  document="./openapi/mobile-lan.yaml"
+  operations={[
+    { path: '/SyncClipboard.json', method: 'get' },
+    { path: '/SyncClipboard.json', method: 'put' },
+    { path: '/file/{dataName}', method: 'get' },
+    { path: '/file/{dataName}', method: 'put' }
+  ]}
+  showTitle
+  showDescription
+/>

--- a/docs-site/content/docs/en/reference/mobile-api.mdx
+++ b/docs-site/content/docs/en/reference/mobile-api.mdx
@@ -21,7 +21,7 @@ mobile clients section.
     { path: '/SyncClipboard.json', method: 'get' },
     { path: '/SyncClipboard.json', method: 'put' },
     { path: '/file/{dataName}', method: 'get' },
-    { path: '/file/{dataName}', method: 'put' }
+    { path: '/file/{dataName}', method: 'put' },
   ]}
   showTitle
   showDescription

--- a/docs-site/content/docs/zh/reference/meta.json
+++ b/docs-site/content/docs/zh/reference/meta.json
@@ -2,5 +2,5 @@
   "title": "参考",
   "icon": "Wrench",
   "defaultOpen": true,
-  "pages": ["cli"]
+  "pages": ["cli", "mobile-api"]
 }

--- a/docs-site/content/docs/zh/reference/mobile-api.mdx
+++ b/docs-site/content/docs/zh/reference/mobile-api.mdx
@@ -19,7 +19,7 @@ description: 桌面守护进程对外暴露的、SyncClipboard 兼容的 HTTP �
     { path: '/SyncClipboard.json', method: 'get' },
     { path: '/SyncClipboard.json', method: 'put' },
     { path: '/file/{dataName}', method: 'get' },
-    { path: '/file/{dataName}', method: 'put' }
+    { path: '/file/{dataName}', method: 'put' },
   ]}
   showTitle
   showDescription

--- a/docs-site/content/docs/zh/reference/mobile-api.mdx
+++ b/docs-site/content/docs/zh/reference/mobile-api.mdx
@@ -1,0 +1,26 @@
+---
+title: 移动端 LAN API
+description: 桌面守护进程对外暴露的、SyncClipboard 兼容的 HTTP 接口，供移动端客户端使用。
+---
+
+桌面守护进程在 LAN 上提供一个体量很小、与 SyncClipboard 协议兼容的 HTTP 服务，
+让已配对的移动设备 —— iOS 快捷指令、Android 或任意第三方 SyncClipboard
+客户端 —— 都可以读取与推送剪贴板内容。
+
+所有接口都挂在**根路径**（`/SyncClipboard.json`、`/file/{dataName}`），并通过
+**HTTP Basic 认证**校验。用户名 / 密码由桌面端在配对流程中签发，且与一台
+已登记的移动设备一一绑定。
+
+配对流程见 [配对](../guides/pairing)，以及移动端客户端章节中的 SyncClipboard 标签。
+
+<APIPage
+  document="./openapi/mobile-lan.yaml"
+  operations={[
+    { path: '/SyncClipboard.json', method: 'get' },
+    { path: '/SyncClipboard.json', method: 'put' },
+    { path: '/file/{dataName}', method: 'get' },
+    { path: '/file/{dataName}', method: 'put' }
+  ]}
+  showTitle
+  showDescription
+/>

--- a/docs-site/openapi/mobile-lan.yaml
+++ b/docs-site/openapi/mobile-lan.yaml
@@ -1,0 +1,269 @@
+openapi: 3.1.0
+info:
+  title: UniClipboard Mobile LAN API
+  version: '1.0.0'
+  summary: SyncClipboard-compatible LAN endpoints exposed by the desktop daemon.
+  description: |
+    The desktop daemon exposes a small SyncClipboard-compatible HTTP service on the
+    LAN so a paired mobile client (iOS Shortcuts, Android, or any SyncClipboard
+    client) can read and push clipboard items.
+
+    All requests require **HTTP Basic Authentication**. Credentials are minted on the
+    desktop side when the user pairs a mobile device — username and password are
+    bound to a single registered device. Unauthenticated or wrong-credential
+    requests get `401 Unauthorized` with `WWW-Authenticate: Basic`.
+
+    The wire format follows the SyncClipboard project's JSON schema. Field casing
+    is fixed by that protocol; the desktop also accepts PascalCase aliases on
+    the request side because iOS Shortcuts emits `Type` (PascalCase) for the
+    `type` field while the rest of the body is camelCase.
+
+    Maximum request body size for both `PUT` endpoints is **16 MiB**.
+  contact:
+    name: UniClipboard
+    url: https://github.com/mkdir700/uniclipboard
+servers:
+  - url: http://{host}:{port}
+    description: Desktop daemon on the LAN
+    variables:
+      host:
+        default: 192.168.1.10
+        description: LAN IP of the desktop running UniClipboard
+      port:
+        default: '12700'
+        description: Port the daemon advertised during pairing
+tags:
+  - name: Clipboard
+    description: Clipboard metadata read/write (SyncClipboard JSON document).
+  - name: File
+    description: Binary payload transfer for image and file clipboard items.
+security:
+  - basicAuth: []
+paths:
+  /SyncClipboard.json:
+    get:
+      tags: [Clipboard]
+      operationId: getSyncClipboard
+      summary: Fetch the latest clipboard item
+      description: |
+        Returns the most recent clipboard entry on the desktop, translated into
+        the SyncClipboard wire DTO. For Image / File items, the binary payload
+        is fetched separately via `GET /file/{dataName}`.
+      responses:
+        '200':
+          description: Latest clipboard entry exists.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SyncClipboardDoc'
+              examples:
+                text:
+                  summary: Text clipboard
+                  value:
+                    type: Text
+                    text: hello from desktop
+                    hasData: false
+                    size: 18
+                    hash: 2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824
+                image:
+                  summary: Image clipboard
+                  value:
+                    type: Image
+                    text: ''
+                    dataName: clipboard.png
+                    hasData: true
+                    size: 142536
+                    hash: 9b2cf964fa8c0b5a...
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          description: No clipboard entry on the desktop yet.
+        '500':
+          description: Clipboard snapshot port failure on the desktop.
+    put:
+      tags: [Clipboard]
+      operationId: putSyncClipboard
+      summary: Push a clipboard item from the mobile device
+      description: |
+        Accepts a SyncClipboard wire DTO. The body is decoded, mapped into the
+        application model, and applied through the inbound apply pipeline as if
+        it came from a peer device.
+
+        Both camelCase and PascalCase keys are accepted (`Type`, `HasData`,
+        `DataName`, …) because the iOS Shortcuts client emits a mixed-case body.
+
+        Decode failure produces `400 Bad Request`; payloads larger than 16 MiB
+        produce `413 Payload Too Large`.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SyncClipboardDoc'
+            examples:
+              text:
+                summary: Push plain text
+                value:
+                  type: Text
+                  text: hello from phone
+                  hasData: false
+                  size: 16
+              file:
+                summary: Push file metadata (PascalCase as emitted by iOS Shortcuts)
+                value:
+                  hasData: true
+                  Type: File
+                  dataName: foo.pdf
+                  text: foo.pdf
+      responses:
+        '200':
+          description: Applied. Body is intentionally empty — SyncClipboard clients only check status.
+        '400':
+          description: Body could not be parsed as a SyncClipboard document or `type` value is unknown.
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '413':
+          description: Body exceeds 16 MiB.
+        '500':
+          description: Inbound apply pipeline failure on the desktop.
+  /file/{dataName}:
+    parameters:
+      - name: dataName
+        in: path
+        required: true
+        description: |
+          Filename advertised by the matching `SyncClipboard.json` document.
+          Used to look up the staged payload for Image / File clipboard items.
+        schema:
+          type: string
+        example: clipboard.png
+    get:
+      tags: [File]
+      operationId: getClipboardFile
+      summary: Download the binary payload for a clipboard item
+      description: |
+        Returns the raw bytes of the most recent Image / File clipboard entry
+        whose `dataName` matches. The `Content-Type` header reflects the
+        sniffed MIME type.
+      responses:
+        '200':
+          description: |
+            Binary payload for the requested file. The actual `Content-Type`
+            response header reflects the sniffed MIME (e.g. `image/png`,
+            `image/jpeg`, …) and not necessarily `application/octet-stream`.
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          description: No clipboard entry matched `dataName`, or its staged payload is gone.
+        '500':
+          description: Snapshot port failure or staging I/O failure on the desktop.
+    put:
+      tags: [File]
+      operationId: putClipboardFile
+      summary: Upload a binary payload to stage as a clipboard item
+      description: |
+        Accepts the raw bytes of an image or file. The desktop stages the bytes
+        into the inbound mobile buffer, where they will be paired with a
+        subsequent `PUT /SyncClipboard.json` describing the same `dataName`.
+
+        ### MIME handling
+
+        Some clients (notably iOS Shortcuts uploading `.jpg` / `.png`) send
+        `application/octet-stream` or omit `Content-Type`. The desktop sniffs
+        the file's magic bytes (and falls back to the extension) to recover an
+        accurate `image/*` MIME so macOS NSPasteboard can render the image
+        correctly. If the sniff fails, the original `Content-Type` is kept.
+
+        Recognised image magics: JPEG, PNG, GIF, WEBP, BMP, TIFF.
+
+        Maximum body size is 16 MiB.
+      requestBody:
+        required: true
+        description: |
+          Raw bytes. Set `Content-Type` to the actual MIME of the upload
+          (`image/png`, `image/jpeg`, `application/pdf`, …) when known. If
+          `application/octet-stream` is sent for image uploads, the desktop
+          will sniff the magic bytes and recover the correct `image/*` MIME.
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+      responses:
+        '200':
+          description: Bytes accepted and staged.
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '413':
+          description: Body exceeds 16 MiB.
+        '500':
+          description: Inbound apply pipeline failure on the desktop.
+components:
+  securitySchemes:
+    basicAuth:
+      type: http
+      scheme: basic
+      description: |
+        Username and password are minted on the desktop during device pairing
+        and are bound to a single mobile device record.
+  responses:
+    Unauthorized:
+      description: |
+        Missing, malformed, or wrong Basic credentials. The response carries
+        `WWW-Authenticate: Basic`.
+      headers:
+        WWW-Authenticate:
+          schema:
+            type: string
+            example: 'Basic realm="UniClipboard"'
+  schemas:
+    SyncClipboardDoc:
+      type: object
+      description: |
+        SyncClipboard wire DTO. Field casing is fixed by the SyncClipboard
+        project's protocol: the value of `type` is PascalCase, all keys are
+        camelCase. On the request side the desktop also accepts PascalCase
+        aliases (`Type`, `Text`, `DataName`, `HasData`, `Size`, `Hash`).
+      required: [type, hasData, size]
+      properties:
+        type:
+          description: Item kind. PascalCase by SyncClipboard convention.
+          type: string
+          enum: [Text, Image, File, Group]
+        text:
+          description: |
+            For Text items, the clipboard text. For Image / File items, this
+            field is typically the displayed filename or empty.
+          type: string
+          default: ''
+        dataName:
+          description: |
+            Filename associated with the binary payload. Required for Image /
+            File items, omitted for plain Text.
+          type: string
+          nullable: true
+        hasData:
+          description: |
+            True iff a binary payload accompanies this entry (i.e. an Image or
+            File item with bytes available via `/file/{dataName}`).
+          type: boolean
+          default: false
+        size:
+          description: Size in bytes of the binary payload (0 for plain Text).
+          type: integer
+          format: int64
+          minimum: 0
+          default: 0
+        hash:
+          description: |
+            SHA-256 hex digest of the wire content. Mobile clients may omit it
+            on `PUT`; the desktop fills it in on `GET` for SyncClipboard
+            desktop-client compatibility.
+          type: string
+          nullable: true
+          example: 2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -15,11 +15,13 @@
     "@orama/tokenizers": "^3.1.18",
     "fumadocs-core": "16.8.7",
     "fumadocs-mdx": "14.3.2",
+    "fumadocs-openapi": "^10.8.1",
     "fumadocs-ui": "16.8.7",
     "lucide-react": "^1.14.0",
     "next": "16.2.4",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
+    "shiki": "^4.0.2",
     "tailwind-merge": "^3.5.0"
   },
   "devDependencies": {

--- a/docs-site/src/app/global.css
+++ b/docs-site/src/app/global.css
@@ -1,7 +1,9 @@
 @import 'tailwindcss';
 @import 'fumadocs-ui/css/neutral.css';
 @import 'fumadocs-ui/css/preset.css';
+@import 'fumadocs-openapi/css/preset.css';
 @source '../../node_modules/fumadocs-ui/dist/**/*.js';
+@source '../../node_modules/fumadocs-openapi/dist/**/*.js';
 
 /* Mirror uc-website tokens (Manrope + Linear/Vercel-minimal palette). */
 :root {

--- a/docs-site/src/components/api-page.tsx
+++ b/docs-site/src/components/api-page.tsx
@@ -1,0 +1,4 @@
+import { createAPIPage } from 'fumadocs-openapi/ui'
+import { openapi } from '@/lib/openapi'
+
+export const APIPage = createAPIPage(openapi)

--- a/docs-site/src/components/mdx.tsx
+++ b/docs-site/src/components/mdx.tsx
@@ -1,9 +1,11 @@
 import defaultMdxComponents from 'fumadocs-ui/mdx'
 import type { MDXComponents } from 'mdx/types'
+import { APIPage } from '@/components/api-page'
 
 export function getMDXComponents(components?: MDXComponents) {
   return {
     ...defaultMdxComponents,
+    APIPage,
     ...components,
   } satisfies MDXComponents
 }

--- a/docs-site/src/lib/openapi.ts
+++ b/docs-site/src/lib/openapi.ts
@@ -1,0 +1,5 @@
+import { createOpenAPI } from 'fumadocs-openapi/server'
+
+export const openapi = createOpenAPI({
+  input: ['./openapi/mobile-lan.yaml'],
+})


### PR DESCRIPTION
## Summary

- Add an OpenAPI 3.1 spec (`docs-site/openapi/mobile-lan.yaml`) covering the four SyncClipboard-compatible LAN endpoints (`GET`/`PUT /SyncClipboard.json`, `GET`/`PUT /file/{dataName}`) — Basic Auth, `SyncClipboardDoc` schema, PascalCase aliases, 16 MiB cap, MIME-sniffing notes
- Wire `fumadocs-openapi` (+ `shiki`) into the docs-site: `lib/openapi.ts`, `components/api-page.tsx`, MDX components, Tailwind preset import
- Ship en + zh reference pages at `reference/mobile-api` rendering the spec via `<APIPage>`, plus `meta.json` updates

## Test plan

- [x] `bun run check:docs` (en/zh mirror + anchor check)
- [x] `bun run types:check`
- [x] `bun run build` (84/84 static pages, includes /en|zh/reference/mobile-api)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Mobile LAN API documentation available in English and Chinese
  * Includes interactive API reference with endpoint specifications for clipboard synchronization over LAN
  * Documents HTTP Basic Authentication requirements and available operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->