### PR TITLE
fix(clipboard/preview): truncate long URL in LinkPreview within ScrollArea

### DIFF
--- a/src/components/clipboard/ClipboardPreview.tsx
+++ b/src/components/clipboard/ClipboardPreview.tsx
@@ -102,7 +102,7 @@ const ClipboardPreview: React.FC<ClipboardPreviewProps> = ({ item, actions }) =>
         {isLargeText ? (
           <div className="absolute inset-0">{renderContent()}</div>
         ) : (
-          <ScrollArea className="h-full">
+          <ScrollArea className="h-full [&_[data-slot=scroll-area-viewport]>div]:!block">
             <div className="min-h-full">{renderContent()}</div>
           </ScrollArea>
         )}


### PR DESCRIPTION
## Summary
- Long URLs in `LinkPreview` were overflowing the row because Radix `ScrollArea` injects an inner `display: table` div whose content-sized width defeats `truncate` on descendants.
- Override that single layer to `block` for the clipboard preview's `ScrollArea` so `truncate` works again. Scoped via `[&_[data-slot=scroll-area-viewport]>div]:!block` so the global `ScrollArea` component is untouched.

## Test plan
- [ ] Copy a long URL (e.g. `https://preview.docs.uniclipboard.app/docs/zh/reference/search-internals`) and select it in the clipboard list — the row should ellipsize cleanly with no horizontal overflow.
- [ ] Verify other `ScrollArea` usages (Settings, Devices, Mobile sync sheet) still scroll vertically as before.