### PR TITLE
fix(quick-panel/macos): paste sometimes lost due to focus race

### DIFF
--- a/src-tauri/crates/uc-tauri/Cargo.toml
+++ b/src-tauri/crates/uc-tauri/Cargo.toml
@@ -61,7 +61,7 @@ windows = { version = "0.61", features = [
 [target.'cfg(target_os = "macos")'.dependencies]
 core-foundation = "0.10"
 objc2 = "0.6"
-objc2-app-kit = { version = "0.3", features = ["NSEvent", "NSScreen", "NSPanel", "NSResponder", "NSWindow", "NSColor", "NSGraphics"] }
+objc2-app-kit = { version = "0.3", features = ["NSEvent", "NSScreen", "NSPanel", "NSResponder", "NSWindow", "NSColor", "NSGraphics", "NSWorkspace", "NSRunningApplication", "libc"] }
 core-graphics = "0.24"
 objc2-foundation = { version = "0.3", features = ["NSGeometry", "objc2-core-foundation"] }
 

--- a/src-tauri/crates/uc-tauri/src/quick_panel/macos.rs
+++ b/src-tauri/crates/uc-tauri/src/quick_panel/macos.rs
@@ -13,9 +13,24 @@ use core_graphics::event_source::{CGEventSource, CGEventSourceStateID};
 use objc2::ffi::object_setClass;
 use objc2::runtime::AnyObject;
 use objc2::{define_class, msg_send, ClassType};
-use objc2_app_kit::{NSColor, NSPanel, NSWindowStyleMask};
+use objc2_app_kit::{
+    NSApplicationActivationOptions, NSColor, NSPanel, NSRunningApplication, NSWindowStyleMask,
+    NSWorkspace,
+};
+use std::sync::Mutex;
+use std::time::Duration;
 use tauri::WebviewWindow;
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
+
+/// pid of the application that was frontmost just before the quick panel was shown.
+///
+/// Captured by [`remember_previous_app`] before the panel grabs key window status,
+/// and used by [`restore_previous_app`] to send focus back to the right place
+/// before posting the synthetic Cmd+V.
+///
+/// 显示快捷面板前的最前台应用 pid。面板抢走 key window 之前记录，
+/// 粘贴时再用它显式把焦点送回正确的应用。
+static PREVIOUS_FRONTMOST_PID: Mutex<Option<i32>> = Mutex::new(None);
 
 // Custom NSPanel subclass that overrides `canBecomeKeyWindow` to return YES.
 // NSPanel without a title bar (`decorations: false`) returns NO by default,
@@ -119,6 +134,79 @@ pub fn show_panel(window: &WebviewWindow) {
         panel.orderFrontRegardless();
         panel.makeKeyWindow();
     }
+}
+
+/// Record the pid of the currently frontmost application.
+///
+/// Must be called **before** the panel becomes key window — otherwise the
+/// frontmost app is already us. Skipped if frontmost is our own process.
+///
+/// 记录当前最前台应用的 pid。必须在面板成为 key window 之前调用。
+pub fn remember_previous_app() {
+    let our_pid = std::process::id() as i32;
+    let pid = NSWorkspace::sharedWorkspace()
+        .frontmostApplication()
+        .map(|app| app.processIdentifier());
+    let recorded = pid.filter(|p| *p != our_pid);
+    if let Ok(mut guard) = PREVIOUS_FRONTMOST_PID.lock() {
+        *guard = recorded;
+    }
+    if let Some(p) = recorded {
+        debug!(pid = p, "Quick panel: remembered previous frontmost app");
+    } else {
+        debug!("Quick panel: no previous frontmost app to remember (or it was us)");
+    }
+}
+
+/// Activate the previously frontmost application and poll until it actually
+/// becomes frontmost (or `timeout` elapses).
+///
+/// Returns `true` if the target app was observed as frontmost before timing
+/// out. The caller should still post the synthetic keystroke even on `false`,
+/// since on macOS 14+ activation can succeed without us being able to confirm.
+///
+/// 激活之前记录的最前台应用，并轮询直到它真正成为前台（或超时）。
+fn activate_and_wait(pid: i32, timeout: Duration) -> bool {
+    let Some(app) = NSRunningApplication::runningApplicationWithProcessIdentifier(pid) else {
+        warn!(pid, "Previous app not found by pid; cannot restore focus");
+        return false;
+    };
+
+    // Empty options: ActivateIgnoringOtherApps is deprecated on macOS 14+
+    // and `activateAllWindows` would yank background windows we don't want.
+    let activated = app.activateWithOptions(NSApplicationActivationOptions::empty());
+    if !activated {
+        debug!(pid, "activateWithOptions returned false");
+    }
+
+    let workspace = NSWorkspace::sharedWorkspace();
+    let deadline = std::time::Instant::now() + timeout;
+    let step = Duration::from_millis(10);
+    loop {
+        if let Some(front) = workspace.frontmostApplication() {
+            if front.processIdentifier() == pid {
+                return true;
+            }
+        }
+        if std::time::Instant::now() >= deadline {
+            return false;
+        }
+        std::thread::sleep(step);
+    }
+}
+
+/// Restore focus to the application that was frontmost before the panel opened.
+///
+/// Returns `true` if the previous app is confirmed frontmost (safe to paste);
+/// `false` if no pid was recorded, the app is gone, or the wait timed out.
+///
+/// 把焦点送回打开面板前的最前台应用。
+pub fn restore_previous_app() -> bool {
+    let pid = match PREVIOUS_FRONTMOST_PID.lock().ok().and_then(|g| *g) {
+        Some(p) => p,
+        None => return false,
+    };
+    activate_and_wait(pid, Duration::from_millis(200))
 }
 
 /// Simulate Cmd+V paste keystroke via CoreGraphics CGEvent.

--- a/src-tauri/crates/uc-tauri/src/quick_panel/mod.rs
+++ b/src-tauri/crates/uc-tauri/src/quick_panel/mod.rs
@@ -338,6 +338,11 @@ pub fn show(app: &tauri::AppHandle) {
     if let Some(window) = app.get_webview_window(PANEL_LABEL) {
         #[cfg(target_os = "windows")]
         windows::remember_previous_foreground(&window);
+        // macOS: capture frontmost app *before* the panel becomes key window,
+        // so paste() can explicitly send focus back instead of relying on
+        // NSPanel's NonactivatingPanel hint (which races on busy systems).
+        #[cfg(target_os = "macos")]
+        macos::remember_previous_app();
 
         if let Err(e) = window.set_size(tauri::LogicalSize::new(width, height)) {
             warn!(error = %e, "Failed to reset quick panel size");
@@ -450,9 +455,24 @@ pub fn set_layout(app: &tauri::AppHandle, scale: f64, preview_expanded: bool) {
 pub fn paste(app: &tauri::AppHandle) -> Result<(), String> {
     #[cfg(target_os = "macos")]
     {
-        dismiss(app);
-        // Small delay for the panel to fully hide before simulating keystrokes
-        std::thread::sleep(std::time::Duration::from_millis(50));
+        // Hide the panel first so it stops being the key window.
+        if let Some(window) = app.get_webview_window(PANEL_LABEL) {
+            let _ = window.hide();
+        }
+        // Explicitly send focus back to the previously frontmost app and wait
+        // until it is observed as frontmost. Relying on NonactivatingPanel
+        // alone races: when show_panel() called makeKeyWindow(), key status
+        // doesn't always return to the target app within the previous fixed
+        // 50ms sleep, and Cmd+V is then sent to the wrong responder (or
+        // dropped entirely).
+        let restored = macos::restore_previous_app();
+        if !restored {
+            // Either no previous app was recorded, the app is gone, or the
+            // 200ms poll timed out. Fall back to a small sleep — the system
+            // may still finish the focus handoff a moment later.
+            warn!("Quick panel paste: previous app focus not confirmed; posting Cmd+V anyway");
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        }
         macos::simulate_paste()?;
         Ok(())
     }


### PR DESCRIPTION
## Summary

- `paste()` on macOS previously did `dismiss → sleep 50ms → post Cmd+V` and relied on NSPanel's `NonactivatingPanel` to hand focus back. On busy systems (or when the panel had taken key window via `makeKeyWindow`), key/responder status didn't always return to the user's previous app within that 50ms window — so the synthetic Cmd+V landed on the wrong responder or got dropped entirely. Symptom: pressing Enter / Cmd+1..9 in the quick panel sometimes does nothing.
- Capture the frontmost app's pid in `show()` (before the panel can become key window), then in `paste()` explicitly `activateWithOptions` that `NSRunningApplication` and poll `NSWorkspace.frontmostApplication` up to 200ms until the target app is observed frontmost. Only then post Cmd+V.
- Fall back to the old 50ms sleep if no pid was recorded, the app has quit, or the wait times out, so the worst case is no worse than today.

This brings the macOS path structurally in line with the existing Windows path (`remember_previous_foreground` / `restore_previous_foreground`).

Refs #592 (the part about Cmd+1 / Enter selection-and-paste failing intermittently — same root cause as Enter, both go through `paste_to_previous_app`). Does **not** address the search-prefix-matching point in that issue, which is unrelated.

## Files

- `src-tauri/crates/uc-tauri/Cargo.toml` — add `NSWorkspace`, `NSRunningApplication`, `libc` features to `objc2-app-kit`
- `src-tauri/crates/uc-tauri/src/quick_panel/macos.rs` — `PREVIOUS_FRONTMOST_PID` + `remember_previous_app()` + `restore_previous_app()` (polls `frontmostApplication` up to 200ms)
- `src-tauri/crates/uc-tauri/src/quick_panel/mod.rs` — call `remember_previous_app()` in `show()`; rewrite the macOS arm of `paste()` to restore-then-paste

## Test plan

- [x] Open quick panel, press Enter on top item — paste lands in the previous app.
- [x] Open quick panel, press Cmd+1..9 — same.
- [ ] Repeat under load (Time Machine running, browser warming up, IME switching mid-shortcut) — previously this was where the 50ms sleep ran out; should now wait for the focus handoff.
- [ ] Open quick panel from the desktop with no other app frontmost — `remember_previous_app` records nothing, `restore_previous_app` returns false, fallback 50ms sleep + Cmd+V (no regression).
- [ ] Open quick panel, switch the previous app to one that gets force-quit before Enter — `runningApplicationWithProcessIdentifier` returns nil, fallback path runs, no panic.
- [ ] Esc / blur dismiss path still works (no paste, no focus tampering).
- [ ] Build: `cargo check -p uc-tauri` ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved focus restoration on macOS: the quick panel now properly returns focus to the previously active application after closing, instead of leaving focus with the panel window.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/UniClipboard/UniClipboard/pull/593)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->