### PR TITLE
fix: select stable previous release for stable changelog

### DIFF
--- a/scripts/__tests__/previous-published-release.test.ts
+++ b/scripts/__tests__/previous-published-release.test.ts
@@ -86,6 +86,35 @@ describe('selectPreviousPublishedRelease', () => {
     expect(release?.tagName).toBe('v0.3.3')
   })
 
+  it('uses the latest stable release before the target when preparing a stable release', () => {
+    const release = selectPreviousPublishedRelease(
+      [
+        {
+          tagName: 'v0.8.0-alpha.3',
+          isDraft: false,
+          isPrerelease: true,
+          publishedAt: '2026-05-10T10:15:00Z',
+        },
+        {
+          tagName: 'v0.7.2',
+          isDraft: false,
+          isPrerelease: false,
+          publishedAt: '2026-04-30T08:20:00Z',
+        },
+        {
+          tagName: 'v0.7.1',
+          isDraft: false,
+          isPrerelease: false,
+          publishedAt: '2026-04-20T08:20:00Z',
+        },
+      ],
+      '0.8.0'
+    )
+
+    expect(release?.tagName).toBe('v0.7.2')
+    expect(release?.version).toBe('0.7.2')
+  })
+
   it('returns null when no published release exists below the target version', () => {
     const release = selectPreviousPublishedRelease(
       [

--- a/scripts/previous-published-release.js
+++ b/scripts/previous-published-release.js
@@ -70,12 +70,14 @@ function normalizeRelease(release) {
 
 export function selectPreviousPublishedRelease(releases, currentVersion) {
   const normalizedCurrentVersion = stripVersionTagPrefix(currentVersion)
+  const currentIsStable = parseSemver(normalizedCurrentVersion).prerelease === null
 
   const candidates = releases
     .filter(release => !release.isDraft)
     .filter(release => Boolean(release.publishedAt))
     .map(normalizeRelease)
     .filter(release => compareVersions(release.version, normalizedCurrentVersion) < 0)
+    .filter(release => !currentIsStable || parseSemver(release.version).prerelease === null)
     .sort((left, right) => compareVersions(right.version, left.version))
 
   return candidates[0] ?? null


### PR DESCRIPTION
## Summary
- Select the previous stable release when preparing a stable release changelog
- Keep prerelease changelogs using the latest prior prerelease when applicable
- Add a regression test for stable release context

## Tests
- bun run test --run
- bunx prettier --check scripts/previous-published-release.js scripts/__tests__/previous-published-release.test.ts