### PR TITLE
feat: paste as plain text with Option/Alt modifier

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -40,6 +40,8 @@
         "@tauri-apps/plugin-notification": "^2.3.3",
         "@tauri-apps/plugin-opener": "^2.5.2",
         "@tauri-apps/plugin-updater": "^2.9.0",
+        "@types/culori": "^4.0.1",
+        "culori": "^4.0.2",
         "framer-motion": "^12.23.26",
         "i18next": "^25.7.3",
         "input-otp": "^1.4.2",
@@ -48,6 +50,7 @@
         "pino": "^10.3.1",
         "radix-ui": "^1.4.3",
         "react": "^18.3.1",
+        "react-colorful": "^5.7.0",
         "react-dom": "^18.3.1",
         "react-hotkeys-hook": "^5.2.1",
         "react-i18next": "^16.5.0",
@@ -707,6 +710,8 @@
 
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
+    "@types/culori": ["@types/culori@4.0.1", "", {}, "sha512-43M51r/22CjhbOXyGT361GZ9vncSVQ39u62x5eJdBQFviI8zWp2X5jzqg7k4M6PVgDQAClpy2bUe2dtwEgEDVQ=="],
+
     "@types/debug": ["@types/debug@4.1.12", "", { "dependencies": { "@types/ms": "*" } }, "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ=="],
 
     "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
@@ -988,6 +993,8 @@
     "cssstyle": ["cssstyle@5.3.7", "", { "dependencies": { "@asamuzakjp/css-color": "^4.1.1", "@csstools/css-syntax-patches-for-csstree": "^1.0.21", "css-tree": "^3.1.0", "lru-cache": "^11.2.4" } }, "sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ=="],
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
+
+    "culori": ["culori@4.0.2", "", {}, "sha512-1+BhOB8ahCn4O0cep0Sh2l9KCOfOdY+BXJnKMHFFzDEouSr/el18QwXEMRlOj9UY5nCeA8UN3a/82rUWRBeyBw=="],
 
     "data-uri-to-buffer": ["data-uri-to-buffer@4.0.1", "", {}, "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="],
 
@@ -1776,6 +1783,8 @@
     "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
 
     "react": ["react@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ=="],
+
+    "react-colorful": ["react-colorful@5.7.0", "", { "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-fuesYIemttah97XmsIHmz4OORDHiSFzyc9HMAIrCHJou2jaRQmL8cFJ76K4zQhhj8jzwOBlOi4BaGTjjOZCfTg=="],
 
     "react-dom": ["react-dom@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0", "scheduler": "^0.23.2" }, "peerDependencies": { "react": "^18.3.1" } }, "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw=="],
 

--- a/src-tauri/crates/uc-application/src/facade/clipboard_restore/mod.rs
+++ b/src-tauri/crates/uc-application/src/facade/clipboard_restore/mod.rs
@@ -12,7 +12,8 @@ use uc_core::ports::{
 
 use crate::clipboard_write::ClipboardWriteCoordinator;
 use crate::usecases::clipboard_restore::{
-    RestoreClipboardSelectionUseCase, TouchClipboardEntryUseCase,
+    PlainRestoreOutcome, RestoreClipboardEntryAsPlainTextUseCase, RestoreClipboardSelectionUseCase,
+    TouchClipboardEntryUseCase,
 };
 
 #[derive(Debug, thiserror::Error)]
@@ -53,6 +54,7 @@ pub struct ClipboardRestoreFacadeDeps {
 
 pub struct ClipboardRestoreFacade {
     restore_uc: RestoreClipboardSelectionUseCase,
+    plain_uc: RestoreClipboardEntryAsPlainTextUseCase,
     touch_uc: TouchClipboardEntryUseCase,
 }
 
@@ -71,6 +73,15 @@ impl ClipboardRestoreFacade {
 
         let restore_uc = RestoreClipboardSelectionUseCase::new(
             entry_repo.clone(),
+            write_coordinator.clone(),
+            selection_repo.clone(),
+            representation_repo.clone(),
+            payload_resolver.clone(),
+            blob_store.clone(),
+            integration_mode,
+        );
+        let plain_uc = RestoreClipboardEntryAsPlainTextUseCase::new(
+            entry_repo.clone(),
             write_coordinator,
             selection_repo,
             representation_repo,
@@ -82,6 +93,7 @@ impl ClipboardRestoreFacade {
 
         Self {
             restore_uc,
+            plain_uc,
             touch_uc,
         }
     }
@@ -95,15 +107,59 @@ impl ClipboardRestoreFacade {
             .await
             .map_err(|err| map_restore_error(err, entry_id))?;
 
-        if let Err(err) = self.touch_uc.execute(&parsed_id).await {
+        self.touch_after_restore(&parsed_id, entry_id).await;
+        Ok(())
+    }
+
+    /// 「以纯文本形式」恢复条目到系统剪贴板。
+    ///
+    /// 流程：先尝试 plain 路径（只写 `text/plain` 表示）；条目没有任何可用的
+    /// plain 表示时，静默降级到 `restore_entry` 同等的多格式恢复路径——用户
+    /// 视角就是"按 Option 没生效"，不弹错误。
+    ///
+    /// LRU 触摸：无论走 plain 路径还是降级路径，恢复成功后都调用
+    /// `TouchClipboardEntryUseCase`，行为与 `restore_entry` 一致。
+    #[instrument(skip_all, fields(entry_id = %entry_id))]
+    pub async fn restore_entry_as_plain_text(
+        &self,
+        entry_id: &str,
+    ) -> Result<(), ClipboardRestoreError> {
+        let parsed_id = EntryId::from(entry_id);
+
+        let outcome = self
+            .plain_uc
+            .execute(&parsed_id)
+            .await
+            .map_err(|err| map_restore_error(err, entry_id))?;
+
+        match outcome {
+            PlainRestoreOutcome::Done => {
+                self.touch_after_restore(&parsed_id, entry_id).await;
+                Ok(())
+            }
+            PlainRestoreOutcome::NoPlainTextAvailable => {
+                tracing::info!(
+                    entry_id = %entry_id,
+                    "restore_entry_as_plain_text: no plain rep available, falling back to multi-format restore"
+                );
+                self.restore_uc
+                    .execute(&parsed_id)
+                    .await
+                    .map_err(|err| map_restore_error(err, entry_id))?;
+                self.touch_after_restore(&parsed_id, entry_id).await;
+                Ok(())
+            }
+        }
+    }
+
+    async fn touch_after_restore(&self, parsed_id: &EntryId, entry_id: &str) {
+        if let Err(err) = self.touch_uc.execute(parsed_id).await {
             tracing::warn!(
                 error = %err,
                 entry_id = %entry_id,
                 "touch_clipboard_entry failed after restore"
             );
         }
-
-        Ok(())
     }
 }
 

--- a/src-tauri/crates/uc-application/src/usecases/clipboard_restore/mod.rs
+++ b/src-tauri/crates/uc-application/src/usecases/clipboard_restore/mod.rs
@@ -3,8 +3,12 @@
 //! `ClipboardRestoreFacade`.
 
 pub(crate) mod file_snapshot;
+pub(crate) mod restore_as_plain_text;
 pub(crate) mod restore_selection;
 pub(crate) mod touch_entry;
 
+pub(crate) use restore_as_plain_text::{
+    PlainRestoreOutcome, RestoreClipboardEntryAsPlainTextUseCase,
+};
 pub(crate) use restore_selection::RestoreClipboardSelectionUseCase;
 pub(crate) use touch_entry::TouchClipboardEntryUseCase;

--- a/src-tauri/crates/uc-application/src/usecases/clipboard_restore/restore_as_plain_text.rs
+++ b/src-tauri/crates/uc-application/src/usecases/clipboard_restore/restore_as_plain_text.rs
@@ -1,0 +1,664 @@
+//! 「以纯文本形式恢复条目到系统剪贴板」用例。
+//!
+//! 目的：用户按住 Option / Alt 触发粘贴时，希望目标应用粘出纯文本，而不是
+//! Markdown 源码 / HTML 标签 / RTF 等富文本。系统剪贴板的"目标应用挑哪个
+//! 格式粘"决定权来自源端"摆了哪些菜"——本用例只往剪贴板写入 `text/plain`
+//! 一种表示，让目标应用别无选择。
+//!
+//! 与 `RestoreClipboardSelectionUseCase` 的边界：
+//! - 该用例只尝试 plain 路径：在 selection 的候选 rep 中找出 mime 为
+//!   `text/plain`（或等价的 `public.utf8-plain-text` UTI / `text` format_id）
+//!   的那一份，单独打包成 snapshot 写入。
+//! - 若条目根本不存在 plain 表示（纯图片 / 纯文件 / 纯 HTML 等极少数情况），
+//!   返回 `PlainRestoreOutcome::NoPlainTextAvailable` 让 facade 决定降级。
+//!   本用例**不**自己回退——降级是编排职责，留给 facade。
+//!
+//! 自写抑制：复用 `ClipboardWriteCoordinator` + `ClipboardWriteIntent::LocalRestore`。
+//! `origin_guard_key` 在仅含 plain rep 的 snapshot 上计算结果为 `text:<hash>`，
+//! 与 watcher 回声端口计算结果一致，hash 守卫稳定命中；即便遇到极端 hash miss，
+//! coordinator 的一次性 `set_next_origin(LocalRestore, 2s)` 兜底，watcher 不会
+//! 把这次恢复重新当作新条目落库。
+//!
+//! payload 读取：必须通过 `ClipboardPayloadResolverPort.resolve()`——Staged 状态
+//! 下 `rep.inline_data` 是 normalizer 留下的 500 字符预览截断版，直接读会粘出
+//! 残缺文本。这一约束与 `RestoreClipboardSelectionUseCase` 一致。
+
+use anyhow::Result;
+use std::sync::Arc;
+use tracing::{debug, info, warn};
+
+use uc_core::{
+    blob::ports::BlobReaderPort,
+    clipboard::{
+        is_plain_text_mime_or_format, ClipboardIntegrationMode, ObservedClipboardRepresentation,
+        PersistedClipboardRepresentation, SystemClipboardSnapshot,
+    },
+    ids::EntryId,
+    ports::{
+        clipboard::{ClipboardPayloadResolverPort, ResolvedClipboardPayload},
+        ClipboardEntryRepositoryPort, ClipboardRepresentationRepositoryPort,
+        ClipboardSelectionRepositoryPort,
+    },
+};
+
+use crate::clipboard_write::{ClipboardWriteCoordinator, ClipboardWriteIntent};
+
+/// 本用例的可观察执行结果。
+///
+/// `Done`：成功把纯文本写入了系统剪贴板。
+/// `NoPlainTextAvailable`：条目下没有任何可用的 `text/plain` 表示，facade
+/// 应当降级到多格式恢复路径。这是预期的业务结果，不是错误。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PlainRestoreOutcome {
+    Done,
+    NoPlainTextAvailable,
+}
+
+pub(crate) struct RestoreClipboardEntryAsPlainTextUseCase {
+    clipboard_repo: Arc<dyn ClipboardEntryRepositoryPort>,
+    coordinator: Arc<ClipboardWriteCoordinator>,
+    selection_repo: Arc<dyn ClipboardSelectionRepositoryPort>,
+    representation_repo: Arc<dyn ClipboardRepresentationRepositoryPort>,
+    payload_resolver: Arc<dyn ClipboardPayloadResolverPort>,
+    blob_store: Arc<dyn BlobReaderPort>,
+    mode: ClipboardIntegrationMode,
+}
+
+impl RestoreClipboardEntryAsPlainTextUseCase {
+    pub(crate) fn new(
+        clipboard_repo: Arc<dyn ClipboardEntryRepositoryPort>,
+        coordinator: Arc<ClipboardWriteCoordinator>,
+        selection_repo: Arc<dyn ClipboardSelectionRepositoryPort>,
+        representation_repo: Arc<dyn ClipboardRepresentationRepositoryPort>,
+        payload_resolver: Arc<dyn ClipboardPayloadResolverPort>,
+        blob_store: Arc<dyn BlobReaderPort>,
+        mode: ClipboardIntegrationMode,
+    ) -> Self {
+        Self {
+            clipboard_repo,
+            coordinator,
+            selection_repo,
+            representation_repo,
+            payload_resolver,
+            blob_store,
+            mode,
+        }
+    }
+
+    pub(crate) async fn execute(&self, entry_id: &EntryId) -> Result<PlainRestoreOutcome> {
+        info!(entry_id = %entry_id, "restore_plain.execute requested");
+
+        if !self.mode.allow_os_write() {
+            return Err(anyhow::anyhow!(
+                "System clipboard writes disabled (UC_CLIPBOARD_MODE=passive)"
+            ));
+        }
+
+        let snapshot = match self.build_plain_snapshot(entry_id).await? {
+            Some(snapshot) => snapshot,
+            None => {
+                info!(
+                    entry_id = %entry_id,
+                    "restore_plain.execute: no text/plain representation available — caller should fall back"
+                );
+                return Ok(PlainRestoreOutcome::NoPlainTextAvailable);
+            }
+        };
+
+        self.coordinator
+            .write(snapshot, ClipboardWriteIntent::LocalRestore)
+            .await?;
+
+        Ok(PlainRestoreOutcome::Done)
+    }
+
+    /// 收集 selection 中所有候选 rep，挑出第一份「能解析出字节」的 plain text rep
+    /// 打包成单 rep snapshot。返回 `None` 表示没有任何 plain rep 可用，调用方
+    /// 应当走降级路径。
+    ///
+    /// 候选顺序与 `RestoreClipboardSelectionUseCase::build_snapshot` 保持一致：
+    /// paste_rep → primary → preview → secondary（整体去重）。这样在 selection
+    /// 策略已经把 plain 选为 paste_rep 的常见场景下，第一个候选就是它，省去
+    /// 多余的 resolver 调用。
+    async fn build_plain_snapshot(
+        &self,
+        entry_id: &EntryId,
+    ) -> Result<Option<SystemClipboardSnapshot>> {
+        debug!(entry_id = %entry_id, "restore_plain.build_snapshot start");
+
+        let entry = self
+            .clipboard_repo
+            .get_entry(entry_id)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("Entry not found"))?;
+
+        let selection = self
+            .selection_repo
+            .get_selection(entry_id)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("Selection not found"))?;
+
+        let mut candidate_ids = Vec::new();
+        candidate_ids.push(selection.selection.paste_rep_id.clone());
+        candidate_ids.push(selection.selection.primary_rep_id.clone());
+        candidate_ids.push(selection.selection.preview_rep_id.clone());
+        candidate_ids.extend(selection.selection.secondary_rep_ids.clone());
+
+        let mut seen = std::collections::HashSet::new();
+        candidate_ids.retain(|rep_id| seen.insert(rep_id.clone()));
+
+        for rep_id in &candidate_ids {
+            let rep = match self
+                .representation_repo
+                .get_representation(&entry.event_id, rep_id)
+                .await?
+            {
+                Some(rep) => rep,
+                None => continue,
+            };
+
+            if !Self::is_plain_text(&rep) {
+                continue;
+            }
+
+            match self.resolve_bytes(&rep).await {
+                Ok(bytes) => {
+                    let observed = ObservedClipboardRepresentation::new(
+                        rep.id.clone(),
+                        rep.format_id.clone(),
+                        rep.mime_type.clone(),
+                        bytes,
+                    );
+
+                    debug!(
+                        entry_id = %entry_id,
+                        event_id = %entry.event_id,
+                        plain_rep_id = %rep.id,
+                        size_bytes = observed.bytes.len(),
+                        "restore_plain.build_snapshot packed plain representation"
+                    );
+
+                    return Ok(Some(SystemClipboardSnapshot {
+                        ts_ms: chrono::Utc::now().timestamp_millis(),
+                        representations: vec![observed],
+                    }));
+                }
+                Err(err) => {
+                    // 候选 plain rep 解析失败，继续尝试下一个候选。常见原因：
+                    // Staged 状态下 cache+spool 都拿不到字节（与多格式恢复对
+                    // secondary rep 的处理对称——跳过 + warn，不打断流程）。
+                    warn!(
+                        entry_id = %entry_id,
+                        rep_id = %rep.id,
+                        error = %err,
+                        "restore_plain.build_snapshot: skipping plain rep due to resolve failure"
+                    );
+                    continue;
+                }
+            }
+        }
+
+        Ok(None)
+    }
+
+    fn is_plain_text(rep: &PersistedClipboardRepresentation) -> bool {
+        is_plain_text_mime_or_format(rep.mime_type.as_ref(), &rep.format_id)
+    }
+
+    async fn resolve_bytes(&self, rep: &PersistedClipboardRepresentation) -> Result<Vec<u8>> {
+        match self.payload_resolver.resolve(rep).await? {
+            ResolvedClipboardPayload::Inline { bytes, .. } => Ok(bytes),
+            ResolvedClipboardPayload::BlobRef { blob_id, .. } => {
+                self.blob_store.get(&blob_id).await.map_err(|err| {
+                    anyhow::anyhow!(
+                        "Failed to fetch plain text blob {} for rep {}: {}",
+                        blob_id,
+                        rep.id,
+                        err
+                    )
+                })
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! 锁定本用例对 facade 的两条契约路径：
+    //! - 有 plain rep → `Done` + 系统剪贴板仅收到含单一 plain rep 的 snapshot
+    //! - 无 plain rep → `NoPlainTextAvailable` + 系统剪贴板未被写入
+    //!
+    //! 所有 port 通过 `mockall::mock!` 注入。未在测试中 `expect_*` 的方法
+    //! mockall 会在调用时 panic（strict 模式），等同于"不应被调用"的断言。
+    use super::*;
+    use anyhow::Result as AnyResult;
+    use async_trait::async_trait;
+    use std::sync::{Arc, Mutex};
+    use std::time::Duration;
+    use uc_core::clipboard::{
+        ClipboardChangeOrigin, ClipboardEntry, ClipboardIntegrationMode, ClipboardSelection,
+        ClipboardSelectionDecision, MimeType, PayloadAvailability,
+        PersistedClipboardRepresentation, SelectionPolicyVersion, SystemClipboardSnapshot,
+    };
+    use uc_core::ids::{EntryId, EventId, FormatId, RepresentationId};
+    use uc_core::ports::clipboard::{
+        ClipboardChangeOriginPort, ClipboardPayloadResolverPort, PayloadResolveError,
+        ProcessingUpdateOutcome, ResolvedClipboardPayload, SystemClipboardPort,
+    };
+    use uc_core::ports::{
+        ClipboardEntryRepositoryPort, ClipboardRepresentationRepositoryPort,
+        ClipboardSelectionRepositoryPort,
+    };
+    use uc_core::BlobId;
+
+    fn make_rep(
+        id: &str,
+        mime: &str,
+        format: &str,
+        data: &[u8],
+    ) -> PersistedClipboardRepresentation {
+        PersistedClipboardRepresentation::new(
+            RepresentationId::from(id),
+            FormatId::from(format),
+            Some(MimeType(mime.to_string())),
+            data.len() as i64,
+            Some(data.to_vec()),
+            None,
+        )
+    }
+
+    fn make_entry(entry_id: &str, event_id: &str) -> ClipboardEntry {
+        ClipboardEntry::new(EntryId::from(entry_id), EventId::from(event_id), 0, None, 0)
+    }
+
+    fn make_selection(
+        entry_id: &str,
+        paste_rep_id: &str,
+        secondary: Vec<&str>,
+    ) -> ClipboardSelectionDecision {
+        ClipboardSelectionDecision::new(
+            EntryId::from(entry_id),
+            ClipboardSelection {
+                primary_rep_id: RepresentationId::from(paste_rep_id),
+                secondary_rep_ids: secondary.into_iter().map(RepresentationId::from).collect(),
+                preview_rep_id: RepresentationId::from(paste_rep_id),
+                paste_rep_id: RepresentationId::from(paste_rep_id),
+                policy_version: SelectionPolicyVersion::V1,
+            },
+        )
+    }
+
+    mockall::mock! {
+        EntryRepo {}
+        #[async_trait]
+        impl ClipboardEntryRepositoryPort for EntryRepo {
+            async fn save_entry_and_selection(
+                &self,
+                entry: &ClipboardEntry,
+                selection: &ClipboardSelectionDecision,
+            ) -> AnyResult<()>;
+            async fn get_entry(&self, entry_id: &EntryId) -> AnyResult<Option<ClipboardEntry>>;
+            async fn list_entries(&self, limit: usize, offset: usize) -> AnyResult<Vec<ClipboardEntry>>;
+            async fn touch_entry(&self, entry_id: &EntryId, active_time_ms: i64) -> AnyResult<bool>;
+            async fn delete_entry(&self, entry_id: &EntryId) -> AnyResult<()>;
+            async fn find_entry_id_by_snapshot_hash(
+                &self,
+                snapshot_hash: &str,
+            ) -> AnyResult<Option<EntryId>>;
+        }
+    }
+
+    mockall::mock! {
+        SelectionRepo {}
+        #[async_trait]
+        impl ClipboardSelectionRepositoryPort for SelectionRepo {
+            async fn get_selection(
+                &self,
+                entry_id: &EntryId,
+            ) -> AnyResult<Option<ClipboardSelectionDecision>>;
+            async fn delete_selection(&self, entry_id: &EntryId) -> AnyResult<()>;
+        }
+    }
+
+    /// `ClipboardRepresentationRepositoryPort` 的 `update_processing_result` 方法
+    /// 同时持有 `Option<&BlobId>` 与 `Option<&str>` 两个借用参数，mockall 无法
+    /// 推断出与 `&self` 协同的生命周期（详见 `restore_selection.rs` 的
+    /// `FakeRepo` 注释）。本 trait 因此 hand-roll，其他 trait 仍走 mockall。
+    struct FakeRepRepo {
+        reps: Vec<PersistedClipboardRepresentation>,
+    }
+
+    #[async_trait]
+    impl ClipboardRepresentationRepositoryPort for FakeRepRepo {
+        async fn get_representation(
+            &self,
+            _: &EventId,
+            rep_id: &RepresentationId,
+        ) -> AnyResult<Option<PersistedClipboardRepresentation>> {
+            Ok(self.reps.iter().find(|r| &r.id == rep_id).cloned())
+        }
+        async fn get_representation_by_id(
+            &self,
+            _: &RepresentationId,
+        ) -> AnyResult<Option<PersistedClipboardRepresentation>> {
+            unimplemented!()
+        }
+        async fn get_representation_by_blob_id(
+            &self,
+            _: &BlobId,
+        ) -> AnyResult<Option<PersistedClipboardRepresentation>> {
+            unimplemented!()
+        }
+        async fn update_blob_id(&self, _: &RepresentationId, _: &BlobId) -> AnyResult<()> {
+            unimplemented!()
+        }
+        async fn update_blob_id_if_none(
+            &self,
+            _: &RepresentationId,
+            _: &BlobId,
+        ) -> AnyResult<bool> {
+            unimplemented!()
+        }
+        async fn update_processing_result(
+            &self,
+            _: &RepresentationId,
+            _: &[PayloadAvailability],
+            _: Option<&BlobId>,
+            _: PayloadAvailability,
+            _: Option<&str>,
+        ) -> AnyResult<ProcessingUpdateOutcome> {
+            unimplemented!()
+        }
+    }
+
+    mockall::mock! {
+        Resolver {}
+        #[async_trait]
+        impl ClipboardPayloadResolverPort for Resolver {
+            async fn resolve(
+                &self,
+                representation: &PersistedClipboardRepresentation,
+            ) -> Result<ResolvedClipboardPayload, PayloadResolveError>;
+        }
+    }
+
+    mockall::mock! {
+        BlobReader {}
+        #[async_trait]
+        impl uc_core::blob::ports::BlobReaderPort for BlobReader {
+            async fn get(&self, blob_id: &BlobId) -> AnyResult<Vec<u8>>;
+        }
+    }
+
+    mockall::mock! {
+        SystemClipboard {}
+        #[async_trait]
+        impl SystemClipboardPort for SystemClipboard {
+            fn read_snapshot(&self) -> AnyResult<SystemClipboardSnapshot>;
+            fn write_snapshot(&self, snapshot: SystemClipboardSnapshot) -> AnyResult<()>;
+        }
+    }
+
+    mockall::mock! {
+        ChangeOrigin {}
+        #[async_trait]
+        impl ClipboardChangeOriginPort for ChangeOrigin {
+            async fn set_next_origin(&self, origin: ClipboardChangeOrigin, ttl: Duration);
+            async fn consume_origin_or_default(
+                &self,
+                default_origin: ClipboardChangeOrigin,
+            ) -> ClipboardChangeOrigin;
+            async fn has_pending_origin(&self) -> bool;
+            async fn remember_remote_snapshot_hash(&self, snapshot_hash: String, ttl: Duration);
+            async fn remember_local_snapshot_hash(&self, snapshot_hash: String, ttl: Duration);
+            async fn consume_origin_for_snapshot_or_default(
+                &self,
+                snapshot_hash: &str,
+                default_origin: ClipboardChangeOrigin,
+            ) -> ClipboardChangeOrigin;
+        }
+    }
+
+    /// 把 `payload_resolver.resolve` 配置成"按 inline_data 直读"——所有测试 rep
+    /// 都走 inline 路径，blob_store 不会被触达。
+    fn expect_inline_resolves(resolver: &mut MockResolver) {
+        resolver.expect_resolve().returning(|rep| {
+            let bytes = rep
+                .inline_data
+                .clone()
+                .ok_or_else(|| PayloadResolveError::Integrity {
+                    rep_id: rep.id.clone(),
+                    reason: "test resolver requires inline_data".to_string(),
+                })?;
+            Ok(ResolvedClipboardPayload::Inline {
+                mime: rep
+                    .mime_type
+                    .as_ref()
+                    .map(|m| m.as_str().to_string())
+                    .unwrap_or_default(),
+                bytes,
+            })
+        });
+    }
+
+    /// coordinator 内部对 origin port 的两层守卫调用，本测试不验证具体守卫
+    /// 细节（coordinator 自身已在 `clipboard_write/coordinator.rs` 测过），
+    /// 这里只让所有相关方法以 default 行为通过。
+    fn expect_permissive_origin(origin: &mut MockChangeOrigin) {
+        origin
+            .expect_remember_local_snapshot_hash()
+            .returning(|_, _| ());
+        origin.expect_set_next_origin().returning(|_, _| ());
+    }
+
+    /// 用 mockall 把每次 `write_snapshot` 收到的 snapshot 累计起来供断言查阅，
+    /// 同时给 `SystemClipboardPort` 套上 Arc 引用以便测试与 coordinator 共享。
+    fn recording_system_clipboard() -> (
+        Arc<MockSystemClipboard>,
+        Arc<Mutex<Vec<SystemClipboardSnapshot>>>,
+    ) {
+        let writes = Arc::new(Mutex::new(Vec::<SystemClipboardSnapshot>::new()));
+        let writes_for_mock = writes.clone();
+        let mut clipboard = MockSystemClipboard::new();
+        clipboard.expect_write_snapshot().returning(move |snap| {
+            writes_for_mock.lock().unwrap().push(snap);
+            Ok(())
+        });
+        (Arc::new(clipboard), writes)
+    }
+
+    /// 组装一个 use case + 写入记录句柄。调用方先在 mocks 上设好 `expect_*`，
+    /// 再传进来；本 helper 负责注入 coordinator 与 integration mode。
+    fn build_use_case(
+        entry_repo: MockEntryRepo,
+        selection_repo: MockSelectionRepo,
+        rep_repo: FakeRepRepo,
+        resolver: MockResolver,
+        blob_reader: MockBlobReader,
+        clipboard: Arc<MockSystemClipboard>,
+        origin: MockChangeOrigin,
+    ) -> RestoreClipboardEntryAsPlainTextUseCase {
+        let coordinator = Arc::new(ClipboardWriteCoordinator::new(clipboard, Arc::new(origin)));
+        RestoreClipboardEntryAsPlainTextUseCase::new(
+            Arc::new(entry_repo),
+            coordinator,
+            Arc::new(selection_repo),
+            Arc::new(rep_repo),
+            Arc::new(resolver),
+            Arc::new(blob_reader),
+            ClipboardIntegrationMode::Full,
+        )
+    }
+
+    /// 条目同时持有 plain + html 两份 rep，paste_rep 指向 plain：
+    /// 用例应当只把 plain rep 写入系统剪贴板，绝不把 html 一起带上。
+    #[tokio::test]
+    async fn done_when_plain_rep_is_paste_rep() {
+        let entry = make_entry("entry-1", "event-1");
+        let plain = make_rep("rep-plain", "text/plain", "text", b"hello world");
+        let html = make_rep(
+            "rep-html",
+            "text/html",
+            "html",
+            b"<p>hello <b>world</b></p>",
+        );
+        let decision = make_selection("entry-1", "rep-plain", vec!["rep-html"]);
+
+        let mut entry_repo = MockEntryRepo::new();
+        entry_repo
+            .expect_get_entry()
+            .returning(move |_| Ok(Some(entry.clone())));
+
+        let mut selection_repo = MockSelectionRepo::new();
+        selection_repo
+            .expect_get_selection()
+            .returning(move |_| Ok(Some(decision.clone())));
+
+        let rep_repo = FakeRepRepo {
+            reps: vec![plain.clone(), html],
+        };
+
+        let mut resolver = MockResolver::new();
+        expect_inline_resolves(&mut resolver);
+
+        let blob_reader = MockBlobReader::new();
+        let (clipboard, writes) = recording_system_clipboard();
+        let mut origin = MockChangeOrigin::new();
+        expect_permissive_origin(&mut origin);
+
+        let uc = build_use_case(
+            entry_repo,
+            selection_repo,
+            rep_repo,
+            resolver,
+            blob_reader,
+            clipboard,
+            origin,
+        );
+
+        let outcome = uc
+            .execute(&EntryId::from("entry-1"))
+            .await
+            .expect("execute should succeed");
+        assert_eq!(outcome, PlainRestoreOutcome::Done);
+
+        let writes = writes.lock().unwrap();
+        assert_eq!(writes.len(), 1, "exactly one OS clipboard write expected");
+        let reps = &writes[0].representations;
+        assert_eq!(reps.len(), 1, "snapshot must contain only the plain rep");
+        assert_eq!(reps[0].id, plain.id);
+        assert_eq!(reps[0].bytes, b"hello world");
+    }
+
+    /// 条目根本没有 plain 表示（典型富文本场景：复制自 PDF 等）。用例应当
+    /// 返回 `NoPlainTextAvailable` 让 facade 走降级路径，并且**不**写入系统
+    /// 剪贴板——否则降级时会出现两次 OS 写入。
+    ///
+    /// 这里 system clipboard 与 origin 都不 `expect_*` 任何方法，mockall 在
+    /// 这两者上的任何调用都会 panic——就是"绝不写入"的断言。
+    #[tokio::test]
+    async fn no_plain_when_only_rich_text_reps_present() {
+        let entry = make_entry("entry-2", "event-2");
+        let html = make_rep(
+            "rep-html",
+            "text/html",
+            "html",
+            b"<p>only rich text here</p>",
+        );
+        let rtf = make_rep(
+            "rep-rtf",
+            "text/rtf",
+            "rtf",
+            b"{\\rtf1\\ansi only rich text}",
+        );
+        let decision = make_selection("entry-2", "rep-html", vec!["rep-rtf"]);
+
+        let mut entry_repo = MockEntryRepo::new();
+        entry_repo
+            .expect_get_entry()
+            .returning(move |_| Ok(Some(entry.clone())));
+
+        let mut selection_repo = MockSelectionRepo::new();
+        selection_repo
+            .expect_get_selection()
+            .returning(move |_| Ok(Some(decision.clone())));
+
+        let rep_repo = FakeRepRepo {
+            reps: vec![html, rtf],
+        };
+
+        let resolver = MockResolver::new();
+        let blob_reader = MockBlobReader::new();
+        let clipboard = Arc::new(MockSystemClipboard::new());
+        let origin = MockChangeOrigin::new();
+
+        let uc = build_use_case(
+            entry_repo,
+            selection_repo,
+            rep_repo,
+            resolver,
+            blob_reader,
+            clipboard,
+            origin,
+        );
+
+        let outcome = uc
+            .execute(&EntryId::from("entry-2"))
+            .await
+            .expect("execute should succeed");
+        assert_eq!(outcome, PlainRestoreOutcome::NoPlainTextAvailable);
+    }
+
+    /// 极端但真实的场景：paste_rep 选了 html，plain 只挂在 secondary 列表里。
+    /// 用例必须扫完候选才能定位 plain，不能因为 paste_rep 不是 plain 就放弃。
+    #[tokio::test]
+    async fn done_when_plain_rep_is_only_in_secondary() {
+        let entry = make_entry("entry-3", "event-3");
+        let html = make_rep("rep-html", "text/html", "html", b"<p>hi</p>");
+        let plain = make_rep("rep-plain", "text/plain", "text", b"hi");
+        let decision = make_selection("entry-3", "rep-html", vec!["rep-plain"]);
+
+        let mut entry_repo = MockEntryRepo::new();
+        entry_repo
+            .expect_get_entry()
+            .returning(move |_| Ok(Some(entry.clone())));
+
+        let mut selection_repo = MockSelectionRepo::new();
+        selection_repo
+            .expect_get_selection()
+            .returning(move |_| Ok(Some(decision.clone())));
+
+        let rep_repo = FakeRepRepo {
+            reps: vec![html, plain.clone()],
+        };
+
+        let mut resolver = MockResolver::new();
+        expect_inline_resolves(&mut resolver);
+
+        let blob_reader = MockBlobReader::new();
+        let (clipboard, writes) = recording_system_clipboard();
+        let mut origin = MockChangeOrigin::new();
+        expect_permissive_origin(&mut origin);
+
+        let uc = build_use_case(
+            entry_repo,
+            selection_repo,
+            rep_repo,
+            resolver,
+            blob_reader,
+            clipboard,
+            origin,
+        );
+
+        let outcome = uc
+            .execute(&EntryId::from("entry-3"))
+            .await
+            .expect("execute should succeed");
+        assert_eq!(outcome, PlainRestoreOutcome::Done);
+
+        let writes = writes.lock().unwrap();
+        assert_eq!(writes.len(), 1);
+        assert_eq!(writes[0].representations.len(), 1);
+        assert_eq!(writes[0].representations[0].id, plain.id);
+    }
+}

--- a/src-tauri/crates/uc-core/src/clipboard/mod.rs
+++ b/src-tauri/crates/uc-core/src/clipboard/mod.rs
@@ -26,8 +26,8 @@ pub use policy::*;
 pub use selection::*;
 pub use snapshot::*;
 pub use system::{
-    is_file_mime_or_format, ObservedClipboardRepresentation, RepresentationHash, SnapshotHash,
-    SystemClipboardSnapshot,
+    is_file_mime_or_format, is_plain_text_mime_or_format, ObservedClipboardRepresentation,
+    RepresentationHash, SnapshotHash, SystemClipboardSnapshot,
 };
 
 pub use decision::{ClipboardContentActionDecision, DuplicationHint, RejectReason};

--- a/src-tauri/crates/uc-core/src/clipboard/system.rs
+++ b/src-tauri/crates/uc-core/src/clipboard/system.rs
@@ -87,8 +87,16 @@ impl ObservedClipboardRepresentation {
     }
 }
 
-pub(crate) fn is_plain_text_representation(rep: &ObservedClipboardRepresentation) -> bool {
-    if let Some(mime) = rep.mime.as_ref() {
+/// 判断一组 (mime, format_id) 是否表示「纯文本」（`text/plain` 家族）。
+///
+/// 该判断是领域规则，跨表示类型（`Observed*` / `Persisted*`）共享语义：
+/// - `text/plain` 与其参数化变体（`text/plain; charset=utf-8` 等）
+/// - macOS UTI `public.utf8-plain-text`
+/// - format_id 为 `text` 的兜底分支（无 mime 元信息时）
+///
+/// 不包含 `text/html` / `text/rtf` / `text/markdown` 等富文本子类型。
+pub fn is_plain_text_mime_or_format(mime: Option<&MimeType>, format_id: &FormatId) -> bool {
+    if let Some(mime) = mime {
         let mime_str = mime.as_str();
         if mime_str.eq_ignore_ascii_case("text/plain")
             || mime_str.to_ascii_lowercase().starts_with("text/plain;")
@@ -97,7 +105,11 @@ pub(crate) fn is_plain_text_representation(rep: &ObservedClipboardRepresentation
             return true;
         }
     }
-    rep.format_id.eq_ignore_ascii_case("text")
+    format_id.eq_ignore_ascii_case("text")
+}
+
+pub(crate) fn is_plain_text_representation(rep: &ObservedClipboardRepresentation) -> bool {
+    is_plain_text_mime_or_format(rep.mime.as_ref(), &rep.format_id)
 }
 
 fn is_text_representation(rep: &ObservedClipboardRepresentation) -> bool {

--- a/src-tauri/crates/uc-webserver/src/api/routes.rs
+++ b/src-tauri/crates/uc-webserver/src/api/routes.rs
@@ -13,7 +13,7 @@
 
 use std::sync::Arc;
 
-use axum::extract::{Path, State};
+use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::middleware;
 use axum::response::IntoResponse;
@@ -117,16 +117,34 @@ async fn health(State(state): State<DaemonApiState>) -> impl IntoResponse {
     Json(state.health_response())
 }
 
+/// Restore endpoint 的可选 query 参数。
+///
+/// `plain=true` 时走「以纯文本形式恢复」路径——只把 `text/plain` 表示写入
+/// 系统剪贴板，让目标应用别无选择地粘出纯文本（Markdown 源码 / HTML 标签 /
+/// RTF 等富文本被剔除）。条目若没有 plain 表示，facade 静默降级为多格式恢复。
+///
+/// `plain=false` 或缺省时与历史行为完全一致：多格式恢复。
+#[derive(Debug, Default, serde::Deserialize)]
+struct RestoreQuery {
+    #[serde(default)]
+    plain: bool,
+}
+
 async fn restore_clipboard_entry_handler(
     State(state): State<DaemonApiState>,
     Path(entry_id): Path<String>,
+    Query(query): Query<RestoreQuery>,
 ) -> impl IntoResponse {
     let app = match state.app_facade_or_error() {
         Ok(app) => app,
         Err(error) => return error.into_response(),
     };
 
-    tracing::info!(entry_id = %entry_id, "daemon restore request received");
+    tracing::info!(
+        entry_id = %entry_id,
+        plain = query.plain,
+        "daemon restore request received"
+    );
 
     let restore_facade = match app.clipboard_restore.as_ref() {
         Some(facade) => facade,
@@ -138,9 +156,19 @@ async fn restore_clipboard_entry_handler(
         }
     };
 
-    match restore_facade.restore_entry(&entry_id).await {
+    let result = if query.plain {
+        restore_facade.restore_entry_as_plain_text(&entry_id).await
+    } else {
+        restore_facade.restore_entry(&entry_id).await
+    };
+
+    match result {
         Ok(()) => {
-            tracing::info!(entry_id = %entry_id, "daemon restore request succeeded");
+            tracing::info!(
+                entry_id = %entry_id,
+                plain = query.plain,
+                "daemon restore request succeeded"
+            );
             restore_success_response().into_response()
         }
         Err(error) => restore_error_to_response(error, &entry_id).into_response(),

--- a/src/api/daemon/clipboard.ts
+++ b/src/api/daemon/clipboard.ts
@@ -224,13 +224,26 @@ export async function deleteClipboardEntry(id: string): Promise<void> {
  * daemon 负责来源追踪和出站同步。
  *
  * @param id Entry ID to restore.
+ * @param opts.plainOnly When true, write only the `text/plain` representation
+ *   to the OS clipboard so that target applications paste as plain text.
+ *   Falls back silently to multi-format restore if the entry has no plain rep.
+ *
+ *   传 `plainOnly: true` 时只把 `text/plain` 表示写入系统剪贴板，让目标
+ *   应用粘出纯文本（Markdown 源码 / HTML 标签 / RTF 等富文本被剔除）。
+ *   条目没有 plain 表示时由 daemon 静默降级为多格式恢复。
  * @throws {DaemonApiError} On HTTP errors, session failures, or entry not found.
  */
-export async function restoreClipboardEntry(id: string): Promise<RestoreResult> {
+export async function restoreClipboardEntry(
+  id: string,
+  opts?: { plainOnly?: boolean }
+): Promise<RestoreResult> {
   const options: RequestOptions = {
     method: 'POST',
   }
-  await daemonClient.request<void>(`${CLIPBOARD_RESTORE}/${id}`, options)
+  const path = opts?.plainOnly
+    ? `${CLIPBOARD_RESTORE}/${id}?plain=true`
+    : `${CLIPBOARD_RESTORE}/${id}`
+  await daemonClient.request<void>(path, options)
   return { success: true }
 }
 

--- a/src/quick-panel/ClipboardHistoryPanel.tsx
+++ b/src/quick-panel/ClipboardHistoryPanel.tsx
@@ -285,11 +285,11 @@ const ClipboardHistoryPanel: React.FC = () => {
   ])
 
   const handleSelect = useCallback(
-    async (index: number) => {
+    async (index: number, plainOnly?: boolean) => {
       const item = filteredItems[index]
       if (!item) return
       try {
-        await restoreClipboardEntry(item.id)
+        await restoreClipboardEntry(item.id, plainOnly ? { plainOnly: true } : undefined)
         await pasteToApp()
       } catch (err) {
         log.error({ err }, 'Failed to restore clipboard entry')
@@ -360,7 +360,7 @@ const ClipboardHistoryPanel: React.FC = () => {
       if ((e.metaKey || e.ctrlKey) && e.key >= '0' && e.key <= '9') {
         e.preventDefault()
         const index = e.key === '0' ? 9 : parseInt(e.key) - 1
-        if (index < filteredItems.length) void handleSelect(index)
+        if (index < filteredItems.length) void handleSelect(index, e.altKey)
         return
       }
 
@@ -392,7 +392,7 @@ const ClipboardHistoryPanel: React.FC = () => {
           break
         case 'Enter':
           e.preventDefault()
-          void handleSelect(selectedIndex)
+          void handleSelect(selectedIndex, e.altKey)
           break
       }
     },

--- a/src/quick-panel/components/HistoryPane.tsx
+++ b/src/quick-panel/components/HistoryPane.tsx
@@ -40,7 +40,7 @@ interface HistoryPaneProps {
   onHover: (index: number) => void
   onHistoryMouseMove: () => void
   onSearchChange: (value: string) => void
-  onSelect: (index: number) => void
+  onSelect: (index: number, plainOnly?: boolean) => void
   onUnlock: () => void
   searchInputRef: React.Ref<HTMLInputElement>
   searchQuery: string

--- a/src/quick-panel/components/PanelItem.tsx
+++ b/src/quick-panel/components/PanelItem.tsx
@@ -9,7 +9,7 @@ interface PanelItemProps {
   index: number
   isSelected: boolean
   hoverDisabled: boolean
-  onSelect: (index: number) => void
+  onSelect: (index: number, plainOnly?: boolean) => void
   onHover: (index: number) => void
   itemRef?: React.Ref<HTMLDivElement>
   shortcutKey?: string
@@ -31,7 +31,7 @@ const PanelItem: React.FC<PanelItemProps> = React.memo(
               ? 'text-foreground'
               : 'text-foreground hover:bg-muted/50',
         ].join(' ')}
-        onClick={() => onSelect(index)}
+        onClick={e => onSelect(index, e.altKey)}
         onMouseEnter={() => onHover(index)}
       >
         <Icon


### PR DESCRIPTION
## Summary

- Holding **Option** (macOS) / **Alt** (Windows) when triggering paste from the quick panel writes only the `text/plain` representation to the OS clipboard, so target apps paste as plain text (no more pasted Markdown source, HTML tags, or RTF).
- Three trigger entry points all honour the modifier: `Enter`, click on item, and `Cmd/Ctrl + 1–9` shortcuts.
- Silently falls back to the existing multi-format restore when the entry has no plain rep (image, file, pure HTML, etc.) — user perception is "Option did nothing on this one", no error popup.
- Self-write suppression is inherited verbatim from `ClipboardWriteCoordinator` with `LocalRestore` intent. `origin_guard_key` stays stable on a single plain rep because `meaningful_origin_key` prefers `text/plain` over rich-text — the watcher therefore won't re-record the plain-only restore as a new history entry.

Closes #642.

## Architecture notes

- New use case `RestoreClipboardEntryAsPlainTextUseCase` in `uc-application`, exposed only via `ClipboardRestoreFacade::restore_entry_as_plain_text` (§11.4 facade boundary).
- The use case returns `PlainRestoreOutcome::NoPlainTextAvailable` instead of erroring; the facade interprets that as a fallback signal and delegates to the existing `RestoreClipboardSelectionUseCase`. Keeps each use case to one action (§8.1).
- `uc-core` exports a new `pub fn is_plain_text_mime_or_format(mime, format_id)` mirroring the existing `is_file_mime_or_format`, so the application layer can run the rule against `PersistedClipboardRepresentation` without rebuilding the predicate.
- HTTP shape: `POST /clipboard/restore/{id}?plain=true` — additive and backward-compatible; existing clients see no behaviour change.

## Test plan

### Automated
- [x] `cargo test -p uc-application --lib` — 430 passed (3 new tests for the plain-only use case)
- [x] `cargo check` — uc-core / uc-application / uc-webserver compile clean
- [x] `tsc --noEmit` — frontend type-check passes

### Manual (macOS)
- [ ] Copy a Markdown link, open quick panel, press `Option+Enter` → rich-text editor (Notes / Pages) pastes the plain text label, **not** the `[text](url)` source
- [ ] Same scenario with `Option`-click on the item — same result
- [ ] Same scenario with `Option+Cmd+1` — same result
- [ ] Plain `Enter` (no Option) still pastes the rich Markdown source (no regression)
- [ ] `Option+Enter` on an image-only entry → silently falls back, pastes the image
- [ ] After `Option+Enter` on entry X, the entry stays at the top of history (LRU touch verified)
- [ ] After `Option+Enter`, the history list does **not** grow by a new entry (watcher self-write suppression verified)

### Manual (Windows)
- [ ] Repeat the six macOS checks with `Alt+Enter` / `Alt`-click / `Alt+Ctrl+1`

### Edge cases worth poking
- [ ] Within 2 seconds, do a normal restore on entry X, then `Option+Enter` on the same entry — second write must not produce a duplicate history entry (`origin_guard_key` overlap)
- [ ] Entry whose plain body is large (> 16 KB inline threshold, Staged state) — `Option+Enter` should paste the full bytes, not the 500-char preview truncation (resolver path)