### PR TITLE
ci: consolidate cache writes in warmup workflows

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -15,6 +15,11 @@ on:
           - 'windows-latest'
           - 'all'
         default: 'all'
+      save_cache:
+        description: '是否保存构建缓存(用于手动验证 cache warmup)'
+        required: false
+        type: boolean
+        default: false
   workflow_call:
     inputs:
       platform:
@@ -27,6 +32,11 @@ on:
         required: false
         type: string
         default: ''
+      save_cache:
+        description: '是否保存构建缓存'
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   setup-matrix:
@@ -97,7 +107,7 @@ jobs:
           workspaces: "src-tauri -> target"
           shared-key: cli-${{ matrix.target }}
           # 只在 main 写缓存,tag/PR 只读。详见 build.yml 同名 step 的注释。
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+          save-if: ${{ inputs.save_cache || github.ref == 'refs/heads/main' }}
 
       - name: build CLI binary
         working-directory: src-tauri

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,11 @@ on:
           - 'beta'
           - 'rc'
         default: 'stable'
+      save_cache:
+        description: '是否保存构建缓存(用于手动验证 cache warmup)'
+        required: false
+        type: boolean
+        default: false
   workflow_call:
     inputs:
       platform:
@@ -42,6 +47,11 @@ on:
         required: false
         type: string
         default: 'stable'
+      save_cache:
+        description: '是否保存构建缓存'
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   setup-matrix:
@@ -120,14 +130,15 @@ jobs:
           # Windows Post Cache Rust 上传单次 ~2m43s (25682907543),tag run
           # 通常基于刚合入 main 的代码,命中已存的 main cache 即可,不必再
           # 写一份等价的进 GHA cache (10GB 上限)。
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+          save-if: ${{ inputs.save_cache || github.ref == 'refs/heads/main' }}
 
-      - name: Cache Bun dependencies
+      - name: Restore Bun dependencies
+        id: bun-cache
         # Windows NTFS 上压缩 ~/.bun/install/cache 的小文件极慢:
         # 25682907543 run 实测 Post Cache 步骤 7m37s,而 bun install 本身只
         # 1m12s — 缓存反成负优化。Linux/macOS post-cache ~20-30s,保留。
         if: runner.os != 'Windows'
-        uses: actions/cache@v5
+        uses: actions/cache/restore@v5
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
@@ -136,6 +147,15 @@ jobs:
 
       - name: install frontend dependencies
         run: bun install
+
+      - name: Save Bun dependencies
+        # 只有 main 或显式 save_cache 的 warmup 写 Bun cache。tag release
+        # 默认只读取,避免在 10GB GHA cache 配额里挤掉主线预热结果。
+        if: runner.os != 'Windows' && (inputs.save_cache || github.ref == 'refs/heads/main') && steps.bun-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v5
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
 
       - name: resolve app version
         id: app-version

--- a/.github/workflows/cache-warmup.yml
+++ b/.github/workflows/cache-warmup.yml
@@ -8,8 +8,77 @@ on:
   workflow_dispatch:
 
 jobs:
-  warmup:
+  warmup-release-app:
+    name: Warm release app caches
     uses: ./.github/workflows/build.yml
     with:
       platform: 'all'
+      save_cache: true
     secrets: inherit
+
+  warmup-windows-cli:
+    # 先预热 Windows CLI:这是最近 release 没命中的关键路径。
+    # CLI 全平台 cache 会明显挤占 10GB 配额,如后续确实需要再按平台扩展。
+    name: Warm Windows CLI cache
+    uses: ./.github/workflows/build-cli.yml
+    with:
+      platform: 'windows-latest'
+      save_cache: true
+    secrets: inherit
+
+  warmup-pr-check-rust:
+    name: Warm PR check Rust cache
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "src-tauri -> target"
+          shared-key: pr-check
+          save-if: true
+
+      - name: Check Rust workspace
+        working-directory: src-tauri
+        run: cargo check --workspace --locked
+
+  warmup-coverage-rust:
+    name: Warm coverage Rust cache
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Setup Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1.15.2
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "src-tauri -> target"
+          shared-key: coverage
+          save-if: true
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf xvfb
+
+      - name: Generate coverage report
+        run: |
+          cd src-tauri
+          xvfb-run -a cargo llvm-cov --lcov --output-path lcov.info --workspace

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -26,6 +26,8 @@ jobs:
         with:
           workspaces: "src-tauri -> target"
           shared-key: coverage
+          # PR 只读 default branch cache,写入由 cache-warmup 统一负责。
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install system dependencies
         run: |

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -38,8 +38,11 @@ jobs:
         with:
           bun-version: latest
 
-      - name: Cache Bun dependencies
-        uses: actions/cache@v4
+      - name: Restore Bun dependencies
+        # PR 只读取 default branch 上由 cache-warmup 写入的 Bun cache。
+        # actions/cache 会在 miss 时自动保存,这里用 restore 子 action 避免
+        # 每个 refs/pull/*/merge 写出重复 cache 并挤掉 release 预热缓存。
+        uses: actions/cache/restore@v4
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
@@ -73,6 +76,8 @@ jobs:
         with:
           workspaces: "src-tauri -> target"
           shared-key: pr-check
+          # PR 只读 default branch cache,写入由 cache-warmup 统一负责。
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Check Rust workspace
         working-directory: src-tauri


### PR DESCRIPTION
## Summary

- Route PR and coverage jobs to read caches without creating pull-request-scoped cache entries.
- Add explicit save_cache inputs for build and CLI workflows.
- Expand cache-warmup to seed release app, Windows CLI, PR check, and coverage caches from the selected ref.

## Verification

- git diff --check
- Node YAML parse for modified workflows
- actionlint 1.7.12
- Cache Warmup workflow passed on branch ci/cache-warmup-write-scope: https://github.com/UniClipboard/UniClipboard/actions/runs/25773626277

## Notes

The branch warmup validates cache writes for this workflow definition. After merge, run Cache Warmup once on main so release/tag workflows can read default-branch-scoped caches.