### PR TITLE
chore(ci): make PR cache steps read-only and warm docs-bun

### DIFF
--- a/.github/workflows/cache-warmup.yml
+++ b/.github/workflows/cache-warmup.yml
@@ -52,6 +52,34 @@ jobs:
         working-directory: src-tauri
         run: cargo check --workspace --locked
 
+  warmup-docs-bun:
+    # docs-check.yml PR 阶段只 restore Linux-docs-bun-*,这里负责在 main 上写。
+    name: Warm docs Bun cache
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: docs-site
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Cache Bun dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            docs-site/node_modules
+            ~/.bun/install/cache
+          key: ${{ runner.os }}-docs-bun-${{ hashFiles('docs-site/bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-docs-bun-
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
   warmup-coverage-rust:
     name: Warm coverage Rust cache
     runs-on: ubuntu-latest

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -25,8 +25,11 @@ jobs:
         with:
           bun-version: latest
 
-      - name: Cache Bun dependencies
-        uses: actions/cache@v4
+      - name: Restore Bun dependencies
+        # PR 只读取 default branch 上由 cache-warmup 写入的 docs Bun cache。
+        # actions/cache 会在 miss 时自动保存,这里用 restore 子 action 避免
+        # 每个 refs/pull/*/merge 写出重复 cache 并挤掉 release 预热缓存。
+        uses: actions/cache/restore@v4
         with:
           path: |
             docs-site/node_modules

--- a/.github/workflows/frontend-coverage.yml
+++ b/.github/workflows/frontend-coverage.yml
@@ -25,8 +25,11 @@ jobs:
         with:
           bun-version: latest
 
-      - name: Cache Bun dependencies
-        uses: actions/cache@v4
+      - name: Restore Bun dependencies
+        # PR 只读取 default branch 上由 cache-warmup 写入的 Bun cache。
+        # actions/cache 会在 miss 时自动保存,这里用 restore 子 action 避免
+        # 每个 refs/pull/*/merge 写出重复 cache 并挤掉 release 预热缓存。
+        uses: actions/cache/restore@v4
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -93,8 +93,11 @@ jobs:
         with:
           bun-version: latest
 
-      - name: Cache Bun dependencies
-        uses: actions/cache@v4
+      - name: Restore Bun dependencies
+        # PR 只读取 default branch 上由 cache-warmup 写入的 Bun cache。
+        # actions/cache 会在 miss 时自动保存,这里用 restore 子 action 避免
+        # 每个 refs/pull/*/merge 写出重复 cache 并挤掉 release 预热缓存。
+        uses: actions/cache/restore@v4
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}


### PR DESCRIPTION
## Summary

- PR runs were creating per-PR copies of `Linux-bun-*` and `Linux-docs-bun-*` GHA caches that no later PR could hit (cache scoping is per-ref), polluting the 10 GB quota and crowding out the release/main entries that `cache-warmup.yml` deliberately maintains. (65d33507)
- The three remaining read-write cache sites — `frontend-tests` in `pr-check.yml`, `frontend-coverage.yml`, `docs-check.yml` — are now `actions/cache/restore@v4`, matching the pattern already used by `pr-check.yml#frontend` and the Rust cache jobs.
- Added a `warmup-docs-bun` job to `cache-warmup.yml` so `Linux-docs-bun-*` is still populated weekly from `main` (previously only `Linux-bun-*` was warmed, via `build.yml`). Without this, `docs-check` PR runs would always cache-miss.
- Docs left as-is — CI-internal change, no user-facing surface affected.

## Test plan

- [x] `git grep -n 'actions/cache@' .github/workflows/` — confirmed the only remaining `actions/cache@v4` reads-and-writes are in `cache-warmup.yml` (intentional, that job is the writer).
- [ ] After merge to `main`: next scheduled `cache-warmup` run (Mon 00:00 UTC) populates `Linux-docs-bun-*` once, then subsequent `docs-check` PRs should restore it without producing new ref-scoped copies.
- [ ] After merge to `main`: open a no-op PR touching `docs-site/` and confirm the GHA cache list no longer gains a `Linux-docs-bun-*` entry scoped to `refs/pull/<N>/merge`. Same check with a `src/**` PR for `Linux-bun-*`.
- [ ] Note: the small `v0-rust-coverage-Linux-x64-*` ~1.2 KB stub entries that `Swatinem/rust-cache@v2` writes on PR runs are intentional metadata lookup keys and are out of scope here.