### PR TITLE
feat(clipboard-sync): dedupe rapid inbound replays via moka TTL cache

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -9690,6 +9690,7 @@ dependencies = [
  "image",
  "libc",
  "mockall 0.13.1",
+ "moka",
  "qrcode",
  "semver",
  "serde",

--- a/src-tauri/crates/uc-application/Cargo.toml
+++ b/src-tauri/crates/uc-application/Cargo.toml
@@ -48,6 +48,10 @@ image = { version = "0.25", default-features = false, features = ["png"] }
 # Compares last_seen_version (port-stored String) against current build
 # version to derive `UpgradeStatus`.
 semver = "1"
+# Concurrent TTL cache with bounded capacity. Used by ApplyInbound to dedupe
+# rapid-replay inbound frames (content_hash / visible_key → entry_id) without
+# rolling a custom expiring map.
+moka = { version = "0.12", default-features = false, features = ["sync"] }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/src-tauri/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/tests.rs
+++ b/src-tauri/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/tests.rs
@@ -115,6 +115,18 @@ fn fixture_input(text: &str) -> (ApplyInboundInput, String) {
     )
 }
 
+fn fixture_input_from_snapshot(snapshot: SystemClipboardSnapshot) -> (ApplyInboundInput, String) {
+    let (plaintext, content_hash) = encode_snapshot_to_v3_bytes(&snapshot).unwrap();
+    (
+        ApplyInboundInput {
+            from_device: DeviceId::new("peer-x"),
+            content_hash: content_hash.clone(),
+            plaintext,
+        },
+        content_hash,
+    )
+}
+
 fn build(
     repo: MockEntryRepo,
     capture: MockCapture,
@@ -231,6 +243,187 @@ async fn duplicate_skipped_when_hash_already_local() {
             content_hash: hash,
             existing_entry_id: EntryId::from("entry-existing"),
         }
+    );
+}
+
+#[tokio::test]
+async fn rapid_duplicate_skipped_even_when_repo_has_not_caught_up() {
+    let (input, hash) = fixture_input("rapid-same");
+
+    let mut repo = MockEntryRepo::new();
+    repo.expect_find_entry_id_by_snapshot_hash()
+        .with(eq(hash.clone()))
+        .times(2)
+        .returning(|_| Ok(None));
+
+    let mut capture = MockCapture::new();
+    capture
+        .expect_capture()
+        .times(1)
+        .returning(|_, _| Ok(Some(EntryId::from("entry-first"))));
+
+    let mut write = MockWrite::new();
+    write.expect_write().times(1).returning(|_| Ok(()));
+
+    let uc = build(repo, capture, write);
+    let first = uc
+        .execute(input.clone())
+        .await
+        .expect("first rapid inbound applies");
+    assert_eq!(
+        first,
+        ApplyOutcome::Applied {
+            entry_id: EntryId::from("entry-first")
+        }
+    );
+
+    let second = uc
+        .execute(input)
+        .await
+        .expect("second rapid inbound is filtered");
+    assert_eq!(
+        second,
+        ApplyOutcome::DuplicateSkipped {
+            content_hash: hash,
+            existing_entry_id: EntryId::from("entry-first"),
+        }
+    );
+}
+
+#[tokio::test]
+async fn visible_duplicate_skipped_across_channel_representation_expansion() {
+    let visible_text = b"same-ui".to_vec();
+    let first_snapshot = SystemClipboardSnapshot {
+        ts_ms: 1_700_000_000_000,
+        representations: vec![ObservedClipboardRepresentation::new(
+            RepresentationId::new(),
+            FormatId::from("text"),
+            Some(MimeType("text/plain".to_string())),
+            visible_text.clone(),
+        )],
+    };
+    let second_snapshot = SystemClipboardSnapshot {
+        ts_ms: 1_700_000_000_250,
+        representations: vec![
+            ObservedClipboardRepresentation::new(
+                RepresentationId::new(),
+                FormatId::from("text"),
+                Some(MimeType("text/plain".to_string())),
+                visible_text.clone(),
+            ),
+            ObservedClipboardRepresentation::new(
+                RepresentationId::new(),
+                FormatId::from("public.utf8-plain-text"),
+                None,
+                visible_text.clone(),
+            ),
+            ObservedClipboardRepresentation::new(
+                RepresentationId::new(),
+                FormatId::from("NSStringPboardType"),
+                None,
+                visible_text,
+            ),
+        ],
+    };
+    let (first_input, first_hash) = fixture_input_from_snapshot(first_snapshot);
+    let (second_input, second_hash) = fixture_input_from_snapshot(second_snapshot);
+    assert_ne!(first_hash, second_hash);
+
+    let mut repo = MockEntryRepo::new();
+    repo.expect_find_entry_id_by_snapshot_hash()
+        .times(2)
+        .returning(|_| Ok(None));
+
+    let mut capture = MockCapture::new();
+    capture
+        .expect_capture()
+        .times(1)
+        .returning(|_, _| Ok(Some(EntryId::from("entry-visible"))));
+
+    let mut write = MockWrite::new();
+    write.expect_write().times(1).returning(|_| Ok(()));
+
+    let uc = build(repo, capture, write);
+    let first = uc
+        .execute(first_input)
+        .await
+        .expect("first visible content applies");
+    assert_eq!(
+        first,
+        ApplyOutcome::Applied {
+            entry_id: EntryId::from("entry-visible")
+        }
+    );
+
+    tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+
+    let second = uc
+        .execute(second_input)
+        .await
+        .expect("expanded visible duplicate is filtered");
+    assert_eq!(
+        second,
+        ApplyOutcome::DuplicateSkipped {
+            content_hash: second_hash,
+            existing_entry_id: EntryId::from("entry-visible"),
+        }
+    );
+}
+
+#[tokio::test]
+async fn visible_duplicate_window_expires() {
+    let first_snapshot = SystemClipboardSnapshot {
+        ts_ms: 1_700_000_000_000,
+        representations: vec![ObservedClipboardRepresentation::new(
+            RepresentationId::new(),
+            FormatId::from("text"),
+            Some(MimeType("text/plain".to_string())),
+            b"expires".to_vec(),
+        )],
+    };
+    let second_snapshot = SystemClipboardSnapshot {
+        ts_ms: 1_700_000_003_000,
+        representations: vec![ObservedClipboardRepresentation::new(
+            RepresentationId::new(),
+            FormatId::from("public.utf8-plain-text"),
+            None,
+            b"expires".to_vec(),
+        )],
+    };
+    let (first_input, _) = fixture_input_from_snapshot(first_snapshot);
+    let (second_input, _) = fixture_input_from_snapshot(second_snapshot);
+
+    let mut repo = MockEntryRepo::new();
+    repo.expect_find_entry_id_by_snapshot_hash()
+        .times(2)
+        .returning(|_| Ok(None));
+
+    let mut capture = MockCapture::new();
+    capture
+        .expect_capture()
+        .times(2)
+        .returning(|_, _| Ok(Some(EntryId::new())));
+
+    let mut write = MockWrite::new();
+    write.expect_write().times(2).returning(|_| Ok(()));
+
+    let uc = build(repo, capture, write);
+    assert!(
+        matches!(
+            uc.execute(first_input).await,
+            Ok(ApplyOutcome::Applied { .. })
+        ),
+        "first visible content applies"
+    );
+
+    tokio::time::sleep(std::time::Duration::from_millis(2100)).await;
+
+    assert!(
+        matches!(
+            uc.execute(second_input).await,
+            Ok(ApplyOutcome::Applied { .. })
+        ),
+        "same visible content applies again after the merge window expires"
     );
 }
 

--- a/src-tauri/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/usecase.rs
+++ b/src-tauri/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/usecase.rs
@@ -1,7 +1,9 @@
 //! `ApplyInboundClipboardUseCase` —— 入站剪贴板流程的编排主体。
 
 use std::sync::Arc;
+use std::time::Duration;
 
+use moka::sync::Cache;
 use tracing::{debug, error, info, instrument, warn};
 
 use uc_core::ids::EntryId;
@@ -18,11 +20,21 @@ use super::materializer::InboundBlobMaterializer;
 use super::ports::{InboundCapture, InboundWrite};
 use super::{ApplyInboundError, ApplyInboundInput, ApplyOutcome};
 
+const RAPID_DUPLICATE_WINDOW: Duration = Duration::from_millis(200);
+const VISIBLE_DUPLICATE_WINDOW: Duration = Duration::from_secs(2);
+const RECENT_INBOUND_MAX_RECORDS: u64 = 128;
+
 pub struct ApplyInboundClipboardUseCase {
     entry_repo: Arc<dyn ClipboardEntryRepositoryPort>,
     capture: Arc<dyn InboundCapture>,
     write: Arc<dyn InboundWrite>,
     blob_materializer: Option<Arc<dyn InboundBlobMaterializer>>,
+    /// 短窗口去重：content_hash → entry_id。过滤同一 peer 反复推送完全
+    /// 相同字节的回声帧。
+    recent_content_hashes: Cache<String, EntryId>,
+    /// 略长窗口去重：visible_key → entry_id。捕获"同一可见内容、不同
+    /// content_hash"的场景（peer 重发时扩展了 representations）。
+    recent_visible_content: Cache<String, EntryId>,
     /// Optional host-event emitter for surfacing the inbound entry to UI
     /// before the fetch+capture pipeline finishes. Wired only in daemon
     /// mode; tests / CLI leave it `None`.
@@ -41,6 +53,14 @@ impl ApplyInboundClipboardUseCase {
             write,
             blob_materializer: None,
             host_event_emitter: None,
+            recent_content_hashes: Cache::builder()
+                .max_capacity(RECENT_INBOUND_MAX_RECORDS)
+                .time_to_live(RAPID_DUPLICATE_WINDOW)
+                .build(),
+            recent_visible_content: Cache::builder()
+                .max_capacity(RECENT_INBOUND_MAX_RECORDS)
+                .time_to_live(VISIBLE_DUPLICATE_WINDOW)
+                .build(),
         }
     }
 
@@ -68,6 +88,30 @@ impl ApplyInboundClipboardUseCase {
         let emitter = cell.read().unwrap_or_else(|p| p.into_inner()).clone();
         if let Err(err) = emitter.emit(event) {
             warn!(error = %err, "apply_inbound: failed to emit host event");
+        }
+    }
+
+    fn find_recent_duplicate(
+        &self,
+        content_hash: &str,
+        visible_key: Option<&str>,
+    ) -> Option<EntryId> {
+        if let Some(id) = self.recent_content_hashes.get(content_hash) {
+            return Some(id);
+        }
+        self.recent_visible_content.get(visible_key?)
+    }
+
+    fn remember_recent_inbound(
+        &self,
+        content_hash: String,
+        visible_key: Option<String>,
+        entry_id: EntryId,
+    ) {
+        self.recent_content_hashes
+            .insert(content_hash, entry_id.clone());
+        if let Some(visible_key) = visible_key {
+            self.recent_visible_content.insert(visible_key, entry_id);
         }
     }
 
@@ -190,6 +234,20 @@ impl ApplyInboundClipboardUseCase {
             }
         };
 
+        let visible_key = snapshot.meaningful_origin_key();
+        if let Some(existing_entry_id) =
+            self.find_recent_duplicate(&input.content_hash, visible_key.as_deref())
+        {
+            debug!(
+                existing_entry_id = %existing_entry_id,
+                "inbound dropped: rapid duplicate of recently applied entry"
+            );
+            return Ok(ApplyOutcome::DuplicateSkipped {
+                content_hash: input.content_hash,
+                existing_entry_id,
+            });
+        }
+
         // 3. Persist via the same capture pipeline local copies use
         // (D5: same schema). Cloning the snapshot lets us keep one for
         // the OS write below; capture takes ownership of the original.
@@ -223,6 +281,7 @@ impl ApplyInboundClipboardUseCase {
         // - macOS / Linux:`write_snapshot_multi` 的降级分支用 `SelectRepresentationPolicyV1`
         //   选 paste-priority rep 后走单 rep 快路径(行为与上游 `narrow_to_primary` 等价)
         debug!(entry_id = %entry_id, "inbound: entry persisted, scheduling background OS clipboard write");
+        self.remember_recent_inbound(input.content_hash.clone(), visible_key, entry_id.clone());
 
         let write_port = Arc::clone(&self.write);
         let entry_id_for_write = entry_id.clone();


### PR DESCRIPTION
fixes: #604

## Summary

- Adds a short-window dedup layer to `ApplyInboundClipboardUseCase` so a peer re-pushing identical bytes (or the same visible content with expanded representations) within seconds doesn't double-apply while the repo's `content_hash` query hasn't caught up yet.
- Two disjoint windows, keyed independently:
  - `content_hash → entry_id`, **200ms / 128 entries** — guards against rapid echo of identical bytes
  - `visible_key  → entry_id`, **2s / 128 entries** — guards against channel-expansion echoes where the same visible content arrives with additional representations and a different `content_hash`
- Backed by `moka::sync::Cache` (concurrent, bounded, per-cache TTL, lock-free read path). No outer `Mutex`, no custom expiring container, no `O(n)` linear scans, no key-extraction trait machinery.

## Why moka

`moka` is the de-facto TTL cache in the Rust ecosystem. The dedup-window semantics here are textbook: bounded capacity + uniform TTL + key/value lookup. Rolling a custom `VecDeque`-based "expiring window" gave us:
- `O(n)` `push`/`find_by_hash` for what should be `O(1)` amortised
- A bespoke `ExpiringWindowRecord` trait that hides the key inside the value via `unique_hash()` — non-idiomatic for `K: Hash + Eq`
- An outer `Mutex` over a non-thread-safe container

`moka` was already an indirect dep via hickory-resolver, so the build cost is marginal. Cache built with `default-features = false, features = ["sync"]` to avoid pulling the `future` runtime.

## What was considered but **not** changed

Audited `uc-infra` and `uc-platform` for similar candidates. None should be migrated:
- `uc-infra/src/clipboard/representation_cache.rs` — has business-defined eviction policy (prefer evicting `Completed` entries, protect `Pending/Processing` from being kicked). `moka`'s TinyLFU can't express this.
- `uc-infra/src/clipboard/change_origin.rs` — uses per-entry TTL (2s for Local vs 60s for Remote), composite `(hash, origin)` dedupe key, and FIFO-on-consume semantics. `moka` can't directly model all three.
- `uc-platform/*` — no self-rolled caches; the two `cached_snapshot` fields are single `Option` slots in Wayland protocol listeners.

## Test plan

- [x] `cargo test -p uc-application --lib apply_inbound` — all 14 tests pass, including:
  - `rapid_duplicate_skipped_even_when_repo_has_not_caught_up` (200ms window)
  - `visible_duplicate_skipped_across_channel_representation_expansion` (2s window, real-time `tokio::time::sleep`)
  - `visible_duplicate_window_expires` (verifies TTL expiry)
- [ ] Manual cross-device smoke: paste rapid identical content from peer → first applies, second filtered.