### PR TITLE
fix(clipboard-write): break OS-clipboard hammer-loop + harden tracing

### DIFF
--- a/src-tauri/crates/uc-application/src/clipboard_write/coordinator.rs
+++ b/src-tauri/crates/uc-application/src/clipboard_write/coordinator.rs
@@ -15,15 +15,35 @@
 //! `uc-app`.
 
 use anyhow::Result;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
-use std::time::Duration;
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 use tracing::Instrument;
-use tracing::{error, info_span};
+use tracing::{error, info, info_span, warn};
 
 use uc_core::clipboard::ClipboardChangeOrigin;
 use uc_core::clipboard::SystemClipboardSnapshot;
 use uc_core::ports::clipboard::{ClipboardChangeOriginPort, SystemClipboardPort};
+
+/// Number of consecutive OS-write failures that trip the circuit.
+///
+/// Chosen empirically against Sentry issue UNICLIPBOARD-RUST-F (35 minutes /
+/// 50 failed writes on a single Windows host whose clipboard was held by an
+/// AV/IME process). 5 lets a couple of transient retries through; beyond
+/// that the clipboard is clearly unavailable and we stop hammering it.
+const CIRCUIT_FAILURE_THRESHOLD: u32 = 5;
+
+/// Default duration the circuit stays open after tripping.
+///
+/// Long enough that the contending process (AV scan / IME hook / RDP clip
+/// proxy) has time to release the clipboard, short enough that recovery is
+/// invisible to a typing user. Inbound writes during this window are
+/// rejected immediately (no OS call, no guard registration).
+///
+/// Production `new()` uses this constant; tests use `with_cooldown` to pass
+/// a millisecond-scale value so they can exercise the recovery path
+/// without literally sleeping 30 seconds.
+const DEFAULT_CIRCUIT_OPEN_DURATION: Duration = Duration::from_secs(30);
 
 /// Represents the intent behind a programmatic clipboard write.
 ///
@@ -61,6 +81,18 @@ pub struct ClipboardWriteCoordinator {
     /// `has_pending_origin()` check that conflated attribution guards with
     /// active write operations.
     writing: AtomicBool,
+    /// Number of consecutive OS-write failures since the last success.
+    /// Reset to 0 on any successful write; reset to 0 when the circuit trips
+    /// (so the next post-cooldown window starts clean).
+    consecutive_failures: AtomicU32,
+    /// `Some(instant)` while the breaker is open — incoming writes are
+    /// rejected without touching the OS clipboard or registering a guard.
+    /// `None` means the circuit is closed (normal operation).
+    circuit_open_until: Mutex<Option<Instant>>,
+    /// How long the breaker stays open after tripping. Per-instance so
+    /// tests can use a millisecond-scale value while production uses the
+    /// `DEFAULT_CIRCUIT_OPEN_DURATION` constant.
+    cooldown: Duration,
 }
 
 impl ClipboardWriteCoordinator {
@@ -68,10 +100,97 @@ impl ClipboardWriteCoordinator {
         system_clipboard: Arc<dyn SystemClipboardPort>,
         clipboard_change_origin: Arc<dyn ClipboardChangeOriginPort>,
     ) -> Self {
+        Self::with_cooldown(
+            system_clipboard,
+            clipboard_change_origin,
+            DEFAULT_CIRCUIT_OPEN_DURATION,
+        )
+    }
+
+    /// Construct with a custom circuit-breaker cooldown. Intended for tests
+    /// that need to exercise the recovery path without literally waiting
+    /// 30 seconds. Not exposed outside the crate in production builds; use
+    /// `new` for normal construction.
+    pub(crate) fn with_cooldown(
+        system_clipboard: Arc<dyn SystemClipboardPort>,
+        clipboard_change_origin: Arc<dyn ClipboardChangeOriginPort>,
+        cooldown: Duration,
+    ) -> Self {
         Self {
             system_clipboard,
             clipboard_change_origin,
             writing: AtomicBool::new(false),
+            consecutive_failures: AtomicU32::new(0),
+            circuit_open_until: Mutex::new(None),
+            cooldown,
+        }
+    }
+
+    /// Returns `Some(remaining_duration)` if the breaker is currently open,
+    /// `None` if the circuit is closed. Also auto-closes the circuit when
+    /// the open window has elapsed (lazy cooldown reset).
+    fn circuit_check(&self) -> Option<Duration> {
+        let mut guard = self.circuit_open_until.lock().expect("poisoned");
+        match *guard {
+            Some(until) => {
+                let now = Instant::now();
+                if now >= until {
+                    *guard = None;
+                    info!(
+                        event = "circuit_recovered",
+                        reason = "cooldown_elapsed",
+                        "clipboard_write_coordinator: circuit breaker closed after cooldown"
+                    );
+                    None
+                } else {
+                    Some(until - now)
+                }
+            }
+            None => None,
+        }
+    }
+
+    /// Record a failed OS write; trip the breaker if the threshold is reached.
+    ///
+    /// Returns the new consecutive-failure count (post-increment) so the
+    /// caller can include it in its own structured error event without
+    /// re-reading the atomic. Note: on a trip the atomic is reset to 0,
+    /// but the returned value still reflects the pre-reset count — i.e.
+    /// "this was failure number N which tripped the circuit".
+    fn record_failure(&self) -> u32 {
+        let new_count = self.consecutive_failures.fetch_add(1, Ordering::AcqRel) + 1;
+        if new_count >= CIRCUIT_FAILURE_THRESHOLD {
+            let until = Instant::now() + self.cooldown;
+            *self.circuit_open_until.lock().expect("poisoned") = Some(until);
+            self.consecutive_failures.store(0, Ordering::Release);
+            warn!(
+                event = "circuit_tripped",
+                error_kind = "circuit_tripped",
+                consecutive_failures = new_count,
+                threshold = CIRCUIT_FAILURE_THRESHOLD,
+                cooldown_ms = self.cooldown.as_millis() as u64,
+                "clipboard_write_coordinator: circuit breaker tripped — pausing OS writes"
+            );
+        }
+        new_count
+    }
+
+    /// Record a successful OS write — clears the failure counter and any
+    /// stale open circuit (defensive; the open path normally lazy-closes).
+    ///
+    /// Emits an `info` recovery event if the success follows one or more
+    /// failures, so operators can pair the "first failure" log line with
+    /// a corresponding "recovered" line.
+    fn record_success(&self) {
+        let prev = self.consecutive_failures.swap(0, Ordering::AcqRel);
+        if prev > 0 {
+            *self.circuit_open_until.lock().expect("poisoned") = None;
+            info!(
+                event = "circuit_recovered",
+                reason = "success_after_failure",
+                recovered_after_failures = prev,
+                "clipboard_write_coordinator: OS clipboard write recovered"
+            );
         }
     }
 
@@ -120,6 +239,28 @@ impl ClipboardWriteCoordinator {
     ) -> Result<()> {
         let origin_guard_key = snapshot.origin_guard_key();
 
+        // Circuit breaker check — when the OS clipboard is unavailable
+        // (typically held by AV / IME / RDP), keep hammering it produces
+        // nothing but Sentry noise (see UNICLIPBOARD-RUST-F: 50 failed
+        // writes in 35 minutes on a single host). Skip the OS call entirely
+        // and do NOT register a guard — without an actual write the
+        // watcher won't fire, so leftover guards would just mis-attribute
+        // a future unrelated change.
+        if let Some(remaining) = self.circuit_check() {
+            warn!(
+                event = "circuit_open_skip",
+                error_kind = "circuit_open",
+                remaining_secs = remaining.as_secs(),
+                intent = ?intent,
+                origin_guard_key = %origin_guard_key,
+                "clipboard_write_coordinator: circuit breaker open — skipping OS write"
+            );
+            anyhow::bail!(
+                "clipboard write skipped: circuit breaker open ({}s remaining)",
+                remaining.as_secs()
+            );
+        }
+
         async {
             // Register the appropriate hash guard before writing.
             match intent {
@@ -145,20 +286,34 @@ impl ClipboardWriteCoordinator {
             // writes start from a clean slate (and so outages surface in Seq/stdout
             // instead of being hidden in the `Err` bubbling back up the call chain).
             if let Err(err) = self.system_clipboard.write_snapshot(snapshot) {
-                error!(
-                    error = %err,
-                    intent = ?intent,
-                    origin_guard_key = %origin_guard_key,
-                    "clipboard_write_coordinator: OS clipboard write failed"
-                );
                 self.clipboard_change_origin
                     .consume_origin_for_snapshot_or_default(
                         &origin_guard_key,
                         ClipboardChangeOrigin::LocalCapture,
                     )
                     .await;
+                // Record failure first so the error event below can include
+                // the post-increment count and `circuit_tripped` derived state.
+                // Whoever reads Sentry can pair `error_kind=os_write_failed`
+                // with `consecutive_failures` and `circuit_tripped` to see
+                // immediately whether this is the Nth failure in a row.
+                let consecutive_failures = self.record_failure();
+                let circuit_tripped = consecutive_failures >= CIRCUIT_FAILURE_THRESHOLD;
+                error!(
+                    event = "os_write_failed",
+                    error_kind = "os_write_failed",
+                    error = %err,
+                    intent = ?intent,
+                    origin_guard_key = %origin_guard_key,
+                    consecutive_failures,
+                    threshold = CIRCUIT_FAILURE_THRESHOLD,
+                    circuit_tripped,
+                    "clipboard_write_coordinator: OS clipboard write failed"
+                );
                 return Err(err);
             }
+
+            self.record_success();
 
             match intent {
                 ClipboardWriteIntent::LocalRestore => {
@@ -191,5 +346,213 @@ impl ClipboardWriteCoordinator {
             origin_guard_key = %origin_guard_key
         ))
         .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Circuit-breaker behavioural tests.
+    //!
+    //! These exercise the three states transitions added in response to
+    //! UNICLIPBOARD-RUST-F (50 OS-clipboard failures on a single Windows
+    //! host in 35 minutes):
+    //!
+    //! 1. Five consecutive failures trip the breaker; the sixth call MUST
+    //!    short-circuit without invoking the OS port at all.
+    //! 2. After the cooldown elapses the breaker auto-closes and subsequent
+    //!    writes reach the OS again.
+    //! 3. A single success resets the failure counter so a subsequent
+    //!    streak doesn't inherit stale credit.
+    //!
+    //! Tests run on the tokio current-thread runtime; cooldown is shortened
+    //! via `with_cooldown` to keep wall-clock waits in the ms range.
+    use super::*;
+    use async_trait::async_trait;
+    use mockall::mock;
+    use std::sync::atomic::AtomicU32;
+    use uc_core::clipboard::ClipboardChangeOrigin;
+    use uc_core::ids::{FormatId, RepresentationId};
+    use uc_core::{MimeType, ObservedClipboardRepresentation};
+
+    mock! {
+        SystemClipboard {}
+        #[async_trait]
+        impl SystemClipboardPort for SystemClipboard {
+            fn read_snapshot(&self) -> Result<SystemClipboardSnapshot>;
+            fn write_snapshot(&self, snapshot: SystemClipboardSnapshot) -> Result<()>;
+        }
+    }
+
+    mock! {
+        ChangeOrigin {}
+        #[async_trait]
+        impl ClipboardChangeOriginPort for ChangeOrigin {
+            async fn set_next_origin(&self, origin: ClipboardChangeOrigin, ttl: Duration);
+            async fn consume_origin_or_default(
+                &self,
+                default_origin: ClipboardChangeOrigin,
+            ) -> ClipboardChangeOrigin;
+            async fn has_pending_origin(&self) -> bool;
+            async fn remember_remote_snapshot_hash(&self, snapshot_hash: String, ttl: Duration);
+            async fn remember_local_snapshot_hash(&self, snapshot_hash: String, ttl: Duration);
+            async fn consume_origin_for_snapshot_or_default(
+                &self,
+                snapshot_hash: &str,
+                default_origin: ClipboardChangeOrigin,
+            ) -> ClipboardChangeOrigin;
+        }
+    }
+
+    fn make_snapshot() -> SystemClipboardSnapshot {
+        SystemClipboardSnapshot {
+            ts_ms: 0,
+            representations: vec![ObservedClipboardRepresentation::new(
+                RepresentationId::new(),
+                FormatId::from("text"),
+                Some(MimeType("text/plain".to_string())),
+                b"x".to_vec(),
+            )],
+        }
+    }
+
+    fn permissive_origin_mock() -> MockChangeOrigin {
+        // Origin port is exercised but its specific calls are not what we're
+        // testing here — accept any call count, return defaults.
+        let mut origin = MockChangeOrigin::new();
+        origin
+            .expect_remember_remote_snapshot_hash()
+            .returning(|_, _| ());
+        origin
+            .expect_remember_local_snapshot_hash()
+            .returning(|_, _| ());
+        origin
+            .expect_consume_origin_for_snapshot_or_default()
+            .returning(|_, default| default);
+        origin.expect_set_next_origin().returning(|_, _| ());
+        origin
+    }
+
+    /// 5 consecutive OS failures must trip the breaker, after which the
+    /// 6th call short-circuits without invoking the underlying port.
+    /// Mockall's `.times(5)` asserts exactly 5 OS calls — if the 6th
+    /// leaked through, mock expectations would fail on drop.
+    #[tokio::test]
+    async fn five_failures_trip_breaker_and_block_sixth_call() {
+        let mut clipboard = MockSystemClipboard::new();
+        clipboard
+            .expect_write_snapshot()
+            .times(5)
+            .returning(|_| Err(anyhow::anyhow!("simulated OS clipboard failure")));
+
+        let coord =
+            ClipboardWriteCoordinator::new(Arc::new(clipboard), Arc::new(permissive_origin_mock()));
+
+        // First five calls go to the OS and each fail.
+        for i in 0..5 {
+            let r = coord
+                .write(make_snapshot(), ClipboardWriteIntent::RemotePush)
+                .await;
+            assert!(r.is_err(), "call {i} should propagate OS Err");
+        }
+
+        // Sixth call must NOT reach the mock (times(5) would fail otherwise).
+        let err = coord
+            .write(make_snapshot(), ClipboardWriteIntent::RemotePush)
+            .await
+            .expect_err("breaker should reject 6th call");
+        assert!(
+            err.to_string().contains("circuit breaker open"),
+            "expected circuit-open error, got: {err}"
+        );
+    }
+
+    /// After cooldown elapses the breaker auto-closes; the next call
+    /// reaches the OS and (in this test) succeeds.
+    #[tokio::test]
+    async fn breaker_recovers_after_cooldown() {
+        let counter = Arc::new(AtomicU32::new(0));
+        let c = counter.clone();
+
+        let mut clipboard = MockSystemClipboard::new();
+        // 5 fails to trip + 1 success after cooldown = 6 OS calls total.
+        clipboard
+            .expect_write_snapshot()
+            .times(6)
+            .returning(move |_| {
+                let n = c.fetch_add(1, Ordering::SeqCst);
+                if n < 5 {
+                    Err(anyhow::anyhow!("simulated OS failure"))
+                } else {
+                    Ok(())
+                }
+            });
+
+        let coord = ClipboardWriteCoordinator::with_cooldown(
+            Arc::new(clipboard),
+            Arc::new(permissive_origin_mock()),
+            Duration::from_millis(80),
+        );
+
+        // Trip the breaker.
+        for _ in 0..5 {
+            let _ = coord
+                .write(make_snapshot(), ClipboardWriteIntent::RemotePush)
+                .await;
+        }
+
+        // Immediate retry blocked by open breaker.
+        let err = coord
+            .write(make_snapshot(), ClipboardWriteIntent::RemotePush)
+            .await
+            .expect_err("breaker should still be open");
+        assert!(
+            err.to_string().contains("circuit breaker open"),
+            "got: {err}"
+        );
+
+        // Wait past cooldown — slightly more than 80ms to avoid flakiness.
+        tokio::time::sleep(Duration::from_millis(150)).await;
+
+        // Now the breaker should be closed; write reaches OS and succeeds.
+        coord
+            .write(make_snapshot(), ClipboardWriteIntent::RemotePush)
+            .await
+            .expect("write should succeed after cooldown");
+    }
+
+    /// A single intervening success resets the consecutive-failure counter,
+    /// so a 4-fail / success / 4-fail pattern (8 fails total but no
+    /// 5-in-a-row streak) must NOT trip the breaker.
+    #[tokio::test]
+    async fn success_resets_consecutive_failure_counter() {
+        let counter = Arc::new(AtomicU32::new(0));
+        let c = counter.clone();
+
+        let mut clipboard = MockSystemClipboard::new();
+        // Pattern: fail x4, ok, fail x4, ok — 10 total OS calls, no trip.
+        // If counter wasn't reset by the first success, the 5th overall fail
+        // (which is the 4th in the second streak) would trip and the 10th
+        // call would be short-circuited, failing `.times(10)`.
+        clipboard
+            .expect_write_snapshot()
+            .times(10)
+            .returning(move |_| {
+                let n = c.fetch_add(1, Ordering::SeqCst);
+                if n == 4 || n == 9 {
+                    Ok(())
+                } else {
+                    Err(anyhow::anyhow!("simulated OS failure"))
+                }
+            });
+
+        let coord =
+            ClipboardWriteCoordinator::new(Arc::new(clipboard), Arc::new(permissive_origin_mock()));
+
+        for _ in 0..10 {
+            let _ = coord
+                .write(make_snapshot(), ClipboardWriteIntent::RemotePush)
+                .await;
+        }
+        // Mock's times(10) asserts every call reached OS — none short-circuited.
     }
 }

--- a/src-tauri/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/usecase.rs
+++ b/src-tauri/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/usecase.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use moka::sync::Cache;
-use tracing::{debug, error, info, instrument, warn};
+use tracing::{debug, error, info, instrument, warn, Instrument};
 
 use uc_core::ids::EntryId;
 use uc_core::ports::ClipboardEntryRepositoryPort;
@@ -285,15 +285,32 @@ impl ApplyInboundClipboardUseCase {
 
         let write_port = Arc::clone(&self.write);
         let entry_id_for_write = entry_id.clone();
-        tokio::spawn(async move {
-            if let Err(e) = write_port.write(snapshot_for_write).await {
-                error!(
-                    error = %e,
-                    entry_id = %entry_id_for_write,
-                    "inbound: OS clipboard background write failed after capture"
-                );
+        let from_device_for_write = input.from_device.clone();
+        let content_hash_for_write = input.content_hash.clone();
+        let origin_guard_key_for_write = snapshot_for_write.origin_guard_key();
+        // `.in_current_span()` keeps the spawned task under `apply_inbound.execute`
+        // so trace_id / from_device / content_hash propagate into the failure event.
+        // Without this the background failure was a context-less orphan in Sentry —
+        // the missing peer_id field is exactly what made the recent UNICLIPBOARD-RUST-F
+        // triage take an extra hour (couldn't tell whether 50 failures were one peer
+        // hammering or many peers each pushing once).
+        tokio::spawn(
+            async move {
+                if let Err(e) = write_port.write(snapshot_for_write).await {
+                    error!(
+                        event = "inbound_os_write_failed",
+                        error_kind = "inbound_os_write_failed",
+                        error = %e,
+                        entry_id = %entry_id_for_write,
+                        from_device = %from_device_for_write,
+                        content_hash = %content_hash_for_write,
+                        origin_guard_key = %origin_guard_key_for_write,
+                        "inbound: OS clipboard background write failed after capture"
+                    );
+                }
             }
-        });
+            .in_current_span(),
+        );
 
         info!(entry_id = %entry_id, "inbound clipboard applied");
 

--- a/src-tauri/crates/uc-platform/src/clipboard/platform/windows.rs
+++ b/src-tauri/crates/uc-platform/src/clipboard/platform/windows.rs
@@ -207,11 +207,42 @@ fn png_to_dibv5(png_bytes: &[u8]) -> Result<Vec<u8>> {
 /// 单次写入尝试的最大次数。
 ///
 /// `ERROR_CLIPBOARD_NOT_OPEN (1418)` 在大多数情况下是瞬态的（消息泵、GDI 竞争
-/// 或其他进程短暂打开剪贴板）。经验上第二次尝试几乎都能成功；3 次兜底保守。
-const MAX_WRITE_ATTEMPTS: u32 = 3;
+/// 或其他进程短暂打开剪贴板）。经验上第二次尝试几乎都能成功。
+///
+/// 4 次而非 3 次：Sentry RUST-F 显示某些 Windows 机器上剪贴板会被反病毒/输入法/
+/// RDP 会话独占数十秒（`OSError(5) ERROR_ACCESS_DENIED`），毫秒级退避完全碰不
+/// 到让出窗口。配合下面秒级退避表，整体重试覆盖 ~2.6s 长尾。
+const MAX_WRITE_ATTEMPTS: u32 = 4;
 
 /// 每次重试前的退避（毫秒）。索引 = attempt 次数，0 次不退避。
-const RETRY_BACKOFF_MS: [u64; MAX_WRITE_ATTEMPTS as usize] = [0, 20, 40];
+///
+/// 之前是 `[0, 20, 40]`（共 60ms），对短暂的 GDI/消息泵竞争够用，但拦不住
+/// `ERROR_ACCESS_DENIED` 这类长尾独占。改为秒级退避覆盖反病毒扫描、输入法
+/// hook、RDP 剪贴板代理等长时间持有剪贴板的场景。仍然有界——超过 ~2.6s 的
+/// 持续独占会被上层 circuit breaker（`ClipboardWriteCoordinator`）兜底。
+const RETRY_BACKOFF_MS: [u64; MAX_WRITE_ATTEMPTS as usize] = [0, 100, 500, 2000];
+
+/// Classify a Windows clipboard write error into a stable `error_kind` tag.
+///
+/// Used in `warn!` / `error!` events to give Sentry a column it can
+/// `group_by` independent of the (often-localized) error message string.
+/// Keep these strings stable — they are referenced in dashboards and queries.
+fn classify_windows_write_error(err: &anyhow::Error) -> &'static str {
+    let s = err.to_string();
+    // OSError(5) = ERROR_ACCESS_DENIED — clipboard held exclusively by
+    // another process (AV scan, IME hook, RDP clip proxy, clipboard manager).
+    // The literal "拒绝访问" is the localized message from a zh-CN host;
+    // matching both keeps the kind language-independent.
+    if s.contains("OSError(5)") || s.contains("ERROR_ACCESS_DENIED") || s.contains("拒绝访问") {
+        "os_clipboard_access_denied"
+    // OSError(1418) = ERROR_CLIPBOARD_NOT_OPEN — transient GDI / message-pump
+    // race. Usually clears on the next retry.
+    } else if s.contains("OSError(1418)") || s.contains("ERROR_CLIPBOARD_NOT_OPEN") {
+        "os_clipboard_not_open"
+    } else {
+        "os_clipboard_write_other"
+    }
+}
 
 /// Windows 原子多 representation 写入。
 ///
@@ -274,6 +305,12 @@ const RETRY_BACKOFF_MS: [u64; MAX_WRITE_ATTEMPTS as usize] = [0, 20, 40];
 /// 2. **整体重试**：整个会话（open → empty → 逐 rep 写入）作为一个原子单元，
 ///    失败后退避重试，最多 `MAX_WRITE_ATTEMPTS` 次。兜底其他瞬态因素
 ///    （第三方剪贴板工具抢句柄、消息泵偶发竞争等）。
+#[tracing::instrument(
+    name = "windows.write_snapshot_multi",
+    level = "debug",
+    skip(snapshot),
+    fields(rep_count = snapshot.representations.len())
+)]
 pub(crate) fn write_snapshot_multi_windows(snapshot: SystemClipboardSnapshot) -> Result<()> {
     // 前置扫描：如果没有任何 rep 是我们能写的（text/plain、text/html 或 image/png），
     // 直接 bail；**不**打开 Windows 剪贴板、**不**调 empty()。
@@ -365,9 +402,13 @@ pub(crate) fn write_snapshot_multi_windows(snapshot: SystemClipboardSnapshot) ->
                 return Ok(());
             }
             Err(e) => {
+                let error_kind = classify_windows_write_error(&e);
                 warn!(
+                    event = "windows_multi_write_attempt_failed",
+                    error_kind,
                     attempt = attempt + 1,
                     max_attempts = MAX_WRITE_ATTEMPTS,
+                    backoff_ms = RETRY_BACKOFF_MS[attempt as usize],
                     error = %e,
                     "Windows 原子多 rep 写入本次尝试失败"
                 );
@@ -375,6 +416,24 @@ pub(crate) fn write_snapshot_multi_windows(snapshot: SystemClipboardSnapshot) ->
             }
         }
     }
+
+    // Cumulative backoff so operators can correlate "how long did we
+    // actually wait" vs "Sentry timestamp delta" without having to
+    // re-derive it from the RETRY_BACKOFF_MS constant table.
+    let cumulative_backoff_ms: u64 = RETRY_BACKOFF_MS.iter().sum();
+    let final_error_kind = last_err
+        .as_ref()
+        .map(classify_windows_write_error)
+        .unwrap_or("unknown");
+    error!(
+        event = "windows_multi_write_exhausted",
+        error_kind = "windows_multi_write_exhausted",
+        final_attempt_error_kind = final_error_kind,
+        max_attempts = MAX_WRITE_ATTEMPTS,
+        cumulative_backoff_ms,
+        error = ?last_err.as_ref().map(|e| e.to_string()),
+        "Windows 多 rep 写入：所有重试已耗尽"
+    );
 
     anyhow::bail!(
         "Windows 多 rep 写入：{} 次尝试均失败；最后一次错误：{}",

--- a/src-tauri/crates/uc-webserver/src/api/server.rs
+++ b/src-tauri/crates/uc-webserver/src/api/server.rs
@@ -240,14 +240,49 @@ pub(crate) async fn request_tracing_middleware(request: Request<Body>, next: Nex
     };
 
     match level_action {
-        "server_error" => tracing::error!(
-            request_id = %request_id,
-            method = %method,
-            path = %path,
-            status = status.as_u16(),
-            elapsed_ms,
-            "daemon http request failed (server error)"
-        ),
+        // 5xx splitted by status — Sentry groups events by message template, so
+        // emitting a per-status static message+error_kind lets timeout, upstream-
+        // unavailable, and internal-error 5xx fingerprint into separate issues
+        // instead of drowning in one mega-group (see UNICLIPBOARD-RUST-5: 61
+        // events that turned out to mix 500 client bugs and 503 backend outage).
+        "server_error" => match status.as_u16() {
+            503 => tracing::error!(
+                request_id = %request_id,
+                method = %method,
+                path = %path,
+                status = 503u16,
+                elapsed_ms,
+                error_kind = "upstream_unavailable",
+                "daemon http upstream unavailable"
+            ),
+            504 => tracing::error!(
+                request_id = %request_id,
+                method = %method,
+                path = %path,
+                status = 504u16,
+                elapsed_ms,
+                error_kind = "gateway_timeout",
+                "daemon http gateway timeout"
+            ),
+            500 => tracing::error!(
+                request_id = %request_id,
+                method = %method,
+                path = %path,
+                status = 500u16,
+                elapsed_ms,
+                error_kind = "internal_error",
+                "daemon http handler internal error"
+            ),
+            code => tracing::error!(
+                request_id = %request_id,
+                method = %method,
+                path = %path,
+                status = code,
+                elapsed_ms,
+                error_kind = "server_error_other",
+                "daemon http server error (other 5xx)"
+            ),
+        },
         "client_error" => tracing::warn!(
             request_id = %request_id,
             method = %method,


### PR DESCRIPTION
## Why

Triaging the top prod Sentry issue [UNICLIPBOARD-RUST-F](https://mkdir700.sentry.io/issues/UNICLIPBOARD-RUST-F) (and its mirror `RUST-E`) — 50 OS-clipboard writes failed in 35 minutes on a single Windows host (`DESKTOP-JJS8E5F`, CN Nanchang, `uc-bootstrap@0.7.0`), each with:

```
error: "Windows 多 rep 写入：3 次尝试均失败；最后一次错误：
        OpenClipboard failed after retries: OSError(5): 拒绝访问。"
intent: "RemotePush"
```

The initial hypothesis "same content pushed repeatedly" turned out to be wrong — sampling 5 events across the 35-minute window revealed **5 different `origin_guard_key` values**. These are 50 distinct content pushes, each defeated by a process that held the Windows clipboard for ~35 minutes straight (AV scanner / IME hook / RDP clip proxy / clipboard manager). The daemon's 60ms total retry backoff never had a chance, and there was no upper-layer circuit breaker, so each push burned three OS calls and one Sentry event.

## What this PR does

### 1. P0 — circuit breaker + longer Windows retry backoff (the actual fix)

- `ClipboardWriteCoordinator` trips after 5 consecutive OS-write failures, holds the breaker open for 30 seconds, and refuses OS writes (without registering an origin guard) during the open window. Caps Sentry spam at ~5 events per affected user per outage instead of one-per-push.
- `windows.rs::MAX_WRITE_ATTEMPTS` 3 → 4 and `RETRY_BACKOFF_MS` `[0, 20, 40]ms` → `[0, 100, 500, 2000]ms` (~2.6s total). Old 60ms total backoff was useless against tens-of-seconds clipboard holds.

### 2. Observability hardening (avoid this triage taking 3 hours again)

This triage took the time it did mostly because of observability gaps. The PR closes the ones it directly touched, following `.claude/skills/tracing-best-practices`:

- **Stable `error_kind` field** on every failure event so Sentry can group by stable category instead of localized message string:
  - Coordinator: `os_write_failed`, `circuit_open`, `circuit_tripped`
  - Windows platform: `os_clipboard_access_denied`, `os_clipboard_not_open`, `os_clipboard_write_other`, `windows_multi_write_exhausted`
  - Inbound: `inbound_os_write_failed`
- **Counters in the failure event**: `consecutive_failures`, `circuit_tripped`, `cumulative_backoff_ms`, `final_attempt_error_kind`. A single Sentry event now tells operators "Nth failure in a row, breaker tripped on this one" — no cross-referencing log history needed.
- **`apply_inbound` background spawn uses `.in_current_span()`** so `from_device`, `content_hash`, and `origin_guard_key` are present on the failure event. The absence of these exact fields is what made it hard to tell "one peer hammering" from "many peers each pushing once" during triage.
- **5xx fingerprint split** at `webserver/server.rs:243`. Before: every 5xx fingerprinted on the same `"daemon http request failed (server error)"` message and mixed 500 client bugs with 503 backend outages (`UNICLIPBOARD-RUST-5` collected 61 such events). After: 503 / 504 / 500 / other emit four distinct static messages so Sentry auto-splits.

## Tests

- New `coordinator::tests` module with 3 mockall tests:
  - `five_failures_trip_breaker_and_block_sixth_call` — 5 failures trip the breaker; mockall `.times(5)` asserts the 6th never leaks through to the OS port.
  - `breaker_recovers_after_cooldown` — uses `with_cooldown(80ms)` test ctor; 5 failures trip, immediate retry blocked, after 150ms sleep the write reaches the OS and succeeds.
  - `success_resets_consecutive_failure_counter` — fail x4 / ok / fail x4 / ok pattern (8 fails, no 5-in-a-row) must NOT trip.
- Full sweep: `uc-application` 424 + `uc-platform` 29 + `uc-webserver` 45 = **498 tests, 0 failed**.

## Related (separate issues for follow-up work)

- **#624** — Surface "clipboard busy" state to user (P1, frontend)
- **#625** — Send nack to remote peer when OS clipboard write fails (P2, sync protocol)
- **#626** — Backend `pairing invitation service` 503/504 investigation (separate root cause)

## What this PR does NOT do

- Does not change frontend (separate #624)
- Does not modify the sync protocol or send nacks to peers (separate #625)
- Does not touch backend services (separate #626)

## Test plan

- [x] `cargo check -p uc-platform -p uc-application -p uc-webserver` passes
- [x] `cargo test -p uc-application -p uc-platform -p uc-webserver --lib` — 498/498 pass
- [x] New circuit-breaker tests cover the three core state transitions
- [ ] Manual smoke on Windows: with an artificial clipboard-hold tool, verify Sentry events stop after ~5 attempts and resume ~30s after release
