### PR TITLE
fix(release): 匹配 CLI Linux 包的 musl target

### DIFF
--- a/scripts/generate-release-notes.js
+++ b/scripts/generate-release-notes.js
@@ -144,7 +144,9 @@ function buildCliInstallerTable({ artifactsDir, baseUrl }) {
   const linux = findFirstFile(
     artifactsDir,
     file =>
-      file.startsWith('uniclipboard-cli-') && file.includes('linux-gnu') && file.endsWith('.tar.gz')
+      file.startsWith('uniclipboard-cli-') &&
+      file.includes('linux-musl') &&
+      file.endsWith('.tar.gz')
   )
   const windows = findFirstFile(
     artifactsDir,


### PR DESCRIPTION
## Summary
- `build-cli.yml` 已把 Linux CLI 切到 `x86_64-unknown-linux-musl` 静态构建,但 `scripts/generate-release-notes.js` 仍按 `linux-gnu` 过滤产物,导致 release notes 的 CLI 下载表抓不到 Linux 包(例如 `uniclipboard-cli-0.7.0-alpha.6-x86_64-unknown-linux-musl.tar.gz`)。
- 把过滤条件改为 `linux-musl` 以匹配现行产物命名。

## Test plan
- [ ] 触发下一次 alpha/stable 发版,确认 release notes 的 CLI Installer 表里出现 Linux x86_64 行

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release notes generation tooling to adjust CLI artifact selection for Linux distributions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->