### PR TITLE
fix(settings): make schema backward-compatible via struct-level serde(default) (#581)

### DIFF
--- a/src-tauri/crates/uc-core/src/settings/defaults.rs
+++ b/src-tauri/crates/uc-core/src/settings/defaults.rs
@@ -299,7 +299,10 @@ impl Default for Settings {
 
 #[cfg(test)]
 mod tests {
-    use crate::settings::model::{NetworkSettings, Settings, CURRENT_SCHEMA_VERSION};
+    use crate::settings::model::{
+        ContentTypes, FileSyncSettings, NetworkSettings, Settings, SyncFrequency, Theme,
+        CURRENT_SCHEMA_VERSION,
+    };
 
     /// Pitfall 2 防御：默认值必须为 true（允许 fallback），保护老用户
     /// 跨网段同步行为。改 false = breaking change。
@@ -390,5 +393,163 @@ mod tests {
         let json = r#"{ "network": { "allow_relay_fallback": true, "allow_overlay_network_addrs": false } }"#;
         let s: Settings = serde_json::from_str(json).expect("parse explicit overlay false");
         assert!(!s.network.allow_overlay_network_addrs);
+    }
+
+    // ============================================================
+    // Issue #581 回归测试：旧版本 settings.json 在升级后被新版本读取时,
+    // 缺失字段必须自动回退到 `Default::default()` 的业务默认值,
+    // 反序列化不得失败。
+    //
+    // 核心场景:`file_sync` 段在 fed7ada2 之前没有 `small_file_threshold`
+    // 字段,daemon 启动时反序列化整个 Settings 直接报错。
+    // ============================================================
+
+    /// Issue #581 直接复现:`file_sync` 段缺 `small_file_threshold`,
+    /// 必须能反序列化并回退到默认 10 MB。
+    #[test]
+    fn file_sync_missing_small_file_threshold_falls_back_to_default() {
+        let json = r#"{
+            "file_sync": {
+                "file_sync_enabled": true,
+                "max_file_size": 5368709120,
+                "file_cache_quota_per_device": 524288000,
+                "file_retention_hours": 24,
+                "file_auto_cleanup": true
+            }
+        }"#;
+        let s: Settings = serde_json::from_str(json).expect("must not error on missing field");
+        assert_eq!(s.file_sync.small_file_threshold, 10 * 1024 * 1024);
+        assert!(s.file_sync.file_sync_enabled);
+        assert_eq!(s.file_sync.max_file_size, 5 * 1024 * 1024 * 1024);
+    }
+
+    /// `file_sync` 段为空对象时,所有字段都回退到默认值。
+    #[test]
+    fn file_sync_empty_object_falls_back_to_full_default() {
+        let json = r#"{ "file_sync": {} }"#;
+        let s: Settings = serde_json::from_str(json).expect("empty file_sync must parse");
+        let expected = FileSyncSettings::default();
+        assert_eq!(s.file_sync, expected);
+    }
+
+    /// `general` 段缺 `telemetry_enabled` 字段,必须回退默认 true。
+    #[test]
+    fn general_missing_telemetry_enabled_falls_back_to_default() {
+        let json = r#"{
+            "general": {
+                "auto_start": false,
+                "silent_start": false,
+                "auto_check_update": true,
+                "theme": "system",
+                "theme_color": null,
+                "language": null,
+                "device_name": null
+            }
+        }"#;
+        let s: Settings = serde_json::from_str(json).expect("missing telemetry must parse");
+        assert!(s.general.telemetry_enabled);
+    }
+
+    /// `general` 段缺多个字段时仍能解析,缺失字段全部回退。
+    #[test]
+    fn general_partial_object_fills_missing_fields() {
+        let json = r#"{ "general": { "auto_start": true } }"#;
+        let s: Settings = serde_json::from_str(json).expect("partial general must parse");
+        assert!(s.general.auto_start);
+        // 其余字段全部走默认
+        assert!(!s.general.silent_start);
+        assert!(s.general.auto_check_update);
+        assert_eq!(s.general.theme, Theme::System);
+        assert!(s.general.telemetry_enabled);
+    }
+
+    /// `sync` 段缺 `content_types` 与 `auto_sync`,均回退默认。
+    #[test]
+    fn sync_missing_fields_fall_back_to_default() {
+        let json = r#"{ "sync": { "sync_frequency": "interval" } }"#;
+        let s: Settings = serde_json::from_str(json).expect("partial sync must parse");
+        assert_eq!(s.sync.sync_frequency, SyncFrequency::Interval);
+        assert!(s.sync.auto_sync);
+        assert_eq!(s.sync.content_types, ContentTypes::default());
+    }
+
+    /// `security` 段缺所有字段时回退默认,且未来加新字段不会再 break 启动。
+    #[test]
+    fn security_empty_object_falls_back_to_default() {
+        let json = r#"{ "security": {} }"#;
+        let s: Settings = serde_json::from_str(json).expect("empty security must parse");
+        assert!(!s.security.encryption_enabled);
+        assert!(!s.security.passphrase_configured);
+        assert!(!s.security.auto_unlock_enabled);
+    }
+
+    /// `pairing` 段缺字段时回退到 `PairingSettings::default()` —— `serde_with`
+    /// 装饰器与 struct 级 `#[serde(default)]` 协同工作。
+    #[test]
+    fn pairing_partial_object_fills_missing_fields() {
+        let json = r#"{ "pairing": { "max_retries": 7 } }"#;
+        let s: Settings = serde_json::from_str(json).expect("partial pairing must parse");
+        assert_eq!(s.pairing.max_retries, 7);
+        assert_eq!(s.pairing.protocol_version, "1.0.0");
+        assert_eq!(s.pairing.step_timeout, std::time::Duration::from_secs(30));
+    }
+
+    /// `mobile_sync` 段缺 `lan_advertise_ip` / `lan_port` 时回退 None。
+    #[test]
+    fn mobile_sync_missing_optional_fields_fall_back_to_none() {
+        let json = r#"{ "mobile_sync": { "enabled": true } }"#;
+        let s: Settings = serde_json::from_str(json).expect("partial mobile_sync must parse");
+        assert!(s.mobile_sync.enabled);
+        assert!(!s.mobile_sync.lan_listen_enabled);
+        assert!(s.mobile_sync.lan_advertise_ip.is_none());
+        assert!(s.mobile_sync.lan_port.is_none());
+    }
+
+    /// 综合回归:模拟 v0.2 时代的 settings.json(只有 general/sync,
+    /// 完全没有 file_sync / network / mobile_sync 等后续新增段),
+    /// 必须能直接反序列化为完整 Settings。
+    #[test]
+    fn legacy_v02_settings_json_loads_with_all_defaults() {
+        let json = r#"{
+            "schema_version": 1,
+            "general": { "auto_start": true, "theme": "dark" },
+            "sync": { "auto_sync": false, "sync_frequency": "interval" }
+        }"#;
+        let s: Settings = serde_json::from_str(json).expect("legacy settings must parse");
+
+        assert_eq!(s.schema_version, 1);
+        assert!(s.general.auto_start);
+        assert_eq!(s.general.theme, Theme::Dark);
+        assert!(s.general.telemetry_enabled);
+        assert!(!s.sync.auto_sync);
+        assert_eq!(s.sync.content_types, ContentTypes::default());
+
+        // 后续新增段全部走 Default
+        assert_eq!(s.file_sync, FileSyncSettings::default());
+        assert!(s.network.allow_relay_fallback);
+        assert!(!s.network.allow_overlay_network_addrs);
+        assert!(!s.mobile_sync.enabled);
+    }
+
+    /// 显式字段值不被 `#[serde(default)]` 误覆盖。
+    #[test]
+    fn explicit_file_sync_values_are_preserved() {
+        let json = r#"{
+            "file_sync": {
+                "file_sync_enabled": false,
+                "small_file_threshold": 1024,
+                "max_file_size": 2048,
+                "file_cache_quota_per_device": 4096,
+                "file_retention_hours": 1,
+                "file_auto_cleanup": false
+            }
+        }"#;
+        let s: Settings = serde_json::from_str(json).expect("explicit file_sync must parse");
+        assert!(!s.file_sync.file_sync_enabled);
+        assert_eq!(s.file_sync.small_file_threshold, 1024);
+        assert_eq!(s.file_sync.max_file_size, 2048);
+        assert_eq!(s.file_sync.file_cache_quota_per_device, 4096);
+        assert_eq!(s.file_sync.file_retention_hours, 1);
+        assert!(!s.file_sync.file_auto_cleanup);
     }
 }

--- a/src-tauri/crates/uc-core/src/settings/model.rs
+++ b/src-tauri/crates/uc-core/src/settings/model.rs
@@ -6,7 +6,11 @@ use serde_with::{serde_as, DurationSeconds};
 
 pub const CURRENT_SCHEMA_VERSION: u32 = 1;
 
+// 所有 settings struct 统一使用 `#[serde(default)]`：缺字段时回退到
+// `Default::default()`（在 `defaults.rs` 中实现），保证向后兼容。
+// 详见 issue #581：旧版本 settings.json 缺新增字段会让 daemon 启动失败。
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
 pub struct GeneralSettings {
     pub auto_start: bool,
     pub silent_start: bool,
@@ -17,17 +21,11 @@ pub struct GeneralSettings {
     pub device_name: Option<String>,
     /// Update channel preference. `None` means auto-detect from version string;
     /// `Some(channel)` means the user has overridden the channel.
-    #[serde(default)]
     pub update_channel: Option<UpdateChannel>,
     /// Whether anonymous diagnostic telemetry is enabled.
     /// When `true` and a Sentry DSN is configured, the app forwards
     /// errors / warnings / structured logs (never clipboard content).
-    #[serde(default = "default_telemetry_enabled")]
     pub telemetry_enabled: bool,
-}
-
-fn default_telemetry_enabled() -> bool {
-    true
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -59,6 +57,7 @@ pub enum ShortcutKey {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
 pub struct ContentTypes {
     pub text: bool,
     pub image: bool,
@@ -69,11 +68,10 @@ pub struct ContentTypes {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
 pub struct SyncSettings {
     pub auto_sync: bool,
     pub sync_frequency: SyncFrequency,
-
-    #[serde(default)]
     pub content_types: ContentTypes,
 }
 
@@ -122,7 +120,7 @@ pub enum RuleEvaluation {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
+#[serde(default, rename_all = "snake_case")]
 pub struct RetentionPolicy {
     pub enabled: bool,
     pub rules: Vec<RetentionRule>,
@@ -131,7 +129,7 @@ pub struct RetentionPolicy {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
+#[serde(default, rename_all = "snake_case")]
 pub struct SecuritySettings {
     /// 是否启用本地数据加密
     pub encryption_enabled: bool,
@@ -146,12 +144,12 @@ pub struct SecuritySettings {
     ///
     /// 仅用于 UI 与流程判断
     /// 需要用户在系统弹窗中选择“始终允许”才能静默生效
-    #[serde(default)]
     pub auto_unlock_enabled: bool,
 }
 
 #[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
 pub struct PairingSettings {
     #[serde_as(as = "DurationSeconds<u64>")]
     pub step_timeout: Duration,
@@ -164,6 +162,7 @@ pub struct PairingSettings {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
 pub struct FileSyncSettings {
     pub file_sync_enabled: bool,
     pub small_file_threshold: u64,
@@ -187,13 +186,19 @@ pub struct FileSyncSettings {
 // ======================================================================
 
 /// 网络相关设置（LAN-only Mode 字段族）。
+///
+/// `#[serde(default)]` 让缺字段时回退到 `Default::default()`：
+/// - `allow_relay_fallback = true`（允许 fallback，breaking change 警惕）
+/// - `allow_overlay_network_addrs = false`（默认过滤虚拟网卡候选）
+///
+/// 修改默认值前请先 grep `LAN-only Mode` 文档与 changelog。
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
 pub struct NetworkSettings {
     /// 是否允许 iroh 在直连失败时回落到公网中继。
     /// `true`（默认）= 允许 fallback，跨网段设备仍可通过 relay 同步；
     /// `false` = LAN-only，禁用 relay，跨网段设备会失联。
     /// 业务正向语义：UI "LAN-only Mode = ON" → 此字段 = `false`。
-    #[serde(default = "default_allow_relay_fallback")]
     pub allow_relay_fallback: bool,
 
     /// 是否允许把 VPN / overlay 类虚拟网卡地址（CGNAT 100.64.0.0/10、
@@ -207,22 +212,7 @@ pub struct NetworkSettings {
     /// 与本字段无关，永远过滤。
     ///
     /// 修改后需重启 daemon 生效（iroh endpoint bind-time 常量）。
-    #[serde(default = "default_allow_overlay_network_addrs")]
     pub allow_overlay_network_addrs: bool,
-}
-
-// 默认 true = 允许 fallback。
-// 改成 false 会让所有跨网段老用户突然离线，属于 breaking change。
-// 修改默认值前请先 grep `LAN-only Mode` 文档与 changelog。
-fn default_allow_relay_fallback() -> bool {
-    true
-}
-
-// 默认 false = 过滤虚拟网卡候选（保持 v0.6.x 起的现行行为）。
-// 改成 true 会让 100.64/10 + fd7a:115c:a1e0::/48 重新出现在
-// peer 候选列表里，可能引入对端不可达的死候选拖慢 path-race。
-fn default_allow_overlay_network_addrs() -> bool {
-    false
 }
 
 // ======================================================================
@@ -261,37 +251,26 @@ fn default_allow_overlay_network_addrs() -> bool {
 /// 任意字段变更后都需要重启 daemon 才能生效(v1 不做配置热重载,详见
 /// `.context/mobile-sync/SPEC.md` §1.2.5)。
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
 pub struct MobileSyncSettings {
     /// 是否启用移动端同步 LAN 监听总开关。
     /// 默认 `false`:移动端同步对未配对的局域网邻居有暴露面,必须由
     /// 用户在设置页显式开启。
-    #[serde(default = "default_mobile_sync_enabled")]
     pub enabled: bool,
 
     /// LAN listener 子开关。`enabled=true` 时由本字段决定 daemon 启动
     /// 后是否真的把 listener spawn 起来(绑 0.0.0.0:lan_port);否则不起
     /// listener。默认 `false`。
-    #[serde(default = "default_mobile_sync_lan_listen_enabled")]
     pub lan_listen_enabled: bool,
 
     /// 写进 install URL / 二维码的 LAN IPv4 字符串(用户从 list-interfaces
     /// 挑一个)。仅决定 iPhone 端 base_url, 不决定 daemon socket bind
     /// (daemon 永远绑 `0.0.0.0`)。`None` 对应 UI 的"自动"选项,退回
     /// `0.0.0.0`(iPhone 连不上,需挑具体 IP)。
-    #[serde(default)]
     pub lan_advertise_ip: Option<String>,
 
     /// 用户自定义的 LAN 监听端口。`None` 时取默认 `42720`(SPEC §3.2)。
-    #[serde(default)]
     pub lan_port: Option<u16>,
-}
-
-fn default_mobile_sync_enabled() -> bool {
-    false
-}
-
-fn default_mobile_sync_lan_listen_enabled() -> bool {
-    false
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary

- 给所有 settings 子 struct 加 struct 级 `#[serde(default)]`：缺字段时回退到 `Default::default()`，业务默认值仍由 `defaults.rs` 单点维护
- 删除冗余的字段级 `#[serde(default = "fn")]` 与对应的 `default_*` 自由函数，收敛到唯一真相源
- 加 10 个 backward-compat 回归测试，含 issue #581 的直接复现 (`file_sync` 缺 `small_file_threshold`) 与 v0.2 时代 `settings.json` 综合升级场景

Closes #581

## Why

旧版本 `settings.json` 缺任何后续新增字段（`small_file_threshold` 只是这次撞到的具体例子）都会让 serde 反序列化失败，in-process daemon 启动直接挂：

```text
WARN  uc_tauri::run:268  Failed to load settings for startup: missing field `small_file_threshold` ...
ERROR uc_tauri::run:249  Daemon startup/probe failed during Tauri bootstrap
```

`uc_tauri::run` 这一层 warn 后回退默认，但 daemon assembly 内部又走一次反序列化，没有同样的兜底。

## Approach

按 issue 描述的“方案 B 务实方向”实施，但用 struct 级 `#[serde(default)]` 取代字段级 `#[serde(default = "fn")]`：

- serde 看到 struct 级 `#[serde(default)]` 时先实例化 `T::default()`，再用 JSON 字段覆盖
- 每个 struct 的 `Default` impl 已经在 `defaults.rs` 写好，业务默认值唯一收敛在那里
- 未来加新字段只需更新 `Default` impl 一处，不会再触发 missing field 错误，也不需要每个新字段写一个 `default_xxx` 函数

也清理了原本散落的：

- 6 个 `default_*` 自由函数 (`default_telemetry_enabled` / `default_allow_relay_fallback` / `default_allow_overlay_network_addrs` / `default_mobile_sync_enabled` / `default_mobile_sync_lan_listen_enabled` / 其它字段级 `#[serde(default)]`)
- 5 处字段级 `#[serde(default = "...")]` 标注

## Test plan

- [x] `cargo test -p uc-core settings::` — 19 passed (原 9 + 新增 10)
  - `file_sync_missing_small_file_threshold_falls_back_to_default` — issue #581 直接复现
  - `legacy_v02_settings_json_loads_with_all_defaults` — 模拟 v0.2 时代 settings.json
  - `general/sync/security/pairing/mobile_sync` 各自的 partial-object 用例
  - `explicit_file_sync_values_are_preserved` — 显式字段值不被 default 误覆盖
- [x] `cargo check --all-targets` — 全 workspace 编译通过

## Out of scope

- 长期建议中的“CI lint 守门”和 `schema_version` 真正启用，需要单独 issue 规划；本 PR 只解决 daemon 启动直接挂的紧急问题

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression tests to ensure settings files from previous versions load correctly with missing configuration sections automatically filled with defaults.

* **Refactor**
  * Improved backward compatibility of settings deserialization to better handle older or incomplete configuration files.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/UniClipboard/UniClipboard/pull/586)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->