### PR TITLE
ci: skip format/coverage on docs-only PRs

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,11 +1,6 @@
 name: Coverage
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'src-tauri/**'
-      - '.github/workflows/coverage.yml'
   pull_request:
     paths:
       - 'src-tauri/**'

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -5,6 +5,21 @@ on:
   pull_request:
     branches: [main]
     types: [opened, synchronize, reopened]
+    paths:
+      - 'src/**'
+      - 'src-tauri/**'
+      - 'package.json'
+      - 'bun.lock'
+      - 'tsconfig*.json'
+      - 'vite.config.ts'
+      - 'tailwind.config.js'
+      - 'eslint.config.js'
+      - 'index.html'
+      - 'quick-panel.html'
+      - 'public/**'
+      - '.prettierrc*'
+      - 'prettier.config.*'
+      - '.github/workflows/format.yml'
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
- `format.yml`: add `paths` filter so doc-only PRs (and PRs touching only other workflow files) no longer trigger the format check.
- `coverage.yml`: drop the redundant `push: main` trigger; coverage now runs only on PRs touching `src-tauri/**`, eliminating the duplicate run that happens right after merge.

## Why
Both workflows previously fired on commits/PRs they had no business inspecting:
- `format.yml` had no `paths`, so every PR — including pure markdown / workflow-only PRs — paid the cost of installing Rust + Bun and running `cargo fmt` / `prettier`.
- `coverage.yml` ran twice for any PR touching `src-tauri/**`: once on the PR, once again on `main` after merge. The post-merge run rebuilds GTK/webkit deps and re-runs `cargo llvm-cov` for no incremental signal.

## Caveats
- If `Format Check` or `coverage` is currently a **required status check** in `Settings → Branches → main`, PRs that don't touch the matched paths will sit forever in `Expected — Waiting for status to be reported`. We should drop those from the required list (or add a dummy noop job) before merging this.
- Codecov's main baseline will now come from the latest PR head commit instead of a dedicated `main` push. In practice Codecov associates by SHA so the dashboard should keep working; if the baseline ever drifts, we can add a tiny coverage job that runs only on release tags.

## Test plan
- [ ] Confirm `Format Check` / `coverage` are not required checks on `main` (or accept the consequences and add dummies).
- [ ] Open a follow-up doc-only PR after merge — neither workflow should appear in its checks list.
- [ ] Open a follow-up `src-tauri/**` PR after merge — both should run on the PR, and only `coverage` should *not* re-run after merging.