### PR TITLE
fix(uc-platform): macOS build broken — narrow rustix eventfd path to linux only

### DIFF
--- a/src-tauri/crates/uc-platform/Cargo.toml
+++ b/src-tauri/crates/uc-platform/Cargo.toml
@@ -101,27 +101,31 @@ tracing-subscriber = { version = "0.3", features = ["registry", "fmt", "env-filt
 [target.'cfg(all(target_os = "linux", target_env = "musl"))'.dependencies]
 libdbus-sys = { version = "0.2", features = ["vendored"] }
 
-# Unix-only:eventfd-backed shutdown channel for the platform clipboard
-# event loop (`crates/uc-platform/src/clipboard/event_loop.rs`). The Linux
-# Wayland / X11 watcher implementations integrate this fd into their poll
-# set so they can wake instantly on shutdown without spinning. Other Unix
-# (macOS) only needs the Condvar branch but the eventfd is cheap.
-[target.'cfg(unix)'.dependencies]
-rustix = { version = "0.38", features = ["event", "fs", "pipe"] }
-
-# Linux-only:native Wayland data-control client + native X11 selection client
-# for the platform clipboard backend. `clipboard-rs` is the legacy/transitional
-# implementation that Phase 1 wraps via `clipboard_rs_adapter`; Phase 2 adds
-# the Wayland code path here, Phase 3 swaps the X11 path to `x11rb` directly,
-# Phase 4 then narrows `clipboard-rs` to `cfg(any(target_os="macos",
-# target_os="windows"))`. Pinning notes:
-#   * wayland-client 0.31.x is the current stable line; wayland-rs follows
-#     semver so 0.31 → 0.32 will require a porting pass.
-#   * wayland-protocols-wlr 0.3.x exposes `zwlr_data_control_v1` (used by
-#     niri / sway / hyprland / KDE Plasma).
-#   * wayland-protocols 0.32 with `staging` feature exposes
-#     `ext_data_control_v1` (used by GNOME mutter 47+).
+# Linux-only dependencies for the platform clipboard backend:
+#
+# * rustix — eventfd-backed shutdown channel for the platform clipboard event
+#   loop (`crates/uc-platform/src/clipboard/event_loop.rs`) + poll/pipe
+#   primitives consumed by the Wayland data-control implementations under
+#   `clipboard/platform/linux/wayland/`. rustix's `event::eventfd` is gated
+#   to linux_kernel / freebsd / illumos / espidf upstream, so we cannot use
+#   `cfg(unix)` here — macOS would fail to find `EventfdFlags`. macOS /
+#   Windows / other Unix use the Condvar-only path in `event_loop.rs`.
+#
+# * wayland-client / wayland-protocols(-wlr) — native Wayland data-control
+#   client + native X11 selection client for the platform clipboard backend.
+#   `clipboard-rs` is the legacy/transitional implementation that Phase 1
+#   wraps via `clipboard_rs_adapter`; Phase 2 adds the Wayland code path
+#   here, Phase 3 swaps the X11 path to `x11rb` directly, Phase 4 then
+#   narrows `clipboard-rs` to `cfg(any(target_os="macos", target_os="windows"))`.
+#   Pinning notes:
+#     * wayland-client 0.31.x is the current stable line; wayland-rs follows
+#       semver so 0.31 → 0.32 will require a porting pass.
+#     * wayland-protocols-wlr 0.3.x exposes `zwlr_data_control_v1` (used by
+#       niri / sway / hyprland / KDE Plasma).
+#     * wayland-protocols 0.32 with `staging` feature exposes
+#       `ext_data_control_v1` (used by GNOME mutter 47+).
 [target.'cfg(target_os = "linux")'.dependencies]
+rustix = { version = "0.38", features = ["event", "fs", "pipe"] }
 wayland-client = "0.31"
 wayland-protocols = { version = "0.32", features = ["client", "staging"] }
 wayland-protocols-wlr = { version = "0.3", features = ["client"] }

--- a/src-tauri/crates/uc-platform/src/clipboard/event_loop.rs
+++ b/src-tauri/crates/uc-platform/src/clipboard/event_loop.rs
@@ -12,20 +12,23 @@
 //!
 //! ## ShutdownRx semantics
 //!
-//! - On Unix the channel additionally exposes an `eventfd` so a Wayland / X11
+//! - On Linux the channel additionally exposes an `eventfd` so a Wayland / X11
 //!   loop can include it directly in `poll(2)` and wake instantly without a
 //!   helper thread. Adapters that block on a foreign C event loop (e.g.
 //!   `clipboard_rs::ClipboardWatcherContext::start_watch`) instead spawn a tiny
 //!   helper thread that calls [`ShutdownRx::wait`] and forwards the signal.
+//!   macOS / Windows / other Unix have no eventfd and rely on the Condvar path
+//!   exclusively.
 //! - The channel is single-shot: signalling more than once is idempotent and
 //!   waiting after a signal returns immediately.
 
 use anyhow::Result;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Condvar, Mutex};
+#[cfg(target_os = "linux")]
 use tracing::warn;
 
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 use std::os::fd::{AsRawFd, OwnedFd, RawFd};
 
 use super::watcher::ClipboardWatcher;
@@ -34,7 +37,7 @@ struct ShutdownInner {
     signaled: AtomicBool,
     cv_lock: Mutex<()>,
     cv: Condvar,
-    #[cfg(unix)]
+    #[cfg(target_os = "linux")]
     eventfd: Option<OwnedFd>,
 }
 
@@ -51,12 +54,13 @@ pub struct ShutdownRx {
 
 /// Create a new shutdown channel.
 ///
-/// On Unix the inner [`ShutdownInner`] also owns a non-blocking `eventfd` so
+/// On Linux the inner [`ShutdownInner`] also owns a non-blocking `eventfd` so
 /// pollable adapters can integrate it without spawning a helper thread. If
 /// eventfd creation fails (extremely unusual) the channel still works via the
-/// Condvar path; only [`ShutdownRx::raw_fd`] returns `None`.
+/// Condvar path; only [`ShutdownRx::raw_fd`] returns `None`. macOS / Windows /
+/// other Unix have no eventfd and use the Condvar path exclusively.
 pub fn shutdown_channel() -> (ShutdownTx, ShutdownRx) {
-    #[cfg(unix)]
+    #[cfg(target_os = "linux")]
     let eventfd = match rustix::event::eventfd(
         0,
         rustix::event::EventfdFlags::CLOEXEC | rustix::event::EventfdFlags::NONBLOCK,
@@ -75,7 +79,7 @@ pub fn shutdown_channel() -> (ShutdownTx, ShutdownRx) {
         signaled: AtomicBool::new(false),
         cv_lock: Mutex::new(()),
         cv: Condvar::new(),
-        #[cfg(unix)]
+        #[cfg(target_os = "linux")]
         eventfd,
     });
 
@@ -101,7 +105,7 @@ impl ShutdownTx {
             self.inner.cv.notify_all();
         }
         // Wake fd pollers.
-        #[cfg(unix)]
+        #[cfg(target_os = "linux")]
         {
             if let Some(fd) = self.inner.eventfd.as_ref() {
                 let buf = 1u64.to_ne_bytes();
@@ -130,12 +134,14 @@ impl ShutdownRx {
         }
     }
 
-    /// Unix-only raw fd of the underlying eventfd.
+    /// Linux-only raw fd of the underlying eventfd.
     ///
     /// Returns `None` if eventfd creation failed. Adapters using this for
     /// `poll(2)` must still fall back to checking [`Self::is_signaled`] in
-    /// their poll loop in case the fd is unavailable.
-    #[cfg(unix)]
+    /// their poll loop in case the fd is unavailable. Only exposed on Linux:
+    /// macOS / Windows / other Unix have no eventfd, so pollable adapters must
+    /// be Linux-gated as well.
+    #[cfg(target_os = "linux")]
     pub fn raw_fd(&self) -> Option<RawFd> {
         self.inner.eventfd.as_ref().map(|fd| fd.as_raw_fd())
     }


### PR DESCRIPTION
## Summary

- `rustix::event::eventfd` / `EventfdFlags` are gated upstream to `linux_kernel / freebsd / illumos / espidf`, but `crates/uc-platform/src/clipboard/event_loop.rs` was calling them under `#[cfg(unix)]`. macOS is unix but has no eventfd, so `cargo check` / `bun tauri:dev` failed with `E0425` / `E0433`.
- Narrowed the eventfd-backed shutdown channel (field, constructor, `signal()` fd write, `raw_fd()` accessor, related `use` lines, `tracing::warn` import) from `#[cfg(unix)]` to `#[cfg(target_os = "linux")]`. macOS / Windows / other Unix already only needed the `Condvar` path — `raw_fd()`'s only consumers live under `platform/linux/wayland/protocol/{ext,wlr}.rs`.
- Collapsed the rustix dependency in `crates/uc-platform/Cargo.toml` from `cfg(unix)` to the existing `cfg(target_os = "linux")` block. The two linux target blocks had to be merged to avoid Cargo's `duplicate key` TOML error.

## Why

Without this fix, every macOS dev hitting `bun tauri:dev` (or `cargo check` from a clean checkout) is blocked at the `uc-platform` compile step. The Wayland data-control work that landed in #603 introduced the `cfg(unix)` assumption, which only happened to compile because Linux CI is the canonical build target.

## Test plan

- [x] `cargo check --workspace` on macOS (was previously broken with E0425/E0433)
- [ ] `cargo check --workspace` on Linux still green (CI)
- [ ] `cargo check --workspace` on Windows still green (CI)
- [ ] Linux clipboard event loop still wakes instantly on shutdown via eventfd (no behaviour change — same code path, just stricter `cfg`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refined clipboard handling to be Linux-specific, optimizing platform-level event management. Previous Unix-wide support has been narrowed to focus on Linux implementations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/UniClipboard/UniClipboard/pull/609)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->