### PR TITLE
perf(dev): use line-tables-only debug info to cut link time

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -43,6 +43,14 @@ cargo-clippy = []
 # 仅供 `bun tauri:build:dev` 使用，避免本地 dev 构建产物覆盖 prod 安装的数据。
 dev-profile = ["uc-tauri/dev-profile"]
 
+# dev profile:用 line-tables-only 替代完整 dwarf,大幅缩短 link 阶段。
+# 实测 inner-loop 11s → 4s(-65%),target 体积 46GB → 4.4GB(-91%)。
+# 保留行号信息,panic backtrace / 断点 by line / #[track_caller] 全部正常;
+# 牺牲的是 lldb 里看变量值时的类型详细信息(平时调试一般不依赖)。
+[profile.dev]
+debug = "line-tables-only"
+split-debuginfo = "unpacked"
+
 # dev profile package overrides:让 Argon2 / Blake3 / chacha20 等密码学 crate
 # 在 debug 构建下也走 opt-level=3。背景:mobile_lan basic auth 每次 PUT 都要
 # 跑一次 Argon2id verify(m=64MB t=3 p=4),release 下 ~74ms,debug 下 ~1.26s。


### PR DESCRIPTION
## Summary

Switch `profile.dev` from default full dwarf to `debug = "line-tables-only"` + explicit `split-debuginfo = "unpacked"`. Aligns dev profile with the existing release profile (which already uses `line-tables-only` for Sentry symbolication).

## Measured impact (Apple M4, this repo)

| Metric | Before | After | Δ |
|---|---:|---:|---:|
| Inner-loop rebuild (`touch main.rs && cargo build`) | 11.08 s | 3.84 s | **-65%** |
| `target/` size | 46 GB | 4.4 GB | **-91%** |
| `user time` during rebuild | 3.38 s | 3.25 s | -4% |

`user time` barely moves — the entire wall-time win is in the link phase. macOS `ld` is single-threaded and was spending most of its time collecting dwarf into the `.dSYM` bundle.

## What still works

- Panic backtraces with file + line
- `#[track_caller]`
- lldb breakpoints by source line
- Sentry stack trace symbolication (release profile is unchanged and already uses `line-tables-only`)

## Trade-off

lldb local variable inspection (`p var_name`, frame variables view) loses type-level detail. Function and argument names are still resolved by symbol, but rich type info is reduced. If you primarily debug via `dbg!()`, `tracing`, or panic backtraces, you will not notice this.

## Test plan

- [x] Inner-loop rebuild measured end-to-end (`cargo build --timings`)
- [x] Clean build from scratch passes (2m 25s on this hardware)
- [x] Resulting binary launches and runs normally
- [ ] CI green