### PR TITLE
feat(mobile-sync): show username and add device password rotation

### DIFF
--- a/src-tauri/crates/uc-application/src/facade/mobile_sync/facade.rs
+++ b/src-tauri/crates/uc-application/src/facade/mobile_sync/facade.rs
@@ -12,7 +12,8 @@
 //! |---|---|---|
 //! | [`MobileSyncFacade::register_device`] | `RegisterMobileShortcutDeviceUseCase` | 颁发 (username,password) + 渲染 install URL 二维码 |
 //! | [`MobileSyncFacade::revoke_device`] | `RevokeMobileDeviceUseCase` | 注销已登记设备 |
-//! | [`MobileSyncFacade::list_devices`] | `ListMobileDevicesUseCase` | 列出已登记设备(不含 password_hash / username) |
+//! | [`MobileSyncFacade::list_devices`] | `ListMobileDevicesUseCase` | 列出已登记设备(不含 password_hash) |
+//! | [`MobileSyncFacade::rotate_password`] | `RotateMobilePasswordUseCase` | 给已登记设备换一份新密码(返回一次性明文) |
 //! | [`MobileSyncFacade::get_settings`] | `GetMobileSyncSettingsUseCase` | 读 enabled + LAN URL + install methods |
 //! | [`MobileSyncFacade::update_settings`] | `UpdateMobileSyncSettingsUseCase` | 写 enabled, 返回 restart_required |
 //! | [`MobileSyncFacade::list_lan_interfaces`] | `ListLanInterfacesUseCase` | 列出可作为二维码 URL 的 RFC1918 网卡 |
@@ -56,7 +57,7 @@ use crate::usecases::mobile_sync::{
     latest_snapshot_adapter::LatestClipboardSnapshotAdapter,
     list_devices::ListMobileDevicesUseCase, list_lan_interfaces::ListLanInterfacesUseCase,
     register_device::RegisterMobileShortcutDeviceUseCase, revoke_device::RevokeMobileDeviceUseCase,
-    update_settings::UpdateMobileSyncSettingsUseCase,
+    rotate_password::RotateMobilePasswordUseCase, update_settings::UpdateMobileSyncSettingsUseCase,
 };
 
 // ── 对外类型 re-export ─────────────────────────────────────────────────
@@ -90,6 +91,9 @@ pub use crate::usecases::mobile_sync::register_device::{
 pub use crate::usecases::mobile_sync::register_device::SYNC_CLIPBOARD_EX_INSTALL_URL;
 pub use crate::usecases::mobile_sync::revoke_device::{
     RevokeMobileDeviceError, RevokeMobileDeviceInput,
+};
+pub use crate::usecases::mobile_sync::rotate_password::{
+    RotateMobilePasswordError, RotateMobilePasswordInput, RotateMobilePasswordOutput,
 };
 pub use crate::usecases::mobile_sync::update_settings::{
     UpdateMobileSyncSettingsError, UpdateMobileSyncSettingsInput, UpdateMobileSyncSettingsOutput,
@@ -138,6 +142,7 @@ pub struct MobileSyncFacade {
     register_device: RegisterMobileShortcutDeviceUseCase,
     revoke_device: RevokeMobileDeviceUseCase,
     list_devices: ListMobileDevicesUseCase,
+    rotate_password: RotateMobilePasswordUseCase,
     get_settings: GetMobileSyncSettingsUseCase,
     update_settings: UpdateMobileSyncSettingsUseCase,
     list_lan_interfaces: ListLanInterfacesUseCase,
@@ -170,7 +175,7 @@ impl MobileSyncFacade {
 
         Self {
             register_device: RegisterMobileShortcutDeviceUseCase::new(
-                credentials_minter,
+                credentials_minter.clone(),
                 password_hasher.clone(),
                 device_repo.clone(),
                 settings.clone(),
@@ -179,6 +184,11 @@ impl MobileSyncFacade {
             ),
             revoke_device: RevokeMobileDeviceUseCase::new(device_repo.clone()),
             list_devices: ListMobileDevicesUseCase::new(device_repo.clone()),
+            rotate_password: RotateMobilePasswordUseCase::new(
+                device_repo.clone(),
+                password_hasher.clone(),
+                credentials_minter,
+            ),
             get_settings: GetMobileSyncSettingsUseCase::new(settings.clone(), endpoint_info),
             update_settings: UpdateMobileSyncSettingsUseCase::new(settings),
             list_lan_interfaces: ListLanInterfacesUseCase::new(lan_interface_probe),
@@ -214,9 +224,21 @@ impl MobileSyncFacade {
     }
 
     /// 列出已登记设备摘要。结果按"最近活跃 desc → 创建时间 desc"排序,
-    /// 不包含 `password_hash` / `username`。
+    /// 不包含 `password_hash`(`username` 透传给 UI 作为辅助识别字段)。
     pub async fn list_devices(&self) -> Result<Vec<MobileDeviceSummary>, ListMobileDevicesError> {
         self.list_devices.execute().await
+    }
+
+    /// 给一台已登记设备换一份新密码。`input.password = None` 走 minter 自动
+    /// 颁发;`Some(p)` 走自定义路径(校验长度)。返回值的 `password` 字段是
+    /// **唯一一次**面向用户的明文回显, 之后只以 PHC 形式存在于服务端 sqlite。
+    /// 旧密码立即失效,UI 必须提示用户同步更新 iPhone shortcut 里的 password
+    /// 字段, 否则下次同步将收到 401。
+    pub async fn rotate_password(
+        &self,
+        input: RotateMobilePasswordInput,
+    ) -> Result<RotateMobilePasswordOutput, RotateMobilePasswordError> {
+        self.rotate_password.execute(input).await
     }
 
     /// 读移动端同步设置 + 当前 LAN URL + 可用 install methods 的合成视图。
@@ -432,6 +454,20 @@ mod tests {
             _: Option<String>,
         ) -> Result<(), MobileDeviceError> {
             Ok(())
+        }
+        async fn update_password_hash(
+            &self,
+            id: &MobileDeviceId,
+            new_hash: String,
+        ) -> Result<bool, MobileDeviceError> {
+            let mut devs = self.devices.lock().unwrap();
+            match devs.iter_mut().find(|d| d.device_id == *id) {
+                Some(d) => {
+                    d.password_hash = new_hash;
+                    Ok(true)
+                }
+                None => Ok(false),
+            }
         }
     }
 
@@ -840,5 +876,111 @@ mod tests {
             err,
             AuthenticateBasicAuthError::InvalidCredentials
         ));
+    }
+
+    #[tokio::test]
+    async fn rotate_password_invalidates_old_password_and_keeps_username() {
+        // 端到端验证:rotate 之后旧密码 401, 新密码 200, username/device_id
+        // 不变。把整条 register → rotate → authenticate 链路串起来跑。
+        let direct_device = MobileDevice {
+            device_id: MobileDeviceId::new("did_rot"),
+            label: "iPhone".into(),
+            client_type: uc_core::mobile_sync::MobileClientType::IosShortcut,
+            username: "mobile_rotme".into(),
+            password_hash: "phc:original-pass".into(),
+            created_at_ms: 1,
+            last_seen_at_ms: None,
+            last_seen_ip: None,
+            reported_name: None,
+            reported_os: None,
+        };
+        let repo = Arc::new(InMemoryDeviceRepo::default());
+        repo.save(&direct_device).await.unwrap();
+
+        let entry_repo: Arc<dyn ClipboardEntryRepositoryPort> = Arc::new(UnusedEntryRepo);
+        let apply_inbound = Arc::new(ApplyInboundClipboardUseCase::new(
+            entry_repo.clone(),
+            Arc::new(UnusedCapture),
+            Arc::new(UnusedWrite),
+        ));
+
+        let facade = MobileSyncFacade::new(MobileSyncFacadeDeps {
+            clock: Arc::new(FixedClock(1_000)),
+            credentials_minter: Arc::new(StaticMinter),
+            password_hasher: Arc::new(FakeHasher),
+            device_repo: repo.clone(),
+            endpoint_info: Arc::new(FixedEndpoint),
+            lan_interface_probe: Arc::new(StubLanProbe),
+            settings: Arc::new(InMemorySettings::default()),
+            apply_inbound,
+            incoming_buffer: Arc::new(IncomingMobileBuffer::new()),
+            file_staging: Arc::new(UnusedStaging),
+            snapshot_ports: MobileSyncSnapshotPorts {
+                entry_repo,
+                selection_repo: Arc::new(UnusedSelectionRepo),
+                representation_repo: Arc::new(UnusedRepRepo),
+                payload_resolver: Arc::new(UnusedResolver),
+                blob_reader: Arc::new(UnusedBlobReader),
+            },
+        });
+
+        // 1. 旧密码可用
+        let old_header = format!(
+            "basic {}",
+            base64::engine::general_purpose::STANDARD.encode("mobile_rotme:original-pass")
+        );
+        facade
+            .authenticate_basic(AuthenticateBasicAuthInput {
+                authorization_header: old_header.clone(),
+            })
+            .await
+            .expect("old password ok before rotate");
+
+        // 2. rotate 到自定义新密码
+        let out = facade
+            .rotate_password(RotateMobilePasswordInput {
+                device_id: MobileDeviceId::new("did_rot"),
+                password: Some("brand-new-pass".into()),
+            })
+            .await
+            .expect("rotate ok");
+        assert_eq!(out.username, "mobile_rotme");
+        assert_eq!(out.password, "brand-new-pass");
+        assert_eq!(out.device_id.as_str(), "did_rot");
+
+        // 3. 旧密码立即失效
+        let err = facade
+            .authenticate_basic(AuthenticateBasicAuthInput {
+                authorization_header: old_header,
+            })
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            AuthenticateBasicAuthError::InvalidCredentials
+        ));
+
+        // 4. 新密码可用
+        let new_header = format!(
+            "basic {}",
+            base64::engine::general_purpose::STANDARD.encode("mobile_rotme:brand-new-pass")
+        );
+        let auth = facade
+            .authenticate_basic(AuthenticateBasicAuthInput {
+                authorization_header: new_header,
+            })
+            .await
+            .expect("new password ok after rotate");
+        assert_eq!(auth.device.username, "mobile_rotme");
+
+        // 5. rotate 不存在的 device → NotFound
+        let err = facade
+            .rotate_password(RotateMobilePasswordInput {
+                device_id: MobileDeviceId::new("did_ghost"),
+                password: None,
+            })
+            .await
+            .unwrap_err();
+        assert!(matches!(err, RotateMobilePasswordError::NotFound(_)));
     }
 }

--- a/src-tauri/crates/uc-application/src/facade/mobile_sync/mod.rs
+++ b/src-tauri/crates/uc-application/src/facade/mobile_sync/mod.rs
@@ -19,6 +19,7 @@ pub use facade::{
     MobileSyncFacadeDeps, MobileSyncSettingsView, MobileSyncSnapshotPorts,
     RegisterMobileShortcutDeviceError, RegisterMobileShortcutDeviceInput,
     RegisterMobileShortcutDeviceOutput, RevokeMobileDeviceError, RevokeMobileDeviceInput,
+    RotateMobilePasswordError, RotateMobilePasswordInput, RotateMobilePasswordOutput,
     ShortcutInstallMethod, ShortcutInstallMethodOption, SyncClipboardItemType, SyncClipboardMeta,
     UpdateMobileSyncSettingsError, UpdateMobileSyncSettingsInput, UpdateMobileSyncSettingsOutput,
     SYNC_CLIPBOARD_EX_INSTALL_URL,

--- a/src-tauri/crates/uc-application/src/usecases/mobile_sync/authenticate_basic.rs
+++ b/src-tauri/crates/uc-application/src/usecases/mobile_sync/authenticate_basic.rs
@@ -207,11 +207,50 @@ fn translate_device_error(err: MobileDeviceError) -> AuthenticateBasicAuthError 
 mod tests {
     use super::*;
 
-    use std::sync::Mutex;
-
     use async_trait::async_trait;
 
     use uc_core::mobile_sync::{MobileClientType, MobileDeviceId};
+
+    mockall::mock! {
+        DeviceRepo {}
+        #[async_trait]
+        impl MobileDeviceRepositoryPort for DeviceRepo {
+            async fn save(&self, device: &MobileDevice) -> Result<(), MobileDeviceError>;
+            async fn find_by_username(
+                &self,
+                username: &str,
+            ) -> Result<Option<MobileDevice>, MobileDeviceError>;
+            async fn find_by_device_id(
+                &self,
+                device_id: &MobileDeviceId,
+            ) -> Result<Option<MobileDevice>, MobileDeviceError>;
+            async fn list_all(&self) -> Result<Vec<MobileDevice>, MobileDeviceError>;
+            async fn delete(&self, device_id: &MobileDeviceId) -> Result<bool, MobileDeviceError>;
+            async fn record_activity(
+                &self,
+                device_id: &MobileDeviceId,
+                last_seen_at_ms: i64,
+                last_seen_ip: Option<String>,
+                reported_name: Option<String>,
+                reported_os: Option<String>,
+            ) -> Result<(), MobileDeviceError>;
+            async fn update_password_hash(
+                &self,
+                device_id: &MobileDeviceId,
+                new_password_hash: String,
+            ) -> Result<bool, MobileDeviceError>;
+        }
+    }
+
+    mockall::mock! {
+        Hasher {}
+        #[async_trait]
+        impl PasswordHasherPort for Hasher {
+            async fn hash(&self, password: &str) -> Result<String, PasswordHasherError>;
+            async fn verify(&self, password: &str, phc: &str)
+                -> Result<bool, PasswordHasherError>;
+        }
+    }
 
     fn make_device(username: &str, phc: &str) -> MobileDevice {
         MobileDevice {
@@ -228,89 +267,33 @@ mod tests {
         }
     }
 
-    #[derive(Default)]
-    struct InMemoryRepo {
-        devices: Mutex<Vec<MobileDevice>>,
-        force_storage_err: bool,
-    }
-    #[async_trait]
-    impl MobileDeviceRepositoryPort for InMemoryRepo {
-        async fn save(&self, _: &MobileDevice) -> Result<(), MobileDeviceError> {
-            unreachable!("auth 不调用 save")
-        }
-        async fn find_by_username(
-            &self,
-            username: &str,
-        ) -> Result<Option<MobileDevice>, MobileDeviceError> {
-            if self.force_storage_err {
-                return Err(MobileDeviceError::Storage("disk gone".into()));
-            }
-            Ok(self
-                .devices
-                .lock()
-                .unwrap()
-                .iter()
-                .find(|d| d.username == username)
-                .cloned())
-        }
-        async fn find_by_device_id(
-            &self,
-            _: &MobileDeviceId,
-        ) -> Result<Option<MobileDevice>, MobileDeviceError> {
-            unreachable!("auth 不调用 find_by_device_id")
-        }
-        async fn list_all(&self) -> Result<Vec<MobileDevice>, MobileDeviceError> {
-            unreachable!("auth 不调用 list_all")
-        }
-        async fn delete(&self, _: &MobileDeviceId) -> Result<bool, MobileDeviceError> {
-            unreachable!("auth 不调用 delete")
-        }
-        async fn record_activity(
-            &self,
-            _: &MobileDeviceId,
-            _: i64,
-            _: Option<String>,
-            _: Option<String>,
-            _: Option<String>,
-        ) -> Result<(), MobileDeviceError> {
-            unreachable!("auth 不调用 record_activity")
-        }
+    /// 把 device 列表包装成 mock repo —— find_by_username 按 username 命中
+    /// 返回对应 device, 找不到返回 None。其它方法不设 expectation, 一旦被
+    /// 调用 mockall 会自动 panic。
+    fn repo_with(devices: Vec<MobileDevice>) -> MockDeviceRepo {
+        let mut repo = MockDeviceRepo::new();
+        repo.expect_find_by_username().returning(move |username| {
+            Ok(devices.iter().find(|d| d.username == username).cloned())
+        });
+        repo
     }
 
-    /// 极简 hasher: 用纯字符串相等模拟 verify, 让单测不真跑 Argon2。
-    /// 此 fake 把 "phc:plain" 视为该 plain 对应的 hash; verify 比较即可。
-    #[derive(Default)]
-    struct FakeHasher {
-        force_internal: bool,
-    }
-    #[async_trait]
-    impl PasswordHasherPort for FakeHasher {
-        async fn hash(&self, password: &str) -> Result<String, PasswordHasherError> {
-            if self.force_internal {
-                return Err(PasswordHasherError::Internal("forced".into()));
-            }
-            Ok(format!("phc:{password}"))
-        }
-        async fn verify(&self, password: &str, phc: &str) -> Result<bool, PasswordHasherError> {
-            if self.force_internal {
-                return Err(PasswordHasherError::Internal("forced".into()));
-            }
-            // 特殊值用来模拟 PHC 损坏。
+    /// "phc:<plain>" 形态的伪 hasher —— 不真跑 Argon2,但表达"密码与 PHC
+    /// 是否对应"的语义。verify 时 PHC == `format!("phc:{password}")` 即视
+    /// 为命中。
+    fn fake_hasher() -> MockHasher {
+        let mut h = MockHasher::new();
+        h.expect_verify().returning(|password, phc| {
             if phc == "PHC_BROKEN" {
                 return Err(PasswordHasherError::InvalidPhc("malformed".into()));
             }
             Ok(phc == format!("phc:{password}"))
-        }
+        });
+        h
     }
 
     fn build_uc(devices: Vec<MobileDevice>) -> AuthenticateBasicAuthUseCase {
-        AuthenticateBasicAuthUseCase::new(
-            Arc::new(InMemoryRepo {
-                devices: Mutex::new(devices),
-                force_storage_err: false,
-            }),
-            Arc::new(FakeHasher::default()),
-        )
+        AuthenticateBasicAuthUseCase::new(Arc::new(repo_with(devices)), Arc::new(fake_hasher()))
     }
 
     fn header_for(username: &str, password: &str) -> String {
@@ -379,7 +362,13 @@ mod tests {
 
     #[tokio::test]
     async fn rejects_malformed_header() {
-        let uc = build_uc(vec![]);
+        // 头解析失败时 use case 仍跑一次 dummy verify(防侧信道),所以
+        // hasher.verify 必须能被调用 —— 用 fake_hasher() 即可(任意输入
+        // 都返 Ok(false))。仓储**永远不该**在头坏时被查,断言 never。
+        let mut repo = MockDeviceRepo::new();
+        repo.expect_find_by_username().never();
+        let uc = AuthenticateBasicAuthUseCase::new(Arc::new(repo), Arc::new(fake_hasher()));
+
         for bad in [
             "",
             "basic",
@@ -419,13 +408,11 @@ mod tests {
 
     #[tokio::test]
     async fn translates_storage_error() {
-        let uc = AuthenticateBasicAuthUseCase::new(
-            Arc::new(InMemoryRepo {
-                devices: Mutex::new(vec![]),
-                force_storage_err: true,
-            }),
-            Arc::new(FakeHasher::default()),
-        );
+        let mut repo = MockDeviceRepo::new();
+        repo.expect_find_by_username()
+            .returning(|_| Err(MobileDeviceError::Storage("disk gone".into())));
+        let uc = AuthenticateBasicAuthUseCase::new(Arc::new(repo), Arc::new(fake_hasher()));
+
         let err = uc
             .execute(AuthenticateBasicAuthInput {
                 authorization_header: header_for("mobile_aaaa", "x"),
@@ -441,15 +428,13 @@ mod tests {
     #[tokio::test]
     async fn translates_hasher_internal_error() {
         let device = make_device("mobile_aaaa", "phc:hunter2");
-        let uc = AuthenticateBasicAuthUseCase::new(
-            Arc::new(InMemoryRepo {
-                devices: Mutex::new(vec![device]),
-                force_storage_err: false,
-            }),
-            Arc::new(FakeHasher {
-                force_internal: true,
-            }),
-        );
+        let mut hasher = MockHasher::new();
+        hasher
+            .expect_verify()
+            .returning(|_, _| Err(PasswordHasherError::Internal("forced".into())));
+
+        let uc =
+            AuthenticateBasicAuthUseCase::new(Arc::new(repo_with(vec![device])), Arc::new(hasher));
         let err = uc
             .execute(AuthenticateBasicAuthInput {
                 authorization_header: header_for("mobile_aaaa", "hunter2"),

--- a/src-tauri/crates/uc-application/src/usecases/mobile_sync/list_devices.rs
+++ b/src-tauri/crates/uc-application/src/usecases/mobile_sync/list_devices.rs
@@ -6,11 +6,12 @@
 //! 1. **不泄漏 `password_hash`**：core 层的 [`MobileDevice`] 含
 //!    `password_hash` 字段（`uc-core/src/mobile_sync/device.rs`），那是
 //!    server 端鉴权用的 Argon2id PHC。上层（前端 / CLI）一旦能看到 PHC 就
-//!    构成攻击面（暴露 KDF 参数 + salt + hash 给离线爆破）。`username` 也
-//!    一并不暴露 —— 用户在 SyncClipboard shortcut 里看到的 username 不需要
-//!    在桌面端列表里再展示一次, 设备列表只用 label / 最近活跃做识别。所以
-//!    use case 把这些都替换为应用层 view [`MobileDeviceSummary`], 仅暴露
-//!    面向用户展示需要的字段。
+//!    构成攻击面（暴露 KDF 参数 + salt + hash 给离线爆破）。`username` 则
+//!    透传给 view —— 用户希望在桌面设备列表上能直接看到该设备的登录账号
+//!    用作识别（与 label 互补：label 可改名重复, username 是 server 主键
+//!    级稳定的)，与 password_hash 那种"绝对不能出 application 层"的强约
+//!    束不同。所以 use case 把 password_hash 剥掉，其余字段（含 username）
+//!    一并落进应用层 view [`MobileDeviceSummary`]。
 //!
 //! 2. **排序由 use case 决定**：repository port 不承诺顺序（不同 adapter
 //!    自由实现），UI 期望"最近活跃在前，新登记在前"——这是应用语义而非
@@ -30,7 +31,7 @@ use uc_core::ports::MobileDeviceRepositoryPort;
 
 // ─── public-shaped (output / error) ─────────────────────────────────────
 
-/// UI / CLI 可消费的设备视图：去掉 `token_hash`，其余字段透传。
+/// UI / CLI 可消费的设备视图：去掉 `password_hash`，其余字段透传。
 ///
 /// 与 core 层 [`MobileDevice`] 是有意分离的两套类型 —— core 是真相、
 /// summary 是展示。它们形态相似但语义不同，未来 core 字段调整不应自动
@@ -40,6 +41,9 @@ pub struct MobileDeviceSummary {
     pub device_id: MobileDeviceId,
     pub label: String,
     pub client_type: MobileClientType,
+    /// 设备登录账号（Basic Auth 用户名）。展示给用户作为辅助识别 ——
+    /// label 可重命名重复，username 在 server 端是稳定主键。
+    pub username: String,
     pub created_at_ms: i64,
     pub last_seen_at_ms: Option<i64>,
     pub last_seen_ip: Option<String>,
@@ -53,11 +57,8 @@ impl MobileDeviceSummary {
             device_id,
             label,
             client_type,
-            // 故意丢弃 —— 这两个是 view 层的安全边界。
-            // username: 用户在 shortcut 客户端里管它就够了, 桌面端列表
-            //           不暴露(避免 UI 截图时被旁观者读到)。
-            // password_hash: Argon2id PHC, 永不出 application 层。
-            username: _,
+            username,
+            // 故意丢弃 —— Argon2id PHC，永不出 application 层。
             password_hash: _,
             created_at_ms,
             last_seen_at_ms,
@@ -69,6 +70,7 @@ impl MobileDeviceSummary {
             device_id,
             label,
             client_type,
+            username,
             created_at_ms,
             last_seen_at_ms,
             last_seen_ip,
@@ -144,9 +146,38 @@ fn translate_device_error(err: MobileDeviceError) -> ListMobileDevicesError {
 mod tests {
     use super::*;
 
-    use std::sync::Mutex;
-
     use async_trait::async_trait;
+
+    mockall::mock! {
+        DeviceRepo {}
+        #[async_trait]
+        impl MobileDeviceRepositoryPort for DeviceRepo {
+            async fn save(&self, device: &MobileDevice) -> Result<(), MobileDeviceError>;
+            async fn find_by_username(
+                &self,
+                username: &str,
+            ) -> Result<Option<MobileDevice>, MobileDeviceError>;
+            async fn find_by_device_id(
+                &self,
+                device_id: &MobileDeviceId,
+            ) -> Result<Option<MobileDevice>, MobileDeviceError>;
+            async fn list_all(&self) -> Result<Vec<MobileDevice>, MobileDeviceError>;
+            async fn delete(&self, device_id: &MobileDeviceId) -> Result<bool, MobileDeviceError>;
+            async fn record_activity(
+                &self,
+                device_id: &MobileDeviceId,
+                last_seen_at_ms: i64,
+                last_seen_ip: Option<String>,
+                reported_name: Option<String>,
+                reported_os: Option<String>,
+            ) -> Result<(), MobileDeviceError>;
+            async fn update_password_hash(
+                &self,
+                device_id: &MobileDeviceId,
+                new_password_hash: String,
+            ) -> Result<bool, MobileDeviceError>;
+        }
+    }
 
     fn make_device(
         id: &str,
@@ -168,81 +199,38 @@ mod tests {
         }
     }
 
-    /// 极简 list-only repo。除 `list_all` 之外的方法 panic 以暴露误用。
-    struct FakeRepo {
-        devices: Mutex<Vec<MobileDevice>>,
-        force_storage_err: bool,
-    }
-
-    impl FakeRepo {
-        fn new(devices: Vec<MobileDevice>) -> Self {
-            Self {
-                devices: Mutex::new(devices),
-                force_storage_err: false,
-            }
-        }
-    }
-
-    #[async_trait]
-    impl MobileDeviceRepositoryPort for FakeRepo {
-        async fn save(&self, _: &MobileDevice) -> Result<(), MobileDeviceError> {
-            unreachable!("list 不调用 save")
-        }
-        async fn find_by_username(
-            &self,
-            _: &str,
-        ) -> Result<Option<MobileDevice>, MobileDeviceError> {
-            unreachable!("list 不调用 find_by_username")
-        }
-        async fn find_by_device_id(
-            &self,
-            _: &MobileDeviceId,
-        ) -> Result<Option<MobileDevice>, MobileDeviceError> {
-            unreachable!("list 不调用 find_by_device_id")
-        }
-        async fn list_all(&self) -> Result<Vec<MobileDevice>, MobileDeviceError> {
-            if self.force_storage_err {
-                return Err(MobileDeviceError::Storage("disk gone".into()));
-            }
-            Ok(self.devices.lock().unwrap().clone())
-        }
-        async fn delete(&self, _: &MobileDeviceId) -> Result<bool, MobileDeviceError> {
-            unreachable!("list 不调用 delete")
-        }
-        async fn record_activity(
-            &self,
-            _: &MobileDeviceId,
-            _: i64,
-            _: Option<String>,
-            _: Option<String>,
-            _: Option<String>,
-        ) -> Result<(), MobileDeviceError> {
-            unreachable!("list 不调用 record_activity")
-        }
+    /// 用 mockall 装出一个"返回固定 list_all 结果"的 repo。其它方法不设
+    /// expectation, 一旦被误用 mockall 自动 panic。
+    fn repo_returning(devices: Vec<MobileDevice>) -> MockDeviceRepo {
+        let mut repo = MockDeviceRepo::new();
+        repo.expect_list_all()
+            .returning(move || Ok(devices.clone()));
+        repo
     }
 
     #[tokio::test]
     async fn empty_when_no_devices() {
-        let uc = ListMobileDevicesUseCase::new(Arc::new(FakeRepo::new(vec![])));
+        let uc = ListMobileDevicesUseCase::new(Arc::new(repo_returning(vec![])));
         let out = uc.execute().await.expect("ok");
         assert!(out.is_empty());
     }
 
     #[tokio::test]
-    async fn drops_token_hash_in_summary() {
+    async fn drops_password_hash_but_keeps_username_in_summary() {
         // 通过编译期的字段集就能保证 —— 这个测试只是 belt-and-suspenders,
-        // 防止后续往 summary 加 token_hash 字段时无人察觉。
+        // 防止后续不小心把 password_hash 加进 summary。
+        // username 现在是显式暴露字段，用作 UI 辅助识别（与 label 互补）。
         let device = make_device("did_x", "phone", 1_000, Some(2_000));
-        let uc = ListMobileDevicesUseCase::new(Arc::new(FakeRepo::new(vec![device])));
+        let uc = ListMobileDevicesUseCase::new(Arc::new(repo_returning(vec![device])));
         let out = uc.execute().await.expect("ok");
         assert_eq!(out.len(), 1);
 
-        // 显式列出 summary 的字段并断言：summary 里不再有 token_hash 字段
-        // —— 任何人想加都会在这里失败。
         let s = &out[0];
         assert_eq!(s.device_id.as_str(), "did_x");
         assert_eq!(s.label, "phone");
         assert_eq!(s.client_type, MobileClientType::IosShortcut);
+        // username 现在显式透传 —— make_device 把它构成 `mobile_<id>`。
+        assert_eq!(s.username, "mobile_did_x");
         assert_eq!(s.created_at_ms, 1_000);
         assert_eq!(s.last_seen_at_ms, Some(2_000));
     }
@@ -256,7 +244,7 @@ mod tests {
             make_device("did_c", "C 新 + 没活跃", 1_000, None),
             make_device("did_d", "D 中间活跃", 70, Some(5_000)),
         ];
-        let uc = ListMobileDevicesUseCase::new(Arc::new(FakeRepo::new(devices)));
+        let uc = ListMobileDevicesUseCase::new(Arc::new(repo_returning(devices)));
         let out = uc.execute().await.expect("ok");
 
         let order: Vec<&str> = out.iter().map(|s| s.device_id.as_str()).collect();
@@ -267,11 +255,11 @@ mod tests {
 
     #[tokio::test]
     async fn translates_storage_error() {
-        let repo = Arc::new(FakeRepo {
-            devices: Mutex::new(vec![]),
-            force_storage_err: true,
-        });
-        let uc = ListMobileDevicesUseCase::new(repo);
+        let mut repo = MockDeviceRepo::new();
+        repo.expect_list_all()
+            .returning(|| Err(MobileDeviceError::Storage("disk gone".into())));
+
+        let uc = ListMobileDevicesUseCase::new(Arc::new(repo));
         let err = uc.execute().await.unwrap_err();
         assert!(
             matches!(err, ListMobileDevicesError::PersistenceFailed(ref s) if s.contains("disk gone")),

--- a/src-tauri/crates/uc-application/src/usecases/mobile_sync/mod.rs
+++ b/src-tauri/crates/uc-application/src/usecases/mobile_sync/mod.rs
@@ -29,5 +29,6 @@ pub(crate) mod list_devices;
 pub(crate) mod list_lan_interfaces;
 pub(crate) mod register_device;
 pub(crate) mod revoke_device;
+pub(crate) mod rotate_password;
 pub(crate) mod sync_clipboard_mapping;
 pub(crate) mod update_settings;

--- a/src-tauri/crates/uc-application/src/usecases/mobile_sync/register_device.rs
+++ b/src-tauri/crates/uc-application/src/usecases/mobile_sync/register_device.rs
@@ -536,107 +536,144 @@ fn translate_hasher_error(err: PasswordHasherError) -> RegisterMobileShortcutDev
 mod tests {
     use super::*;
 
-    use std::sync::Mutex;
-
     use async_trait::async_trait;
 
     use uc_core::mobile_sync::MobileDeviceId;
     use uc_core::settings::model::Settings;
 
-    // ── fixtures ────────────────────────────────────────────────────
+    // ── port mocks ─────────────────────────────────────────────────────
 
-    struct FixedClock(i64);
-    impl ClockPort for FixedClock {
-        fn now_ms(&self) -> i64 {
-            self.0
+    mockall::mock! {
+        DeviceRepo {}
+        #[async_trait]
+        impl MobileDeviceRepositoryPort for DeviceRepo {
+            async fn save(&self, device: &MobileDevice) -> Result<(), MobileDeviceError>;
+            async fn find_by_username(
+                &self,
+                username: &str,
+            ) -> Result<Option<MobileDevice>, MobileDeviceError>;
+            async fn find_by_device_id(
+                &self,
+                device_id: &MobileDeviceId,
+            ) -> Result<Option<MobileDevice>, MobileDeviceError>;
+            async fn list_all(&self) -> Result<Vec<MobileDevice>, MobileDeviceError>;
+            async fn delete(&self, device_id: &MobileDeviceId) -> Result<bool, MobileDeviceError>;
+            async fn record_activity(
+                &self,
+                device_id: &MobileDeviceId,
+                last_seen_at_ms: i64,
+                last_seen_ip: Option<String>,
+                reported_name: Option<String>,
+                reported_os: Option<String>,
+            ) -> Result<(), MobileDeviceError>;
+            async fn update_password_hash(
+                &self,
+                device_id: &MobileDeviceId,
+                new_password_hash: String,
+            ) -> Result<bool, MobileDeviceError>;
         }
     }
 
-    struct DeterministicMinter;
-    impl MobileCredentialsMinterPort for DeterministicMinter {
-        fn mint_credentials(&self) -> MintedCredentials {
-            MintedCredentials {
-                username: "mobile_aabbccdd".into(),
-                password: "deterministic-password-22".into(),
-                password_hash: "$argon2id$v=19$m=64,t=1,p=1$AAAAAAAAAAAAAAAA$test".into(),
-                device_id: MobileDeviceId::new("did_aaaa"),
-            }
+    mockall::mock! {
+        Hasher {}
+        #[async_trait]
+        impl PasswordHasherPort for Hasher {
+            async fn hash(&self, password: &str) -> Result<String, PasswordHasherError>;
+            async fn verify(&self, password: &str, phc: &str)
+                -> Result<bool, PasswordHasherError>;
         }
     }
 
-    /// 把每次 hash 调用记录下来,便于断言 use case 是否真去 hash 了自定义
-    /// password(而不是回退用 minter 的 phc 字符串)。
-    #[derive(Default)]
-    struct RecordingHasher {
-        hashed: Mutex<Vec<String>>,
-    }
-    #[async_trait]
-    impl PasswordHasherPort for RecordingHasher {
-        async fn hash(&self, password: &str) -> Result<String, PasswordHasherError> {
-            self.hashed.lock().unwrap().push(password.to_string());
-            Ok(format!("phc-of:{password}"))
-        }
-        async fn verify(&self, _password: &str, _phc: &str) -> Result<bool, PasswordHasherError> {
-            unreachable!("register flow does not call verify")
+    mockall::mock! {
+        Minter {}
+        impl MobileCredentialsMinterPort for Minter {
+            fn mint_credentials(&self) -> MintedCredentials;
         }
     }
 
-    /// hash() 永远报内部错误的 fixture,断言 use case 把它翻成
-    /// `PasswordHashFailed`。
-    struct FailingHasher;
-    #[async_trait]
-    impl PasswordHasherPort for FailingHasher {
-        async fn hash(&self, _password: &str) -> Result<String, PasswordHasherError> {
+    mockall::mock! {
+        SettingsPortImpl {}
+        #[async_trait]
+        impl SettingsPort for SettingsPortImpl {
+            async fn load(&self) -> anyhow::Result<Settings>;
+            async fn save(&self, settings: &Settings) -> anyhow::Result<()>;
+        }
+    }
+
+    mockall::mock! {
+        ClockImpl {}
+        impl ClockPort for ClockImpl {
+            fn now_ms(&self) -> i64;
+        }
+    }
+
+    mockall::mock! {
+        Probe {}
+        #[async_trait]
+        impl LanInterfaceProbePort for Probe {
+            async fn list_interfaces(&self) -> Result<Vec<LanInterface>, LanInterfaceProbeError>;
+        }
+    }
+
+    // ── helpers ────────────────────────────────────────────────────────
+
+    /// minter 永远返回的 fixed MintedCredentials —— 测试断言里写的字面值。
+    const MINTER_USERNAME: &str = "mobile_aabbccdd";
+    const MINTER_PASSWORD: &str = "deterministic-password-22";
+    const MINTER_PHC: &str = "$argon2id$v=19$m=64,t=1,p=1$AAAAAAAAAAAAAAAA$test";
+    const MINTER_DEVICE_ID: &str = "did_aaaa";
+
+    fn deterministic_minter() -> MockMinter {
+        let mut m = MockMinter::new();
+        m.expect_mint_credentials().returning(|| MintedCredentials {
+            username: MINTER_USERNAME.into(),
+            password: MINTER_PASSWORD.into(),
+            password_hash: MINTER_PHC.into(),
+            device_id: MobileDeviceId::new(MINTER_DEVICE_ID),
+        });
+        m
+    }
+
+    /// 把每次 hash 调用产出一个 `phc-of:<plain>` 形态的 PHC,便于断言 use
+    /// case 真去 hash 了自定义 password(而不是回退用 minter 的 phc)。
+    /// mockall 的 expect_hash() 没有 .times() 约束默认任意次数;调用方在
+    /// 需要时显式加 .times(N) 即可。
+    fn recording_hasher() -> MockHasher {
+        let mut h = MockHasher::new();
+        h.expect_hash().returning(|p| Ok(format!("phc-of:{p}")));
+        h
+    }
+
+    fn failing_hasher() -> MockHasher {
+        let mut h = MockHasher::new();
+        h.expect_hash().returning(|_| {
             Err(PasswordHasherError::Internal(
                 "simulated hash failure".into(),
             ))
-        }
-        async fn verify(&self, _password: &str, _phc: &str) -> Result<bool, PasswordHasherError> {
-            unreachable!()
-        }
+        });
+        h
     }
 
-    #[derive(Default)]
-    struct InMemoryDeviceRepo {
-        saved: Mutex<Vec<MobileDevice>>,
-        /// 预置:这些 username 视为"已被占用",`find_by_username` 命中。
-        preexisting: Mutex<Vec<String>>,
+    /// 默认 device_repo:save 永远 OK,find_by_username 永远找不到。供大多数
+    /// happy-path / 校验失败测试使用,测试想"定制 username 已占用"时单独构造。
+    fn empty_device_repo() -> MockDeviceRepo {
+        let mut r = MockDeviceRepo::new();
+        r.expect_save().returning(|_| Ok(()));
+        r.expect_find_by_username().returning(|_| Ok(None));
+        r
     }
-    impl InMemoryDeviceRepo {
-        fn with_existing_username(name: &str) -> Self {
-            let s = Self::default();
-            s.preexisting.lock().unwrap().push(name.to_string());
-            s
-        }
-    }
-    #[async_trait]
-    impl MobileDeviceRepositoryPort for InMemoryDeviceRepo {
-        async fn save(&self, device: &MobileDevice) -> Result<(), MobileDeviceError> {
-            self.saved.lock().unwrap().push(device.clone());
-            Ok(())
-        }
-        async fn find_by_username(
-            &self,
-            username: &str,
-        ) -> Result<Option<MobileDevice>, MobileDeviceError> {
-            // 真正存在的(saved 里)优先;之外再看 preexisting fixture 名单。
-            let saved = self.saved.lock().unwrap();
-            if let Some(d) = saved.iter().find(|d| d.username == username) {
-                return Ok(Some(d.clone()));
-            }
-            drop(saved);
-            if self
-                .preexisting
-                .lock()
-                .unwrap()
-                .iter()
-                .any(|u| u == username)
-            {
+
+    /// 把指定 username 设为"已被占用",触发 `UsernameTaken` 校验路径。
+    fn device_repo_with_existing_username(name: &'static str) -> MockDeviceRepo {
+        let mut r = MockDeviceRepo::new();
+        r.expect_save().returning(|_| Ok(()));
+        r.expect_find_by_username().returning(move |u| {
+            if u == name {
                 Ok(Some(MobileDevice {
                     device_id: MobileDeviceId::new("did_existing"),
                     label: "existing".into(),
                     client_type: MobileClientType::IosShortcut,
-                    username: username.to_string(),
+                    username: u.to_string(),
                     password_hash: "phc:existing".into(),
                     created_at_ms: 0,
                     last_seen_at_ms: None,
@@ -647,87 +684,57 @@ mod tests {
             } else {
                 Ok(None)
             }
-        }
-        async fn find_by_device_id(
-            &self,
-            _: &MobileDeviceId,
-        ) -> Result<Option<MobileDevice>, MobileDeviceError> {
-            Ok(None)
-        }
-        async fn list_all(&self) -> Result<Vec<MobileDevice>, MobileDeviceError> {
-            Ok(self.saved.lock().unwrap().clone())
-        }
-        async fn delete(&self, _: &MobileDeviceId) -> Result<bool, MobileDeviceError> {
-            Ok(true)
-        }
-        async fn record_activity(
-            &self,
-            _: &MobileDeviceId,
-            _: i64,
-            _: Option<String>,
-            _: Option<String>,
-            _: Option<String>,
-        ) -> Result<(), MobileDeviceError> {
-            Ok(())
-        }
+        });
+        r
     }
 
-    /// 内存 SettingsPort: `lan_listen_enabled` 由测试控制;`lan_advertise_ip`
-    /// 固定 192.168.1.5 + 端口 42720, 让 base_url 推出 "http://192.168.1.5:42720"。
-    struct FixedSettings {
-        lan_listen_enabled: bool,
-    }
-    #[async_trait]
-    impl SettingsPort for FixedSettings {
-        async fn load(&self) -> anyhow::Result<Settings> {
-            let mut s = Settings::default();
-            s.mobile_sync.enabled = self.lan_listen_enabled;
-            s.mobile_sync.lan_listen_enabled = self.lan_listen_enabled;
-            s.mobile_sync.lan_advertise_ip = Some("192.168.1.5".into());
-            s.mobile_sync.lan_port = Some(42720);
-            Ok(s)
-        }
-        async fn save(&self, _: &Settings) -> anyhow::Result<()> {
-            unreachable!("register_device must not save settings")
-        }
+    /// `lan_advertise_ip = Some("192.168.1.5") + lan_port = 42720`,加可控的
+    /// `lan_listen_enabled` flag。base_url 推为 `http://192.168.1.5:42720`。
+    fn settings_port_lan_advertise(lan_listen_enabled: bool) -> MockSettingsPortImpl {
+        let mut s = MockSettingsPortImpl::new();
+        s.expect_load().returning(move || {
+            let mut settings = Settings::default();
+            settings.mobile_sync.enabled = lan_listen_enabled;
+            settings.mobile_sync.lan_listen_enabled = lan_listen_enabled;
+            settings.mobile_sync.lan_advertise_ip = Some("192.168.1.5".into());
+            settings.mobile_sync.lan_port = Some(42720);
+            Ok(settings)
+        });
+        s
     }
 
-    /// 默认测试 probe:返回空列表。原 happy path 测试都用 lan_advertise_ip
-    /// = Some(...),不会走 auto-pick,所以空列表 probe 已够用;auto-pick 路径
-    /// 由 `auto_picks_first_rfc1918_when_advertise_ip_unset` 等单独构造。
-    struct EmptyLanProbe;
-    #[async_trait]
-    impl LanInterfaceProbePort for EmptyLanProbe {
-        async fn list_interfaces(&self) -> Result<Vec<LanInterface>, LanInterfaceProbeError> {
-            Ok(Vec::new())
-        }
+    /// `lan_advertise_ip = None` —— 触发 use case 自己 auto-pick 的路径。
+    fn settings_port_auto() -> MockSettingsPortImpl {
+        let mut s = MockSettingsPortImpl::new();
+        s.expect_load().returning(|| {
+            let mut settings = Settings::default();
+            settings.mobile_sync.enabled = true;
+            settings.mobile_sync.lan_listen_enabled = true;
+            settings.mobile_sync.lan_advertise_ip = None;
+            settings.mobile_sync.lan_port = Some(42720);
+            Ok(settings)
+        });
+        s
     }
 
-    /// 测试 probe:返回固定的 LAN 接口列表(用于断言 auto-pick 排序口径)。
-    struct FixedLanProbe(Vec<LanInterface>);
-    #[async_trait]
-    impl LanInterfaceProbePort for FixedLanProbe {
-        async fn list_interfaces(&self) -> Result<Vec<LanInterface>, LanInterfaceProbeError> {
-            Ok(self.0.clone())
-        }
+    fn clock_at(ms: i64) -> MockClockImpl {
+        let mut c = MockClockImpl::new();
+        c.expect_now_ms().returning(move || ms);
+        c
     }
 
-    /// `lan_advertise_ip = None` 的 SettingsPort 变体:其它字段同
-    /// `FixedSettings`,只有 advertise_ip 留空,触发 auto-pick 分支。
-    struct AutoSettings;
-    #[async_trait]
-    impl SettingsPort for AutoSettings {
-        async fn load(&self) -> anyhow::Result<Settings> {
-            let mut s = Settings::default();
-            s.mobile_sync.enabled = true;
-            s.mobile_sync.lan_listen_enabled = true;
-            s.mobile_sync.lan_advertise_ip = None;
-            s.mobile_sync.lan_port = Some(42720);
-            Ok(s)
-        }
-        async fn save(&self, _: &Settings) -> anyhow::Result<()> {
-            unreachable!("register_device must not save settings")
-        }
+    fn probe_returning(ifaces: Vec<LanInterface>) -> MockProbe {
+        let mut p = MockProbe::new();
+        p.expect_list_interfaces()
+            .returning(move || Ok(ifaces.clone()));
+        p
+    }
+
+    fn probe_failing() -> MockProbe {
+        let mut p = MockProbe::new();
+        p.expect_list_interfaces()
+            .returning(|| Err(LanInterfaceProbeError::Probe("ifaddr crashed".into())));
+        p
     }
 
     fn iface(name: &str, ip: [u8; 4]) -> LanInterface {
@@ -738,14 +745,17 @@ mod tests {
         }
     }
 
+    /// 标准 happy-path 装配:固定 minter / recording hasher / empty repo /
+    /// 默认 LAN advertise settings / 1_000ms clock / 空 probe(LAN 已配置时
+    /// 走不到 auto-pick,empty probe 即可)。`lan_listen_enabled` 控开关。
     fn build_uc(lan_listen_enabled: bool) -> RegisterMobileShortcutDeviceUseCase {
         RegisterMobileShortcutDeviceUseCase::new(
-            Arc::new(DeterministicMinter),
-            Arc::new(RecordingHasher::default()),
-            Arc::new(InMemoryDeviceRepo::default()),
-            Arc::new(FixedSettings { lan_listen_enabled }),
-            Arc::new(FixedClock(1_000)),
-            Arc::new(EmptyLanProbe),
+            Arc::new(deterministic_minter()),
+            Arc::new(recording_hasher()),
+            Arc::new(empty_device_repo()),
+            Arc::new(settings_port_lan_advertise(lan_listen_enabled)),
+            Arc::new(clock_at(1_000)),
+            Arc::new(probe_returning(vec![])),
         )
     }
 
@@ -917,14 +927,12 @@ mod tests {
     #[tokio::test]
     async fn rejects_username_already_taken() {
         let uc = RegisterMobileShortcutDeviceUseCase::new(
-            Arc::new(DeterministicMinter),
-            Arc::new(RecordingHasher::default()),
-            Arc::new(InMemoryDeviceRepo::with_existing_username("alice_001")),
-            Arc::new(FixedSettings {
-                lan_listen_enabled: true,
-            }),
-            Arc::new(FixedClock(1_000)),
-            Arc::new(EmptyLanProbe),
+            Arc::new(deterministic_minter()),
+            Arc::new(recording_hasher()),
+            Arc::new(device_repo_with_existing_username("alice_001")),
+            Arc::new(settings_port_lan_advertise(true)),
+            Arc::new(clock_at(1_000)),
+            Arc::new(probe_returning(vec![])),
         );
         let err = uc
             .execute(RegisterMobileShortcutDeviceInput {
@@ -944,16 +952,22 @@ mod tests {
 
     #[tokio::test]
     async fn accepts_custom_password() {
-        let hasher = Arc::new(RecordingHasher::default());
+        // 通过 mockall expectation 直接断言 hasher 收到自定义明文 + 被调用
+        // 恰好一次 —— 比手写 RecordingHasher 自己累积的 Vec 更精确。
+        let mut hasher = MockHasher::new();
+        hasher
+            .expect_hash()
+            .with(mockall::predicate::eq("correct horse battery staple"))
+            .times(1)
+            .returning(|p| Ok(format!("phc-of:{p}")));
+
         let uc = RegisterMobileShortcutDeviceUseCase::new(
-            Arc::new(DeterministicMinter),
-            hasher.clone(),
-            Arc::new(InMemoryDeviceRepo::default()),
-            Arc::new(FixedSettings {
-                lan_listen_enabled: true,
-            }),
-            Arc::new(FixedClock(1_000)),
-            Arc::new(EmptyLanProbe),
+            Arc::new(deterministic_minter()),
+            Arc::new(hasher),
+            Arc::new(empty_device_repo()),
+            Arc::new(settings_port_lan_advertise(true)),
+            Arc::new(clock_at(1_000)),
+            Arc::new(probe_returning(vec![])),
         );
         let out = uc
             .execute(RegisterMobileShortcutDeviceInput {
@@ -970,10 +984,8 @@ mod tests {
             "phc-of:correct horse battery staple"
         );
         // username 走 minter
-        assert_eq!(out.username, "mobile_aabbccdd");
-
-        // 断言 hasher 真被调用了 1 次。
-        assert_eq!(hasher.hashed.lock().unwrap().len(), 1);
+        assert_eq!(out.username, MINTER_USERNAME);
+        // hasher 调用次数由 mockall 在 drop 时自动 verify (.times(1) 上面已断言)
     }
 
     #[tokio::test]
@@ -1017,14 +1029,12 @@ mod tests {
     #[tokio::test]
     async fn translates_hasher_internal_error() {
         let uc = RegisterMobileShortcutDeviceUseCase::new(
-            Arc::new(DeterministicMinter),
-            Arc::new(FailingHasher),
-            Arc::new(InMemoryDeviceRepo::default()),
-            Arc::new(FixedSettings {
-                lan_listen_enabled: true,
-            }),
-            Arc::new(FixedClock(1_000)),
-            Arc::new(EmptyLanProbe),
+            Arc::new(deterministic_minter()),
+            Arc::new(failing_hasher()),
+            Arc::new(empty_device_repo()),
+            Arc::new(settings_port_lan_advertise(true)),
+            Arc::new(clock_at(1_000)),
+            Arc::new(probe_returning(vec![])),
         );
         let err = uc
             .execute(RegisterMobileShortcutDeviceInput {
@@ -1058,19 +1068,19 @@ mod tests {
         assert_eq!(out.device.username, "alice_pro");
         assert_eq!(out.device.password_hash, "phc-of:a-strong-password");
         // device_id 永远来自 minter。
-        assert_eq!(out.device.device_id.as_str(), "did_aaaa");
+        assert_eq!(out.device.device_id.as_str(), MINTER_DEVICE_ID);
     }
 
     // ── tests: auto-pick advertise_ip ─────────────────────────────────
 
-    fn build_uc_auto(probe: Arc<dyn LanInterfaceProbePort>) -> RegisterMobileShortcutDeviceUseCase {
+    fn build_uc_auto(probe: MockProbe) -> RegisterMobileShortcutDeviceUseCase {
         RegisterMobileShortcutDeviceUseCase::new(
-            Arc::new(DeterministicMinter),
-            Arc::new(RecordingHasher::default()),
-            Arc::new(InMemoryDeviceRepo::default()),
-            Arc::new(AutoSettings),
-            Arc::new(FixedClock(1_000)),
-            probe,
+            Arc::new(deterministic_minter()),
+            Arc::new(recording_hasher()),
+            Arc::new(empty_device_repo()),
+            Arc::new(settings_port_auto()),
+            Arc::new(clock_at(1_000)),
+            Arc::new(probe),
         )
     }
 
@@ -1078,12 +1088,12 @@ mod tests {
     async fn auto_picks_first_rfc1918_when_advertise_ip_unset() {
         // 故意打乱顺序,断言走"10/8 → 172.16/12 → 192.168/16,段内字典序"。
         // 期望挑 10.0.0.5(10.x 段最小)。
-        let probe = Arc::new(FixedLanProbe(vec![
+        let probe = probe_returning(vec![
             iface("en1", [192, 168, 1, 5]),
             iface("en2", [10, 0, 0, 5]),
             iface("en3", [172, 16, 0, 5]),
             iface("en4", [10, 1, 1, 1]),
-        ]));
+        ]);
         let uc = build_uc_auto(probe);
         let out = uc.execute(label_only("iPhone")).await.expect("ok");
         assert_eq!(out.base_url, "http://10.0.0.5:42720");
@@ -1092,7 +1102,7 @@ mod tests {
     #[tokio::test]
     async fn auto_skips_loopback_and_non_rfc1918() {
         // 全是被剔除的接口 → 退化成"没有可用 LAN" → NoLanInterfaceAvailable。
-        let probe = Arc::new(FixedLanProbe(vec![
+        let probe = probe_returning(vec![
             LanInterface {
                 name: "lo0".into(),
                 ipv4: std::net::Ipv4Addr::new(127, 0, 0, 1),
@@ -1101,7 +1111,7 @@ mod tests {
             iface("en_pub", [8, 8, 8, 8]),
             iface("en_cgnat", [100, 64, 1, 5]),
             iface("en_link", [169, 254, 1, 5]),
-        ]));
+        ]);
         let uc = build_uc_auto(probe);
         let err = uc.execute(label_only("iPhone")).await.unwrap_err();
         assert!(matches!(
@@ -1112,14 +1122,7 @@ mod tests {
 
     #[tokio::test]
     async fn auto_translates_probe_failure() {
-        struct FailingProbe;
-        #[async_trait]
-        impl LanInterfaceProbePort for FailingProbe {
-            async fn list_interfaces(&self) -> Result<Vec<LanInterface>, LanInterfaceProbeError> {
-                Err(LanInterfaceProbeError::Probe("ifaddr crashed".into()))
-            }
-        }
-        let uc = build_uc_auto(Arc::new(FailingProbe));
+        let uc = build_uc_auto(probe_failing());
         let err = uc.execute(label_only("iPhone")).await.unwrap_err();
         assert!(matches!(
             err,

--- a/src-tauri/crates/uc-application/src/usecases/mobile_sync/revoke_device.rs
+++ b/src-tauri/crates/uc-application/src/usecases/mobile_sync/revoke_device.rs
@@ -85,94 +85,63 @@ fn translate_device_error(err: MobileDeviceError) -> RevokeMobileDeviceError {
 mod tests {
     use super::*;
 
-    use std::sync::Mutex;
-
     use async_trait::async_trait;
+    use mockall::predicate::eq;
 
     use uc_core::mobile_sync::MobileDevice;
 
-    /// 极简内存 repo：只承担 `delete` 路径所需的语义；其它方法 panic
-    /// 以便万一被误用立刻暴露。
-    #[derive(Default)]
-    struct FakeRepo {
-        existing: Mutex<Vec<MobileDeviceId>>,
-        last_deleted: Mutex<Option<MobileDeviceId>>,
-        force_storage_err: bool,
-    }
-
-    impl FakeRepo {
-        fn with_existing(ids: Vec<&str>) -> Self {
-            Self {
-                existing: Mutex::new(ids.into_iter().map(MobileDeviceId::new).collect()),
-                last_deleted: Mutex::new(None),
-                force_storage_err: false,
-            }
-        }
-    }
-
-    #[async_trait]
-    impl MobileDeviceRepositoryPort for FakeRepo {
-        async fn save(&self, _: &MobileDevice) -> Result<(), MobileDeviceError> {
-            unreachable!("revoke 不调用 save")
-        }
-        async fn find_by_username(
-            &self,
-            _: &str,
-        ) -> Result<Option<MobileDevice>, MobileDeviceError> {
-            unreachable!("revoke 不调用 find_by_username")
-        }
-        async fn find_by_device_id(
-            &self,
-            _: &MobileDeviceId,
-        ) -> Result<Option<MobileDevice>, MobileDeviceError> {
-            unreachable!("revoke 不调用 find_by_device_id")
-        }
-        async fn list_all(&self) -> Result<Vec<MobileDevice>, MobileDeviceError> {
-            unreachable!("revoke 不调用 list_all")
-        }
-        async fn delete(&self, id: &MobileDeviceId) -> Result<bool, MobileDeviceError> {
-            if self.force_storage_err {
-                return Err(MobileDeviceError::Storage("disk gone".into()));
-            }
-            let mut existing = self.existing.lock().unwrap();
-            let before = existing.len();
-            existing.retain(|x| x.as_str() != id.as_str());
-            *self.last_deleted.lock().unwrap() = Some(id.clone());
-            Ok(existing.len() < before)
-        }
-        async fn record_activity(
-            &self,
-            _: &MobileDeviceId,
-            _: i64,
-            _: Option<String>,
-            _: Option<String>,
-            _: Option<String>,
-        ) -> Result<(), MobileDeviceError> {
-            unreachable!("revoke 不调用 record_activity")
+    mockall::mock! {
+        DeviceRepo {}
+        #[async_trait]
+        impl MobileDeviceRepositoryPort for DeviceRepo {
+            async fn save(&self, device: &MobileDevice) -> Result<(), MobileDeviceError>;
+            async fn find_by_username(
+                &self,
+                username: &str,
+            ) -> Result<Option<MobileDevice>, MobileDeviceError>;
+            async fn find_by_device_id(
+                &self,
+                device_id: &MobileDeviceId,
+            ) -> Result<Option<MobileDevice>, MobileDeviceError>;
+            async fn list_all(&self) -> Result<Vec<MobileDevice>, MobileDeviceError>;
+            async fn delete(&self, device_id: &MobileDeviceId) -> Result<bool, MobileDeviceError>;
+            async fn record_activity(
+                &self,
+                device_id: &MobileDeviceId,
+                last_seen_at_ms: i64,
+                last_seen_ip: Option<String>,
+                reported_name: Option<String>,
+                reported_os: Option<String>,
+            ) -> Result<(), MobileDeviceError>;
+            async fn update_password_hash(
+                &self,
+                device_id: &MobileDeviceId,
+                new_password_hash: String,
+            ) -> Result<bool, MobileDeviceError>;
         }
     }
 
     #[tokio::test]
     async fn deletes_existing_device() {
-        let repo = Arc::new(FakeRepo::with_existing(vec!["did_x"]));
-        let uc = RevokeMobileDeviceUseCase::new(repo.clone());
-        uc.execute(RevokeMobileDeviceInput {
-            device_id: MobileDeviceId::new("did_x"),
-        })
-        .await
-        .expect("should succeed");
+        let target = MobileDeviceId::new("did_x");
+        let mut repo = MockDeviceRepo::new();
+        repo.expect_delete()
+            .with(eq(target.clone()))
+            .times(1)
+            .returning(|_| Ok(true));
 
-        assert_eq!(
-            repo.last_deleted.lock().unwrap().as_ref().unwrap().as_str(),
-            "did_x"
-        );
-        assert!(repo.existing.lock().unwrap().is_empty());
+        let uc = RevokeMobileDeviceUseCase::new(Arc::new(repo));
+        uc.execute(RevokeMobileDeviceInput { device_id: target })
+            .await
+            .expect("should succeed");
     }
 
     #[tokio::test]
     async fn returns_not_found_when_missing() {
-        let repo = Arc::new(FakeRepo::with_existing(vec![]));
-        let uc = RevokeMobileDeviceUseCase::new(repo);
+        let mut repo = MockDeviceRepo::new();
+        repo.expect_delete().returning(|_| Ok(false));
+
+        let uc = RevokeMobileDeviceUseCase::new(Arc::new(repo));
         let err = uc
             .execute(RevokeMobileDeviceInput {
                 device_id: MobileDeviceId::new("did_missing"),
@@ -187,12 +156,11 @@ mod tests {
 
     #[tokio::test]
     async fn translates_storage_error() {
-        let repo = Arc::new(FakeRepo {
-            existing: Mutex::new(vec![MobileDeviceId::new("did_x")]),
-            last_deleted: Mutex::new(None),
-            force_storage_err: true,
-        });
-        let uc = RevokeMobileDeviceUseCase::new(repo);
+        let mut repo = MockDeviceRepo::new();
+        repo.expect_delete()
+            .returning(|_| Err(MobileDeviceError::Storage("disk gone".into())));
+
+        let uc = RevokeMobileDeviceUseCase::new(Arc::new(repo));
         let err = uc
             .execute(RevokeMobileDeviceInput {
                 device_id: MobileDeviceId::new("did_x"),

--- a/src-tauri/crates/uc-application/src/usecases/mobile_sync/rotate_password.rs
+++ b/src-tauri/crates/uc-application/src/usecases/mobile_sync/rotate_password.rs
@@ -1,0 +1,546 @@
+//! `RotateMobilePasswordUseCase` —— 给一台已登记设备换一份新密码。
+//!
+//! ## 为什么单独一个 use case 而不是复用 register
+//!
+//! 注册和轮换在用户视角是两件事:注册产出新设备身份(device_id / username
+//! / 凭据 + install URL + QR);轮换只换"凭据"中的密码,设备身份不变。
+//! 强行复用 register 会把 LAN 探测 / QR 渲染 / settings 校验拖进来,而轮换
+//! 路径其实只关心 device_repo + password_hasher + minter 三个端口。
+//!
+//! ## 流程
+//!
+//! 1. `find_by_device_id` 查到目标设备 → 拿到稳定的 `username` 与其它字段
+//!    (`NotFound` 直接返回)。
+//! 2. 决定新明文:`input.password = Some(p)` → 校验长度;`None` → 走 minter
+//!    取新明文(只用 `MintedCredentials.password`,**不**取 username /
+//!    device_id —— 这台设备已经有自己的稳定身份)。
+//! 3. `password_hasher.hash(new_plaintext)` → 拿到新 PHC。
+//! 4. `device_repo.update_password_hash(device_id, new_phc)`:`Ok(true)` 表示
+//!    成功;`Ok(false)` 表示设备在我们 read-then-write 之间被并发撤销 ——
+//!    翻成 `NotFound`,与 step 1 的语义保持一致。
+//! 5. 返回 `(device_id, username, new_plaintext)` —— 明文是**唯一一次**面向
+//!    用户回显, 之后只以 PHC 形式存在。
+//!
+//! ## 安全语义
+//!
+//! 轮换成功后,旧密码立即失效:任何还在用旧密码的 iPhone shortcut 下次请求
+//! 必收 401。这不是 use case 主动做的事 —— 是 `authenticate_basic` 路径在
+//! 鉴权时永远 verify 当前 PHC,所以 PHC 一换,旧密码自动作废。
+//!
+//! 不验证旧密码:这是设备主自己的桌面端在轮换自己的设备凭据,信任边界
+//! 在桌面端(daemon 进程主),不在 LAN 端。如果有人能通过 daemon 调用本
+//! use case,他已经有比"知道旧密码"更高的权限。
+
+use std::sync::Arc;
+
+use tracing::{instrument, warn};
+
+use uc_core::mobile_sync::{MintedCredentials, MobileDeviceError, MobileDeviceId};
+use uc_core::ports::{
+    MobileCredentialsMinterPort, MobileDeviceRepositoryPort, PasswordHasherError,
+    PasswordHasherPort,
+};
+
+use super::register_device::{MAX_PASSWORD_LEN, MIN_PASSWORD_LEN};
+
+// ─── public-shaped (input / output / error) ─────────────────────────────
+
+/// 调用方提交的请求。`password = None` 走 minter 自动颁发新明文;`Some(p)`
+/// 走自定义路径,本 use case 校验长度。
+#[derive(Debug, Clone)]
+pub struct RotateMobilePasswordInput {
+    pub device_id: MobileDeviceId,
+    pub password: Option<String>,
+}
+
+/// 轮换成功的产物。`password` 是**唯一一次**明文回显 —— 之后只以
+/// PHC 形式存在。前端必须立即在 modal 里展示给用户,并提示"旧密码已失
+/// 效, 请同步更新 iPhone shortcut 里的 password 字段"。
+#[derive(Debug, Clone)]
+pub struct RotateMobilePasswordOutput {
+    pub device_id: MobileDeviceId,
+    /// 设备登录账号(轮换不变)。一并返回方便前端展示"账号 + 新密码"
+    /// 而无需再查一次设备。
+    pub username: String,
+    pub password: String,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum RotateMobilePasswordError {
+    /// 目标设备不存在 —— 用户已撤销 / UI 列表过期 / 并发竞争。
+    #[error("device not found: {0}")]
+    NotFound(MobileDeviceId),
+
+    /// 自定义 password 长度低于 [`MIN_PASSWORD_LEN`]。
+    #[error("password too short (min {min} chars)")]
+    PasswordTooShort { min: usize },
+
+    /// 自定义 password 长度超过 [`MAX_PASSWORD_LEN`]。Argon2id DOS 防护。
+    #[error("password too long (max {max} chars)")]
+    PasswordTooLong { max: usize },
+
+    /// 哈希失败(算法库内部错误)。
+    #[error("password hashing failed: {0}")]
+    PasswordHashFailed(String),
+
+    /// 持久化失败(底层存储错误)。
+    #[error("device persistence failed: {0}")]
+    PersistenceFailed(String),
+}
+
+// ─── use case ───────────────────────────────────────────────────────────
+
+pub(crate) struct RotateMobilePasswordUseCase {
+    device_repo: Arc<dyn MobileDeviceRepositoryPort>,
+    password_hasher: Arc<dyn PasswordHasherPort>,
+    credentials_minter: Arc<dyn MobileCredentialsMinterPort>,
+}
+
+impl RotateMobilePasswordUseCase {
+    pub(crate) fn new(
+        device_repo: Arc<dyn MobileDeviceRepositoryPort>,
+        password_hasher: Arc<dyn PasswordHasherPort>,
+        credentials_minter: Arc<dyn MobileCredentialsMinterPort>,
+    ) -> Self {
+        Self {
+            device_repo,
+            password_hasher,
+            credentials_minter,
+        }
+    }
+
+    #[instrument(skip(self, input), fields(custom_password = input.password.is_some()))]
+    pub(crate) async fn execute(
+        &self,
+        input: RotateMobilePasswordInput,
+    ) -> Result<RotateMobilePasswordOutput, RotateMobilePasswordError> {
+        // 1. 查目标设备 —— 拿到稳定的 username。
+        let device = self
+            .device_repo
+            .find_by_device_id(&input.device_id)
+            .await
+            .map_err(translate_device_error)?
+            .ok_or_else(|| RotateMobilePasswordError::NotFound(input.device_id.clone()))?;
+
+        // 2. 决定新明文。
+        let new_password = match input.password {
+            Some(p) => {
+                validate_password_length(&p)?;
+                p
+            }
+            None => {
+                let MintedCredentials { password, .. } = self.credentials_minter.mint_credentials();
+                password
+            }
+        };
+
+        // 3. hash → PHC
+        let new_phc = self
+            .password_hasher
+            .hash(&new_password)
+            .await
+            .map_err(translate_hasher_error)?;
+
+        // 4. 更新仓储。Ok(false) → 设备在 read-then-write 之间被撤销,翻
+        //    成 NotFound 让 UI 提示刷新。
+        let updated = self
+            .device_repo
+            .update_password_hash(&device.device_id, new_phc)
+            .await
+            .map_err(translate_device_error)?;
+        if !updated {
+            warn!(
+                device_id = %device.device_id,
+                "device disappeared between find and update_password_hash (concurrent revoke)"
+            );
+            return Err(RotateMobilePasswordError::NotFound(device.device_id));
+        }
+
+        // 5. 一次性回显新明文。
+        Ok(RotateMobilePasswordOutput {
+            device_id: device.device_id,
+            username: device.username,
+            password: new_password,
+        })
+    }
+}
+
+// ─── helpers ────────────────────────────────────────────────────────────
+
+fn validate_password_length(password: &str) -> Result<(), RotateMobilePasswordError> {
+    let len = password.chars().count();
+    if len < MIN_PASSWORD_LEN {
+        return Err(RotateMobilePasswordError::PasswordTooShort {
+            min: MIN_PASSWORD_LEN,
+        });
+    }
+    if len > MAX_PASSWORD_LEN {
+        return Err(RotateMobilePasswordError::PasswordTooLong {
+            max: MAX_PASSWORD_LEN,
+        });
+    }
+    Ok(())
+}
+
+fn translate_device_error(err: MobileDeviceError) -> RotateMobilePasswordError {
+    match err {
+        MobileDeviceError::Storage(msg) => RotateMobilePasswordError::PersistenceFailed(msg),
+        // rotate 路径不应触发 AlreadyExists / UsernameCollision —— 走到这里
+        // 说明 adapter 实现违反契约, 兜底翻成 PersistenceFailed。
+        other => RotateMobilePasswordError::PersistenceFailed(other.to_string()),
+    }
+}
+
+fn translate_hasher_error(err: PasswordHasherError) -> RotateMobilePasswordError {
+    match err {
+        PasswordHasherError::InvalidPhc(msg) => {
+            RotateMobilePasswordError::PasswordHashFailed(format!("invalid phc: {msg}"))
+        }
+        PasswordHasherError::Internal(msg) => RotateMobilePasswordError::PasswordHashFailed(msg),
+    }
+}
+
+// ─── tests ──────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    //! mockall 单测:三个 ports(device repo / hasher / minter)各自 mock,
+    //! 用 expectations 表达"这次调用应该被传什么参数 / 应该返回什么"。
+    //! 与手写 fixture 相比,断言入参的 .with(eq(...)) 让"use case 真的把
+    //! 正确的值送下去了"也变成可观测的 —— 比如 update_password_hash 必须
+    //! 收到 hasher 算出的那串 PHC,而不是其它东西。
+    use super::*;
+
+    use async_trait::async_trait;
+    use mockall::predicate::eq;
+
+    use uc_core::mobile_sync::{MobileClientType, MobileDevice};
+
+    // ── port mocks ─────────────────────────────────────────────────────
+
+    mockall::mock! {
+        DeviceRepo {}
+        #[async_trait]
+        impl MobileDeviceRepositoryPort for DeviceRepo {
+            async fn save(&self, device: &MobileDevice) -> Result<(), MobileDeviceError>;
+            async fn find_by_username(
+                &self,
+                username: &str,
+            ) -> Result<Option<MobileDevice>, MobileDeviceError>;
+            async fn find_by_device_id(
+                &self,
+                device_id: &MobileDeviceId,
+            ) -> Result<Option<MobileDevice>, MobileDeviceError>;
+            async fn list_all(&self) -> Result<Vec<MobileDevice>, MobileDeviceError>;
+            async fn delete(&self, device_id: &MobileDeviceId) -> Result<bool, MobileDeviceError>;
+            async fn record_activity(
+                &self,
+                device_id: &MobileDeviceId,
+                last_seen_at_ms: i64,
+                last_seen_ip: Option<String>,
+                reported_name: Option<String>,
+                reported_os: Option<String>,
+            ) -> Result<(), MobileDeviceError>;
+            async fn update_password_hash(
+                &self,
+                device_id: &MobileDeviceId,
+                new_password_hash: String,
+            ) -> Result<bool, MobileDeviceError>;
+        }
+    }
+
+    mockall::mock! {
+        Hasher {}
+        #[async_trait]
+        impl PasswordHasherPort for Hasher {
+            async fn hash(&self, password: &str) -> Result<String, PasswordHasherError>;
+            async fn verify(&self, password: &str, phc: &str)
+                -> Result<bool, PasswordHasherError>;
+        }
+    }
+
+    mockall::mock! {
+        Minter {}
+        impl MobileCredentialsMinterPort for Minter {
+            fn mint_credentials(&self) -> MintedCredentials;
+        }
+    }
+
+    // ── helpers ────────────────────────────────────────────────────────
+
+    fn fixture_device(id: &str, username: &str) -> MobileDevice {
+        MobileDevice {
+            device_id: MobileDeviceId::new(id),
+            label: "phone".into(),
+            client_type: MobileClientType::IosShortcut,
+            username: username.into(),
+            password_hash: "phc:OLD".into(),
+            created_at_ms: 1_000,
+            last_seen_at_ms: None,
+            last_seen_ip: None,
+            reported_name: None,
+            reported_os: None,
+        }
+    }
+
+    /// 大多数测试只用前两个 mock + 一个 minter,这里把 minter 的"产出哪个
+    /// 明文"参数化,让每个测试自由选择(rotate path 只用 minter.password,
+    /// 其它字段是无关项,统一填 placeholder)。
+    fn minter_emitting(password: &'static str) -> MockMinter {
+        let mut m = MockMinter::new();
+        m.expect_mint_credentials()
+            .returning(move || MintedCredentials {
+                username: "mobile_unused".into(),
+                password: password.into(),
+                password_hash: "$argon2id$test$minted".into(),
+                device_id: MobileDeviceId::new("did_unused"),
+            });
+        m
+    }
+
+    /// 钩入"identity-like"hasher:输出 `phc:<plaintext>`。配合 .with(eq(..))
+    /// 就能在 update_password_hash 的入参上断言"hasher 算出的 PHC 真的被
+    /// 送进了仓储",这是手写 fixture 表达不出来的。
+    fn identity_hasher_for(plaintext: &'static str) -> MockHasher {
+        let mut h = MockHasher::new();
+        h.expect_hash()
+            .with(eq(plaintext))
+            .returning(|p| Ok(format!("phc:{p}")));
+        h
+    }
+
+    // ── tests ──────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn rotates_to_minted_password_when_input_is_none() {
+        let device = fixture_device("did_x", "mobile_alice");
+        let device_id = device.device_id.clone();
+
+        let mut repo = MockDeviceRepo::new();
+        repo.expect_find_by_device_id()
+            .with(eq(device_id.clone()))
+            .returning({
+                let device = device.clone();
+                move |_| Ok(Some(device.clone()))
+            });
+        repo.expect_update_password_hash()
+            .with(
+                eq(device_id.clone()),
+                eq("phc:minted-rotate-pw-22".to_string()),
+            )
+            .returning(|_, _| Ok(true));
+
+        let uc = RotateMobilePasswordUseCase::new(
+            Arc::new(repo),
+            Arc::new(identity_hasher_for("minted-rotate-pw-22")),
+            Arc::new(minter_emitting("minted-rotate-pw-22")),
+        );
+
+        let out = uc
+            .execute(RotateMobilePasswordInput {
+                device_id: device_id.clone(),
+                password: None,
+            })
+            .await
+            .expect("ok");
+
+        assert_eq!(out.password, "minted-rotate-pw-22");
+        assert_eq!(out.username, "mobile_alice");
+        assert_eq!(out.device_id, device_id);
+    }
+
+    #[tokio::test]
+    async fn rotates_to_custom_password_when_provided() {
+        let device = fixture_device("did_x", "mobile_alice");
+        let device_id = device.device_id.clone();
+
+        let mut repo = MockDeviceRepo::new();
+        repo.expect_find_by_device_id().returning({
+            let device = device.clone();
+            move |_| Ok(Some(device.clone()))
+        });
+        repo.expect_update_password_hash()
+            .with(
+                eq(device_id.clone()),
+                eq("phc:brand-new-pass-42".to_string()),
+            )
+            .returning(|_, _| Ok(true));
+
+        // minter 不应被调用 —— 给一个会让 mockall 在意外触发时报错的 mock
+        let mut minter = MockMinter::new();
+        minter.expect_mint_credentials().never();
+
+        let uc = RotateMobilePasswordUseCase::new(
+            Arc::new(repo),
+            Arc::new(identity_hasher_for("brand-new-pass-42")),
+            Arc::new(minter),
+        );
+
+        let out = uc
+            .execute(RotateMobilePasswordInput {
+                device_id,
+                password: Some("brand-new-pass-42".into()),
+            })
+            .await
+            .expect("ok");
+
+        assert_eq!(out.password, "brand-new-pass-42");
+    }
+
+    #[tokio::test]
+    async fn returns_not_found_for_missing_device() {
+        let mut repo = MockDeviceRepo::new();
+        repo.expect_find_by_device_id().returning(|_| Ok(None));
+        // 找不到设备就不应再走 hasher / update_password_hash,断言一下没被调用
+        repo.expect_update_password_hash().never();
+        let mut hasher = MockHasher::new();
+        hasher.expect_hash().never();
+
+        let uc = RotateMobilePasswordUseCase::new(
+            Arc::new(repo),
+            Arc::new(hasher),
+            Arc::new(MockMinter::new()),
+        );
+
+        let err = uc
+            .execute(RotateMobilePasswordInput {
+                device_id: MobileDeviceId::new("did_ghost"),
+                password: None,
+            })
+            .await
+            .unwrap_err();
+        assert!(matches!(err, RotateMobilePasswordError::NotFound(_)));
+    }
+
+    #[tokio::test]
+    async fn returns_not_found_when_concurrent_revoke_between_find_and_update() {
+        // find 返回 Some, 但 update_password_hash 返回 false (并发撤销)。
+        // use case 必须翻成 NotFound, 而不是把它吞掉。
+        let device = fixture_device("did_x", "mobile_alice");
+        let device_id = device.device_id.clone();
+
+        let mut repo = MockDeviceRepo::new();
+        repo.expect_find_by_device_id().returning({
+            let device = device.clone();
+            move |_| Ok(Some(device.clone()))
+        });
+        repo.expect_update_password_hash()
+            .returning(|_, _| Ok(false));
+
+        let uc = RotateMobilePasswordUseCase::new(
+            Arc::new(repo),
+            Arc::new(identity_hasher_for("minted-rotate-pw-22")),
+            Arc::new(minter_emitting("minted-rotate-pw-22")),
+        );
+
+        let err = uc
+            .execute(RotateMobilePasswordInput {
+                device_id,
+                password: None,
+            })
+            .await
+            .unwrap_err();
+        assert!(matches!(err, RotateMobilePasswordError::NotFound(_)));
+    }
+
+    #[tokio::test]
+    async fn rejects_password_too_short() {
+        // 长度校验在 find 之后, 仓库 / hasher 不应被任何方式调用 —— 让两者
+        // 都拿不到 expectation, 一旦被调用 mockall 会自动 panic。
+        let device = fixture_device("did_x", "mobile_alice");
+        let mut repo = MockDeviceRepo::new();
+        repo.expect_find_by_device_id().returning({
+            let device = device.clone();
+            move |_| Ok(Some(device.clone()))
+        });
+        repo.expect_update_password_hash().never();
+        let mut hasher = MockHasher::new();
+        hasher.expect_hash().never();
+
+        let uc = RotateMobilePasswordUseCase::new(
+            Arc::new(repo),
+            Arc::new(hasher),
+            Arc::new(MockMinter::new()),
+        );
+
+        let err = uc
+            .execute(RotateMobilePasswordInput {
+                device_id: device.device_id,
+                password: Some("a".repeat(MIN_PASSWORD_LEN - 1)),
+            })
+            .await
+            .unwrap_err();
+        match err {
+            RotateMobilePasswordError::PasswordTooShort { min } => {
+                assert_eq!(min, MIN_PASSWORD_LEN)
+            }
+            other => panic!("expected PasswordTooShort, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn rejects_password_too_long() {
+        let device = fixture_device("did_x", "mobile_alice");
+        let mut repo = MockDeviceRepo::new();
+        repo.expect_find_by_device_id().returning({
+            let device = device.clone();
+            move |_| Ok(Some(device.clone()))
+        });
+        repo.expect_update_password_hash().never();
+        let mut hasher = MockHasher::new();
+        hasher.expect_hash().never();
+
+        let uc = RotateMobilePasswordUseCase::new(
+            Arc::new(repo),
+            Arc::new(hasher),
+            Arc::new(MockMinter::new()),
+        );
+
+        let err = uc
+            .execute(RotateMobilePasswordInput {
+                device_id: device.device_id,
+                password: Some("a".repeat(MAX_PASSWORD_LEN + 1)),
+            })
+            .await
+            .unwrap_err();
+        match err {
+            RotateMobilePasswordError::PasswordTooLong { max } => assert_eq!(max, MAX_PASSWORD_LEN),
+            other => panic!("expected PasswordTooLong, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn translates_hasher_internal_error() {
+        let device = fixture_device("did_x", "mobile_alice");
+        let mut repo = MockDeviceRepo::new();
+        repo.expect_find_by_device_id().returning({
+            let device = device.clone();
+            move |_| Ok(Some(device.clone()))
+        });
+        // hasher 失败 → 不该走到 update
+        repo.expect_update_password_hash().never();
+
+        let mut hasher = MockHasher::new();
+        hasher
+            .expect_hash()
+            .returning(|_| Err(PasswordHasherError::Internal("simulated".into())));
+
+        let uc = RotateMobilePasswordUseCase::new(
+            Arc::new(repo),
+            Arc::new(hasher),
+            Arc::new(MockMinter::new()),
+        );
+
+        let err = uc
+            .execute(RotateMobilePasswordInput {
+                device_id: device.device_id,
+                password: Some("some-strong-pass".into()),
+            })
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            RotateMobilePasswordError::PasswordHashFailed(_)
+        ));
+    }
+}

--- a/src-tauri/crates/uc-core/src/ports/mobile_sync.rs
+++ b/src-tauri/crates/uc-core/src/ports/mobile_sync.rs
@@ -116,6 +116,21 @@ pub trait MobileDeviceRepositoryPort: Send + Sync {
         reported_name: Option<String>,
         reported_os: Option<String>,
     ) -> Result<(), MobileDeviceError>;
+
+    /// 替换某台设备的 `password_hash`。其它字段保持不变。
+    ///
+    /// 用于密码轮换(rotate)用例 —— 用户在 UI 上请求"换一份新密码",
+    /// application 层先 hash 新明文,再调本方法把 PHC 字符串换掉。
+    ///
+    /// 返回 `Ok(true)` 表示真实更新了一行;`Ok(false)` 表示 device_id 不
+    /// 存在(用户已撤销 / UI 列表过期 —— application 层据此提示刷新)。
+    /// 这与 [`Self::delete`] 的"返回值表达存在性"语义保持一致,避免应用
+    /// 层为这种 race 单独处理。
+    async fn update_password_hash(
+        &self,
+        device_id: &MobileDeviceId,
+        new_password_hash: String,
+    ) -> Result<bool, MobileDeviceError>;
 }
 
 // ─── endpoint info ───────────────────────────────────────────────────────

--- a/src-tauri/crates/uc-infra/src/db/repositories/mobile_device_repo.rs
+++ b/src-tauri/crates/uc-infra/src/db/repositories/mobile_device_repo.rs
@@ -183,6 +183,24 @@ where
         Ok(affected > 0)
     }
 
+    async fn update_password_hash(
+        &self,
+        device_id_value: &MobileDeviceId,
+        new_password_hash: String,
+    ) -> Result<bool, MobileDeviceError> {
+        let needle = device_id_value.as_str().to_string();
+        let affected = self
+            .executor
+            .run(move |conn| {
+                diesel::update(mobile_device.filter(device_id.eq(&needle)))
+                    .set(password_hash.eq(new_password_hash))
+                    .execute(conn)
+                    .map_err(|e| anyhow::anyhow!(e.to_string()))
+            })
+            .map_err(|e| MobileDeviceError::Storage(e.to_string()))?;
+        Ok(affected > 0)
+    }
+
     async fn record_activity(
         &self,
         device_id_value: &MobileDeviceId,
@@ -395,5 +413,35 @@ mod tests {
         repo.record_activity(&MobileDeviceId::new("did_ghost"), 1, None, None, None)
             .await
             .unwrap();
+    }
+
+    #[tokio::test]
+    async fn update_password_hash_replaces_only_phc_and_keeps_other_fields() {
+        let (repo, _t) = make_repo();
+        let d = fixture("did_x", "0001", "phone");
+        repo.save(&d).await.unwrap();
+
+        let updated = repo
+            .update_password_hash(&d.device_id, "$argon2id$test$rotated".into())
+            .await
+            .unwrap();
+        assert!(updated);
+
+        let got = repo.find_by_device_id(&d.device_id).await.unwrap().unwrap();
+        assert_eq!(got.password_hash, "$argon2id$test$rotated");
+        // 其它字段必须保持不变
+        assert_eq!(got.label, d.label);
+        assert_eq!(got.username, d.username);
+        assert_eq!(got.created_at_ms, d.created_at_ms);
+    }
+
+    #[tokio::test]
+    async fn update_password_hash_returns_false_when_device_missing() {
+        let (repo, _t) = make_repo();
+        let updated = repo
+            .update_password_hash(&MobileDeviceId::new("did_ghost"), "phc".into())
+            .await
+            .unwrap();
+        assert!(!updated);
     }
 }

--- a/src-tauri/crates/uc-infra/src/mobile_sync/device_repo.rs
+++ b/src-tauri/crates/uc-infra/src/mobile_sync/device_repo.rs
@@ -105,6 +105,21 @@ impl MobileDeviceRepositoryPort for InMemoryMobileDeviceRepository {
         }
         Ok(())
     }
+
+    async fn update_password_hash(
+        &self,
+        device_id: &MobileDeviceId,
+        new_password_hash: String,
+    ) -> Result<bool, MobileDeviceError> {
+        let mut guard = self.devices.lock().await;
+        match guard.get_mut(device_id) {
+            Some(device) => {
+                device.password_hash = new_password_hash;
+                Ok(true)
+            }
+            None => Ok(false),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -224,5 +239,35 @@ mod tests {
         repo.record_activity(&MobileDeviceId::new("did_ghost"), 5_000, None, None, None)
             .await
             .unwrap();
+    }
+
+    #[tokio::test]
+    async fn update_password_hash_replaces_only_phc_field() {
+        let repo = InMemoryMobileDeviceRepository::new();
+        let d = device("did_x", "0001", "phone");
+        repo.save(&d).await.unwrap();
+
+        let updated = repo
+            .update_password_hash(&d.device_id, "$argon2id$test$rotated".into())
+            .await
+            .unwrap();
+        assert!(updated);
+
+        let got = repo.find_by_device_id(&d.device_id).await.unwrap().unwrap();
+        assert_eq!(got.password_hash, "$argon2id$test$rotated");
+        // 其它字段保持不变
+        assert_eq!(got.label, d.label);
+        assert_eq!(got.username, d.username);
+        assert_eq!(got.created_at_ms, d.created_at_ms);
+    }
+
+    #[tokio::test]
+    async fn update_password_hash_returns_false_when_device_missing() {
+        let repo = InMemoryMobileDeviceRepository::new();
+        let updated = repo
+            .update_password_hash(&MobileDeviceId::new("did_ghost"), "phc".into())
+            .await
+            .unwrap();
+        assert!(!updated);
     }
 }

--- a/src-tauri/crates/uc-tauri/src/commands/mobile_sync.rs
+++ b/src-tauri/crates/uc-tauri/src/commands/mobile_sync.rs
@@ -18,6 +18,7 @@ use uc_application::facade::mobile_sync::{
     MobileDeviceSummary, MobileSyncFacade, MobileSyncSettingsView,
     RegisterMobileShortcutDeviceError, RegisterMobileShortcutDeviceInput,
     RegisterMobileShortcutDeviceOutput, RevokeMobileDeviceError, RevokeMobileDeviceInput,
+    RotateMobilePasswordError, RotateMobilePasswordInput, RotateMobilePasswordOutput,
     ShortcutInstallMethod, ShortcutInstallMethodOption, UpdateMobileSyncSettingsError,
     UpdateMobileSyncSettingsInput, UpdateMobileSyncSettingsOutput,
 };
@@ -166,6 +167,24 @@ impl From<ListMobileDevicesError> for MobileSyncError {
     }
 }
 
+impl From<RotateMobilePasswordError> for MobileSyncError {
+    fn from(err: RotateMobilePasswordError) -> Self {
+        match err {
+            RotateMobilePasswordError::NotFound(id) => Self::DeviceNotFound {
+                device_id: id.into_string(),
+            },
+            RotateMobilePasswordError::PasswordTooShort { min } => Self::PasswordTooShort { min },
+            RotateMobilePasswordError::PasswordTooLong { max } => Self::PasswordTooLong { max },
+            RotateMobilePasswordError::PasswordHashFailed(message) => {
+                Self::PasswordHashFailed { message }
+            }
+            RotateMobilePasswordError::PersistenceFailed(message) => {
+                Self::PersistenceFailed { message }
+            }
+        }
+    }
+}
+
 impl From<GetMobileSyncSettingsError> for MobileSyncError {
     fn from(err: GetMobileSyncSettingsError) -> Self {
         match err {
@@ -260,14 +279,47 @@ fn client_type_wire(t: &MobileClientType) -> &'static str {
     t.as_wire_str()
 }
 
+/// `rotate_mobile_password` 入参。`password = None` (字段缺失或 null) 走
+/// minter 自动颁发新明文;给值则按规则严格校验。
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RotateMobilePasswordArgs {
+    pub device_id: String,
+    #[serde(default)]
+    pub password: Option<String>,
+}
+
+/// `rotate_mobile_password` 返回值。`password` 是**唯一一次**面向用户的
+/// 明文回显 —— 之后只以 PHC 形式存在。前端必须立即在 modal 里展示, 并
+/// 提示用户同步更新 iPhone shortcut 里的 password 字段(旧密码已立即
+/// 失效)。
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RotateMobilePasswordResult {
+    pub device_id: String,
+    pub username: String,
+    pub password: String,
+}
+
+impl From<RotateMobilePasswordOutput> for RotateMobilePasswordResult {
+    fn from(out: RotateMobilePasswordOutput) -> Self {
+        Self {
+            device_id: out.device_id.into_string(),
+            username: out.username,
+            password: out.password,
+        }
+    }
+}
+
 /// `list_mobile_devices` 单条结果。来自 `MobileDeviceSummary`，不含
-/// password_hash / username。
+/// password_hash；username 透传给前端作为辅助识别字段。
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct MobileDeviceView {
     pub device_id: String,
     pub label: String,
     pub client_type: String,
+    pub username: String,
     pub created_at_ms: i64,
     pub last_seen_at_ms: Option<i64>,
     pub last_seen_ip: Option<String>,
@@ -281,6 +333,7 @@ impl From<MobileDeviceSummary> for MobileDeviceView {
             device_id: s.device_id.into_string(),
             label: s.label,
             client_type: client_type_wire(&s.client_type).to_string(),
+            username: s.username,
             created_at_ms: s.created_at_ms,
             last_seen_at_ms: s.last_seen_at_ms,
             last_seen_ip: s.last_seen_ip,
@@ -508,7 +561,7 @@ pub async fn revoke_mobile_device(
 }
 
 /// 列出已登记设备。结果按"最近活跃 desc → 创建时间 desc"排序。不含
-/// password_hash / username。
+/// password_hash；username 作为辅助识别字段透传给前端。
 #[tauri::command]
 pub async fn list_mobile_devices(
     runtime: State<'_, Arc<TauriAppRuntime>>,
@@ -525,6 +578,38 @@ pub async fn list_mobile_devices(
         let facade = mobile_sync_facade(&runtime)?;
         let devices = facade.list_devices().await?;
         Ok(devices.into_iter().map(Into::into).collect())
+    }
+    .instrument(span)
+    .await
+}
+
+/// 给一台已登记设备换一份新密码。`password = None`(字段缺失 / null)走
+/// minter 自动颁发;给值则按 8–256 字符校验。返回值 `password` 是**唯一一次**
+/// 明文回显 —— 之后只以 PHC 存在,UI 必须立即展示并告知用户同步更新 iPhone
+/// shortcut 里的 password 字段(旧密码已立即失效)。
+#[tauri::command]
+pub async fn rotate_mobile_password(
+    runtime: State<'_, Arc<TauriAppRuntime>>,
+    args: RotateMobilePasswordArgs,
+    _trace: Option<TraceMetadata>,
+) -> Result<RotateMobilePasswordResult, MobileSyncError> {
+    let span = info_span!(
+        "command.mobile_sync.rotate_password",
+        device_id = %args.device_id,
+        custom_password = args.password.is_some(),
+        trace_id = tracing::field::Empty,
+        trace_ts = tracing::field::Empty,
+    );
+    record_trace_fields(&span, &_trace);
+
+    async move {
+        let facade = mobile_sync_facade(&runtime)?;
+        let input = RotateMobilePasswordInput {
+            device_id: MobileDeviceId::new(args.device_id),
+            password: args.password,
+        };
+        let out = facade.rotate_password(input).await?;
+        Ok(RotateMobilePasswordResult::from(out))
     }
     .instrument(span)
     .await
@@ -737,6 +822,59 @@ mod tests {
         assert_eq!(dto.client_type, "ios_shortcut");
         assert_eq!(dto.device_id, "did_test");
         assert_eq!(dto.password, "secretpw");
+    }
+
+    #[test]
+    fn rotate_args_password_optional() {
+        // 不给 password → 走 minter 自动颁发
+        let json = r#"{"deviceId": "did_x"}"#;
+        let args: RotateMobilePasswordArgs = serde_json::from_str(json).unwrap();
+        assert_eq!(args.device_id, "did_x");
+        assert!(args.password.is_none());
+    }
+
+    #[test]
+    fn rotate_args_with_custom_password_camel_case() {
+        let json = r#"{"deviceId": "did_x", "password": "brand-new"}"#;
+        let args: RotateMobilePasswordArgs = serde_json::from_str(json).unwrap();
+        assert_eq!(args.device_id, "did_x");
+        assert_eq!(args.password.as_deref(), Some("brand-new"));
+    }
+
+    #[test]
+    fn rotate_result_serializes_camel_case() {
+        // 走 facade output → DTO 转换路径,断言 device_id / username / password
+        // 都按 camelCase 序列化(前端 wire 形态)。
+        use uc_core::mobile_sync::MobileDeviceId;
+        let dto = RotateMobilePasswordResult::from(RotateMobilePasswordOutput {
+            device_id: MobileDeviceId::new("did_rot"),
+            username: "mobile_alice".into(),
+            password: "fresh-pw".into(),
+        });
+        let json = serde_json::to_value(&dto).unwrap();
+        assert_eq!(json["deviceId"], "did_rot");
+        assert_eq!(json["username"], "mobile_alice");
+        assert_eq!(json["password"], "fresh-pw");
+    }
+
+    #[test]
+    fn rotate_error_not_found_translates_to_device_not_found_with_camel_case() {
+        let app_err = RotateMobilePasswordError::NotFound(
+            uc_core::mobile_sync::MobileDeviceId::new("did_ghost"),
+        );
+        let mapped = MobileSyncError::from(app_err);
+        let json = serde_json::to_value(&mapped).unwrap();
+        assert_eq!(json["code"], "DEVICE_NOT_FOUND");
+        assert_eq!(json["deviceId"], "did_ghost");
+    }
+
+    #[test]
+    fn rotate_error_password_too_short_translates_with_min_field() {
+        let app_err = RotateMobilePasswordError::PasswordTooShort { min: 8 };
+        let mapped = MobileSyncError::from(app_err);
+        let json = serde_json::to_value(&mapped).unwrap();
+        assert_eq!(json["code"], "PASSWORD_TOO_SHORT");
+        assert_eq!(json["min"], 8);
     }
 
     #[test]

--- a/src-tauri/crates/uc-tauri/src/run.rs
+++ b/src-tauri/crates/uc-tauri/src/run.rs
@@ -461,6 +461,7 @@ pub fn run(tauri_ctx: tauri::Context<tauri::Wry>) -> anyhow::Result<()> {
             crate::commands::mobile_sync::register_mobile_device,
             crate::commands::mobile_sync::revoke_mobile_device,
             crate::commands::mobile_sync::list_mobile_devices,
+            crate::commands::mobile_sync::rotate_mobile_password,
             crate::commands::mobile_sync::get_mobile_sync_settings,
             crate::commands::mobile_sync::update_mobile_sync_settings,
             crate::commands::mobile_sync::list_mobile_lan_interfaces,

--- a/src-tauri/crates/uc-webserver/src/mobile_lan/test_support.rs
+++ b/src-tauri/crates/uc-webserver/src/mobile_lan/test_support.rs
@@ -128,6 +128,20 @@ pub(crate) async fn build_facade_with_seeded_device(
         ) -> Result<(), MobileDeviceError> {
             Ok(())
         }
+        async fn update_password_hash(
+            &self,
+            id: &MobileDeviceId,
+            new_hash: String,
+        ) -> Result<bool, MobileDeviceError> {
+            let mut devs = self.devices.lock().unwrap();
+            match devs.iter_mut().find(|d| d.device_id == *id) {
+                Some(d) => {
+                    d.password_hash = new_hash;
+                    Ok(true)
+                }
+                None => Ok(false),
+            }
+        }
     }
 
     struct FakeHasher;

--- a/src/api/tauri-command/mobile_sync.ts
+++ b/src/api/tauri-command/mobile_sync.ts
@@ -97,6 +97,9 @@ export interface MobileDeviceView {
   deviceId: string
   label: string
   clientType: MobileClientType
+  /** Basic Auth 用户名 —— 展示给用户作为辅助识别（label 可重命名重复，
+   *  username 是 server 端稳定主键）。 */
+  username: string
   createdAtMs: number
   lastSeenAtMs: number | null
   lastSeenIp: string | null
@@ -188,9 +191,54 @@ export async function revokeMobileDevice(deviceId: string): Promise<void> {
   await invokeWithTrace<void>('revoke_mobile_device', { deviceId })
 }
 
+export interface RotateMobilePasswordArgs {
+  deviceId: string
+  /**
+   * Optional custom password. Leave undefined (or omit) to auto-mint a fresh
+   * minter-generated value. When provided, validated against the same
+   * 8–256-char rule the register flow uses.
+   */
+  password?: string
+}
+
+export interface RotateMobilePasswordResult {
+  deviceId: string
+  /** Stable login username — unchanged by rotation, returned for UI convenience. */
+  username: string
+  /**
+   * Plaintext password — returned **only this once**.
+   *
+   * After the modal that surfaces this value closes, the password is
+   * unrecoverable (server only stores the Argon2id PHC hash). The previously
+   * registered password is invalidated immediately on the daemon side, so the
+   * user must update their iPhone shortcut's password field before the next
+   * sync (otherwise the iPhone receives 401).
+   *
+   * UI must:
+   * 1. Show prominently in a copy-friendly modal
+   * 2. Block close until the user explicitly confirms they have saved it
+   * 3. Make the "rotate iPhone shortcut password field" call-to-action
+   *    unmissable
+   * 4. Never log, persist, or send to any analytics
+   */
+  password: string
+}
+
+/**
+ * Rotate the password of a previously registered device. Old password is
+ * invalidated atomically on the daemon side; the response carries the
+ * one-time plaintext of the new password — see `RotateMobilePasswordResult`.
+ */
+export async function rotateMobilePassword(
+  args: RotateMobilePasswordArgs
+): Promise<RotateMobilePasswordResult> {
+  return await invokeWithTrace<RotateMobilePasswordResult>('rotate_mobile_password', { args })
+}
+
 /**
  * List currently registered devices, sorted by recent activity then
- * registration time. Does NOT include `password_hash` or `username`.
+ * registration time. Does NOT include `password_hash`. `username` is
+ * exposed as an auxiliary identifier for the UI (paired with `label`).
  */
 export async function listMobileDevices(): Promise<MobileDeviceView[]> {
   return await invokeWithTrace<MobileDeviceView[]>('list_mobile_devices')

--- a/src/components/device/MobileSyncDevicesPanel.tsx
+++ b/src/components/device/MobileSyncDevicesPanel.tsx
@@ -15,8 +15,15 @@
  *   │ Mobile Sync                            [Configure] [+ Add]  │
  *   ├─ List container ────────────────────────────────────────────┤
  *   │ 📱 My iPhone              5m ago · .42                  ⌫  │
+ *   │    mobile_a1b2c3d4                                          │
  *   │ 📱 Pixel                  never                          ⌫  │
+ *   │    mobile_e5f6g7h8                                          │
  *   └─────────────────────────────────────────────────────────────┘
+ *
+ * 每行双行布局: 主行 label, 副行 username (Basic Auth 账号), 与 macOS
+ * 系统设置 / Tailscale 的 "primary text + secondary text" 风格一致。
+ * username 暴露在 UI 上是有意决策 —— label 可重命名重复, username 是
+ * server 端稳定的识别主键, 帮用户区分多台同名设备。
  *
  * Header 只放标题 + Configure + Add(状态文案/监听 URL/bind 错误均收
  * 进 SettingsSheet,主页面保持极简)。设备列表是单个圆角容器 + divide-y
@@ -29,12 +36,14 @@
  * - revoke 流程不变
  */
 
-import { Plus, RefreshCw, Settings2, Smartphone, Trash2 } from 'lucide-react'
+import { KeyRound, Plus, RefreshCw, Settings2, Smartphone, Trash2 } from 'lucide-react'
 import React, { useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import AddMobileSyncDeviceDialog from './AddMobileSyncDeviceDialog'
 import MobileSyncCredentialModal from './MobileSyncCredentialModal'
 import MobileSyncSettingsSheet from './MobileSyncSettingsSheet'
+import RotatedPasswordModal from './RotatedPasswordModal'
+import RotateMobilePasswordDialog from './RotateMobilePasswordDialog'
 import {
   isMobileSyncError,
   listMobileDevices,
@@ -43,6 +52,7 @@ import {
   type MobileSyncError,
   type MobileSyncSettingsView,
   type RegisterMobileDeviceResult,
+  type RotateMobilePasswordResult,
 } from '@/api/tauri-command/mobile_sync'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import {
@@ -77,6 +87,9 @@ const MobileSyncDevicesPanel: React.FC = () => {
   const [revokeTarget, setRevokeTarget] = useState<MobileDeviceView | null>(null)
   const [revokeBusy, setRevokeBusy] = useState(false)
 
+  const [rotateTarget, setRotateTarget] = useState<MobileDeviceView | null>(null)
+  const [rotatedPayload, setRotatedPayload] = useState<RotateMobilePasswordResult | null>(null)
+
   const translate = useCallback((err: unknown): string => translateMobileSyncError(t, err), [t])
 
   const loadDevices = useCallback(async () => {
@@ -105,6 +118,14 @@ const MobileSyncDevicesPanel: React.FC = () => {
   const handleAddSuccess = useCallback(
     (result: RegisterMobileDeviceResult) => {
       setCredentialPayload(result)
+      void loadDevices()
+    },
+    [loadDevices]
+  )
+
+  const handleRotateSuccess = useCallback(
+    (result: RotateMobilePasswordResult) => {
+      setRotatedPayload(result)
       void loadDevices()
     },
     [loadDevices]
@@ -182,6 +203,7 @@ const MobileSyncDevicesPanel: React.FC = () => {
                     key={device.deviceId}
                     device={device}
                     onRevoke={() => setRevokeTarget(device)}
+                    onRotate={() => setRotateTarget(device)}
                   />
                 ))}
               </ul>
@@ -236,6 +258,19 @@ const MobileSyncDevicesPanel: React.FC = () => {
         payload={credentialPayload}
         onClose={() => setCredentialPayload(null)}
       />
+
+      <RotateMobilePasswordDialog
+        open={rotateTarget !== null}
+        onOpenChange={open => {
+          if (!open) setRotateTarget(null)
+        }}
+        device={
+          rotateTarget ? { deviceId: rotateTarget.deviceId, label: rotateTarget.label } : null
+        }
+        onSuccess={handleRotateSuccess}
+      />
+
+      <RotatedPasswordModal payload={rotatedPayload} onClose={() => setRotatedPayload(null)} />
     </>
   )
 }
@@ -245,9 +280,10 @@ const MobileSyncDevicesPanel: React.FC = () => {
 interface DeviceRowProps {
   device: MobileDeviceView
   onRevoke: () => void
+  onRotate: () => void
 }
 
-const DeviceRow: React.FC<DeviceRowProps> = ({ device, onRevoke }) => {
+const DeviceRow: React.FC<DeviceRowProps> = ({ device, onRevoke, onRotate }) => {
   const { t } = useTranslation()
 
   return (
@@ -258,18 +294,29 @@ const DeviceRow: React.FC<DeviceRowProps> = ({ device, onRevoke }) => {
 
       <div className="min-w-0 flex-1">
         <p className="truncate text-sm font-medium text-foreground">{device.label}</p>
+        <p className="truncate font-mono text-xs text-muted-foreground">{device.username}</p>
       </div>
 
-      <Button
-        variant="ghost"
-        size="icon-sm"
-        className="shrink-0 opacity-0 transition-opacity group-hover:opacity-100"
-        onClick={onRevoke}
-        aria-label={t('devices.mobileSync.revoke.confirm')}
-        title={t('devices.mobileSync.revoke.confirm')}
-      >
-        <Trash2 className="h-4 w-4" />
-      </Button>
+      <div className="flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100">
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          onClick={onRotate}
+          aria-label={t('devices.mobileSync.rotate.button')}
+          title={t('devices.mobileSync.rotate.button')}
+        >
+          <KeyRound className="h-4 w-4" />
+        </Button>
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          onClick={onRevoke}
+          aria-label={t('devices.mobileSync.revoke.confirm')}
+          title={t('devices.mobileSync.revoke.confirm')}
+        >
+          <Trash2 className="h-4 w-4" />
+        </Button>
+      </div>
     </li>
   )
 }

--- a/src/components/device/RotateMobilePasswordDialog.tsx
+++ b/src/components/device/RotateMobilePasswordDialog.tsx
@@ -1,0 +1,174 @@
+/**
+ * RotateMobilePasswordDialog —— 给已配对设备换密码。
+ *
+ * 与 AddMobileSyncDeviceDialog 的关键差异:
+ * - 不要 label 输入(设备身份不变)
+ * - 不要 username 自定义(server 主键稳定)
+ * - 只需一个 password 输入,留空 = auto-mint
+ * - 用户提交 → rotate command → 父组件接住 result,弹 RotatedPasswordModal
+ *
+ * 警告横幅必不可少:用户必须知道"提交后旧密码立即失效,移动端客户端
+ * 在更新之前会同步失败"。这是与 register 不同的关键风险点(register 时
+ * 移动端还没接入,谈不上"中断"),不能省。
+ */
+
+import { Loader2 } from 'lucide-react'
+import React, { useCallback, useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import {
+  isMobileSyncError,
+  rotateMobilePassword,
+  type MobileSyncError,
+  type RotateMobilePasswordResult,
+} from '@/api/tauri-command/mobile_sync'
+import { Input } from '@/components/ui'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Label } from '@/components/ui/label'
+import { toast } from '@/components/ui/toast'
+import { createLogger } from '@/lib/logger'
+
+const log = createLogger('rotate-mobile-password-dialog')
+
+interface Props {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  /** 目标设备 —— null 时本组件不渲染。 */
+  device: { deviceId: string; label: string } | null
+  /** rotate 成功后回调:父组件据此弹 result modal + 刷新列表。 */
+  onSuccess: (result: RotateMobilePasswordResult) => void
+}
+
+const RotateMobilePasswordDialog: React.FC<Props> = ({ open, onOpenChange, device, onSuccess }) => {
+  const { t } = useTranslation()
+
+  const [password, setPassword] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+
+  // 每次重开 dialog 时重置表单 —— 避免上一次输入残留
+  useEffect(() => {
+    if (open) {
+      setPassword('')
+      setSubmitting(false)
+    }
+  }, [open])
+
+  const handleSubmit = useCallback(async () => {
+    if (!device) return
+    setSubmitting(true)
+    try {
+      const result = await rotateMobilePassword({
+        deviceId: device.deviceId,
+        password: password.length > 0 ? password : undefined,
+      })
+      onSuccess(result)
+      onOpenChange(false)
+    } catch (err) {
+      log.error({ err, deviceId: device.deviceId }, 'failed to rotate mobile password')
+      toast.error(translateRotateError(t, err))
+    } finally {
+      setSubmitting(false)
+    }
+  }, [device, onOpenChange, onSuccess, password, t])
+
+  if (!device) return null
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={next => {
+        if (!submitting) onOpenChange(next)
+      }}
+    >
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>
+            {t('devices.mobileSync.rotate.dialog.title', { label: device.label })}
+          </DialogTitle>
+          <DialogDescription>{t('devices.mobileSync.rotate.dialog.subtitle')}</DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          {/* 警告横幅 —— rotate 与 register 的关键差异 */}
+          <div className="rounded-md border border-amber-500/30 bg-amber-500/10 p-3">
+            <p className="text-xs text-amber-700/90 dark:text-amber-400/90">
+              {t('devices.mobileSync.rotate.dialog.warning')}
+            </p>
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="rotate-password">
+              {t('devices.mobileSync.rotate.dialog.passwordLabel')}
+            </Label>
+            <Input
+              id="rotate-password"
+              type="password"
+              autoFocus
+              value={password}
+              onChange={e => setPassword(e.target.value)}
+              placeholder={t('devices.mobileSync.rotate.dialog.passwordPlaceholder')}
+              disabled={submitting}
+              autoComplete="new-password"
+            />
+            <p className="text-xs text-muted-foreground/80">
+              {t('devices.mobileSync.rotate.dialog.passwordHelp')}
+            </p>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => onOpenChange(false)} disabled={submitting}>
+            {t('devices.mobileSync.rotate.dialog.cancel')}
+          </Button>
+          <Button onClick={handleSubmit} disabled={submitting}>
+            {submitting && <Loader2 className="h-4 w-4 animate-spin" />}
+            {submitting
+              ? t('devices.mobileSync.rotate.dialog.submitting')
+              : t('devices.mobileSync.rotate.dialog.submit')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+// rotate 路径的 error 子集:与 register 共享 password 长度 / hash 失败 /
+// persistence,新增 deviceNotFound(rotate 特有 — register 不会撞)。其余
+// 走兜底 unknown。集中在本组件,与 panel / add dialog 的 translator 不
+// 共享 —— 三个动作未来文案可能分化(rotate 强调"同步更新移动端客户端")。
+function translateRotateError(t: ReturnType<typeof useTranslation>['t'], err: unknown): string {
+  if (isMobileSyncError(err)) {
+    const e = err as MobileSyncError
+    switch (e.code) {
+      case 'DEVICE_NOT_FOUND':
+        return t('devices.mobileSync.errors.deviceNotFound')
+      case 'PASSWORD_TOO_SHORT':
+        return t('devices.mobileSync.errors.passwordTooShort', { min: e.min })
+      case 'PASSWORD_TOO_LONG':
+        return t('devices.mobileSync.errors.passwordTooLong', { max: e.max })
+      case 'PASSWORD_HASH_FAILED':
+        return t('devices.mobileSync.errors.passwordHashFailed', { message: e.message })
+      case 'PERSISTENCE_FAILED':
+        return t('devices.mobileSync.errors.persistenceFailed', { message: e.message })
+      case 'FACADE_UNAVAILABLE':
+        return t('devices.mobileSync.errors.facadeUnavailable')
+      default: {
+        const message = (e as { message?: string }).message ?? e.code
+        return t('devices.mobileSync.errors.unknown', { message })
+      }
+    }
+  }
+  const message = err instanceof Error ? err.message : String(err)
+  return t('devices.mobileSync.errors.unknown', { message })
+}
+
+export const __test__ = { translateRotateError }
+
+export default RotateMobilePasswordDialog

--- a/src/components/device/RotatedPasswordModal.tsx
+++ b/src/components/device/RotatedPasswordModal.tsx
@@ -1,0 +1,219 @@
+/**
+ * RotatedPasswordModal —— 密码轮换成功后的一次性凭据展示。
+ *
+ * 与 MobileSyncCredentialModal 的关键差异:
+ * - 没有 QR / install URL / platform tab —— 用户已经装过移动端客户端,
+ *   只需把新密码填进客户端的 password 字段
+ * - 没有 password 显示/隐藏切换:这是新生成的明文,显示出来就是重点
+ * - 强警告:旧密码已立即失效,移动端必须更新才能继续同步
+ * - 与 register 共享的不变量:password 是**唯一一次**回显,UI 必须强制
+ *   用户勾选「我已保存」才允许关闭,关闭后服务端只剩 PHC,无法再取回
+ */
+
+import { Check, Copy } from 'lucide-react'
+import React, { useCallback, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { type RotateMobilePasswordResult } from '@/api/tauri-command/mobile_sync'
+import { Button } from '@/components/ui/button'
+import { Checkbox } from '@/components/ui/checkbox'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Label } from '@/components/ui/label'
+import { toast } from '@/components/ui/toast'
+import { cn } from '@/lib/utils'
+
+interface Props {
+  /** rotate 成功的 payload。`null` 表示 modal 关闭。 */
+  payload: RotateMobilePasswordResult | null
+  onClose: () => void
+}
+
+const RotatedPasswordModal: React.FC<Props> = ({ payload, onClose }) => {
+  const { t } = useTranslation()
+  const [acknowledged, setAcknowledged] = useState(false)
+  const [hintActive, setHintActive] = useState(false)
+  const acknowledgeRef = useRef<HTMLLabelElement>(null)
+
+  const handleClose = useCallback(() => {
+    setAcknowledged(false)
+    setHintActive(false)
+    onClose()
+  }, [onClose])
+
+  const handleAcknowledge = useCallback((v: boolean) => {
+    setAcknowledged(v)
+    if (v) setHintActive(false)
+  }, [])
+
+  const flagUnacknowledged = useCallback(() => {
+    setHintActive(true)
+    acknowledgeRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+  }, [])
+
+  const tryClose = useCallback(() => {
+    if (!acknowledged) {
+      flagUnacknowledged()
+      return
+    }
+    handleClose()
+  }, [acknowledged, flagUnacknowledged, handleClose])
+
+  if (!payload) return null
+
+  return (
+    <Dialog
+      open
+      onOpenChange={open => {
+        if (!open) tryClose()
+      }}
+    >
+      <DialogContent
+        className="flex max-h-[85vh] flex-col gap-0 overflow-hidden p-0 sm:max-w-md"
+        onEscapeKeyDown={e => {
+          if (!acknowledged) {
+            e.preventDefault()
+            flagUnacknowledged()
+          }
+        }}
+        onPointerDownOutside={e => {
+          if (!acknowledged) {
+            e.preventDefault()
+            flagUnacknowledged()
+          }
+        }}
+        onInteractOutside={e => {
+          if (!acknowledged) {
+            e.preventDefault()
+            flagUnacknowledged()
+          }
+        }}
+      >
+        <DialogHeader className="px-4 pt-4 pb-2">
+          <DialogTitle>{t('devices.mobileSync.rotate.result.title')}</DialogTitle>
+          <DialogDescription>{t('devices.mobileSync.rotate.result.subtitle')}</DialogDescription>
+        </DialogHeader>
+
+        <div className="flex-1 space-y-4 overflow-y-auto px-4 py-2">
+          {/* 强警告:旧密码立即失效 */}
+          <div className="rounded-md border border-amber-500/30 bg-amber-500/10 p-3">
+            <p className="text-xs text-amber-700/90 dark:text-amber-400/90">
+              {t('devices.mobileSync.rotate.result.warning')}
+            </p>
+          </div>
+
+          {/* Username (read-only, 用作"对应哪台设备" 的提示) */}
+          <ReadOnlyField
+            label={t('devices.mobileSync.rotate.result.usernameLabel')}
+            value={payload.username}
+          />
+
+          {/* 新密码 —— 默认显示,必须显眼 */}
+          <ReadOnlyField
+            label={t('devices.mobileSync.rotate.result.passwordLabel')}
+            value={payload.password}
+            primary
+          />
+
+          {/* 强制勾选 —— 同 credential modal 的视觉模式 */}
+          <label
+            ref={acknowledgeRef}
+            className={cn(
+              'flex cursor-pointer items-start gap-2 rounded-md border bg-card p-3 transition-all',
+              hintActive
+                ? 'border-primary bg-primary/10 ring-4 ring-primary/30 shadow-md shadow-primary/20'
+                : 'border-border/60'
+            )}
+          >
+            <Checkbox
+              checked={acknowledged}
+              onCheckedChange={v => handleAcknowledge(v === true)}
+              className={cn('mt-0.5', hintActive && 'border-primary ring-3 ring-primary/40')}
+            />
+            <span className={cn('text-sm', hintActive && 'font-medium text-primary')}>
+              {t('devices.mobileSync.rotate.result.confirmSaved')}
+            </span>
+          </label>
+        </div>
+
+        {hintActive && (
+          <div
+            className="border-t bg-destructive/5 px-4 py-2 text-xs text-destructive"
+            role="alert"
+          >
+            {t('devices.mobileSync.rotate.result.closeBlocked')}
+          </div>
+        )}
+
+        <DialogFooter className="m-0">
+          <Button onClick={tryClose}>{t('devices.mobileSync.rotate.result.close')}</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+interface ReadOnlyFieldProps {
+  label: string
+  value: string
+  /** primary=true 时给一点强调底色,用于"重点字段"如新密码。 */
+  primary?: boolean
+}
+
+const ReadOnlyField: React.FC<ReadOnlyFieldProps> = ({ label, value, primary }) => {
+  const { t } = useTranslation()
+  const [copied, setCopied] = useState(false)
+
+  const handleCopy = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(value)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 1500)
+    } catch {
+      toast.error('Copy failed')
+    }
+  }, [value])
+
+  return (
+    <div className="space-y-1">
+      <Label className="text-xs uppercase tracking-wider text-muted-foreground">{label}</Label>
+      <div
+        className={cn(
+          'flex items-center gap-1 rounded-md border px-3 py-2',
+          primary ? 'border-primary/40 bg-primary/5' : 'border-border/60 bg-card'
+        )}
+      >
+        <span className="min-w-0 flex-1 truncate font-mono text-sm">{value}</span>
+        <Button
+          type="button"
+          size="icon-sm"
+          variant="ghost"
+          aria-label={
+            copied
+              ? t('devices.mobileSync.rotate.result.copied')
+              : t('devices.mobileSync.rotate.result.copy')
+          }
+          title={
+            copied
+              ? t('devices.mobileSync.rotate.result.copied')
+              : t('devices.mobileSync.rotate.result.copy')
+          }
+          onClick={handleCopy}
+        >
+          {copied ? (
+            <Check className="h-3.5 w-3.5 text-emerald-500" />
+          ) : (
+            <Copy className="h-3.5 w-3.5" />
+          )}
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+export default RotatedPasswordModal

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,11 +1,25 @@
 import * as React from 'react'
 import { cn } from '@/lib/utils'
 
-function Input({ className, type, ...props }: React.ComponentProps<'input'>) {
+// macOS WKWebView 默认对 <input> 开启拼写检查 / 词典纠错 / 首字母大写,
+// 而 UniClipboard 大量输入框装的是 ID / username / URL / 配对码等机器
+// 字符串,纠错出来的字符通常会被后端校验直接打回。在 wrapper 层统一关
+// 掉,业务代码可通过显式传同名 prop 覆盖(例如真的需要自然语言纠错时)。
+function Input({
+  className,
+  type,
+  autoCorrect,
+  autoCapitalize,
+  spellCheck,
+  ...props
+}: React.ComponentProps<'input'>) {
   return (
     <input
       type={type}
       data-slot="input"
+      autoCorrect={autoCorrect ?? 'off'}
+      autoCapitalize={autoCapitalize ?? 'off'}
+      spellCheck={spellCheck ?? false}
       className={cn(
         'h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40',
         className

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -826,6 +826,32 @@
         "confirm": "Revoke",
         "cancel": "Cancel"
       },
+      "rotate": {
+        "button": "Change password",
+        "dialog": {
+          "title": "Change password for {{label}}",
+          "subtitle": "The server only stores a password hash, so the current one cannot be shown. After rotating, update the password field in your mobile client.",
+          "passwordLabel": "New password (optional)",
+          "passwordPlaceholder": "Leave empty to auto-generate",
+          "passwordHelp": "Empty → auto-generated strong password. Custom must be 8–256 chars.",
+          "warning": "The old password is invalidated immediately. The mobile client won't sync until its password field is updated.",
+          "submit": "Generate new password",
+          "submitting": "Working...",
+          "cancel": "Cancel"
+        },
+        "result": {
+          "title": "New password generated",
+          "subtitle": "Here is the new password — shown only this once. Copy it now and paste it into the password field of your mobile client.",
+          "usernameLabel": "Username",
+          "passwordLabel": "New password",
+          "copy": "Copy password",
+          "copied": "Copied",
+          "warning": "The old password no longer works. The mobile client must use this new password to keep syncing.",
+          "confirmSaved": "I have saved the new password",
+          "close": "Close",
+          "closeBlocked": "Confirm \"I have saved the new password\" first"
+        }
+      },
       "errors": {
         "facadeUnavailable": "Mobile sync is not enabled in this build",
         "labelEmpty": "Device label cannot be empty",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -817,6 +817,32 @@
         "confirm": "撤销",
         "cancel": "取消"
       },
+      "rotate": {
+        "button": "修改密码",
+        "dialog": {
+          "title": "为 {{label}} 修改密码",
+          "subtitle": "服务端只保存密码哈希，无法显示当前密码。生成新密码后请同步更新移动端客户端中的 password 字段。",
+          "passwordLabel": "新密码（可选）",
+          "passwordPlaceholder": "留空将自动生成",
+          "passwordHelp": "留空 → 自动生成强密码；自定义需 8–256 字符。",
+          "warning": "提交后旧密码立即失效。移动端客户端在更新 password 字段前将无法同步。",
+          "submit": "生成新密码",
+          "submitting": "处理中...",
+          "cancel": "取消"
+        },
+        "result": {
+          "title": "新密码已生成",
+          "subtitle": "下面是新密码，仅显示这一次。请立即复制并更新到移动端客户端的 password 字段。",
+          "usernameLabel": "用户名",
+          "passwordLabel": "新密码",
+          "copy": "复制密码",
+          "copied": "已复制",
+          "warning": "旧密码已失效。移动端客户端必须用此新密码才能继续同步。",
+          "confirmSaved": "我已保存新密码",
+          "close": "关闭",
+          "closeBlocked": "请先勾选「我已保存新密码」"
+        }
+      },
       "errors": {
         "facadeUnavailable": "移动端同步功能未启用",
         "labelEmpty": "设备名称不能为空",


### PR DESCRIPTION
## Summary

- 设备列表行新增 username 副行(label 主 + username 副,font-mono),做辅助识别 —— label 可重命名重复,username 是 server 端稳定主键。
- 新增"修改密码"动作:服务端只存 Argon2id PHC 看不到当前密码,改为允许用户轮换出一份新明文。改动贯穿 7 层(core port 加 `update_password_hash` → in-memory + Diesel 双仓库实现 → 新 `RotateMobilePasswordUseCase` → facade `rotate_password()` → tauri `rotate_mobile_password` command → ts wrapper → UI:DeviceRow KeyRound 按钮 + RotateMobilePasswordDialog + RotatedPasswordModal 强制确认),i18n 中"iPhone Shortcut"统一改成"移动端客户端 / mobile client"覆盖未来 Android / 鸿蒙等 SyncClipboard 兼容客户端。
- `Input` wrapper 默认关 macOS WKWebView 的 spellcheck / autocorrect / autocapitalize —— 项目大量输入框是 ID / username / URL / 配对码等机器字符串,词典纠错改成奇怪的字典词后被后端校验直接打回;业务可显式传同名 prop opt-in 自然语言纠错。
- 5 个 mobile_sync use case 单测从手写 fixture 改用 `mockall::mock!{}`(与 `get_file.rs` 等已有风格对齐),用 `.never()` / `.with(eq(..))` / `.times(N)` 表达"必须不被调用 / 入参约束 / 调用次数",代码量减半;facade 端到端测试和 webserver test_support 保留 in-memory 仓库(要"真存真读" 不是 mock)。

## Test plan

- [x] cargo test -p uc-application mobile_sync — 111 passed (rotate use case 7 + facade end-to-end 1 新增)
- [x] cargo test -p uc-tauri mobile_sync — 17 passed (rotate DTO/error 5 新增)
- [x] cargo test -p uc-infra mobile_sync — 38 passed (update_password_hash 4 新增)
- [x] cargo check --workspace clean
- [x] pnpm tsc --noEmit clean
- [x] pnpm vitest run src/components/device src/pages — 33 passed
- [ ] 手动验证 GUI:添加设备 → 列表行显示 username → 点 KeyRound → rotate dialog → 提交 → result modal 强制确认 → 旧密码 401 / 新密码 200

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added mobile device password rotation with optional auto-generation or custom password entry
  * Display device username alongside device label in the mobile sync devices list
  * New confirmation modal for securely viewing newly rotated passwords with copy-to-clipboard

* **Improvements**
  * Disabled browser autocorrect, autocapitalization, and spellcheck on text inputs for better control

* **Localization**
  * Added English and Chinese translations for password rotation interface

<!-- end of auto-generated comment: release notes by coderabbit.ai -->