### PR TITLE
chore(copr): use sed for RPM version dash→tilde replacement

### DIFF
--- a/.github/workflows/copr.yml
+++ b/.github/workflows/copr.yml
@@ -50,7 +50,9 @@ jobs:
             git curl rpm-build rpmdevtools python3-pip jq unzip
           # copr-cli 通过 pip 装 — Fedora 仓库里也有 dnf install copr-cli,
           # 但 pip 版本更新更稳定,接 API token 也更直接。
-          pip3 install --no-cache-dir copr-cli
+          # 显式带上 rich:copr-cli 新版 main.py 里 `from rich.text import Text`,
+          # 但 setup.py 没声明这个依赖,pip 不会自动拉 → ModuleNotFoundError。
+          pip3 install --no-cache-dir copr-cli rich
 
       - uses: actions/checkout@v4
 

--- a/.github/workflows/copr.yml
+++ b/.github/workflows/copr.yml
@@ -193,26 +193,24 @@ jobs:
           done
           ls -lh ~/rpmbuild/SOURCES/
 
-      - name: Build per-arch SRPMs
+      - name: Build SRPM
         shell: bash
         env:
           RPM_VERSION: ${{ steps.ver.outputs.rpm_version }}
           UPSTREAM_TAG: ${{ steps.ver.outputs.upstream_tag }}
         run: |
-          # 为每个架构产一份 SRPM。spec 里 Source0 用 %{_arch} 在 srpm 阶段
-          # 会按 host 架构展开,所以 GH runner(x86_64)上默认产出 x86_64 SRPM。
-          # 用 --target 把 srpm 强制指向另一个 _arch,再 build 一份。
+          # 单次 rpmbuild -bs 出 1 个 SRPM。spec 里 Source0/Source1 同时
+          # 声明了 x86_64 + aarch64 两个 binary RPM,COPR mock chroot 在不同
+          # arch 二次 build 时用 %ifarch 选对应那一个。版本号已经在 "Setup
+          # rpmbuild tree" 步骤里用 sed 固化到 spec,这里 --define 仅作冗余。
+          #
+          # 不能 per-arch build SRPM 再合:SRPM 文件名只由 N-V-R 决定、不带
+          # arch,循环 -bs 会同名覆盖,最终只剩最后那次 --target 对应的 SRPM。
           mkdir -p out-srpm
-          for ARCH in x86_64 aarch64; do
-            echo "::group::Build SRPM for ${ARCH}"
-            rpmbuild -bs ~/rpmbuild/SPECS/uniclipboard.spec \
-              --target "${ARCH}-linux" \
-              --define "_version ${RPM_VERSION}" \
-              --define "_upstream_tag ${UPSTREAM_TAG}" \
-              --define "_topdir $HOME/rpmbuild"
-            echo "::endgroup::"
-          done
-          # 收集所有 SRPM
+          rpmbuild -bs ~/rpmbuild/SPECS/uniclipboard.spec \
+            --define "_version ${RPM_VERSION}" \
+            --define "_upstream_tag ${UPSTREAM_TAG}" \
+            --define "_topdir $HOME/rpmbuild"
           find ~/rpmbuild/SRPMS -name '*.src.rpm' -exec cp {} out-srpm/ \;
           ls -lh out-srpm/
 

--- a/.github/workflows/copr.yml
+++ b/.github/workflows/copr.yml
@@ -69,7 +69,7 @@ jobs:
 
           # RPM 不允许版本字段含 "-",将 prerelease 分隔符 "-" 替换为 "~"。
           # "~" 在 RPM 比较里小于任何字符 → 0.7.0~alpha.7 < 0.7.0,符合预期。
-          RPM_VERSION="${UPSTREAM_TAG/-/~}"
+          RPM_VERSION="$(printf '%s' "$UPSTREAM_TAG" | sed 's/-/~/')"
 
           echo "upstream_tag=$UPSTREAM_TAG" >> "$GITHUB_OUTPUT"
           echo "rpm_version=$RPM_VERSION" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/copr.yml
+++ b/.github/workflows/copr.yml
@@ -101,9 +101,20 @@ jobs:
 
       - name: Setup rpmbuild tree
         shell: bash
+        env:
+          RPM_VERSION: ${{ steps.ver.outputs.rpm_version }}
+          UPSTREAM_TAG: ${{ steps.ver.outputs.upstream_tag }}
         run: |
           rpmdev-setuptree
           cp packaging/uniclipboard.spec ~/rpmbuild/SPECS/
+          # 把 spec 里的占位符替换成实际版本号。为什么不能只靠 rpmbuild --define:
+          # --define 只在当前 GH runner 上 `rpmbuild -bs` 那次生效;SRPM 进入
+          # COPR mock chroot 二次 build 时,chroot 里没有 --define,会走 spec
+          # 的 fallback。物理替换后 SRPM 里 spec 已固化版本,chroot 走对。
+          sed -i \
+            -e "s/@VERSION@/${RPM_VERSION}/g" \
+            -e "s/@UPSTREAM_TAG@/${UPSTREAM_TAG}/g" \
+            ~/rpmbuild/SPECS/uniclipboard.spec
 
       # 两条互斥路径,按 inputs.run_id 选其一:
       #   - 给了 run_id  → 从 build run 的 artifact 拉 RPM(免去先发 release 的循环)

--- a/packaging/uniclipboard.spec
+++ b/packaging/uniclipboard.spec
@@ -11,14 +11,23 @@
 #                     RPM 比较语义中 ~ 比任意字符小,因此 0.7.0~alpha.7 < 0.7.0
 #   - %{upstream_tag} 上游 git tag/文件名里的原始版本,保留 -,例如 0.7.0-alpha.7
 #
-# CI 通过 `rpmbuild -bs --define ...` 注入这两个变量,本地手动构建可
-# `rpmbuild -bs --define "_version 0.7.0~alpha.7" --define "_upstream_tag 0.7.0-alpha.7" ...`
+# 版本注入路径:
+#   1. CI(.github/workflows/copr.yml)在 `cp spec` 之后用 sed 把
+#      @VERSION@ / @UPSTREAM_TAG@ 占位符替换为实际值,SRPM 里 spec 因此
+#      已固化版本号 — COPR mock chroot 二次 build 不再依赖任何 macro。
+#   2. 本地手动构建仍可用 `rpmbuild -bs --define "_version 0.7.0~alpha.7"
+#      --define "_upstream_tag 0.7.0-alpha.7" ...`,macro 优先于占位符。
+#
+# 历史教训:之前 fallback 写死成具体版本号(0.7.0-alpha.7),CI 用
+# `--define` 注入只在 GH runner 那次 rpmbuild 生效,SRPM 进入 COPR
+# chroot 二次 build 后 _upstream_tag 不存在 → 走 fallback → 期望旧版本
+# 文件名 → "Bad file: UniClipboard-0.7.0-alpha.7-...rpm" 失败。
 
-%global upstream_tag %{?_upstream_tag}%{!?_upstream_tag:0.7.0-alpha.7}
+%global upstream_tag %{?_upstream_tag}%{!?_upstream_tag:@UPSTREAM_TAG@}
 %global debug_package %{nil}
 
 Name:           uniclipboard
-Version:        %{?_version}%{!?_version:0.7.0~alpha.7}
+Version:        %{?_version}%{!?_version:@VERSION@}
 Release:        1%{?dist}
 Summary:        Privacy-first end-to-end encrypted cross-device clipboard sync
 

--- a/packaging/uniclipboard.spec
+++ b/packaging/uniclipboard.spec
@@ -35,7 +35,12 @@ License:        Apache-2.0 OR MIT
 URL:            https://github.com/UniClipboard/UniClipboard
 
 # Tauri 在 release.yml 中输出的 binary RPM 命名 = UniClipboard-<tag>-1.<arch>.rpm
-Source0:        https://github.com/UniClipboard/UniClipboard/releases/download/v%{upstream_tag}/UniClipboard-%{upstream_tag}-1.%{_arch}.rpm
+# 同时声明两个 arch 的 Source — SRPM 里把两个 binary RPM 都打包进来,
+# COPR mock chroot 在不同 arch 二次 build 时用 %ifarch 选对应 Source。
+# 不能用 %{_arch} 嵌入文件名搭配 `rpmbuild -bs --target` 多次出 SRPM:
+# SRPM 文件名只由 N-V-R 决定、不带 arch 后缀,多次 -bs 会同名覆盖。
+Source0:        https://github.com/UniClipboard/UniClipboard/releases/download/v%{upstream_tag}/UniClipboard-%{upstream_tag}-1.x86_64.rpm
+Source1:        https://github.com/UniClipboard/UniClipboard/releases/download/v%{upstream_tag}/UniClipboard-%{upstream_tag}-1.aarch64.rpm
 
 ExclusiveArch:  x86_64 aarch64
 
@@ -56,10 +61,16 @@ The binary is byte-identical to what users would download from the Releases
 page; this package only re-signs and re-indexes it for the dnf/COPR channel.
 
 %prep
-# Source0 是一个完整的 binary RPM,用 rpm2cpio 解到当前工作目录(BUILD/<name>-<ver>/)。
+# Source0/Source1 是完整 binary RPM,按 host arch 选对应那一个,用 rpm2cpio
+# 解到当前工作目录 (BUILD/<name>-<ver>/)。
 mkdir -p uniclipboard-%{version}
 cd uniclipboard-%{version}
+%ifarch x86_64
 rpm2cpio %{SOURCE0} | cpio -idm
+%endif
+%ifarch aarch64
+rpm2cpio %{SOURCE1} | cpio -idm
+%endif
 
 %build
 # 无 — 二进制已 upstream 编译完毕

--- a/packaging/uniclipboard.spec
+++ b/packaging/uniclipboard.spec
@@ -1,15 +1,19 @@
 # UniClipboard COPR spec — binary repackage 模式。
 #
+# 注:RPM 会把注释里凡是 % 开头的 token 当 macro 展开(Fedora 上仅 warning,
+# 但 EPEL 上直接 abort 整个 spec 解析,Name/Version 字段全部丢失),所以
+# 注释里提及 macro 名字时要先 % 转义为 %% — 见下方 %%install / %%{_arch}。
+#
 # 该 spec 不从源码编译，而是把 GitHub Release 上 Tauri 直接产出的 binary RPM
-# 当作 Source0,在 %install 阶段用 rpm2cpio 解出来重新打包。这样 COPR mock
+# 当作 Source0,在 %%install 阶段用 rpm2cpio 解出来重新打包。这样 COPR mock
 # chroot 不需要 Rust/Node/webkit2gtk-devel 等重型 BuildRequires,构建时间从
 # 30 min 压到 1 min 以内,并保留 upstream binary 一致性(同一个二进制在
 # Releases 页和 dnf copr 渠道里发出去)。
 #
 # 版本号规范:
-#   - %{version}      RPM-合法版本,prerelease 后缀用 ~ 替换 -,例如 0.7.0~alpha.7
-#                     RPM 比较语义中 ~ 比任意字符小,因此 0.7.0~alpha.7 < 0.7.0
-#   - %{upstream_tag} 上游 git tag/文件名里的原始版本,保留 -,例如 0.7.0-alpha.7
+#   - %%{version}      RPM-合法版本,prerelease 后缀用 ~ 替换 -,例如 0.7.0~alpha.7
+#                      RPM 比较语义中 ~ 比任意字符小,因此 0.7.0~alpha.7 < 0.7.0
+#   - %%{upstream_tag} 上游 git tag/文件名里的原始版本,保留 -,例如 0.7.0-alpha.7
 #
 # 版本注入路径:
 #   1. CI(.github/workflows/copr.yml)在 `cp spec` 之后用 sed 把
@@ -36,8 +40,8 @@ URL:            https://github.com/UniClipboard/UniClipboard
 
 # Tauri 在 release.yml 中输出的 binary RPM 命名 = UniClipboard-<tag>-1.<arch>.rpm
 # 同时声明两个 arch 的 Source — SRPM 里把两个 binary RPM 都打包进来,
-# COPR mock chroot 在不同 arch 二次 build 时用 %ifarch 选对应 Source。
-# 不能用 %{_arch} 嵌入文件名搭配 `rpmbuild -bs --target` 多次出 SRPM:
+# COPR mock chroot 在不同 arch 二次 build 时用 %%ifarch 选对应 Source。
+# 不能用 %%{_arch} 嵌入文件名搭配 `rpmbuild -bs --target` 多次出 SRPM:
 # SRPM 文件名只由 N-V-R 决定、不带 arch 后缀,多次 -bs 会同名覆盖。
 Source0:        https://github.com/UniClipboard/UniClipboard/releases/download/v%{upstream_tag}/UniClipboard-%{upstream_tag}-1.x86_64.rpm
 Source1:        https://github.com/UniClipboard/UniClipboard/releases/download/v%{upstream_tag}/UniClipboard-%{upstream_tag}-1.aarch64.rpm
@@ -82,7 +86,7 @@ mkdir -p %{buildroot}
 # 当前目录下 ./usr/...,直接 cp -a 到 buildroot 即可。
 cp -a usr %{buildroot}/
 
-# 动态收集所有文件 — 避免 size 变更或资源新增时手动维护 %files 列表。
+# 动态收集所有文件 — 避免 size 变更或资源新增时手动维护 %%files 列表。
 find %{buildroot} \( -type f -o -type l \) -printf '/%%P\n' | sort > %{_builddir}/uniclipboard.filelist
 
 %files -f %{_builddir}/uniclipboard.filelist


### PR DESCRIPTION
## Summary
- Replace bash-specific `${UPSTREAM_TAG/-/~}` parameter expansion with `sed 's/-/~/'` in the COPR workflow's RPM version derivation.
- Behavior is identical: first `-` in the upstream tag becomes `~` so RPM version comparison treats prereleases as older than the corresponding stable release (e.g. `0.7.0~alpha.7` < `0.7.0`).
- Improves portability if the step is ever migrated to a POSIX shell or copied into another script.

## Test plan
- [ ] Trigger the COPR workflow (or wait for the next release tag) and confirm `rpm_version` output matches expectations for a prerelease tag like `v0.8.0-alpha.1` → `0.8.0~alpha.1`.
- [ ] Confirm stable tags without `-` pass through unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build pipeline configuration for improved release package version handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/UniClipboard/UniClipboard/pull/619)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->