### PR TITLE
ci: dispatch snap and copr publishing asynchronously

### DIFF
--- a/.github/workflows/copr.yml
+++ b/.github/workflows/copr.yml
@@ -7,8 +7,9 @@ run-name: "copr-${{ inputs.version || github.event.release.tag_name || 'auto' }}
 #      draft(release.yml:290 `draft: channel != 'alpha'`),draft asset 在公开
 #      `releases/download/` URL 上一律 404。等到人工把 draft 发布,公开 URL 才可
 #      下载,此时 `release.published` 事件触发,COPR 拿到的 RPM 是真的可达的。
-#   2. workflow_dispatch — 手动重跑某个版本(常见场景:COPR build 临时挂了,
-#      release.yml 已经跑完不想全量重发)。
+#   2. workflow_dispatch — 手动重跑某个版本,也供 release.yml 在 alpha 自动
+#      发布完成后异步触发。alpha release 是由 workflow 自动创建并发布的,
+#      不要只依赖 release.published,否则可能不会带起本 workflow。
 on:
   release:
     types: [published]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -389,22 +389,62 @@ jobs:
           REPO_NAME=$(echo "${{ github.repository }}" | cut -d'/' -f2)
           echo "https://${REPO_OWNER}.github.io/${REPO_NAME}/${{ needs.validate.outputs.channel }}.json" >> $GITHUB_STEP_SUMMARY
 
-  snap:
-    # 与 create-release 并行 (都依赖 build + build-cli 完成),不再串行
-    # 等待 create-release。snap 从 source 自己构建,不消费 release 产物;
-    # 但 needs build/build-cli 保证 snap 只在 Tauri/CLI 构建通过后才跑,
-    # 避免 source 本身有问题时还浪费 snapcraft runner。
+  dispatch-snap:
+    # snap 构建耗时较长,不能作为 reusable job 挂在 release 里等待。
+    # 这里仅异步触发独立的 snap.yml,让主发布流程在常规产物完成后尽快结束。
     #
-    # 渠道映射: alpha→edge, beta→beta, rc→candidate, stable→stable。
-    # 注意:reusable workflow call job 不支持 continue-on-error
-    # (GH Actions 限制),snap 失败会把整条 release 标红。snap 仅作
-    # Linux 老 distro 覆盖的补充分发,失败可在 snap.yml 直接 dispatch 重跑。
-    name: Build & publish snap
-    needs: [validate, build, build-cli]
-    if: ${{ success() }}
-    uses: ./.github/workflows/snap.yml
-    with:
-      channel: ${{ needs.validate.outputs.channel == 'alpha' && 'edge' || needs.validate.outputs.channel == 'rc' && 'candidate' || needs.validate.outputs.channel }}
-      release: true
-      branch: ${{ inputs.branch || '' }}
-    secrets: inherit
+    # 渠道映射:alpha→edge,beta→beta,rc→candidate,stable→stable。
+    # beta / rc / stable 仍由人工发布 GitHub Release 后触发 snap.yml。
+    # snap.yml 保留手动入口,触发失败或 Snap Store 临时问题时可单独补跑。
+    name: Dispatch snap workflow
+    needs: [validate, create-release]
+    if: ${{ success() && needs.validate.outputs.channel == 'alpha' }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - name: Dispatch snap build
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.validate.outputs.version }}
+          SNAP_CHANNEL: ${{ needs.validate.outputs.channel == 'alpha' && 'edge' || needs.validate.outputs.channel == 'rc' && 'candidate' || needs.validate.outputs.channel }}
+        run: |
+          gh api \
+            --method POST \
+            "repos/${{ github.repository }}/actions/workflows/snap.yml/dispatches" \
+            -f ref="v${VERSION}" \
+            -f inputs[channel]="${SNAP_CHANNEL}" \
+            -f inputs[release]="true" \
+            -f inputs[branch]=""
+
+          echo "Dispatched snap.yml for v${VERSION} (${SNAP_CHANNEL})." >> "$GITHUB_STEP_SUMMARY"
+
+  dispatch-copr-alpha:
+    # alpha release 由本 workflow 自动发布,不会稳定触发 copr.yml 的
+    # release.published 入口。这里异步触发 COPR,避免漏发,同时不等待 COPR 完成。
+    #
+    # stable / beta / rc 仍由人工发布 GitHub Release 后触发 copr.yml,
+    # 避免 draft 还没确认就进入外部分发渠道。
+    name: Dispatch COPR workflow for alpha
+    needs: [validate, create-release]
+    if: ${{ success() && needs.validate.outputs.channel == 'alpha' }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - name: Dispatch COPR build
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.validate.outputs.version }}
+        run: |
+          gh api \
+            --method POST \
+            "repos/${{ github.repository }}/actions/workflows/copr.yml/dispatches" \
+            -f ref="v${VERSION}" \
+            -f inputs[version]="${VERSION}" \
+            -f inputs[project]="uniclipboard-alpha" \
+            -f inputs[run_ids]=""
+
+          echo "Dispatched copr.yml for v${VERSION} (uniclipboard-alpha)." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -1,5 +1,5 @@
 name: 'Snap'
-run-name: "snap-${{ inputs.channel || 'edge' }}-${{ github.run_number }}"
+run-name: "snap-${{ inputs.channel || github.event.release.tag_name || 'edge' }}-${{ github.run_number }}"
 
 # Snap 走 strict + gnome extension,base=core22 让产物在 Ubuntu 20.04 / RHEL 9
 # / openSUSE Leap 这类 webkit2gtk-4.1 缺位的老 distro 上也能跑(snap 内部
@@ -11,6 +11,8 @@ run-name: "snap-${{ inputs.channel || 'edge' }}-${{ github.run_number }}"
 # 生成,详见 README/CONTRIBUTING)。secret 缺失时 publish 步骤跳过,只产
 # workflow artifact。
 on:
+  release:
+    types: [published]
   workflow_dispatch:
     inputs:
       channel:
@@ -57,6 +59,9 @@ on:
 
 jobs:
   build:
+    # alpha 由 release.yml 在自动发布完成后显式 dispatch,这里的
+    # release.published 入口只承接人工发布的 beta / rc / stable。
+    if: ${{ github.event_name != 'release' || !contains(github.event.release.tag_name, '-alpha') }}
     name: Build snap (amd64)
     # snap build 必须在 Ubuntu host 上跑,snapcraft action 自带 LXD;
     # 我们用 22.04 跟 base=core22 对齐,snapcraft action-build 装的工具链
@@ -67,9 +72,39 @@ jobs:
       contents: read
 
     steps:
+      - name: Resolve snap metadata
+        id: snap-meta
+        env:
+          INPUT_BRANCH: ${{ inputs.branch }}
+          INPUT_CHANNEL: ${{ inputs.channel }}
+          INPUT_RELEASE: ${{ inputs.release }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          REF="${INPUT_BRANCH:-}"
+          if [ -z "$REF" ]; then
+            REF="${RELEASE_TAG:-${GITHUB_REF}}"
+          fi
+
+          CHANNEL="${INPUT_CHANNEL:-}"
+          if [ -z "$CHANNEL" ]; then
+            VERSION="${RELEASE_TAG#v}"
+            case "$VERSION" in
+              *-alpha*) CHANNEL="edge" ;;
+              *-beta*) CHANNEL="beta" ;;
+              *-rc*) CHANNEL="candidate" ;;
+              *) CHANNEL="stable" ;;
+            esac
+          fi
+
+          RELEASE="${INPUT_RELEASE:-true}"
+
+          echo "ref=$REF" >> "$GITHUB_OUTPUT"
+          echo "channel=$CHANNEL" >> "$GITHUB_OUTPUT"
+          echo "release=$RELEASE" >> "$GITHUB_OUTPUT"
+
       - uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.branch || github.ref }}
+          ref: ${{ steps.snap-meta.outputs.ref }}
 
       - name: Build snap
         id: build
@@ -90,7 +125,7 @@ jobs:
 
       - name: Check snap store credentials
         id: check-creds
-        if: ${{ inputs.release }}
+        if: ${{ steps.snap-meta.outputs.release == 'true' }}
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
         run: |
@@ -103,10 +138,10 @@ jobs:
           fi
 
       - name: Publish to snap store
-        if: ${{ inputs.release && steps.check-creds.outputs.publish == 'true' }}
+        if: ${{ steps.snap-meta.outputs.release == 'true' && steps.check-creds.outputs.publish == 'true' }}
         uses: snapcore/action-publish@v1
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
         with:
           snap: ${{ steps.build.outputs.snap }}
-          release: ${{ inputs.channel }}
+          release: ${{ steps.snap-meta.outputs.channel }}


### PR DESCRIPTION
## Summary
- stop release.yml from waiting on the long-running snap build
- dispatch snap asynchronously for alpha, while beta/rc/stable snap publishing waits for GitHub Release publish
- dispatch COPR asynchronously for alpha so automatic alpha releases do not miss COPR publishing

## Validation
- ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].sort.each { |f| YAML.load_file(f); puts "ok #{f}" }'\n- git diff --check\n- go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/release.yml .github/workflows/snap.yml .github/workflows/copr.yml\n- verified snap.yml and copr.yml are active via GitHub API\n\nNo publishing workflow was manually dispatched during validation.