### PR TITLE
fix(invitation-code): preserve last char when pasting XXXX-XXXX form

### DIFF
--- a/src/components/InvitationCodeInput.tsx
+++ b/src/components/InvitationCodeInput.tsx
@@ -59,6 +59,18 @@ export function InvitationCodeInput({
     onChange(cleaned)
   }
 
+  // Strip the `XXXX-XXXX` hyphen on paste so the underlying `<input>`'s
+  // maxLength=8 does not lop off the final character of a 9-char clipboard
+  // payload before our onChange filter runs. Passing this transformer also
+  // forces input-otp to route paste through JS (preventDefault + manual
+  // setValue) on non-iOS browsers, sidestepping the maxLength truncation.
+  const handlePaste = (text: string) =>
+    text
+      .toUpperCase()
+      .split('')
+      .filter(c => ALLOWED_CHARS.test(c))
+      .join('')
+
   const finalSlotClass = cn(slotClass, invalid && invalidSlotClass)
 
   return (
@@ -66,6 +78,7 @@ export function InvitationCodeInput({
       maxLength={INVITATION_CODE_LENGTH}
       value={value}
       onChange={handleChange}
+      pasteTransformer={handlePaste}
       disabled={disabled}
       aria-invalid={invalid || undefined}
       containerClassName={cn('justify-center gap-3', className)}


### PR DESCRIPTION
## Summary
- 粘贴 `XXXX-XXXX` 形式（9 字符含连字符）的邀请码时，最后一位字符会丢失：底层 `<input>` 的 `maxLength=8` 会先把粘贴内容截到 8 字符，等不到我们的 `onChange` 过滤掉连字符就已经少了一位。
- 给 `InputOTP` 加上 `pasteTransformer`，先把不允许的字符（含连字符）剥掉再交给 input-otp。这同时把粘贴路径切到 JS 处理（`preventDefault` + 手动 `setValue`），绕开了浏览器原生的 `maxLength` 截断。

## Test plan
- [x] 复制 `ABCD-EFGH`，粘贴到邀请码输入框，确认 8 个槽位填满 `ABCDEFGH`，最后一位 `H` 没有丢失
- [x] 复制 `ABCDEFGH`（无连字符），粘贴后同样填满 8 位
- [x] 复制带小写 / 多余字符的字符串（如 `abcd-efgh!!`），确认仅保留 `ABCDEFGH`
- [x] iOS Safari 下手工粘贴仍然正常（`pasteTransformer` 在 iOS 走原生路径，行为应保持不变）

close: #601 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where pasting invitation codes containing hyphens (e.g., XXXX-XXXX) would drop the final character during paste.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/UniClipboard/UniClipboard/pull/602)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->