### PR TITLE
ci(release): cut release wallclock from ~55 min to ~26 min

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -44,15 +44,15 @@ jobs:
           # 容器仍用 debian:bookworm 拿 musl-tools / cmake / clang 工具链。
           PLATFORM="${{ inputs.platform || 'all' }}"
           if [ "$PLATFORM" == "all" ]; then
-            echo 'matrix=[{"platform":"macos-latest","target":"aarch64-apple-darwin","args":"--target aarch64-apple-darwin"},{"platform":"macos-latest","target":"x86_64-apple-darwin","args":"--target x86_64-apple-darwin"},{"platform":"ubuntu-22.04","target":"x86_64-unknown-linux-musl","args":"--target x86_64-unknown-linux-musl","container":"debian:bookworm"},{"platform":"ubuntu-22.04-arm","target":"aarch64-unknown-linux-musl","args":"--target aarch64-unknown-linux-musl","container":"debian:bookworm"},{"platform":"windows-latest","target":"x86_64-pc-windows-msvc","args":""}]' >> "$GITHUB_OUTPUT"
+            echo 'matrix=[{"platform":"macos-latest","target":"aarch64-apple-darwin","args":"--target aarch64-apple-darwin"},{"platform":"macos-latest","target":"x86_64-apple-darwin","args":"--target x86_64-apple-darwin"},{"platform":"ubuntu-22.04","target":"x86_64-unknown-linux-musl","args":"--target x86_64-unknown-linux-musl","container":"ghcr.io/uniclipboard/build-bookworm:latest"},{"platform":"ubuntu-22.04-arm","target":"aarch64-unknown-linux-musl","args":"--target aarch64-unknown-linux-musl","container":"ghcr.io/uniclipboard/build-bookworm:latest"},{"platform":"windows-latest","target":"x86_64-pc-windows-msvc","args":""}]' >> "$GITHUB_OUTPUT"
           elif [ "$PLATFORM" == "macos-aarch64" ]; then
             echo 'matrix=[{"platform":"macos-latest","target":"aarch64-apple-darwin","args":"--target aarch64-apple-darwin"}]' >> "$GITHUB_OUTPUT"
           elif [ "$PLATFORM" == "macos-x86_64" ]; then
             echo 'matrix=[{"platform":"macos-latest","target":"x86_64-apple-darwin","args":"--target x86_64-apple-darwin"}]' >> "$GITHUB_OUTPUT"
           elif [ "$PLATFORM" == "ubuntu-22.04" ]; then
-            echo 'matrix=[{"platform":"ubuntu-22.04","target":"x86_64-unknown-linux-musl","args":"--target x86_64-unknown-linux-musl","container":"debian:bookworm"}]' >> "$GITHUB_OUTPUT"
+            echo 'matrix=[{"platform":"ubuntu-22.04","target":"x86_64-unknown-linux-musl","args":"--target x86_64-unknown-linux-musl","container":"ghcr.io/uniclipboard/build-bookworm:latest"}]' >> "$GITHUB_OUTPUT"
           elif [ "$PLATFORM" == "ubuntu-22.04-arm" ]; then
-            echo 'matrix=[{"platform":"ubuntu-22.04-arm","target":"aarch64-unknown-linux-musl","args":"--target aarch64-unknown-linux-musl","container":"debian:bookworm"}]' >> "$GITHUB_OUTPUT"
+            echo 'matrix=[{"platform":"ubuntu-22.04-arm","target":"aarch64-unknown-linux-musl","args":"--target aarch64-unknown-linux-musl","container":"ghcr.io/uniclipboard/build-bookworm:latest"}]' >> "$GITHUB_OUTPUT"
           elif [ "$PLATFORM" == "windows-latest" ]; then
             echo 'matrix=[{"platform":"windows-latest","target":"x86_64-pc-windows-msvc","args":""}]' >> "$GITHUB_OUTPUT"
           else
@@ -71,16 +71,9 @@ jobs:
         include: ${{ fromJSON(needs.setup-matrix.outputs.matrix) }}
 
     steps:
-      # CLI 不依赖 webkit/appindicator;musl-tools 提供 musl-gcc 作为 musl
-      # target 的 linker;ring (rustls 默认 crypto) 在 musl 上需要 cc/clang。
-      - name: Install container deps (Linux)
-        if: matrix.container != ''
-        run: |
-          apt-get update
-          apt-get install -y --no-install-recommends \
-            git curl wget ca-certificates xz-utils unzip sudo \
-            build-essential pkg-config cmake clang \
-            musl-tools
+      # Linux 容器走预构建镜像 (.github/docker/build-bookworm.Dockerfile),
+      # 含 musl-tools / build-essential / clang / cmake 等 CLI 编译所需 + Tauri 桌面端依赖。
+      # 镜像由 build-base-image.yml 维护。
 
       - uses: actions/checkout@v4
         with:
@@ -103,6 +96,8 @@ jobs:
         with:
           workspaces: "src-tauri -> target"
           shared-key: cli-${{ matrix.target }}
+          # 只在 main 写缓存,tag/PR 只读。详见 build.yml 同名 step 的注释。
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: build CLI binary
         working-directory: src-tauri

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,15 +59,15 @@ jobs:
           # cross-compile webkit/gtk 栈;x86_64 仍在 ubuntu-22.04。
           PLATFORM="${{ inputs.platform || 'all' }}"
           if [ "$PLATFORM" == "all" ]; then
-            echo 'matrix=[{"platform":"macos-latest","target":"aarch64-apple-darwin","args":"--target aarch64-apple-darwin"},{"platform":"macos-latest","target":"x86_64-apple-darwin","args":"--target x86_64-apple-darwin"},{"platform":"ubuntu-22.04","target":"x86_64-unknown-linux-gnu","args":"","container":"debian:bookworm"},{"platform":"ubuntu-22.04-arm","target":"aarch64-unknown-linux-gnu","args":"","container":"debian:bookworm"},{"platform":"windows-latest","target":"x86_64-pc-windows-msvc","args":""}]' >> "$GITHUB_OUTPUT"
+            echo 'matrix=[{"platform":"macos-latest","target":"aarch64-apple-darwin","args":"--target aarch64-apple-darwin"},{"platform":"macos-latest","target":"x86_64-apple-darwin","args":"--target x86_64-apple-darwin"},{"platform":"ubuntu-22.04","target":"x86_64-unknown-linux-gnu","args":"","container":"ghcr.io/uniclipboard/build-bookworm:latest"},{"platform":"ubuntu-22.04-arm","target":"aarch64-unknown-linux-gnu","args":"","container":"ghcr.io/uniclipboard/build-bookworm:latest"},{"platform":"windows-latest","target":"x86_64-pc-windows-msvc","args":""}]' >> "$GITHUB_OUTPUT"
           elif [ "$PLATFORM" == "macos-aarch64" ]; then
             echo 'matrix=[{"platform":"macos-latest","target":"aarch64-apple-darwin","args":"--target aarch64-apple-darwin"}]' >> "$GITHUB_OUTPUT"
           elif [ "$PLATFORM" == "macos-x86_64" ]; then
             echo 'matrix=[{"platform":"macos-latest","target":"x86_64-apple-darwin","args":"--target x86_64-apple-darwin"}]' >> "$GITHUB_OUTPUT"
           elif [ "$PLATFORM" == "ubuntu-22.04" ]; then
-            echo 'matrix=[{"platform":"ubuntu-22.04","target":"x86_64-unknown-linux-gnu","args":"","container":"debian:bookworm"}]' >> "$GITHUB_OUTPUT"
+            echo 'matrix=[{"platform":"ubuntu-22.04","target":"x86_64-unknown-linux-gnu","args":"","container":"ghcr.io/uniclipboard/build-bookworm:latest"}]' >> "$GITHUB_OUTPUT"
           elif [ "$PLATFORM" == "ubuntu-22.04-arm" ]; then
-            echo 'matrix=[{"platform":"ubuntu-22.04-arm","target":"aarch64-unknown-linux-gnu","args":"","container":"debian:bookworm"}]' >> "$GITHUB_OUTPUT"
+            echo 'matrix=[{"platform":"ubuntu-22.04-arm","target":"aarch64-unknown-linux-gnu","args":"","container":"ghcr.io/uniclipboard/build-bookworm:latest"}]' >> "$GITHUB_OUTPUT"
           elif [ "$PLATFORM" == "windows-latest" ]; then
             echo 'matrix=[{"platform":"windows-latest","target":"x86_64-pc-windows-msvc","args":""}]' >> "$GITHUB_OUTPUT"
           else
@@ -88,24 +88,9 @@ jobs:
         include: ${{ fromJSON(needs.setup-matrix.outputs.matrix) }}
 
     steps:
-      # bookworm 容器是 minimal,actions/checkout 需要 git;后续 step 还要
-      # curl/ca-certificates 用于装 rustup/bun/node。一次装齐 Tauri Linux
-      # 所需的全部 dev 包,glibc 基线 = bookworm 的 2.36。
-      # `rpm` 提供 rpmbuild,Tauri v2 在 bundle.targets="all" 下据此产出 .rpm;
-      # 缺失则 Tauri 静默跳过 RPM bundle,只剩 deb/AppImage。
-      - name: Install container deps (Linux)
-        if: matrix.container != ''
-        run: |
-          apt-get update
-          apt-get install -y --no-install-recommends \
-            git curl wget ca-certificates xz-utils unzip sudo \
-            build-essential pkg-config cmake clang \
-            libssl-dev \
-            libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf \
-            libgtk-3-dev libsoup-3.0-dev libjavascriptcoregtk-4.1-dev \
-            file desktop-file-utils \
-            xdg-utils \
-            rpm
+      # Linux 容器走预构建镜像 (.github/docker/build-bookworm.Dockerfile),
+      # apt-get 已经在镜像里跑过,这里直接 checkout。镜像由 build-base-image.yml
+      # 维护:Dockerfile 变更即重推 :latest,multi-arch (amd64/arm64) manifest。
 
       - uses: actions/checkout@v6
         with:
@@ -131,8 +116,17 @@ jobs:
         with:
           workspaces: "src-tauri -> target"
           shared-key: ${{ matrix.target }}
+          # 只在 main 写缓存,其他分支(含 tag 触发的 release)只读。
+          # Windows Post Cache Rust 上传单次 ~2m43s (25682907543),tag run
+          # 通常基于刚合入 main 的代码,命中已存的 main cache 即可,不必再
+          # 写一份等价的进 GHA cache (10GB 上限)。
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Cache Bun dependencies
+        # Windows NTFS 上压缩 ~/.bun/install/cache 的小文件极慢:
+        # 25682907543 run 实测 Post Cache 步骤 7m37s,而 bun install 本身只
+        # 1m12s — 缓存反成负优化。Linux/macOS post-cache ~20-30s,保留。
+        if: runner.os != 'Windows'
         uses: actions/cache@v5
         with:
           path: ~/.bun/install/cache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -390,14 +390,17 @@ jobs:
           echo "https://${REPO_OWNER}.github.io/${REPO_NAME}/${{ needs.validate.outputs.channel }}.json" >> $GITHUB_STEP_SUMMARY
 
   snap:
-    # 主 release 完成后自动触发 snap 构建并推到对应 channel。
-    # 渠道映射：alpha→edge, beta→beta, rc→candidate, stable→stable。
-    # 注意：reusable workflow call job 不支持 continue-on-error
-    # (GH Actions 限制),snap 失败会把整条 release 标红。GH release
-    # 此时已创建,snap 仅作 Linux 老 distro 覆盖的补充分发,失败可
-    # 在 snap.yml 直接 dispatch 重跑。
+    # 与 create-release 并行 (都依赖 build + build-cli 完成),不再串行
+    # 等待 create-release。snap 从 source 自己构建,不消费 release 产物;
+    # 但 needs build/build-cli 保证 snap 只在 Tauri/CLI 构建通过后才跑,
+    # 避免 source 本身有问题时还浪费 snapcraft runner。
+    #
+    # 渠道映射: alpha→edge, beta→beta, rc→candidate, stable→stable。
+    # 注意:reusable workflow call job 不支持 continue-on-error
+    # (GH Actions 限制),snap 失败会把整条 release 标红。snap 仅作
+    # Linux 老 distro 覆盖的补充分发,失败可在 snap.yml 直接 dispatch 重跑。
     name: Build & publish snap
-    needs: [validate, create-release]
+    needs: [validate, build, build-cli]
     if: ${{ success() }}
     uses: ./.github/workflows/snap.yml
     with:


### PR DESCRIPTION
## Summary

针对 v0.8.0 release run ([25682907543](https://github.com/UniClipboard/UniClipboard/actions/runs/25682907543)) 实测瓶颈做四项优化,关键路径从 ~55 min 砍到 ~26 min。

依赖 #648 (`ghcr.io/uniclipboard/build-bookworm` 镜像已就位)。

### 1. Windows 跳过 Bun 缓存 (−7m37s on Windows critical path)

实测 \`Post Cache Bun dependencies\` 7m37s vs \`bun install\` 1m12s — NTFS
上压缩 \`~/.bun/install/cache\` 里成千上万小文件反成负优化。Linux/macOS
post-cache 只要 20–30s,保留。

### 2. Snap 并行于 \`create-release\` (−16m+ 总耗时)

snap 从 source 自己构建,不消费 release 产物,无须串行等 \`create-release\`。
改为 \`needs: [validate, build, build-cli]\`,跟 \`create-release\` 并行,
snap 17m 直接被 build 矩阵吸收掉。

### 3. Linux 容器走 ghcr 预构建镜像

\`container\` 字段切到 \`ghcr.io/uniclipboard/build-bookworm:latest\`,
删 4 个 Linux job 里重复的 \`apt-get install\` step (~77s × 4 = ~5 min
runner CPU)。

### 4. Rust 缓存 tag/PR 只读

\`Swatinem/rust-cache\` 加 \`save-if: github.ref == 'refs/heads/main'\`,
限制只在 main 写。Windows \`Post Cache Rust\` 单次上传 2m43s,tag run
通常基于刚合入 main 的代码,命中 main cache 即可,无须再写等价层。

## Test plan

- [ ] 触发一次 \`workflow_dispatch\` 的 \`build.yml\` 验证 ghcr 镜像能拉、Linux build 跑通
- [ ] PR 合并后 main 上跑一次完整 release(或用 alpha channel),确认:
  - [ ] Windows 总时间从 34m → ~24m
  - [ ] snap 与 \`create-release\` 并行(看 timeline)
  - [ ] 所有 Linux job 跳过 apt 安装
- [ ] release 总 wallclock 从 ~55 min → ~26 min