### PR TITLE
fix(ui): restore saved window scale on startup

### DIFF
--- a/src/__tests__/main.window-ui.test.ts
+++ b/src/__tests__/main.window-ui.test.ts
@@ -1,0 +1,77 @@
+import type { ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => {
+  const render = vi.fn()
+  return {
+    applyPlatformEffectPreferences: vi.fn(),
+    applyPlatformTypographyScale: vi.fn(),
+    applyDeviceMetaToSentry: vi.fn(),
+    attachConsole: vi.fn(() => Promise.resolve()),
+    connectDaemonWs: vi.fn(() => Promise.resolve()),
+    createRoot: vi.fn(() => ({ render })),
+    getDeviceMeta: vi.fn(() => Promise.resolve({})),
+    initSentry: vi.fn(),
+    initializeWindowUi: vi.fn(),
+    registerDaemonShutdownListener: vi.fn(() => Promise.resolve()),
+    render,
+  }
+})
+
+vi.mock('react-dom/client', () => ({
+  default: { createRoot: mocks.createRoot },
+  createRoot: mocks.createRoot,
+}))
+
+vi.mock('@tauri-apps/plugin-log', () => ({
+  attachConsole: mocks.attachConsole,
+}))
+
+vi.mock('@/api/runtime', () => ({
+  getDeviceMeta: mocks.getDeviceMeta,
+}))
+
+vi.mock('@/lib/daemon-ws-bootstrap', () => ({
+  connectDaemonWs: mocks.connectDaemonWs,
+  registerDaemonShutdownListener: mocks.registerDaemonShutdownListener,
+}))
+
+vi.mock('@/lib/window-ui', () => ({
+  applyPlatformEffectPreferences: mocks.applyPlatformEffectPreferences,
+  applyPlatformTypographyScale: mocks.applyPlatformTypographyScale,
+  initializeWindowUi: mocks.initializeWindowUi,
+}))
+
+vi.mock('@/observability/sentry', () => ({
+  applyDeviceMetaToSentry: mocks.applyDeviceMetaToSentry,
+  initSentry: mocks.initSentry,
+  Sentry: {
+    ErrorBoundary: ({ children }: { children: ReactNode }) => children,
+  },
+}))
+
+vi.mock('@/store', () => ({
+  store: {},
+}))
+
+vi.mock('@/App', () => ({
+  default: () => null,
+}))
+
+describe('main window bootstrap', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    document.body.innerHTML = '<div id="root"></div>'
+  })
+
+  it('启动主窗口时应用已保存的窗口 UI 设置', async () => {
+    await import('@/main')
+
+    expect(mocks.initializeWindowUi).toHaveBeenCalledTimes(1)
+    expect(mocks.createRoot).toHaveBeenCalledWith(document.getElementById('root'))
+    expect(mocks.initializeWindowUi.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.createRoot.mock.invocationCallOrder[0]!
+    )
+  })
+})

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,7 +7,7 @@ import './i18n'
 import { store } from './store'
 import { getDeviceMeta } from '@/api/runtime'
 import { connectDaemonWs, registerDaemonShutdownListener } from '@/lib/daemon-ws-bootstrap'
-import { applyPlatformEffectPreferences, applyPlatformTypographyScale } from '@/lib/window-ui'
+import { initializeWindowUi } from '@/lib/window-ui'
 import { applyDeviceMetaToSentry, initSentry, Sentry } from '@/observability/sentry'
 
 // Sentry init runs before React mounts so that the global ErrorBoundary,
@@ -43,8 +43,7 @@ if (typeof window !== 'undefined') {
   })
 }
 
-applyPlatformTypographyScale()
-applyPlatformEffectPreferences()
+initializeWindowUi()
 
 // 初始化日志系统：将后端日志输出到浏览器 DevTools
 const initLogging = async () => {


### PR DESCRIPTION
## Summary
- Use the shared window UI bootstrap in the main webview so persisted UI scale is restored on startup.
- Add a regression test that locks startup UI initialization before React mounts.

## Testing
- `bunx vitest run src/__tests__/main.window-ui.test.ts src/lib/__tests__/ui-scale.test.ts src/components/__tests__/GlobalShortcuts.zoom.test.tsx`
- `bun run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined window UI initialization by consolidating related setup operations into a unified initialization process.

* **Tests**
  * Added comprehensive test suite to verify window UI initialization and proper sequence of operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/UniClipboard/UniClipboard/pull/669)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->