### PR TITLE
ci(cli): add aarch64-unknown-linux-musl to CLI build matrix

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -11,6 +11,7 @@ on:
           - 'macos-aarch64'
           - 'macos-x86_64'
           - 'ubuntu-22.04'
+          - 'ubuntu-22.04-arm'
           - 'windows-latest'
           - 'all'
         default: 'all'
@@ -36,24 +37,26 @@ jobs:
       - name: Generate matrix
         id: set-matrix
         run: |
-          # CLI Linux target 选 x86_64-unknown-linux-musl 静态编译:
+          # CLI Linux target 选 musl 静态编译:
           # uc-cli 走 ring + rustls (无 aws-lc-sys / 无 openssl-sys),依赖图
           # 里没有 C 库,musl 静态链可以一气呵成,glibc 完全无关。产物可直接
           # 在任意 Linux (包括 Ubuntu 20.04 / Alpine / 老 RHEL) 上跑。
           # 容器仍用 debian:bookworm 拿 musl-tools / cmake / clang 工具链。
           PLATFORM="${{ inputs.platform || 'all' }}"
           if [ "$PLATFORM" == "all" ]; then
-            echo 'matrix=[{"platform":"macos-latest","target":"aarch64-apple-darwin","args":"--target aarch64-apple-darwin"},{"platform":"macos-latest","target":"x86_64-apple-darwin","args":"--target x86_64-apple-darwin"},{"platform":"ubuntu-22.04","target":"x86_64-unknown-linux-musl","args":"--target x86_64-unknown-linux-musl","container":"debian:bookworm"},{"platform":"windows-latest","target":"x86_64-pc-windows-msvc","args":""}]' >> "$GITHUB_OUTPUT"
+            echo 'matrix=[{"platform":"macos-latest","target":"aarch64-apple-darwin","args":"--target aarch64-apple-darwin"},{"platform":"macos-latest","target":"x86_64-apple-darwin","args":"--target x86_64-apple-darwin"},{"platform":"ubuntu-22.04","target":"x86_64-unknown-linux-musl","args":"--target x86_64-unknown-linux-musl","container":"debian:bookworm"},{"platform":"ubuntu-22.04-arm","target":"aarch64-unknown-linux-musl","args":"--target aarch64-unknown-linux-musl","container":"debian:bookworm"},{"platform":"windows-latest","target":"x86_64-pc-windows-msvc","args":""}]' >> "$GITHUB_OUTPUT"
           elif [ "$PLATFORM" == "macos-aarch64" ]; then
             echo 'matrix=[{"platform":"macos-latest","target":"aarch64-apple-darwin","args":"--target aarch64-apple-darwin"}]' >> "$GITHUB_OUTPUT"
           elif [ "$PLATFORM" == "macos-x86_64" ]; then
             echo 'matrix=[{"platform":"macos-latest","target":"x86_64-apple-darwin","args":"--target x86_64-apple-darwin"}]' >> "$GITHUB_OUTPUT"
           elif [ "$PLATFORM" == "ubuntu-22.04" ]; then
             echo 'matrix=[{"platform":"ubuntu-22.04","target":"x86_64-unknown-linux-musl","args":"--target x86_64-unknown-linux-musl","container":"debian:bookworm"}]' >> "$GITHUB_OUTPUT"
+          elif [ "$PLATFORM" == "ubuntu-22.04-arm" ]; then
+            echo 'matrix=[{"platform":"ubuntu-22.04-arm","target":"aarch64-unknown-linux-musl","args":"--target aarch64-unknown-linux-musl","container":"debian:bookworm"}]' >> "$GITHUB_OUTPUT"
           elif [ "$PLATFORM" == "windows-latest" ]; then
             echo 'matrix=[{"platform":"windows-latest","target":"x86_64-pc-windows-msvc","args":""}]' >> "$GITHUB_OUTPUT"
           else
-            echo "Error: Unknown platform '$PLATFORM'. Valid options: all, macos-aarch64, macos-x86_64, ubuntu-22.04, windows-latest"
+            echo "Error: Unknown platform '$PLATFORM'. Valid options: all, macos-aarch64, macos-x86_64, ubuntu-22.04, ubuntu-22.04-arm, windows-latest"
             exit 1
           fi
 
@@ -91,7 +94,7 @@ jobs:
       - name: install Rust stable
         uses: dtolnay/rust-toolchain@stable
         with:
-          # Linux 走 musl,需要 rustup 装 x86_64-unknown-linux-musl target;
+          # Linux 走 musl,需要 rustup 装对应 musl target;
           # macOS 装两个 darwin target;Windows host=msvc 装 noop。
           targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || matrix.target }}
 
@@ -116,8 +119,11 @@ jobs:
         # (glibc / musl) 都能直接 exec。这才符合 ace8685f 切 musl 的初衷。
         env:
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER: musl-gcc
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER: musl-gcc
           CC_x86_64_unknown_linux_musl: musl-gcc
+          CC_aarch64_unknown_linux_musl: musl-gcc
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_RUSTFLAGS: "-C relocation-model=static"
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUSTFLAGS: "-C relocation-model=static"
         run: cargo build --release -p uc-cli ${{ matrix.args }}
 
       - name: import Apple certificate (macOS only)

--- a/scripts/generate-release-notes.js
+++ b/scripts/generate-release-notes.js
@@ -143,6 +143,9 @@ function buildInstallerTable({ artifactsDir, baseUrl }) {
 }
 
 function buildCliInstallerTable({ artifactsDir, baseUrl }) {
+  const isArm = file => /aarch64|arm64/.test(file)
+  const isX64 = file => /x86_64|x64|amd64/.test(file)
+
   const macosArm64 = findFirstFile(
     artifactsDir,
     file =>
@@ -157,11 +160,20 @@ function buildCliInstallerTable({ artifactsDir, baseUrl }) {
       file.includes('x86_64-apple-darwin') &&
       file.endsWith('.tar.gz')
   )
-  const linux = findFirstFile(
+  const linuxX64 = findFirstFile(
     artifactsDir,
     file =>
       file.startsWith('uniclipboard-cli-') &&
       file.includes('linux-musl') &&
+      isX64(file) &&
+      file.endsWith('.tar.gz')
+  )
+  const linuxArm64 = findFirstFile(
+    artifactsDir,
+    file =>
+      file.startsWith('uniclipboard-cli-') &&
+      file.includes('linux-musl') &&
+      isArm(file) &&
       file.endsWith('.tar.gz')
   )
   const windows = findFirstFile(
@@ -176,7 +188,8 @@ function buildCliInstallerTable({ artifactsDir, baseUrl }) {
   const rows = []
   if (macosArm64) rows.push(makeRow('macOS', 'Apple Silicon (M1/M2/M3)', macosArm64))
   if (macosX64) rows.push(makeRow('macOS', 'Intel', macosX64))
-  if (linux) rows.push(makeRow('Linux', 'x86_64', linux))
+  if (linuxX64) rows.push(makeRow('Linux', 'x86_64', linuxX64))
+  if (linuxArm64) rows.push(makeRow('Linux', 'aarch64', linuxArm64))
   if (windows) rows.push(makeRow('Windows', 'x86_64', windows))
 
   if (rows.length === 0) {


### PR DESCRIPTION
## Summary
- 在 `build-cli.yml` 矩阵中追加 `ubuntu-22.04-arm` runner + `aarch64-unknown-linux-musl` target，为 uc-cli 产出静态 Linux ARM64 二进制
- 新增对应的 musl linker / CC / RUSTFLAGS 环境变量，保持与 x86_64 相同的静态链接策略
- `generate-release-notes.js` 按 `x86_64` / `aarch64` 拆分 Linux 行，发版页面分别列出两种架构下载链接

## Test plan
- [ ] 手动触发 `build-cli.yml` 选 `ubuntu-22.04-arm`，确认产物为 `aarch64-unknown-linux-musl` 静态二进制
- [ ] 触发 `all`，确认四个平台 + Linux ARM 共 5 个产物全部生成
- [ ] 跑一次 release dry-run，确认发布说明里同时出现 Linux x86_64 与 aarch64 两行