### PR TITLE
fix: confirm alpha update channel

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -20,8 +20,9 @@ on:
       - 'public/**'
       - '.github/workflows/pr-check.yml'
 
-# 拆 frontend / rust 两个 job 并行：
+# 拆 frontend / frontend-tests / rust 三个 job 并行：
 # - frontend: bun install + tsc + vite build (类型检查 + 产物构建)
+# - frontend-tests: bun install + vitest run (前端单元测试)
 # - rust: cargo check --workspace --locked (不再带 --all-targets --all-features，
 #   PR 阶段不为 test/bench/全 feature 编译。test 在 coverage.yml 跑)
 # 完整的 tauri build / 签名 / 公证 仍只在 release 工作流跑。
@@ -51,6 +52,32 @@ jobs:
 
       - name: Type check & build frontend
         run: bun run build
+
+  frontend-tests:
+    name: Frontend Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Cache Bun dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
+      - name: Install frontend dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run frontend tests
+        run: bun run test -- --run
 
   rust:
     name: Rust Check

--- a/src/components/setting/AboutSection.tsx
+++ b/src/components/setting/AboutSection.tsx
@@ -1,5 +1,5 @@
 import { getVersion } from '@tauri-apps/api/app'
-import { Loader2 } from 'lucide-react'
+import { Loader2, TriangleAlert } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { SettingGroup } from './SettingGroup'
@@ -12,6 +12,7 @@ import {
   AlertDialogDescription,
   AlertDialogFooter,
   AlertDialogHeader,
+  AlertDialogMedia,
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
 import { Badge } from '@/components/ui/badge'
@@ -54,6 +55,10 @@ function getChannelLabel(channel: string): string {
   return labels[channel] ?? channel
 }
 
+function normalizeUpdateChannel(value: string): UpdateChannel | null {
+  return value === 'auto' ? null : (value as UpdateChannel)
+}
+
 const AboutSection: React.FC = () => {
   const { t } = useTranslation()
   const { setting, loading: settingLoading, updateGeneralSetting } = useSetting()
@@ -62,7 +67,9 @@ const AboutSection: React.FC = () => {
   const [appVersion, setAppVersion] = useState<string>('')
   const [autoCheckUpdate, setAutoCheckUpdate] = useState(setting?.general.autoCheckUpdate ?? true)
   const [updateChannel, setUpdateChannel] = useState<UpdateChannel | null>(null)
+  const [pendingUpdateChannel, setPendingUpdateChannel] = useState<UpdateChannel | null>(null)
   const [updateDialogOpen, setUpdateDialogOpen] = useState(false)
+  const [alphaWarningOpen, setAlphaWarningOpen] = useState(false)
   const [saving, setSaving] = useState(false)
   const isInstallingUpdate = downloadProgress.phase !== 'idle'
   const isBusy = settingLoading || saving
@@ -104,21 +111,50 @@ const AboutSection: React.FC = () => {
     }
   }
 
-  const handleUpdateChannelChange = async (value: string) => {
+  const applyUpdateChannelChange = async (newChannel: UpdateChannel | null) => {
+    if (newChannel === updateChannel) return
+
     const previous = updateChannel
     try {
       setSaving(true)
-      const newChannel = value === 'auto' ? null : (value as UpdateChannel)
       setUpdateChannel(newChannel)
       await updateGeneralSetting({ updateChannel: newChannel })
-      // Immediately check for updates on the new channel
-      checkForUpdates().catch(err => log.error({ err }, 'Failed to check for updates'))
+      checkForUpdates(newChannel).catch(err => log.error({ err }, 'Failed to check for updates'))
     } catch (error) {
       log.error({ err: error }, '更改更新频道失败')
       setUpdateChannel(previous)
     } finally {
       setSaving(false)
     }
+  }
+
+  const handleUpdateChannelChange = (value: string) => {
+    const newChannel = normalizeUpdateChannel(value)
+    if (newChannel === updateChannel) return
+
+    if (newChannel === 'alpha' && updateChannel !== 'alpha') {
+      setPendingUpdateChannel(newChannel)
+      setAlphaWarningOpen(true)
+      return
+    }
+
+    void applyUpdateChannelChange(newChannel)
+  }
+
+  const handleAlphaWarningOpenChange = (open: boolean) => {
+    setAlphaWarningOpen(open)
+    if (!open) {
+      setPendingUpdateChannel(null)
+    }
+  }
+
+  const handleConfirmAlphaChannel = () => {
+    const channel = pendingUpdateChannel
+    setAlphaWarningOpen(false)
+    setPendingUpdateChannel(null)
+
+    if (channel !== 'alpha') return
+    void applyUpdateChannelChange(channel)
   }
 
   const handleCheckUpdate = async () => {
@@ -328,6 +364,36 @@ const AboutSection: React.FC = () => {
               disabled={isInstallingUpdate}
             >
               {t('update.updateNow')}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <AlertDialog open={alphaWarningOpen} onOpenChange={handleAlphaWarningOpenChange}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogMedia className="bg-amber-500/10 text-amber-600 dark:text-amber-400">
+              <TriangleAlert className="size-5" />
+            </AlertDialogMedia>
+            <AlertDialogTitle>
+              {t('settings.sections.about.updateChannel.alphaWarning.title')}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {t('settings.sections.about.updateChannel.alphaWarning.description')}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={saving}>
+              {t('settings.sections.about.updateChannel.alphaWarning.cancel')}
+            </AlertDialogCancel>
+            <AlertDialogAction
+              disabled={saving}
+              onClick={event => {
+                event.preventDefault()
+                handleConfirmAlphaChannel()
+              }}
+            >
+              {t('settings.sections.about.updateChannel.alphaWarning.confirm')}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/src/components/setting/__tests__/AboutSection.test.tsx
+++ b/src/components/setting/__tests__/AboutSection.test.tsx
@@ -3,7 +3,8 @@ import userEvent from '@testing-library/user-event'
 import AboutSection from '@/components/setting/AboutSection'
 import { SettingContext } from '@/contexts/setting-context'
 import { UpdateContext } from '@/contexts/update-context'
-import type { Settings } from '@/types/setting'
+import type { UpdateContextType } from '@/contexts/update-context'
+import type { SettingContextType, Settings } from '@/types/setting'
 
 vi.mock('@tauri-apps/api/app', () => ({
   getVersion: vi.fn().mockResolvedValue('0.4.0-alpha.6'),
@@ -18,6 +19,29 @@ vi.mock('react-i18next', () => ({
 vi.mock('@/hooks/useShortcutLayer', () => ({
   useShortcutLayer: vi.fn(),
 }))
+
+beforeAll(() => {
+  if (!HTMLElement.prototype.hasPointerCapture) {
+    Object.defineProperty(HTMLElement.prototype, 'hasPointerCapture', {
+      value: () => false,
+    })
+  }
+  if (!HTMLElement.prototype.setPointerCapture) {
+    Object.defineProperty(HTMLElement.prototype, 'setPointerCapture', {
+      value: () => undefined,
+    })
+  }
+  if (!HTMLElement.prototype.releasePointerCapture) {
+    Object.defineProperty(HTMLElement.prototype, 'releasePointerCapture', {
+      value: () => undefined,
+    })
+  }
+  if (!HTMLElement.prototype.scrollIntoView) {
+    Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
+      value: () => undefined,
+    })
+  }
+})
 
 const baseSetting: Settings = {
   schemaVersion: 1,
@@ -71,6 +95,61 @@ const baseSetting: Settings = {
   },
 }
 
+interface RenderAboutSectionOptions {
+  setting?: Settings
+  updateGeneralSetting?: SettingContextType['updateGeneralSetting']
+  checkForUpdates?: UpdateContextType['checkForUpdates']
+  isCheckingUpdate?: boolean
+}
+
+function renderAboutSection({
+  setting = baseSetting,
+  updateGeneralSetting = vi
+    .fn<SettingContextType['updateGeneralSetting']>()
+    .mockResolvedValue(undefined),
+  checkForUpdates = vi.fn<UpdateContextType['checkForUpdates']>().mockResolvedValue(null),
+  isCheckingUpdate = false,
+}: RenderAboutSectionOptions = {}) {
+  const user = userEvent.setup()
+
+  const view = render(
+    <SettingContext.Provider
+      value={{
+        setting,
+        loading: false,
+        error: null,
+        updateSetting: vi.fn(),
+        updateGeneralSetting,
+        updateSyncSetting: vi.fn(),
+        updateSecuritySetting: vi.fn(),
+        updateRetentionPolicy: vi.fn(),
+        updateKeyboardShortcuts: vi.fn(),
+        updateFileSyncSetting: vi.fn(),
+        updateNetworkSetting: vi.fn().mockResolvedValue({ restartRequired: false }),
+      }}
+    >
+      <UpdateContext.Provider
+        value={{
+          updateInfo: null,
+          isCheckingUpdate,
+          checkForUpdates,
+          installUpdate: vi.fn(),
+          downloadProgress: { downloaded: 0, total: null, phase: 'idle' as const },
+        }}
+      >
+        <AboutSection />
+      </UpdateContext.Provider>
+    </SettingContext.Provider>
+  )
+
+  return {
+    ...view,
+    user,
+    updateGeneralSetting,
+    checkForUpdates,
+  }
+}
+
 describe('AboutSection', () => {
   it('runs update check when clicking the button', async () => {
     const checkForUpdates = vi.fn().mockResolvedValue({
@@ -80,39 +159,9 @@ describe('AboutSection', () => {
       body: 'Bug fixes',
     })
 
-    render(
-      <SettingContext.Provider
-        value={{
-          setting: baseSetting,
-          loading: false,
-          error: null,
-          updateSetting: vi.fn(),
-          updateGeneralSetting: vi.fn(),
-          updateSyncSetting: vi.fn(),
-          updateSecuritySetting: vi.fn(),
-          updateRetentionPolicy: vi.fn(),
-          updateKeyboardShortcuts: vi.fn(),
-          updateFileSyncSetting: vi.fn(),
-          updateNetworkSetting: vi.fn().mockResolvedValue({ restartRequired: false }),
-        }}
-      >
-        <UpdateContext.Provider
-          value={{
-            updateInfo: null,
-            isCheckingUpdate: false,
-            checkForUpdates,
-            installUpdate: vi.fn(),
-            downloadProgress: { downloaded: 0, total: null, phase: 'idle' as const },
-          }}
-        >
-          <AboutSection />
-        </UpdateContext.Provider>
-      </SettingContext.Provider>
-    )
+    const { user } = renderAboutSection({ checkForUpdates })
 
-    await userEvent.click(
-      screen.getByRole('button', { name: 'settings.sections.about.checkUpdate' })
-    )
+    await user.click(screen.getByRole('button', { name: 'settings.sections.about.checkUpdate' }))
 
     await waitFor(() => {
       expect(checkForUpdates).toHaveBeenCalledTimes(1)
@@ -124,39 +173,11 @@ describe('AboutSection', () => {
   it('toggles auto update checks', async () => {
     const updateGeneralSetting = vi.fn().mockResolvedValue(undefined)
 
-    render(
-      <SettingContext.Provider
-        value={{
-          setting: baseSetting,
-          loading: false,
-          error: null,
-          updateSetting: vi.fn(),
-          updateGeneralSetting,
-          updateSyncSetting: vi.fn(),
-          updateSecuritySetting: vi.fn(),
-          updateRetentionPolicy: vi.fn(),
-          updateKeyboardShortcuts: vi.fn(),
-          updateFileSyncSetting: vi.fn(),
-          updateNetworkSetting: vi.fn().mockResolvedValue({ restartRequired: false }),
-        }}
-      >
-        <UpdateContext.Provider
-          value={{
-            updateInfo: null,
-            isCheckingUpdate: false,
-            checkForUpdates: vi.fn(),
-            installUpdate: vi.fn(),
-            downloadProgress: { downloaded: 0, total: null, phase: 'idle' as const },
-          }}
-        >
-          <AboutSection />
-        </UpdateContext.Provider>
-      </SettingContext.Provider>
-    )
+    const { user } = renderAboutSection({ updateGeneralSetting })
 
     expect(screen.getByText('settings.sections.about.autoCheckUpdate.label')).toBeInTheDocument()
 
-    await userEvent.click(screen.getByRole('switch'))
+    await user.click(screen.getByRole('switch'))
 
     await waitFor(() => {
       expect(updateGeneralSetting).toHaveBeenCalledWith({ autoCheckUpdate: false })
@@ -164,35 +185,7 @@ describe('AboutSection', () => {
   })
 
   it('shows loading feedback while checking for updates', () => {
-    const { container } = render(
-      <SettingContext.Provider
-        value={{
-          setting: baseSetting,
-          loading: false,
-          error: null,
-          updateSetting: vi.fn(),
-          updateGeneralSetting: vi.fn(),
-          updateSyncSetting: vi.fn(),
-          updateSecuritySetting: vi.fn(),
-          updateRetentionPolicy: vi.fn(),
-          updateKeyboardShortcuts: vi.fn(),
-          updateFileSyncSetting: vi.fn(),
-          updateNetworkSetting: vi.fn().mockResolvedValue({ restartRequired: false }),
-        }}
-      >
-        <UpdateContext.Provider
-          value={{
-            updateInfo: null,
-            isCheckingUpdate: true,
-            checkForUpdates: vi.fn(),
-            installUpdate: vi.fn(),
-            downloadProgress: { downloaded: 0, total: null, phase: 'idle' as const },
-          }}
-        >
-          <AboutSection />
-        </UpdateContext.Provider>
-      </SettingContext.Provider>
-    )
+    const { container } = renderAboutSection({ isCheckingUpdate: true })
 
     const checkButton = screen.getByRole('button', {
       name: 'settings.sections.about.checkingUpdate',
@@ -201,5 +194,48 @@ describe('AboutSection', () => {
     expect(checkButton).toBeDisabled()
     expect(checkButton).toHaveAttribute('aria-busy', 'true')
     expect(container.querySelector('.animate-spin')).toBeTruthy()
+  })
+
+  it('checks the newly selected channel immediately after saving it', async () => {
+    const updateGeneralSetting = vi.fn().mockResolvedValue(undefined)
+    const checkForUpdates = vi.fn().mockResolvedValue(null)
+    const { user } = renderAboutSection({ updateGeneralSetting, checkForUpdates })
+
+    await user.click(screen.getByRole('combobox'))
+    await user.click(
+      await screen.findByRole('option', { name: 'settings.sections.about.updateChannel.stable' })
+    )
+
+    await waitFor(() => {
+      expect(updateGeneralSetting).toHaveBeenCalledWith({ updateChannel: 'stable' })
+    })
+    expect(checkForUpdates).toHaveBeenCalledWith('stable')
+  })
+
+  it('warns before switching to alpha and checks alpha after confirmation', async () => {
+    const updateGeneralSetting = vi.fn().mockResolvedValue(undefined)
+    const checkForUpdates = vi.fn().mockResolvedValue(null)
+    const { user } = renderAboutSection({ updateGeneralSetting, checkForUpdates })
+
+    await user.click(screen.getByRole('combobox'))
+    await user.click(
+      await screen.findByRole('option', { name: 'settings.sections.about.updateChannel.alpha' })
+    )
+
+    expect(
+      await screen.findByText('settings.sections.about.updateChannel.alphaWarning.title')
+    ).toBeInTheDocument()
+    expect(updateGeneralSetting).not.toHaveBeenCalled()
+
+    await user.click(
+      screen.getByRole('button', {
+        name: 'settings.sections.about.updateChannel.alphaWarning.confirm',
+      })
+    )
+
+    await waitFor(() => {
+      expect(updateGeneralSetting).toHaveBeenCalledWith({ updateChannel: 'alpha' })
+    })
+    expect(checkForUpdates).toHaveBeenCalledWith('alpha')
   })
 })

--- a/src/contexts/UpdateContext.tsx
+++ b/src/contexts/UpdateContext.tsx
@@ -10,6 +10,7 @@ import {
 import { toast } from '@/components/ui/toast'
 import { useSetting } from '@/hooks/useSetting'
 import { createLogger } from '@/lib/logger'
+import type { UpdateChannel } from '@/types/setting'
 
 const log = createLogger('update-context')
 
@@ -27,27 +28,49 @@ export const UpdateProvider: React.FC<UpdateProviderProps> = ({ children }) => {
     total: null,
     phase: 'idle',
   })
-  const isCheckingRef = useRef(false)
+  const activeCheckRef = useRef<Promise<UpdateMetadata | null> | null>(null)
+  const activeCheckChannelRef = useRef<UpdateChannel | null>(null)
   const hasCheckedOnStartup = useRef(false)
 
-  const checkForUpdates = useCallback(async () => {
-    if (isCheckingRef.current) {
-      return updateInfo
-    }
-
-    isCheckingRef.current = true
+  const runCheckForChannel = useCallback(async (channel: UpdateChannel | null) => {
     setIsCheckingUpdate(true)
+    const check = checkForUpdate(channel)
+    activeCheckRef.current = check
+    activeCheckChannelRef.current = channel
 
     try {
-      const channel = setting?.general?.updateChannel ?? null
-      const update = await checkForUpdate(channel)
+      const update = await check
       setUpdateInfo(update)
       return update
     } finally {
-      isCheckingRef.current = false
-      setIsCheckingUpdate(false)
+      if (activeCheckRef.current === check) {
+        activeCheckRef.current = null
+        activeCheckChannelRef.current = null
+        setIsCheckingUpdate(false)
+      }
     }
-  }, [updateInfo, setting?.general?.updateChannel])
+  }, [])
+
+  const checkForUpdates = useCallback(
+    async (channelOverride?: UpdateChannel | null) => {
+      const channel =
+        channelOverride === undefined ? (setting?.general?.updateChannel ?? null) : channelOverride
+      const activeCheck = activeCheckRef.current
+
+      if (activeCheck) {
+        if (activeCheckChannelRef.current === channel) {
+          return activeCheck
+        }
+
+        await activeCheck.catch(error => {
+          log.error({ err: error }, '等待上一次更新检查完成失败')
+        })
+      }
+
+      return runCheckForChannel(channel)
+    },
+    [runCheckForChannel, setting?.general?.updateChannel]
+  )
 
   const doInstallUpdate = useCallback(async () => {
     setDownloadProgress({ downloaded: 0, total: null, phase: 'downloading' })

--- a/src/contexts/__tests__/UpdateContext.test.tsx
+++ b/src/contexts/__tests__/UpdateContext.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { checkForUpdate } from '@/api/updater'
 import { SettingContext } from '@/contexts/setting-context'
 import { UpdateProvider } from '@/contexts/UpdateContext'
@@ -71,6 +72,16 @@ const baseSetting: Settings = {
 const UpdateConsumer = () => {
   const { updateInfo } = useUpdate()
   return <div>{updateInfo?.version ?? 'none'}</div>
+}
+
+const ManualAlphaCheckConsumer = () => {
+  const { checkForUpdates } = useUpdate()
+
+  return (
+    <button type="button" onClick={() => void checkForUpdates('alpha')}>
+      check alpha
+    </button>
+  )
 }
 
 describe('UpdateProvider', () => {
@@ -176,6 +187,48 @@ describe('UpdateProvider', () => {
 
     await waitFor(() => {
       expect(checkForUpdateMock).not.toHaveBeenCalled()
+    })
+  })
+
+  it('uses explicit channel override for manual checks', async () => {
+    const user = userEvent.setup()
+    const disabledSetting: Settings = {
+      ...baseSetting,
+      general: {
+        ...baseSetting.general,
+        autoCheckUpdate: false,
+        updateChannel: 'stable',
+      },
+    }
+
+    checkForUpdateMock.mockResolvedValue(null)
+
+    render(
+      <SettingContext.Provider
+        value={{
+          setting: disabledSetting,
+          loading: false,
+          error: null,
+          updateSetting: vi.fn(),
+          updateGeneralSetting: vi.fn(),
+          updateSyncSetting: vi.fn(),
+          updateSecuritySetting: vi.fn(),
+          updateRetentionPolicy: vi.fn(),
+          updateKeyboardShortcuts: vi.fn(),
+          updateFileSyncSetting: vi.fn(),
+          updateNetworkSetting: vi.fn().mockResolvedValue({ restartRequired: false }),
+        }}
+      >
+        <UpdateProvider>
+          <ManualAlphaCheckConsumer />
+        </UpdateProvider>
+      </SettingContext.Provider>
+    )
+
+    await user.click(screen.getByRole('button', { name: 'check alpha' }))
+
+    await waitFor(() => {
+      expect(checkForUpdateMock).toHaveBeenCalledWith('alpha')
     })
   })
 })

--- a/src/contexts/update-context.ts
+++ b/src/contexts/update-context.ts
@@ -1,11 +1,12 @@
 import { createContext } from 'react'
 import type { UpdateMetadata, DownloadProgress } from '@/api/updater'
+import type { UpdateChannel } from '@/types/setting'
 
 export interface UpdateContextType {
   updateInfo: UpdateMetadata | null
   isCheckingUpdate: boolean
   downloadProgress: DownloadProgress
-  checkForUpdates: () => Promise<UpdateMetadata | null>
+  checkForUpdates: (channelOverride?: UpdateChannel | null) => Promise<UpdateMetadata | null>
   installUpdate: () => Promise<void>
 }
 

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -420,7 +420,13 @@
           "stable": "Stable",
           "beta": "Beta",
           "alpha": "Alpha",
-          "rc": "Release Candidate"
+          "rc": "Release Candidate",
+          "alphaWarning": {
+            "title": "Switch to Alpha?",
+            "description": "Alpha builds may include features and regressions that have not been fully validated. UniClipboard will check the alpha channel immediately after switching.",
+            "cancel": "Cancel",
+            "confirm": "Switch"
+          }
         },
         "copyright": "© 2025 UniClipboard Team. All rights reserved.",
         "links": {

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -411,7 +411,13 @@
           "stable": "稳定版",
           "beta": "测试版",
           "alpha": "内测版",
-          "rc": "候选版"
+          "rc": "候选版",
+          "alphaWarning": {
+            "title": "切换到内测版？",
+            "description": "内测版可能包含未充分验证的功能和回归问题。切换后会立即检查内测版更新。",
+            "cancel": "取消",
+            "confirm": "继续切换"
+          }
         },
         "copyright": "© 2025 UniClipboard Team. All rights reserved.",
         "links": {


### PR DESCRIPTION
## Summary
- warn before switching the About page update channel to alpha
- run the immediate update check against the newly saved channel
- allow manual update checks to pass an explicit channel override
- add a dedicated Frontend Tests PR check that runs Vitest

## Tests
- bun run test -- --run
- npx vitest run src/components/setting/__tests__/AboutSection.test.tsx src/contexts/__tests__/UpdateContext.test.tsx
- npx tsc --noEmit
- npx prettier --check .github/workflows/pr-check.yml