### PR TITLE
feat(telemetry): split sync_deferred from sync_failed; add failure_stage

### DIFF
--- a/docs/architecture/telemetry-events.md
+++ b/docs/architecture/telemetry-events.md
@@ -15,7 +15,7 @@
 判断有据可依。本草案聚焦 issue #549 的"第一版必须埋点"中 **最关键的两段**：
 
 - **Activation 漏斗**：`app_first_open` → `pairing_succeeded` → `first_clipboard_sync_succeeded`
-- **Reliability**：`sync_attempted` / `sync_succeeded` / `sync_failed`
+- **Reliability**：`sync_attempted` / `sync_succeeded` / `sync_failed` / `sync_deferred`
 
 Acquisition、Retention、Engagement、Friction 沿用同一 schema 与命名规则，但
 事件清单延后到 v1 实施过程中按需补齐，不在本文件穷举。
@@ -290,7 +290,13 @@ pub enum LatencyBucket {
 
 ### 7.2 Reliability
 
-`sync_attempted` / `sync_succeeded` / `sync_failed` 三件套，properties：
+可靠性事件家族：`sync_attempted` / `sync_succeeded` / `sync_failed` / `sync_deferred`。
+
+`sync_attempted` 在 dispatch 之前固定发一次（每个 peer 一条），并与
+`sync_succeeded` / `sync_failed` / `sync_deferred` 形成 1:1 配对。前三者共享
+`SyncEventProps`；`sync_deferred` 使用 `SyncDeferredProps`（见下文）。
+
+`SyncEventProps`：
 
 ```rust
 pub struct SyncEventProps {
@@ -301,8 +307,42 @@ pub struct SyncEventProps {
     pub peer_os: Option<Os>,            // 已知则填，不要因为缺失就丢事件
     pub sync_latency_ms: Option<u32>,   // 仅成功事件携带
     pub failure_reason: Option<FailureReason>,  // 仅失败事件携带
+    pub failure_stage: Option<SyncFailureStage>, // 仅失败事件携带
 }
 ```
+
+`sync_failed` 表示一次同步相关尝试失败，不等同于用户感知的最终失败。
+dashboard 计算"最终同步失败率"时不应直接统计所有 `sync_failed`；应只统计
+`failure_stage = terminal_delivery`，或统计明确的终态策略失败（例如
+`failure_stage = local_policy`）。
+
+另外有一个非失败事件：
+
+```rust
+pub struct SyncDeferredProps {
+    pub direction: Direction,
+    pub payload_type: PayloadType,
+    pub payload_size_bucket: PayloadSizeBucket,
+    pub peer_os: Option<Os>,
+    pub defer_reason: SyncDeferReason,
+}
+```
+
+`sync_deferred` 表示发送前就已知目标不可用，本次不可达不计入用户感知失败口径。
+当前用于"目标设备已知离线，仍尝试发送但连接不上"的情况。
+
+`sync_deferred` 与 `sync_attempted` 始终成对出现（attempted 在 dispatch 之前
+固定发送一次）。dashboard 端聚合关系：
+
+- `attempted = succeeded + failed + deferred`
+- 用户感知尝试 = `attempted - deferred`
+- 用户感知失败率分子使用 `failure_stage = terminal_delivery`，分母使用
+  `attempted - deferred`
+
+不带 `transport_type`：deferred 时本次没有真实发送，记录任何 transport 都是
+误导性数据。如果未来要标注"原计划的"transport，请单独命名字段以避免与
+`sync_attempted` / `sync_succeeded` / `sync_failed` 上"实际使用的"transport
+混淆。
 
 ### 7.3 FailureReason 枚举（sync_failed 专用）
 
@@ -318,6 +358,46 @@ pub enum FailureReason {
     Unknown,            // 兜底，但占比应被监控并定期拆细
 }
 ```
+
+### 7.3a SyncFailureStage 枚举（sync_failed 专用）
+
+```rust
+pub enum SyncFailureStage {
+    ImmediateSend,      // 即时发送尝试失败，通常可进入 pending / retry
+    LocalPolicy,        // 本机策略在发送前拒绝，如 payload 过大
+    TerminalDelivery,   // pending / retry 耗尽后的终态投递失败
+}
+```
+
+### 7.3b SyncDeferReason 枚举（sync_deferred 专用）
+
+```rust
+pub enum SyncDeferReason {
+    PeerKnownOffline,   // 发送前 presence 已知对端离线
+}
+```
+
+**这是一个开放枚举**：`PeerKnownOffline` 是当前唯一变体，但 deferred 概念覆盖
+所有"预期不可用 / 本次不应计入失败口径"的场景。未来可能加入的扩展点，例如：
+
+- 对端不在白名单 / send 已被禁用 → 当前在 dispatch 前就被过滤，不会进入 spawn
+- 本地策略主动跳过（低电量、不计费网络、暂停同步）
+- 网络节流 / 配额耗尽
+
+新增 reason 前先确认：该原因是否真"不应计入用户感知失败率"。如果只是"用户感知
+失败的另一种解释"，应进 `FailureReason` + 合适的 `SyncFailureStage`，而不是
+deferred。
+
+当前 outbound dispatch 路径的采样规则（每行还隐含一个伴随的 `sync_attempted`，
+在 dispatch 之前发出，下表只列出 dispatch 完成后的结果事件）：
+
+| 事件 | 条件 | 关键字段 | 解释 |
+|---|---|---|---|
+| `sync_deferred` | 发送前 `PresencePort::current_state == Offline`，且 dispatch 仍返回 `Offline` | `defer_reason = peer_known_offline` | 对端本来就已知离线，连接不上是预期不可用，不计入尝试失败 |
+| `sync_failed` | 发送前不是已知离线，但 dispatch 返回 `Offline` | `failure_reason = peer_offline`, `failure_stage = immediate_send` | 发送前没有明确离线 verdict，仍不可达；用于网络/恢复诊断，不计入最终失败率 |
+| `sync_failed` | dispatch 返回 `Io` / peer wire 边界拒绝 | `failure_reason = network_error`, `failure_stage = immediate_send` | 已进入发送路径但连接 / I/O / wire 边界失败，等待恢复或重试口径处理 |
+| `sync_failed` | 本机策略拒绝 | `failure_reason = file_too_large`, `failure_stage = local_policy` | 本机策略确定该 payload 不能按当前通道发送 |
+| `sync_failed` | 本机内部错误 | `failure_reason = unknown`, `failure_stage = immediate_send` | 需要排查的内部错误口径 |
 
 `Unknown` 占比是 **架构债务指标**：高于 5% 时就要专门排查并新增枚举值。
 

--- a/src-tauri/crates/uc-application/src/facade/clipboard/facade.rs
+++ b/src-tauri/crates/uc-application/src/facade/clipboard/facade.rs
@@ -154,6 +154,7 @@ impl ClipboardSyncFacade {
         let dispatch_uc = Arc::new(DispatchClipboardEntryUseCase::new(
             Arc::clone(&deps.peer_addr_repo),
             Arc::clone(&deps.member_repo),
+            Arc::clone(&deps.presence),
             Arc::clone(&deps.transfer_cipher),
             Arc::clone(&deps.clipboard_dispatch),
             Arc::clone(&deps.device_identity),
@@ -575,6 +576,13 @@ mod tests {
         m
     }
 
+    fn make_presence_unknown() -> MockPresence {
+        let mut m = MockPresence::new();
+        m.expect_current_state()
+            .returning(|_| ReachabilityState::Unknown);
+        m
+    }
+
     /// Wire the facade with the given mock ports + a `FakeReceiver`. The
     /// FakeReceiver is returned alongside so the caller can `publish(...)`
     /// during the test. `member_repo` defaults to "all peers allowed"
@@ -611,8 +619,8 @@ mod tests {
     /// Verdict 1 — `dispatch_entry` delegates to the inner use case and
     /// returns the public-shape outcome. mockall asserts: peer_addr_repo
     /// listed once, encrypt called once, dispatch called once for peer-a.
-    /// Presence is intentionally NOT consulted (see dispatch_entry.rs
-    /// module doc on iteration source).
+    /// Presence is read only for telemetry classification; it must not filter
+    /// dispatch candidates (see dispatch_entry.rs module doc on iteration source).
     #[tokio::test]
     async fn dispatch_entry_returns_public_outcome_for_online_peer() {
         let mut repo = MockPeerAddrRepo::new();
@@ -620,7 +628,7 @@ mod tests {
             .times(1)
             .returning(|| Ok(vec![record("peer-a")]));
 
-        let presence = MockPresence::new();
+        let presence = make_presence_unknown();
 
         let mut cipher = MockCipher::new();
         cipher
@@ -666,7 +674,7 @@ mod tests {
         // Dispatch path is unused in this test; register no expectations.
         // peer_addr_repo / presence likewise unused.
         let repo = MockPeerAddrRepo::new();
-        let presence = MockPresence::new();
+        let presence = make_presence_unknown();
         let dispatch = MockDispatch::new();
 
         let mut cipher = MockCipher::new();
@@ -729,7 +737,7 @@ mod tests {
             .times(1)
             .returning(|| Ok(vec![record("peer-a")]));
 
-        let presence = MockPresence::new();
+        let presence = make_presence_unknown();
 
         let mut cipher = MockCipher::new();
         // Encrypt gets the V3 envelope bytes, not the raw text. We just
@@ -793,7 +801,7 @@ mod tests {
     #[tokio::test]
     async fn spawn_ingest_handle_drops_clean() {
         let repo = MockPeerAddrRepo::new();
-        let presence = MockPresence::new();
+        let presence = make_presence_unknown();
         let dispatch = MockDispatch::new();
         // Zero decrypt expectations — no inbound is published, so decrypt
         // must never be called even by a leaked task.

--- a/src-tauri/crates/uc-application/src/usecases/clipboard_sync/dispatch_entry.rs
+++ b/src-tauri/crates/uc-application/src/usecases/clipboard_sync/dispatch_entry.rs
@@ -54,13 +54,13 @@ use uc_core::ids::DeviceId;
 use uc_core::ports::security::TransferCipherPort;
 use uc_core::ports::{
     ClipboardDispatchError, ClipboardDispatchPort, ClipboardHeader, ClockPort, DeviceIdentityPort,
-    DispatchAck, FirstSyncStatePort, LocalIdentityPort, PeerAddressRepositoryPort, SettingsPort,
-    SyncPayload,
+    DispatchAck, FirstSyncStatePort, LocalIdentityPort, PeerAddressRepositoryPort, PresencePort,
+    ReachabilityState, SettingsPort, SyncPayload,
 };
 use uc_core::MemberRepositoryPort;
 use uc_observability::analytics::{
-    AnalyticsPort, Direction, Event, FailureReason, PayloadSizeBucket, PayloadType, SyncEventProps,
-    TransportType,
+    AnalyticsPort, Direction, Event, FailureReason, PayloadSizeBucket, PayloadType,
+    SyncDeferReason, SyncDeferredProps, SyncEventProps, SyncFailureStage, TransportType,
 };
 
 /// Slice 8c-1 · classify the dispatched payload by category priority
@@ -96,6 +96,52 @@ fn map_dispatch_error_to_failure_reason(err: &ClipboardDispatchError) -> Failure
         ClipboardDispatchError::PeerRejected(_) => FailureReason::NetworkError,
         ClipboardDispatchError::Io(_) => FailureReason::NetworkError,
         ClipboardDispatchError::Internal(_) => FailureReason::Unknown,
+    }
+}
+
+/// 将即时 dispatch 错误映射为产品分析口径。
+///
+/// `sync_failed` 在当前路径代表"一次即时发送尝试失败"，不是"最终投递失败"。
+/// 对端不可达和网络类错误应留给 pending/retry 或恢复流程继续处理；本地策略拒绝
+/// 才是当前 payload 的终态失败。
+fn dispatch_failure_stage(err: &ClipboardDispatchError) -> SyncFailureStage {
+    match err {
+        ClipboardDispatchError::LocalPolicyExceeded(_) => SyncFailureStage::LocalPolicy,
+        ClipboardDispatchError::Internal(_) => SyncFailureStage::ImmediateSend,
+        ClipboardDispatchError::Offline
+        | ClipboardDispatchError::PeerRejected(_)
+        | ClipboardDispatchError::Io(_) => SyncFailureStage::ImmediateSend,
+    }
+}
+
+async fn capture_sync_attempted(
+    analytics: &Arc<dyn AnalyticsPort>,
+    first_sync_state: &Arc<dyn FirstSyncStatePort>,
+    payload_type: PayloadType,
+    payload_size_bucket: PayloadSizeBucket,
+) {
+    analytics.capture(Event::SyncAttempted(SyncEventProps {
+        direction: Direction::Outbound,
+        payload_type,
+        payload_size_bucket,
+        transport_type: TransportType::P2pDirect,
+        peer_os: None,
+        sync_latency_ms: None,
+        failure_reason: None,
+        failure_stage: None,
+    }));
+    // Slice 8c-2 · funnel: first attempt fires regardless of outcome — keeps
+    // the "started but failed" 漏点信号。deferred 路径也会调用本函数，确保
+    // attempted 时序一致；dashboard 端用 `attempted - deferred` 推导用户感知尝试。
+    match first_sync_state.mark_first_sync_attempted().await {
+        Ok(true) => analytics.capture(Event::FirstClipboardSyncAttempted {
+            direction: Direction::Outbound,
+        }),
+        Ok(false) => {}
+        Err(err) => warn!(
+            error = %err,
+            "first_sync_state.mark_first_sync_attempted failed; skipping fire",
+        ),
     }
 }
 
@@ -160,6 +206,7 @@ pub(crate) enum DispatchSyncError {
 pub(crate) struct DispatchClipboardEntryUseCase {
     peer_addr_repo: Arc<dyn PeerAddressRepositoryPort>,
     member_repo: Arc<dyn MemberRepositoryPort>,
+    presence: Arc<dyn PresencePort>,
     transfer_cipher: Arc<dyn TransferCipherPort>,
     clipboard_dispatch: Arc<dyn ClipboardDispatchPort>,
     device_identity: Arc<dyn DeviceIdentityPort>,
@@ -183,6 +230,7 @@ impl DispatchClipboardEntryUseCase {
     pub(crate) fn new(
         peer_addr_repo: Arc<dyn PeerAddressRepositoryPort>,
         member_repo: Arc<dyn MemberRepositoryPort>,
+        presence: Arc<dyn PresencePort>,
         transfer_cipher: Arc<dyn TransferCipherPort>,
         clipboard_dispatch: Arc<dyn ClipboardDispatchPort>,
         device_identity: Arc<dyn DeviceIdentityPort>,
@@ -195,6 +243,7 @@ impl DispatchClipboardEntryUseCase {
         Self {
             peer_addr_repo,
             member_repo,
+            presence,
             transfer_cipher,
             clipboard_dispatch,
             device_identity,
@@ -308,18 +357,19 @@ impl DispatchClipboardEntryUseCase {
         // child 上也写一份是冗余 —— 但 root span 不一定总在同一个 trace，
         // 在 worker 任务里显式 carry 更稳。
         //
-        // Slice 8c-1 · each spawned task fires its own per-peer
-        // `sync_attempted` (before the wire call) and either
-        // `sync_succeeded` (with `sync_latency_ms`) or `sync_failed`
-        // (with `failure_reason`) inside the same async block — keeps
-        // analytics atomically paired with the dispatch outcome and
-        // avoids a second match arm in the merge loop.
+        // Slice 8c-1 · each spawned task fires per-peer telemetry. `sync_attempted`
+        // 始终在 dispatch 前发一次，保证时序一致；`sync_succeeded` / `sync_failed`
+        // / `sync_deferred` 与 attempted 形成 1:1 配对。known-offline peer 仍尝试
+        // 发送（presence 可能 stale）；若 dispatch 仍判为 Offline，结果事件用
+        // `sync_deferred` 而不是 `sync_failed`，因为那是预期不可用，不该计入
+        // 用户感知失败口径（dashboard 以 `attempted - deferred` 推导用户感知尝试）。
         let payload_type = payload_type_from_categories(&input.categories);
         let payload_size_bucket = PayloadSizeBucket::from_bytes(input.plaintext.len() as u64);
         let mut set: JoinSet<(DeviceId, Result<DispatchAck, ClipboardDispatchError>)> =
             JoinSet::new();
         for device_id in &candidates {
             let dispatch = Arc::clone(&self.clipboard_dispatch);
+            let presence = Arc::clone(&self.presence);
             let analytics = Arc::clone(&self.analytics);
             let first_sync_state = Arc::clone(&self.first_sync_state);
             let header = header.clone();
@@ -335,29 +385,19 @@ impl DispatchClipboardEntryUseCase {
             );
             set.spawn(
                 async move {
-                    analytics.capture(Event::SyncAttempted(SyncEventProps {
-                        direction: Direction::Outbound,
+                    // attempted 始终在 dispatch 前发，时序与口径保持单一：
+                    //   attempted = succeeded + failed + deferred
+                    //   用户感知尝试 = attempted - deferred
+                    // 详见 docs/architecture/telemetry-events.md §7.3b。
+                    let preflight_state = presence.current_state(&device_id).await;
+                    let known_offline = matches!(preflight_state, ReachabilityState::Offline);
+                    capture_sync_attempted(
+                        &analytics,
+                        &first_sync_state,
                         payload_type,
                         payload_size_bucket,
-                        transport_type: TransportType::P2pDirect,
-                        peer_os: None,
-                        sync_latency_ms: None,
-                        failure_reason: None,
-                    }));
-                    // Slice 8c-2 · funnel: first attempt fires regardless of
-                    // outcome — keeps the "started but failed"漏点信号. Race
-                    // 防护由 port impl 的 Mutex 守住，N 个 spawn 中只有一个
-                    // 返回 Ok(true)。
-                    match first_sync_state.mark_first_sync_attempted().await {
-                        Ok(true) => analytics.capture(Event::FirstClipboardSyncAttempted {
-                            direction: Direction::Outbound,
-                        }),
-                        Ok(false) => {}
-                        Err(err) => warn!(
-                            error = %err,
-                            "first_sync_state.mark_first_sync_attempted failed; skipping fire",
-                        ),
-                    }
+                    )
+                    .await;
 
                     let started_at = Instant::now();
                     let result = dispatch.dispatch(&device_id, &header, payload).await;
@@ -372,7 +412,17 @@ impl DispatchClipboardEntryUseCase {
                             peer_os: None,
                             sync_latency_ms: Some(duration_ms),
                             failure_reason: None,
+                            failure_stage: None,
                         }),
+                        Err(ClipboardDispatchError::Offline) if known_offline => {
+                            Event::SyncDeferred(SyncDeferredProps {
+                                direction: Direction::Outbound,
+                                payload_type,
+                                payload_size_bucket,
+                                peer_os: None,
+                                defer_reason: SyncDeferReason::PeerKnownOffline,
+                            })
+                        }
                         Err(err) => Event::SyncFailed(SyncEventProps {
                             direction: Direction::Outbound,
                             payload_type,
@@ -381,6 +431,7 @@ impl DispatchClipboardEntryUseCase {
                             peer_os: None,
                             sync_latency_ms: None,
                             failure_reason: Some(map_dispatch_error_to_failure_reason(err)),
+                            failure_stage: Some(dispatch_failure_stage(err)),
                         }),
                     };
                     let is_ok = result.is_ok();
@@ -581,12 +632,10 @@ impl DispatchClipboardEntryUseCase {
 //       `Mutex<FnMut>` would serialise concurrent `.returning()` closures
 //       (Phase 1 T6's `SleepyPresence`).
 //
-// For this file: the dispatch use case calls 2 async ports + 4 read-only
-// ports; no broadcast emit, no wall-time concurrency assertion. All six
-// ports are mocked with `mockall::mock!`. `PresencePort` was dropped
-// from this use case's deps once we stopped pre-filtering by online
-// state (see module doc); peers are enumerated from `peer_addr_repo`
-// only, and per-target offline verdicts come from the dispatch port.
+// For this file: the dispatch use case calls 2 async ports + read-only
+// ports; no broadcast emit, no wall-time concurrency assertion. Most ports
+// are mocked with `mockall::mock!`. `PresencePort::current_state` is read
+// only for telemetry classification and never filters dispatch candidates.
 
 #[cfg(test)]
 mod tests {
@@ -595,11 +644,13 @@ mod tests {
     use async_trait::async_trait;
     use chrono::Utc;
     use mockall::predicate::*;
+    use tokio::sync::broadcast;
 
     use uc_core::ports::security::{TransferCipherError, TransferCipherPort};
     use uc_core::ports::{
         ClockPort, DeviceIdentityPort, FirstSyncStateError, LocalIdentityError, LocalIdentityPort,
-        PeerAddressError, PeerAddressRecord, PeerAddressRepositoryPort, SettingsPort,
+        PeerAddressError, PeerAddressRecord, PeerAddressRepositoryPort, PresenceError,
+        PresenceEvent, PresencePort, ReachabilityState, SettingsPort,
     };
     use uc_core::security::IdentityFingerprint;
     use uc_core::settings::model::Settings;
@@ -721,6 +772,26 @@ mod tests {
         }
     }
 
+    struct StaticPresence(ReachabilityState);
+    #[async_trait]
+    impl PresencePort for StaticPresence {
+        async fn ensure_reachable(
+            &self,
+            _device: &DeviceId,
+        ) -> Result<ReachabilityState, PresenceError> {
+            Ok(self.0)
+        }
+
+        async fn current_state(&self, _device: &DeviceId) -> ReachabilityState {
+            self.0
+        }
+
+        fn subscribe(&self) -> broadcast::Receiver<PresenceEvent> {
+            let (_tx, rx) = broadcast::channel(1);
+            rx
+        }
+    }
+
     // ── helpers ─────────────────────────────────────────────────────────
 
     fn fp(seed: u8) -> IdentityFingerprint {
@@ -817,9 +888,37 @@ mod tests {
         analytics: Arc<dyn AnalyticsPort>,
         first_sync_state: Arc<dyn FirstSyncStatePort>,
     ) -> DispatchClipboardEntryUseCase {
+        build_uc_with_presence_and_first_sync_state(
+            peer_addr_repo,
+            member_repo,
+            Arc::new(StaticPresence(ReachabilityState::Unknown)),
+            cipher,
+            dispatch,
+            device_identity,
+            local_identity,
+            settings,
+            analytics,
+            first_sync_state,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn build_uc_with_presence_and_first_sync_state(
+        peer_addr_repo: MockPeerAddrRepo,
+        member_repo: MockMemberRepo,
+        presence: Arc<dyn PresencePort>,
+        cipher: MockCipher,
+        dispatch: MockDispatch,
+        device_identity: MockDeviceId_,
+        local_identity: MockLocalIdentity,
+        settings: MockSettings_,
+        analytics: Arc<dyn AnalyticsPort>,
+        first_sync_state: Arc<dyn FirstSyncStatePort>,
+    ) -> DispatchClipboardEntryUseCase {
         DispatchClipboardEntryUseCase::new(
             Arc::new(peer_addr_repo),
             Arc::new(member_repo),
+            presence,
             Arc::new(cipher),
             Arc::new(dispatch),
             Arc::new(device_identity),
@@ -1540,6 +1639,7 @@ mod tests {
         assert_eq!(sample.transport_type, TransportType::P2pDirect);
         assert!(sample.sync_latency_ms.is_some());
         assert!(sample.failure_reason.is_none());
+        assert!(sample.failure_stage.is_none());
     }
 
     #[tokio::test]
@@ -1582,6 +1682,174 @@ mod tests {
         match &events[1] {
             Event::SyncFailed(p) => {
                 assert_eq!(p.failure_reason, Some(FailureReason::PeerOffline));
+                assert_eq!(p.failure_stage, Some(SyncFailureStage::ImmediateSend));
+                assert!(p.sync_latency_ms.is_none());
+            }
+            other => panic!("expected SyncFailed, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn analytics_defers_instead_of_failing_when_peer_was_already_offline() {
+        let mut repo = MockPeerAddrRepo::new();
+        repo.expect_list()
+            .times(1)
+            .returning(|| Ok(vec![record("peer-off")]));
+
+        let mut cipher = MockCipher::new();
+        cipher
+            .expect_encrypt()
+            .times(1)
+            .returning(|p| Ok(p.to_vec()));
+
+        let mut dispatch = MockDispatch::new();
+        dispatch
+            .expect_dispatch()
+            .with(eq(DeviceId::new("peer-off")), always(), always())
+            .times(1)
+            .returning(|_, _, _| Err(ClipboardDispatchError::Offline));
+
+        let analytics = Arc::new(CapturingAnalyticsSink::default());
+        let uc = build_uc_with_presence_and_first_sync_state(
+            repo,
+            make_member_repo_all_enabled(),
+            Arc::new(StaticPresence(ReachabilityState::Offline)),
+            cipher,
+            dispatch,
+            make_device_identity("self-device"),
+            make_local_identity_stub(),
+            make_settings_stub(),
+            analytics.clone(),
+            Arc::new(AllMarkedFirstSyncState),
+        );
+
+        uc.execute(input()).await.expect("dispatch ok");
+
+        // attempted 始终前置，deferred 与 attempted 形成配对。
+        // dashboard 端用 `attempted - deferred` 推导用户感知尝试，
+        // 用户感知失败率不再把 known-offline 的不可达计入。
+        let events = analytics.events();
+        assert_eq!(events.len(), 2, "got {events:?}");
+        assert!(
+            matches!(&events[0], Event::SyncAttempted(_)),
+            "first event should be SyncAttempted, got {:?}",
+            events[0],
+        );
+        match &events[1] {
+            Event::SyncDeferred(p) => {
+                assert_eq!(p.defer_reason, SyncDeferReason::PeerKnownOffline);
+                assert_eq!(p.direction, Direction::Outbound);
+            }
+            other => panic!("expected SyncDeferred, got {other:?}"),
+        }
+    }
+
+    /// Presence 可能 stale：声明 Offline 但 dispatch 实际成功。此时不走 deferred
+    /// 分支（deferred guard 只覆盖 dispatch 返回 Offline 的情况），仍应得到
+    /// `SyncAttempted` + `SyncSucceeded`，时序与 not-known-offline 路径一致。
+    #[tokio::test]
+    async fn attempted_then_succeeded_even_when_peer_was_known_offline() {
+        let mut repo = MockPeerAddrRepo::new();
+        repo.expect_list()
+            .times(1)
+            .returning(|| Ok(vec![record("peer-stale")]));
+
+        let mut cipher = MockCipher::new();
+        cipher
+            .expect_encrypt()
+            .times(1)
+            .returning(|p| Ok(p.to_vec()));
+
+        let mut dispatch = MockDispatch::new();
+        dispatch
+            .expect_dispatch()
+            .with(eq(DeviceId::new("peer-stale")), always(), always())
+            .times(1)
+            .returning(|_, _, _| Ok(DispatchAck::Accepted));
+
+        let analytics = Arc::new(CapturingAnalyticsSink::default());
+        let uc = build_uc_with_presence_and_first_sync_state(
+            repo,
+            make_member_repo_all_enabled(),
+            Arc::new(StaticPresence(ReachabilityState::Offline)),
+            cipher,
+            dispatch,
+            make_device_identity("self-device"),
+            make_local_identity_stub(),
+            make_settings_stub(),
+            analytics.clone(),
+            Arc::new(AllMarkedFirstSyncState),
+        );
+
+        uc.execute(input()).await.expect("dispatch ok");
+
+        let events = analytics.events();
+        assert_eq!(events.len(), 2, "got {events:?}");
+        assert!(
+            matches!(&events[0], Event::SyncAttempted(_)),
+            "first event should be SyncAttempted, got {:?}",
+            events[0],
+        );
+        match &events[1] {
+            Event::SyncSucceeded(p) => {
+                assert!(p.sync_latency_ms.is_some());
+                assert!(p.failure_reason.is_none());
+                assert!(p.failure_stage.is_none());
+            }
+            other => panic!("expected SyncSucceeded, got {other:?}"),
+        }
+    }
+
+    /// known_offline guard 只保护 `dispatch == Offline` 的不可达。如果对端
+    /// 已知离线但 dispatch 报告其他错误（peer 拒收 / IO / 内部错误），仍属
+    /// 真失败：发 `sync_attempted` + `sync_failed`，`stage = ImmediateSend`。
+    #[tokio::test]
+    async fn attempted_then_failed_when_known_offline_peer_returns_non_offline_error() {
+        let mut repo = MockPeerAddrRepo::new();
+        repo.expect_list()
+            .times(1)
+            .returning(|| Ok(vec![record("peer-broken")]));
+
+        let mut cipher = MockCipher::new();
+        cipher
+            .expect_encrypt()
+            .times(1)
+            .returning(|p| Ok(p.to_vec()));
+
+        let mut dispatch = MockDispatch::new();
+        dispatch
+            .expect_dispatch()
+            .with(eq(DeviceId::new("peer-broken")), always(), always())
+            .times(1)
+            .returning(|_, _, _| Err(ClipboardDispatchError::Io("broken pipe".into())));
+
+        let analytics = Arc::new(CapturingAnalyticsSink::default());
+        let uc = build_uc_with_presence_and_first_sync_state(
+            repo,
+            make_member_repo_all_enabled(),
+            Arc::new(StaticPresence(ReachabilityState::Offline)),
+            cipher,
+            dispatch,
+            make_device_identity("self-device"),
+            make_local_identity_stub(),
+            make_settings_stub(),
+            analytics.clone(),
+            Arc::new(AllMarkedFirstSyncState),
+        );
+
+        uc.execute(input()).await.expect("dispatch ok");
+
+        let events = analytics.events();
+        assert_eq!(events.len(), 2, "got {events:?}");
+        assert!(
+            matches!(&events[0], Event::SyncAttempted(_)),
+            "first event should be SyncAttempted, got {:?}",
+            events[0],
+        );
+        match &events[1] {
+            Event::SyncFailed(p) => {
+                assert_eq!(p.failure_reason, Some(FailureReason::NetworkError));
+                assert_eq!(p.failure_stage, Some(SyncFailureStage::ImmediateSend));
                 assert!(p.sync_latency_ms.is_none());
             }
             other => panic!("expected SyncFailed, got {other:?}"),
@@ -1726,6 +1994,34 @@ mod tests {
             ),
         ] {
             assert_eq!(map_dispatch_error_to_failure_reason(&err), expected);
+        }
+    }
+
+    #[test]
+    fn dispatch_failure_stage_classifies_failure_phase() {
+        for (err, expected) in [
+            (
+                ClipboardDispatchError::Offline,
+                SyncFailureStage::ImmediateSend,
+            ),
+            (
+                ClipboardDispatchError::Io("broken pipe".into()),
+                SyncFailureStage::ImmediateSend,
+            ),
+            (
+                ClipboardDispatchError::PeerRejected("bad header".into()),
+                SyncFailureStage::ImmediateSend,
+            ),
+            (
+                ClipboardDispatchError::LocalPolicyExceeded("too big".into()),
+                SyncFailureStage::LocalPolicy,
+            ),
+            (
+                ClipboardDispatchError::Internal("boom".into()),
+                SyncFailureStage::ImmediateSend,
+            ),
+        ] {
+            assert_eq!(dispatch_failure_stage(&err), expected);
         }
     }
 }

--- a/src-tauri/crates/uc-observability/src/analytics/events.rs
+++ b/src-tauri/crates/uc-observability/src/analytics/events.rs
@@ -79,6 +79,8 @@ pub enum Event {
     SyncSucceeded(SyncEventProps),
     /// 同步失败。`failure_reason` 必填，`sync_latency_ms` 必空。
     SyncFailed(SyncEventProps),
+    /// 同步暂缓。目标在发送前已知不可用，本次不可达不计入失败。
+    SyncDeferred(SyncDeferredProps),
 }
 
 impl Event {
@@ -97,6 +99,7 @@ impl Event {
             Event::SyncAttempted(_) => "sync_attempted",
             Event::SyncSucceeded(_) => "sync_succeeded",
             Event::SyncFailed(_) => "sync_failed",
+            Event::SyncDeferred(_) => "sync_deferred",
         }
     }
 
@@ -160,6 +163,10 @@ impl Event {
                     .and_then(|v| v.as_object().cloned())
                     .unwrap_or_default()
             }
+            Event::SyncDeferred(p) => serde_json::to_value(p)
+                .ok()
+                .and_then(|v| v.as_object().cloned())
+                .unwrap_or_default(),
         }
     }
 }
@@ -172,7 +179,8 @@ fn to_map(value: Value) -> Map<String, Value> {
 ///
 /// 对称约束：
 /// - `SyncSucceeded` 必须设置 `sync_latency_ms`，不设 `failure_reason`。
-/// - `SyncFailed` 必须设置 `failure_reason`，不设 `sync_latency_ms`。
+/// - `SyncFailed` 必须设置 `failure_reason` / `failure_stage`，不设
+///   `sync_latency_ms`。
 /// - `SyncAttempted` 两者都不设。
 ///
 /// 这些约束在 v1 不靠类型系统强制——`Event::properties` 直接序列化整个
@@ -191,6 +199,35 @@ pub struct SyncEventProps {
     /// 仅 `SyncFailed` 携带。
     #[serde(skip_serializing_if = "Option::is_none")]
     pub failure_reason: Option<FailureReason>,
+    /// 仅 `SyncFailed` 携带。用于把本地策略拒绝、即时发送失败和后续终态失败
+    /// 分桶，避免 dashboard 把所有失败混成一个口径。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub failure_stage: Option<SyncFailureStage>,
+}
+
+/// `sync_deferred` 的 properties。
+///
+/// 该事件表示"这次不应计入同步尝试失败率"。典型场景：发送前 presence 已经
+/// 知道目标设备离线，后续 dispatch 仍然不可达。代码仍可尝试发送以防 presence
+/// 过期，但产品分析上这是预期不可用，不是失败。
+///
+/// 不带 `transport_type`：deferred 时本次根本没有发生真实发送，记录任何
+/// transport 都是误导性数据（dashboard 按 transport 切片会得到虚假结论）。
+/// 如果未来要标注"原计划的"transport，请单独命名字段以避免混淆。
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SyncDeferredProps {
+    pub direction: Direction,
+    pub payload_type: PayloadType,
+    pub payload_size_bucket: PayloadSizeBucket,
+    pub peer_os: Option<Os>,
+    pub defer_reason: SyncDeferReason,
+}
+
+/// 同步暂缓原因（`sync_deferred` 专用）。
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum SyncDeferReason {
+    PeerKnownOffline,
 }
 
 /// 同步方向。
@@ -237,6 +274,20 @@ pub enum FailureReason {
     ClipboardPermission,
     EncryptionMismatch,
     Unknown,
+}
+
+/// 同步失败发生的阶段（`sync_failed` 专用）。
+///
+/// `ImmediateSend` 是当前 outbound dispatch 路径最常见的失败阶段，代表一次
+/// 即时投递尝试没有完成；它不是最终投递失败。`LocalPolicy` 代表本机策略在
+/// 发送前已经确定该 payload 不可投递（例如过大）。`TerminalDelivery` 预留给
+/// 后续 pending/retry 耗尽后的最终失败事件。
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum SyncFailureStage {
+    ImmediateSend,
+    LocalPolicy,
+    TerminalDelivery,
 }
 
 /// 配对失败原因（`pairing_failed` 专用）。
@@ -475,6 +526,7 @@ mod tests {
             peer_os: None,
             sync_latency_ms: None,
             failure_reason: None,
+            failure_stage: None,
         };
         assert_eq!(
             Event::SyncAttempted(sample_props.clone()).name(),
@@ -485,6 +537,17 @@ mod tests {
             "sync_succeeded"
         );
         assert_eq!(Event::SyncFailed(sample_props).name(), "sync_failed");
+        assert_eq!(
+            Event::SyncDeferred(SyncDeferredProps {
+                direction: Direction::Outbound,
+                payload_type: PayloadType::Text,
+                payload_size_bucket: PayloadSizeBucket::Lt1Kb,
+                peer_os: None,
+                defer_reason: SyncDeferReason::PeerKnownOffline,
+            })
+            .name(),
+            "sync_deferred"
+        );
     }
 
     // —— 区间边界 ————————————————————————————————————————————
@@ -591,6 +654,23 @@ mod tests {
                 "FailureReason::{reason:?}"
             );
         }
+
+        for (stage, expected) in [
+            (SyncFailureStage::ImmediateSend, "immediate_send"),
+            (SyncFailureStage::LocalPolicy, "local_policy"),
+            (SyncFailureStage::TerminalDelivery, "terminal_delivery"),
+        ] {
+            assert_eq!(
+                serde_json::to_value(stage).unwrap(),
+                expected,
+                "SyncFailureStage::{stage:?}"
+            );
+        }
+
+        assert_eq!(
+            serde_json::to_value(SyncDeferReason::PeerKnownOffline).unwrap(),
+            "peer_known_offline"
+        );
     }
 
     #[test]
@@ -687,15 +767,17 @@ mod tests {
             peer_os: Some(Os::Macos),
             sync_latency_ms: Some(42),
             failure_reason: None,
+            failure_stage: None,
         });
         let props = event.properties();
         assert_eq!(props.get("sync_latency_ms"), Some(&json!(42)));
         // None 字段必须从 wire 完全消失，避免 PostHog 误判为"显式 null"。
         assert!(!props.contains_key("failure_reason"));
+        assert!(!props.contains_key("failure_stage"));
     }
 
     #[test]
-    fn sync_failed_omits_latency() {
+    fn sync_failed_marks_failure_sampling_scope() {
         let event = Event::SyncFailed(SyncEventProps {
             direction: Direction::Inbound,
             payload_type: PayloadType::Image,
@@ -704,10 +786,33 @@ mod tests {
             peer_os: None,
             sync_latency_ms: None,
             failure_reason: Some(FailureReason::Timeout),
+            failure_stage: Some(SyncFailureStage::ImmediateSend),
         });
         let props = event.properties();
         assert_eq!(props.get("failure_reason"), Some(&json!("timeout")));
+        assert_eq!(props.get("failure_stage"), Some(&json!("immediate_send")));
         assert!(!props.contains_key("sync_latency_ms"));
+    }
+
+    #[test]
+    fn sync_deferred_uses_non_failure_reason_field() {
+        let event = Event::SyncDeferred(SyncDeferredProps {
+            direction: Direction::Outbound,
+            payload_type: PayloadType::Text,
+            payload_size_bucket: PayloadSizeBucket::Lt1Kb,
+            peer_os: None,
+            defer_reason: SyncDeferReason::PeerKnownOffline,
+        });
+        let props = event.properties();
+        assert_eq!(
+            props.get("defer_reason"),
+            Some(&json!("peer_known_offline"))
+        );
+        assert!(!props.contains_key("failure_reason"));
+        assert!(!props.contains_key("failure_stage"));
+        assert!(!props.contains_key("sync_latency_ms"));
+        // deferred 没有实际发送，不应携带 transport_type，避免 dashboard 误读。
+        assert!(!props.contains_key("transport_type"));
     }
 
     #[test]

--- a/src-tauri/crates/uc-observability/src/analytics/mod.rs
+++ b/src-tauri/crates/uc-observability/src/analytics/mod.rs
@@ -28,7 +28,8 @@ pub use context::{
 };
 pub use events::{
     Direction, Event, FailureReason, LatencyBucket, NameLengthBucket, PairingFailureReason,
-    PairingMethod, PayloadSizeBucket, PayloadType, SetupEntry, SyncEventProps, TransportType,
+    PairingMethod, PayloadSizeBucket, PayloadType, SetupEntry, SyncDeferReason, SyncDeferredProps,
+    SyncEventProps, SyncFailureStage, TransportType,
 };
 pub use ids::{load_or_create as load_or_create_ids, reset as reset_ids, AnalyticsIds};
 pub use port::{AnalyticsPort, NoopAnalyticsSink};

--- a/src-tauri/crates/uc-observability/src/analytics/port.rs
+++ b/src-tauri/crates/uc-observability/src/analytics/port.rs
@@ -69,6 +69,7 @@ mod tests {
             peer_os: None,
             sync_latency_ms: None,
             failure_reason: None,
+            failure_stage: None,
         }));
     }
 

--- a/src-tauri/crates/uc-observability/src/analytics/sinks/mod.rs
+++ b/src-tauri/crates/uc-observability/src/analytics/sinks/mod.rs
@@ -84,7 +84,7 @@ mod tests {
     };
     use super::super::events::{
         Direction, Event, FailureReason, PayloadSizeBucket, PayloadType, SyncEventProps,
-        TransportType,
+        SyncFailureStage, TransportType,
     };
     use super::*;
     use uuid::Uuid;
@@ -158,6 +158,7 @@ mod tests {
             peer_os: None,
             sync_latency_ms: None,
             failure_reason: Some(FailureReason::Timeout),
+            failure_stage: Some(SyncFailureStage::ImmediateSend),
         });
         let payload = build_event_payload(&event, &ctx);
 
@@ -169,6 +170,10 @@ mod tests {
         assert_eq!(
             payload.get("failure_reason").and_then(Value::as_str),
             Some("timeout")
+        );
+        assert_eq!(
+            payload.get("failure_stage").and_then(Value::as_str),
+            Some("immediate_send")
         );
         assert_eq!(
             payload.get("transport_type").and_then(Value::as_str),

--- a/src-tauri/crates/uc-observability/src/analytics/sinks/stdout.rs
+++ b/src-tauri/crates/uc-observability/src/analytics/sinks/stdout.rs
@@ -190,11 +190,16 @@ mod tests {
                 peer_os: None,
                 sync_latency_ms: None,
                 failure_reason: Some(super::super::super::events::FailureReason::Timeout),
+                failure_stage: Some(super::super::super::events::SyncFailureStage::ImmediateSend),
             }));
         });
         assert!(captured.contains("\"event\":\"sync_failed\""), "{captured}");
         assert!(
             captured.contains("\"failure_reason\":\"timeout\""),
+            "{captured}"
+        );
+        assert!(
+            captured.contains("\"failure_stage\":\"immediate_send\""),
             "{captured}"
         );
         assert!(


### PR DESCRIPTION
## Summary

- 新增 `sync_deferred` 事件，把"对端已知离线导致不可达"从 `sync_failed` 中拆出，避免被误算入用户感知失败率
- 给 `sync_failed` 加 `failure_stage` 字段（`immediate_send` / `local_policy` / `terminal_delivery`），让 dashboard 能按阶段分桶失败
- 统一 `sync_attempted` 时序：始终在 dispatch 之前发一次，与 `succeeded` / `failed` / `deferred` 形成 1:1 配对；dashboard 用 `attempted - deferred` 推导用户感知尝试

## Dashboard 口径

```
attempted = succeeded + failed + deferred
用户感知尝试 = attempted - deferred
最终失败率 = failed[stage=terminal_delivery] / (attempted - deferred)
```

`SyncDeferredProps` 不带 `transport_type`：deferred 路径没有真实发送，记录任何 transport 都是误导性数据。详见 `docs/architecture/telemetry-events.md` §7.2 / §7.3a / §7.3b。

## Test plan

- [x] `cargo test -p uc-observability --lib` — 67/67 通过（含新增 `sync_deferred_uses_non_failure_reason_field` 等）
- [x] `cargo test -p uc-application --lib` — 445/445 通过（含新增 `analytics_defers_instead_of_failing_when_peer_was_already_offline` / `attempted_then_succeeded_even_when_peer_was_known_offline` / `attempted_then_failed_when_known_offline_peer_returns_non_offline_error` / `dispatch_failure_stage_classifies_failure_phase`）
- [ ] 上线后 PostHog 上确认 `sync_deferred` 事件 schema 与文档一致，且 `sync_failed` 携带 `failure_stage`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Enhanced telemetry event documentation with expanded reliability tracking model and failure classification guidance.

* **New Features**
  * Added `sync_deferred` event to distinguish deferred syncs from failures when peers are known unavailable.
  * Introduced `failure_stage` field for failed sync events to provide granular failure classification (e.g., local policy, immediate send).
  * Improved sync failure tracking with peer availability awareness for more precise failure categorization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/UniClipboard/UniClipboard/pull/671)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->