### PR TITLE
Add passphrase fallback for space unlock

### DIFF
--- a/src-tauri/crates/uc-infra/src/security/space_access_adapter.rs
+++ b/src-tauri/crates/uc-infra/src/security/space_access_adapter.rs
@@ -95,6 +95,59 @@ fn map_aead_error_for_unwrap(err: v1_aead::AeadError) -> SpaceAccessError {
     }
 }
 
+/// 把 master-key unwrap 阶段的 AEAD 失败按"业务输入错 vs 系统级故障"分级
+/// 落 tracing event,再走 `map_aead_error_for_unwrap` 翻译到上层错误。
+///
+/// 三条调用路径语义统一:
+/// - `unlock`: KEK 由当前 passphrase 现派生,unwrap 失败 ⇒ 用户输错口令。
+/// - `try_resume_session`: KEK 直接读 keyring,unwrap 失败 ⇒ keyring 中
+///   KEK 与磁盘 keyslot 漂移(典型场景:在另一台设备上改了口令,本机
+///   keyring 没同步刷新)。仍是用户可恢复的输入路径——`load_kek` 拿到
+///   的 KEK 不是密码学库故障,只是不对的字节。
+/// - `derive_master_key_for_proof`: joiner 用本端 passphrase 派生 KEK 解
+///   sponsor 包来的 wrapped master key,unwrap 失败 ⇒ 双方口令不一致。
+///
+/// 三种场景的共同点是 `AeadError::DecryptFailed` 永远代表"业务输入侧
+/// 失败,UI 引导用户重输",不应作为 `error!` 级告警污染 Sentry 面板。
+/// 其余变体 (`InvalidKey` / `EncryptFailed` / 长度异常等) 才是密码学库
+/// 不该发生的故障,保留 `error!` 让 Sentry 抓到。
+fn map_and_log_unwrap_aead_error(err: v1_aead::AeadError, path: &'static str) -> SpaceAccessError {
+    match &err {
+        v1_aead::AeadError::DecryptFailed => {
+            warn!(
+                path,
+                "unwrap_master_key rejected: KEK does not match wrapped master key (passphrase mismatch or keyring/keyslot drift)"
+            );
+        }
+        other => {
+            error!(
+                path,
+                error = ?other,
+                "unwrap_master_key failed: unexpected AEAD failure"
+            );
+        }
+    }
+    map_aead_error_for_unwrap(err)
+}
+
+/// KDF (Argon2id) 失败属于密码学库底层故障——参数已由 keyslot 固定,
+/// 输入 passphrase 字节合法,这一步不该失败。走 `error!` + `Internal`。
+fn map_and_log_kdf_error(err: String, path: &'static str) -> SpaceAccessError {
+    error!(path, error = %err, "derive_kek_argon2id failed: unexpected KDF failure");
+    SpaceAccessError::Internal(err)
+}
+
+/// `wrap_master_key_xchacha` / `MasterKey::generate` 等"本地新建密钥物料"
+/// 路径上的失败同样属于密码学库底层故障。走 `error!` + `Internal`。
+fn map_and_log_local_crypto_error(
+    err: String,
+    path: &'static str,
+    op: &'static str,
+) -> SpaceAccessError {
+    error!(path, op, error = %err, "local crypto operation failed");
+    SpaceAccessError::Internal(err)
+}
+
 impl DefaultSpaceAccessAdapter {
     /// 私有 helper：执行首次初始化的核心步骤
     /// （生成 KeySlot 草稿 → 派生 KEK → 生成 MasterKey → 包装 → 落盘 →
@@ -104,38 +157,41 @@ impl DefaultSpaceAccessAdapter {
         scope: &KeyScope,
         passphrase: &DomainPassphrase,
     ) -> Result<KeySlot, SpaceAccessError> {
+        const PATH: &str = "first_time_init";
+
         let keyslot_draft = KeySlot::draft_v1(scope.clone())
-            .map_err(|e| SpaceAccessError::Internal(e.to_string()))?;
+            .map_err(|e| map_and_log_local_crypto_error(e.to_string(), PATH, "draft_keyslot_v1"))?;
         debug!("keyslot draft created");
 
         let legacy = LegacyPassphrase(passphrase.expose().to_string());
         let kek = v1_aead::derive_kek_argon2id(&legacy, &keyslot_draft.salt, &keyslot_draft.kdf)
-            .map_err(SpaceAccessError::Internal)?;
+            .map_err(|e| map_and_log_kdf_error(e, PATH))?;
         debug!("KEK derived");
 
-        let master_key =
-            MasterKey::generate().map_err(|e| SpaceAccessError::Internal(e.to_string()))?;
+        let master_key = MasterKey::generate().map_err(|e| {
+            map_and_log_local_crypto_error(e.to_string(), PATH, "generate_master_key")
+        })?;
         debug!("master key generated");
 
         let blob = v1_aead::wrap_master_key_xchacha(&kek, &master_key)
-            .map_err(|e| SpaceAccessError::Internal(e.to_string()))?;
+            .map_err(|e| map_and_log_local_crypto_error(e.to_string(), PATH, "wrap_master_key"))?;
         debug!("master key wrapped");
 
         let keyslot = keyslot_draft.finalize(WrappedMasterKey { blob });
 
         if let Err(e) = self.key_material.store_kek(scope, &kek).await {
-            error!(error = %e, "store_kek failed");
+            error!(path = PATH, error = %e, "store_kek failed");
             return Err(map_encryption_error(e));
         }
         self.kek_observed.store(true, Ordering::Release);
 
         if let Err(e) = self.key_material.store_keyslot(&keyslot).await {
-            error!(error = %e, "store_keyslot failed");
+            error!(path = PATH, error = %e, "store_keyslot failed, rolling back KEK");
             if let Err(err) = self.key_material.delete_keyslot(scope).await {
-                warn!(error = %err, "rollback delete_keyslot failed");
+                warn!(path = PATH, error = %err, "rollback delete_keyslot failed");
             }
             if let Err(err) = self.key_material.delete_kek(scope).await {
-                warn!(error = %err, "rollback delete_kek failed");
+                warn!(path = PATH, error = %err, "rollback delete_kek failed");
             }
             self.kek_observed.store(false, Ordering::Release);
             return Err(map_encryption_error(e));
@@ -158,26 +214,28 @@ impl SpaceAccessPort for DefaultSpaceAccessAdapter {
         space_id: &SpaceId,
         passphrase: &DomainPassphrase,
     ) -> Result<ActiveSpace, SpaceAccessError> {
+        const PATH: &str = "initialize";
         let span = info_span!("infra.space_access.initialize", space_id = %space_id);
         async {
             info!("initializing new space");
 
-            if self
-                .key_material
-                .keyslot_exists()
-                .await
-                .map_err(|e| SpaceAccessError::Internal(e.to_string()))?
-            {
+            if self.key_material.keyslot_exists().await.map_err(|e| {
+                error!(path = PATH, error = %e, "keyslot_exists probe failed");
+                SpaceAccessError::Internal(e.to_string())
+            })? {
+                warn!(
+                    path = PATH,
+                    "initialize rejected: keyslot already exists on disk"
+                );
                 return Err(SpaceAccessError::AlreadyInitialized);
             }
 
-            let profile = self
-                .current_profile
-                .current_profile()
-                .await
-                .map_err(|e| SpaceAccessError::Internal(e.to_string()))?;
+            let profile = self.current_profile.current_profile().await.map_err(|e| {
+                error!(path = PATH, error = %e, "current_profile resolution failed");
+                SpaceAccessError::Internal(e.to_string())
+            })?;
             let scope = key_scope_from_profile(&profile);
-            debug!(scope = %scope_identifier(&scope), "got key scope");
+            debug!(path = PATH, scope = %scope_identifier(&scope), "got key scope");
 
             self.do_first_time_init(&scope, passphrase).await?;
 
@@ -193,45 +251,50 @@ impl SpaceAccessPort for DefaultSpaceAccessAdapter {
         space_id: &SpaceId,
         passphrase: &DomainPassphrase,
     ) -> Result<ActiveSpace, SpaceAccessError> {
+        const PATH: &str = "unlock";
         let span = info_span!("infra.space_access.unlock", space_id = %space_id);
         async {
             info!("unlocking space with passphrase");
 
-            if !self
-                .key_material
-                .keyslot_exists()
-                .await
-                .map_err(|e| SpaceAccessError::Internal(e.to_string()))?
-            {
+            if !self.key_material.keyslot_exists().await.map_err(|e| {
+                error!(path = PATH, error = %e, "keyslot_exists probe failed");
+                SpaceAccessError::Internal(e.to_string())
+            })? {
+                warn!(
+                    path = PATH,
+                    "unlock rejected: no keyslot on disk (not initialized)"
+                );
                 return Err(SpaceAccessError::NotInitialized);
             }
 
-            let profile = self
-                .current_profile
-                .current_profile()
-                .await
-                .map_err(|e| SpaceAccessError::Internal(e.to_string()))?;
+            let profile = self.current_profile.current_profile().await.map_err(|e| {
+                error!(path = PATH, error = %e, "current_profile resolution failed");
+                SpaceAccessError::Internal(e.to_string())
+            })?;
             let scope = key_scope_from_profile(&profile);
+            debug!(path = PATH, scope = %scope_identifier(&scope), "got key scope");
 
-            let keyslot = self
-                .key_material
-                .load_keyslot(&scope)
-                .await
-                .map_err(map_encryption_error)?;
+            let keyslot = self.key_material.load_keyslot(&scope).await.map_err(|e| {
+                warn!(path = PATH, error = %e, "load_keyslot failed");
+                map_encryption_error(e)
+            })?;
 
-            let wrapped_master_key = keyslot
-                .wrapped_master_key
-                .as_ref()
-                .ok_or(SpaceAccessError::CorruptedKeyMaterial)?;
+            let wrapped_master_key = keyslot.wrapped_master_key.as_ref().ok_or_else(|| {
+                warn!(
+                    path = PATH,
+                    "keyslot on disk has no wrapped_master_key (corrupted key material)"
+                );
+                SpaceAccessError::CorruptedKeyMaterial
+            })?;
 
             let legacy = LegacyPassphrase(passphrase.expose().to_string());
             let kek = v1_aead::derive_kek_argon2id(&legacy, &keyslot.salt, &keyslot.kdf)
-                .map_err(SpaceAccessError::Internal)?;
-            debug!("KEK derived from passphrase");
+                .map_err(|e| map_and_log_kdf_error(e, PATH))?;
+            debug!(path = PATH, "KEK derived from passphrase");
 
             let master_key = v1_aead::unwrap_master_key_xchacha(&kek, &wrapped_master_key.blob)
-                .map_err(map_aead_error_for_unwrap)?;
-            debug!("master key unwrapped");
+                .map_err(|e| map_and_log_unwrap_aead_error(e, PATH))?;
+            debug!(path = PATH, "master key unwrapped");
 
             // 把派生出的 KEK 重新写入 keyring,保持 keyring 与最新口令对齐
             // (让下次静默 startup 路径仍可命中)。失败仅 warn,不影响本次解锁。
@@ -269,26 +332,42 @@ impl SpaceAccessPort for DefaultSpaceAccessAdapter {
     }
 
     async fn factory_reset(&self, space_id: &SpaceId) -> Result<(), SpaceAccessError> {
+        const PATH: &str = "factory_reset";
         let span = info_span!("infra.space_access.factory_reset", space_id = %space_id);
         async {
-            let profile = self
-                .current_profile
-                .current_profile()
-                .await
-                .map_err(|e| SpaceAccessError::Internal(e.to_string()))?;
+            info!(path = PATH, "factory reset requested");
+
+            let profile = self.current_profile.current_profile().await.map_err(|e| {
+                error!(path = PATH, error = %e, "current_profile resolution failed");
+                SpaceAccessError::Internal(e.to_string())
+            })?;
             let scope = key_scope_from_profile(&profile);
+            debug!(path = PATH, scope = %scope_identifier(&scope), "got key scope");
 
             // 幂等: 不存在的物料视为已经删除,不报错。
             match self.key_material.delete_keyslot(&scope).await {
-                Ok(()) | Err(EncryptionError::KeyNotFound) => {}
-                Err(e) => return Err(map_encryption_error(e)),
+                Ok(()) => debug!(path = PATH, "keyslot deleted"),
+                Err(EncryptionError::KeyNotFound) => {
+                    debug!(path = PATH, "keyslot already absent (idempotent)")
+                }
+                Err(e) => {
+                    error!(path = PATH, error = %e, "delete_keyslot failed");
+                    return Err(map_encryption_error(e));
+                }
             }
             match self.key_material.delete_kek(&scope).await {
-                Ok(()) | Err(EncryptionError::KeyNotFound) => {}
-                Err(e) => return Err(map_encryption_error(e)),
+                Ok(()) => debug!(path = PATH, "KEK deleted from keyring"),
+                Err(EncryptionError::KeyNotFound) => {
+                    debug!(path = PATH, "KEK already absent in keyring (idempotent)")
+                }
+                Err(e) => {
+                    error!(path = PATH, error = %e, "delete_kek failed");
+                    return Err(map_encryption_error(e));
+                }
             }
             self.kek_observed.store(false, Ordering::Release);
             self.session.clear();
+            info!(path = PATH, "factory reset completed");
             Ok(())
         }
         .instrument(span)
@@ -299,6 +378,7 @@ impl SpaceAccessPort for DefaultSpaceAccessAdapter {
         &self,
         space_id: &SpaceId,
     ) -> Result<Option<ActiveSpace>, SpaceAccessError> {
+        const PATH: &str = "try_resume_session";
         let span = info_span!("infra.space_access.try_resume_session", space_id = %space_id);
         async {
             info!("attempting silent session resume from keyring");
@@ -313,42 +393,48 @@ impl SpaceAccessPort for DefaultSpaceAccessAdapter {
                 return Ok(Some(ActiveSpace::new(space_id.clone())));
             }
 
-            if !self
-                .key_material
-                .keyslot_exists()
-                .await
-                .map_err(|e| SpaceAccessError::Internal(e.to_string()))?
-            {
-                info!("no keyslot on disk, no session to resume");
+            if !self.key_material.keyslot_exists().await.map_err(|e| {
+                error!(path = PATH, error = %e, "keyslot_exists probe failed");
+                SpaceAccessError::Internal(e.to_string())
+            })? {
+                info!(path = PATH, "no keyslot on disk, no session to resume");
                 return Ok(None);
             }
 
-            let profile = self
-                .current_profile
-                .current_profile()
-                .await
-                .map_err(|e| SpaceAccessError::Internal(e.to_string()))?;
+            let profile = self.current_profile.current_profile().await.map_err(|e| {
+                error!(path = PATH, error = %e, "current_profile resolution failed");
+                SpaceAccessError::Internal(e.to_string())
+            })?;
             let scope = key_scope_from_profile(&profile);
+            debug!(path = PATH, scope = %scope_identifier(&scope), "got key scope");
 
-            let keyslot = self
-                .key_material
-                .load_keyslot(&scope)
-                .await
-                .map_err(map_encryption_error)?;
-            let wrapped_master_key = keyslot
-                .wrapped_master_key
-                .as_ref()
-                .ok_or(SpaceAccessError::CorruptedKeyMaterial)?;
+            let keyslot = self.key_material.load_keyslot(&scope).await.map_err(|e| {
+                warn!(path = PATH, error = %e, "load_keyslot failed during resume");
+                map_encryption_error(e)
+            })?;
+            let wrapped_master_key = keyslot.wrapped_master_key.as_ref().ok_or_else(|| {
+                warn!(
+                    path = PATH,
+                    "keyslot on disk has no wrapped_master_key (corrupted key material)"
+                );
+                SpaceAccessError::CorruptedKeyMaterial
+            })?;
 
             // 静默路径: 直接读 keyring 缓存的 KEK,不重新派生。
-            let kek = self
-                .key_material
-                .load_kek(&scope)
-                .await
-                .map_err(map_encryption_error)?;
+            // load_kek 失败通常意味着 keyring 中没有这条 KEK——首次启动 /
+            // keyring 被清 / 跨设备 profile 迁移——属于业务正常路径,
+            // 上层会回退到要求用户重新输入口令走 unlock。warn 级别即可。
+            let kek = self.key_material.load_kek(&scope).await.map_err(|e| {
+                warn!(
+                    path = PATH,
+                    error = %e,
+                    "load_kek from keyring failed; caller will fall back to passphrase unlock"
+                );
+                map_encryption_error(e)
+            })?;
 
             let master_key = v1_aead::unwrap_master_key_xchacha(&kek, &wrapped_master_key.blob)
-                .map_err(map_aead_error_for_unwrap)?;
+                .map_err(|e| map_and_log_unwrap_aead_error(e, PATH))?;
 
             // load_kek 成功 + unwrap 成功 ⇒ keychain 中 KEK 与本机 keyslot 匹配。
             // 标记本进程已观察到该 KEK,后续 verify_keychain_access /
@@ -365,6 +451,7 @@ impl SpaceAccessPort for DefaultSpaceAccessAdapter {
     }
 
     async fn verify_keychain_access(&self) -> Result<bool, SpaceAccessError> {
+        const PATH: &str = "verify_keychain_access";
         let span = info_span!("infra.space_access.verify_keychain_access");
         async {
             // 缓存命中:本进程内已成功 load_kek / store_kek 过——keychain
@@ -372,6 +459,7 @@ impl SpaceAccessPort for DefaultSpaceAccessAdapter {
             // 等价于一次 set_secret/get_secret 系统调用,可能触发新一轮
             // 授权弹窗。
             if self.kek_observed.load(Ordering::Acquire) {
+                debug!(path = PATH, "kek_observed cached, skip keychain probe");
                 return Ok(true);
             }
 
@@ -379,7 +467,10 @@ impl SpaceAccessPort for DefaultSpaceAccessAdapter {
                 .current_profile
                 .current_profile()
                 .await
-                .map_err(|e| SpaceAccessError::Internal(e.to_string()))?;
+                .map_err(|e| {
+                    error!(path = PATH, error = %e, "current_profile resolution failed");
+                    SpaceAccessError::Internal(e.to_string())
+                })?;
             let scope = key_scope_from_profile(&profile);
 
             // 探测: 把"权限被拒绝"和"keyring 暂时不可用"都视为 "Always Allow 未授予"
@@ -387,12 +478,25 @@ impl SpaceAccessPort for DefaultSpaceAccessAdapter {
             match self.key_material.load_kek(&scope).await {
                 Ok(_) => {
                     self.kek_observed.store(true, Ordering::Release);
+                    debug!(path = PATH, "keychain access verified via load_kek probe");
                     Ok(true)
                 }
-                Err(EncryptionError::PermissionDenied) => Ok(false),
-                Err(EncryptionError::KeyringError(_)) => Ok(false),
-                Err(EncryptionError::KeyNotFound) => Err(SpaceAccessError::NotInitialized),
-                Err(other) => Err(SpaceAccessError::Internal(other.to_string())),
+                Err(EncryptionError::PermissionDenied) => {
+                    warn!(path = PATH, "keychain access denied (Always Allow not granted)");
+                    Ok(false)
+                }
+                Err(EncryptionError::KeyringError(msg)) => {
+                    warn!(path = PATH, error = %msg, "keyring transiently unavailable; treat as not-granted");
+                    Ok(false)
+                }
+                Err(EncryptionError::KeyNotFound) => {
+                    info!(path = PATH, "no KEK in keychain for current profile");
+                    Err(SpaceAccessError::NotInitialized)
+                }
+                Err(other) => {
+                    error!(path = PATH, error = %other, "unexpected load_kek failure during keychain probe");
+                    Err(SpaceAccessError::Internal(other.to_string()))
+                }
             }
         }
         .instrument(span)
@@ -400,29 +504,34 @@ impl SpaceAccessPort for DefaultSpaceAccessAdapter {
     }
 
     async fn derive_subkey(&self, salt: &[u8], info: &[u8]) -> Result<[u8; 32], SpaceAccessError> {
+        const PATH: &str = "derive_subkey";
         if !self.session.is_ready() {
+            warn!(path = PATH, "derive_subkey called while session not ready");
             return Err(SpaceAccessError::NotUnlocked);
         }
-        let master_key = self
-            .session
-            .get_master_key()
-            .map_err(map_encryption_error)?;
+        let master_key = self.session.get_master_key().map_err(|e| {
+            error!(path = PATH, error = %e, "get_master_key from session failed");
+            map_encryption_error(e)
+        })?;
 
         let hkdf = Hkdf::<Sha256>::new(Some(salt), master_key.as_bytes());
         let mut okm = [0u8; 32];
-        hkdf.expand(info, &mut okm)
-            .map_err(|e| SpaceAccessError::Internal(format!("HKDF expand: {e}")))?;
+        hkdf.expand(info, &mut okm).map_err(|e| {
+            error!(path = PATH, error = %e, "HKDF expand failed (unexpected — output length is fixed 32)");
+            SpaceAccessError::Internal(format!("HKDF expand: {e}"))
+        })?;
         Ok(okm)
     }
 
     async fn current_session_proof_key(&self) -> Result<Option<ProofDerivedKey>, SpaceAccessError> {
+        const PATH: &str = "current_session_proof_key";
         if !self.session.is_ready() {
             return Ok(None);
         }
-        let master_key = self
-            .session
-            .get_master_key()
-            .map_err(map_encryption_error)?;
+        let master_key = self.session.get_master_key().map_err(|e| {
+            error!(path = PATH, error = %e, "get_master_key from session failed");
+            map_encryption_error(e)
+        })?;
         Ok(Some(ProofDerivedKey::from_bytes(master_key.into_bytes())))
     }
 
@@ -431,6 +540,7 @@ impl SpaceAccessPort for DefaultSpaceAccessAdapter {
         space_id: &SpaceId,
         passphrase: &DomainPassphrase,
     ) -> Result<JoinOffer, SpaceAccessError> {
+        const PATH: &str = "prepare_join_offer";
         let span = info_span!("infra.space_access.prepare_join_offer", space_id = %space_id);
         async {
             info!("preparing sponsor join offer");
@@ -439,16 +549,22 @@ impl SpaceAccessPort for DefaultSpaceAccessAdapter {
                 .key_material
                 .keyslot_exists()
                 .await
-                .map_err(|e| SpaceAccessError::Internal(e.to_string()))?;
-            debug!(already_initialized, "checked keyslot existence");
+                .map_err(|e| {
+                    error!(path = PATH, error = %e, "keyslot_exists probe failed");
+                    SpaceAccessError::Internal(e.to_string())
+                })?;
+            debug!(path = PATH, already_initialized, "checked keyslot existence");
 
             let profile = self
                 .current_profile
                 .current_profile()
                 .await
-                .map_err(|e| SpaceAccessError::Internal(e.to_string()))?;
+                .map_err(|e| {
+                    error!(path = PATH, error = %e, "current_profile resolution failed");
+                    SpaceAccessError::Internal(e.to_string())
+                })?;
             let scope = key_scope_from_profile(&profile);
-            debug!(scope = %scope_identifier(&scope), "got key scope");
+            debug!(path = PATH, scope = %scope_identifier(&scope), "got key scope");
 
             // Branch A — 运行时已初始化的 sponsor 路径: 从 key_material 读已有 keyslot,
             // 不重新生成 MasterKey。passphrase 参数此时不参与派生。
@@ -458,9 +574,19 @@ impl SpaceAccessPort for DefaultSpaceAccessAdapter {
                     .key_material
                     .load_keyslot(&scope)
                     .await
-                    .map_err(map_encryption_error)?;
-                let keyslot_blob = serde_json::to_vec(&keyslot)
-                    .map_err(|e| SpaceAccessError::Internal(format!("serialize keyslot: {e}")))?;
+                    .map_err(|e| {
+                        warn!(path = PATH, branch = "already_initialized", error = %e, "load_keyslot failed");
+                        map_encryption_error(e)
+                    })?;
+                let keyslot_blob = serde_json::to_vec(&keyslot).map_err(|e| {
+                    error!(
+                        path = PATH,
+                        branch = "already_initialized",
+                        error = %e,
+                        "serialize keyslot to wire blob failed"
+                    );
+                    SpaceAccessError::Internal(format!("serialize keyslot: {e}"))
+                })?;
                 let mut challenge_nonce = [0u8; 32];
                 rand::rng().fill_bytes(&mut challenge_nonce);
                 info!("sponsor join offer prepared (runtime, already initialized)");
@@ -474,8 +600,15 @@ impl SpaceAccessPort for DefaultSpaceAccessAdapter {
             // Branch B — 首次 setup sponsor 路径: 未初始化,走完整 KEK 派生 +
             // MasterKey 生成 + 包装 + 落盘 + 标记 Initialized。
             let keyslot = self.do_first_time_init(&scope, passphrase).await?;
-            let keyslot_blob = serde_json::to_vec(&keyslot)
-                .map_err(|e| SpaceAccessError::Internal(format!("serialize keyslot: {e}")))?;
+            let keyslot_blob = serde_json::to_vec(&keyslot).map_err(|e| {
+                error!(
+                    path = PATH,
+                    branch = "first_time_init",
+                    error = %e,
+                    "serialize freshly-initialized keyslot to wire blob failed"
+                );
+                SpaceAccessError::Internal(format!("serialize keyslot: {e}"))
+            })?;
             let mut challenge_nonce = [0u8; 32];
             rand::rng().fill_bytes(&mut challenge_nonce);
 
@@ -495,24 +628,35 @@ impl SpaceAccessPort for DefaultSpaceAccessAdapter {
         offer: &JoinOffer,
         passphrase: &DomainPassphrase,
     ) -> Result<ProofDerivedKey, SpaceAccessError> {
+        const PATH: &str = "derive_master_key_for_proof";
         let span = info_span!("infra.space_access.derive_master_key_for_proof", space_id = %offer.space_id);
         async {
             info!("deriving master key from pairing offer");
 
-            let keyslot: KeySlot = serde_json::from_slice(&offer.keyslot_blob)
-                .map_err(|_| SpaceAccessError::CorruptedKeyMaterial)?;
+            let keyslot: KeySlot = serde_json::from_slice(&offer.keyslot_blob).map_err(|e| {
+                warn!(
+                    path = PATH,
+                    error = %e,
+                    offer_blob_len = offer.keyslot_blob.len(),
+                    "failed to deserialize keyslot from offer blob (corrupted wire data)"
+                );
+                SpaceAccessError::CorruptedKeyMaterial
+            })?;
             let scope = keyslot.scope.clone();
-            debug!(scope = %scope_identifier(&scope), "parsed keyslot from offer blob");
+            debug!(path = PATH, scope = %scope_identifier(&scope), "parsed keyslot from offer blob");
 
-            let wrapped_master_key = keyslot
-                .wrapped_master_key
-                .as_ref()
-                .ok_or(SpaceAccessError::CorruptedKeyMaterial)?;
+            let wrapped_master_key = keyslot.wrapped_master_key.as_ref().ok_or_else(|| {
+                warn!(
+                    path = PATH,
+                    "offer keyslot has no wrapped_master_key (corrupted offer)"
+                );
+                SpaceAccessError::CorruptedKeyMaterial
+            })?;
 
             let legacy = LegacyPassphrase(passphrase.expose().to_string());
             let kek = v1_aead::derive_kek_argon2id(&legacy, &keyslot.salt, &keyslot.kdf)
-                .map_err(SpaceAccessError::Internal)?;
-            debug!("KEK derived from passphrase and offer keyslot");
+                .map_err(|e| map_and_log_kdf_error(e, PATH))?;
+            debug!(path = PATH, "KEK derived from passphrase and offer keyslot");
 
             // 先 unwrap 验证 KEK + keyslot 真的匹配,再动本机持久状态。
             // 之前的顺序是 store_kek → store_keyslot → unwrap, unwrap 失败时
@@ -523,29 +667,26 @@ impl SpaceAccessPort for DefaultSpaceAccessAdapter {
             // 需要手动 factory_reset"就来源于此)。把 unwrap 抬到 store
             // 之前,失败时直接返回, 本机原状一字不动。
             let master_key = v1_aead::unwrap_master_key_xchacha(&kek, &wrapped_master_key.blob)
-                .map_err(|e| {
-                    error!(error = ?e, "unwrap_master_key failed");
-                    map_aead_error_for_unwrap(e)
-                })?;
-            debug!("master key unwrapped");
+                .map_err(|e| map_and_log_unwrap_aead_error(e, PATH))?;
+            debug!(path = PATH, "master key unwrapped");
 
             // unwrap 已确认 KEK + keyslot 匹配, 再覆盖本机磁盘 / keyring。
             // 此处仍有"store_keyslot 失败 → delete_kek 回滚把刚刚覆盖的本机
             // 原 KEK 一并删掉"的窄窗口(需要 keyring/磁盘真实 IO 失败),
             // 影响远小于 unwrap 失败这条常见路径, 留作后续单独修复。
             if let Err(e) = self.key_material.store_kek(&scope, &kek).await {
-                error!(error = %e, "store_kek failed");
+                error!(path = PATH, error = %e, "store_kek failed");
                 return Err(map_encryption_error(e));
             }
             self.kek_observed.store(true, Ordering::Release);
 
             if let Err(e) = self.key_material.store_keyslot(&keyslot).await {
-                error!(error = %e, "store_keyslot failed");
+                error!(path = PATH, error = %e, "store_keyslot failed, rolling back KEK");
                 if let Err(err) = self.key_material.delete_keyslot(&scope).await {
-                    warn!(error = %err, "rollback delete_keyslot failed");
+                    warn!(path = PATH, error = %err, "rollback delete_keyslot failed");
                 }
                 if let Err(err) = self.key_material.delete_kek(&scope).await {
-                    warn!(error = %err, "rollback delete_kek failed");
+                    warn!(path = PATH, error = %err, "rollback delete_kek failed");
                 }
                 self.kek_observed.store(false, Ordering::Release);
                 return Err(map_encryption_error(e));

--- a/src-tauri/crates/uc-tauri/src/commands/mod.rs
+++ b/src-tauri/crates/uc-tauri/src/commands/mod.rs
@@ -3,6 +3,7 @@ pub mod error;
 pub mod mobile_sync;
 pub mod quick_panel;
 pub mod restart;
+pub mod space_setup;
 pub mod startup;
 pub mod storage;
 pub mod tray;

--- a/src-tauri/crates/uc-tauri/src/commands/space_setup.rs
+++ b/src-tauri/crates/uc-tauri/src/commands/space_setup.rs
@@ -1,0 +1,219 @@
+//! Space-setup Tauri commands —— GUI 走 in-process facade 直调
+//! `SpaceSetupFacade` / `EncryptionFacade`（与 mobile_sync 同模式，不经
+//! webserver）。
+//!
+//! 两个对外 command:
+//!
+//! 1. [`unlock_space_with_passphrase`] —— 用户在前端 modal 输入口令后调用。
+//!    `passphrase` **不出 Tauri 进程**: 不经 HTTP / TCP socket，直接
+//!    `runtime.app_facade().space_setup.unlock_space(input)`。这是 GUI 端
+//!    打破 "keyring 与 keyslot 漂移" 死结的唯一安全通路。
+//!
+//! 2. [`try_silent_unlock`] —— in-process 等价于历史 HTTP
+//!    `POST /encryption/unlock`，启动期 auto-unlock 走它。`passphrase`
+//!    **不参与**——只从 keyring 读 KEK + 试 unwrap; keyring miss / 漂移
+//!    时返回 `resumed: false`，由前端弹 modal 走 [`unlock_space_with_passphrase`]
+//!    兜底。
+//!
+//! `GuiInProcess` 模式下 daemon 与 Tauri 同进程、共享同一份 `AppFacade`,
+//! 所以 in-process 调成功后 `InMemorySession` 立即 ready, 同进程内的
+//! clipboard watcher / sync 等 deferred services 由前端继续 POST
+//! `/lifecycle/ready` 触发(uc-tauri/AGENTS.md "shell 不重新拼业务流程")。
+
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+use tauri::State;
+use tracing::{info_span, Instrument};
+use uc_application::facade::space_setup::UnlockSpaceError;
+use uc_application::facade::{UnlockSpaceInput, UnlockSpaceResult};
+use uc_platform::ports::observability::TraceMetadata;
+
+use crate::bootstrap::TauriAppRuntime;
+use crate::commands::record_trace_fields;
+
+// ============================================================================
+// unlock_space_with_passphrase ─ 用户主动输入口令解锁
+// ============================================================================
+
+/// 前端 modal 提交的解锁请求。
+///
+/// `passphrase` 在 Tauri IPC 边界以明文存在,**绝不**应当再往 HTTP/TCP
+/// 上序列化(那等于送到本机 socket 上,违反 §安全)——这一边界仅止于
+/// 同进程内 invoke handler。
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UnlockSpaceArgs {
+    pub passphrase: String,
+}
+
+/// 解锁成功后返回的最小元数据。
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UnlockSpaceResultDto {
+    pub space_id: String,
+}
+
+impl From<UnlockSpaceResult> for UnlockSpaceResultDto {
+    fn from(out: UnlockSpaceResult) -> Self {
+        Self {
+            space_id: out.space_id.to_string(),
+        }
+    }
+}
+
+/// 前端可 `error.code` switch 的 typed 错误。序列化形态:
+/// `{"code": "WRONG_PASSPHRASE"}` / `{"code": "INTERNAL", "message": "..."}`。
+#[derive(Debug, Clone, Serialize, thiserror::Error)]
+#[serde(
+    tag = "code",
+    rename_all = "SCREAMING_SNAKE_CASE",
+    rename_all_fields = "camelCase"
+)]
+pub enum UnlockSpaceCommandError {
+    /// space_setup facade 尚未装配——bootstrap 还没跑完或装配失败。
+    /// 前端应延后重试或提示用户重启应用。
+    #[error("space setup facade not available in this runtime")]
+    FacadeUnavailable,
+
+    /// 没有 setup 过——前端应引导走 init / join 流程,而不是 unlock。
+    #[error("setup has not been completed")]
+    SetupNotCompleted,
+
+    /// `setup_status.has_completed=true` 但磁盘 keyslot 缺失。
+    /// 前端应引导 factory reset。
+    #[error("space is not initialized on this device")]
+    SpaceNotInitialized,
+
+    /// 口令不能 unwrap 已存 master key。前端应在 modal 中提示
+    /// "口令错误,请重试",**不关闭** modal。
+    #[error("wrong passphrase")]
+    WrongPassphrase,
+
+    /// keyslot 文件存在但版本不支持 / 反序列化失败。再正确的口令也
+    /// 派生不出能解开的 KEK。前端应引导 factory reset 或重新 join。
+    #[error("space key material is corrupted")]
+    CorruptedKeyMaterial,
+
+    /// 兜底:IO / 序列化 / migration resume 等非预期失败。`message`
+    /// 仅面向开发者日志,前端展示通用错误对话框 + Sentry 上报即可。
+    #[error("unlock failed: {message}")]
+    Internal { message: String },
+}
+
+impl From<UnlockSpaceError> for UnlockSpaceCommandError {
+    fn from(err: UnlockSpaceError) -> Self {
+        match err {
+            UnlockSpaceError::SetupNotCompleted => Self::SetupNotCompleted,
+            UnlockSpaceError::SpaceNotInitialized => Self::SpaceNotInitialized,
+            UnlockSpaceError::WrongPassphrase => Self::WrongPassphrase,
+            UnlockSpaceError::CorruptedKeyMaterial => Self::CorruptedKeyMaterial,
+            UnlockSpaceError::Internal(message) => Self::Internal { message },
+        }
+    }
+}
+
+/// 用户主动输入口令解锁(in-process)。
+///
+/// 调用链:Tauri command → `runtime.app_facade().space_setup` →
+/// `SpaceSetupFacade::unlock_space(input)` →
+/// `UnlockSpaceUseCase` → `SpaceAccessPort::unlock(space_id, passphrase)`。
+/// 全程同进程,`passphrase` 不进任何 socket。
+///
+/// 成功后 `InMemorySession::set_master_key` 已写入,session 立即 ready;
+/// 前端继续调 `POST /lifecycle/ready` 触发 daemon deferred services
+/// (clipboard watcher / sync 等)启动。
+#[tauri::command]
+pub async fn unlock_space_with_passphrase(
+    runtime: State<'_, Arc<TauriAppRuntime>>,
+    args: UnlockSpaceArgs,
+    _trace: Option<TraceMetadata>,
+) -> Result<UnlockSpaceResultDto, UnlockSpaceCommandError> {
+    let span = info_span!(
+        "command.space_setup.unlock_space_with_passphrase",
+        trace_id = tracing::field::Empty,
+        trace_ts = tracing::field::Empty,
+    );
+    record_trace_fields(&span, &_trace);
+
+    async move {
+        let facade = runtime
+            .app_facade()
+            .space_setup
+            .get()
+            .cloned()
+            .ok_or(UnlockSpaceCommandError::FacadeUnavailable)?;
+        let input = UnlockSpaceInput {
+            passphrase: args.passphrase,
+        };
+        let out = facade.unlock_space(input).await?;
+        Ok(UnlockSpaceResultDto::from(out))
+    }
+    .instrument(span)
+    .await
+}
+
+// ============================================================================
+// try_silent_unlock ─ 启动期 / modal 弹出前的 keyring resume 探测
+// ============================================================================
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TrySilentUnlockResult {
+    /// `true` = keyring 命中 + unwrap 成功,session 已 ready;
+    /// `false` = "没什么可恢复的"(还没 setup / setup 完但 keyslot 缺失);
+    /// 注意 keyring 与 keyslot **漂移**会走 `Err` 而不是 `Ok(false)`,
+    /// 前端据此区分"该弹解锁 modal" vs "该走 init/join 引导"。
+    pub resumed: bool,
+}
+
+#[derive(Debug, Clone, Serialize, thiserror::Error)]
+#[serde(
+    tag = "code",
+    rename_all = "SCREAMING_SNAKE_CASE",
+    rename_all_fields = "camelCase"
+)]
+pub enum TrySilentUnlockError {
+    /// app facade 尚未装配。
+    #[error("app facade not available in this runtime")]
+    FacadeUnavailable,
+
+    /// keyring 中 KEK 与磁盘 keyslot 漂移 / 损坏 / 其他非预期错误。
+    /// 前端应弹出 "Unlock space" modal 收集明文口令,走
+    /// [`unlock_space_with_passphrase`] 兜底。
+    #[error("silent unlock failed: {message}")]
+    Internal { message: String },
+}
+
+/// In-process 等价于历史 HTTP `POST /encryption/unlock`(silent keyring
+/// resume,不接受 passphrase)。**这是替换 `DaemonQueryClient::unlock_encryption()`
+/// 的 in-process 路径**——GUI 与 daemon 同进程,完全没必要再绕 HTTP。
+///
+/// 语义保持原 endpoint 一致: `Ok(true)` keyring 命中、`Ok(false)`
+/// "nothing to resume"(空 profile / 还没 setup)、`Err` 异常 / 漂移。
+#[tauri::command]
+pub async fn try_silent_unlock(
+    runtime: State<'_, Arc<TauriAppRuntime>>,
+    _trace: Option<TraceMetadata>,
+) -> Result<TrySilentUnlockResult, TrySilentUnlockError> {
+    let span = info_span!(
+        "command.space_setup.try_silent_unlock",
+        trace_id = tracing::field::Empty,
+        trace_ts = tracing::field::Empty,
+    );
+    record_trace_fields(&span, &_trace);
+
+    async move {
+        let resumed = runtime
+            .app_facade()
+            .encryption
+            .unlock()
+            .await
+            .map_err(|err| TrySilentUnlockError::Internal {
+                message: err.to_string(),
+            })?;
+        Ok(TrySilentUnlockResult { resumed })
+    }
+    .instrument(span)
+    .await
+}

--- a/src-tauri/crates/uc-tauri/src/run.rs
+++ b/src-tauri/crates/uc-tauri/src/run.rs
@@ -409,7 +409,19 @@ pub fn run(tauri_ctx: tauri::Context<tauri::Wry>) -> anyhow::Result<()> {
                     info!("[Startup] Silent start: skipping startup barrier window show");
                 }
 
-                // 1. Auto-unlock (non-blocking) via daemon API if enabled in settings
+                // 1. Auto-unlock (non-blocking) via in-process facade if enabled in settings.
+                //
+                // 历史上这里走的是 `DaemonQueryClient::unlock_encryption()` HTTP RPC
+                // —— GUI 与 daemon 在 `DaemonRunMode::GuiInProcess` 下同进程,
+                // 共享同一份 `AppFacade`,经 HTTP 等于自己给自己发 TCP 报文。
+                // 改成 in-process 调 `EncryptionFacade::unlock()`(silent keyring
+                // resume,不接受 passphrase)——语义保持原 endpoint 一致, 但
+                // (a) 不再依赖 daemon connection_state ready, 启动延迟更短;
+                // (b) 故障面减少一层(无需经 axum router / auth middleware)。
+                //
+                // `lifecycle_retry` 仍走 HTTP——它真正是"通知 daemon-side 的
+                // service lifecycle 推进", 跨调用方/被调用方角色, 保留 RPC
+                // 边界更稳。这一步仍需等 daemon connection_state 填充。
                 let runtime_for_auto_unlock = runtime.clone();
                 let daemon_conn_for_unlock = daemon_connection_state.clone();
                 tauri::async_runtime::spawn(async move {
@@ -427,10 +439,34 @@ pub fn run(tauri_ctx: tauri::Context<tauri::Wry>) -> anyhow::Result<()> {
                         return;
                     }
 
-                    // daemon bootstrap 与 backend init 是并发 spawn 的——
-                    // 必须等 connection_state 被填充后再下发 unlock，
-                    // 否则首次 RPC 直接 401-no-connection-info 把整个
-                    // auto-unlock + lifecycle_retry 跳过。
+                    match runtime_for_auto_unlock
+                        .app_facade()
+                        .encryption
+                        .unlock()
+                        .await
+                    {
+                        Ok(true) => {
+                            info!("[Startup] Encryption auto-unlocked via in-process facade");
+                        }
+                        Ok(false) => {
+                            info!(
+                                "[Startup] Encryption not initialized or keyring miss; skip auto-unlock"
+                            );
+                            return;
+                        }
+                        Err(e) => {
+                            warn!(
+                                error = %e,
+                                "[Startup] In-process auto-unlock failed; user will need to enter passphrase via Unlock modal"
+                            );
+                            return;
+                        }
+                    }
+
+                    // Daemon lifecycle retry 仍走 HTTP——它驱动 daemon-side 的
+                    // deferred services (clipboard watcher / sync) 启动, 跨
+                    // 调用方/被调用方角色, RPC 边界更稳。需要等 connection_state
+                    // 填充避免 401-no-connection-info。
                     if !wait_for_daemon_connection(
                         &daemon_conn_for_unlock,
                         AUTO_UNLOCK_DAEMON_READY_TIMEOUT,
@@ -440,25 +476,12 @@ pub fn run(tauri_ctx: tauri::Context<tauri::Wry>) -> anyhow::Result<()> {
                     {
                         warn!(
                             timeout_secs = AUTO_UNLOCK_DAEMON_READY_TIMEOUT.as_secs(),
-                            "[Startup] Daemon connection not ready in time; skipping auto-unlock"
+                            "[Startup] Daemon connection not ready in time; skipping lifecycle retry"
                         );
                         return;
                     }
 
                     let client = uc_daemon_client::DaemonQueryClient::new(daemon_conn_for_unlock);
-                    match client.unlock_encryption().await {
-                        Ok(true) => {
-                            info!("[Startup] Daemon encryption auto-unlocked");
-                        }
-                        Ok(false) => {
-                            info!("[Startup] Encryption not initialized, skip");
-                        }
-                        Err(e) => {
-                            warn!("[Startup] Daemon encryption unlock failed: {}", e);
-                            return;
-                        }
-                    }
-
                     if let Err(e) = client.lifecycle_retry().await {
                         warn!("[Startup] Daemon lifecycle retry failed: {}", e);
                     } else {
@@ -509,6 +532,9 @@ pub fn run(tauri_ctx: tauri::Context<tauri::Wry>) -> anyhow::Result<()> {
             crate::commands::mobile_sync::get_mobile_sync_settings,
             crate::commands::mobile_sync::update_mobile_sync_settings,
             crate::commands::mobile_sync::list_mobile_lan_interfaces,
+            // Space setup commands (in-process facade — passphrase never leaves the Tauri process)
+            crate::commands::space_setup::unlock_space_with_passphrase,
+            crate::commands::space_setup::try_silent_unlock,
         ])
         .build(tauri_ctx)
         .map_err(|error| anyhow::anyhow!("error building tauri application: {error}"))?

--- a/src/api/security.ts
+++ b/src/api/security.ts
@@ -3,18 +3,32 @@
  *
  * 安全 API 模块 — daemon 加密端点的类型化访问器。
  *
- * # Daemon Endpoints / Daemon 端点
+ * # Daemon Endpoints (read-only) / Daemon 端点(只读)
  * - `GET /encryption/state` → current encryption initialization & session state
- * - `POST /encryption/unlock` → auto-unlock encryption session (keyring-based, no passphrase)
- * - `POST /encryption/lock` → lock encryption session (clear master key)
  * - `GET /encryption/keychain-access` → verify Keychain "Always Allow" permission
+ *
+ * # Tauri Commands (in-process) / Tauri 命令(同进程)
+ * - `try_silent_unlock` → silent keyring resume (replaces `POST /encryption/unlock`)
+ * - `unlock_space_with_passphrase` → user-driven passphrase unlock (NEW;
+ *   only safe path for plaintext passphrase — never crosses HTTP boundary)
+ *
+ * Migration note: `unlockEncryptionSession` historically wrapped
+ * `POST /encryption/unlock`. As of the in-process facade migration it now
+ * delegates to the Tauri command `try_silent_unlock` — same semantics
+ * (keyring-only, no passphrase) but no longer round-trips through the daemon
+ * webserver. Existing call sites do not need to change.
  */
 
 import {
   getEncryptionState as daemonGetEncryptionState,
-  unlockEncryption as daemonUnlockEncryption,
   verifyKeychainAccess as daemonVerifyKeychainAccess,
 } from './daemon/encryption'
+import {
+  isTrySilentUnlockError,
+  isUnlockSpaceError,
+  trySilentUnlock as tauriTrySilentUnlock,
+  unlockSpaceWithPassphrase as tauriUnlockSpaceWithPassphrase,
+} from './tauri-command/space_setup'
 import { createLogger } from '@/lib/logger'
 
 const log = createLogger('security')
@@ -33,7 +47,12 @@ export interface EncryptionSessionStatus {
   sessionReady: boolean
 }
 
-// ── Daemon-based functions ─────────────────────────────────────
+// Re-export the typed error union so call sites can pattern-match in catch
+// blocks without reaching into the tauri-command layer directly.
+export type { UnlockSpaceError } from './tauri-command/space_setup'
+export { isUnlockSpaceError } from './tauri-command/space_setup'
+
+// ── Daemon-based read-only functions ───────────────────────────
 
 /**
  * Fetch encryption session status from the daemon.
@@ -50,26 +69,6 @@ export async function getEncryptionSessionStatus(): Promise<EncryptionSessionSta
 }
 
 /**
- * Auto-unlock the encryption session via the daemon.
- *
- * 通过 daemon 自动解锁加密会话（从 keychain 获取 KEK，无需 passphrase）。
- *
- * Uses daemon HTTP API: `POST /encryption/unlock`
- *
- * @returns True on success, false if encryption not initialized.
- * @throws On unlock errors.
- */
-export async function unlockEncryptionSession(): Promise<boolean> {
-  try {
-    await daemonUnlockEncryption()
-    return true
-  } catch (error) {
-    log.error({ err: error }, 'Failed to unlock encryption session')
-    throw error
-  }
-}
-
-/**
  * Verify macOS Keychain "Always Allow" permission for this app.
  *
  * 验证此应用的 macOS Keychain "始终允许" 权限。
@@ -81,4 +80,76 @@ export async function unlockEncryptionSession(): Promise<boolean> {
  */
 export async function verifyKeychainAccess(): Promise<boolean> {
   return daemonVerifyKeychainAccess()
+}
+
+// ── In-process unlock paths ────────────────────────────────────
+
+/**
+ * Silent keyring-only unlock attempt (in-process).
+ *
+ * 用 keyring 中已存 KEK 静默解锁,不接受 passphrase。
+ *
+ * Replaces the historical `POST /encryption/unlock` HTTP path with a
+ * Tauri command invocation — same semantics, but no HTTP round-trip
+ * (GUI and daemon share the same `AppFacade` in `GuiInProcess` mode).
+ *
+ * @returns `true` if the session was resumed from the keyring,
+ *          `false` if there is nothing to resume (no setup yet / keyslot missing).
+ * @throws An exception when the keyring is *present but mismatches* the
+ *          on-disk keyslot, or any other unexpected failure. Callers should
+ *          fall back to prompting the user for the passphrase via
+ *          {@link unlockSpaceWithPassphrase} when this rejects.
+ */
+export async function unlockEncryptionSession(): Promise<boolean> {
+  try {
+    const { resumed } = await tauriTrySilentUnlock()
+    return resumed
+  } catch (error) {
+    if (isTrySilentUnlockError(error)) {
+      log.warn(
+        { code: error.code },
+        'Silent unlock failed — caller should fall back to passphrase prompt'
+      )
+    } else {
+      log.error({ err: error }, 'Silent unlock failed with non-typed error')
+    }
+    throw error
+  }
+}
+
+/**
+ * User-driven passphrase unlock (in-process, plaintext never leaves the process).
+ *
+ * 用户主动输入明文口令解锁。
+ *
+ * Plaintext passphrase is sent over the Tauri IPC boundary only — it never
+ * crosses HTTP / TCP socket (which is why this lives on the in-process
+ * facade path, not the daemon webserver). The Sentry breadcrumb in
+ * `invokeWithTrace` automatically redacts the `passphrase` field.
+ *
+ * After this returns successfully the in-process daemon's `InMemorySession`
+ * is ready. The caller must additionally hit `POST /lifecycle/ready` to
+ * actually start the daemon's deferred clipboard / sync services — the
+ * same step taken after `init` / `redeem`.
+ *
+ * @throws {UnlockSpaceError} typed union — switch on `error.code`.
+ */
+export async function unlockSpaceWithPassphrase(passphrase: string): Promise<{ spaceId: string }> {
+  try {
+    return await tauriUnlockSpaceWithPassphrase(passphrase)
+  } catch (error) {
+    if (isUnlockSpaceError(error)) {
+      // WrongPassphrase is the common user-input case — log at info, not
+      // warn/error, to avoid noisy alarms on every retry. Other variants
+      // are genuinely unexpected and worth warn-level logs.
+      if (error.code === 'WRONG_PASSPHRASE') {
+        log.info('unlock_space_with_passphrase rejected: wrong passphrase')
+      } else {
+        log.warn({ code: error.code }, 'unlock_space_with_passphrase failed')
+      }
+    } else {
+      log.error({ err: error }, 'unlock_space_with_passphrase failed with non-typed error')
+    }
+    throw error
+  }
 }

--- a/src/api/tauri-command/space_setup.ts
+++ b/src/api/tauri-command/space_setup.ts
@@ -1,0 +1,125 @@
+/**
+ * Space setup Tauri command wrappers — passphrase-bearing unlock path.
+ *
+ * GUI 走 in-process facade 直调 `uc-application::SpaceSetupFacade` /
+ * `EncryptionFacade`,不经 daemon webserver。这是承载 **明文口令** 的
+ * 唯一前端通路:passphrase 通过 Tauri IPC 直接到同进程的 Rust 入口,
+ * **绝不**走 HTTP/TCP socket (避免本机其他进程嗅探 + 减少故障面)。
+ *
+ * Backend: `src-tauri/crates/uc-tauri/src/commands/space_setup.rs`
+ *
+ * 设计参考:
+ * - `[GUI 走 in-process facade]` 项目原则:webserver 只留给 LAN 业务,
+ *   GUI 业务一律直调 facade
+ * - `api/tauri-command/mobile_sync.ts` 同模式先例
+ */
+
+import { invokeWithTrace } from '@/lib/tauri-command'
+
+// ============================================================================
+// Error taxonomy — discriminated unions mirroring Rust side
+// ============================================================================
+
+/**
+ * 用户口令解锁的失败枚举,镜像 Rust `UnlockSpaceCommandError`。
+ *
+ * 前端在 catch 块里 `switch (error.code)` 分支处理 UX:
+ * - `WRONG_PASSPHRASE`: 提示重输,**保留** modal,不关闭也不清空
+ * - `CORRUPTED_KEY_MATERIAL`: 不可恢复,引导用户走 factory reset / 重新 join
+ * - `SETUP_NOT_COMPLETED` / `SPACE_NOT_INITIALIZED`: 引导走 init / join 流程
+ *   (一般不会触发到这里,因为 UnlockPage 是 setup 完成后才出现的)
+ * - `FACADE_UNAVAILABLE`: bootstrap 还没跑完;延后重试或提示重启应用
+ * - `INTERNAL`: 兜底,展示通用错误 + Sentry 上报
+ */
+export type UnlockSpaceError =
+  | { code: 'FACADE_UNAVAILABLE' }
+  | { code: 'SETUP_NOT_COMPLETED' }
+  | { code: 'SPACE_NOT_INITIALIZED' }
+  | { code: 'WRONG_PASSPHRASE' }
+  | { code: 'CORRUPTED_KEY_MATERIAL' }
+  | { code: 'INTERNAL'; message: string }
+
+/**
+ * Silent (keyring) unlock 失败枚举,镜像 Rust `TrySilentUnlockError`。
+ *
+ * `Internal` 覆盖所有 "keyring miss + keyslot 漂移 + 其他非预期";前端
+ * 看到 Err 即应当弹 passphrase modal 兜底,而不是把 message 直接展给用户。
+ */
+export type TrySilentUnlockError =
+  | { code: 'FACADE_UNAVAILABLE' }
+  | { code: 'INTERNAL'; message: string }
+
+/** Type guard for `unlockSpaceWithPassphrase` rejections. */
+export function isUnlockSpaceError(error: unknown): error is UnlockSpaceError {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    typeof (error as { code: unknown }).code === 'string'
+  )
+}
+
+/** Type guard for `trySilentUnlock` rejections. */
+export function isTrySilentUnlockError(error: unknown): error is TrySilentUnlockError {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    typeof (error as { code: unknown }).code === 'string'
+  )
+}
+
+// ============================================================================
+// DTOs
+// ============================================================================
+
+export interface UnlockSpaceWithPassphraseArgs {
+  passphrase: string
+}
+
+export interface UnlockSpaceResult {
+  spaceId: string
+}
+
+export interface TrySilentUnlockResult {
+  /**
+   * `true` = keyring 命中 + unwrap 成功,session 已 ready;
+   * `false` = "没什么可恢复的" (还没 setup / setup 完但 keyslot 缺失);
+   * 注意 keyring 与 keyslot **漂移** 会走 reject 路径而不是 `Ok(false)`,
+   * 调用方据此区分 "弹解锁 modal" vs "走 init/join 引导"。
+   */
+  resumed: boolean
+}
+
+// ============================================================================
+// Command wrappers
+// ============================================================================
+
+/**
+ * 用户主动输入明文口令解锁 space (in-process)。
+ *
+ * `passphrase` 仅在 Tauri IPC 边界以明文存在,**绝不**应再次序列化到
+ * HTTP/TCP 上 —— `invokeWithTrace` 内置的 Sentry breadcrumb 已通过
+ * `@/observability/redaction` 把 `passphrase` 字段脱敏,放心传。
+ *
+ * 成功后同进程 daemon 的 `InMemorySession` 已 ready;调用方还需触发
+ * 一次 daemon `POST /lifecycle/ready` 才能让 clipboard watcher / sync
+ * 等 deferred services 真正启动 (现有 init/redeem 路径之后也是这么走的)。
+ */
+export async function unlockSpaceWithPassphrase(passphrase: string): Promise<UnlockSpaceResult> {
+  return await invokeWithTrace<UnlockSpaceResult>('unlock_space_with_passphrase', {
+    args: { passphrase },
+  })
+}
+
+/**
+ * Silent keyring resume —— 启动期 auto-unlock + modal 弹出前的探测。
+ *
+ * In-process 等价于历史 HTTP `POST /encryption/unlock` (不接受 passphrase)。
+ * 语义保持原 endpoint 一致: `resumed=true` keyring 命中、`resumed=false`
+ * "nothing to resume" (空 profile / 还没 setup)、reject = 异常 / 漂移
+ * (调用方应弹 passphrase modal 兜底)。
+ */
+export async function trySilentUnlock(): Promise<TrySilentUnlockResult> {
+  return await invokeWithTrace<TrySilentUnlockResult>('try_silent_unlock')
+}

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -452,6 +452,26 @@
       "cancel": "Cancel",
       "verifying": "Verifying access...",
       "error": "Keychain Always Allow permission not detected. Please try again and make sure to select \"Always Allow\" in the macOS Keychain prompt."
+    },
+    "passphraseModal": {
+      "title": "Enter your space passphrase",
+      "description": "Auto-unlock could not retrieve the key from the keychain. Enter the passphrase you set for this space to unlock manually.",
+      "passphraseLabel": "Passphrase",
+      "passphrasePlaceholder": "Enter your passphrase",
+      "submit": "Unlock",
+      "submitting": "Unlocking...",
+      "cancel": "Cancel",
+      "show": "Show passphrase",
+      "hide": "Hide passphrase",
+      "hint": "After unlocking once, the keychain will be refreshed so future sessions can auto-unlock again."
+    },
+    "errors": {
+      "wrongPassphrase": "Wrong passphrase. Please try again.",
+      "corruptedKeyMaterial": "The local key material is corrupted. You'll need to reset this space and re-join from another device to recover.",
+      "setupNotCompleted": "Setup is not complete on this device yet. Please run setup first.",
+      "spaceNotInitialized": "No space exists on this device. Please initialize a new space or join from another device.",
+      "facadeUnavailable": "The app is still starting up. Please wait a moment and try again.",
+      "internal": "Unlock failed unexpectedly. Please try again or restart the application."
     }
   },
   "language": {

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -443,6 +443,26 @@
       "cancel": "取消",
       "verifying": "正在验证访问权限...",
       "error": "未检测到钥匙串始终允许授权。请重试，并确保在 macOS 钥匙串提示中选择「始终允许」。"
+    },
+    "passphraseModal": {
+      "title": "请输入空间口令",
+      "description": "自动解锁无法从钥匙串中读取密钥，请输入您为该空间设置的口令以手动解锁。",
+      "passphraseLabel": "口令",
+      "passphrasePlaceholder": "输入您的口令",
+      "submit": "解锁",
+      "submitting": "正在解锁...",
+      "cancel": "取消",
+      "show": "显示口令",
+      "hide": "隐藏口令",
+      "hint": "手动解锁成功后，钥匙串将被刷新，后续启动可以恢复自动解锁。"
+    },
+    "errors": {
+      "wrongPassphrase": "口令错误，请重新输入。",
+      "corruptedKeyMaterial": "本机密钥材料已损坏，需要重置该空间并从其他设备重新加入才能恢复。",
+      "setupNotCompleted": "本设备尚未完成 setup，请先执行 setup。",
+      "spaceNotInitialized": "本设备没有可解锁的空间，请新建空间或从其他设备加入。",
+      "facadeUnavailable": "应用仍在启动中，请稍后重试。",
+      "internal": "解锁失败，请重试或重启应用。"
     }
   },
   "language": {

--- a/src/pages/UnlockPage.tsx
+++ b/src/pages/UnlockPage.tsx
@@ -1,7 +1,13 @@
-import { Lock, Unlock, Loader2 } from 'lucide-react'
+import { Eye, EyeOff, Loader2, Lock, Unlock } from 'lucide-react'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { unlockEncryptionSession, verifyKeychainAccess } from '@/api/security'
+import {
+  isUnlockSpaceError,
+  unlockEncryptionSession,
+  unlockSpaceWithPassphrase,
+  verifyKeychainAccess,
+  type UnlockSpaceError,
+} from '@/api/security'
 import {
   AlertDialog,
   AlertDialogContent,
@@ -11,6 +17,7 @@ import {
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
 import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Switch } from '@/components/ui/switch'
 import { usePlatform } from '@/hooks/usePlatform'
@@ -23,32 +30,143 @@ interface UnlockPageProps {
   onUnlockSucceeded?: () => void
 }
 
+/**
+ * 把 `UnlockSpaceError` 翻成 i18n key——按 error.code 选展示文案,WRONG_PASSPHRASE
+ * 是用户最常见的可恢复错误,其他都是不可恢复需要引导用户做别的操作。
+ */
+function unlockErrorI18nKey(error: UnlockSpaceError): string {
+  switch (error.code) {
+    case 'WRONG_PASSPHRASE':
+      return 'unlock.errors.wrongPassphrase'
+    case 'CORRUPTED_KEY_MATERIAL':
+      return 'unlock.errors.corruptedKeyMaterial'
+    case 'SETUP_NOT_COMPLETED':
+      return 'unlock.errors.setupNotCompleted'
+    case 'SPACE_NOT_INITIALIZED':
+      return 'unlock.errors.spaceNotInitialized'
+    case 'FACADE_UNAVAILABLE':
+      return 'unlock.errors.facadeUnavailable'
+    case 'INTERNAL':
+      return 'unlock.errors.internal'
+  }
+}
+
 export default function UnlockPage({ onUnlockSucceeded }: UnlockPageProps) {
   const { t } = useTranslation()
   const { setting, updateSecuritySetting, loading: settingsLoading } = useSetting()
   const { isMac } = usePlatform()
+
+  // ── Silent unlock (top-level button) state ─────────────────────────────
   const [unlocking, setUnlocking] = useState(false)
+
+  // ── Passphrase modal state — only opened when silent unlock can't recover ──
+  const [showPassphraseModal, setShowPassphraseModal] = useState(false)
+  const [passphrase, setPassphrase] = useState('')
+  const [showPassphrase, setShowPassphrase] = useState(false)
+  const [submitting, setSubmitting] = useState(false)
+  // 错误以已翻译过的 i18n key 形式存储 — 不放原始 error.code,避免外层重渲染时
+  // 失去 t() 上下文。clearOnInputChange 在用户继续输入时被重置。
+  const [errorKey, setErrorKey] = useState<string | null>(null)
   const [showKeychainModal, setShowKeychainModal] = useState(false)
   const [verifying, setVerifying] = useState(false)
   const [verifyError, setVerifyError] = useState<string | null>(null)
 
+  /**
+   * 入口:用户点 Unlock 按钮。
+   *
+   * 1. 先尝试 silent (keyring) unlock(in-process,无 passphrase)
+   * 2. `resumed=true` → 直接成功通知 parent
+   * 3. `resumed=false` 或 reject → 弹 passphrase modal 让用户手动输入
+   *
+   * 区别于原行为(旧版只把 silent 失败 log warn 然后停止):新增 modal 兜底
+   * 是修复"keyring 与磁盘 keyslot 漂移"场景下用户被卡死的产品缺口。
+   */
   const handleUnlock = async () => {
     setUnlocking(true)
     try {
       const unlocked = await unlockEncryptionSession()
       if (unlocked) {
-        // Unlock success means the daemon session is ready now.
-        // Notify the parent immediately instead of waiting solely on async WS delivery.
+        // Silent unlock 成功 — session 立即 ready,通知 parent。
+        // 不依赖 WS 异步推送, 避免首屏闪烁。
         onUnlockSucceeded?.()
-      } else {
-        // unlock_encryption_session returned false — encryption was not initialized
-        // or the session was already ready. Do not animate out; reset state.
-        log.warn('Unlock returned false — encryption may not be initialized')
-        setUnlocking(false)
+        return
       }
+      // Silent unlock 返回 false = "keyring 没东西可恢复"。在 setup 已完成
+      // 的前提下这其实是漂移/损坏 — 弹 modal 让用户用口令兜底。
+      log.warn('Silent unlock returned false — opening passphrase modal as fallback')
+      openPassphraseModal()
     } catch (error) {
-      log.error({ err: error }, 'Unlock failed')
+      // Silent unlock 抛错 = keyring 与 keyslot 漂移 / FacadeUnavailable / 其他
+      // 异常。一律弹 modal:让用户用口令派生 KEK + 刷新 keyring(unlock 内部
+      // 的 store_kek refresh),把漂移修好。
+      log.warn({ err: error }, 'Silent unlock rejected — opening passphrase modal as fallback')
+      openPassphraseModal()
+    } finally {
       setUnlocking(false)
+    }
+  }
+
+  const openPassphraseModal = () => {
+    setPassphrase('')
+    setShowPassphrase(false)
+    setErrorKey(null)
+    setShowPassphraseModal(true)
+  }
+
+  const closePassphraseModal = () => {
+    setShowPassphraseModal(false)
+    setPassphrase('')
+    setShowPassphrase(false)
+    setErrorKey(null)
+  }
+
+  /**
+   * 用户在 modal 提交明文口令:
+   * - 成功 → 关闭 modal + 通知 parent
+   * - WRONG_PASSPHRASE → 保留 modal,清空 errorKey 之外的 state,提示重输
+   * - 其他错误码 → 保留 modal,展示对应引导文案,**不**自动清空 passphrase
+   *   (用户可能想编辑后重提交)
+   */
+  const handleSubmitPassphrase = async () => {
+    const trimmed = passphrase
+    if (trimmed.length === 0) {
+      // 空口令理论上和 WrongPassphrase 等价,但提前拦截可以省一次 Tauri IPC。
+      setErrorKey('unlock.errors.wrongPassphrase')
+      return
+    }
+    setSubmitting(true)
+    setErrorKey(null)
+    try {
+      await unlockSpaceWithPassphrase(trimmed)
+      // session 已 ready;同进程 daemon 会被 parent 触发 lifecycle/ready
+      // (App.tsx 现有路径)启动 deferred services。
+      closePassphraseModal()
+      onUnlockSucceeded?.()
+    } catch (error) {
+      if (isUnlockSpaceError(error)) {
+        setErrorKey(unlockErrorI18nKey(error))
+      } else {
+        // 非 typed 错误 — 例如 IPC bridge 自身的异常。展通用错误。
+        log.error({ err: error }, 'Unexpected non-typed unlock error')
+        setErrorKey('unlock.errors.internal')
+      }
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const handlePassphraseKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    // Enter 直接提交,跟 setup screen 一致的输入习惯。
+    if (e.key === 'Enter' && !submitting) {
+      handleSubmitPassphrase()
+    }
+  }
+
+  const handlePassphraseChange = (value: string) => {
+    setPassphrase(value)
+    // 用户开始重新输入 → 清掉旧的错误提示,UI 反馈更顺。
+    if (errorKey !== null) {
+      setErrorKey(null)
     }
   }
 
@@ -179,6 +297,80 @@ export default function UnlockPage({ onUnlockSucceeded }: UnlockPageProps) {
                 </>
               ) : (
                 t('unlock.keychainModal.confirm')
+              )}
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <AlertDialog open={showPassphraseModal}>
+        <AlertDialogContent
+          onEscapeKeyDown={event => {
+            if (submitting) {
+              event.preventDefault()
+              return
+            }
+            closePassphraseModal()
+          }}
+        >
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t('unlock.passphraseModal.title')}</AlertDialogTitle>
+            <AlertDialogDescription>
+              {t('unlock.passphraseModal.description')}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+
+          <div className="space-y-2">
+            <Label htmlFor="unlock-passphrase" className="text-sm">
+              {t('unlock.passphraseModal.passphraseLabel')}
+            </Label>
+            <div className="relative">
+              <Input
+                id="unlock-passphrase"
+                type={showPassphrase ? 'text' : 'password'}
+                value={passphrase}
+                onChange={e => handlePassphraseChange(e.target.value)}
+                onKeyDown={handlePassphraseKeyDown}
+                disabled={submitting}
+                placeholder={t('unlock.passphraseModal.passphrasePlaceholder')}
+                className="pr-10"
+                autoFocus
+                aria-invalid={errorKey !== null}
+              />
+              <button
+                type="button"
+                onClick={() => setShowPassphrase(v => !v)}
+                disabled={submitting}
+                aria-label={t(
+                  showPassphrase ? 'unlock.passphraseModal.hide' : 'unlock.passphraseModal.show'
+                )}
+                className="absolute right-0 top-0 flex h-full items-center px-3 text-muted-foreground transition-colors hover:text-foreground disabled:opacity-50"
+              >
+                {showPassphrase ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+              </button>
+            </div>
+          </div>
+
+          {errorKey && (
+            <div className="rounded-lg border border-destructive/20 bg-destructive/5 p-3">
+              <p className="text-sm font-medium text-destructive">{t(errorKey)}</p>
+            </div>
+          )}
+
+          <p className="text-xs text-muted-foreground">{t('unlock.passphraseModal.hint')}</p>
+
+          <AlertDialogFooter>
+            <Button variant="outline" onClick={closePassphraseModal} disabled={submitting}>
+              {t('unlock.passphraseModal.cancel')}
+            </Button>
+            <Button onClick={handleSubmitPassphrase} disabled={submitting}>
+              {submitting ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  {t('unlock.passphraseModal.submitting')}
+                </>
+              ) : (
+                t('unlock.passphraseModal.submit')
               )}
             </Button>
           </AlertDialogFooter>

--- a/src/pages/__tests__/UnlockPage.test.tsx
+++ b/src/pages/__tests__/UnlockPage.test.tsx
@@ -1,13 +1,22 @@
-import { render, screen, act } from '@testing-library/react'
+import { render, screen, act, fireEvent, waitFor } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { unlockEncryptionSession, verifyKeychainAccess } from '@/api/security'
+import {
+  unlockEncryptionSession,
+  unlockSpaceWithPassphrase,
+  verifyKeychainAccess,
+} from '@/api/security'
 import i18n from '@/i18n'
 import UnlockPage from '@/pages/UnlockPage'
 
-vi.mock('@/api/security', () => ({
-  unlockEncryptionSession: vi.fn(),
-  verifyKeychainAccess: vi.fn(),
-}))
+vi.mock('@/api/security', async () => {
+  const actual = await vi.importActual<typeof import('@/api/security')>('@/api/security')
+  return {
+    ...actual,
+    unlockEncryptionSession: vi.fn(),
+    unlockSpaceWithPassphrase: vi.fn(),
+    verifyKeychainAccess: vi.fn(),
+  }
+})
 
 vi.mock('@/hooks/usePlatform', () => ({
   usePlatform: () => ({ isMac: false }),
@@ -30,7 +39,7 @@ describe('UnlockPage', () => {
     vi.mocked(verifyKeychainAccess).mockResolvedValue(true)
   })
 
-  it('notifies parent immediately when unlock succeeds', async () => {
+  it('notifies parent immediately when silent unlock succeeds', async () => {
     const onUnlockSucceeded = vi.fn()
     vi.mocked(unlockEncryptionSession).mockResolvedValue(true)
 
@@ -41,6 +50,145 @@ describe('UnlockPage', () => {
     })
 
     expect(unlockEncryptionSession).toHaveBeenCalledTimes(1)
+    expect(unlockSpaceWithPassphrase).not.toHaveBeenCalled()
     expect(onUnlockSucceeded).toHaveBeenCalledTimes(1)
+  })
+
+  it('opens passphrase modal when silent unlock returns false (nothing to resume)', async () => {
+    const onUnlockSucceeded = vi.fn()
+    vi.mocked(unlockEncryptionSession).mockResolvedValue(false)
+
+    render(<UnlockPage onUnlockSucceeded={onUnlockSucceeded} />)
+
+    await act(async () => {
+      screen.getByRole('button', { name: i18n.t('unlock.button') }).click()
+    })
+
+    expect(onUnlockSucceeded).not.toHaveBeenCalled()
+    expect(screen.getByText(i18n.t('unlock.passphraseModal.title'))).toBeInTheDocument()
+  })
+
+  it('opens passphrase modal when silent unlock rejects (keyring/keyslot drift)', async () => {
+    const onUnlockSucceeded = vi.fn()
+    vi.mocked(unlockEncryptionSession).mockRejectedValue({
+      code: 'INTERNAL',
+      message: 'silent unlock failed: WrongPassphrase',
+    })
+
+    render(<UnlockPage onUnlockSucceeded={onUnlockSucceeded} />)
+
+    await act(async () => {
+      screen.getByRole('button', { name: i18n.t('unlock.button') }).click()
+    })
+
+    expect(onUnlockSucceeded).not.toHaveBeenCalled()
+    expect(screen.getByText(i18n.t('unlock.passphraseModal.title'))).toBeInTheDocument()
+  })
+
+  it('successfully unlocks with a correct passphrase from the modal', async () => {
+    const onUnlockSucceeded = vi.fn()
+    vi.mocked(unlockEncryptionSession).mockResolvedValue(false)
+    vi.mocked(unlockSpaceWithPassphrase).mockResolvedValue({ spaceId: 'space-x' })
+
+    render(<UnlockPage onUnlockSucceeded={onUnlockSucceeded} />)
+
+    await act(async () => {
+      screen.getByRole('button', { name: i18n.t('unlock.button') }).click()
+    })
+
+    const passphraseInput = screen.getByLabelText(
+      i18n.t('unlock.passphraseModal.passphraseLabel')
+    ) as HTMLInputElement
+    fireEvent.change(passphraseInput, { target: { value: 'correct-horse-battery-staple' } })
+
+    await act(async () => {
+      screen.getByRole('button', { name: i18n.t('unlock.passphraseModal.submit') }).click()
+    })
+
+    expect(unlockSpaceWithPassphrase).toHaveBeenCalledWith('correct-horse-battery-staple')
+    expect(onUnlockSucceeded).toHaveBeenCalledTimes(1)
+    // Modal closes
+    expect(screen.queryByText(i18n.t('unlock.passphraseModal.title'))).not.toBeInTheDocument()
+  })
+
+  it('shows WRONG_PASSPHRASE message and keeps modal open on wrong passphrase', async () => {
+    const onUnlockSucceeded = vi.fn()
+    vi.mocked(unlockEncryptionSession).mockResolvedValue(false)
+    vi.mocked(unlockSpaceWithPassphrase).mockRejectedValue({ code: 'WRONG_PASSPHRASE' })
+
+    render(<UnlockPage onUnlockSucceeded={onUnlockSucceeded} />)
+
+    await act(async () => {
+      screen.getByRole('button', { name: i18n.t('unlock.button') }).click()
+    })
+
+    const passphraseInput = screen.getByLabelText(
+      i18n.t('unlock.passphraseModal.passphraseLabel')
+    ) as HTMLInputElement
+    fireEvent.change(passphraseInput, { target: { value: 'wrong-passphrase' } })
+
+    await act(async () => {
+      screen.getByRole('button', { name: i18n.t('unlock.passphraseModal.submit') }).click()
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText(i18n.t('unlock.errors.wrongPassphrase'))).toBeInTheDocument()
+    })
+    expect(onUnlockSucceeded).not.toHaveBeenCalled()
+    // Modal stays open so the user can retry
+    expect(screen.getByText(i18n.t('unlock.passphraseModal.title'))).toBeInTheDocument()
+  })
+
+  it('shows CORRUPTED_KEY_MATERIAL guidance when the keyslot is broken', async () => {
+    const onUnlockSucceeded = vi.fn()
+    vi.mocked(unlockEncryptionSession).mockResolvedValue(false)
+    vi.mocked(unlockSpaceWithPassphrase).mockRejectedValue({ code: 'CORRUPTED_KEY_MATERIAL' })
+
+    render(<UnlockPage onUnlockSucceeded={onUnlockSucceeded} />)
+
+    await act(async () => {
+      screen.getByRole('button', { name: i18n.t('unlock.button') }).click()
+    })
+
+    const passphraseInput = screen.getByLabelText(
+      i18n.t('unlock.passphraseModal.passphraseLabel')
+    ) as HTMLInputElement
+    fireEvent.change(passphraseInput, { target: { value: 'whatever' } })
+
+    await act(async () => {
+      screen.getByRole('button', { name: i18n.t('unlock.passphraseModal.submit') }).click()
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText(i18n.t('unlock.errors.corruptedKeyMaterial'))).toBeInTheDocument()
+    })
+  })
+
+  it('clears the error message as soon as the user keeps typing', async () => {
+    vi.mocked(unlockEncryptionSession).mockResolvedValue(false)
+    vi.mocked(unlockSpaceWithPassphrase).mockRejectedValue({ code: 'WRONG_PASSPHRASE' })
+
+    render(<UnlockPage />)
+
+    await act(async () => {
+      screen.getByRole('button', { name: i18n.t('unlock.button') }).click()
+    })
+
+    const passphraseInput = screen.getByLabelText(
+      i18n.t('unlock.passphraseModal.passphraseLabel')
+    ) as HTMLInputElement
+    fireEvent.change(passphraseInput, { target: { value: 'wrong' } })
+
+    await act(async () => {
+      screen.getByRole('button', { name: i18n.t('unlock.passphraseModal.submit') }).click()
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText(i18n.t('unlock.errors.wrongPassphrase'))).toBeInTheDocument()
+    })
+
+    fireEvent.change(passphraseInput, { target: { value: 'wrong-extra' } })
+
+    expect(screen.queryByText(i18n.t('unlock.errors.wrongPassphrase'))).not.toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary
- add an in-process passphrase unlock fallback when silent unlock cannot recover the space
- route GUI silent unlock through the shared in-process facade instead of the daemon HTTP path
- add unlock modal copy and tests for fallback, retry, and error states

## Verification
- npx vitest run src/pages/__tests__/UnlockPage.test.tsx
- cargo check -p uc-tauri -p uc-infra
- npx tsc --noEmit
- npx eslint src/api/security.ts src/api/tauri-command/space_setup.ts src/pages/UnlockPage.tsx src/pages/__tests__/UnlockPage.test.tsx
- cargo fmt --check
- bun run build