### PR TITLE
ci: bump release-chain actions to Node 24-compatible majors

### DIFF
--- a/.github/workflows/build-base-image.yml
+++ b/.github/workflows/build-base-image.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Lowercase image name
         id: img

--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -82,12 +82,12 @@ jobs:
             build-essential pkg-config cmake clang \
             musl-tools
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.branch || github.ref }}
 
       - name: setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: lts/*
 
@@ -235,7 +235,7 @@ jobs:
           echo "archive=$ARCHIVE" >> "$GITHUB_OUTPUT"
 
       - name: upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: cli-${{ matrix.target }}
           path: uniclipboard-cli-*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,14 +58,14 @@ jobs:
       channel: ${{ steps.set-outputs.outputs.channel }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event_name == 'push' && github.ref || inputs.branch }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node.js
         if: github.event_name == 'workflow_dispatch'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: lts/*
 
@@ -176,17 +176,17 @@ jobs:
       pages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event_name == 'push' && github.ref || inputs.branch }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: lts/*
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           path: artifacts
 

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -67,7 +67,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.branch || github.ref }}
 
@@ -81,7 +81,7 @@ jobs:
       - name: Upload .snap as workflow artifact
         # 即便 publish 走 store,也保留 artifact 用于离线分发 / 调试
         # (`snap install --dangerous file.snap`)。retention 7 天够用。
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: uniclipboard-amd64-snap
           path: ${{ steps.build.outputs.snap }}


### PR DESCRIPTION
## Summary

`release.yml` / `build-cli.yml` / `snap.yml` / `build-base-image.yml` 里残留的 `actions/checkout@v4` / `setup-node@v4` / `upload-artifact@v4` / `download-artifact@v4` 全部对齐到 Node 24 runtime 版本(已在 `build.yml` 验证过):

| Action | 旧 | 新 |
|---|---|---|
| `actions/checkout` | v4 | v6 |
| `actions/setup-node` | v4 | v6 |
| `actions/upload-artifact` | v4 | v7 |
| `actions/download-artifact` | v4 | v6 |

## 为什么

消除 v0.8.0 release run ([25682907543](https://github.com/UniClipboard/UniClipboard/actions/runs/25682907543)) 上每个 release job 都在报的:

> Node.js 20 actions are deprecated. ... Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026.

提前升级,避免 2026-09-16 强制下线时大面积 break。

## 不在范围内

- `pr-check.yml` / `format.yml` / `docs-check.yml` / `coverage.yml` / `alpha-build.yml` / `prepare-release.yml` / `tag-on-merge.yml` / `copr.yml` / `deploy-worker.yml` 这些非 release 链路的 workflow 不动,留作后续单独清理,避免本次改动范围扩散。

## Test plan

- [ ] PR 合并后下次 PR / release / snap / base-image 触发时不再出现 Node 20 deprecation 告警
- [ ] 现有 workflow 逻辑无任何 behavioural change(纯版本号升级)