### PR TITLE
ci: use prebuilt image for PR rust check

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -23,6 +23,7 @@ on:
 
 permissions:
   contents: read
+  packages: read
   pull-requests: read
 
 # 拆 frontend / frontend-tests / rust 三个 job：
@@ -113,7 +114,11 @@ jobs:
     runs-on: ubuntu-latest
     # 复用 build-base-image.yml 维护的 bookworm 镜像,避免 PR job 每次访问
     # apt 源安装 webkit/gtk 依赖。镜像已包含 cargo check 所需系统包。
-    container: ghcr.io/uniclipboard/build-bookworm:latest
+    container:
+      image: ghcr.io/uniclipboard/build-bookworm:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -18,6 +18,7 @@ on:
       - 'index.html'
       - 'quick-panel.html'
       - 'public/**'
+      - '.github/docker/build-bookworm.Dockerfile'
       - '.github/workflows/pr-check.yml'
 
 permissions:
@@ -47,6 +48,7 @@ jobs:
           filters: |
             rust:
               - 'src-tauri/**'
+              - '.github/docker/build-bookworm.Dockerfile'
               - '.github/workflows/pr-check.yml'
 
   frontend:
@@ -109,18 +111,15 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.rust == 'true' }}
     runs-on: ubuntu-latest
+    # 复用 build-base-image.yml 维护的 bookworm 镜像,避免 PR job 每次访问
+    # apt 源安装 webkit/gtk 依赖。镜像已包含 cargo check 所需系统包。
+    container: ghcr.io/uniclipboard/build-bookworm:latest
 
     steps:
       - uses: actions/checkout@v4
 
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
-
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
## Summary
- run the PR Rust check inside the existing `ghcr.io/uniclipboard/build-bookworm:latest` container
- remove per-PR `apt-get update/install` for webkit/gtk system packages
- include the base image Dockerfile in PR/Rust change detection paths

## Validation
- `python3 -c 'import yaml; data=yaml.safe_load(open(".github/workflows/pr-check.yml", encoding="utf-8")); assert data["jobs"]["rust"]["container"] == "ghcr.io/uniclipboard/build-bookworm:latest"; print("workflow yaml ok")'`\n- `git diff --check`\n\nContext: run 25783723981 / job 75732018621 stalled in `Install system dependencies` while `apt-get update` was retrying Ubuntu apt mirrors.