### PR TITLE
chore: migrate to trunk-based workflow (retire dev branch)

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,7 +2,7 @@ name: Coverage
 
 on:
   push:
-    branches: [main, dev]
+    branches: [main]
     paths:
       - 'src-tauri/**'
       - '.github/workflows/coverage.yml'

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -3,7 +3,7 @@ run-name: 'Format check for ${{ github.head_ref || github.ref_name }}'
 
 on:
   pull_request:
-    branches: [main, dev, develop]
+    branches: [main]
     types: [opened, synchronize, reopened]
 
 permissions:

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -28,11 +28,6 @@ on:
           - beta
           - rc
         default: stable
-      base_branch:
-        description: 'Branch to base the release off'
-        required: false
-        type: string
-        default: main
 
 jobs:
   prepare:
@@ -46,7 +41,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.base_branch }}
+          ref: main
           token: ${{ secrets.REPO_BOT_TOKEN }}
           fetch-depth: 0
 
@@ -246,7 +241,7 @@ jobs:
           > **Do not manually create a tag.** Merging this PR handles everything.
           EOF
           )" \
-            --base "${{ inputs.base_branch }}" \
+            --base main \
             --head "release/v${VERSION}")
 
           echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/tag-on-merge.yml
+++ b/.github/workflows/tag-on-merge.yml
@@ -4,7 +4,7 @@ run-name: tag-${{ github.event.pull_request.head.ref }}
 on:
   pull_request:
     types: [closed]
-    branches: [main, dev]
+    branches: [main]
 
 jobs:
   tag-release:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,14 +156,15 @@ If you are unsure whether a change is a localized bug fix or a structural one, d
 
 ## Branching Strategy
 
-The project uses a **release-branch workflow** anchored on `main`:
+The project uses a **trunk-based workflow** anchored on `main`:
 
-- **`main`** — always reflects the most recently shipped release. Direct merges from `dev` are not allowed.
-- **`dev`** — the integration branch where day-to-day work lands.
-- **`release/vX.Y.Z[-channel.N]`** — cut from `main` when preparing a release. Once published, the release branch is merged back into both `main` and `dev`.
-- **Feature branches** — branch from `dev`, name them descriptively (e.g. `feat/quick-panel-search`, `fix/devices-online-state`).
+- **`main`** — the trunk. Every change lands here through a pull request. `main` must stay buildable and shippable at all times.
+- **`release/vX.Y.Z[-channel.N]`** — cut from `main` by the `prepare-release` workflow when preparing a release (alpha / beta / rc / stable). Merging the release PR back into `main` triggers tagging and artifact builds; the release branch is auto-deleted afterwards.
+- **Feature branches** — branch from `main`, name them descriptively (e.g. `feat/quick-panel-search`, `fix/devices-online-state`).
 
-When opening a PR, target the `dev` branch unless the maintainers explicitly ask you to target a release branch.
+When opening a PR, target `main` unless the maintainers explicitly ask you to target a release branch.
+
+Unfinished work should not be merged. If a feature is not ready to ship, keep it on its feature branch (or behind a runtime gate) rather than merging a half-finished change into `main`.
 
 ## Commit Conventions
 
@@ -282,7 +283,7 @@ If you add a new top-level doc, add a pointer to it from `AGENTS.md` so future c
 
 ### Before You Open a PR
 
-- Rebase onto the latest `dev`.
+- Rebase onto the latest `main`.
 - Make sure `bun run lint`, `bun run format`, `bun test`, and `cargo test` (where relevant) all pass locally.
 - Keep the diff focused. Open separate PRs for unrelated changes.
 

--- a/CONTRIBUTING_ZH.md
+++ b/CONTRIBUTING_ZH.md
@@ -156,14 +156,15 @@ bun tauri build
 
 ## 分支策略
 
-项目使用以 `main` 为锚的 **release-branch 工作流**：
+项目使用以 `main` 为锚的 **trunk-based 工作流**：
 
-- **`main`**：始终对应最近一次发布的版本。**不允许**直接从 `dev` 合并。
-- **`dev`**：日常开发的集成分支。
-- **`release/vX.Y.Z[-channel.N]`**：准备发布时从 `main` 切出的分支。发布完成后再反向合并回 `main` 与 `dev`。
-- **功能分支**：从 `dev` 切出，命名要有描述性（如 `feat/quick-panel-search`、`fix/devices-online-state`）。
+- **`main`**：主干（trunk）。所有改动通过 PR 进入这里。`main` 必须始终保持可构建、可发布。
+- **`release/vX.Y.Z[-channel.N]`**：发版（alpha / beta / rc / stable）时由 `prepare-release` workflow 从 `main` 切出。release PR 合回 `main` 后会自动打 tag 并构建产物，release 分支随后自动删除。
+- **功能分支**：从 `main` 切出，命名要有描述性（如 `feat/quick-panel-search`、`fix/devices-online-state`）。
 
-提 PR 时默认目标分支是 `dev`，除非维护者明确要求你目标到某个 release 分支。
+提 PR 时默认目标分支是 `main`，除非维护者明确要求你目标到某个 release 分支。
+
+未完成的工作不要合入。功能没准备好就留在 feature 分支上（或加运行时 gate），不要把半成品合进 `main`。
 
 ## Commit 规范
 
@@ -284,7 +285,7 @@ bun run test:coverage   # 在 src-tauri/target/llvm-cov 下生成 HTML 报告
 
 ### 提 PR 之前
 
-- 先 rebase 到最新的 `dev`。
+- 先 rebase 到最新的 `main`。
 - 本地确认 `bun run lint`、`bun run format`、`bun test`、`cargo test`（涉及时）都能通过。
 - 保持 diff 聚焦。互不相关的改动请拆成独立 PR。
 

--- a/src/components/clipboard/ClipboardPreview.tsx
+++ b/src/components/clipboard/ClipboardPreview.tsx
@@ -102,7 +102,7 @@ const ClipboardPreview: React.FC<ClipboardPreviewProps> = ({ item, actions }) =>
         {isLargeText ? (
           <div className="absolute inset-0">{renderContent()}</div>
         ) : (
-          <ScrollArea className="h-full">
+          <ScrollArea className="h-full [&_[data-slot=scroll-area-viewport]>div]:!block">
             <div className="min-h-full">{renderContent()}</div>
           </ScrollArea>
         )}


### PR DESCRIPTION
## Summary

切换到 trunk-based workflow，准备退役 `dev` 分支。

发 0.7.0 stable 时暴露了 release-branch 工作流的缺口：`prepare-release.yml` 的 `base_branch` 一肩挑两职（切 release 的源 + PR 目标），所以 stable-from-dev 场景必须事后手动改 PR base 并解 merge 冲突。trunk-based 之后这个歧义消失，发版命令简化成 `gh workflow run prepare-release.yml -f version=X.Y.Z -f channel=stable`。

## Changes

- **cherry-pick** `4f7a046b fix(clipboard/preview): truncate long URL in LinkPreview within ScrollArea (#596)` — 该 commit 在 PR #595 切 release 分支后才进 dev，单独带过来
- **chore(ci)**:
  - `coverage.yml` / `tag-on-merge.yml` / `format.yml`：触发器从 `[main, dev]` 改为 `[main]`
  - `prepare-release.yml`：删 `base_branch` 输入参数，硬编码 `main`
- **docs(contributing)**：CONTRIBUTING.md / CONTRIBUTING_ZH.md 的分支策略章节改述为 trunk-based

## After this PR is merged — manual steps

1. 关闭 dev 上的 in-flight feature 分支或 rebase 到 main：
   - `feat/analytics-gate` (24 ahead-of-dev)
   - `mkdir700/snap-daemon-sidecar-spawn` (7 ahead-of-dev)
   - `mkdir700/theme-switcher-redesign` (1 ahead-of-dev, PR #582 — 需 retarget 到 main)
2. 删除已合并的 feature 分支：`mkdir700/e2e-matrix-test-plan`、`mkdir700/clipboard-source-app`、`mkdir700/redefine-unlock-gui-only`
3. 删除 dev 远程分支

## Test plan

- [x] CI workflow 触发器语法正确（`branches: [main]`）
- [x] `prepare-release.yml` 不再引用 `inputs.base_branch`
- [ ] PR check workflow 通过

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed scroll area display in clipboard preview content.

* **Chores**
  * Consolidated CI/CD workflows to focus on primary development branch.
  * Updated contributor guidelines to reflect streamlined branching strategy.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/UniClipboard/UniClipboard/pull/598)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->