### PR TITLE
feat(packaging): RPM bundles + Fedora COPR (dnf install uniclipboard)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,7 @@ on:
           - 'macos-aarch64'
           - 'macos-x86_64'
           - 'ubuntu-22.04'
+          - 'ubuntu-22.04-arm'
           - 'windows-latest'
           - 'all'
         default: 'all'
@@ -51,21 +52,26 @@ jobs:
       - name: Generate matrix
         id: set-matrix
         run: |
-          # Linux 构建在 host=ubuntu-22.04 上启容器跑 (debian:bookworm, glibc 2.36),
-          # 其他 platform (macOS/Windows) 不带 container 字段 → 直接在 host runner 跑。
+          # Linux 构建在 host=ubuntu-22.04 / ubuntu-22.04-arm 上启容器跑
+          # (debian:bookworm, glibc 2.36),其他 platform (macOS/Windows) 不带
+          # container 字段 → 直接在 host runner 跑。
+          # aarch64 走 native arm runner (ubuntu-22.04-arm),避免在 x86 容器里
+          # cross-compile webkit/gtk 栈;x86_64 仍在 ubuntu-22.04。
           PLATFORM="${{ inputs.platform || 'all' }}"
           if [ "$PLATFORM" == "all" ]; then
-            echo 'matrix=[{"platform":"macos-latest","target":"aarch64-apple-darwin","args":"--target aarch64-apple-darwin"},{"platform":"macos-latest","target":"x86_64-apple-darwin","args":"--target x86_64-apple-darwin"},{"platform":"ubuntu-22.04","target":"x86_64-unknown-linux-gnu","args":"","container":"debian:bookworm"},{"platform":"windows-latest","target":"x86_64-pc-windows-msvc","args":""}]' >> "$GITHUB_OUTPUT"
+            echo 'matrix=[{"platform":"macos-latest","target":"aarch64-apple-darwin","args":"--target aarch64-apple-darwin"},{"platform":"macos-latest","target":"x86_64-apple-darwin","args":"--target x86_64-apple-darwin"},{"platform":"ubuntu-22.04","target":"x86_64-unknown-linux-gnu","args":"","container":"debian:bookworm"},{"platform":"ubuntu-22.04-arm","target":"aarch64-unknown-linux-gnu","args":"","container":"debian:bookworm"},{"platform":"windows-latest","target":"x86_64-pc-windows-msvc","args":""}]' >> "$GITHUB_OUTPUT"
           elif [ "$PLATFORM" == "macos-aarch64" ]; then
             echo 'matrix=[{"platform":"macos-latest","target":"aarch64-apple-darwin","args":"--target aarch64-apple-darwin"}]' >> "$GITHUB_OUTPUT"
           elif [ "$PLATFORM" == "macos-x86_64" ]; then
             echo 'matrix=[{"platform":"macos-latest","target":"x86_64-apple-darwin","args":"--target x86_64-apple-darwin"}]' >> "$GITHUB_OUTPUT"
           elif [ "$PLATFORM" == "ubuntu-22.04" ]; then
             echo 'matrix=[{"platform":"ubuntu-22.04","target":"x86_64-unknown-linux-gnu","args":"","container":"debian:bookworm"}]' >> "$GITHUB_OUTPUT"
+          elif [ "$PLATFORM" == "ubuntu-22.04-arm" ]; then
+            echo 'matrix=[{"platform":"ubuntu-22.04-arm","target":"aarch64-unknown-linux-gnu","args":"","container":"debian:bookworm"}]' >> "$GITHUB_OUTPUT"
           elif [ "$PLATFORM" == "windows-latest" ]; then
             echo 'matrix=[{"platform":"windows-latest","target":"x86_64-pc-windows-msvc","args":""}]' >> "$GITHUB_OUTPUT"
           else
-            echo "Error: Unknown platform '$PLATFORM'. Valid options: all, macos-aarch64, macos-x86_64, ubuntu-22.04, windows-latest"
+            echo "Error: Unknown platform '$PLATFORM'. Valid options: all, macos-aarch64, macos-x86_64, ubuntu-22.04, ubuntu-22.04-arm, windows-latest"
             exit 1
           fi
 
@@ -85,6 +91,8 @@ jobs:
       # bookworm 容器是 minimal,actions/checkout 需要 git;后续 step 还要
       # curl/ca-certificates 用于装 rustup/bun/node。一次装齐 Tauri Linux
       # 所需的全部 dev 包,glibc 基线 = bookworm 的 2.36。
+      # `rpm` 提供 rpmbuild,Tauri v2 在 bundle.targets="all" 下据此产出 .rpm;
+      # 缺失则 Tauri 静默跳过 RPM bundle,只剩 deb/AppImage。
       - name: Install container deps (Linux)
         if: matrix.container != ''
         run: |
@@ -96,7 +104,8 @@ jobs:
             libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf \
             libgtk-3-dev libsoup-3.0-dev libjavascriptcoregtk-4.1-dev \
             file desktop-file-utils \
-            xdg-utils
+            xdg-utils \
+            rpm
 
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/copr.yml
+++ b/.github/workflows/copr.yml
@@ -24,6 +24,11 @@ on:
           - 'uniclipboard'
           - 'uniclipboard-alpha'
         default: 'uniclipboard-alpha'
+      run_ids:
+        description: 'RPM 来源 build run ID(逗号分隔多个) — 留空走 GitHub Release;给 ID 时从这些 build run 的 artifact 直接取 RPM(免去先发 release 的循环依赖)'
+        required: false
+        type: string
+        default: ''
 
 jobs:
   build-srpm-and-publish:
@@ -36,11 +41,13 @@ jobs:
     container: fedora:latest
     permissions:
       contents: read
+      # 跨 workflow run 拉 artifact 需要 actions:read。
+      actions: read
     steps:
       - name: Install build tooling
         run: |
           dnf -y install --setopt=install_weak_deps=False \
-            git curl rpm-build rpmdevtools python3-pip
+            git curl rpm-build rpmdevtools python3-pip jq unzip
           # copr-cli 通过 pip 装 — Fedora 仓库里也有 dnf install copr-cli,
           # 但 pip 版本更新更稳定,接 API token 也更直接。
           pip3 install --no-cache-dir copr-cli
@@ -96,20 +103,73 @@ jobs:
           rpmdev-setuptree
           cp packaging/uniclipboard.spec ~/rpmbuild/SPECS/
 
-      - name: Download upstream binary RPMs into SOURCES
+      # 两条互斥路径,按 inputs.run_id 选其一:
+      #   - 给了 run_id  → 从 build run 的 artifact 拉 RPM(免去先发 release 的循环)
+      #   - 没给 run_id  → 从 GitHub Release 的 asset 拉 RPM(自动 workflow_run 模式默认走这条)
+      - name: Download RPMs from build run artifact (run_ids mode)
+        if: github.event_name == 'workflow_dispatch' && inputs.run_ids != ''
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_IDS: ${{ inputs.run_ids }}
+        run: |
+          # RUN_IDS 形如 "25618035983,25618036765" — 多 run 场景常见于
+          # build.yml 按架构分别 dispatch 时(每个 run 只产一个架构 artifact)。
+          # 遍历每个 run,用 GitHub REST API 列其下 artifact,过滤 name 后缀
+          # linux-gnu (匹配 build.yml 上传名 `uniclipboard-<arch>-unknown-linux-gnu`),
+          # 拉 zip 到 /tmp,unzip -j 把内层 *.rpm 平铺到 SOURCES。
+          mkdir -p ~/rpmbuild/SOURCES /tmp/copr-art
+          IFS=',' read -ra RUNS <<< "${RUN_IDS}"
+          for RUN_ID in "${RUNS[@]}"; do
+            RUN_ID="${RUN_ID// /}"  # 去掉用户 input 里可能的空格
+            [ -z "$RUN_ID" ] && continue
+            echo "::group::Run ${RUN_ID} — list artifacts"
+            API="https://api.github.com/repos/UniClipboard/UniClipboard/actions/runs/${RUN_ID}/artifacts"
+            curl -fsSL \
+              -H "Authorization: Bearer ${GH_TOKEN}" \
+              -H "Accept: application/vnd.github+json" \
+              "${API}" > "/tmp/copr-art/list-${RUN_ID}.json"
+            echo "::endgroup::"
+
+            jq -r '.artifacts[] | select(.name | test("linux-gnu$")) | "\(.id)\t\(.name)"' \
+              "/tmp/copr-art/list-${RUN_ID}.json" | while IFS=$'\t' read -r id name; do
+              [ -z "$id" ] && continue
+              echo "::group::Fetch artifact ${name} (id=${id}, run=${RUN_ID})"
+              curl -fsSL \
+                -H "Authorization: Bearer ${GH_TOKEN}" \
+                -H "Accept: application/vnd.github+json" \
+                "https://api.github.com/repos/UniClipboard/UniClipboard/actions/artifacts/${id}/zip" \
+                -o "/tmp/copr-art/${name}.zip"
+              # zip 内层路径形如 release/bundle/rpm/UniClipboard-...rpm,
+              # -j 平铺剥目录,只匹配 *.rpm(不要 *.rpm.sig — 那是 Tauri updater 用的,
+              # COPR 重打的 RPM 会自己签 COPR GPG key)。
+              unzip -j -o -d ~/rpmbuild/SOURCES/ "/tmp/copr-art/${name}.zip" '*/rpm/*.rpm'
+              rm "/tmp/copr-art/${name}.zip"
+              echo "::endgroup::"
+            done
+          done
+
+          echo "--- SOURCES contents ---"
+          ls -lh ~/rpmbuild/SOURCES/
+
+          # 健全性检查:必须同时有 x86_64 和 aarch64 两个 RPM,缺一个就 fail-fast
+          # 避免后续 SRPM build 阶段报模糊错误。
+          for arch in x86_64 aarch64; do
+            if ! ls ~/rpmbuild/SOURCES/UniClipboard-*"${arch}".rpm >/dev/null 2>&1; then
+              echo "::error::Missing ${arch} RPM in artifacts. Did you pass both run_ids?"
+              exit 1
+            fi
+          done
+
+      - name: Download upstream binary RPMs from GitHub Release
+        if: github.event_name == 'workflow_run' || (github.event_name == 'workflow_dispatch' && inputs.run_ids == '')
         shell: bash
         env:
           UPSTREAM_TAG: ${{ steps.ver.outputs.upstream_tag }}
         run: |
-          # spec 的 Source0 用 %{_arch} 在 mock 阶段会展开成 srpm chroot 架构。
-          # SRPM 必须包含两个架构的 binary RPM 都能找到的源文件 — 但实际上
-          # SRPM 只需要包含一个 Source0(spec 渲染时锁定)。我们的策略是:
-          #   * 在 GitHub Actions 上为每个架构分别 rpmbuild -bs 出独立 SRPM
-          #   * 然后把两个 SRPM 都 submit 给 COPR(同一 build 任务可以传多个 SRPM)
-          # 但更简单做法:让 COPR 在每个 chroot 里重新 download Source0 —
-          # 但 COPR mock chroot 默认无网络。所以坚持把 Source0 嵌进 SRPM。
+          # spec 的 Source0 在 SRPM 构建阶段会被嵌入 .src.rpm,COPR mock chroot
+          # 拿到 SRPM 后不需要联网。这里 GH runner 上 curl 拉到 SOURCES/ 即可。
           mkdir -p ~/rpmbuild/SOURCES
-
           BASE_URL="https://github.com/UniClipboard/UniClipboard/releases/download/v${UPSTREAM_TAG}"
           for ARCH in x86_64 aarch64; do
             FILE="UniClipboard-${UPSTREAM_TAG}-1.${ARCH}.rpm"

--- a/.github/workflows/copr.yml
+++ b/.github/workflows/copr.yml
@@ -1,0 +1,200 @@
+name: 'Publish to COPR'
+run-name: "copr-${{ inputs.version || 'auto' }}-${{ github.run_number }}"
+
+# 触发时机:
+#   1. release.yml 完成 (workflow_run) — 自动跟进 dnf 渠道,跟 snap.yml 对位。
+#   2. workflow_dispatch — 手动重跑某个版本(常见场景:COPR build 临时挂了,
+#      release.yml 已经跑完不想全量重发)。
+on:
+  workflow_run:
+    workflows: ['Release']
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: '要发布的版本(不带 v 前缀,例如 0.7.0-alpha.7)。留空 = 读 package.json'
+        required: false
+        type: string
+        default: ''
+      project:
+        description: 'COPR 项目名 — 主仓 = uniclipboard,预发渠道 = uniclipboard-alpha 等'
+        required: true
+        type: choice
+        options:
+          - 'uniclipboard'
+          - 'uniclipboard-alpha'
+        default: 'uniclipboard-alpha'
+
+jobs:
+  build-srpm-and-publish:
+    # workflow_run 触发时,只在 Release workflow 成功后才跑;失败则跳过。
+    # workflow_dispatch 没有 conclusion 字段,这条件对它返回 true。
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    # Fedora 镜像里有 rpmbuild / rpmdevtools / spectool / dnf,免去在 Ubuntu
+    # 上手动装 rpm 工具链。fedora:latest = 滚动 stable,可读性高且常 cached。
+    container: fedora:latest
+    permissions:
+      contents: read
+    steps:
+      - name: Install build tooling
+        run: |
+          dnf -y install --setopt=install_weak_deps=False \
+            git curl rpm-build rpmdevtools python3-pip
+          # copr-cli 通过 pip 装 — Fedora 仓库里也有 dnf install copr-cli,
+          # 但 pip 版本更新更稳定,接 API token 也更直接。
+          pip3 install --no-cache-dir copr-cli
+
+      - uses: actions/checkout@v4
+
+      - name: Resolve version
+        id: ver
+        shell: bash
+        run: |
+          # 决策树:
+          #   workflow_dispatch 给了 input.version → 直接用
+          #   否则                                  → 读 package.json
+          if [ -n "${{ inputs.version }}" ]; then
+            UPSTREAM_TAG="${{ inputs.version }}"
+          else
+            UPSTREAM_TAG=$(python3 -c "import json; print(json.load(open('package.json'))['version'])")
+          fi
+
+          # RPM 不允许版本字段含 "-",将 prerelease 分隔符 "-" 替换为 "~"。
+          # "~" 在 RPM 比较里小于任何字符 → 0.7.0~alpha.7 < 0.7.0,符合预期。
+          RPM_VERSION="${UPSTREAM_TAG/-/~}"
+
+          echo "upstream_tag=$UPSTREAM_TAG" >> "$GITHUB_OUTPUT"
+          echo "rpm_version=$RPM_VERSION" >> "$GITHUB_OUTPUT"
+          echo "Resolved upstream_tag=$UPSTREAM_TAG rpm_version=$RPM_VERSION"
+
+      - name: Determine COPR project
+        id: project
+        shell: bash
+        run: |
+          # 渠道映射规则(对应 release.yml 的 channel 推断):
+          #   workflow_dispatch  → 用 inputs.project(用户选)
+          #   workflow_run       → 看 upstream_tag 是否含 alpha/beta/rc
+          #     含       → uniclipboard-alpha
+          #     不含     → uniclipboard
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            PROJECT="${{ inputs.project }}"
+          else
+            UPSTREAM_TAG="${{ steps.ver.outputs.upstream_tag }}"
+            if [[ "$UPSTREAM_TAG" =~ -(alpha|beta|rc) ]]; then
+              PROJECT="uniclipboard-alpha"
+            else
+              PROJECT="uniclipboard"
+            fi
+          fi
+          echo "name=$PROJECT" >> "$GITHUB_OUTPUT"
+          echo "Selected COPR project: $PROJECT"
+
+      - name: Setup rpmbuild tree
+        shell: bash
+        run: |
+          rpmdev-setuptree
+          cp packaging/uniclipboard.spec ~/rpmbuild/SPECS/
+
+      - name: Download upstream binary RPMs into SOURCES
+        shell: bash
+        env:
+          UPSTREAM_TAG: ${{ steps.ver.outputs.upstream_tag }}
+        run: |
+          # spec 的 Source0 用 %{_arch} 在 mock 阶段会展开成 srpm chroot 架构。
+          # SRPM 必须包含两个架构的 binary RPM 都能找到的源文件 — 但实际上
+          # SRPM 只需要包含一个 Source0(spec 渲染时锁定)。我们的策略是:
+          #   * 在 GitHub Actions 上为每个架构分别 rpmbuild -bs 出独立 SRPM
+          #   * 然后把两个 SRPM 都 submit 给 COPR(同一 build 任务可以传多个 SRPM)
+          # 但更简单做法:让 COPR 在每个 chroot 里重新 download Source0 —
+          # 但 COPR mock chroot 默认无网络。所以坚持把 Source0 嵌进 SRPM。
+          mkdir -p ~/rpmbuild/SOURCES
+
+          BASE_URL="https://github.com/UniClipboard/UniClipboard/releases/download/v${UPSTREAM_TAG}"
+          for ARCH in x86_64 aarch64; do
+            FILE="UniClipboard-${UPSTREAM_TAG}-1.${ARCH}.rpm"
+            echo "Fetching ${FILE}..."
+            curl -fL --retry 3 --retry-delay 5 \
+              -o "$HOME/rpmbuild/SOURCES/${FILE}" \
+              "${BASE_URL}/${FILE}"
+          done
+          ls -lh ~/rpmbuild/SOURCES/
+
+      - name: Build per-arch SRPMs
+        shell: bash
+        env:
+          RPM_VERSION: ${{ steps.ver.outputs.rpm_version }}
+          UPSTREAM_TAG: ${{ steps.ver.outputs.upstream_tag }}
+        run: |
+          # 为每个架构产一份 SRPM。spec 里 Source0 用 %{_arch} 在 srpm 阶段
+          # 会按 host 架构展开,所以 GH runner(x86_64)上默认产出 x86_64 SRPM。
+          # 用 --target 把 srpm 强制指向另一个 _arch,再 build 一份。
+          mkdir -p out-srpm
+          for ARCH in x86_64 aarch64; do
+            echo "::group::Build SRPM for ${ARCH}"
+            rpmbuild -bs ~/rpmbuild/SPECS/uniclipboard.spec \
+              --target "${ARCH}-linux" \
+              --define "_version ${RPM_VERSION}" \
+              --define "_upstream_tag ${UPSTREAM_TAG}" \
+              --define "_topdir $HOME/rpmbuild"
+            echo "::endgroup::"
+          done
+          # 收集所有 SRPM
+          find ~/rpmbuild/SRPMS -name '*.src.rpm' -exec cp {} out-srpm/ \;
+          ls -lh out-srpm/
+
+      - name: Configure copr-cli
+        shell: bash
+        env:
+          COPR_LOGIN: ${{ secrets.COPR_LOGIN }}
+          COPR_TOKEN: ${{ secrets.COPR_TOKEN }}
+          COPR_USERNAME: ${{ secrets.COPR_USERNAME }}
+        run: |
+          if [ -z "$COPR_LOGIN" ] || [ -z "$COPR_TOKEN" ] || [ -z "$COPR_USERNAME" ]; then
+            echo "::error::Missing COPR_LOGIN / COPR_TOKEN / COPR_USERNAME secrets"
+            echo "::error::Get them from https://copr.fedorainfracloud.org/api/"
+            exit 1
+          fi
+          mkdir -p ~/.config
+          cat > ~/.config/copr <<EOF
+          [copr-cli]
+          login = ${COPR_LOGIN}
+          username = ${COPR_USERNAME}
+          token = ${COPR_TOKEN}
+          copr_url = https://copr.fedorainfracloud.org
+          EOF
+          chmod 600 ~/.config/copr
+
+      - name: Submit build to COPR
+        shell: bash
+        env:
+          COPR_USERNAME: ${{ secrets.COPR_USERNAME }}
+        run: |
+          PROJECT="${{ steps.project.outputs.name }}"
+          # 一次提交多个 SRPM 给同一 COPR build:--nowait 让命令立即返回,
+          # 否则 GH job 会被 COPR build 队列阻塞 30+ min。
+          # 如果想等结果,把 --nowait 去掉(默认会 watch 直至 succeeded/failed)。
+          for SRPM in out-srpm/*.src.rpm; do
+            echo "::group::copr build ${COPR_USERNAME}/${PROJECT} ${SRPM}"
+            copr-cli build "${COPR_USERNAME}/${PROJECT}" "${SRPM}"
+            echo "::endgroup::"
+          done
+
+      - name: Summary
+        shell: bash
+        run: |
+          PROJECT="${{ steps.project.outputs.name }}"
+          USERNAME="${{ secrets.COPR_USERNAME }}"
+          echo "## COPR build submitted :package:" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Project**: \`${USERNAME}/${PROJECT}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Version**: ${{ steps.ver.outputs.rpm_version }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Upstream tag**: v${{ steps.ver.outputs.upstream_tag }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Track build status: https://copr.fedorainfracloud.org/coprs/${USERNAME}/${PROJECT}/builds/" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "End-user install:" >> "$GITHUB_STEP_SUMMARY"
+          echo '```bash' >> "$GITHUB_STEP_SUMMARY"
+          echo "sudo dnf copr enable ${USERNAME}/${PROJECT}" >> "$GITHUB_STEP_SUMMARY"
+          echo "sudo dnf install uniclipboard" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ on:
           - 'macos-aarch64'
           - 'macos-x86_64'
           - 'ubuntu-22.04'
+          - 'ubuntu-22.04-arm'
           - 'windows-latest'
         default: 'all'
       bump:
@@ -235,6 +236,7 @@ jobs:
             -name "*.dmg" -o \
             -name "*.app.tar.gz" -o \
             -name "*.deb" -o \
+            -name "*.rpm" -o \
             -name "*.AppImage" -o \
             -name "*.msi" -o \
             -name "*.exe" -o \

--- a/README.md
+++ b/README.md
@@ -82,12 +82,23 @@ Visit the [GitHub Releases](https://github.com/UniClipboard/UniClipboard/release
 
 Each release ships `.deb`, `.rpm`, and `.AppImage` artifacts for both `x86_64` and `aarch64` (where supported).
 
+**Fedora / RHEL / openSUSE — via COPR (recommended, auto-updating)**
+
+```bash
+sudo dnf copr enable mkdir700/uniclipboard-alpha   # alpha channel; or mkdir700/uniclipboard for stable
+sudo dnf install uniclipboard
+```
+
+After enabling, `sudo dnf upgrade` will pick up new releases automatically.
+
+**Or download a single .rpm / .deb / AppImage from the Releases page:**
+
 ```bash
 # Debian / Ubuntu
 sudo dpkg -i uniclipboard_<version>_amd64.deb
 sudo apt-get install -f                                 # resolve missing deps if any
 
-# Fedora / RHEL / openSUSE (dnf)
+# Fedora / RHEL / openSUSE (one-shot, no COPR)
 sudo dnf install ./UniClipboard-<version>-1.x86_64.rpm
 
 # AppImage (any distro)
@@ -95,7 +106,7 @@ chmod +x UniClipboard_<version>_amd64.AppImage
 ./UniClipboard_<version>_amd64.AppImage
 ```
 
-> RPM/DEB packages do not auto-update from inside the app — use `dnf upgrade` / `apt upgrade` against your package source. The AppImage is what the in-app updater uses on Linux.
+> Packaged installs (COPR / one-shot rpm / deb) do not auto-update from inside the app — use `dnf upgrade` / `apt upgrade` against your package source. The AppImage is what the in-app updater uses on Linux.
 
 ### Homebrew (macOS)
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,25 @@ It enables seamless and secure syncing of text, images, and files across multipl
 
 Visit the [GitHub Releases](https://github.com/UniClipboard/UniClipboard/releases) page to download the installation package for your operating system.
 
+### Linux
+
+Each release ships `.deb`, `.rpm`, and `.AppImage` artifacts for both `x86_64` and `aarch64` (where supported).
+
+```bash
+# Debian / Ubuntu
+sudo dpkg -i uniclipboard_<version>_amd64.deb
+sudo apt-get install -f                                 # resolve missing deps if any
+
+# Fedora / RHEL / openSUSE (dnf)
+sudo dnf install ./UniClipboard-<version>-1.x86_64.rpm
+
+# AppImage (any distro)
+chmod +x UniClipboard_<version>_amd64.AppImage
+./UniClipboard_<version>_amd64.AppImage
+```
+
+> RPM/DEB packages do not auto-update from inside the app — use `dnf upgrade` / `apt upgrade` against your package source. The AppImage is what the in-app updater uses on Linux.
+
 ### Homebrew (macOS)
 
 On macOS, install via the official tap [`UniClipboard/homebrew-tap`](https://github.com/UniClipboard/homebrew-tap):

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -82,12 +82,23 @@ UniClipboard 是一款以 **隐私优先** 为核心理念的跨设备剪贴板�
 
 每次发布都会同时构建 `.deb`、`.rpm` 与 `.AppImage` 三种格式，覆盖 `x86_64` 与 `aarch64`（如平台支持）。
 
+**Fedora / RHEL / openSUSE — 推荐 COPR 仓库（自动跟随版本更新）**
+
+```bash
+sudo dnf copr enable mkdir700/uniclipboard-alpha   # alpha 渠道；正式版请用 mkdir700/uniclipboard
+sudo dnf install uniclipboard
+```
+
+启用后 `sudo dnf upgrade` 会自动拉取新版本。
+
+**或者从 Releases 页面单独下载 .rpm / .deb / AppImage：**
+
 ```bash
 # Debian / Ubuntu
 sudo dpkg -i uniclipboard_<version>_amd64.deb
 sudo apt-get install -f                                 # 如有缺失依赖，由 apt 补齐
 
-# Fedora / RHEL / openSUSE（dnf）
+# Fedora / RHEL / openSUSE（一次性手动安装）
 sudo dnf install ./UniClipboard-<version>-1.x86_64.rpm
 
 # AppImage（任意发行版）
@@ -95,7 +106,7 @@ chmod +x UniClipboard_<version>_amd64.AppImage
 ./UniClipboard_<version>_amd64.AppImage
 ```
 
-> RPM/DEB 包不会通过 App 内的更新器自动升级，请用 `dnf upgrade` / `apt upgrade` 走系统包管理器。Linux 上 App 内更新器只对 AppImage 生效。
+> 经包管理器（COPR / dnf / apt）安装的版本不会通过 App 内的更新器自动升级，请用 `dnf upgrade` / `apt upgrade` 走系统包管理器。Linux 上 App 内更新器只对 AppImage 生效。
 
 ### Homebrew（macOS）
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -8,7 +8,7 @@
 >
 > 无需云账号，无需第三方服务器。你的剪贴板从未以任何人能读懂的形式离开过你的设备。
 
-UniClipboard 是一款以**隐私优先**为核心理念的跨设备剪贴板同步工具。它支持在多台设备之间无缝、安全地同步文本、图片和文件，无论设备处于同一 Wi-Fi 还是不同网络环境。数据在传输与本地存储阶段均保持加密，仅在用户设备本地解密，服务器与网络层永远无法访问明文。
+UniClipboard 是一款以 **隐私优先** 为核心理念的跨设备剪贴板同步工具。它支持在多台设备之间无缝、安全地同步文本、图片和文件，无论设备处于同一 Wi-Fi 还是不同网络环境。数据在传输与本地存储阶段均保持加密，仅在用户设备本地解密，服务器与网络层永远无法访问明文。
 
 ![Image](https://github.com/user-attachments/assets/8d339467-5bbe-4afa-9235-1d26cbff82c9)
 
@@ -77,6 +77,25 @@ UniClipboard 是一款以**隐私优先**为核心理念的跨设备剪贴板同
 ### 从 Releases 下载
 
 访问 [GitHub Releases](https://github.com/UniClipboard/UniClipboard/releases) 页面，下载适合您操作系统的安装包。
+
+### Linux
+
+每次发布都会同时构建 `.deb`、`.rpm` 与 `.AppImage` 三种格式，覆盖 `x86_64` 与 `aarch64`（如平台支持）。
+
+```bash
+# Debian / Ubuntu
+sudo dpkg -i uniclipboard_<version>_amd64.deb
+sudo apt-get install -f                                 # 如有缺失依赖，由 apt 补齐
+
+# Fedora / RHEL / openSUSE（dnf）
+sudo dnf install ./UniClipboard-<version>-1.x86_64.rpm
+
+# AppImage（任意发行版）
+chmod +x UniClipboard_<version>_amd64.AppImage
+./UniClipboard_<version>_amd64.AppImage
+```
+
+> RPM/DEB 包不会通过 App 内的更新器自动升级，请用 `dnf upgrade` / `apt upgrade` 走系统包管理器。Linux 上 App 内更新器只对 AppImage 生效。
 
 ### Homebrew（macOS）
 
@@ -258,4 +277,4 @@ uniclip status / start / stop   # 守护进程生命周期
 
 ---
 
-💡 **有问题或建议?** [创建 Issue](https://github.com/UniClipboard/UniClipboard/issues/new) 或联系我们讨论!
+💡 **有问题或建议？** [创建 Issue](https://github.com/UniClipboard/UniClipboard/issues/new) 或联系我们讨论！

--- a/docs-site/content/docs/en/getting-started/install.mdx
+++ b/docs-site/content/docs/en/getting-started/install.mdx
@@ -82,35 +82,61 @@ Download the one you want from the
 
 <Tab value="Linux">
 
-The recommended path is Snap. The Snap is built with strict
-confinement on `core22` and bundles its own GTK + WebKit stack, so it
-runs the same on Ubuntu 20.04+, Debian 11+, RHEL 9, openSUSE Leap, and
-similar.
+Each release ships `.deb`, `.rpm`, and `.AppImage` artifacts for both `x86_64` and `aarch64`. Pick the channel that fits your distribution:
+
+### Fedora / RHEL / openSUSE — recommended: COPR
+
+Install via [Fedora COPR](https://copr.fedorainfracloud.org/coprs/mkdir700/) and `dnf upgrade` will track new releases automatically:
+
+```bash
+# Alpha channel (includes pre-releases, updated more often)
+sudo dnf copr enable mkdir700/uniclipboard-alpha
+sudo dnf install uniclipboard
+
+# Stable channel (final releases only)
+sudo dnf copr enable mkdir700/uniclipboard
+sudo dnf install uniclipboard
+```
+
+See the [COPR deployment notes](https://github.com/UniClipboard/UniClipboard/blob/main/docs/packaging/COPR.md) for project setup details.
+
+### Ubuntu / Debian / older distros — recommended: Snap
+
+The Snap is built with strict confinement on `core22` and bundles its own GTK + WebKit stack, so it runs the same on Ubuntu 20.04+, Debian 11+, RHEL 9, openSUSE Leap, and similar.
 
 ```bash
 sudo snap install uniclipboard
 ```
 
-Don't have `snapd`? See the
-[Snapcraft install guide](https://snapcraft.io/docs/installing-snapd)
-for your distribution.
+Don't have `snapd`? See the [Snapcraft install guide](https://snapcraft.io/docs/installing-snapd) for your distribution.
 
-Prefer not to use Snap? An AppImage is also published with each
-release. Download it from the
-[Releases](https://github.com/UniClipboard/UniClipboard/releases) page,
-mark it executable, and run it:
+### Any distro — AppImage
+
+An AppImage is also published with each release. Download it from the [Releases](https://github.com/UniClipboard/UniClipboard/releases) page, mark it executable, and run it:
 
 ```bash
-chmod +x UniClipboard-*.AppImage
-./UniClipboard-*.AppImage
+chmod +x UniClipboard_<version>_amd64.AppImage
+./UniClipboard_<version>_amd64.AppImage
+```
+
+AppImage is the only Linux format the in-app updater supports — packages installed via COPR / Snap / dpkg do not auto-update from inside the app; use your package manager instead.
+
+### One-shot install of a single .deb / .rpm
+
+Prefer not to add a repo? Download a single package from Releases:
+
+```bash
+# Debian / Ubuntu
+sudo dpkg -i uniclipboard_<version>_amd64.deb
+sudo apt-get install -f                                 # resolve missing deps if any
+
+# Fedora / RHEL / openSUSE (one-shot, no COPR)
+sudo dnf install ./UniClipboard-<version>-1.x86_64.rpm
 ```
 
 ### Headless / server install (CLI only)
 
-For servers, SSH sessions, or anything without a desktop, install just
-the `uniclip` CLI from Releases — look for the `uniclip-<version>-<arch>`
-artefact (statically linked against musl). The CLI runs the daemon
-in-process, so no GUI is required.
+For servers, SSH sessions, or anything without a desktop, install just the `uniclip` CLI from Releases — look for the `uniclip-<version>-<arch>` artefact (statically linked against musl). The CLI runs the daemon in-process, so no GUI is required.
 
 </Tab>
 

--- a/docs-site/content/docs/en/guides/troubleshooting.mdx
+++ b/docs-site/content/docs/en/guides/troubleshooting.mdx
@@ -377,8 +377,14 @@ keyring's KEK entry will be overwritten by the next `init`.
 <Tab value="Uninstall and wipe everything">
 
 1. Quit the GUI; `uniclip stop`.
-2. Uninstall the package (Homebrew / MSI / Snap / AppImage as
-   appropriate).
+2. Uninstall the package:
+   - macOS Homebrew: `brew uninstall --cask uniclipboard && brew uninstall uniclipboard`
+   - Windows MSI: Control Panel → Programs & Features → Uninstall
+   - Linux Snap: `sudo snap remove uniclipboard`
+   - Linux COPR (dnf): `sudo dnf remove uniclipboard && sudo dnf copr disable mkdir700/uniclipboard-alpha`
+   - Linux .deb: `sudo apt remove uniclipboard`
+   - Linux .rpm (one-shot install): `sudo dnf remove uniclipboard`
+   - AppImage: delete the `.AppImage` file.
 3. Delete the data directory (paths above).
 4. **Manually** clean keyring entries:
    - macOS Keychain: search `uniclipboard`, delete entries.

--- a/docs-site/content/docs/zh/getting-started/install.mdx
+++ b/docs-site/content/docs/zh/getting-started/install.mdx
@@ -76,30 +76,61 @@ Windows 提供两种形态：
 
 <Tab value="Linux">
 
-Linux 推荐使用 Snap。Snap 包基于 `core22` 严格沙箱构建，自带 GTK + WebKit 运行时，因此在 Ubuntu
-20.04+、Debian 11+、RHEL 9、openSUSE Leap 等老发行版上都能正常运行。
+每次发布都会构建 `.deb`、`.rpm` 与 `.AppImage` 三种格式，覆盖 `x86_64` 与 `aarch64`。按你的发行版挑最合适的渠道：
+
+### Fedora / RHEL / openSUSE — 推荐 COPR
+
+通过 [Fedora COPR](https://copr.fedorainfracloud.org/coprs/mkdir700/) 一键安装并自动跟随版本升级：
+
+```bash
+# Alpha 渠道（含预发布版本，更新更频繁）
+sudo dnf copr enable mkdir700/uniclipboard-alpha
+sudo dnf install uniclipboard
+
+# 正式渠道（仅稳定版）
+sudo dnf copr enable mkdir700/uniclipboard
+sudo dnf install uniclipboard
+```
+
+启用后 `sudo dnf upgrade` 会自动拉取新版本。详见 [COPR 部署手册](https://github.com/UniClipboard/UniClipboard/blob/main/docs/packaging/COPR.md)。
+
+### Ubuntu / Debian / 老发行版 — 推荐 Snap
+
+Snap 包基于 `core22` 严格沙箱构建，自带 GTK + WebKit 运行时，因此在 Ubuntu 20.04+、Debian 11+、RHEL 9、openSUSE Leap 等老发行版上都能正常运行。
 
 ```bash
 sudo snap install uniclipboard
 ```
 
-没有 `snapd`？请参考
-[Snapcraft 安装指南](https://snapcraft.io/docs/installing-snapd)
-查看你所用发行版的安装方式。
+没有 `snapd`？请参考 [Snapcraft 安装指南](https://snapcraft.io/docs/installing-snapd) 查看你所用发行版的安装方式。
 
-不想用 Snap？每个 release 也会发布 AppImage。从
-[Releases](https://github.com/UniClipboard/UniClipboard/releases)
-页面下载，赋予可执行权限即可运行：
+### 任意发行版 — AppImage
+
+每个 release 也会发布 AppImage。从 [Releases](https://github.com/UniClipboard/UniClipboard/releases) 页面下载，赋予可执行权限即可运行：
 
 ```bash
-chmod +x UniClipboard-*.AppImage
-./UniClipboard-*.AppImage
+chmod +x UniClipboard_<version>_amd64.AppImage
+./UniClipboard_<version>_amd64.AppImage
+```
+
+AppImage 是 Linux 上 App 内更新器唯一支持的自更新格式 —— 走 COPR / Snap / dpkg 安装的版本不会通过应用内更新器升级，请用对应包管理器。
+
+### 一次性手动安装单个 .deb / .rpm
+
+不想加仓库？也可以从 Releases 直接下单文件安装：
+
+```bash
+# Debian / Ubuntu
+sudo dpkg -i uniclipboard_<version>_amd64.deb
+sudo apt-get install -f                                 # 如有缺失依赖，由 apt 补齐
+
+# Fedora / RHEL / openSUSE（一次性，不加 COPR 仓库）
+sudo dnf install ./UniClipboard-<version>-1.x86_64.rpm
 ```
 
 ### 无桌面环境（仅安装 CLI）
 
-服务器、SSH 会话或任何没有桌面的环境，可以从 Releases 单独下载 `uniclip` CLI ——
-查找 `uniclip-<version>-<arch>` 产物（与 musl 静态链接）。CLI 内置守护进程，无需 GUI 即可运行。
+服务器、SSH 会话或任何没有桌面的环境，可以从 Releases 单独下载 `uniclip` CLI —— 查找 `uniclip-<version>-<arch>` 产物（与 musl 静态链接）。CLI 内置守护进程，无需 GUI 即可运行。
 
 </Tab>
 

--- a/docs-site/content/docs/zh/guides/troubleshooting.mdx
+++ b/docs-site/content/docs/zh/guides/troubleshooting.mdx
@@ -289,7 +289,14 @@ rm -rf ~/.local/share/app.uniclipboard.desktop
 <Tab value="完全卸载并清干净">
 
 1. 退出 GUI，`uniclip stop`。
-2. 卸载安装包（Homebrew / MSI / Snap / AppImage 按对应方式卸）。
+2. 卸载安装包：
+   - macOS Homebrew：`brew uninstall --cask uniclipboard && brew uninstall uniclipboard`
+   - Windows MSI：控制面板 → 程序与功能 → 卸载
+   - Linux Snap：`sudo snap remove uniclipboard`
+   - Linux COPR (dnf)：`sudo dnf remove uniclipboard && sudo dnf copr disable mkdir700/uniclipboard-alpha`
+   - Linux .deb：`sudo apt remove uniclipboard`
+   - Linux .rpm（手动装的）：`sudo dnf remove uniclipboard`
+   - AppImage：直接删 `.AppImage` 文件即可。
 3. 删除数据目录（同上）。
 4. **手动** 清理系统密钥环条目：
    - macOS Keychain：搜 `uniclipboard`，删条目。

--- a/docs/packaging/COPR.md
+++ b/docs/packaging/COPR.md
@@ -1,0 +1,141 @@
+# COPR 发布手册
+
+本文档说明如何把 UniClipboard 发布到 [Fedora COPR](https://copr.fedorainfracloud.org/)，让 Fedora/RHEL/openSUSE 用户能用 `dnf install uniclipboard` 一键安装并自动跟随版本升级。
+
+> 本管线与 `.github/workflows/snap.yml` 对位 — snap 走 Snapcraft，dnf 走 COPR，构成 Linux 双渠道分发。
+
+## 整体方案
+
+- **打包模式**：binary repackage。COPR 不重新编译 Tauri，而是把 GitHub Release 上 `release.yml` 已经产出的 binary RPM 当作 Source0，在 COPR mock chroot 里 `rpm2cpio` 解包后重新装配。
+  - 优点：构建时间从 30 min（重新跑 Tauri）压到 1 min；二进制与 Releases 页严格一致；不需要把 webkit2gtk-devel 等重型依赖塞进 COPR chroot。
+  - 缺点：违反 Fedora "build from source" 原则 — 因此不能进 Fedora 官方仓库，只能走 COPR 第三方渠道。这是有意取舍。
+- **渠道映射**：
+  - `mkdir700/uniclipboard` → 正式版（无 prerelease 后缀的 tag）
+  - `mkdir700/uniclipboard-alpha` → alpha/beta/rc 预发版
+- **触发**：`Release` workflow 成功后自动触发；也支持 `workflow_dispatch` 手动重发某个版本。
+
+## 一次性准备
+
+### 1. 在 COPR 上创建项目
+
+1. 访问 https://copr.fedorainfracloud.org/，用 Fedora Account / GitHub OAuth 登录。
+2. 顶部 **New Project**，分别创建：
+   - `uniclipboard`（正式版）
+   - `uniclipboard-alpha`（预发版）
+3. 每个项目的 **Build options → Chroots** 至少勾上：
+   - `fedora-40-x86_64`、`fedora-40-aarch64`
+   - `fedora-41-x86_64`、`fedora-41-aarch64`
+   - `fedora-rawhide-x86_64`（可选，跟踪 Fedora 滚动）
+   - `epel-9-x86_64`、`epel-9-aarch64`（覆盖 RHEL 9 / Rocky / Alma）
+4. 项目 **Settings → Description** 建议填上"Repackage of upstream UniClipboard binary RPMs from GitHub Releases. See https://github.com/UniClipboard/UniClipboard"，方便 COPR 主页用户识别。
+
+### 2. 取 COPR API token
+
+1. 访问 https://copr.fedorainfracloud.org/api/，登录后页面会展示一段 `~/.config/copr` 的内容，长这样：
+
+   ```ini
+   [copr-cli]
+   login = xxxxxxxxxxxxxxxx
+   username = mkdir700
+   token = yyyyyyyyyyyyyyyy
+   copr_url = https://copr.fedorainfracloud.org
+   # expiration date: 2027-05-09
+   ```
+
+2. 把三个字段记到 GitHub 仓库 secrets：
+
+   | secret 名 | 值 |
+   |---|---|
+   | `COPR_LOGIN` | `login` 字段（短的那个） |
+   | `COPR_TOKEN` | `token` 字段（长的那个） |
+   | `COPR_USERNAME` | COPR 用户名（`mkdir700`） |
+
+   路径：`Settings → Secrets and variables → Actions → New repository secret`。
+
+3. token 默认有效期约 6 个月。COPR 主页 token 过期前会提醒，到期后重新访问 API 页拿新 token 替换 secret 即可。
+
+### 3. 检查 spec 中的 maintainer email
+
+`packaging/uniclipboard.spec` 末尾 changelog 块里写的是 `mkdir700 <release@uniclipboard.app>`。如果你不持有这个邮箱，改成你 COPR 注册时用的邮箱，否则 COPR 不会拒绝构建，但用户在 `dnf info uniclipboard` 里看到的 packager 信息会不一致。
+
+## 触发流程
+
+### 自动触发（推荐）
+
+1. 走常规 release：手动 `gh workflow run release.yml -f bump=patch -f channel=alpha`，或者打 git tag `vX.Y.Z`。
+2. `Release` workflow 跑完后，`Publish to COPR`（`copr.yml`）通过 `workflow_run` 自动起来。
+3. 它会按 tag 后缀决定推到哪个 COPR 项目：
+   - tag 含 `-alpha` / `-beta` / `-rc` → `uniclipboard-alpha`
+   - 其余 → `uniclipboard`
+4. job 结束在 `GITHUB_STEP_SUMMARY` 里能看到 COPR build 链接。COPR 端跑完 mock chroot（每个 chroot 1-3 min）后包就会进入仓库。
+
+### 手动重发
+
+`Release` 已经发完但 COPR 那次失败了？直接 dispatch：
+
+```bash
+gh workflow run copr.yml \
+  -f version=0.7.0-alpha.7 \
+  -f project=uniclipboard-alpha
+```
+
+`version` 不填则读 `package.json`。`project` 必须显式选。
+
+## 用户侧使用
+
+```bash
+# alpha 渠道
+sudo dnf copr enable mkdir700/uniclipboard-alpha
+sudo dnf install uniclipboard
+
+# 正式渠道
+sudo dnf copr enable mkdir700/uniclipboard
+sudo dnf install uniclipboard
+
+# 切换渠道：先关旧渠道再开新渠道
+sudo dnf copr disable mkdir700/uniclipboard-alpha
+sudo dnf copr enable mkdir700/uniclipboard
+sudo dnf install uniclipboard --refresh
+```
+
+之后 `sudo dnf upgrade` 会自动跟随 COPR 仓库里的最新版。
+
+## 故障排查
+
+### COPR build 失败：`Source0: Bad URL`
+
+原因：spec 里 `Source0` 用的 GitHub Release URL 在那个版本 tag 下不存在该架构的 RPM。
+
+排查：手动 curl 一下：
+
+```bash
+curl -fsSLI \
+  "https://github.com/UniClipboard/UniClipboard/releases/download/v0.7.0-alpha.7/UniClipboard-0.7.0-alpha.7-1.x86_64.rpm"
+```
+
+返回 200 才说明文件存在。如果 404，回头检查 `release.yml` 是否真的产出并上传了 RPM（参考 `assemble-update-manifest.js` 收集逻辑）。
+
+### COPR build 失败：`error: cpio: lsetfilecon failed`
+
+mock chroot 里 SELinux context 不能写，cpio 在还原 xattr 时报错但 payload 已经解出来了。一般忽略即可，rpmbuild 会继续走 `%install`。如果它真的中止，把 spec 的 `%prep` 改成 `rpm2cpio %{SOURCE0} | cpio -idm --no-preserve-owner` 跳过 metadata 还原。
+
+### `dnf install uniclipboard` 报缺依赖
+
+最常见是 `webkit2gtk4.1` 在 RHEL/Rocky 9 上叫 `webkit2gtk4.0` 或 `webkit2gtk5.0`，包名映射不一样。短期 workaround：在 spec 里加 conditional：
+
+```spec
+%if 0%{?rhel} >= 9
+Requires: webkit2gtk4.0
+%else
+Requires: webkit2gtk4.1
+%endif
+```
+
+中长期解决方案是再写一个 RHEL 专门的 SRPM，或在 spec 上层加一组 BuildArch/dist 条件。
+
+## 维护清单
+
+- [ ] COPR token 到期前更新 `COPR_TOKEN` secret
+- [ ] 新增 Fedora 版本（如 fedora-42）时去 COPR 项目 Settings 勾上对应 chroot
+- [ ] Tauri 升级导致依赖名变化（如 webkit2gtk-4.1 → 4.2）时同步改 spec 的 `Requires`
+- [ ] 当 release.yml 改动 RPM 文件名规范时（例如 `UniClipboard-` → `uniclipboard-`），同步修改 spec 的 `Source0` 和 workflow 的 `download` 步骤

--- a/packaging/uniclipboard.spec
+++ b/packaging/uniclipboard.spec
@@ -1,0 +1,73 @@
+# UniClipboard COPR spec — binary repackage 模式。
+#
+# 该 spec 不从源码编译，而是把 GitHub Release 上 Tauri 直接产出的 binary RPM
+# 当作 Source0,在 %install 阶段用 rpm2cpio 解出来重新打包。这样 COPR mock
+# chroot 不需要 Rust/Node/webkit2gtk-devel 等重型 BuildRequires,构建时间从
+# 30 min 压到 1 min 以内,并保留 upstream binary 一致性(同一个二进制在
+# Releases 页和 dnf copr 渠道里发出去)。
+#
+# 版本号规范:
+#   - %{version}      RPM-合法版本,prerelease 后缀用 ~ 替换 -,例如 0.7.0~alpha.7
+#                     RPM 比较语义中 ~ 比任意字符小,因此 0.7.0~alpha.7 < 0.7.0
+#   - %{upstream_tag} 上游 git tag/文件名里的原始版本,保留 -,例如 0.7.0-alpha.7
+#
+# CI 通过 `rpmbuild -bs --define ...` 注入这两个变量,本地手动构建可
+# `rpmbuild -bs --define "_version 0.7.0~alpha.7" --define "_upstream_tag 0.7.0-alpha.7" ...`
+
+%global upstream_tag %{?_upstream_tag}%{!?_upstream_tag:0.7.0-alpha.7}
+%global debug_package %{nil}
+
+Name:           uniclipboard
+Version:        %{?_version}%{!?_version:0.7.0~alpha.7}
+Release:        1%{?dist}
+Summary:        Privacy-first end-to-end encrypted cross-device clipboard sync
+
+License:        Apache-2.0 OR MIT
+URL:            https://github.com/UniClipboard/UniClipboard
+
+# Tauri 在 release.yml 中输出的 binary RPM 命名 = UniClipboard-<tag>-1.<arch>.rpm
+Source0:        https://github.com/UniClipboard/UniClipboard/releases/download/v%{upstream_tag}/UniClipboard-%{upstream_tag}-1.%{_arch}.rpm
+
+ExclusiveArch:  x86_64 aarch64
+
+# 运行时依赖 — 与 Tauri v2 + webkit2gtk-4.1 栈一致。
+# 包名在 Fedora 与 RHEL/openSUSE 系略有差异,这里用 Fedora 主线名;COPR
+# 默认 chroot 都是 Fedora/EPEL,后续要扩展到 openSUSE 再加 conditional。
+Requires:       webkit2gtk4.1
+Requires:       gtk3
+Requires:       libappindicator-gtk3
+Requires:       librsvg2
+
+%description
+UniClipboard is a privacy-first, end-to-end encrypted, cross-device clipboard
+sync tool built with Rust and Tauri.
+
+This package repackages the upstream binary RPM published on GitHub Releases.
+The binary is byte-identical to what users would download from the Releases
+page; this package only re-signs and re-indexes it for the dnf/COPR channel.
+
+%prep
+# Source0 是一个完整的 binary RPM,用 rpm2cpio 解到当前工作目录(BUILD/<name>-<ver>/)。
+mkdir -p uniclipboard-%{version}
+cd uniclipboard-%{version}
+rpm2cpio %{SOURCE0} | cpio -idm
+
+%build
+# 无 — 二进制已 upstream 编译完毕
+
+%install
+cd uniclipboard-%{version}
+mkdir -p %{buildroot}
+# 上游 RPM payload 是绝对路径 (/usr/bin/..., /usr/share/...),解出来后是
+# 当前目录下 ./usr/...,直接 cp -a 到 buildroot 即可。
+cp -a usr %{buildroot}/
+
+# 动态收集所有文件 — 避免 size 变更或资源新增时手动维护 %files 列表。
+find %{buildroot} \( -type f -o -type l \) -printf '/%%P\n' | sort > %{_builddir}/uniclipboard.filelist
+
+%files -f %{_builddir}/uniclipboard.filelist
+
+%changelog
+# changelog 由 CI 在 build 时通过 `--define` 注入或追加;此处保留占位。
+* Sat May 09 2026 mkdir700 <release@uniclipboard.app> - 0.7.0~alpha.7-1
+- Initial COPR packaging — binary repackage of upstream GitHub release

--- a/scripts/generate-release-notes.js
+++ b/scripts/generate-release-notes.js
@@ -97,16 +97,28 @@ function findFirstFile(artifactsDir, predicate) {
 }
 
 function buildInstallerTable({ artifactsDir, baseUrl }) {
-  const macosArm64 = findFirstFile(
+  // Tauri v2 Linux 产物命名约定:
+  //   .deb       — `<lower-product>_<version>_<amd64|arm64>.deb`        (Debian arch)
+  //   .rpm       — `<ProductName>-<version>-1.<x86_64|aarch64>.rpm`     (RPM arch)
+  //   .AppImage  — `<lower-product>_<version>_<amd64|aarch64>.AppImage` (混用)
+  // 用 isArm 判别同时覆盖 arm64/aarch64 两种写法。
+  const isArm = file => /aarch64|arm64/.test(file)
+  const isX64 = file => /x86_64|x64|amd64/.test(file)
+
+  const macosArm64 = findFirstFile(artifactsDir, file => file.endsWith('.dmg') && isArm(file))
+  const macosX64 = findFirstFile(artifactsDir, file => file.endsWith('.dmg') && isX64(file))
+  const linuxDebX64 = findFirstFile(artifactsDir, file => file.endsWith('.deb') && isX64(file))
+  const linuxDebArm = findFirstFile(artifactsDir, file => file.endsWith('.deb') && isArm(file))
+  const linuxRpmX64 = findFirstFile(artifactsDir, file => file.endsWith('.rpm') && isX64(file))
+  const linuxRpmArm = findFirstFile(artifactsDir, file => file.endsWith('.rpm') && isArm(file))
+  const linuxAppImageX64 = findFirstFile(
     artifactsDir,
-    file => file.endsWith('.dmg') && (file.includes('aarch64') || file.includes('arm64'))
+    file => file.endsWith('.AppImage') && isX64(file)
   )
-  const macosX64 = findFirstFile(
+  const linuxAppImageArm = findFirstFile(
     artifactsDir,
-    file => file.endsWith('.dmg') && (file.includes('x64') || file.includes('x86_64'))
+    file => file.endsWith('.AppImage') && isArm(file)
   )
-  const linuxDeb = findFirstFile(artifactsDir, file => file.endsWith('.deb'))
-  const linuxAppImage = findFirstFile(artifactsDir, file => file.endsWith('.AppImage'))
   const windowsExe = findFirstFile(artifactsDir, file => file.endsWith('.exe'))
 
   const makeRow = (platform, arch, fileName) =>
@@ -115,8 +127,12 @@ function buildInstallerTable({ artifactsDir, baseUrl }) {
   const rows = []
   if (macosArm64) rows.push(makeRow('macOS', 'Apple Silicon (M1/M2/M3)', macosArm64))
   if (macosX64) rows.push(makeRow('macOS', 'Intel', macosX64))
-  if (linuxDeb) rows.push(makeRow('Linux', 'Debian/Ubuntu (.deb)', linuxDeb))
-  if (linuxAppImage) rows.push(makeRow('Linux', 'AppImage', linuxAppImage))
+  if (linuxDebX64) rows.push(makeRow('Linux', 'Debian/Ubuntu x86_64 (.deb)', linuxDebX64))
+  if (linuxDebArm) rows.push(makeRow('Linux', 'Debian/Ubuntu aarch64 (.deb)', linuxDebArm))
+  if (linuxRpmX64) rows.push(makeRow('Linux', 'Fedora/RHEL x86_64 (.rpm)', linuxRpmX64))
+  if (linuxRpmArm) rows.push(makeRow('Linux', 'Fedora/RHEL aarch64 (.rpm)', linuxRpmArm))
+  if (linuxAppImageX64) rows.push(makeRow('Linux', 'AppImage x86_64', linuxAppImageX64))
+  if (linuxAppImageArm) rows.push(makeRow('Linux', 'AppImage aarch64', linuxAppImageArm))
   if (windowsExe) rows.push(makeRow('Windows', 'x86_64', windowsExe))
 
   if (rows.length === 0) {


### PR DESCRIPTION
## Summary

- **RPM bundle support**: build.yml 容器装 `rpm`,Tauri v2 `bundle.targets: \"all\"` 自动产出 `.rpm`;matrix 加 `ubuntu-22.04-arm` native arm runner,覆盖 x86_64 + aarch64 两个架构
- **Release pipeline**: release.yml 收集 `*.rpm` 进 release-assets;generate-release-notes.js 在 App Installation 表格里按架构分行,新增 6 行 Linux 产物(deb/rpm/AppImage × x86_64/aarch64)
- **Fedora COPR 渠道**: 新增 `packaging/uniclipboard.spec`(binary repackage 模式) + `.github/workflows/copr.yml`,自动在 Release 后把 RPM 推到 \`mkdir700/uniclipboard{,-alpha}\`,用户走 \`sudo dnf copr enable mkdir700/uniclipboard-alpha && sudo dnf install uniclipboard\` 一键安装并自动跟随版本升级
- **README + 部署手册**: README.md / README_ZH.md 加 dnf 安装段落;docs/packaging/COPR.md 中文手册(COPR 项目创建、API token、GH secrets、故障排查)

## Test plan

- [x] **build.yml 验证(已跑)**: `gh workflow run build.yml -f platform=ubuntu-22.04 / ubuntu-22.04-arm` → run 25618035983 / 25618036765 都成功,产出 deb/rpm/AppImage × 2 架构,sentry debug symbols 上传正常
- [ ] **copr.yml 验证(合并到 main 后)**: \`gh workflow run copr.yml -f version=0.7.0-alpha.7 -f project=uniclipboard-alpha -f run_ids=25618035983,25618036765\`
  - 期望: GH job 成功 submit 两个 SRPM 到 \`mkdir700/uniclipboard-alpha\`
  - 期望: COPR mock chroot 在 fedora-40/41 / aarch64+x86_64 上 build succeeded
  - 期望: Fedora 实机 \`sudo dnf copr enable mkdir700/uniclipboard-alpha && sudo dnf install uniclipboard\` 装上 0.7.0~alpha.7-1 版本
- [ ] release.yml 下次自动触发 copr.yml 链路(待下次正式发版验证)

## 备注:何时能测 COPR

GitHub workflow_dispatch 限制 workflow 文件必须出现在 default branch (main) 才能注册 dispatches endpoint。本 PR 合到 dev 后,需要等下次按 release-branch 模型把 dnf-copr 改动同步到 main(下次发版或单独同步)才能 \`gh workflow run copr.yml\`。

期间可以本地用 fedora docker 容器手动跑 spec 验证 SRPM build,详见 docs/packaging/COPR.md。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added COPR repository support for Fedora/RHEL/openSUSE users with stable and alpha channels
  * Expanded Linux support to include ARM architecture builds
  * Linux packages now available in .deb, .rpm, and AppImage formats

* **Documentation**
  * Updated installation instructions with detailed Linux setup guides (English and Chinese)
  * Added COPR packaging documentation for Linux distribution maintainers

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/UniClipboard/UniClipboard/pull/589)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->