### PR TITLE
fix: correct typo in test function name (policys -> policies)

### DIFF
--- a/src-tauri/crates/uc-application/src/clipboard_write/primary_rep_selector.rs
+++ b/src-tauri/crates/uc-application/src/clipboard_write/primary_rep_selector.rs
@@ -113,7 +113,7 @@ mod tests {
     }
 
     #[test]
-    fn multi_rep_narrows_to_policys_paste_rep() {
+    fn multi_rep_narrows_to_policies_paste_rep() {
         // text/plain + text/html + image/png. V1's DefaultPaste ranks
         // RichText (html) above PlainText above Image (see
         // `uc-core::clipboard::policy::v1::SelectRepresentationPolicyV1::score`),


### PR DESCRIPTION
Fixes #615.

Corrects the misspelled test function name `multi_rep_narrows_to_policys_paste_rep` → `multi_rep_narrows_to_policies_paste_rep` in `src-tauri/crates/uc-application/src/clipboard_write/primary_rep_selector.rs`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Fixed a typo in a test function name.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/UniClipboard/UniClipboard/pull/616)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->