### PR TITLE
ci(docker): add prebuilt bookworm base image for Linux builds

### DIFF
--- a/.github/docker/build-bookworm.Dockerfile
+++ b/.github/docker/build-bookworm.Dockerfile
@@ -1,0 +1,27 @@
+# Build container for UniClipboard Linux Tauri + CLI builds.
+#
+# 替代 .github/workflows/{build,build-cli}.yml 里每次重复 1m+ 的
+# `apt-get install` step。镜像同时覆盖:
+#   - Tauri 桌面端 (webkit2gtk-4.1 / appindicator / gtk3 / rpm 等)
+#   - CLI musl 静态编译 (musl-tools)
+#
+# glibc 基线锁在 bookworm 的 2.36 — 跟工作流里 container=debian:bookworm
+# 的预期一致。multi-arch (linux/amd64 + linux/arm64) 由 build workflow
+# 通过 buildx 推送,aarch64 host 自动选到 arm64 manifest。
+
+FROM debian:bookworm-slim
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      git curl wget ca-certificates xz-utils unzip sudo \
+      build-essential pkg-config cmake clang \
+      libssl-dev \
+      libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf \
+      libgtk-3-dev libsoup-3.0-dev libjavascriptcoregtk-4.1-dev \
+      file desktop-file-utils \
+      xdg-utils \
+      rpm \
+      musl-tools \
+ && rm -rf /var/lib/apt/lists/*

--- a/.github/workflows/build-base-image.yml
+++ b/.github/workflows/build-base-image.yml
@@ -1,0 +1,90 @@
+name: 'Build base container image'
+run-name: "build-base-image-${{ github.run_number }}"
+
+# 触发条件:
+#   - main 上 Dockerfile / 本 workflow 自身变更 → 自动重建 :latest
+#   - 手动 dispatch → 临时改完想立刻测一遍
+#
+# 镜像被 build.yml / build-cli.yml 在 container.image 字段引用,push 完
+# 必须在 GitHub Packages 页把 visibility 调成 public,否则 reusable build
+# 拉镜像会 401(public 后 anonymous pull 直接命中,无需带 credentials)。
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/docker/build-bookworm.Dockerfile'
+      - '.github/workflows/build-base-image.yml'
+
+env:
+  REGISTRY: ghcr.io
+  # GHCR path 必须小写,这里强制 lowercase 以防 owner 大小写不一致
+  IMAGE_NAME: ${{ github.repository_owner }}/build-bookworm
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Lowercase image name
+        id: img
+        run: |
+          name="${IMAGE_NAME,,}"
+          echo "image=${REGISTRY}/${name}" >> "$GITHUB_OUTPUT"
+
+      # buildx + qemu 用来一次产出 amd64 + arm64 双 arch manifest,
+      # 这样 ubuntu-22.04 (x86_64) 和 ubuntu-22.04-arm (aarch64) host
+      # 拉同一个 tag 自动解析到对应 arch 的层。
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ steps.img.outputs.image }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha,prefix=sha-,format=short
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .github/docker
+          file: .github/docker/build-bookworm.Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # GHA cache 让重复构建只重跑变更的 RUN layer,通常 < 30s
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Summary
+        run: |
+          echo "## Base image pushed :package:" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Tags:" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          echo "${{ steps.meta.outputs.tags }}" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "> 首次推送后请到 Packages 设置里把 visibility 改为 public," >> "$GITHUB_STEP_SUMMARY"
+          echo "> 否则 build.yml / build-cli.yml 拉镜像会 401。" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

- 在 `.github/docker/build-bookworm.Dockerfile` 沉淀 Tauri 桌面端 + CLI musl 编译所需的全部 apt 依赖。
- 新增 `.github/workflows/build-base-image.yml`：main 上 Dockerfile 变更自动构建 multi-arch (amd64 + arm64) 镜像，推到 `ghcr.io/uniclipboard/build-bookworm:latest`。
- 目的：替代 `build.yml` / `build-cli.yml` 里每次重跑 ~77s × 4 Linux job 的 `apt-get install` step。

镜像未来由后续 PR 引用为 container（本 PR 暂未切流量，先把镜像基础设施沉淀下来）。

## ⚠️ 合并后必须手动操作

GHCR 镜像首次推送默认 **private**。public repo 的 reusable workflow 用 `container.image` 字段拉私有镜像会 401。合并后请：

1. 等 `build-base-image.yml` 在 main 上自动跑完（~3–5 min），产出 `ghcr.io/uniclipboard/build-bookworm:latest`
2. 打开 https://github.com/orgs/UniClipboard/packages/container/build-bookworm/settings
3. `Danger Zone` → `Change package visibility` → **Public** → 输入包名确认

完成后，后续 release-optimization PR（把 build container 切到该镜像）才能合并。

## Test plan

- [ ] PR 合并后 `build-base-image.yml` 在 main 上自动触发
- [ ] amd64 + arm64 manifest 都成功推送
- [ ] 在 GHCR Packages 页面把可见性切到 Public
- [ ] 手动 dispatch 一次 `build-base-image.yml` 确认增量构建 < 30s（GHA 缓存命中）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented automated multi-architecture Docker image builds with support for both AMD64 and ARM64 platforms.
  * Added build infrastructure to support containerized compilation of desktop and CLI applications.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/UniClipboard/UniClipboard/pull/648)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->