### PR TITLE
docs(skill): clarify version/channel interaction in trigger-prepare-release

### DIFF
--- a/.claude/skills/trigger-prepare-release/SKILL.md
+++ b/.claude/skills/trigger-prepare-release/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: trigger-prepare-release
-description: Trigger the prepare-release workflow on GitHub Actions. Supports optional arguments for version, bump type, channel, and base branch. Defaults to bump=patch, channel=alpha, base_branch=current branch.
+description: Trigger the prepare-release workflow on GitHub Actions. Supports optional arguments for version, bump type, and channel. Defaults to bump=patch, channel=stable.
 metadata:
   author: mark
-  version: "1.1.0"
+  version: "1.2.0"
 allowed-tools: Bash(gh:*), Bash(git:*)
 ---
 
@@ -11,56 +11,86 @@ allowed-tools: Bash(gh:*), Bash(git:*)
 
 Trigger the `prepare-release.yml` workflow on GitHub Actions.
 
+The workflow always runs against `main` (hardcoded inside the workflow) and produces a `release/v<version>` branch + PR.
+
 ## Arguments
 
-All arguments are optional. Parse from user input (e.g. `/trigger-prepare-release channel=beta bump=minor`):
+All arguments are optional.
 
-| Parameter     | Default               | Description                                      |
-| ------------- | --------------------- | ------------------------------------------------ |
-| `version`     | *(empty)*             | Exact semver version (e.g. `0.5.0`), no `v` prefix. If set, `bump` is ignored. |
-| `bump`        | `patch`               | Version bump type: `patch`, `minor`, `major`     |
-| `channel`     | `alpha`               | Release channel: `stable`, `alpha`, `beta`, `rc` |
-| `base_branch` | current git branch    | Branch to base the release off                   |
+| Parameter | Default   | Description                                                                                                          |
+| --------- | --------- | -------------------------------------------------------------------------------------------------------------------- |
+| `version` | *(empty)* | Exact semver, no `v` prefix. **Include the channel suffix if you want one** (e.g. `0.9.0-alpha.1`). Overrides `bump` AND `channel`. |
+| `bump`    | `patch`   | Version bump type: `patch`, `minor`, `major`. Only used when `version` is empty.                                     |
+| `channel` | `stable`  | Release channel: `stable`, `alpha`, `beta`, `rc`. Only used when `version` is empty.                                 |
+
+### Critical: how `version` interacts with `channel`
+
+The workflow's `Determine version` step is:
+
+```sh
+if [ -n "$version" ]; then
+  VERSION="$version"        # used verbatim, channel ignored
+else
+  VERSION=$(bump-version.js --type "$bump" --channel "$channel" --dry-run ...)
+fi
+```
+
+So:
+
+- ✅ `version=0.9.0-alpha.1` → release `v0.9.0-alpha.1` (correct way to ship an alpha at an exact version)
+- ❌ `version=0.9.0` + `channel=alpha` → release `v0.9.0` (channel **silently ignored**, this is the trap)
+- ✅ `bump=minor` + `channel=alpha` → script computes next alpha (e.g. `v0.9.0-alpha.1`)
 
 ## Workflow
 
-### 1. Determine Parameters
+### 1. Parse arguments
 
-- Parse any user-provided arguments, fill the rest with defaults.
-- For `base_branch`, if not explicitly provided, detect via `git branch --show-current`.
+Accept either `key=value` form (`channel=beta bump=minor`) or positional tokens (`/trigger-prepare-release 0.9.0-alpha.1`). For each positional token, classify by shape:
 
-### 2. Confirm with User
+| Token shape                                              | Classified as | Examples                              |
+| -------------------------------------------------------- | ------------- | ------------------------------------- |
+| Looks like semver (digit-dot-digit, optional `-suffix.N`) | `version`     | `0.9.0`, `0.9.0-alpha.1`, `1.2.3-rc.2` |
+| One of `stable` / `alpha` / `beta` / `rc` (bare word)    | `channel`     | `alpha`, `rc`                         |
+| One of `patch` / `minor` / `major`                       | `bump`        | `minor`                               |
 
-Before triggering, display the resolved parameters and ask for confirmation:
+**Ambiguity rule:** if the user supplies a semver-shaped token AND a bare channel word (e.g. `0.9.0 alpha.1` or `0.9.0 alpha`), do NOT split them across `version`/`channel` — that triggers the trap above. Instead, ask the user whether they meant:
+
+- `version=0.9.0-alpha.1` (exact version with suffix), or
+- `bump=minor channel=alpha` (let the script compute the next alpha)
+
+### 2. Confirm with user
+
+Display the resolved parameters and ask for confirmation before triggering:
 
 ```
 Will trigger prepare-release with:
-  version:     (empty)
-  bump:        patch
-  channel:     alpha
-  base_branch: dev
+  version: 0.9.0-alpha.1
+  bump:    (ignored — version is set)
+  channel: (ignored — version is set)
 Proceed? (y/n)
 ```
 
-### 3. Trigger the Workflow
+If `version` is empty, show resolved `bump` and `channel` instead.
+
+### 3. Trigger the workflow
 
 ```bash
 gh workflow run prepare-release.yml \
   --repo UniClipboard/UniClipboard \
-  --ref <base_branch> \
+  --ref main \
+  -f version=<version> \
   -f bump=<bump> \
-  -f channel=<channel> \
-  -f base_branch=<base_branch>
+  -f channel=<channel>
 ```
 
-If `version` is provided, add `-f version=<version>`.
+Omit `-f version=` when `version` is empty. `--ref` is always `main` because the workflow checks out `main` internally regardless.
 
-### 4. Confirm Dispatch
+### 4. Confirm dispatch
 
-After triggering, wait a few seconds then show the latest run:
+After triggering, wait a few seconds and show the latest run:
 
 ```bash
 gh run list --repo UniClipboard/UniClipboard --workflow=prepare-release.yml --limit 1
 ```
 
-Report the run URL to the user so they can monitor progress.
+Report the run URL so the user can monitor progress. The run's name (`prepare-release-v<resolved-version>`) is the easiest way to verify the version came out as expected — check it before walking away.


### PR DESCRIPTION
## Summary

While triggering a 0.9.0 alpha release, the skill resolved `/trigger-prepare-release 0.9.0 alpha.1` into `version=0.9.0 + channel=alpha`. The `prepare-release.yml` workflow, however, ignores `channel` whenever `version` is set, so it produced PR #645 titled `release: v0.9.0` (the closed正式版 PR) instead of `release: v0.9.0-alpha.1`. PR #645 has since been closed and the correct alpha release has been re-triggered.

This PR updates `.claude/skills/trigger-prepare-release/SKILL.md` so a future invocation cannot fall into the same trap.

### Changes

- Document the workflow's actual precedence: `version` overrides **both** `bump` and `channel`. To ship an alpha at an exact version, spell out the suffix (`version=0.9.0-alpha.1`).
- Remove the bogus `base_branch` parameter. The workflow never reads it — it hardcodes a `main` checkout.
- Add a positional-argument parsing table (semver shape → `version`, bare channel word → `channel`, bare bump word → `bump`) plus an ambiguity rule: `0.9.0 alpha.1` must not be auto-split, the skill must ask the user whether they meant `version=0.9.0-alpha.1` or `bump=minor channel=alpha`.
- Align the frontmatter default `channel=stable` with the workflow yaml's actual default (was `alpha`).
- Bump skill version 1.1.0 → 1.2.0.

## Test plan

- [ ] Re-read SKILL.md — the Critical section, parsing table, and ambiguity rule all make the failure mode explicit.
- [ ] Next `/trigger-prepare-release …` invocation that includes a channel suffix is handled correctly (manual verification on the next release).