### PR TITLE
fix(docs): drop redundant /docs prefix in welcome page card links

### DIFF
--- a/docs-site/content/docs/en/index.mdx
+++ b/docs-site/content/docs/en/index.mdx
@@ -13,11 +13,7 @@ relay only ever sees ciphertext.
 ## Quick links
 
 <Cards>
-  <Card
-    title="Install"
-    href="/getting-started/install"
-    description="macOS, Windows, or Linux."
-  />
+  <Card title="Install" href="/getting-started/install" description="macOS, Windows, or Linux." />
   <Card
     title="Quick start"
     href="/getting-started/quick-start"

--- a/docs-site/content/docs/en/index.mdx
+++ b/docs-site/content/docs/en/index.mdx
@@ -15,22 +15,22 @@ relay only ever sees ciphertext.
 <Cards>
   <Card
     title="Install"
-    href="/docs/getting-started/install"
+    href="/getting-started/install"
     description="macOS, Windows, or Linux."
   />
   <Card
     title="Quick start"
-    href="/docs/getting-started/quick-start"
+    href="/getting-started/quick-start"
     description="Create your space and sync your first clip."
   />
   <Card
     title="Pairing & sync"
-    href="/docs/guides/pairing"
+    href="/guides/pairing"
     description="How spaces, invites, and transport fit together."
   />
   <Card
     title="CLI reference"
-    href="/docs/reference/cli"
+    href="/reference/cli"
     description="Headless control via the uniclip CLI."
   />
 </Cards>

--- a/docs-site/content/docs/zh/index.mdx
+++ b/docs-site/content/docs/zh/index.mdx
@@ -19,16 +19,8 @@ UniClipboard 让文本、文件、图片以及富格式剪贴在你的多台设�
     href="/zh/getting-started/quick-start"
     description="创建空间并完成首次同步。"
   />
-  <Card
-    title="配对与同步"
-    href="/zh/guides/pairing"
-    description="空间、邀请码与传输层的关系。"
-  />
-  <Card
-    title="CLI 参考"
-    href="/zh/reference/cli"
-    description="通过 uniclip CLI 进行无界面控制。"
-  />
+  <Card title="配对与同步" href="/zh/guides/pairing" description="空间、邀请码与传输层的关系。" />
+  <Card title="CLI 参考" href="/zh/reference/cli" description="通过 uniclip CLI 进行无界面控制。" />
 </Cards>
 
 ## 为什么选择 UniClipboard

--- a/docs-site/content/docs/zh/index.mdx
+++ b/docs-site/content/docs/zh/index.mdx
@@ -11,22 +11,22 @@ UniClipboard 让文本、文件、图片以及富格式剪贴在你的多台设�
 <Cards>
   <Card
     title="安装"
-    href="/zh/docs/getting-started/install"
+    href="/zh/getting-started/install"
     description="支持 macOS、Windows、Linux。"
   />
   <Card
     title="快速开始"
-    href="/zh/docs/getting-started/quick-start"
+    href="/zh/getting-started/quick-start"
     description="创建空间并完成首次同步。"
   />
   <Card
     title="配对与同步"
-    href="/zh/docs/guides/pairing"
+    href="/zh/guides/pairing"
     description="空间、邀请码与传输层的关系。"
   />
   <Card
     title="CLI 参考"
-    href="/zh/docs/reference/cli"
+    href="/zh/reference/cli"
     description="通过 uniclip CLI 进行无界面控制。"
   />
 </Cards>


### PR DESCRIPTION
## Summary
- The docs site is mounted under `basePath: '/docs'` in `docs-site/next.config.mjs`, so Next.js automatically prepends `/docs` to every internal link.
- The welcome MDX pages were also hand-writing `/docs` (and `/zh/docs`) in the Quick links `<Card>` hrefs, so the rendered URLs became `/docs/docs/...` and `/docs/zh/docs/...` — e.g. https://www.uniclipboard.app/docs/zh/docs/getting-started/install returned 404.
- Drop the redundant `/docs` segment and let `basePath` do the prefixing. `en` is the default locale (`i18n.hideLocale = 'default-locale'`), so the English variant carries no `/en` prefix; `zh` keeps its `/zh` prefix.

## Test plan
- [ ] Run `pnpm --filter docs-site dev` and confirm each welcome card on `/docs` (en) navigates to `/docs/getting-started/install`, `/docs/getting-started/quick-start`, `/docs/guides/pairing`, `/docs/reference/cli` without 404.
- [ ] Same check on `/docs/zh` for the Chinese welcome page (`/docs/zh/getting-started/install`, etc.).
- [ ] Verify the production URL https://www.uniclipboard.app/docs/zh/getting-started/install resolves once deployed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation homepage quick links to use new routing paths across English and Chinese documentation sites.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/UniClipboard/UniClipboard/pull/614)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->