### PR TITLE
fix(daemon-contract): retention settings 422 + wire-contract regressions (#606)

### DIFF
--- a/docs/agent/rust-tauri-rules.md
+++ b/docs/agent/rust-tauri-rules.md
@@ -76,6 +76,25 @@ pub async fn sync_peer(peer_id: &str, attempt: u32) -> Result<(), SyncError> {
 - Verify frontend listener field names match camelCase output.
 - Add a test that proves camelCase keys exist and snake_case keys do not.
 
+## Enum Wire Serialization (`rename_all_fields`)
+
+`#[serde(rename_all = "...")]` on an **enum** only renames the **variant names** — it does **NOT** touch named fields inside struct-style variants. This is a hidden serde footgun that caused issue #606 (PUT `/settings` returning 422 because `RetentionRuleDto::ByAge { max_age }` serialized to `{"byAge": {"max_age": N}}` while the frontend sent `{"byAge": {"maxAge": N}}`).
+
+**Rule:** an enum **MUST** also declare `rename_all_fields = "..."` (matching the variant case style) when **all three** conditions hold:
+
+1. It is an `enum` (not a `struct` — `rename_all` on a struct already covers its fields).
+2. At least one variant is **struct-style** (`Foo { name1, name2 }`, with named fields). Tuple variants `Foo(T)` and unit variants `Foo` are exempt.
+3. Any field name is **multi-word snake_case** (`max_age` → `maxAge` cares; single-word `current` doesn't).
+
+Even when condition 3 is currently false, prefer to **declare `rename_all_fields` defensively** for any enum with struct variants — the next PR that adds a multi-word field will silently emit the wrong wire shape if the attribute is missing.
+
+**Tests:** every such enum must have wire-shape tests that
+
+- assert the camelCase / snake_case wire literal verbatim, and
+- explicitly **reject** the legacy snake_case-in-camelCase-wire (or vice versa) bug shape, so a future revert is caught immediately.
+
+See `uc-daemon-contract::api::dto::settings::retention_rule_dto_tests` for the canonical pattern.
+
 ## Cargo Command Location
 
 - **All Rust-related commands** (`cargo build`, `cargo test`, `cargo check`, etc.) **must be executed from `src-tauri/`.**

--- a/src-tauri/crates/uc-daemon-contract/src/api/dto/settings.rs
+++ b/src-tauri/crates/uc-daemon-contract/src/api/dto/settings.rs
@@ -98,9 +98,13 @@ pub enum SyncFrequencyDto {
     Interval,
 }
 
+// `rename_all = "camelCase"` 只 rename 变体名（`ByAge` → `byAge`），不会改写
+// struct 变体内部的字段名。必须同时加 `rename_all_fields = "camelCase"`，
+// 否则 wire 是 `{"byAge":{"max_age":N}}`，与前端 `{ byAge: { maxAge: N } }`
+// 错位，导致 PUT /settings 反序列化失败返回 422（见 issue #606）。
 #[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", rename_all_fields = "camelCase")]
 pub enum RetentionRuleDto {
     /// 按时间清理
     ByAge {
@@ -707,5 +711,162 @@ mod network_dto_tests {
         assert!(dto.general.is_none());
         assert!(dto.network.is_none());
         assert!(dto.file_sync.is_none());
+    }
+}
+
+/// issue #606 回归守卫 —— `RetentionRuleDto` wire 形态锁定。
+///
+/// 历史背景：旧实现只在枚举上声明 `rename_all = "camelCase"`，serde 只 rename
+/// 变体名（`ByAge` → `byAge`），不会改写 struct 变体内部字段名。结果 wire 是
+/// `{"byAge":{"max_age":N}}`、前端发 `{"byAge":{"maxAge":N}}`，PUT /settings
+/// 反序列化失败返回 422。修复加了 `rename_all_fields = "camelCase"`。
+///
+/// 下面五条用例锁住每个变体的 wire 形态，并显式 reject 旧 bug-shape；
+/// 任何方向回退（删 `rename_all_fields`、把字段改 snake_case 等）都会被抓住。
+#[cfg(test)]
+mod retention_rule_dto_tests {
+    use super::*;
+
+    #[test]
+    fn by_age_wire_uses_camel_case_field() {
+        let rule = RetentionRuleDto::ByAge {
+            max_age: Duration::from_secs(2_592_000),
+        };
+        let wire = serde_json::to_string(&rule).expect("serialize ByAge");
+        assert_eq!(
+            wire, r#"{"byAge":{"maxAge":2592000}}"#,
+            "wire MUST be camelCase inside variant (issue #606)"
+        );
+
+        let parsed: RetentionRuleDto =
+            serde_json::from_str(r#"{"byAge":{"maxAge":86400}}"#).expect("accept camelCase wire");
+        match parsed {
+            RetentionRuleDto::ByAge { max_age } => assert_eq!(max_age.as_secs(), 86400),
+            _ => panic!("unexpected variant"),
+        }
+
+        // 关键负面用例：旧 bug-shape 必须被拒绝，避免回退悄无声息地通过。
+        assert!(
+            serde_json::from_str::<RetentionRuleDto>(r#"{"byAge":{"max_age":86400}}"#).is_err(),
+            "snake_case field on wire MUST be rejected — that's the issue #606 bug shape"
+        );
+    }
+
+    #[test]
+    fn by_count_wire_uses_camel_case_field() {
+        let rule = RetentionRuleDto::ByCount { max_items: 500 };
+        assert_eq!(
+            serde_json::to_string(&rule).unwrap(),
+            r#"{"byCount":{"maxItems":500}}"#
+        );
+
+        let parsed: RetentionRuleDto =
+            serde_json::from_str(r#"{"byCount":{"maxItems":1000}}"#).expect("accept camelCase");
+        match parsed {
+            RetentionRuleDto::ByCount { max_items } => assert_eq!(max_items, 1000),
+            _ => panic!("unexpected variant"),
+        }
+
+        assert!(
+            serde_json::from_str::<RetentionRuleDto>(r#"{"byCount":{"max_items":1}}"#).is_err(),
+            "snake_case field must be rejected"
+        );
+    }
+
+    #[test]
+    fn by_content_type_wire_uses_camel_case_field() {
+        let rule = RetentionRuleDto::ByContentType {
+            content_type: ContentTypesDto {
+                text: true,
+                image: false,
+                link: false,
+                file: false,
+                code_snippet: false,
+                rich_text: false,
+            },
+            max_age: Duration::from_secs(86_400),
+        };
+        let wire = serde_json::to_value(&rule).expect("serialize ByContentType");
+        let expected = serde_json::json!({
+            "byContentType": {
+                "contentType": {
+                    "text": true,
+                    "image": false,
+                    "link": false,
+                    "file": false,
+                    "codeSnippet": false,
+                    "richText": false,
+                },
+                "maxAge": 86_400,
+            }
+        });
+        assert_eq!(wire, expected);
+    }
+
+    #[test]
+    fn by_total_size_and_sensitive_wire_camel_case() {
+        let by_size = RetentionRuleDto::ByTotalSize {
+            max_bytes: 1_073_741_824,
+        };
+        assert_eq!(
+            serde_json::to_string(&by_size).unwrap(),
+            r#"{"byTotalSize":{"maxBytes":1073741824}}"#
+        );
+
+        let sensitive = RetentionRuleDto::Sensitive {
+            max_age: Duration::from_secs(3600),
+        };
+        assert_eq!(
+            serde_json::to_string(&sensitive).unwrap(),
+            r#"{"sensitive":{"maxAge":3600}}"#
+        );
+    }
+
+    /// 端到端：把前端 `StorageSection.setByAgeRule / setByCountRule` 拼出的
+    /// patch body 用 `SettingsPatchDto` 反序列化。修复前这一步在 axum
+    /// `Json<SettingsPatchDto>` 提取器内部抛 `missing field "max_age"`，
+    /// 返回 422（issue #606 用户实际碰到的现象）。
+    #[test]
+    fn settings_patch_dto_accepts_frontend_retention_rules_payload() {
+        let body = r#"{
+            "retentionPolicy": {
+                "enabled": true,
+                "rules": [
+                    {"byAge": {"maxAge": 5184000}},
+                    {"byCount": {"maxItems": 1000}}
+                ],
+                "skipPinned": true,
+                "evaluation": "anyMatch"
+            }
+        }"#;
+
+        let patch: SettingsPatchDto =
+            serde_json::from_str(body).expect("PUT body must deserialize (issue #606)");
+        let retention = patch.retention_policy.expect("retentionPolicy present");
+        let rules = retention.rules.expect("rules present");
+        assert_eq!(rules.len(), 2);
+        match &rules[0] {
+            RetentionRuleDto::ByAge { max_age } => assert_eq!(max_age.as_secs(), 5_184_000),
+            other => panic!("unexpected first rule: {other:?}"),
+        }
+        match &rules[1] {
+            RetentionRuleDto::ByCount { max_items } => assert_eq!(*max_items, 1000),
+            other => panic!("unexpected second rule: {other:?}"),
+        }
+    }
+
+    /// 防御回归：旧 bug-shape（变体内部字段是 snake_case）在 PUT body 层级
+    /// 也必须被拒绝。
+    #[test]
+    fn settings_patch_dto_rejects_legacy_snake_case_inside_variant() {
+        let buggy = r#"{
+            "retentionPolicy": {
+                "rules": [{"byAge": {"max_age": 86400}}]
+            }
+        }"#;
+        assert!(
+            serde_json::from_str::<SettingsPatchDto>(buggy).is_err(),
+            "snake_case field inside variant MUST NOT deserialize — that's the issue #606 bug shape"
+        );
     }
 }

--- a/src-tauri/crates/uc-daemon-contract/src/api/dto/settings.rs
+++ b/src-tauri/crates/uc-daemon-contract/src/api/dto/settings.rs
@@ -870,3 +870,283 @@ mod retention_rule_dto_tests {
         );
     }
 }
+
+/// 子集 A —— enum 变体 wire 形态锁定。
+///
+/// 这些 enum 看起来人畜无害(unit-only 变体没 issue #606 那种"内嵌字段
+/// 被忽略"的坑),但 wire 字面量是与前端 TS 字面量类型硬绑定的契约:
+///   - `ThemeDto` ↔ `type Theme = 'light' | 'dark' | 'system'`
+///   - `UpdateChannelDto` ↔ `type UpdateChannel = 'stable' | 'alpha' | 'beta' | 'rc'`
+///   - `SyncFrequencyDto` ↔ `type SyncFrequency = 'realtime' | 'interval'`
+///   - `RuleEvaluationDto` ↔ `type RuleEvaluation = 'anyMatch' | 'allMatch'`
+///   - `ShortcutKeyDto` (untagged) ↔ `type ShortcutKey = string | string[]`
+///
+/// 任何 PR 误把 `rename_all` 改成另一种风格、或者把 `untagged` 摘掉,
+/// 前端会瞬间不识别但后端编译过 —— 这些测试是兜底的契约 fence。
+///
+/// 特别留意 `RuleEvaluationDto` 是 `camelCase`(`anyMatch`),
+/// 而 `uc-core::RuleEvaluation` 是 `snake_case`(`any_match`)。
+/// wire 与持久化格式不同,转换在 webserver `rule_evaluation_from_dto` 完成。
+#[cfg(test)]
+mod enum_wire_tests {
+    use super::*;
+
+    #[test]
+    fn theme_dto_wire_is_snake_case_lowercase() {
+        assert_eq!(
+            serde_json::to_string(&ThemeDto::Light).unwrap(),
+            r#""light""#
+        );
+        assert_eq!(serde_json::to_string(&ThemeDto::Dark).unwrap(), r#""dark""#);
+        assert_eq!(
+            serde_json::to_string(&ThemeDto::System).unwrap(),
+            r#""system""#
+        );
+
+        let parsed: ThemeDto = serde_json::from_str(r#""dark""#).expect("accept 'dark'");
+        assert_eq!(parsed, ThemeDto::Dark);
+
+        // 防御:误改成 PascalCase / camelCase 必须解析失败。
+        assert!(serde_json::from_str::<ThemeDto>(r#""Light""#).is_err());
+        assert!(serde_json::from_str::<ThemeDto>(r#""systemTheme""#).is_err());
+    }
+
+    #[test]
+    fn update_channel_dto_wire_is_snake_case_lowercase() {
+        for (variant, literal) in [
+            (UpdateChannelDto::Stable, r#""stable""#),
+            (UpdateChannelDto::Alpha, r#""alpha""#),
+            (UpdateChannelDto::Beta, r#""beta""#),
+            (UpdateChannelDto::Rc, r#""rc""#),
+        ] {
+            assert_eq!(serde_json::to_string(&variant).unwrap(), literal);
+            assert_eq!(
+                serde_json::from_str::<UpdateChannelDto>(literal).unwrap(),
+                variant
+            );
+        }
+
+        assert!(serde_json::from_str::<UpdateChannelDto>(r#""RC""#).is_err());
+    }
+
+    #[test]
+    fn sync_frequency_dto_wire_is_snake_case_lowercase() {
+        assert_eq!(
+            serde_json::to_string(&SyncFrequencyDto::Realtime).unwrap(),
+            r#""realtime""#
+        );
+        assert_eq!(
+            serde_json::to_string(&SyncFrequencyDto::Interval).unwrap(),
+            r#""interval""#
+        );
+
+        let parsed: SyncFrequencyDto =
+            serde_json::from_str(r#""realtime""#).expect("accept 'realtime'");
+        assert_eq!(parsed, SyncFrequencyDto::Realtime);
+
+        // 防御:历史上"Realtime"或者"real_time"都不是合法 wire。
+        assert!(serde_json::from_str::<SyncFrequencyDto>(r#""Realtime""#).is_err());
+        assert!(serde_json::from_str::<SyncFrequencyDto>(r#""real_time""#).is_err());
+    }
+
+    /// 关键 fence:`RuleEvaluationDto` 用 camelCase,与 `uc-core` 的 snake_case
+    /// 形态不同。前端 TS 字面量是 `'anyMatch' | 'allMatch'`。
+    #[test]
+    fn rule_evaluation_dto_wire_is_camel_case() {
+        assert_eq!(
+            serde_json::to_string(&RuleEvaluationDto::AnyMatch).unwrap(),
+            r#""anyMatch""#
+        );
+        assert_eq!(
+            serde_json::to_string(&RuleEvaluationDto::AllMatch).unwrap(),
+            r#""allMatch""#
+        );
+
+        let parsed: RuleEvaluationDto =
+            serde_json::from_str(r#""anyMatch""#).expect("accept 'anyMatch'");
+        assert_eq!(parsed, RuleEvaluationDto::AnyMatch);
+
+        // 防御:把 wire 形态改回与 uc-core 同样的 snake_case 会让前端瞬间挂掉。
+        assert!(
+            serde_json::from_str::<RuleEvaluationDto>(r#""any_match""#).is_err(),
+            "RuleEvaluationDto wire MUST be camelCase, not snake_case (前端契约)"
+        );
+    }
+
+    /// `ShortcutKeyDto` 是 `untagged`,wire 直接是 string 或 string[]。
+    /// 如果误改成 `tag = "kind"` 类的 internally-tagged,前端的
+    /// `Record<string, string | string[]>` 会立刻失配。
+    #[test]
+    fn shortcut_key_dto_is_untagged_string_or_array() {
+        let single = ShortcutKeyDto::Single("Ctrl+C".into());
+        assert_eq!(serde_json::to_string(&single).unwrap(), r#""Ctrl+C""#);
+
+        let multi = ShortcutKeyDto::Multiple(vec!["Ctrl+C".into(), "Meta+C".into()]);
+        assert_eq!(
+            serde_json::to_string(&multi).unwrap(),
+            r#"["Ctrl+C","Meta+C"]"#
+        );
+
+        // 反向:两种 wire 都能解析回正确变体。
+        let parsed_single: ShortcutKeyDto =
+            serde_json::from_str(r#""Ctrl+V""#).expect("accept bare string");
+        assert!(matches!(parsed_single, ShortcutKeyDto::Single(s) if s == "Ctrl+V"));
+
+        let parsed_multi: ShortcutKeyDto =
+            serde_json::from_str(r#"["a","b"]"#).expect("accept array");
+        assert!(matches!(parsed_multi, ShortcutKeyDto::Multiple(v) if v.len() == 2));
+    }
+}
+
+/// 子集 B —— `GeneralSettingsPatchDto` 的 `Option<Option<T>>` 字段当前 wire 语义锁定。
+///
+/// `theme_color / language / device_name / update_channel` 的字段类型是
+/// `Option<Option<T>>`,facade 层(`models.rs` line 485+)按三态语义消费:
+/// ```ignore
+/// if let Some(v) = general.theme_color {
+///     existing.general.theme_color = v;  // Some(None) ⇒ 清空, Some(Some(x)) ⇒ 设置
+/// }
+/// ```
+///
+/// 但 **wire 层目前是 2-state**:缺字段和 `null` 都被裸 serde 反序列化成
+/// `None`(外层 Option),只有非 null 值才走到 `Some(...)` 分支。
+/// 这意味着前端无法用 `null` 显式清空一个 `Option<String>` 字段 ——
+/// 这是一个**已知 wire/facade 契约不齐**(类似 issue #606 那种)。
+///
+/// 修法是给这些字段加 `#[serde(with = "serde_with::rust::double_option")]`
+/// 让 `null` ⇒ `Some(None)`、缺字段 ⇒ `None`。但那是行为变更,需要单独 PR
+/// 评估前端是否依赖现行 collapsed 行为,故本 PR 只锁定**当前现实**:
+///   - 缺字段 ⇒ `None`         (不改)
+///   - `null` ⇒ `None`         (⚠️ 与"清空"不可区分 —— 见 TODO)
+///   - 值     ⇒ `Some(Some(v))` (设置新值)
+///
+/// 任一测试 fail = wire 行为漂移,需要回头判断是有意修复还是回归。
+// TODO(#606-followup): 决定是否启用 `serde_with::rust::double_option` 让
+// `null` ⇒ `Some(None)` 真正支持"显式清空",并把下面 explicit_null 用例
+// 的预期从 `None` 改成 `Some(None)`。
+#[cfg(test)]
+mod general_patch_optional_field_wire_tests {
+    use super::*;
+
+    #[test]
+    fn missing_field_means_none() {
+        let body = r#"{}"#;
+        let dto: GeneralSettingsPatchDto = serde_json::from_str(body).expect("deserialize");
+        assert!(dto.theme_color.is_none(), "missing field ⇒ None (不改)");
+        assert!(dto.language.is_none());
+        assert!(dto.device_name.is_none());
+        assert!(dto.update_channel.is_none());
+    }
+
+    /// ⚠️ 当前行为:wire `null` 反序列化成外层 `None`,与缺字段不可区分。
+    /// 修复 TODO 在模块 docstring。
+    #[test]
+    fn explicit_null_collapses_to_none_today() {
+        let body = r#"{
+            "themeColor": null,
+            "language": null,
+            "deviceName": null,
+            "updateChannel": null
+        }"#;
+        let dto: GeneralSettingsPatchDto = serde_json::from_str(body).expect("deserialize");
+        assert_eq!(
+            dto.theme_color, None,
+            "today wire `null` collapses to outer None — see module TODO for 3-state fix"
+        );
+        assert_eq!(dto.language, None);
+        assert_eq!(dto.device_name, None);
+        assert_eq!(dto.update_channel, None);
+    }
+
+    #[test]
+    fn explicit_value_becomes_some_some() {
+        let body = r#"{
+            "themeColor": "blue",
+            "language": "zh-CN",
+            "deviceName": "ws-1",
+            "updateChannel": "beta"
+        }"#;
+        let dto: GeneralSettingsPatchDto = serde_json::from_str(body).expect("deserialize");
+        assert_eq!(dto.theme_color, Some(Some("blue".to_string())));
+        assert_eq!(dto.language, Some(Some("zh-CN".to_string())));
+        assert_eq!(dto.device_name, Some(Some("ws-1".to_string())));
+        assert_eq!(dto.update_channel, Some(Some(UpdateChannelDto::Beta)));
+    }
+}
+
+/// 子集 C —— `Duration` wire 形态(`serde_with::DurationSeconds<u64>`)。
+///
+/// 所有 `PairingSettingsDto` 的 timeout 字段、`RetentionRuleDto::ByAge.max_age`
+/// 都靠 `DurationSeconds<u64>` 把 `Duration` 序列化成秒数 `u64`。误改成
+/// `DurationMilliSeconds` 或 `DurationSecondsWithFrac` 会让前端拿 `number`
+/// 解析出错位的数量级 / 浮点格式。这里把 wire 形态固定下来。
+#[cfg(test)]
+mod duration_wire_tests {
+    use super::*;
+
+    #[test]
+    fn pairing_durations_serialize_as_u64_seconds() {
+        let dto = PairingSettingsDto {
+            step_timeout: Duration::from_secs(30),
+            user_verification_timeout: Duration::from_secs(120),
+            session_timeout: Duration::from_secs(3600),
+            max_retries: 3,
+            protocol_version: "1.0".into(),
+        };
+        let value = serde_json::to_value(&dto).expect("serialize");
+        assert_eq!(
+            value["stepTimeout"],
+            serde_json::json!(30),
+            "Duration MUST serialize as integer seconds, not millis / float / object"
+        );
+        assert_eq!(value["userVerificationTimeout"], serde_json::json!(120));
+        assert_eq!(value["sessionTimeout"], serde_json::json!(3600));
+
+        // 反向:整数秒能正确解析。
+        let body = r#"{
+            "stepTimeout": 30,
+            "userVerificationTimeout": 120,
+            "sessionTimeout": 3600,
+            "maxRetries": 3,
+            "protocolVersion": "1.0"
+        }"#;
+        let parsed: PairingSettingsDto = serde_json::from_str(body).expect("deserialize");
+        assert_eq!(parsed.step_timeout, Duration::from_secs(30));
+        assert_eq!(parsed.user_verification_timeout, Duration::from_secs(120));
+        assert_eq!(parsed.session_timeout, Duration::from_secs(3600));
+    }
+
+    #[test]
+    fn pairing_patch_durations_round_trip_optional_seconds() {
+        // 缺字段 → None (不改)。
+        let empty: PairingSettingsPatchDto =
+            serde_json::from_str(r#"{}"#).expect("deserialize empty");
+        assert!(empty.step_timeout.is_none());
+
+        // 整数秒 → Some(Duration)。
+        let body = r#"{"stepTimeout": 60}"#;
+        let parsed: PairingSettingsPatchDto = serde_json::from_str(body).expect("deserialize");
+        assert_eq!(parsed.step_timeout, Some(Duration::from_secs(60)));
+
+        // 防御:DurationSeconds<u64> 不接受浮点(serde_with 行为)。
+        // 这里只断言"如果未来改成 WithFrac 则该测试需要更新",
+        // 避免静默语义漂移。
+        let frac = r#"{"stepTimeout": 1.5}"#;
+        assert!(
+            serde_json::from_str::<PairingSettingsPatchDto>(frac).is_err(),
+            "DurationSeconds<u64> MUST reject fractional input — change guard for accidental switch to WithFrac"
+        );
+    }
+
+    /// `RetentionRuleDto::ByAge.max_age` 同样用 `DurationSeconds<u64>`,
+    /// 锁定一下整数秒 ↔ Duration 来回都对(防止 issue #606 修复时
+    /// 误把单位改了)。
+    #[test]
+    fn retention_by_age_max_age_is_u64_seconds() {
+        let rule = RetentionRuleDto::ByAge {
+            max_age: Duration::from_secs(2_592_000),
+        };
+        let wire = serde_json::to_value(&rule).expect("serialize");
+        assert_eq!(wire["byAge"]["maxAge"], serde_json::json!(2_592_000u64));
+    }
+}

--- a/src-tauri/crates/uc-daemon-contract/src/api/dto/upgrade.rs
+++ b/src-tauri/crates/uc-daemon-contract/src/api/dto/upgrade.rs
@@ -20,8 +20,18 @@ pub struct GetUpgradeStatusResponse {
 /// Wire encoding uses `kind` discriminator with snake_case variants to
 /// keep parity with the CLI JSON output produced by `uniclip upgrade
 /// status --json`.
+///
+/// 防御性补丁(issue #606 followup):同时声明 `rename_all_fields`,
+/// 避免未来新增多词字段(如 `target_version`)时 wire 字段名漂回
+/// snake_case 与上层契约不一致。当前字段都是单词,加这个对 wire 无影响,
+/// 但锁定未来添加字段的默认风格。详见 `docs/agent/rust-tauri-rules.md`
+/// 的 "Enum Wire Serialization" 一节。
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
-#[serde(tag = "kind", rename_all = "snake_case")]
+#[serde(
+    tag = "kind",
+    rename_all = "snake_case",
+    rename_all_fields = "snake_case"
+)]
 pub enum UpgradeStatusDto {
     /// First time the app is launched on this profile.
     FreshInstall { current: String },

--- a/src-tauri/crates/uc-webserver/tests/settings_retention_smoke.rs
+++ b/src-tauri/crates/uc-webserver/tests/settings_retention_smoke.rs
@@ -1,0 +1,302 @@
+//! 回归测试：retention rules 的 wire ↔ DTO ↔ View ↔ settings.json round-trip。
+//!
+//! 修复 issue #606 —— `RetentionRuleDto` 之前只在枚举上声明 `rename_all = "camelCase"`，
+//! 这只 rename 变体名（`ByAge` → `byAge`），不会改写 struct 变体内部字段名。
+//! 结果 wire 是 `{"byAge":{"max_age":N}}`、前端发 `{"byAge":{"maxAge":N}}`，
+//! Axum `Json` 提取器反序列化失败返回 422，UI 显示
+//! "保存设置失败: DaemonApiError: 422 on /settings"。
+//!
+//! 这里锁定五件事，防止再次回归：
+//!   1. **`byAge` 序列化字段是 `maxAge`**（不是 `max_age`）；
+//!   2. **`byCount` 序列化字段是 `maxItems`**；
+//!   3. **`byContentType` / `byTotalSize` / `sensitive` 同样走 camelCase**；
+//!   4. **GET → PUT round-trip 一致**：把 GET 的 retention rules 原样 PUT 回去
+//!      必须 200 OK、不丢字段、不返回 422；
+//!   5. **handler 反序列化前端实际发送的 wire body**：模仿
+//!      `StorageSection.setByAgeRule / setByCountRule` 构造的 patch 形态。
+//!
+//! ## fixture 范围（沿用 `settings_network_smoke.rs` 模式）
+//!
+//! 不组装完整 axum Router + AppFacade，改为：
+//!   - PUT 模拟：`serde_json::from_str::<SettingsPatchDto>` →
+//!     `settings_patch_from_dto` → `SettingsFacade::update` → `settings_view_to_dto`
+//!   - GET 模拟：`SettingsFacade::get` → `settings_view_to_dto`
+//!   - 持久化：`Mutex<Settings>` in-memory `SettingsPort`
+
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use serde_json::{json, Value};
+use uc_application::facade::settings::SettingsFacade;
+use uc_core::ports::SettingsPort;
+use uc_core::settings::model::Settings;
+use uc_daemon_contract::api::dto::settings::{
+    RetentionRuleDto, SettingsPatchDto, UpdateSettingsResponse,
+};
+use uc_webserver::api::dto::settings::SettingsDto;
+use uc_webserver::api::settings::{settings_patch_from_dto, settings_view_to_dto};
+
+// ============================================================
+// Fixture
+// ============================================================
+
+struct InMemorySettings {
+    settings: Mutex<Settings>,
+}
+
+#[async_trait]
+impl SettingsPort for InMemorySettings {
+    async fn load(&self) -> anyhow::Result<Settings> {
+        Ok(self.settings.lock().unwrap().clone())
+    }
+
+    async fn save(&self, settings: &Settings) -> anyhow::Result<()> {
+        *self.settings.lock().unwrap() = settings.clone();
+        Ok(())
+    }
+}
+
+fn build_facade() -> SettingsFacade {
+    let port: Arc<dyn SettingsPort> = Arc::new(InMemorySettings {
+        settings: Mutex::new(Settings::default()),
+    });
+    SettingsFacade::new(port)
+}
+
+async fn simulate_put(facade: &SettingsFacade, body_json: &str) -> Value {
+    let payload: SettingsPatchDto = serde_json::from_str(body_json).expect("parse PUT body");
+    let view = facade
+        .update(settings_patch_from_dto(payload))
+        .await
+        .expect("settings update");
+    let resp = UpdateSettingsResponse {
+        success: true,
+        data: settings_view_to_dto(view),
+        ts: 0,
+        restart_required: false,
+    };
+    serde_json::to_value(&resp).expect("serialize response")
+}
+
+async fn simulate_get(facade: &SettingsFacade) -> Value {
+    let view = facade.get().await.expect("settings get");
+    let dto: SettingsDto = settings_view_to_dto(view);
+    serde_json::to_value(&dto).expect("serialize get")
+}
+
+// ============================================================
+// 1. 各变体 wire 形态锁定（防 rename_all_fields 被回退）
+// ============================================================
+
+/// `RetentionRuleDto::ByAge` 的 wire 形态必须是 `{"byAge":{"maxAge":N}}`，
+/// 而不是 `{"byAge":{"max_age":N}}` —— 后者是 issue #606 出错的旧形态。
+#[test]
+fn by_age_wire_is_camel_case() {
+    let rule = RetentionRuleDto::ByAge {
+        max_age: std::time::Duration::from_secs(2_592_000),
+    };
+    let wire = serde_json::to_value(&rule).expect("serialize ByAge");
+    assert_eq!(
+        wire,
+        json!({"byAge": {"maxAge": 2_592_000}}),
+        "wire MUST be camelCase inside variant (issue #606 regression guard)"
+    );
+
+    // 反向：camelCase 输入必须能解析；snake_case 输入必须失败（避免后端
+    // 偷偷接受了 snake_case 让 mismatched 前端蒙混过关）。
+    let parsed: RetentionRuleDto = serde_json::from_value(json!({"byAge": {"maxAge": 86400}}))
+        .expect("must accept camelCase wire");
+    match parsed {
+        RetentionRuleDto::ByAge { max_age } => assert_eq!(max_age.as_secs(), 86400),
+        other => panic!("unexpected variant: {:?}", other),
+    }
+
+    assert!(
+        serde_json::from_value::<RetentionRuleDto>(json!({"byAge": {"max_age": 86400}})).is_err(),
+        "snake_case field name on wire must be rejected — that's the bug-shape"
+    );
+}
+
+/// `byCount` 的 wire 形态必须是 `{"byCount":{"maxItems":N}}`。
+#[test]
+fn by_count_wire_is_camel_case() {
+    let rule = RetentionRuleDto::ByCount { max_items: 500 };
+    let wire = serde_json::to_value(&rule).expect("serialize ByCount");
+    assert_eq!(wire, json!({"byCount": {"maxItems": 500}}));
+
+    let parsed: RetentionRuleDto = serde_json::from_value(json!({"byCount": {"maxItems": 1000}}))
+        .expect("must accept camelCase wire");
+    match parsed {
+        RetentionRuleDto::ByCount { max_items } => assert_eq!(max_items, 1000),
+        other => panic!("unexpected variant: {:?}", other),
+    }
+}
+
+/// `byContentType` 的 wire 形态必须是 `{"byContentType":{"contentType":{...}, "maxAge":N}}`。
+#[test]
+fn by_content_type_wire_is_camel_case() {
+    use uc_daemon_contract::api::dto::settings::ContentTypesDto;
+
+    let rule = RetentionRuleDto::ByContentType {
+        content_type: ContentTypesDto {
+            text: true,
+            image: false,
+            link: false,
+            file: false,
+            code_snippet: false,
+            rich_text: false,
+        },
+        max_age: std::time::Duration::from_secs(86_400),
+    };
+    let wire = serde_json::to_value(&rule).expect("serialize ByContentType");
+    let expected = json!({
+        "byContentType": {
+            "contentType": {
+                "text": true,
+                "image": false,
+                "link": false,
+                "file": false,
+                "codeSnippet": false,
+                "richText": false,
+            },
+            "maxAge": 86_400,
+        }
+    });
+    assert_eq!(wire, expected);
+}
+
+/// `byTotalSize` / `sensitive` 一同锁定 —— 单字段变体也走 camelCase。
+#[test]
+fn by_total_size_and_sensitive_wire_camel_case() {
+    let by_size = RetentionRuleDto::ByTotalSize {
+        max_bytes: 1_073_741_824,
+    };
+    assert_eq!(
+        serde_json::to_value(&by_size).unwrap(),
+        json!({"byTotalSize": {"maxBytes": 1_073_741_824u64}})
+    );
+
+    let sensitive = RetentionRuleDto::Sensitive {
+        max_age: std::time::Duration::from_secs(3600),
+    };
+    assert_eq!(
+        serde_json::to_value(&sensitive).unwrap(),
+        json!({"sensitive": {"maxAge": 3600}})
+    );
+}
+
+// ============================================================
+// 2. PUT /settings 端到端 —— 模仿前端 `StorageSection` 实际发送的 patch
+// ============================================================
+
+/// 复现 issue #606 触发路径：前端改"历史保留时间"调 `updateRetentionPolicy({rules: [...] })`，
+/// 最终 PUT body 是 `{"retentionPolicy":{"rules":[{"byAge":{"maxAge":...}}, ...], ...}}`。
+/// 修复前这一步 Axum 会 422 拒掉；修复后必须 200 OK 并写盘 round-trip 成功。
+#[tokio::test]
+async fn put_retention_rules_camelcase_round_trips() {
+    let facade = build_facade();
+
+    // 前端 `setByAgeRule(rules, 60)` + `setByCountRule(rules, 1000)` 拼出的 patch。
+    let put_body = json!({
+        "retentionPolicy": {
+            "enabled": true,
+            "rules": [
+                { "byAge": { "maxAge": 60 * 86_400 } },
+                { "byCount": { "maxItems": 1000 } },
+            ],
+            "skipPinned": true,
+            "evaluation": "anyMatch",
+        }
+    })
+    .to_string();
+
+    let put_resp = simulate_put(&facade, &put_body).await;
+    assert_eq!(
+        put_resp["success"],
+        Value::Bool(true),
+        "PUT /settings must succeed with camelCase retention rules (issue #606)"
+    );
+
+    // PUT 响应里 data.retentionPolicy 必须保留写入的两条规则，且字段名仍是 camelCase。
+    let rules = put_resp["data"]["retentionPolicy"]["rules"]
+        .as_array()
+        .expect("rules array");
+    assert_eq!(rules.len(), 2);
+    assert_eq!(rules[0]["byAge"]["maxAge"], json!(60 * 86_400));
+    assert_eq!(rules[1]["byCount"]["maxItems"], json!(1000));
+
+    // GET 二次确认写盘 → 读取一致。
+    let get_resp = simulate_get(&facade).await;
+    let get_rules = get_resp["retentionPolicy"]["rules"]
+        .as_array()
+        .expect("rules array on GET");
+    assert_eq!(get_rules.len(), 2);
+    assert_eq!(get_rules[0]["byAge"]["maxAge"], json!(60 * 86_400));
+    assert_eq!(get_rules[1]["byCount"]["maxItems"], json!(1000));
+}
+
+/// 把 GET 拿到的 retention rules 原封不动 PUT 回去（前端 `SettingContext.saveSetting`
+/// 的典型路径：先 GET 整份 settings，patch 单个字段，再把整份 PUT 上去）。
+/// 必须 200 OK —— 这是用户在 UI 上拨一下"自动清理"开关就触发的最常见路径。
+#[tokio::test]
+async fn get_then_put_full_retention_section_succeeds() {
+    let facade = build_facade();
+
+    // 先种入一份带规则的 settings（模拟用户已存在的配置）。
+    let seed = json!({
+        "retentionPolicy": {
+            "enabled": true,
+            "rules": [
+                { "byAge": { "maxAge": 14 * 86_400 } },
+                { "byCount": { "maxItems": 200 } },
+            ],
+            "skipPinned": true,
+            "evaluation": "anyMatch",
+        }
+    });
+    let _ = simulate_put(&facade, &seed.to_string()).await;
+
+    // GET 取出整份 retentionPolicy。
+    let snapshot = simulate_get(&facade).await;
+    let retention = &snapshot["retentionPolicy"];
+    assert!(
+        retention.is_object(),
+        "retentionPolicy must be present on GET"
+    );
+
+    // 把 GET 拿到的 retentionPolicy 原样塞进 PUT body —— 这正是 SettingContext
+    // 在用户拨"自动清理"开关时构造 patch 的方式。
+    let full_put = json!({ "retentionPolicy": retention }).to_string();
+    let resp = simulate_put(&facade, &full_put).await;
+    assert_eq!(
+        resp["success"],
+        Value::Bool(true),
+        "round-trip GET → PUT of the full retentionPolicy must succeed"
+    );
+    assert_eq!(
+        resp["data"]["retentionPolicy"]["rules"][0]["byAge"]["maxAge"],
+        json!(14 * 86_400)
+    );
+    assert_eq!(
+        resp["data"]["retentionPolicy"]["rules"][1]["byCount"]["maxItems"],
+        json!(200)
+    );
+}
+
+/// 防御回归：用 issue #606 出错时的旧 wire 形态（snake_case 内部字段）PUT 必须失败。
+/// 这条用例确保如果有人误删 `rename_all_fields` 退回旧行为，CI 会立刻报错。
+#[test]
+fn snake_case_inside_variant_is_rejected_at_wire() {
+    // 旧形态 wire（修复前 daemon 实际发出的 GET 数据形态、也是被 422 拒掉的形态）
+    let buggy_body = r#"{
+        "retentionPolicy": {
+            "rules": [{"byAge": {"max_age": 86400}}]
+        }
+    }"#;
+
+    let result: Result<SettingsPatchDto, _> = serde_json::from_str(buggy_body);
+    assert!(
+        result.is_err(),
+        "snake_case field inside variant must NOT deserialize — that was the bug shape (issue #606)"
+    );
+}


### PR DESCRIPTION
## Summary

- Fixes #606 — modifying retention/history settings returned `DaemonApiError: 422 on /settings`.
- Root cause: `#[serde(rename_all = "camelCase")]` on the enum `RetentionRuleDto` only renames the variant names, **not** field names inside struct-style variants. The wire was `{"byAge":{"max_age":N}}` while the frontend sent `{"byAge":{"maxAge":N}}`, so Axum's `Json` extractor rejected every retention patch with HTTP 422.
- Fix: add `rename_all_fields = "camelCase"` so field names follow the same wire contract.

## Commits

- `a871e396` **fix** — the one-line attribute fix on `RetentionRuleDto`, plus 6 lib regression cases that pin every variant's wire literal and **explicitly reject** the legacy snake-case-in-variant bug shape, plus an integration smoke test mirroring `settings_network_smoke.rs`.
- `0cd0d65c` **test** — 11 more lib regression cases covering the same wire-contract footgun across other vectors (enum literals, `Option<Option<T>>` patch fields, `Duration` serialization), defensive `rename_all_fields` on `UpgradeStatusDto`, and a new "Enum Wire Serialization" rule in `docs/agent/rust-tauri-rules.md`.

## Latent issue surfaced (out of scope, follow-up needed)

`GeneralSettingsPatchDto`'s `Option<Option<T>>` fields (`themeColor / language / deviceName / updateChannel`) look like 3-state but the wire only delivers 2-state today — `null` and a missing field both deserialize to `None`. The facade is written assuming 3-state semantics (`if let Some(v) = ...; existing.x = v;`), so the wire layer cannot currently send "explicitly clear this field" — the regression test in this PR locks the *current* behaviour with a `TODO(#606-followup)` so the next PR that fixes the wire side (probably via `serde_with::rust::double_option`) will see the test fail and update it intentionally.

## Test plan

- [x] `cargo test -p uc-daemon-contract --lib` — 44/44 pass (27 pre-existing + 17 new).
- [x] Reverted the fix locally and re-ran the new tests; they all fail with the expected `missing field "max_age"` error — confirming they actually catch the regression.
- [x] `cargo check -p uc-daemon-contract` clean.
- [ ] CI Linux runs `settings_retention_smoke.rs` integration test (cannot run locally on macOS — `uc-platform/src/clipboard/event_loop.rs` rustix `eventfd` cfg gate missing macOS branch; same constraint applies to the existing `settings_network_smoke.rs`).
- [ ] Manual smoke on a built app: change "history retention" and "max items" — should no longer 422.