### PR TITLE
fix(ui): flatten Linux main layout

### DIFF
--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -1,33 +1,54 @@
 import React, { ReactNode } from 'react'
 import { Sidebar } from '@/components'
 import InsetSurface from '@/components/layout/InsetSurface'
+import { usePlatform } from '@/hooks/usePlatform'
 
 interface MainLayoutProps {
   children: ReactNode
 }
 
 /**
- * Main content layout with sidebar navigation
+ * Linux 系统标题栏布局。
  *
- * Structure (within WindowShell):
- * - Sidebar: Fixed-width navigation (w-16)
- * - Main: Flexible content area (flex-1)
- *
- * Note: This is a content-level layout, not window-level.
- * Window chrome (TitleBar) is handled by WindowShell parent.
+ * Linux/Tauri 当前使用系统窗口标题栏，主内容区不再模拟 macOS/Windows 的内嵌圆角面板。
  */
-const MainLayout: React.FC<MainLayoutProps> = ({ children }) => {
+const LinuxMainLayout: React.FC<MainLayoutProps> = ({ children }) => {
   return (
     <>
-      {/* Sidebar Navigation */}
+      <Sidebar className="border-r border-border/40 bg-background/80 dark:bg-background/60" />
+
+      <main className="relative flex min-h-0 flex-1 flex-col overflow-hidden bg-card text-card-foreground">
+        {children}
+      </main>
+    </>
+  )
+}
+
+/**
+ * 自定义标题栏布局。
+ *
+ * macOS/Windows 继续使用内嵌内容面板，和自绘窗口标题栏保持一致。
+ */
+const InsetMainLayout: React.FC<MainLayoutProps> = ({ children }) => {
+  return (
+    <>
       <Sidebar />
 
-      {/* Main Content Area */}
       <main className="relative flex min-h-0 flex-1 flex-col overflow-hidden pb-2 pr-2">
         <InsetSurface className="flex-1 w-full h-full">{children}</InsetSurface>
       </main>
     </>
   )
+}
+
+const MainLayout: React.FC<MainLayoutProps> = ({ children }) => {
+  const { isLinux, isTauri } = usePlatform()
+
+  if (isLinux && isTauri) {
+    return <LinuxMainLayout>{children}</LinuxMainLayout>
+  }
+
+  return <InsetMainLayout>{children}</InsetMainLayout>
 }
 
 export default MainLayout

--- a/src/layouts/__tests__/MainLayout.test.tsx
+++ b/src/layouts/__tests__/MainLayout.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import MainLayout from '../MainLayout'
+
+const platformState = vi.hoisted(() => ({
+  current: {
+    isWindows: false,
+    isMac: false,
+    isLinux: false,
+    isTauri: false,
+    reduceVisualEffects: false,
+  },
+}))
+
+vi.mock('@/hooks/usePlatform', () => ({
+  usePlatform: () => platformState.current,
+}))
+
+vi.mock('@/components', () => ({
+  Sidebar: ({ className }: { className?: string }) => (
+    <aside data-testid="sidebar" className={className} />
+  ),
+}))
+
+const renderLayout = () =>
+  render(
+    <MainLayout>
+      <div data-testid="content" />
+    </MainLayout>
+  )
+
+describe('MainLayout', () => {
+  it('Linux Tauri 使用无圆角主内容布局', () => {
+    platformState.current = {
+      isWindows: false,
+      isMac: false,
+      isLinux: true,
+      isTauri: true,
+      reduceVisualEffects: true,
+    }
+
+    const { container } = renderLayout()
+    const main = container.querySelector('main')
+
+    expect(main).toHaveClass('bg-card')
+    expect(main).not.toHaveClass('pb-2')
+    expect(main).not.toHaveClass('pr-2')
+    expect(container.innerHTML).not.toContain('rounded-[1.25rem]')
+    expect(screen.getByTestId('sidebar')).toHaveClass('border-r')
+  })
+
+  it('非 Linux Tauri 保持内嵌圆角布局', () => {
+    platformState.current = {
+      isWindows: true,
+      isMac: false,
+      isLinux: false,
+      isTauri: true,
+      reduceVisualEffects: false,
+    }
+
+    const { container } = renderLayout()
+    const main = container.querySelector('main')
+
+    expect(main).toHaveClass('pb-2')
+    expect(main).toHaveClass('pr-2')
+    expect(container.innerHTML).toContain('rounded-[1.25rem]')
+    expect(screen.getByTestId('sidebar').className).not.toContain('border-r')
+  })
+})


### PR DESCRIPTION
## Summary
- Add a Linux/Tauri-specific main layout without the inset rounded content surface.
- Keep the existing inset surface behavior for macOS and Windows.
- Add layout tests for Linux/Tauri and non-Linux/Tauri branches.

## Tests
- bun run test -- src/layouts/__tests__/MainLayout.test.tsx --run
- npx eslint src/layouts/MainLayout.tsx src/layouts/__tests__/MainLayout.test.tsx
- bun run build

Note: full `bun run lint` still fails on pre-existing docs-site/scripts lint issues outside this change.