### PR TITLE
fix(copr): trigger on release.published instead of workflow_run

### DIFF
--- a/.github/workflows/copr.yml
+++ b/.github/workflows/copr.yml
@@ -1,14 +1,17 @@
 name: 'Publish to COPR'
-run-name: "copr-${{ inputs.version || 'auto' }}-${{ github.run_number }}"
+run-name: "copr-${{ inputs.version || github.event.release.tag_name || 'auto' }}-${{ github.run_number }}"
 
 # 触发时机:
-#   1. release.yml 完成 (workflow_run) — 自动跟进 dnf 渠道,跟 snap.yml 对位。
+#   1. release.published — GitHub Release 被正式发布(草稿→发布,或非草稿创建)。
+#      不能用 `workflow_run: Release` — stable 渠道的 release 由 release.yml 创建为
+#      draft(release.yml:290 `draft: channel != 'alpha'`),draft asset 在公开
+#      `releases/download/` URL 上一律 404。等到人工把 draft 发布,公开 URL 才可
+#      下载,此时 `release.published` 事件触发,COPR 拿到的 RPM 是真的可达的。
 #   2. workflow_dispatch — 手动重跑某个版本(常见场景:COPR build 临时挂了,
 #      release.yml 已经跑完不想全量重发)。
 on:
-  workflow_run:
-    workflows: ['Release']
-    types: [completed]
+  release:
+    types: [published]
   workflow_dispatch:
     inputs:
       version:
@@ -32,9 +35,9 @@ on:
 
 jobs:
   build-srpm-and-publish:
-    # workflow_run 触发时,只在 Release workflow 成功后才跑;失败则跳过。
-    # workflow_dispatch 没有 conclusion 字段,这条件对它返回 true。
-    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    # release 事件本身只在 published 时触发(见 on.release.types),不需要再过滤。
+    # workflow_dispatch 任何时候都允许。
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'release'
     runs-on: ubuntu-latest
     # Fedora 镜像里有 rpmbuild / rpmdevtools / spectool / dnf,免去在 Ubuntu
     # 上手动装 rpm 工具链。fedora:latest = 滚动 stable,可读性高且常 cached。
@@ -62,9 +65,15 @@ jobs:
         run: |
           # 决策树:
           #   workflow_dispatch 给了 input.version → 直接用
-          #   否则                                  → 读 package.json
+          #   release 事件                          → 用 release.tag_name(剥掉 v 前缀)
+          #   workflow_dispatch 没给 version       → 兜底读 package.json
+          # 注意:release 事件下不能读 package.json,因为 checkout 默认 ref 是 tag
+          # 对应 commit,但还是优先信任 release tag 本身,避免 tag 与 package.json 漂移。
           if [ -n "${{ inputs.version }}" ]; then
             UPSTREAM_TAG="${{ inputs.version }}"
+          elif [ "${{ github.event_name }}" = "release" ]; then
+            TAG="${{ github.event.release.tag_name }}"
+            UPSTREAM_TAG="${TAG#v}"
           else
             UPSTREAM_TAG=$(python3 -c "import json; print(json.load(open('package.json'))['version'])")
           fi
@@ -175,7 +184,7 @@ jobs:
           done
 
       - name: Download upstream binary RPMs from GitHub Release
-        if: github.event_name == 'workflow_run' || (github.event_name == 'workflow_dispatch' && inputs.run_ids == '')
+        if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.run_ids == '')
         shell: bash
         env:
           UPSTREAM_TAG: ${{ steps.ver.outputs.upstream_tag }}


### PR DESCRIPTION
## Summary

- 修复 COPR auto run 在 stable 渠道必然 404 的 race condition
- `release.yml:290` 把 stable release 创建为草稿,draft asset 在公开 `releases/download/` URL 上 404
- 旧触发器 `workflow_run: Release` 在 release.yml 完成那一刻就跑,此时草稿尚未发布
- 改为 `release: types: [published]`,只在草稿被人工发布(或非草稿创建)时触发
- alpha 因为 `draft: false`,创建即等同发布,行为不变
- 同步:run-name 加入 release tag、Resolve version 用 release.tag_name(而非 package.json)、Download 步骤 if 条件更新

## Repro / 证据

近期 stable 渠道 COPR run 连续失败:
- run 25685840626(v0.8.0)— 17:21:23 触发,17:22:08 curl 404,release 那时还是草稿
- run 25664390662、25625749967 同样模式
- 对照:alpha 渠道(copr-auto-9)在 16:08:26 跑 4m41s 成功 — 因为 alpha 不是草稿

v0.8.0 草稿在 22:02:59 被手动发布(`publishedAt`),早于此 5 小时的 COPR run 自然 404。

## Test plan

- [x] yaml 语法本地检查
- [ ] 合并后,下次 v* 草稿发布时 COPR auto run 走 release event 路径,curl 公开 RPM 不 404
- [ ] alpha 渠道下次发布仍然成功触发(行为应不变)
- [ ] 手动 dispatch 路径不受影响(本 PR 同时已手动触发 v0.8.0 的 COPR 重跑验证)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated COPR publishing workflow to trigger automatically on GitHub releases and automatically detect version from release tags, simplifying the release process.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/UniClipboard/UniClipboard/pull/640)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->