### PR TITLE
feat(mobile-sync): relay mobile uploads to other paired peers

### DIFF
--- a/src-tauri/crates/uc-application/src/facade/mobile_sync/facade.rs
+++ b/src-tauri/crates/uc-application/src/facade/mobile_sync/facade.rs
@@ -51,8 +51,11 @@ use uc_core::ports::{
     PasswordHasherPort, SettingsPort,
 };
 
+use crate::facade::clipboard_outbound::ClipboardOutboundFacade;
 use crate::facade::file_transfer::FileTransferFacade;
+use crate::facade::mobile_sync::outbound_adapter::ClipboardOutboundFanOutAdapter;
 use crate::usecases::clipboard_sync::apply_inbound::ApplyInboundClipboardUseCase;
+use crate::usecases::mobile_sync::apply_incoming::MobileInboundFanOutPort;
 use crate::usecases::mobile_sync::{
     apply_incoming::ApplyIncomingMobileClipUseCase,
     authenticate_basic::AuthenticateBasicAuthUseCase, get_file::GetMobileSyncFileUseCase,
@@ -165,6 +168,25 @@ pub struct MobileSyncFacadeDeps {
     /// (`webserver`)在收 body 期间自己调 `start` / `Progress` —— 本字段
     /// 仅用于 apply 阶段收尾。
     pub file_transfer: Option<Arc<FileTransferFacade>>,
+    /// 可选剪贴板出站 facade。装配处提供时,移动端 `PUT /SyncClipboard.json`
+    /// 成功落地本机后,本 facade 内部会异步把同一份 snapshot 走"本机捕获
+    /// → 出站"完整管线 fan-out 给 Space 内其他已配对设备 ——
+    ///
+    /// - 文本 / 小图 inline 进 V3 envelope;
+    /// - 大图自动剥成 iroh-blobs ref(避免撞 2 MiB wire 上限);
+    /// - 文件用 `BlobTransferFacade::publish_blob_path` 流式发布到
+    ///   iroh-blobs, 构造 free-file V3BlobRef,接收端拉回并改写 file-list
+    ///   rep 成本机 URI ——
+    ///   "手机文件 → 任一桌面 → 所有桌面"的真正传输靠这条路径成立。
+    ///
+    /// 同样受 `OutboundSyncPlanner` 控制 —— 用户在 settings 关了某个类型
+    /// 的同步,mobile fan-out 与本机复制 fan-out 一同被 suppress, 没有
+    /// "mobile 上传可以绕过同步开关"的旁路。
+    ///
+    /// `None` 时静默降级(facade 自测装配 / CLI fallback 等不接 P2P 出站
+    /// 的场景):mobile 上传仅落地本机,不传播 —— 与本字段引入前的行为
+    /// 完全一致, 不退化。
+    pub clipboard_outbound: Option<Arc<ClipboardOutboundFacade>>,
     /// 可选 LAN 监听器生命周期 port,让 `update_settings` 在写盘后立即把
     /// listener 状态对齐到新设置(开/关/换端口),无需重启进程。
     ///
@@ -222,6 +244,7 @@ impl MobileSyncFacade {
             file_staging,
             snapshot_ports,
             file_transfer,
+            clipboard_outbound,
             lan_lifecycle,
         } = deps;
 
@@ -251,12 +274,22 @@ impl MobileSyncFacade {
             update_settings: UpdateMobileSyncSettingsUseCase::new(settings),
             list_lan_interfaces: ListLanInterfacesUseCase::new(lan_interface_probe),
             authenticate_basic: AuthenticateBasicAuthUseCase::new(device_repo, password_hasher),
+            // facade 装配处只能拿到 `ClipboardOutboundFacade`(由 daemon
+            // runtime_assembly 装好),但 use case 依赖的是 use-case-local 的
+            // `MobileInboundFanOutPort` trait。这里就是 facade 层的薄装配点:
+            // 把 facade 包成 adapter, 让 use case 的依赖 surface 不必随出站
+            // 管线演化而膨胀。详见 [`ClipboardOutboundFanOutAdapter`] 与
+            // [`MobileInboundFanOutPort`] 的设计文档。
             apply_incoming: ApplyIncomingMobileClipUseCase::new(
                 apply_inbound,
                 incoming_buffer,
                 file_staging.clone(),
                 clock,
                 file_transfer,
+                clipboard_outbound.map(|outbound| {
+                    Arc::new(ClipboardOutboundFanOutAdapter::new(outbound))
+                        as Arc<dyn MobileInboundFanOutPort>
+                }),
             ),
             get_latest_doc: GetLatestMobileSyncDocUseCase::new(snapshot_port.clone()),
             get_file: GetMobileSyncFileUseCase::new(snapshot_port, file_staging),
@@ -794,6 +827,7 @@ mod tests {
                 blob_reader: Arc::new(UnusedBlobReader),
             },
             file_transfer: None,
+            clipboard_outbound: None,
             lan_lifecycle: None,
         })
     }
@@ -947,6 +981,7 @@ mod tests {
                 blob_reader: Arc::new(UnusedBlobReader),
             },
             file_transfer: None,
+            clipboard_outbound: None,
             lan_lifecycle: None,
         });
 
@@ -1025,6 +1060,7 @@ mod tests {
                 blob_reader: Arc::new(UnusedBlobReader),
             },
             file_transfer: None,
+            clipboard_outbound: None,
             lan_lifecycle: None,
         });
 
@@ -1132,6 +1168,7 @@ mod tests {
                 blob_reader: Arc::new(UnusedBlobReader),
             },
             file_transfer: None,
+            clipboard_outbound: None,
             lan_lifecycle: Some(lifecycle),
         })
     }
@@ -1275,6 +1312,7 @@ mod tests {
                 blob_reader: Arc::new(UnusedBlobReader),
             },
             file_transfer: None,
+            clipboard_outbound: None,
             lan_lifecycle: Some(lifecycle),
         });
 

--- a/src-tauri/crates/uc-application/src/facade/mobile_sync/facade.rs
+++ b/src-tauri/crates/uc-application/src/facade/mobile_sync/facade.rs
@@ -217,6 +217,12 @@ pub struct MobileSyncFacade {
     apply_incoming: ApplyIncomingMobileClipUseCase,
     get_latest_doc: GetLatestMobileSyncDocUseCase,
     get_file: GetMobileSyncFileUseCase,
+    /// `PUT /file` 流式上传入口持有的 staging port 引用。webserver 端
+    /// `put_clipboard_file` handler 在收 body 期间通过 facade 的
+    /// `begin_file_upload` / `append_file_chunk` / `finalize_file_upload` /
+    /// `abort_file_upload` 转发到本 port,字节流不再绕道 use case 层的内存
+    /// buffer。与 `apply_incoming` / `get_file` 共用同一份 Arc。
+    file_staging: Arc<dyn MobileFileStagingPort>,
     /// 见 [`MobileSyncFacadeDeps::lan_lifecycle`]。`None` 表示当前装配不要求
     /// 即时生效(CLI fallback / 单测),`update_settings` 写盘后不调 apply。
     lan_lifecycle: Option<Arc<dyn MobileLanLifecyclePort>>,
@@ -292,7 +298,8 @@ impl MobileSyncFacade {
                 }),
             ),
             get_latest_doc: GetLatestMobileSyncDocUseCase::new(snapshot_port.clone()),
-            get_file: GetMobileSyncFileUseCase::new(snapshot_port, file_staging),
+            get_file: GetMobileSyncFileUseCase::new(snapshot_port, file_staging.clone()),
+            file_staging,
             lan_lifecycle,
             endpoint_info,
         }
@@ -441,13 +448,15 @@ impl MobileSyncFacade {
         self.get_file.execute(data_name).await
     }
 
-    /// `PUT /file/{dataName}` 业务出口:把 (mime, bytes) 暂存进
-    /// `IncomingMobileBuffer`,等待 `PUT /SyncClipboard.json` 触发组装。
-    /// 返回 `Buffered` outcome —— 路由层应回 HTTP 200。
+    /// `PUT /file/{dataName}` 全量字节出口(CLI debug / 测试用)。
     ///
-    /// `source_device_id` 不被本步消费(BufferFile 阶段还没确定要应用),
-    /// 但仍按 use case 契约一并传入,避免 PUT /SyncClipboard.json 时再
-    /// 重新 lookup。
+    /// 生产路径(uc-webserver)走 [`Self::begin_file_upload`] →
+    /// [`Self::append_file_chunk`] → [`Self::finalize_file_upload`] 三段式
+    /// 流式上传,不进本入口。本入口内部仍走相同的 streaming staging API,
+    /// 把整个 bytes 一次 append 进去, 再 finalize → 喂 BufferFile event,
+    /// 这样应用层只剩"已 staged 文件"这一种路径(无两套并行)。
+    ///
+    /// 失败时调 [`Self::abort_file_upload`] 释放半写入的 staging 资源。
     pub async fn put_clipboard_file(
         &self,
         data_name: String,
@@ -456,18 +465,115 @@ impl MobileSyncFacade {
         source_device_id: MobileDeviceId,
         transfer_id: String,
     ) -> Result<ApplyIncomingMobileClipOutcome, ApplyIncomingMobileClipError> {
+        let scope_id = streaming_scope_nonce();
+        let handle = self
+            .file_staging
+            .begin_stage(&scope_id, &data_name, &mime)
+            .await
+            .map_err(|err| {
+                ApplyIncomingMobileClipError::Internal(format!(
+                    "put_clipboard_file: begin_stage failed: {err}"
+                ))
+            })?;
+        if let Err(err) = self.file_staging.append_stage_chunk(&handle, &bytes).await {
+            self.file_staging.abort_stage(handle).await;
+            return Err(ApplyIncomingMobileClipError::Internal(format!(
+                "put_clipboard_file: append_stage_chunk failed: {err}"
+            )));
+        }
+        let staged = match self.file_staging.finalize_stage(handle).await {
+            Ok(staged) => staged,
+            Err(err) => {
+                return Err(ApplyIncomingMobileClipError::Internal(format!(
+                    "put_clipboard_file: finalize_stage failed: {err}"
+                )));
+            }
+        };
         self.apply_incoming
             .execute(ApplyIncomingMobileClipInput {
                 source_device_id,
                 event: IncomingMobileClipEvent::BufferFile {
                     data_name,
                     mime,
-                    bytes,
+                    staged,
                     transfer_id,
                 },
             })
             .await
     }
+
+    /// 开启一次 `PUT /file/{dataName}` 流式上传。返回的 [`StagingHandle`]
+    /// 用于后续 chunk append / finalize / abort。`scope_id` 由调用方按
+    /// "每次入站事件取一段独立 nonce"语义生成,典型用 [`streaming_scope_nonce`]。
+    pub async fn begin_file_upload(
+        &self,
+        scope_id: &str,
+        data_name: &str,
+        mime: &str,
+    ) -> Result<uc_core::mobile_sync::StagingHandle, uc_core::ports::MobileFileStagingError> {
+        self.file_staging
+            .begin_stage(scope_id, data_name, mime)
+            .await
+    }
+
+    /// 把一个 body chunk 喂进流式 staging 会话。0 字节 chunk 合法且为 no-op。
+    /// 单笔会话只允许**串行** append,并发同 handle 行为未定义。
+    pub async fn append_file_chunk(
+        &self,
+        handle: &uc_core::mobile_sync::StagingHandle,
+        chunk: &[u8],
+    ) -> Result<(), uc_core::ports::MobileFileStagingError> {
+        self.file_staging.append_stage_chunk(handle, chunk).await
+    }
+
+    /// 收齐字节后调用,消费 `handle` 完成 staging 并把"已 staged 文件"
+    /// 挂进 IncomingMobileBuffer 等 SyncDoc 配对。返回 `Buffered` 或
+    /// `DecodeFailed` 等 use case outcome,路由层据此映射 HTTP 响应。
+    pub async fn finalize_file_upload(
+        &self,
+        handle: uc_core::mobile_sync::StagingHandle,
+        data_name: String,
+        mime: String,
+        source_device_id: MobileDeviceId,
+        transfer_id: String,
+    ) -> Result<ApplyIncomingMobileClipOutcome, ApplyIncomingMobileClipError> {
+        let staged = self
+            .file_staging
+            .finalize_stage(handle)
+            .await
+            .map_err(|err| {
+                ApplyIncomingMobileClipError::Internal(format!(
+                    "finalize_file_upload: staging finalize failed: {err}"
+                ))
+            })?;
+        self.apply_incoming
+            .execute(ApplyIncomingMobileClipInput {
+                source_device_id,
+                event: IncomingMobileClipEvent::BufferFile {
+                    data_name,
+                    mime,
+                    staged,
+                    transfer_id,
+                },
+            })
+            .await
+    }
+
+    /// 放弃一次 `PUT /file/{dataName}` 流式上传 —— body 中断 / 客户端断流 /
+    /// 任一 append 失败时调用,释放半写入的 staging 资源。fire-and-forget,
+    /// 二次失败由 adapter 内部 log,不向上抛。
+    pub async fn abort_file_upload(&self, handle: uc_core::mobile_sync::StagingHandle) {
+        self.file_staging.abort_stage(handle).await;
+    }
+}
+
+/// 生成 12 hex 字符的 staging scope nonce(uuid v4 simple 形态前 12 位)。
+/// 调用方按"每次入站 PUT /file 取一段独立 nonce"语义使用,与 entry_id
+/// 解耦(entry_id 在 ApplyInbound 内部生成,本阶段还不知道)。
+pub fn streaming_scope_nonce() -> String {
+    let id = uuid::Uuid::new_v4();
+    let s = id.simple().to_string();
+    s[..12].to_string()
 }
 
 #[cfg(test)]
@@ -780,25 +886,53 @@ mod tests {
         }
     }
 
-    struct UnusedStaging;
-    #[async_trait]
-    impl uc_core::ports::MobileFileStagingPort for UnusedStaging {
-        async fn stage_file(
-            &self,
-            _: &str,
-            _: &str,
-            _: &str,
-            _: Vec<u8>,
-        ) -> Result<uc_core::mobile_sync::StagedFile, uc_core::ports::MobileFileStagingError>
-        {
-            unimplemented!("facade smoke tests do not exercise File PUT path")
+    // Facade smoke 测试不触达任何 staging 入口 —— 用 mockall strict mode 的
+    // 未配置 panic 行为承担"防回归",任何方法被意外调到立刻可见。
+    mockall::mock! {
+        Staging {}
+        #[async_trait]
+        impl uc_core::ports::MobileFileStagingPort for Staging {
+            async fn stage_file(
+                &self,
+                scope_id: &str,
+                data_name: &str,
+                mime: &str,
+                bytes: Vec<u8>,
+            ) -> Result<
+                uc_core::mobile_sync::StagedFile,
+                uc_core::ports::MobileFileStagingError,
+            >;
+            async fn read_by_uri(
+                &self,
+                uri: &str,
+            ) -> Result<Vec<u8>, uc_core::ports::MobileFileStagingError>;
+            async fn begin_stage(
+                &self,
+                scope_id: &str,
+                data_name: &str,
+                mime: &str,
+            ) -> Result<
+                uc_core::mobile_sync::StagingHandle,
+                uc_core::ports::MobileFileStagingError,
+            >;
+            async fn append_stage_chunk(
+                &self,
+                handle: &uc_core::mobile_sync::StagingHandle,
+                chunk: &[u8],
+            ) -> Result<(), uc_core::ports::MobileFileStagingError>;
+            async fn finalize_stage(
+                &self,
+                handle: uc_core::mobile_sync::StagingHandle,
+            ) -> Result<
+                uc_core::mobile_sync::StagedFile,
+                uc_core::ports::MobileFileStagingError,
+            >;
+            async fn abort_stage(&self, handle: uc_core::mobile_sync::StagingHandle);
         }
-        async fn read_by_uri(
-            &self,
-            _: &str,
-        ) -> Result<Vec<u8>, uc_core::ports::MobileFileStagingError> {
-            unimplemented!("facade smoke tests do not exercise File GET path")
-        }
+    }
+
+    fn staging_unused() -> Arc<MockStaging> {
+        Arc::new(MockStaging::new())
     }
 
     fn build_facade() -> MobileSyncFacade {
@@ -818,7 +952,7 @@ mod tests {
             settings: Arc::new(InMemorySettings::default()),
             apply_inbound,
             incoming_buffer: Arc::new(IncomingMobileBuffer::new()),
-            file_staging: Arc::new(UnusedStaging),
+            file_staging: staging_unused(),
             snapshot_ports: MobileSyncSnapshotPorts {
                 entry_repo,
                 selection_repo: Arc::new(UnusedSelectionRepo),
@@ -972,7 +1106,7 @@ mod tests {
             settings: Arc::new(InMemorySettings::default()),
             apply_inbound,
             incoming_buffer: Arc::new(IncomingMobileBuffer::new()),
-            file_staging: Arc::new(UnusedStaging),
+            file_staging: staging_unused(),
             snapshot_ports: MobileSyncSnapshotPorts {
                 entry_repo,
                 selection_repo: Arc::new(UnusedSelectionRepo),
@@ -1051,7 +1185,7 @@ mod tests {
             settings: Arc::new(InMemorySettings::default()),
             apply_inbound,
             incoming_buffer: Arc::new(IncomingMobileBuffer::new()),
-            file_staging: Arc::new(UnusedStaging),
+            file_staging: staging_unused(),
             snapshot_ports: MobileSyncSnapshotPorts {
                 entry_repo,
                 selection_repo: Arc::new(UnusedSelectionRepo),
@@ -1159,7 +1293,7 @@ mod tests {
             settings: Arc::new(InMemorySettings::default()),
             apply_inbound,
             incoming_buffer: Arc::new(IncomingMobileBuffer::new()),
-            file_staging: Arc::new(UnusedStaging),
+            file_staging: staging_unused(),
             snapshot_ports: MobileSyncSnapshotPorts {
                 entry_repo,
                 selection_repo: Arc::new(UnusedSelectionRepo),
@@ -1303,7 +1437,7 @@ mod tests {
             settings: Arc::new(InMemorySettings::default()),
             apply_inbound,
             incoming_buffer: Arc::new(IncomingMobileBuffer::new()),
-            file_staging: Arc::new(UnusedStaging),
+            file_staging: staging_unused(),
             snapshot_ports: MobileSyncSnapshotPorts {
                 entry_repo,
                 selection_repo: Arc::new(UnusedSelectionRepo),

--- a/src-tauri/crates/uc-application/src/facade/mobile_sync/mod.rs
+++ b/src-tauri/crates/uc-application/src/facade/mobile_sync/mod.rs
@@ -11,6 +11,7 @@
 mod facade;
 mod outbound_adapter;
 
+pub use facade::streaming_scope_nonce as mobile_sync_streaming_scope_nonce;
 pub use facade::{
     ApplyIncomingMobileClipError, ApplyIncomingMobileClipInput, ApplyIncomingMobileClipOutcome,
     AuthenticateBasicAuthError, AuthenticateBasicAuthInput, AuthenticatedDevice,

--- a/src-tauri/crates/uc-application/src/facade/mobile_sync/mod.rs
+++ b/src-tauri/crates/uc-application/src/facade/mobile_sync/mod.rs
@@ -9,6 +9,7 @@
 //! 详细的方法清单与设计取舍见 [`facade`] 子模块文档。
 
 mod facade;
+mod outbound_adapter;
 
 pub use facade::{
     ApplyIncomingMobileClipError, ApplyIncomingMobileClipInput, ApplyIncomingMobileClipOutcome,

--- a/src-tauri/crates/uc-application/src/facade/mobile_sync/outbound_adapter.rs
+++ b/src-tauri/crates/uc-application/src/facade/mobile_sync/outbound_adapter.rs
@@ -1,0 +1,128 @@
+//! `ClipboardOutboundFanOutAdapter` —— [`MobileInboundFanOutPort`] 的生产
+//! 实现, 把 mobile 入站完成事件接到 [`ClipboardOutboundFacade`] 的完整出
+//! 站管线。
+//!
+//! # 设计意图
+//!
+//! `ApplyIncomingMobileClipUseCase` 通过 [`MobileInboundFanOutPort`] 这层
+//! 薄抽象与"如何把 snapshot 分发出去"解耦, use case 自己不知道
+//! `ClipboardOutboundFacade` 存在 ——
+//!
+//! - **测试时**:fake 实现直接 record 调用, 不必拉真实 dispatcher / blob
+//!   facade / iroh adapter;
+//! - **生产时**:本 adapter 承担"接到 outbound dispatcher、`tokio::spawn`
+//!   fire-and-forget、失败仅 `warn!`、日志字段编排"等具体职责。
+//!
+//! 这样未来要再加一条 fan-out 旁路(例如 telemetry / 第三方协议)只改
+//! adapter 或新增 adapter, 不动 use case 的依赖 surface。
+//!
+//! # 复用本机捕获出站管线
+//!
+//! 本 adapter 调用 [`ClipboardOutboundFacade::dispatch_capture`], 复用
+//! daemon 本机剪贴板捕获完全相同的出站逻辑 ——
+//!
+//! - **文本 / 小图**:inline 进 V3 envelope, 经 iroh 加密通道投递;
+//! - **大图**:超过 `OVERSIZED_REP_THRESHOLD_BYTES` 的 image rep 自动剥
+//!   成 `representation_index = Some(i)` 的 V3BlobRef, 避免撞 iroh wire
+//!   层 2 MiB payload 上限;
+//! - **文件**:`text/uri-list` rep 中的 `file://` URI 被 dispatcher 抽
+//!   出, 字节通过 `BlobTransferFacade::publish_blob_path` 流式 publish
+//!   到 iroh-blobs, 构造 `representation_index = None` 的 free-file
+//!   V3BlobRef。接收端 `InboundBlobMaterializer` 拉回字节并改写 file-list
+//!   rep 成本机 URI —— "手机 → 任一桌面 → 所有桌面"的文件传输闭环靠这条
+//!   路径成立。
+//!
+//! 同样自动受 `OutboundSyncPlanner` 控制 —— 用户在 settings 关了某个类型
+//! 的同步, mobile fan-out 与本机复制 fan-out 一同被 suppress, 不出现
+//! "mobile 上传可以绕过同步开关"的旁路。
+//!
+//! # 错误降级
+//!
+//! `dispatch_capture` 失败仅 `warn!`, 不抛回上层 use case —— mobile 上传
+//! 是否成功只取决于"本机入站是否生效", fan-out 是事后传播, 网络出口故
+//! 障不应倒灌成 HTTP 4xx/5xx 让 iPhone 端误判而触发用户重传。
+//!
+//! [`MobileInboundFanOutPort`]: crate::usecases::mobile_sync::apply_incoming::MobileInboundFanOutPort
+//! [`ClipboardOutboundFacade`]: crate::facade::clipboard_outbound::ClipboardOutboundFacade
+
+use std::sync::Arc;
+
+use tracing::{info, warn};
+
+use uc_core::ids::EntryId;
+use uc_core::mobile_sync::MobileDeviceId;
+use uc_core::{ClipboardChangeOrigin, SystemClipboardSnapshot};
+
+use crate::facade::clipboard_outbound::{
+    ClipboardOutboundFacade, ClipboardOutboundInput, ClipboardOutboundOutcome,
+};
+use crate::usecases::mobile_sync::apply_incoming::MobileInboundFanOutPort;
+
+/// `MobileInboundFanOutPort` 的生产实现, 委托给 [`ClipboardOutboundFacade`]。
+pub(crate) struct ClipboardOutboundFanOutAdapter {
+    outbound: Arc<ClipboardOutboundFacade>,
+}
+
+impl ClipboardOutboundFanOutAdapter {
+    pub(crate) fn new(outbound: Arc<ClipboardOutboundFacade>) -> Self {
+        Self { outbound }
+    }
+}
+
+impl MobileInboundFanOutPort for ClipboardOutboundFanOutAdapter {
+    fn fan_out(
+        &self,
+        entry_id: EntryId,
+        snapshot: SystemClipboardSnapshot,
+        source_device_id: MobileDeviceId,
+    ) {
+        let outbound = Arc::clone(&self.outbound);
+        let entry_id_log = entry_id.clone();
+        let source_log = source_device_id.clone();
+        let entry_id_str = entry_id.as_str().to_string();
+        // origin = LocalCapture: 让 dispatcher 把本机视为"刚捕获了一份
+        // 新内容"的设备 ——
+        // - 触发 file 路径提取 + blob 发布(`RemotePush` 会被 dispatcher
+        //   显式 short-circuit 成 Skipped, 不走 publish);
+        // - 经由 `OutboundSyncPlanner` 与本机复制走同一条策略链路。
+        tokio::spawn(async move {
+            match outbound
+                .dispatch_capture(ClipboardOutboundInput {
+                    entry_id: entry_id_str,
+                    snapshot,
+                    origin: ClipboardChangeOrigin::LocalCapture,
+                })
+                .await
+            {
+                Ok(ClipboardOutboundOutcome::Dispatched {
+                    accepted,
+                    duplicate,
+                    offline,
+                    errored,
+                    blob_ref_count,
+                }) => info!(
+                    entry_id = %entry_id_log,
+                    source = %source_log,
+                    accepted,
+                    duplicate,
+                    offline,
+                    errored,
+                    blob_ref_count,
+                    "mobile_sync fan-out: relayed mobile-inbound snapshot to paired peers"
+                ),
+                Ok(ClipboardOutboundOutcome::Skipped { reason }) => info!(
+                    entry_id = %entry_id_log,
+                    source = %source_log,
+                    reason = %reason,
+                    "mobile_sync fan-out: dispatcher skipped (planner / origin guard)"
+                ),
+                Err(err) => warn!(
+                    entry_id = %entry_id_log,
+                    source = %source_log,
+                    error = %err,
+                    "mobile_sync fan-out: dispatch_capture failed — mobile-inbound NOT relayed to other paired devices"
+                ),
+            }
+        });
+    }
+}

--- a/src-tauri/crates/uc-application/src/facade/mod.rs
+++ b/src-tauri/crates/uc-application/src/facade/mod.rs
@@ -88,6 +88,7 @@ pub use lifecycle::{
     InMemoryLifecycleStatus, LifecycleFacade, LifecycleFacadeDeps, LifecycleFacadeError,
     LifecycleStateView, LifecycleStatusGateway,
 };
+pub use mobile_sync::mobile_sync_streaming_scope_nonce;
 pub use mobile_sync::{
     ApplyIncomingMobileClipError, ApplyIncomingMobileClipInput, ApplyIncomingMobileClipOutcome,
     AuthenticateBasicAuthError, AuthenticateBasicAuthInput, AuthenticatedDevice,

--- a/src-tauri/crates/uc-application/src/usecases/mobile_sync/apply_incoming.rs
+++ b/src-tauri/crates/uc-application/src/usecases/mobile_sync/apply_incoming.rs
@@ -60,6 +60,45 @@ use crate::usecases::clipboard_sync::apply_inbound::{
 use crate::usecases::clipboard_sync::payload_codec::encode_snapshot_to_v3_bytes;
 use crate::usecases::mobile_sync::clipboard_doc::SyncClipboardItemType;
 
+// ─── Fan-out port (use-case-local) ───────────────────────────────────────
+
+/// 移动端入站完成后, 把刚应用到本机的 snapshot 传播给 Space 内其他已配
+/// 对设备的能力抽象。
+///
+/// ## 为什么是 use-case-local trait, 而不是直接持 `Arc<ClipboardOutboundFacade>`
+///
+/// 设计上 use case 不应该跨层去拿一个 facade(facade 是给外部 crate 看
+/// 的对外门面, 不是 use case 的依赖类型)。让本 use case 通过 trait 持
+/// 一个最小的领域端口, 而把"调出站 dispatcher / 异步 spawn / 错误降级
+/// 成 warn / 编辑日志字段"等所有传输细节封到生产 adapter 里, 换来:
+///
+/// - **测试可注入**:fake 实现直接 record 调用, use case 单测可断言
+///   `Applied` 触发一次、`DuplicateSkipped` / 错误分支不触发, 完全脱
+///   离 iroh / blob / outbound dispatcher 整条装配链;
+/// - **依赖收口**:use case 的对外依赖仍只盯"自己关心的领域 collaborator"
+///   (inbound / staging / file_transfer / clock / fan_out), 不随出站
+///   管线演化而膨胀;
+/// - **adapter 可独立演化**:未来要加 telemetry / 按 source_device 走
+///   不同策略 / 复用到非移动端入口, 都改 adapter, 不动 use case。
+///
+/// ## 调用契约
+///
+/// - `fan_out` 是 fire-and-forget:调用立即返回, 真实分发在实现内异步
+///   执行。失败由实现层自己消化(典型 `warn!`), 不抛回 use case ——
+///   mobile 上传 HTTP 响应只取决于本机入站是否生效, fan-out 是事后传
+///   播, 网络出口故障不应倒灌成 4xx/5xx。
+/// - 调用方仅在本机入站产生新 entry(`Applied` 分支)时调用一次, 不在
+///   `DuplicateSkipped` / `DecodeFailed` / `Err(_)` 分支调用。
+/// - `source_device_id` 只用于日志 / telemetry, 实现不应据此做路由决策。
+pub(crate) trait MobileInboundFanOutPort: Send + Sync {
+    fn fan_out(
+        &self,
+        entry_id: EntryId,
+        snapshot: SystemClipboardSnapshot,
+        source_device_id: MobileDeviceId,
+    );
+}
+
 // ─── Public types (pub(crate) per AGENTS.md §11.4) ──────────────────────
 
 /// Input to [`ApplyIncomingMobileClipUseCase::execute`].
@@ -268,6 +307,34 @@ pub(crate) struct ApplyIncomingMobileClipUseCase {
     /// fallback)。BufferFile 分支由 handler 在收 body 期间已经发过
     /// `Started` / `Progress`,本 use case 不重复发。
     file_transfer: Option<Arc<FileTransferFacade>>,
+    /// 可选 fan-out port。装配处提供实现时, SyncDoc apply 成功后(仅
+    /// `Applied` 分支)把刚应用到本机的 snapshot 异步传播给 Space 内
+    /// 其他已配对设备。
+    ///
+    /// 本 use case **只关心"调一下 fan_out"** —— 具体走 iroh 直发 / 走
+    /// 出站 dispatcher / 走文件 blob 发布 / 大图自动剥成 blob ref / 用户
+    /// settings 过滤等所有传输细节, 都封在生产 adapter 里, use case 不感
+    /// 知。这样:
+    ///
+    /// - use case 单测只需 fake 实现 [`MobileInboundFanOutPort`], 不必
+    ///   拉真实 dispatcher / blob facade / iroh adapter, 可断言 fan-out
+    ///   触发时机与参数;
+    /// - 未来扩展(例如同时打点 telemetry、按 source_device 做策略)
+    ///   都改 adapter, 不改 use case;
+    /// - use case 的对外依赖始终只盯"自己关心的领域 collaborator", 不
+    ///   随出站管线演化膨胀。
+    ///
+    /// ## 仅 `Applied` 分支调用
+    ///
+    /// `DuplicateSkipped` 命中本机 dedup —— 这条 content_hash 此前已被
+    /// 本设备处理过, 上次处理时若已 fan-out 过, 重复广播只会浪费带宽
+    /// 并扰乱对端 dedup 时序;`DecodeFailed` / `Err(...)` 表示本机入站
+    /// 根本没成功, 没有"已应用的内容"可广播。
+    ///
+    /// `None` 时静默降级(facade 自测装配 / CLI fallback 等不接出站
+    /// 的入口):mobile 上传仅落地本机, 不传播 —— 与本字段引入前的行
+    /// 为完全一致, 不退化。
+    fan_out: Option<Arc<dyn MobileInboundFanOutPort>>,
 }
 
 impl ApplyIncomingMobileClipUseCase {
@@ -277,6 +344,7 @@ impl ApplyIncomingMobileClipUseCase {
         file_staging: Arc<dyn MobileFileStagingPort>,
         clock: Arc<dyn ClockPort>,
         file_transfer: Option<Arc<FileTransferFacade>>,
+        fan_out: Option<Arc<dyn MobileInboundFanOutPort>>,
     ) -> Self {
         Self {
             inbound,
@@ -284,6 +352,7 @@ impl ApplyIncomingMobileClipUseCase {
             file_staging,
             clock,
             file_transfer,
+            fan_out,
         }
     }
 
@@ -361,14 +430,58 @@ impl ApplyIncomingMobileClipUseCase {
                     snapshot,
                     transfer_id,
                 } = built;
+                // 仅当本装配真的接了 fan-out port 时才克隆 snapshot ——
+                // Image / File 分支的 snapshot 内含完整字节, 无 fan-out
+                // 装配的场景(CLI fallback / 单测)不应该白付一份克隆开销。
+                let snapshot_for_fanout = self.fan_out.as_ref().map(|_| snapshot.clone());
                 let dispatch_outcome = self
                     .dispatch_inbound(source_device_id.clone(), snapshot)
                     .await;
+                self.maybe_fan_out_to_paired_peers(
+                    &source_device_id,
+                    &dispatch_outcome,
+                    snapshot_for_fanout,
+                );
                 self.finalize_transfer_lifecycle(transfer_id, source_device_id, &dispatch_outcome)
                     .await;
                 dispatch_outcome
             }
         }
+    }
+
+    /// 把刚刚应用到本机的移动端 snapshot 交给 [`MobileInboundFanOutPort`]
+    /// 传播到 Space 内其他已配对设备。
+    ///
+    /// 仅在 `Applied` 分支调用一次:`DuplicateSkipped` 命中本机 dedup
+    /// (内容已存在, 不该重复广播);`DecodeFailed` / `Err(...)` 本机
+    /// 入站没成功, 没"已应用的内容"可播。`Buffered` 由 `BufferFile`
+    /// 分支产生, 不走到这里。
+    ///
+    /// 传输细节(走 iroh / 大图剥成 blob ref / 文件流式 publish_blob_path
+    /// / `OutboundSyncPlanner` settings 过滤 / `tokio::spawn` fire-and-forget
+    /// / 失败仅 `warn!`)全部封在生产 adapter 里, 本 use case 不感知 ——
+    /// 见 [`MobileInboundFanOutPort`] 设计意图。
+    fn maybe_fan_out_to_paired_peers(
+        &self,
+        source_device_id: &MobileDeviceId,
+        dispatch_outcome: &Result<ApplyIncomingMobileClipOutcome, ApplyIncomingMobileClipError>,
+        snapshot_for_fanout: Option<SystemClipboardSnapshot>,
+    ) {
+        let Some(fan_out) = self.fan_out.as_ref() else {
+            return;
+        };
+        let Ok(ApplyIncomingMobileClipOutcome::Applied { entry_id }) = dispatch_outcome else {
+            return;
+        };
+        let Some(snapshot) = snapshot_for_fanout else {
+            // fan_out = Some 时上游一定克隆过 snapshot; 走到这里说明上
+            // 游 `snapshot_for_fanout` 被错误构造成 None, 属于编程错误。
+            // 沉默而不是 panic —— 这条 fan-out 只是"事后传播", 不应让
+            // mobile 上传整体失败。
+            warn!("mobile_sync fan-out: fan_out wired but snapshot_for_fanout=None, skipping");
+            return;
+        };
+        fan_out.fan_out(entry_id.clone(), snapshot, source_device_id.clone());
     }
 
     /// SyncDoc apply 完成后把 mobile_lan 路径预先打开的 transfer 关闭。
@@ -840,6 +953,7 @@ mod tests {
             FakeStaging::never_called(),
             Arc::new(FixedClock),
             None,
+            None,
         )
     }
 
@@ -857,6 +971,7 @@ mod tests {
             Arc::new(IncomingMobileBuffer::new()),
             FakeStaging::never_called(),
             Arc::new(FixedClock),
+            None,
             None,
         )
     }
@@ -889,6 +1004,7 @@ mod tests {
             buffer.clone(),
             FakeStaging::never_called(),
             Arc::new(FixedClock),
+            None,
             None,
         );
         (uc, buffer)
@@ -923,6 +1039,7 @@ mod tests {
             staging,
             Arc::new(FixedClock),
             None,
+            None,
         );
         (uc, buffer)
     }
@@ -944,6 +1061,7 @@ mod tests {
             buffer,
             staging,
             Arc::new(FixedClock),
+            None,
             None,
         )
     }
@@ -1028,6 +1146,7 @@ mod tests {
             buffer.clone(),
             FakeStaging::never_called(),
             Arc::new(FixedClock),
+            None,
             None,
         );
         assert_eq!(buffer.len(), 0);
@@ -1296,6 +1415,7 @@ mod tests {
             staging,
             Arc::new(FixedClock),
             None,
+            None,
         );
 
         // 预 seed buffer
@@ -1356,6 +1476,7 @@ mod tests {
             FakeStaging::never_called(),
             Arc::new(FixedClock),
             None,
+            None,
         );
 
         let outcome = uc
@@ -1373,6 +1494,171 @@ mod tests {
                 ..
             } if existing_entry_id == EntryId::from("entry-existing")
         ));
+    }
+
+    // ── fan-out trait wire-up ──────────────────────────────────────────
+    //
+    // 验证 `ApplyIncomingMobileClipUseCase` 与 `MobileInboundFanOutPort`
+    // 之间的接线契约。这一层不验证"传播到 paired peers 的真实行为"——
+    // 那是 `ClipboardOutboundFanOutAdapter` 的责任,改 adapter 不动这里
+    // 的断言;use case 只该保证"在对的分支以对的参数调一次 trait"。
+
+    /// `MobileInboundFanOutPort` 的 in-memory fake, 单测断言用。
+    #[derive(Default)]
+    struct RecordingFanOut {
+        calls: std::sync::Mutex<Vec<(EntryId, SystemClipboardSnapshot, MobileDeviceId)>>,
+    }
+
+    impl RecordingFanOut {
+        fn calls(&self) -> Vec<(EntryId, SystemClipboardSnapshot, MobileDeviceId)> {
+            self.calls.lock().unwrap().clone()
+        }
+    }
+
+    impl MobileInboundFanOutPort for RecordingFanOut {
+        fn fan_out(
+            &self,
+            entry_id: EntryId,
+            snapshot: SystemClipboardSnapshot,
+            source_device_id: MobileDeviceId,
+        ) {
+            self.calls
+                .lock()
+                .unwrap()
+                .push((entry_id, snapshot, source_device_id));
+        }
+    }
+
+    /// `Applied` 分支必须把 `(entry_id, snapshot, source_device_id)` 完整
+    /// 透传给 fan-out port —— 后续 adapter 才有足够信息复用本机捕获出站
+    /// 管线(snapshot 用来抽文件路径 / 发布 blob;entry_id 用作 blob 的
+    /// 发送端归属;source_device_id 给日志做来源识别)。
+    #[tokio::test]
+    async fn applied_branch_invokes_fan_out_with_full_context() {
+        let mut repo = MockEntryRepo::new();
+        repo.expect_find_entry_id_by_snapshot_hash()
+            .times(1)
+            .returning(|_| Ok(None));
+        let mut capture = MockCapture::new();
+        capture
+            .expect_capture()
+            .times(1)
+            .returning(|_, _| Ok(Some(EntryId::from("entry-fanout-1"))));
+        let mut write = MockWrite::new();
+        write.expect_write().times(1).returning(|_| Ok(()));
+        let inbound =
+            ApplyInboundClipboardUseCase::new(Arc::new(repo), Arc::new(capture), Arc::new(write));
+
+        let recorder = Arc::new(RecordingFanOut::default());
+        let uc = ApplyIncomingMobileClipUseCase::new(
+            Arc::new(inbound),
+            Arc::new(IncomingMobileBuffer::new()),
+            FakeStaging::never_called(),
+            Arc::new(FixedClock),
+            None,
+            Some(Arc::clone(&recorder) as Arc<dyn MobileInboundFanOutPort>),
+        );
+
+        let outcome = uc
+            .execute(input_sync_doc(
+                SyncClipboardItemType::Text,
+                "hello from mobile",
+                None,
+            ))
+            .await
+            .expect("text applied ok");
+        assert!(matches!(
+            outcome,
+            ApplyIncomingMobileClipOutcome::Applied { .. }
+        ));
+
+        let calls = recorder.calls();
+        assert_eq!(calls.len(), 1, "Applied 必须触发 fan_out 一次");
+        let (entry_id, snapshot, source) = &calls[0];
+        assert_eq!(*entry_id, EntryId::from("entry-fanout-1"));
+        assert_eq!(*source, MobileDeviceId::new("did_seed"));
+        // snapshot 至少要携带原 rep, 让 adapter 能基于内容抽文件路径 /
+        // 计算 blob ref。这里仅断言 rep 数量, 内容细节由其他 use case
+        // 测试覆盖, 不重复绑定。
+        assert_eq!(snapshot.representations.len(), 1);
+    }
+
+    /// `DuplicateSkipped` 命中本机 dedup —— 这条 content_hash 之前已被
+    /// 本设备处理过, **绝对不能**再 fan-out: 重复广播浪费带宽且可能扰
+    /// 乱对端 dedup 时序。
+    #[tokio::test]
+    async fn duplicate_skipped_does_not_invoke_fan_out() {
+        let mut repo = MockEntryRepo::new();
+        repo.expect_find_entry_id_by_snapshot_hash()
+            .times(1)
+            .returning(|_| Ok(Some(EntryId::from("entry-existing"))));
+        let capture = MockCapture::new();
+        let write = MockWrite::new();
+        let inbound =
+            ApplyInboundClipboardUseCase::new(Arc::new(repo), Arc::new(capture), Arc::new(write));
+
+        let recorder = Arc::new(RecordingFanOut::default());
+        let uc = ApplyIncomingMobileClipUseCase::new(
+            Arc::new(inbound),
+            Arc::new(IncomingMobileBuffer::new()),
+            FakeStaging::never_called(),
+            Arc::new(FixedClock),
+            None,
+            Some(Arc::clone(&recorder) as Arc<dyn MobileInboundFanOutPort>),
+        );
+
+        let outcome = uc
+            .execute(input_sync_doc(
+                SyncClipboardItemType::Text,
+                "already-here",
+                None,
+            ))
+            .await
+            .expect("dedup hit ok");
+        assert!(matches!(
+            outcome,
+            ApplyIncomingMobileClipOutcome::DuplicateSkipped { .. }
+        ));
+        assert_eq!(
+            recorder.calls().len(),
+            0,
+            "DuplicateSkipped 分支不得触发 fan_out"
+        );
+    }
+
+    /// `DecodeFailed` 分支(此例:Text 空 body 在 `build_text_snapshot`
+    /// 阶段被拒绝)本机入站根本没成功 → 没"已应用的内容"可广播 →
+    /// 不调 fan-out。inbound 链全程零调用是顺带钉死的不变量。
+    #[tokio::test]
+    async fn decode_failed_does_not_invoke_fan_out() {
+        let recorder = Arc::new(RecordingFanOut::default());
+        let repo = MockEntryRepo::new();
+        let capture = MockCapture::new();
+        let write = MockWrite::new();
+        let inbound =
+            ApplyInboundClipboardUseCase::new(Arc::new(repo), Arc::new(capture), Arc::new(write));
+        let uc = ApplyIncomingMobileClipUseCase::new(
+            Arc::new(inbound),
+            Arc::new(IncomingMobileBuffer::new()),
+            FakeStaging::never_called(),
+            Arc::new(FixedClock),
+            None,
+            Some(Arc::clone(&recorder) as Arc<dyn MobileInboundFanOutPort>),
+        );
+
+        let outcome = uc
+            .execute(input_sync_doc(SyncClipboardItemType::Text, "", None))
+            .await
+            .expect("decode failure surfaces as outcome, not Err");
+        assert!(matches!(
+            outcome,
+            ApplyIncomingMobileClipOutcome::DecodeFailed { .. }
+        ));
+        assert_eq!(
+            recorder.calls().len(),
+            0,
+            "DecodeFailed 分支不得触发 fan_out"
+        );
     }
 
     /// `mobile_sync:<id>` 伪 DeviceId 的 plumbing: 通过 capture mock 的
@@ -1403,6 +1689,7 @@ mod tests {
             Arc::new(IncomingMobileBuffer::new()),
             FakeStaging::never_called(),
             Arc::new(FixedClock),
+            None,
             None,
         );
 

--- a/src-tauri/crates/uc-application/src/usecases/mobile_sync/apply_incoming.rs
+++ b/src-tauri/crates/uc-application/src/usecases/mobile_sync/apply_incoming.rs
@@ -1610,6 +1610,47 @@ mod tests {
         );
     }
 
+    /// `BufferFile` 分支只把字节挂进 buffer, 不产生"已应用到本机的 entry"——
+    /// SyncDoc 还没到, 当前没有内容可广播。这条 outcome (`Buffered`) 的不变量
+    /// 在 `maybe_fan_out_to_paired_peers` 文档里被显式承诺(只有 `Applied`
+    /// 才触发), 这里用一个 fake fan-out port 把它钉死, 防止未来重构在 PUT
+    /// /file 阶段提前 fan-out 一份"空 envelope"出去。
+    #[tokio::test]
+    async fn buffer_file_does_not_invoke_fan_out() {
+        let recorder = Arc::new(RecordingFanOut::default());
+        // BufferFile 分支不进 inbound 链, mocks 留空 —— 任何意外调用都会
+        // 让 mockall 在 Drop 时 panic, 这本身就是个额外的不变量校验。
+        let repo = MockEntryRepo::new();
+        let capture = MockCapture::new();
+        let write = MockWrite::new();
+        let inbound =
+            ApplyInboundClipboardUseCase::new(Arc::new(repo), Arc::new(capture), Arc::new(write));
+        let uc = ApplyIncomingMobileClipUseCase::new(
+            Arc::new(inbound),
+            Arc::new(IncomingMobileBuffer::new()),
+            staging_never_called(),
+            Arc::new(FixedClock),
+            None,
+            Some(Arc::clone(&recorder) as Arc<dyn MobileInboundFanOutPort>),
+        );
+
+        let outcome = uc
+            .execute(input_buffer_file(
+                "photo.png",
+                "image/png",
+                "file:///tmp/mobile_inbound/buf-fanout/photo.png",
+                "photo.png",
+            ))
+            .await
+            .expect("buffer-file path returns Ok");
+        assert_eq!(outcome, ApplyIncomingMobileClipOutcome::Buffered);
+        assert_eq!(
+            recorder.calls().len(),
+            0,
+            "Buffered 分支不得触发 fan_out (PUT /file 阶段没有 entry 可广播)"
+        );
+    }
+
     /// `mobile_sync:<id>` 伪 DeviceId 的 plumbing: 通过 capture mock 的
     /// `withf` 校验 snapshot 的 ts_ms 来自 FixedClock。`from_device` 的
     /// 字符串校验留给 inbound 的 ports —— 我们已经在 dispatch_inbound 里

--- a/src-tauri/crates/uc-application/src/usecases/mobile_sync/apply_incoming.rs
+++ b/src-tauri/crates/uc-application/src/usecases/mobile_sync/apply_incoming.rs
@@ -40,13 +40,12 @@
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
-use bytes::Bytes;
 use thiserror::Error;
 use tracing::{debug, info, instrument, warn};
 
 use uc_core::file_transfer::FileTransferFailureReason;
 use uc_core::ids::{DeviceId, EntryId, FormatId, RepresentationId};
-use uc_core::mobile_sync::MobileDeviceId;
+use uc_core::mobile_sync::{MobileDeviceId, StagedFile};
 use uc_core::ports::mobile_sync::{MobileFileStagingError, MobileFileStagingPort};
 use uc_core::ports::ClockPort;
 use uc_core::{MimeType, ObservedClipboardRepresentation, SystemClipboardSnapshot};
@@ -126,9 +125,15 @@ pub enum IncomingMobileClipEvent {
         /// for Image / File types — points to the file-buffer entry.
         data_name: Option<String>,
     },
-    /// Triggered by `PUT /file/{data_name}`. Stages bytes in the buffer,
-    /// returns immediately with `Buffered` outcome — the caller must
-    /// still respond HTTP 200.
+    /// Triggered by `PUT /file/{data_name}` 已经落盘 staging 之后。
+    /// 把"已 staged 文件 + transfer_id"挂进 buffer 等 SyncDoc 配对,返回
+    /// `Buffered` outcome —— 路由层应回 HTTP 200。
+    ///
+    /// 注意:本事件**不再携带字节**。handler 在收 body 期间已经通过
+    /// streaming staging API 把字节边收边写到 cache_dir, `staged` 字段携
+    /// 带最终的 `file:///...` URI。SyncDoc apply 阶段:
+    /// - File 类型直接用 URI 拼 `text/uri-list` rep;
+    /// - Image 类型按 URI `read_by_uri` 读回字节内联到 image rep。
     ///
     /// `transfer_id` 由 handler 生成(`mobile-lan:<uuid>` 或 `?upload_id=`
     /// 客户端提供),贯穿到 SyncDoc apply 阶段做 link_transfer_to_entry +
@@ -137,7 +142,7 @@ pub enum IncomingMobileClipEvent {
     BufferFile {
         data_name: String,
         mime: String,
-        bytes: Vec<u8>,
+        staged: StagedFile,
         transfer_id: String,
     },
 }
@@ -194,15 +199,6 @@ struct BuiltSnapshot {
     transfer_id: Option<String>,
 }
 
-/// 12 hex 字符的 staging scope nonce(取 uuid v4 simple 形态前 12 位)。
-/// 用于让 adapter 把同一次入站事件落到独立子目录,与 entry_id 解耦(后者
-/// 在 ApplyInbound 内部生成,staging 时还不知道)。
-fn staging_scope_nonce() -> String {
-    let id = uuid::Uuid::new_v4();
-    let s = id.simple().to_string();
-    s[..12].to_string()
-}
-
 // ─── IncomingMobileBuffer ────────────────────────────────────────────────
 
 const MAX_BUFFERED_FILES: usize = 16;
@@ -210,7 +206,10 @@ const MAX_BUFFERED_FILES: usize = 16;
 #[derive(Debug, Clone)]
 struct BufferedFile {
     mime: String,
-    bytes: Bytes,
+    /// 已经流式落盘的 staging 文件引用。File 类型 SyncDoc apply 时直接
+    /// 用 URI 拼 uri-list rep;Image 类型按 URI `read_by_uri` 把字节读回
+    /// 内联到 image rep。
+    staged: StagedFile,
     /// 协议层 transfer_id —— 由 `PUT /file` handler 在入口处生成
     /// (`mobile-lan:<uuid-v4>` 或客户端通过 `?upload_id=` 提供)。
     /// 让 SyncDoc 阶段拿到真实 entry_id 后能 `link_transfer_to_entry`
@@ -240,7 +239,7 @@ impl IncomingMobileBuffer {
         }
     }
 
-    fn store(&self, data_name: String, mime: String, bytes: Vec<u8>, transfer_id: String) {
+    fn store(&self, data_name: String, mime: String, staged: StagedFile, transfer_id: String) {
         let mut guard = self.inner.lock().unwrap();
         if guard.len() >= MAX_BUFFERED_FILES && !guard.contains_key(&data_name) {
             // Cap reached + new key. Drop one arbitrary existing entry
@@ -259,7 +258,7 @@ impl IncomingMobileBuffer {
             data_name,
             BufferedFile {
                 mime,
-                bytes: Bytes::from(bytes),
+                staged,
                 transfer_id,
             },
         );
@@ -369,18 +368,20 @@ impl ApplyIncomingMobileClipUseCase {
             IncomingMobileClipEvent::BufferFile {
                 data_name,
                 mime,
-                bytes,
+                staged,
                 transfer_id,
             } => {
-                let bytes_len = bytes.len();
+                let uri = staged.uri.as_str().to_string();
+                let sanitized = staged.sanitized_name.clone();
                 self.buffer
-                    .store(data_name.clone(), mime.clone(), bytes, transfer_id.clone());
+                    .store(data_name.clone(), mime.clone(), staged, transfer_id.clone());
                 info!(
                     data_name = %data_name,
                     mime = %mime,
-                    bytes = bytes_len,
+                    sanitized_name = %sanitized,
+                    staged_uri = %uri,
                     transfer_id = %transfer_id,
-                    "mobile_sync apply_incoming: buffered file"
+                    "mobile_sync apply_incoming: buffered staged file"
                 );
                 Ok(ApplyIncomingMobileClipOutcome::Buffered)
             }
@@ -392,8 +393,8 @@ impl ApplyIncomingMobileClipUseCase {
                 let source_device_id = input.source_device_id.clone();
                 let build_result: Result<BuiltSnapshot, BuildSnapshotFailure> = match item_type {
                     SyncClipboardItemType::Text => self.build_text_snapshot(text),
-                    SyncClipboardItemType::Image => self.build_image_snapshot(data_name),
-                    SyncClipboardItemType::File => self.build_file_snapshot(data_name).await,
+                    SyncClipboardItemType::Image => self.build_image_snapshot(data_name).await,
+                    SyncClipboardItemType::File => self.build_file_snapshot(data_name),
                     SyncClipboardItemType::Group => Err(BuildSnapshotFailure::Decode(
                         "Group 类型不在 v1 范围内 (SyncClipboard 协议保留)".into(),
                     )),
@@ -615,7 +616,7 @@ impl ApplyIncomingMobileClipUseCase {
         })
     }
 
-    fn build_image_snapshot(
+    async fn build_image_snapshot(
         &self,
         data_name: Option<String>,
     ) -> Result<BuiltSnapshot, BuildSnapshotFailure> {
@@ -628,11 +629,29 @@ impl ApplyIncomingMobileClipUseCase {
             ))
         })?;
         let transfer_id = buffered.transfer_id.clone();
+        // PUT /file 阶段已经把字节流式落盘到 staging,这里按 URI 把字节读
+        // 回来 —— image rep 标准形态是字节内联(系统剪贴板 image type 要求
+        // rep 持字节),不能像 file 分支那样只挂 URI。来回一次盘换 PUT /file
+        // 阶段不再吃满内存 buffer。
+        let bytes = self
+            .file_staging
+            .read_by_uri(buffered.staged.uri.as_str())
+            .await
+            .map_err(|err| match err {
+                MobileFileStagingError::NotFound => BuildSnapshotFailure::Internal(format!(
+                    "staged image file missing for `{}`: {err}",
+                    name
+                )),
+                _ => BuildSnapshotFailure::Internal(format!(
+                    "read staged image bytes for `{}` failed: {err}",
+                    name
+                )),
+            })?;
         let rep = ObservedClipboardRepresentation::new(
             RepresentationId::new(),
             FormatId::from("image"),
             Some(MimeType(buffered.mime)),
-            buffered.bytes.to_vec(),
+            bytes,
         );
         Ok(BuiltSnapshot {
             snapshot: SystemClipboardSnapshot {
@@ -643,22 +662,14 @@ impl ApplyIncomingMobileClipUseCase {
         })
     }
 
-    /// `File` 分支(P5a.3.5):从 buffer 取裸字节,经 [`MobileFileStagingPort`]
-    /// 物化到 cache_dir,把得到的 `file:///...` URI 拼成 `text/uri-list` rep。
+    /// `File` 分支:从 buffer 取已 staged 文件引用,直接拼成 `text/uri-list`
+    /// rep。
     ///
     /// 与 image 分支的差异:
-    /// - image rep 直接把字节内联进 representation(系统剪贴板要求 image
-    ///   rep 持字节);
-    /// - file rep 标准形态是 file-list:bytes 是 URI 字符串,而非真实文件
-    ///   字节。staging 让接收端有"本机能寻址的 path",iPhone → Mac 才能在
-    ///   `pbpaste` / Finder 拖拽 / 应用 paste 时拿到真实文件。
-    ///
-    /// staging 失败有两种语义:
-    /// - `MobileFileStagingError::InvalidDataName` → 视为业务输入不合法,翻
-    ///   `BuildSnapshotFailure::Decode` → outcome `DecodeFailed`(HTTP 400);
-    /// - `MobileFileStagingError::Io` → 内部故障(磁盘满 / 权限),翻
-    ///   `BuildSnapshotFailure::Internal` → 应用层 `Internal` → HTTP 500。
-    async fn build_file_snapshot(
+    /// - image rep 必须持字节(系统剪贴板 image type 要求);本分支只挂 URI,
+    ///   不读盘 —— file-list 的 wire 形态本来就是 URI 字符串。
+    /// - PUT /file 阶段已经把字节流式落盘,这里不再触发额外的 stage_file 调用。
+    fn build_file_snapshot(
         &self,
         data_name: Option<String>,
     ) -> Result<BuiltSnapshot, BuildSnapshotFailure> {
@@ -672,30 +683,7 @@ impl ApplyIncomingMobileClipUseCase {
         })?;
         let transfer_id = buffered.transfer_id.clone();
 
-        // staging scope:每次 PUT /SyncClipboard.json 的 File 触发一次,
-        // 用 8 hex 随机 nonce 做子目录,与 entry_id 解耦(entry_id 在
-        // ApplyInbound 内部才生成)。adapter 内部清理 / 命名都用这一段。
-        let scope_id = staging_scope_nonce();
-
-        let staged = self
-            .file_staging
-            .stage_file(&scope_id, &name, &buffered.mime, buffered.bytes.to_vec())
-            .await
-            .map_err(|err| match err {
-                MobileFileStagingError::InvalidDataName(msg) => {
-                    BuildSnapshotFailure::Decode(format!("staged data_name unusable: {msg}"))
-                }
-                MobileFileStagingError::Io(msg) => {
-                    BuildSnapshotFailure::Internal(format!("mobile file staging failed: {msg}"))
-                }
-                // NotFound 是 read_by_uri 才会产的变体, stage_file 不应触发。
-                // 万一 adapter 实现走偏返回它, 翻成 Internal 让排障可见。
-                MobileFileStagingError::NotFound => BuildSnapshotFailure::Internal(
-                    "mobile file staging unexpectedly returned NotFound from stage_file".into(),
-                ),
-            })?;
-
-        let uri_list = format!("{}\n", staged.uri.as_str());
+        let uri_list = format!("{}\n", buffered.staged.uri.as_str());
         let rep = ObservedClipboardRepresentation::new(
             RepresentationId::new(),
             FormatId::from("files"),
@@ -704,8 +692,8 @@ impl ApplyIncomingMobileClipUseCase {
         );
         info!(
             data_name = %name,
-            sanitized_name = %staged.sanitized_name,
-            uri = %staged.uri,
+            sanitized_name = %buffered.staged.sanitized_name,
+            uri = %buffered.staged.uri,
             "mobile_sync apply_incoming: file staged into uri-list rep"
         );
         Ok(BuiltSnapshot {
@@ -814,70 +802,61 @@ mod tests {
 
     use crate::usecases::clipboard_sync::apply_inbound::{InboundCapture, InboundWrite};
 
-    // Fake `MobileFileStagingPort` —— 默认行为是"被调用就 panic",特定测试
-    // 用 [`FakeStaging::with_response`] / [`FakeStaging::with_error`] 注入
-    // 可控响应。File 分支以外的测试不应该触发 staging,默认 panic 形态自带
-    // 防回归(文件路径意外被调到时立刻可见)。
-    use uc_core::mobile_sync::StagedFile;
+    use uc_core::mobile_sync::{StagedFile, StagedFileUri, StagingHandle};
     use uc_core::ports::mobile_sync::MobileFileStagingError;
 
-    #[derive(Default)]
-    struct FakeStaging {
-        // `Mutex<Option<...>>` 让单次 `take` 后变成 panic,如果某个测试错
-        // 把 staging 调了两次(典型回归)能立刻看到。
-        response: std::sync::Mutex<Option<Result<StagedFile, MobileFileStagingError>>>,
-        // 记录最后一次调用参数(单测断言用)。
-        last_call: std::sync::Mutex<Option<(String, String, String, Vec<u8>)>>,
+    // 流式落盘改造后,apply_incoming 本身不再触达 staging 写入方法 ——
+    // stage_file / begin_stage / append_stage_chunk / finalize_stage /
+    // abort_stage 都由 facade 入口在 PUT /file 阶段消费。image 分支会调
+    // `read_by_uri` 把 staged 字节读回内联到 image rep,其余方法均不应被
+    // 触达;mockall 默认 strict mode 让未配置的方法被调到就 panic,这正是
+    // 我们要的回归防御。
+    mockall::mock! {
+        Staging {}
+        #[async_trait]
+        impl MobileFileStagingPort for Staging {
+            async fn stage_file(
+                &self,
+                scope_id: &str,
+                data_name: &str,
+                mime: &str,
+                bytes: Vec<u8>,
+            ) -> Result<StagedFile, MobileFileStagingError>;
+            async fn read_by_uri(&self, uri: &str) -> Result<Vec<u8>, MobileFileStagingError>;
+            async fn begin_stage(
+                &self,
+                scope_id: &str,
+                data_name: &str,
+                mime: &str,
+            ) -> Result<StagingHandle, MobileFileStagingError>;
+            async fn append_stage_chunk(
+                &self,
+                handle: &StagingHandle,
+                chunk: &[u8],
+            ) -> Result<(), MobileFileStagingError>;
+            async fn finalize_stage(
+                &self,
+                handle: StagingHandle,
+            ) -> Result<StagedFile, MobileFileStagingError>;
+            async fn abort_stage(&self, handle: StagingHandle);
+        }
     }
 
-    impl FakeStaging {
-        fn never_called() -> Arc<Self> {
-            Arc::new(Self::default())
-        }
-        fn with_response(staged: StagedFile) -> Arc<Self> {
-            Arc::new(Self {
-                response: std::sync::Mutex::new(Some(Ok(staged))),
-                last_call: Default::default(),
-            })
-        }
-        fn with_error(err: MobileFileStagingError) -> Arc<Self> {
-            Arc::new(Self {
-                response: std::sync::Mutex::new(Some(Err(err))),
-                last_call: Default::default(),
-            })
-        }
-        fn last_call(&self) -> Option<(String, String, String, Vec<u8>)> {
-            self.last_call.lock().unwrap().clone()
-        }
+    /// "未配置任何期望"的 staging mock —— mockall strict mode 下任何方法
+    /// 被调到都会 panic, 用于断言"本测试根本不应该触达 staging"。
+    fn staging_never_called() -> Arc<MockStaging> {
+        Arc::new(MockStaging::new())
     }
 
-    #[async_trait]
-    impl MobileFileStagingPort for FakeStaging {
-        async fn read_by_uri(&self, _: &str) -> Result<Vec<u8>, MobileFileStagingError> {
-            // apply_incoming.rs 测试不走 read_by_uri 路径(那是 get_file
-            // 的事), 被调到说明回归。
-            unreachable!("FakeStaging.read_by_uri must not be called from apply_incoming tests")
-        }
-
-        async fn stage_file(
-            &self,
-            scope_id: &str,
-            data_name: &str,
-            mime: &str,
-            bytes: Vec<u8>,
-        ) -> Result<StagedFile, MobileFileStagingError> {
-            *self.last_call.lock().unwrap() = Some((
-                scope_id.to_string(),
-                data_name.to_string(),
-                mime.to_string(),
-                bytes.clone(),
-            ));
-            self.response
-                .lock()
-                .unwrap()
-                .take()
-                .unwrap_or_else(|| panic!("FakeStaging.stage_file called without preset response"))
-        }
+    /// 配置 `read_by_uri` 返回指定字节,其它方法仍为"被调即 panic"。
+    /// 用于 image 分支测试 —— `build_image_snapshot` 会按 staged URI 读字节
+    /// 内联到 image rep。
+    fn staging_with_image_bytes(bytes: Vec<u8>) -> Arc<MockStaging> {
+        let mut mock = MockStaging::new();
+        mock.expect_read_by_uri()
+            .times(1)
+            .return_once(move |_| Ok(bytes));
+        Arc::new(mock)
     }
 
     // ── mockall: same 3 collaborator surfaces apply_inbound's tests use ──
@@ -950,7 +929,7 @@ mod tests {
         ApplyIncomingMobileClipUseCase::new(
             Arc::new(inbound),
             Arc::new(IncomingMobileBuffer::new()),
-            FakeStaging::never_called(),
+            staging_never_called(),
             Arc::new(FixedClock),
             None,
             None,
@@ -969,17 +948,19 @@ mod tests {
         ApplyIncomingMobileClipUseCase::new(
             Arc::new(inbound),
             Arc::new(IncomingMobileBuffer::new()),
-            FakeStaging::never_called(),
+            staging_never_called(),
             Arc::new(FixedClock),
             None,
             None,
         )
     }
 
-    /// Build a use case with a shared buffer + an inbound expecting
-    /// 1 happy path. Returns (use_case, buffer) so the test can pre-seed.
-    fn build_uc_with_buffer_expect_applied(
+    /// 装 inbound = 一条 happy path,buffer + staging mock 由调用方提供。
+    /// image 分支测试需要注入 `read_by_uri` 响应让 build_image_snapshot 拿到
+    /// 字节;其它分支用 `staging_never_called()` 即可。
+    fn build_uc_with_buffer_and_image_bytes_expect_applied(
         entry_id: &str,
+        staging: Arc<MockStaging>,
     ) -> (ApplyIncomingMobileClipUseCase, Arc<IncomingMobileBuffer>) {
         let mut repo = MockEntryRepo::new();
         repo.expect_find_entry_id_by_snapshot_hash()
@@ -1002,7 +983,7 @@ mod tests {
         let uc = ApplyIncomingMobileClipUseCase::new(
             Arc::new(inbound),
             buffer.clone(),
-            FakeStaging::never_called(),
+            staging,
             Arc::new(FixedClock),
             None,
             None,
@@ -1015,7 +996,7 @@ mod tests {
     /// `entry_id`. Used by File-branch happy-path tests.
     fn build_uc_with_buffer_and_staging_expect_applied(
         entry_id: &str,
-        staging: Arc<FakeStaging>,
+        staging: Arc<MockStaging>,
     ) -> (ApplyIncomingMobileClipUseCase, Arc<IncomingMobileBuffer>) {
         let mut repo = MockEntryRepo::new();
         repo.expect_find_entry_id_by_snapshot_hash()
@@ -1048,7 +1029,7 @@ mod tests {
     /// called (decode failure path). Used by File 缺 dataName / staging 错误
     /// 等测试。
     fn build_uc_with_staging_expect_no_inbound(
-        staging: Arc<FakeStaging>,
+        staging: Arc<MockStaging>,
         buffer: Arc<IncomingMobileBuffer>,
     ) -> ApplyIncomingMobileClipUseCase {
         let repo = MockEntryRepo::new();
@@ -1084,14 +1065,18 @@ mod tests {
     fn input_buffer_file(
         data_name: &str,
         mime: &str,
-        bytes: Vec<u8>,
+        staged_uri: &str,
+        sanitized_name: &str,
     ) -> ApplyIncomingMobileClipInput {
         ApplyIncomingMobileClipInput {
             source_device_id: MobileDeviceId::new("did_seed"),
             event: IncomingMobileClipEvent::BufferFile {
                 data_name: data_name.to_string(),
                 mime: mime.to_string(),
-                bytes,
+                staged: StagedFile {
+                    uri: StagedFileUri::new(staged_uri),
+                    sanitized_name: sanitized_name.to_string(),
+                },
                 transfer_id: format!("mobile-lan:test-{data_name}"),
             },
         }
@@ -1144,7 +1129,7 @@ mod tests {
         let uc = ApplyIncomingMobileClipUseCase::new(
             Arc::new(inbound),
             buffer.clone(),
-            FakeStaging::never_called(),
+            staging_never_called(),
             Arc::new(FixedClock),
             None,
             None,
@@ -1155,7 +1140,8 @@ mod tests {
             .execute(input_buffer_file(
                 "photo.png",
                 "image/png",
-                vec![0xDE, 0xAD, 0xBE, 0xEF],
+                "file:///tmp/mobile_inbound/buf01/photo.png",
+                "photo.png",
             ))
             .await
             .expect("buffer-file path returns Ok");
@@ -1168,14 +1154,20 @@ mod tests {
     /// `Applied`. Verifies the two-step PUT protocol's contract.
     #[tokio::test]
     async fn image_applied_after_buffer_then_sync_doc() {
-        let (uc, buffer) = build_uc_with_buffer_expect_applied("entry-image-1");
+        // build_image_snapshot 走 read_by_uri 拿 staged image 字节, 测试注入
+        // 一段 PNG 魔数让链路跑通。
+        let staging = staging_with_image_bytes(vec![0x89, 0x50, 0x4E, 0x47]);
+        let (uc, buffer) =
+            build_uc_with_buffer_and_image_bytes_expect_applied("entry-image-1", staging);
 
-        // step 1: PUT /file/{name}
+        // step 1: PUT /file/{name} —— 在新架构里 handler 已经把字节流式落盘,
+        // 这里直接构造一个"已 staged"的 BufferFile event 模拟 facade 入口的结果。
         let buf_outcome = uc
             .execute(input_buffer_file(
                 "photo.png",
                 "image/png",
-                vec![0x89, 0x50, 0x4E, 0x47],
+                "file:///tmp/mobile_inbound/img01/photo.png",
+                "photo.png",
             ))
             .await
             .unwrap();
@@ -1242,28 +1234,30 @@ mod tests {
         ));
     }
 
-    // ── P5a.3.5 File 分支 5 个新测试 ─────────────────────────────────────
+    // ── File 分支测试 ────────────────────────────────────────────────────
+    //
+    // 流式落盘改造后:
+    // - PUT /file 阶段把字节流式 stage 到 cache_dir(由 webserver 触发,本
+    //   use case 不参与)。BufferFile event 不再携带字节, 只挂"已 staged
+    //   文件"引用。
+    // - SyncDoc File 分支不再调 staging,直接拿 buffer 里的 `StagedFile`
+    //   拼 uri-list rep。原来的"staging IO 失败"测试因此不再属于本 use case
+    //   的语义边界(staging 失败由 facade 流式入口翻译,已在 facade 单测覆盖)。
 
-    /// File happy path: BufferFile (PUT /file) → SyncDoc File (PUT /json) →
-    /// staging port 拼出 macOS URI → file-list rep 写进 capture pipeline →
-    /// `Applied`。校验 buffer 被 drain + staging 被调一次。
+    /// File happy path: BufferFile (PUT /file 已 stage) → SyncDoc File →
+    /// 拼 file-list rep → capture → `Applied`。校验 buffer 被 drain。
     #[tokio::test]
     async fn file_applied_after_buffer_then_sync_doc() {
-        let staged = StagedFile {
-            uri: uc_core::mobile_sync::StagedFileUri::new(
-                "file:///tmp/mobile_inbound/abcdef012345/doc.pdf",
-            ),
-            sanitized_name: "doc.pdf".into(),
-        };
-        let staging = FakeStaging::with_response(staged);
         let (uc, buffer) =
-            build_uc_with_buffer_and_staging_expect_applied("entry-file-1", staging.clone());
+            build_uc_with_buffer_and_staging_expect_applied("entry-file-1", staging_never_called());
 
-        // step 1: PUT /file/{name}
+        // step 1: PUT /file/{name} 的最终结果 —— 字节已被 staging 流式落盘,
+        // event 只挂 URI 入 buffer。
         uc.execute(input_buffer_file(
             "doc.pdf",
             "application/pdf",
-            vec![0x25, 0x50, 0x44, 0x46], // %PDF
+            "file:///tmp/mobile_inbound/abcdef012345/doc.pdf",
+            "doc.pdf",
         ))
         .await
         .unwrap();
@@ -1286,20 +1280,12 @@ mod tests {
             }
         );
         assert_eq!(buffer.len(), 0, "file branch should drain buffer");
-
-        // staging 被调用一次, 入参检查
-        let (scope, name, mime, bytes) =
-            staging.last_call().expect("staging should be called once");
-        assert!(!scope.is_empty(), "scope_id should be a non-empty nonce");
-        assert_eq!(name, "doc.pdf");
-        assert_eq!(mime, "application/pdf");
-        assert_eq!(bytes, vec![0x25, 0x50, 0x44, 0x46]);
     }
 
-    /// File 缺 dataName → `DecodeFailed`, 不进 inbound, staging 不被调用。
+    /// File 缺 dataName → `DecodeFailed`, 不进 inbound。
     #[tokio::test]
     async fn file_decode_failed_on_missing_data_name() {
-        let staging = FakeStaging::never_called();
+        let staging = staging_never_called();
         let buffer = Arc::new(IncomingMobileBuffer::new());
         let uc = build_uc_with_staging_expect_no_inbound(staging, buffer);
         let outcome = uc
@@ -1313,10 +1299,10 @@ mod tests {
     }
 
     /// File buffer miss(没有先 PUT /file 就 PUT /json)→ `DecodeFailed`,
-    /// 不进 inbound, staging 不被调用。
+    /// 不进 inbound。
     #[tokio::test]
     async fn file_decode_failed_on_buffer_miss() {
-        let staging = FakeStaging::never_called();
+        let staging = staging_never_called();
         let buffer = Arc::new(IncomingMobileBuffer::new());
         let uc = build_uc_with_staging_expect_no_inbound(staging, buffer);
         let outcome = uc
@@ -1333,44 +1319,11 @@ mod tests {
         ));
     }
 
-    /// staging port IO 失败 → use case 翻成 `Internal`(application 错误,
-    /// 路由 → HTTP 500), 不进 inbound, buffer 已被 take(空)。
-    #[tokio::test]
-    async fn file_internal_error_on_staging_io_failure() {
-        let staging = FakeStaging::with_error(MobileFileStagingError::Io(
-            "disk full / permission denied".into(),
-        ));
-        let buffer = Arc::new(IncomingMobileBuffer::new());
-        // 预 seed 一份 file 字节
-        buffer.store(
-            "doc.pdf".into(),
-            "application/pdf".into(),
-            vec![0x25, 0x50, 0x44, 0x46],
-            "mobile-lan:test-io".into(),
-        );
-
-        let uc = build_uc_with_staging_expect_no_inbound(staging, buffer.clone());
-        let err = uc
-            .execute(input_sync_doc(
-                SyncClipboardItemType::File,
-                "doc.pdf",
-                Some("doc.pdf"),
-            ))
-            .await
-            .expect_err("staging IO failure should propagate as Err");
-        assert!(matches!(err, ApplyIncomingMobileClipError::Internal(_)));
-        // buffer 已经被 take 走(staging 调用前会 buffer.take), 即便 staging 失败
-        // 也不会回滚 —— 字节已经丢失,但这是协议接受范围(iPhone 会重传)。
-        assert_eq!(buffer.len(), 0, "buffer is taken before staging is called");
-    }
-
-    /// 跨平台 URI 编码 plumbing:mock staging 注入"Windows-shape" URI,
+    /// 跨平台 URI 编码 plumbing:BufferFile 注入"Windows-shape" URI,
     /// 校验 file-list rep bytes 严格按 `\n` 分隔单条 URI 写出。验证 use
-    /// case 不对 URI 形态做任何假设(平台细节由 adapter 负责)。
+    /// case 不对 URI 形态做任何假设(平台细节由 staging adapter 决定)。
     #[tokio::test]
     async fn file_uri_list_rep_propagates_adapter_uri_verbatim() {
-        // 装 inbound 的 capture mock,withf 校验 snapshot 里有 file-list rep
-        // 且 bytes == "{uri}\n",scope_id 不参与字节(只参与 path)。
         let mut repo = MockEntryRepo::new();
         repo.expect_find_entry_id_by_snapshot_hash()
             .times(1)
@@ -1403,28 +1356,24 @@ mod tests {
         let inbound =
             ApplyInboundClipboardUseCase::new(Arc::new(repo), Arc::new(capture), Arc::new(write));
         let buffer = Arc::new(IncomingMobileBuffer::new());
-        let staging = FakeStaging::with_response(StagedFile {
-            uri: uc_core::mobile_sync::StagedFileUri::new(
-                "file:///C:/Users/mark/AppData/Local/uc/mobile_inbound/abc/My%20Photo.png",
-            ),
-            sanitized_name: "My Photo.png".into(),
-        });
         let uc = ApplyIncomingMobileClipUseCase::new(
             Arc::new(inbound),
             buffer.clone(),
-            staging,
+            staging_never_called(),
             Arc::new(FixedClock),
             None,
             None,
         );
 
-        // 预 seed buffer
-        buffer.store(
-            "My Photo.png".into(),
-            "image/png".into(),
-            vec![0x89, 0x50, 0x4E, 0x47],
-            "mobile-lan:test-win".into(),
-        );
+        // BufferFile event 注入 Windows-shape URI
+        uc.execute(input_buffer_file(
+            "My Photo.png",
+            "application/octet-stream",
+            "file:///C:/Users/mark/AppData/Local/uc/mobile_inbound/abc/My%20Photo.png",
+            "My Photo.png",
+        ))
+        .await
+        .unwrap();
 
         let outcome = uc
             .execute(input_sync_doc(
@@ -1473,7 +1422,7 @@ mod tests {
         let uc = ApplyIncomingMobileClipUseCase::new(
             Arc::new(inbound),
             Arc::new(IncomingMobileBuffer::new()),
-            FakeStaging::never_called(),
+            staging_never_called(),
             Arc::new(FixedClock),
             None,
             None,
@@ -1553,7 +1502,7 @@ mod tests {
         let uc = ApplyIncomingMobileClipUseCase::new(
             Arc::new(inbound),
             Arc::new(IncomingMobileBuffer::new()),
-            FakeStaging::never_called(),
+            staging_never_called(),
             Arc::new(FixedClock),
             None,
             Some(Arc::clone(&recorder) as Arc<dyn MobileInboundFanOutPort>),
@@ -1601,7 +1550,7 @@ mod tests {
         let uc = ApplyIncomingMobileClipUseCase::new(
             Arc::new(inbound),
             Arc::new(IncomingMobileBuffer::new()),
-            FakeStaging::never_called(),
+            staging_never_called(),
             Arc::new(FixedClock),
             None,
             Some(Arc::clone(&recorder) as Arc<dyn MobileInboundFanOutPort>),
@@ -1640,7 +1589,7 @@ mod tests {
         let uc = ApplyIncomingMobileClipUseCase::new(
             Arc::new(inbound),
             Arc::new(IncomingMobileBuffer::new()),
-            FakeStaging::never_called(),
+            staging_never_called(),
             Arc::new(FixedClock),
             None,
             Some(Arc::clone(&recorder) as Arc<dyn MobileInboundFanOutPort>),
@@ -1687,7 +1636,7 @@ mod tests {
         let uc = ApplyIncomingMobileClipUseCase::new(
             Arc::new(inbound),
             Arc::new(IncomingMobileBuffer::new()),
-            FakeStaging::never_called(),
+            staging_never_called(),
             Arc::new(FixedClock),
             None,
             None,

--- a/src-tauri/crates/uc-application/src/usecases/mobile_sync/get_file.rs
+++ b/src-tauri/crates/uc-application/src/usecases/mobile_sync/get_file.rs
@@ -262,7 +262,7 @@ mod tests {
     use mockall::predicate::*;
     use uc_core::clipboard::MimeType;
     use uc_core::ids::{EntryId, FormatId};
-    use uc_core::mobile_sync::{LatestPasteRepresentation, StagedFile};
+    use uc_core::mobile_sync::{LatestPasteRepresentation, StagedFile, StagingHandle};
 
     mockall::mock! {
         SnapPort {}
@@ -274,53 +274,58 @@ mod tests {
         }
     }
 
-    /// Fake staging: 默认 `read_by_uri` panic; 可注入预设响应。
-    /// Image / Text / port-error 路径不调 staging,默认 panic 形态自带防回归。
-    #[derive(Default)]
-    struct FakeStaging {
-        read_response: std::sync::Mutex<Option<Result<Vec<u8>, MobileFileStagingError>>>,
+    // get_file 只触达 staging 的 `read_by_uri` —— 其它方法被调到都是回归;
+    // mockall strict mode 下未配置即 panic, 默认形态就承担"防回归"职责。
+    mockall::mock! {
+        Staging {}
+        #[async_trait]
+        impl MobileFileStagingPort for Staging {
+            async fn stage_file(
+                &self,
+                scope_id: &str,
+                data_name: &str,
+                mime: &str,
+                bytes: Vec<u8>,
+            ) -> Result<StagedFile, MobileFileStagingError>;
+            async fn read_by_uri(&self, uri: &str) -> Result<Vec<u8>, MobileFileStagingError>;
+            async fn begin_stage(
+                &self,
+                scope_id: &str,
+                data_name: &str,
+                mime: &str,
+            ) -> Result<StagingHandle, MobileFileStagingError>;
+            async fn append_stage_chunk(
+                &self,
+                handle: &StagingHandle,
+                chunk: &[u8],
+            ) -> Result<(), MobileFileStagingError>;
+            async fn finalize_stage(
+                &self,
+                handle: StagingHandle,
+            ) -> Result<StagedFile, MobileFileStagingError>;
+            async fn abort_stage(&self, handle: StagingHandle);
+        }
     }
 
-    impl FakeStaging {
-        fn never_called() -> Arc<Self> {
-            Arc::new(Self::default())
-        }
-        fn with_read_response(r: Result<Vec<u8>, MobileFileStagingError>) -> Arc<Self> {
-            Arc::new(Self {
-                read_response: std::sync::Mutex::new(Some(r)),
-            })
-        }
+    fn staging_never_called() -> Arc<MockStaging> {
+        Arc::new(MockStaging::new())
     }
 
-    #[async_trait]
-    impl MobileFileStagingPort for FakeStaging {
-        async fn stage_file(
-            &self,
-            _: &str,
-            _: &str,
-            _: &str,
-            _: Vec<u8>,
-        ) -> Result<StagedFile, MobileFileStagingError> {
-            unreachable!("get_file tests must not call stage_file")
-        }
-        async fn read_by_uri(&self, _uri: &str) -> Result<Vec<u8>, MobileFileStagingError> {
-            self.read_response
-                .lock()
-                .unwrap()
-                .take()
-                .unwrap_or_else(|| panic!("FakeStaging.read_by_uri called without preset response"))
-        }
+    fn staging_with_read_response(r: Result<Vec<u8>, MobileFileStagingError>) -> Arc<MockStaging> {
+        let mut mock = MockStaging::new();
+        mock.expect_read_by_uri().times(1).return_once(move |_| r);
+        Arc::new(mock)
     }
 
     fn build_uc_returning(
         rep: Result<Option<LatestPasteRepresentation>, LatestClipboardSnapshotError>,
     ) -> GetMobileSyncFileUseCase {
-        build_uc_returning_with_staging(rep, FakeStaging::never_called())
+        build_uc_returning_with_staging(rep, staging_never_called())
     }
 
     fn build_uc_returning_with_staging(
         rep: Result<Option<LatestPasteRepresentation>, LatestClipboardSnapshotError>,
-        staging: Arc<FakeStaging>,
+        staging: Arc<MockStaging>,
     ) -> GetMobileSyncFileUseCase {
         let mut port = MockSnapPort::new();
         port.expect_latest_paste_representation()
@@ -417,7 +422,7 @@ mod tests {
         // application/octet-stream(SyncClipboard 协议字段对 Shortcut 端无强
         // 语义,扩展名信息走 dataName)。
         let real_bytes = vec![0x25, 0x50, 0x44, 0x46, 0x2D, 0x31, 0x2E, 0x37]; // %PDF-1.7
-        let staging = FakeStaging::with_read_response(Ok(real_bytes.clone()));
+        let staging = staging_with_read_response(Ok(real_bytes.clone()));
         let payload = b"file:///Users/Alice/Documents/note.pdf".to_vec();
         let uc = build_uc_returning_with_staging(
             Ok(Some(rep(
@@ -437,7 +442,7 @@ mod tests {
     async fn file_rep_staging_not_found_returns_not_found() {
         // staging 返 NotFound(URI 不在白名单根 / 文件被运维删) → use case
         // 翻 NotFound,iPhone 收 HTTP 404 不报错。
-        let staging = FakeStaging::with_read_response(Err(MobileFileStagingError::NotFound));
+        let staging = staging_with_read_response(Err(MobileFileStagingError::NotFound));
         let payload = b"file:///orphan/path/doc.pdf".to_vec();
         let uc = build_uc_returning_with_staging(
             Ok(Some(rep(
@@ -456,7 +461,7 @@ mod tests {
     async fn file_rep_staging_io_error_returns_staging_variant() {
         // staging 返 Io(权限 / 中途读盘失败) → use case 翻 Staging(_),
         // 路由层 → HTTP 500。
-        let staging = FakeStaging::with_read_response(Err(MobileFileStagingError::Io(
+        let staging = staging_with_read_response(Err(MobileFileStagingError::Io(
             "simulated permission denied".into(),
         )));
         let payload = b"file:///somewhere/doc.pdf".to_vec();
@@ -477,7 +482,7 @@ mod tests {
     async fn file_rep_with_unparseable_uri_list_returns_not_found() {
         // rep.bytes 全空 / 全是注释 → parse_first_uri 返 None → NotFound。
         // staging 不应被调用(默认 FakeStaging 没设响应,被调到会 panic)。
-        let staging = FakeStaging::never_called();
+        let staging = staging_never_called();
         let payload = b"# only a comment\n\n# another\n".to_vec();
         let uc = build_uc_returning_with_staging(
             Ok(Some(rep(
@@ -521,7 +526,7 @@ mod tests {
         // SyncClipboard request URLs can come back URL-decoded by axum;
         // derive_data_name does percent decode → matches "My Photo.jpg".
         // P5a.3.5: 命中后走 staging 读真字节,而不是返 URI list。
-        let staging = FakeStaging::with_read_response(Ok(b"jpeg-real-bytes".to_vec()));
+        let staging = staging_with_read_response(Ok(b"jpeg-real-bytes".to_vec()));
         let payload = b"file:///tmp/My%20Photo.jpg".to_vec();
         let uc = build_uc_returning_with_staging(
             Ok(Some(rep(

--- a/src-tauri/crates/uc-bootstrap/src/non_gui_runtime.rs
+++ b/src-tauri/crates/uc-bootstrap/src/non_gui_runtime.rs
@@ -17,14 +17,14 @@ use uc_application::deps::AppDeps;
 use uc_application::facade::space_setup::SpaceSetupFacade;
 use uc_application::facade::{
     AppFacade, AppFacadeParts, AppPaths, BlobTransferFacade, ClipboardHistoryFacade,
-    ClipboardHistoryFacadeDeps, ClipboardRestoreFacade, ClipboardRestoreFacadeDeps,
-    ClipboardSyncFacade, DeviceFacade, EmitError, EncryptionFacade, EncryptionFacadeDeps,
-    FileTransferFacade, HostEvent, HostEventEmitterPort, InMemoryLifecycleStatus,
-    IncomingMobileBuffer, LifecycleFacade, LifecycleFacadeDeps, LifecycleStatusGateway,
-    MemberRosterFacade, MobileSyncFacade, MobileSyncFacadeDeps, MobileSyncSnapshotPorts,
-    ResourceFacade, ResourceFacadeDeps, SearchCoordinator, SearchCoordinatorDeps, SearchFacade,
-    SearchFacadeDeps, SettingsFacade, StorageFacade, StorageFacadeDeps, UpgradeFacade,
-    UpgradeFacadeDeps,
+    ClipboardHistoryFacadeDeps, ClipboardOutboundFacade, ClipboardRestoreFacade,
+    ClipboardRestoreFacadeDeps, ClipboardSyncFacade, DeviceFacade, EmitError, EncryptionFacade,
+    EncryptionFacadeDeps, FileTransferFacade, HostEvent, HostEventEmitterPort,
+    InMemoryLifecycleStatus, IncomingMobileBuffer, LifecycleFacade, LifecycleFacadeDeps,
+    LifecycleStatusGateway, MemberRosterFacade, MobileSyncFacade, MobileSyncFacadeDeps,
+    MobileSyncSnapshotPorts, ResourceFacade, ResourceFacadeDeps, SearchCoordinator,
+    SearchCoordinatorDeps, SearchFacade, SearchFacadeDeps, SettingsFacade, StorageFacade,
+    StorageFacadeDeps, UpgradeFacade, UpgradeFacadeDeps,
 };
 use uc_application::{
     ApplyInboundClipboardUseCase, InboundCapture as ApplyInboundCapture,
@@ -185,6 +185,19 @@ pub fn build_mobile_sync_facade(
     // start/stop/rebind listener。CLI fallback 传 `None`,settings 只写盘,
     // 等下次 daemon 进程启动一次性读取(与本字段引入前完全一致的行为)。
     lan_lifecycle: Option<Arc<dyn uc_core::ports::MobileLanLifecyclePort>>,
+    // 同进程内已构造好的 `ClipboardOutboundFacade`(daemon 启动时装配)。
+    // 装入时,移动端 PUT 落地本机后会异步把同一份 snapshot 走"本机捕获
+    // → 出站"完整管线 fan-out 给 Space 内其他已配对设备 ——
+    //
+    // - 文本 / 小图 inline 进 V3 envelope;
+    // - 大图自动剥成 iroh-blobs ref;
+    // - **文件**:`publish_blob_path` 流式发布到 iroh-blobs, 构造 free-file
+    //   V3BlobRef, 接收端拉回并改写 file-list rep 成本机 URI ——
+    //   "手机文件 → 其他桌面"的真正传输靠这条路径成立。
+    //
+    // CLI fallback / 不接 P2P 出站的入口传 `None`, mobile 上传仅落地本机,
+    // 不传播。
+    clipboard_outbound: Option<Arc<ClipboardOutboundFacade>>,
 ) -> Arc<MobileSyncFacade> {
     Arc::new(MobileSyncFacade::new(MobileSyncFacadeDeps {
         clock: deps.system.clock.clone(),
@@ -208,6 +221,7 @@ pub fn build_mobile_sync_facade(
             blob_reader: deps.storage.blob_store.clone(),
         },
         file_transfer,
+        clipboard_outbound,
         lan_lifecycle,
     }))
 }
@@ -296,6 +310,14 @@ pub fn build_app_facade_from_deps(
                 options.file_transfer.clone(),
                 // CLI fallback 装配:无常驻 daemon, 不需要 in-process hot-swap。
                 // settings 改动等下次 daemon 进程启动一次性生效。
+                None,
+                // CLI fallback 不接 outbound dispatcher(`ClipboardOutboundFacade`
+                // 装配链需要 worker 装配过程提供, 见
+                // `uc-desktop::daemon::runtime_assembly`),mobile 上传仅落地
+                // 本机, 不向其他 paired peers fan-out。daemon 入口走
+                // `build_daemon_lifecycle_facades` 那条路径, 在那里以
+                // `Some(clipboard_outbound)` 装入完整 fan-out 能力(含文件 blob
+                // 发布)。
                 None,
             )
         });

--- a/src-tauri/crates/uc-core/src/mobile_sync/mod.rs
+++ b/src-tauri/crates/uc-core/src/mobile_sync/mod.rs
@@ -21,4 +21,4 @@ pub use device::{MobileClientType, MobileDevice, MobileDeviceError, MobileDevice
 pub use endpoint::{LanEndpointInfo, LanListenerStatus};
 pub use lan_interface::LanInterface;
 pub use latest_paste::LatestPasteRepresentation;
-pub use staged_file::{StagedFile, StagedFileUri};
+pub use staged_file::{StagedFile, StagedFileUri, StagingHandle};

--- a/src-tauri/crates/uc-core/src/mobile_sync/staged_file.rs
+++ b/src-tauri/crates/uc-core/src/mobile_sync/staged_file.rs
@@ -44,3 +44,42 @@ pub struct StagedFile {
     /// use case 不直接消费它,但保留在返回值里方便日志 / 排障。
     pub sanitized_name: String,
 }
+
+/// 一次"分块写入中"staging 会话的不透明引用。
+///
+/// 由 staging adapter 在 begin 阶段生成,在后续 append / finalize / abort
+/// 调用中作为这一会话的唯一句柄。token 本身只是个 UUID —— 真正的文件句柄
+/// 与目标 path 由 adapter 在内部按 token 索引维护,uc-core 不感知任何 IO
+/// 资源细节。
+///
+/// 生命周期约束:
+/// - 同一 handle 只能进入 `finalize_stage` **或** `abort_stage` 一次;之后
+///   adapter 已释放对应资源,handle 视为消费完毕,继续传入是协议违规。
+/// - 单笔 staging 会话只允许串行 append;并发 append 同一 handle 的语义
+///   未定义(adapter 可选检测并报错,也可直接交叠写入产生损坏数据)。
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct StagingHandle(uuid::Uuid);
+
+impl StagingHandle {
+    /// 由 adapter 生成新句柄(随机 UUID v4)。
+    pub fn new() -> Self {
+        Self(uuid::Uuid::new_v4())
+    }
+
+    /// 暴露内部 UUID,仅供 adapter 内部按 token 索引资源使用。
+    pub fn token(&self) -> uuid::Uuid {
+        self.0
+    }
+}
+
+impl Default for StagingHandle {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl std::fmt::Display for StagingHandle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0.to_string())
+    }
+}

--- a/src-tauri/crates/uc-core/src/ports/mobile_sync.rs
+++ b/src-tauri/crates/uc-core/src/ports/mobile_sync.rs
@@ -12,7 +12,7 @@ use thiserror::Error;
 
 use crate::mobile_sync::{
     LanEndpointInfo, LanInterface, LanListenerStatus, LatestPasteRepresentation, MintedCredentials,
-    MobileDevice, MobileDeviceError, MobileDeviceId, StagedFile,
+    MobileDevice, MobileDeviceError, MobileDeviceId, StagedFile, StagingHandle,
 };
 
 // ─── credentials minter ──────────────────────────────────────────────────
@@ -340,6 +340,72 @@ pub trait MobileFileStagingPort: Send + Sync {
     /// adapter **不**负责 mime 推断;use case 端按 dataName 扩展名 / SyncClipboard
     /// 协议默认 (`application/octet-stream`) 决定 wire mime。
     async fn read_by_uri(&self, uri: &str) -> Result<Vec<u8>, MobileFileStagingError>;
+
+    /// 开启一段"分块写入"的 staging 会话,返回一个不透明 [`StagingHandle`]
+    /// 供后续 `append_stage_chunk` / `finalize_stage` / `abort_stage` 使用。
+    ///
+    /// 与 [`Self::stage_file`] 的区别:全量字节模式要求调用方先把整个 payload
+    /// 装入内存,本方法允许在收字节的过程中边收边落盘,内存占用与单个 chunk
+    /// 同阶。`data_name` 的 sanitize 与 `scope_id` 的目录隔离语义与 `stage_file`
+    /// 完全等价。`mime` 仅用于排障日志,不参与文件落盘行为。
+    ///
+    /// 错误形态:
+    /// - `InvalidDataName`:sanitize 后兜底仍失败(实际很难触发);
+    /// - `Io`:mkdir / 创建文件失败。
+    ///
+    /// 会话生命周期由 handle 唯一界定 —— adapter 保证:
+    /// - 同一 handle 的资源(打开的 fd / 临时 path)在 `finalize_stage` 或
+    ///   `abort_stage` 返回后必定释放;
+    /// - 在 begin 与 finalize/abort 之间崩溃的 handle 视为 abandoned,
+    ///   adapter 可在后续清理周期回收。
+    async fn begin_stage(
+        &self,
+        scope_id: &str,
+        data_name: &str,
+        mime: &str,
+    ) -> Result<StagingHandle, MobileFileStagingError>;
+
+    /// 把 `chunk` 追加写入由 `handle` 标识的 staging 会话。
+    ///
+    /// 单笔会话只允许**串行** append;同一 handle 的并发 append 语义未定义。
+    /// chunk 大小由调用方决定,adapter 不做窗口聚合;0 字节 chunk 合法且为 no-op。
+    ///
+    /// 错误形态:
+    /// - `Io`:写盘 / 句柄无效(handle 已 finalize/abort 过 / handle 从未由本
+    ///   adapter 颁发)。无独立"未知 handle"变体 —— 协议违规 ≈ IO 故障,
+    ///   都翻成应用层 `Internal`。
+    ///
+    /// 失败后会话状态由 adapter 决定;调用方在收到 `Err` 后应立即调
+    /// `abort_stage` 释放资源,不应再次调本方法。
+    async fn append_stage_chunk(
+        &self,
+        handle: &StagingHandle,
+        chunk: &[u8],
+    ) -> Result<(), MobileFileStagingError>;
+
+    /// 结束一段 staging 会话,消费 `handle`,产出可拼 file-list rep 的
+    /// [`StagedFile`]。
+    ///
+    /// 语义:adapter 保证返回前已 `flush` + `sync_all`,落盘对后续 reader
+    /// 可见。失败时 adapter 自行回收已落盘的部分数据。
+    ///
+    /// 错误形态:
+    /// - `Io`:flush / fsync / URI 派生失败 / handle 已被消费过。
+    async fn finalize_stage(
+        &self,
+        handle: StagingHandle,
+    ) -> Result<StagedFile, MobileFileStagingError>;
+
+    /// 放弃一段 staging 会话,消费 `handle`,best-effort 释放资源(关句柄、
+    /// 删半写入的文件)。
+    ///
+    /// **不**返回 `Result`:调用本方法必然处在已经失败的路径上(客户端断流 /
+    /// chunk 写盘失败 / 上层取消),二次失败只值得 warn 一行,不应再扰动
+    /// 上层错误处理。
+    ///
+    /// 幂等性:重复 abort 同一 handle 行为 = 静默 no-op(adapter 内部 entry
+    /// 已不存在),不报错。
+    async fn abort_stage(&self, handle: StagingHandle);
 }
 
 #[derive(Debug, Error)]

--- a/src-tauri/crates/uc-desktop/src/daemon/app_facade_assembly.rs
+++ b/src-tauri/crates/uc-desktop/src/daemon/app_facade_assembly.rs
@@ -13,7 +13,8 @@ use std::sync::Arc;
 
 use uc_application::deps::AppDeps;
 use uc_application::facade::{
-    AppPaths, BlobTransferFacade, ClipboardSyncFacade, DaemonLifecycleFacades, FileTransferFacade,
+    AppPaths, BlobTransferFacade, ClipboardOutboundFacade, ClipboardSyncFacade,
+    DaemonLifecycleFacades, FileTransferFacade,
 };
 use uc_application::ApplyInboundClipboardUseCase;
 use uc_bootstrap::{build_mobile_sync_facade, SpaceSetupAssembly};
@@ -36,6 +37,13 @@ pub struct DaemonLifecycleFacadesInput<'a> {
     /// (本字段) 与 InboundClipboardFacade (worker 装配),让 LAN PUT 路径
     /// 与 P2P 入站走同一条 ApplyInbound 链 (host event 单一源 / blob 状态共享)。
     pub mobile_sync_apply_inbound: Arc<ApplyInboundClipboardUseCase>,
+    /// daemon worker 装配过程中构造的 `ClipboardOutboundFacade`(与
+    /// `ClipboardWatcherWorker` 共用一份)。同一份实例喂给 mobile_sync
+    /// facade, 让"移动端 PUT 落地本机 → fan-out 给其他桌面"完全走本机捕获
+    /// 的同一条出站管线 ——
+    /// 文件 blob 发布、大图 V3BlobRef 剥离、`OutboundSyncPlanner` 控制
+    /// 都自动适用, 不再重复实现。
+    pub clipboard_outbound: Arc<ClipboardOutboundFacade>,
     /// LAN 监听器生命周期 port —— 让 `update_settings` 写盘后立即把
     /// listener 状态对齐到新设置, 无需重启进程。同一份 controller 实例同时
     /// 喂给 `MobileSyncFacade`(本字段) 与 daemon `run()`(`DaemonApp`),
@@ -57,6 +65,7 @@ pub fn build_daemon_lifecycle_facades(
         blob_transfer,
         file_transfer,
         mobile_sync_apply_inbound,
+        clipboard_outbound,
         lan_lifecycle,
     } = input;
 
@@ -66,6 +75,13 @@ pub fn build_daemon_lifecycle_facades(
         mobile_sync_apply_inbound.clone(),
         Some(file_transfer),
         Some(lan_lifecycle),
+        // 让 mobile_sync facade 在 PUT 落地本机后自动把同一份 snapshot 走
+        // 本机捕获完全相同的出站管线 fan-out 给 Space 内其他已配对设备
+        // —— 闭合"手机 → 任一桌面 → 所有桌面"链路, 文件类型走
+        // iroh-blobs free-file ref(`publish_blob_path`),接收端拉回并改
+        // 写 file-list rep。daemon 这条装配路径必装,CLI fallback 与其他
+        // 无 outbound dispatcher 的入口走 `None`。
+        Some(Arc::clone(&clipboard_outbound)),
     );
 
     let local_device_id = deps.device.device_identity.current_device_id().to_string();

--- a/src-tauri/crates/uc-desktop/src/daemon/host.rs
+++ b/src-tauri/crates/uc-desktop/src/daemon/host.rs
@@ -241,6 +241,7 @@ pub(crate) async fn start_in_process(
             blob_transfer: blob_transfer_facade.clone(),
             file_transfer: file_transfer_facade.clone(),
             mobile_sync_apply_inbound: runtime_workers.apply_inbound.clone(),
+            clipboard_outbound: runtime_workers.clipboard_outbound.clone(),
             lan_lifecycle: Arc::clone(&mobile_lan_lifecycle)
                 as Arc<dyn uc_core::ports::MobileLanLifecyclePort>,
         });

--- a/src-tauri/crates/uc-desktop/src/daemon/runtime_assembly.rs
+++ b/src-tauri/crates/uc-desktop/src/daemon/runtime_assembly.rs
@@ -50,11 +50,19 @@ pub struct DaemonRuntimeAssemblyInput<'a> {
 /// `ApplyInboundClipboardUseCase` 实例 (带 blob materializer + host event
 /// emitter)。同一份实例还要通过 `build_daemon_app_facade` 喂给 mobile
 /// sync facade,所以放进本结构以便 host.rs 共享。P5a.6 引入。
+///
+/// `clipboard_outbound` 同样不是 worker, 而是 worker 装配过程构造的
+/// `ClipboardOutboundFacade` 实例 ——
+/// `ClipboardWatcherWorker` 用它把本机捕获 fan-out 给 paired peers;
+/// `MobileSyncFacade` 也共享这一份, 让"手机上传 → 本机入站 → 同一条
+/// 出站管线 fan-out 给其他桌面"成立, 文件类型的 blob 发布逻辑只此一处,
+/// 不重复实现。
 pub struct DaemonRuntimeWorkers {
     pub clipboard_watcher: Arc<ClipboardWatcherWorker>,
     pub inbound_clipboard_sync: Arc<InboundClipboardSyncWorker>,
     pub file_sync_orchestrator: Arc<FileSyncOrchestratorWorker>,
     pub apply_inbound: Arc<ApplyInboundClipboardUseCase>,
+    pub clipboard_outbound: Arc<ClipboardOutboundFacade>,
 }
 
 /// 构造 daemon runtime worker。
@@ -118,7 +126,7 @@ pub fn build_daemon_runtime_workers(
         input.clipboard_capture_gate,
         clipboard_capture_facade,
         clipboard_live_index_facade,
-        clipboard_outbound_facade,
+        clipboard_outbound_facade.clone(),
     ));
     let clipboard_watcher = Arc::new(ClipboardWatcherWorker::new(
         local_clipboard,
@@ -140,5 +148,6 @@ pub fn build_daemon_runtime_workers(
         inbound_clipboard_sync,
         file_sync_orchestrator,
         apply_inbound: apply_inbound_uc,
+        clipboard_outbound: clipboard_outbound_facade,
     })
 }

--- a/src-tauri/crates/uc-infra/src/mobile_sync/file_staging.rs
+++ b/src-tauri/crates/uc-infra/src/mobile_sync/file_staging.rs
@@ -45,13 +45,18 @@
 //! 路径白名单:URI 字面 → `tokio::fs::read`,文件不存在 → `NotFound`,
 //! 读盘失败 → `Io`。
 
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use tokio::fs::File;
+use tokio::io::AsyncWriteExt;
+use tokio::sync::Mutex;
 use tracing::{debug, warn};
+use uuid::Uuid;
 
-use uc_core::mobile_sync::{StagedFile, StagedFileUri};
+use uc_core::mobile_sync::{StagedFile, StagedFileUri, StagingHandle};
 use uc_core::ports::{MobileFileStagingError, MobileFileStagingPort};
 
 /// 子目录名 —— `<cache_root>/mobile_inbound/<scope_id>/<file>`。
@@ -60,9 +65,25 @@ const STAGING_SUBDIR: &str = "mobile_inbound";
 /// sanitize 失败时的兜底文件名。
 const FALLBACK_FILENAME: &str = "staged.bin";
 
+/// 单次 streaming staging 会话的内部状态(adapter 私有,不出 crate)。
+///
+/// `path` / `sanitized_name` / `scope_segment` 都在 begin 阶段一次性算定,
+/// finalize 拼 URI / abort 尝试清空 scope 目录都直接用,避免 finalize/abort
+/// 阶段再重算 sanitize。
+struct OpenStagingSession {
+    file: File,
+    path: PathBuf,
+    sanitized_name: String,
+    scope_segment: String,
+}
+
 pub struct FilesystemMobileFileStaging {
     /// `stage_file` 写盘用的 root(典型: `AppPaths.file_cache_dir`)。
     cache_root: PathBuf,
+    /// 进行中的 streaming staging 会话:token → 打开的 File + 元数据。
+    /// 用 tokio Mutex(append_stage_chunk 在异步上下文写盘,持锁跨 await
+    /// 必须用 async-aware mutex 否则会阻塞 runtime worker)。
+    open_sessions: Mutex<HashMap<Uuid, OpenStagingSession>>,
 }
 
 impl FilesystemMobileFileStaging {
@@ -86,7 +107,10 @@ impl FilesystemMobileFileStaging {
             cache_root = %cache_root.display(),
             "mobile_sync staging: adapter ready"
         );
-        Arc::new(Self { cache_root })
+        Arc::new(Self {
+            cache_root,
+            open_sessions: Mutex::new(HashMap::new()),
+        })
     }
 
     fn staging_root(&self) -> PathBuf {
@@ -179,6 +203,169 @@ impl MobileFileStagingPort for FilesystemMobileFileStaging {
             uri: StagedFileUri::new(uri),
             sanitized_name: sanitized,
         })
+    }
+
+    async fn begin_stage(
+        &self,
+        scope_id: &str,
+        data_name: &str,
+        mime: &str,
+    ) -> Result<StagingHandle, MobileFileStagingError> {
+        let sanitized = sanitize_basename(data_name);
+        let scope_segment = sanitize_scope(scope_id);
+        let entry_dir = self.staging_root().join(&scope_segment);
+        tokio::fs::create_dir_all(&entry_dir).await.map_err(|e| {
+            MobileFileStagingError::Io(format!(
+                "create staging dir {} failed: {e}",
+                entry_dir.display()
+            ))
+        })?;
+
+        let file_path = entry_dir.join(&sanitized);
+        // create(true) + truncate(true):同一 scope 内重名 → 后者覆盖。scope_id
+        // 由调用方按"每次入站事件取 uuid nonce"语义生成,正常路径下不会撞;
+        // 撞了也是上游 bug,本层不藏。
+        let file = tokio::fs::File::create(&file_path).await.map_err(|e| {
+            MobileFileStagingError::Io(format!(
+                "create staging file {} failed: {e}",
+                file_path.display()
+            ))
+        })?;
+
+        let handle = StagingHandle::new();
+        let token = handle.token();
+        let mut sessions = self.open_sessions.lock().await;
+        sessions.insert(
+            token,
+            OpenStagingSession {
+                file,
+                path: file_path.clone(),
+                sanitized_name: sanitized.clone(),
+                scope_segment: scope_segment.clone(),
+            },
+        );
+        debug!(
+            handle = %token,
+            scope_id = %scope_segment,
+            data_name = %data_name,
+            sanitized = %sanitized,
+            mime = %mime,
+            path = %file_path.display(),
+            "mobile_sync staging: streaming session opened"
+        );
+        Ok(handle)
+    }
+
+    async fn append_stage_chunk(
+        &self,
+        handle: &StagingHandle,
+        chunk: &[u8],
+    ) -> Result<(), MobileFileStagingError> {
+        if chunk.is_empty() {
+            return Ok(());
+        }
+        let token = handle.token();
+        let mut sessions = self.open_sessions.lock().await;
+        let session = sessions.get_mut(&token).ok_or_else(|| {
+            MobileFileStagingError::Io(format!(
+                "append_stage_chunk: unknown or already-consumed handle {token}"
+            ))
+        })?;
+        session.file.write_all(chunk).await.map_err(|e| {
+            MobileFileStagingError::Io(format!(
+                "append_stage_chunk write {} bytes to {} failed: {e}",
+                chunk.len(),
+                session.path.display()
+            ))
+        })?;
+        Ok(())
+    }
+
+    async fn finalize_stage(
+        &self,
+        handle: StagingHandle,
+    ) -> Result<StagedFile, MobileFileStagingError> {
+        let token = handle.token();
+        let mut session = {
+            let mut sessions = self.open_sessions.lock().await;
+            sessions.remove(&token).ok_or_else(|| {
+                MobileFileStagingError::Io(format!(
+                    "finalize_stage: unknown or already-consumed handle {token}"
+                ))
+            })?
+        };
+        // flush + fsync:后续 SyncDoc 阶段会立即 add_path 给 iroh 发布,
+        // 未 sync 的 page cache 在 crash 时可能丢,显式 sync_all 把这条 race
+        // 关掉。代价是大文件多几十 ms,可接受。
+        session.file.flush().await.map_err(|e| {
+            MobileFileStagingError::Io(format!(
+                "finalize_stage flush {} failed: {e}",
+                session.path.display()
+            ))
+        })?;
+        session.file.sync_all().await.map_err(|e| {
+            MobileFileStagingError::Io(format!(
+                "finalize_stage sync_all {} failed: {e}",
+                session.path.display()
+            ))
+        })?;
+        // 显式 drop 让 fd 释放(否则要等 session 出作用域)。
+        drop(session.file);
+
+        let uri = path_to_file_uri(&session.path)?;
+        debug!(
+            handle = %token,
+            scope_id = %session.scope_segment,
+            sanitized = %session.sanitized_name,
+            path = %session.path.display(),
+            uri = %uri,
+            "mobile_sync staging: streaming session finalized"
+        );
+        Ok(StagedFile {
+            uri: StagedFileUri::new(uri),
+            sanitized_name: session.sanitized_name,
+        })
+    }
+
+    async fn abort_stage(&self, handle: StagingHandle) {
+        let token = handle.token();
+        let removed = {
+            let mut sessions = self.open_sessions.lock().await;
+            sessions.remove(&token)
+        };
+        let Some(session) = removed else {
+            // 幂等:已被消费过(可能是先 finalize 后又收到失败回滚 / 双 abort)
+            // → 静默 no-op。
+            return;
+        };
+        // best-effort:先关 fd,再删文件,再尝试删空 scope 目录。任何一步失败
+        // 都只 warn,不向上抛(本方法处在已经失败的路径上,二次失败不值得
+        // 扰动上层错误处理)。
+        drop(session.file);
+
+        if let Err(err) = tokio::fs::remove_file(&session.path).await {
+            // NotFound 不算异常 —— 半写入文件可能根本没创建过(create 后立即
+            // 触发的 abort)。
+            if err.kind() != std::io::ErrorKind::NotFound {
+                warn!(
+                    handle = %token,
+                    path = %session.path.display(),
+                    error = %err,
+                    "mobile_sync staging: abort_stage failed to remove partial file"
+                );
+            }
+        }
+        // 尝试删 scope 目录(只有空时才会成功;非空表明同 scope 还有别的文件,
+        // 留着不动)。failure 是预期的,不报警。
+        let scope_dir = self.staging_root().join(&session.scope_segment);
+        let _ = tokio::fs::remove_dir(&scope_dir).await;
+
+        debug!(
+            handle = %token,
+            scope_id = %session.scope_segment,
+            sanitized = %session.sanitized_name,
+            "mobile_sync staging: streaming session aborted"
+        );
     }
 }
 
@@ -490,5 +677,154 @@ mod tests {
             matches!(err, MobileFileStagingError::Io(_)),
             "expected Io for malformed URI, got {err:?}"
         );
+    }
+
+    // ── streaming stage tests ──────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn streaming_stage_round_trips_chunks_to_final_uri() {
+        let tmp = TempDir::new().unwrap();
+        let adapter = make_adapter(tmp.path());
+
+        let handle = adapter
+            .begin_stage("scope-stream", "video.mp4", "video/mp4")
+            .await
+            .expect("begin_stage ok");
+
+        adapter
+            .append_stage_chunk(&handle, &[0xAA; 1024])
+            .await
+            .expect("append_stage_chunk 1 ok");
+        adapter
+            .append_stage_chunk(&handle, &[0xBB; 512])
+            .await
+            .expect("append_stage_chunk 2 ok");
+        // 0-byte chunk 必须是 no-op
+        adapter
+            .append_stage_chunk(&handle, &[])
+            .await
+            .expect("empty chunk ok");
+
+        let staged = adapter
+            .finalize_stage(handle)
+            .await
+            .expect("finalize_stage ok");
+
+        assert_eq!(staged.sanitized_name, "video.mp4");
+        assert!(staged.uri.as_str().ends_with("/video.mp4"));
+
+        // 落盘内容 = chunk1 || chunk2
+        let path = tmp
+            .path()
+            .join("mobile_inbound")
+            .join("scope-stream")
+            .join("video.mp4");
+        let bytes = tokio::fs::read(&path).await.unwrap();
+        assert_eq!(bytes.len(), 1024 + 512);
+        assert!(bytes[..1024].iter().all(|&b| b == 0xAA));
+        assert!(bytes[1024..].iter().all(|&b| b == 0xBB));
+    }
+
+    #[tokio::test]
+    async fn streaming_stage_abort_removes_partial_file() {
+        let tmp = TempDir::new().unwrap();
+        let adapter = make_adapter(tmp.path());
+
+        let handle = adapter
+            .begin_stage("scope-abort", "partial.bin", "application/octet-stream")
+            .await
+            .expect("begin_stage ok");
+
+        adapter
+            .append_stage_chunk(&handle, &[0xCC; 4096])
+            .await
+            .expect("append ok");
+
+        let path = tmp
+            .path()
+            .join("mobile_inbound")
+            .join("scope-abort")
+            .join("partial.bin");
+        assert!(path.exists(), "file must exist mid-stream");
+
+        adapter.abort_stage(handle).await;
+
+        assert!(
+            !path.exists(),
+            "abort must remove partially-written file at {}",
+            path.display()
+        );
+        // 空 scope 目录也应被回收
+        let scope_dir = tmp.path().join("mobile_inbound").join("scope-abort");
+        assert!(
+            !scope_dir.exists(),
+            "empty scope dir must be removed after abort"
+        );
+    }
+
+    #[tokio::test]
+    async fn streaming_stage_two_concurrent_handles_do_not_collide() {
+        let tmp = TempDir::new().unwrap();
+        let adapter = make_adapter(tmp.path());
+
+        let h_a = adapter
+            .begin_stage("scope-A", "file.bin", "application/octet-stream")
+            .await
+            .expect("begin A");
+        let h_b = adapter
+            .begin_stage("scope-B", "file.bin", "application/octet-stream")
+            .await
+            .expect("begin B");
+
+        // 交叠写入两个 handle —— append 要按各自 token 路由到独立 File
+        adapter.append_stage_chunk(&h_a, b"AAAA").await.unwrap();
+        adapter.append_stage_chunk(&h_b, b"BBBBBB").await.unwrap();
+        adapter.append_stage_chunk(&h_a, b"AA").await.unwrap();
+        adapter.append_stage_chunk(&h_b, b"BB").await.unwrap();
+
+        let staged_a = adapter.finalize_stage(h_a).await.expect("finalize A");
+        let staged_b = adapter.finalize_stage(h_b).await.expect("finalize B");
+
+        let bytes_a = adapter.read_by_uri(staged_a.uri.as_str()).await.unwrap();
+        let bytes_b = adapter.read_by_uri(staged_b.uri.as_str()).await.unwrap();
+
+        assert_eq!(bytes_a, b"AAAAAA");
+        assert_eq!(bytes_b, b"BBBBBBBB");
+    }
+
+    #[tokio::test]
+    async fn streaming_stage_append_after_finalize_returns_error() {
+        let tmp = TempDir::new().unwrap();
+        let adapter = make_adapter(tmp.path());
+
+        let handle = adapter
+            .begin_stage("scope-x", "f.bin", "application/octet-stream")
+            .await
+            .unwrap();
+        // clone handle so we can still call append after finalize consumes one
+        let stale = handle.clone();
+        adapter.append_stage_chunk(&handle, b"hi").await.unwrap();
+        adapter.finalize_stage(handle).await.unwrap();
+
+        let err = adapter
+            .append_stage_chunk(&stale, b"late")
+            .await
+            .expect_err("append on consumed handle must fail");
+        assert!(matches!(err, MobileFileStagingError::Io(_)));
+    }
+
+    #[tokio::test]
+    async fn streaming_stage_double_abort_is_silent() {
+        let tmp = TempDir::new().unwrap();
+        let adapter = make_adapter(tmp.path());
+
+        let handle = adapter
+            .begin_stage("scope-dbl", "f.bin", "application/octet-stream")
+            .await
+            .unwrap();
+        let copy = handle.clone();
+        adapter.abort_stage(handle).await;
+        // 二次 abort 同一 token：不 panic、不报错
+        adapter.abort_stage(copy).await;
     }
 }

--- a/src-tauri/crates/uc-webserver/src/mobile_lan/routes.rs
+++ b/src-tauri/crates/uc-webserver/src/mobile_lan/routes.rs
@@ -72,9 +72,17 @@ use crate::mobile_lan::middleware::basic_auth;
 /// 实测,4 FPS 已经平滑)。
 const PROGRESS_THROTTLE: Duration = Duration::from_millis(250);
 
-/// `PUT /file/{dataName}` 的请求体上限 —— SyncClipboard 桌面端同档 16 MiB。
-/// 真生产仍可能有图像 / RTF 大块上传, 后续 P5a.10 可观测后再调。
-const MAX_FILE_BYTES_STREAM: usize = 16 * 1024 * 1024;
+/// `PUT /file/{dataName}` 请求体的兜底磁盘安全阀。
+///
+/// 用户在手机端主动 PUT 文件,客户端已经知道文件大小;真正的"产品上限"
+/// 由客户端自觉与本机磁盘空间决定,服务端只设一道防止恶意客户端写满盘的
+/// 远端硬上限。
+///
+/// 现写死 10 GiB。
+/// TODO(P6 配置化): 拆到 settings (`mobile_sync.put_file_max_bytes`),按
+/// 用户机型 / 磁盘剩余可配 —— 当前 10 GiB 是个粗略的"任何家用 Mac 都
+/// 不可能因为一次上传爆盘"的安全阀,留出抽象空间但不开复杂度。
+const PUT_FILE_DISK_SANITY_LIMIT: u64 = 10 * 1024 * 1024 * 1024;
 
 /// mobile_lan 路由共享 state。`mobile_sync` 是 PUT/GET 业务入口;
 /// `file_transfer` 是 PUT /file 流式接收过程中 handler 用来发
@@ -353,41 +361,88 @@ async fn put_clipboard_file(
     )
     .await;
 
-    // 流式读 body:每个 chunk 累加到 buffer,每 PROGRESS_THROTTLE 一帧
-    // 调 facade.report_progress。本工程的 lifecycle ReportProgress 走
-    // store + publisher(load_timeline O(N) 全量历史),所以频率必须节
-    // 流否则 O(N²) 会拖死大文件 PUT。
+    // 用 raw_mime 先 begin_stage,后面 mime sniff 不影响落盘行为。
+    let scope_id = uc_application::facade::mobile_sync_streaming_scope_nonce();
+    let handle = match facade
+        .begin_file_upload(&scope_id, &data_name, &raw_mime)
+        .await
+    {
+        Ok(handle) => handle,
+        Err(err) => {
+            fail_lifecycle(
+                file_transfer.as_ref(),
+                &transfer_id,
+                &peer_id,
+                format!("staging begin failed: {err}"),
+            )
+            .await;
+            tracing::warn!(
+                data_name = %data_name,
+                error = %err,
+                "PUT /file: begin_stage failed"
+            );
+            return Err((StatusCode::INTERNAL_SERVER_ERROR, "staging begin failed").into_response());
+        }
+    };
+
+    // 流式读 body:每个 chunk 边收边喂给 staging,handler 端不再持字节。
+    // 进度节流仍按 PROGRESS_THROTTLE 控制 ReportProgress 频率,避免
+    // load_timeline O(N²)。前 64 字节做 mime sniff(image 头魔数最长 14 字节,
+    // 64 字节窗口够用)。
     let mut body_stream = request.into_body().into_data_stream();
-    let mut buffer: Vec<u8> = Vec::new();
+    let mut bytes_received: u64 = 0;
+    let mut sniff_window: Vec<u8> = Vec::with_capacity(64);
     let mut last_progress = Instant::now();
     while let Some(chunk_result) = body_stream.next().await {
         match chunk_result {
             Ok(chunk) => {
-                buffer.extend_from_slice(&chunk);
-                if buffer.len() > MAX_FILE_BYTES_STREAM {
-                    // 超限:fail lifecycle,handler 端 buffer 直接 drop。
-                    // Note: 此时还未走到 facade.put_clipboard_file,所以
-                    // IncomingMobileBuffer 上还没 slot,无需 remove。
+                bytes_received = bytes_received.saturating_add(chunk.len() as u64);
+                if bytes_received > PUT_FILE_DISK_SANITY_LIMIT {
+                    facade.abort_file_upload(handle).await;
                     fail_lifecycle(
                         file_transfer.as_ref(),
                         &transfer_id,
                         &peer_id,
-                        "body exceeds 16 MiB limit".to_string(),
+                        format!(
+                            "body exceeds disk sanity limit ({PUT_FILE_DISK_SANITY_LIMIT} bytes)"
+                        ),
                     )
                     .await;
                     tracing::warn!(
                         data_name = %data_name,
-                        bytes_received = buffer.len(),
-                        "PUT /file: body exceeded MAX_FILE_BYTES_STREAM"
+                        bytes_received,
+                        limit = PUT_FILE_DISK_SANITY_LIMIT,
+                        "PUT /file: body exceeded disk sanity limit"
                     );
                     return Err((StatusCode::PAYLOAD_TOO_LARGE, "body too large").into_response());
+                }
+                if sniff_window.len() < 64 {
+                    let take = (64 - sniff_window.len()).min(chunk.len());
+                    sniff_window.extend_from_slice(&chunk[..take]);
+                }
+                if let Err(err) = facade.append_file_chunk(&handle, &chunk).await {
+                    facade.abort_file_upload(handle).await;
+                    fail_lifecycle(
+                        file_transfer.as_ref(),
+                        &transfer_id,
+                        &peer_id,
+                        format!("staging append failed: {err}"),
+                    )
+                    .await;
+                    tracing::warn!(
+                        data_name = %data_name,
+                        error = %err,
+                        "PUT /file: append_stage_chunk failed"
+                    );
+                    return Err((StatusCode::INTERNAL_SERVER_ERROR, "staging append failed")
+                        .into_response());
                 }
                 if last_progress.elapsed() >= PROGRESS_THROTTLE {
                     report_progress_lifecycle(
                         file_transfer.as_ref(),
                         &transfer_id,
                         &peer_id,
-                        buffer.len() as u64,
+                        bytes_received,
                         total_bytes,
                     )
                     .await;
@@ -395,7 +450,7 @@ async fn put_clipboard_file(
                 }
             }
             Err(e) => {
-                // body 中断 / 连接错误:fail lifecycle + 不 buffer。
+                facade.abort_file_upload(handle).await;
                 fail_lifecycle(
                     file_transfer.as_ref(),
                     &transfer_id,
@@ -412,16 +467,15 @@ async fn put_clipboard_file(
     }
 
     // 收齐 → 补一帧 final progress 让前端进度条停在 100%。complete
-    // 不在这里发 —— body 接收完只表示"字节进了 receiver buffer",
-    // 真正的 transfer 完成要等 SyncDoc apply 写到 entry,
+    // 不在这里发 —— body 接收完只表示"字节进了 staging",真正的 transfer
+    // 完成要等 SyncDoc apply 写到 entry,
     // ApplyIncomingMobileClipUseCase::finalize_transfer_lifecycle 收尾。
-    let final_size = buffer.len() as u64;
-    let final_total = total_bytes.or(Some(final_size));
+    let final_total = total_bytes.or(Some(bytes_received));
     report_progress_lifecycle(
         file_transfer.as_ref(),
         &transfer_id,
         &peer_id,
-        final_size,
+        bytes_received,
         final_total,
     )
     .await;
@@ -431,10 +485,9 @@ async fn put_clipboard_file(
     // 让 octet-stream 一路下沉到剪贴板写入层,会让 image rep 携带非 image/*
     // mime 落到 macOS NSPasteboard 上,系统识别不出 image type、用户读到的
     // 是原始 JPEG 字节(2026-05-08 真机回归 IMG_20260508_200644.jpg 复现)。
-    // 这里在最外层基于 data_name 扩展名 + 文件头魔数嗅探,把 image 类的
-    // mime 修正回正确的 image/* 形态;无法识别时保持原 mime 不动。
+    // sniff_window 在收 body 时已截前 64 字节,够覆盖所有 image 头魔数。
     let effective_mime = if mime_is_unspecific(&raw_mime) {
-        match infer_image_mime(&data_name, &buffer) {
+        match infer_image_mime(&data_name, &sniff_window) {
             Some(sniffed) => {
                 tracing::info!(
                     data_name = %data_name,
@@ -450,18 +503,17 @@ async fn put_clipboard_file(
         raw_mime.clone()
     };
 
-    let bytes_len = buffer.len();
     let log_data_name = data_name.clone();
     let log_mime = effective_mime.clone();
     match facade
-        .put_clipboard_file(data_name, effective_mime, buffer, device_id, transfer_id)
+        .finalize_file_upload(handle, data_name, effective_mime, device_id, transfer_id)
         .await
     {
         Ok(outcome) => {
             tracing::info!(
                 data_name = %log_data_name,
                 mime = %log_mime,
-                bytes = bytes_len,
+                bytes = bytes_received,
                 outcome = ?outcome_kind(&outcome),
                 "PUT /file: 200"
             );

--- a/src-tauri/crates/uc-webserver/src/mobile_lan/test_support.rs
+++ b/src-tauri/crates/uc-webserver/src/mobile_lan/test_support.rs
@@ -242,6 +242,7 @@ pub(crate) async fn build_facade_with_seeded_device(
             blob_reader: Arc::new(NoopBlobReader),
         },
         file_transfer: None,
+        clipboard_outbound: None,
         lan_lifecycle: None,
     }))
 }

--- a/src-tauri/crates/uc-webserver/src/mobile_lan/test_support.rs
+++ b/src-tauri/crates/uc-webserver/src/mobile_lan/test_support.rs
@@ -233,7 +233,7 @@ pub(crate) async fn build_facade_with_seeded_device(
         settings: Arc::new(InMemorySettings::default()),
         apply_inbound,
         incoming_buffer: Arc::new(IncomingMobileBuffer::new()),
-        file_staging: Arc::new(NoopFileStaging),
+        file_staging: NoopFileStaging::new(),
         snapshot_ports: MobileSyncSnapshotPorts {
             entry_repo,
             selection_repo: Arc::new(NoopSelectionRepo),
@@ -369,10 +369,23 @@ impl ApplyInboundWrite for NoopInboundWrite {
     }
 }
 
-// P5a.3.5:File 类型 staging port 的 NoOp。webserver 路由测试不会走到
-// PUT /SyncClipboard.json type=File 的真实 staging 路径(测试只覆盖
-// 401/404/wire),被调到说明回归 —— 直接报错以便定位。
-struct NoopFileStaging;
+// 内存版 NoOp staging,让 webserver 路由测试能跑通 PUT /file 的流式
+// staging 流程而不真正落盘。`stage_file` / `read_by_uri` 仍返 Io 错(路由
+// 测试不该走那两条),streaming 接口在内存里维护 sessions 表,finalize 时
+// 返回固定形态的 fake `file:///` URI(URI 字符串本身不会被路由测试解引用,
+// 后续 SyncDoc 路径才会消费它,但 webserver 单测只 PUT /file 不 PUT JSON)。
+struct NoopFileStaging {
+    sessions: tokio::sync::Mutex<std::collections::HashSet<uuid::Uuid>>,
+}
+
+impl NoopFileStaging {
+    fn new() -> Arc<Self> {
+        Arc::new(Self {
+            sessions: tokio::sync::Mutex::new(std::collections::HashSet::new()),
+        })
+    }
+}
+
 #[async_trait]
 impl uc_core::ports::MobileFileStagingPort for NoopFileStaging {
     async fn stage_file(
@@ -383,7 +396,7 @@ impl uc_core::ports::MobileFileStagingPort for NoopFileStaging {
         _: Vec<u8>,
     ) -> Result<uc_core::mobile_sync::StagedFile, uc_core::ports::MobileFileStagingError> {
         Err(uc_core::ports::MobileFileStagingError::Io(
-            "test_support: NoOp file staging should not be reached".into(),
+            "test_support: NoOp file staging stage_file should not be reached".into(),
         ))
     }
     async fn read_by_uri(
@@ -393,6 +406,49 @@ impl uc_core::ports::MobileFileStagingPort for NoopFileStaging {
         Err(uc_core::ports::MobileFileStagingError::Io(
             "test_support: NoOp file staging read_by_uri should not be reached".into(),
         ))
+    }
+    async fn begin_stage(
+        &self,
+        _scope_id: &str,
+        _data_name: &str,
+        _mime: &str,
+    ) -> Result<uc_core::mobile_sync::StagingHandle, uc_core::ports::MobileFileStagingError> {
+        let handle = uc_core::mobile_sync::StagingHandle::new();
+        self.sessions.lock().await.insert(handle.token());
+        Ok(handle)
+    }
+    async fn append_stage_chunk(
+        &self,
+        handle: &uc_core::mobile_sync::StagingHandle,
+        _chunk: &[u8],
+    ) -> Result<(), uc_core::ports::MobileFileStagingError> {
+        if !self.sessions.lock().await.contains(&handle.token()) {
+            return Err(uc_core::ports::MobileFileStagingError::Io(format!(
+                "test_support NoopFileStaging: unknown handle {}",
+                handle.token()
+            )));
+        }
+        Ok(())
+    }
+    async fn finalize_stage(
+        &self,
+        handle: uc_core::mobile_sync::StagingHandle,
+    ) -> Result<uc_core::mobile_sync::StagedFile, uc_core::ports::MobileFileStagingError> {
+        let token = handle.token();
+        if !self.sessions.lock().await.remove(&token) {
+            return Err(uc_core::ports::MobileFileStagingError::Io(format!(
+                "test_support NoopFileStaging: unknown handle {token} in finalize"
+            )));
+        }
+        Ok(uc_core::mobile_sync::StagedFile {
+            uri: uc_core::mobile_sync::StagedFileUri::new(format!(
+                "file:///tmp/uc-webserver-test/{token}"
+            )),
+            sanitized_name: "test-staged".into(),
+        })
+    }
+    async fn abort_stage(&self, handle: uc_core::mobile_sync::StagingHandle) {
+        self.sessions.lock().await.remove(&handle.token());
     }
 }
 


### PR DESCRIPTION
## Summary

iPhone uploads via SyncClipboard EX used to land on the receiving desktop and stop there — text, image, and file alike stayed local to the single device that served `PUT /SyncClipboard.json`. This PR closes the "phone → any desktop → all desktops" loop:

- The mobile-inbound snapshot is fan-out to every paired peer via the **same outbound dispatcher daemon uses for local clipboard capture**, so all existing wiring (V3 envelope encode, oversized image splitting, `OutboundSyncPlanner` user settings, iroh transfer) applies for free.
- **Files** staged from the mobile buffer are published with `BlobTransferFacade::publish_blob_path` (streaming, not in-memory) and arrive at peers as iroh-blobs free-file refs; the inbound materializer on each peer rewrites them into local `file://` URIs. This is what makes file transfer actually work cross-device — naive `dispatch_snapshot` would have shipped the sender's local path which the receiver can't read.
- **Text + small images** go inline through the V3 envelope; **oversized images** auto-split into `V3BlobRef { representation_index: Some(i) }` to dodge the iroh wire 2 MiB limit.

## Design — why a use-case-local trait

`ApplyIncomingMobileClipUseCase` does **not** depend on `ClipboardOutboundFacade` directly. It depends on a use-case-local `MobileInboundFanOutPort` trait, and the new `ClipboardOutboundFanOutAdapter` (production impl) wraps the facade. This keeps:

- **Use case dependency surface small** — adding fan-out doesn't drag `BlobTransferFacade` / `SettingsPort` / iroh wiring into the use case's awareness.
- **Testability** — fake trait impls let unit tests pin the fan-out contract (Applied → fires once with full context; DuplicateSkipped → never; DecodeFailed → never) without standing up the real dispatcher.
- **Future adapter rewrites** (telemetry, source-specific routing, non-mobile callers) stay isolated to the adapter layer.

The fire-and-forget `tokio::spawn`, error → `warn!` downgrade, and structured logging all live in the adapter — not in the use case — so `dispatch_capture` failures never bleed back as 4xx/5xx and trigger client-side retry storms.

## Assembly plumbing

`DaemonRuntimeWorkers` now exposes the `ClipboardOutboundFacade` it builds, threaded through `DaemonLifecycleFacadesInput` → `build_mobile_sync_facade`. CLI / no-P2P entry points pass `None` and degrade silently to the prior local-only behavior — no functional regression for callers that never had this capability.

## Test plan

- [x] `cargo check --workspace --all-targets` — clean
- [x] `cargo test -p uc-application --lib mobile_sync::` — 119 passed (3 new fan-out specs: Applied-with-full-context, DuplicateSkipped-skips, DecodeFailed-skips)
- [x] `cargo test -p uc-webserver mobile_lan::` — 15 passed (existing webserver routes unaffected)
- [ ] **Real-device regression** (recommended before merge):
  - [ ] Text upload → all desktops receive
  - [ ] Small image (<1 MiB) → all desktops can paste
  - [ ] Large image (>1 MiB) → daemon log shows `outbound: oversized inline rep published as blob`
  - [ ] Small file (PDF, etc.) → other desktops can paste into Finder/Explorer
  - [ ] Large file (hundreds of MB) → daemon log shows `outbound: file blob published (streaming)`; receiver finishes and paste works
  - [ ] Duplicate hash (re-upload same content) → only the first fan-out fires (`DuplicateSkipped` path verified)
  - [ ] Toggle "image sync" off in settings → mobile-uploaded image is skipped at dispatcher (`mobile_sync fan-out: dispatcher skipped (planner / origin guard)` in log)

## Files

- New: `crates/uc-application/src/facade/mobile_sync/outbound_adapter.rs` (adapter, ~120 lines)
- Use case: `apply_incoming.rs` — trait + plumbing + 3 new unit specs
- Facade: `facade/mobile_sync/{mod,facade}.rs` — adapter wiring at `MobileSyncFacade::new`
- Bootstrap: `non_gui_runtime.rs` — `build_mobile_sync_facade` 6th-arg
- Desktop: `runtime_assembly.rs` exposes `clipboard_outbound`; `app_facade_assembly.rs` + `host.rs` thread it through to lifecycle facades
- Test support: `webserver/mobile_lan/test_support.rs` — adds `clipboard_outbound: None`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Streaming file uploads from mobile devices for more efficient handling of large files.
  * Mobile file uploads now distribute to paired devices through the outbound pipeline in daemon mode.
  * Disk safety ceiling enforced for incoming mobile files (10 GiB limit).

* **Refactor**
  * Mobile sync file transfer architecture redesigned for improved performance and reliability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/UniClipboard/UniClipboard/pull/629)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->