### PR TITLE
fix(ui): flatten Linux settings page layout

### DIFF
--- a/src/components/setting/SettingsSidebar.tsx
+++ b/src/components/setting/SettingsSidebar.tsx
@@ -16,9 +16,17 @@ import {
 interface SettingsSidebarProps {
   activeCategory: string
   onCategoryChange: (category: string) => void
+  /**
+   * Linux/Tauri 下设置页改用扁平布局，侧栏需要显式边框来代替原本由 InsetSurface 提供的视觉分隔。
+   */
+  flat?: boolean
 }
 
-const SettingsSidebar: FC<SettingsSidebarProps> = ({ activeCategory, onCategoryChange }) => {
+const SettingsSidebar: FC<SettingsSidebarProps> = ({
+  activeCategory,
+  onCategoryChange,
+  flat = false,
+}) => {
   const { t } = useTranslation()
   const navigate = useNavigate()
 
@@ -31,8 +39,15 @@ const SettingsSidebar: FC<SettingsSidebarProps> = ({ activeCategory, onCategoryC
   }
 
   return (
-    <Sidebar collapsible="none" className="bg-transparent border-none">
-      <SidebarContent className="bg-transparent">
+    <Sidebar
+      collapsible="none"
+      className={
+        flat
+          ? 'border-r border-border/40 bg-background/80 dark:bg-background/60'
+          : 'bg-transparent border-none'
+      }
+    >
+      <SidebarContent className={flat ? '' : 'bg-transparent'}>
         <SidebarGroup>
           <SidebarGroupContent>
             <SidebarMenu>

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -9,6 +9,7 @@ import {
 import SettingsSidebar from '@/components/setting/SettingsSidebar'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { SidebarProvider, SidebarInset } from '@/components/ui/sidebar'
+import { usePlatform } from '@/hooks/usePlatform'
 import { useShortcut } from '@/hooks/useShortcut'
 import { useShortcutScope } from '@/hooks/useShortcutScope'
 import { SettingContentLayout } from '@/layouts'
@@ -57,6 +58,23 @@ function SettingsPage() {
   )
   const ActiveSection = activeCategoryConfig?.Component
 
+  const { isLinux, isTauri } = usePlatform()
+  const useFlatLayout = isLinux && isTauri
+
+  const content = (
+    <SidebarInset className="min-h-0 bg-transparent">
+      <ScrollArea className="flex-1 min-h-0">
+        <div className="p-6">
+          {ActiveSection && (
+            <SettingContentLayout>
+              <ActiveSection />
+            </SettingContentLayout>
+          )}
+        </div>
+      </ScrollArea>
+    </SidebarInset>
+  )
+
   return (
     <SidebarProvider
       style={
@@ -66,20 +84,18 @@ function SettingsPage() {
       }
       className="min-h-0 h-full"
     >
-      <SettingsSidebar activeCategory={activeCategory} onCategoryChange={handleCategoryChange} />
-      <InsetSurface className="mr-2 mb-2">
-        <SidebarInset className="min-h-0 bg-transparent">
-          <ScrollArea className="flex-1 min-h-0">
-            <div className="p-6">
-              {ActiveSection && (
-                <SettingContentLayout>
-                  <ActiveSection />
-                </SettingContentLayout>
-              )}
-            </div>
-          </ScrollArea>
-        </SidebarInset>
-      </InsetSurface>
+      <SettingsSidebar
+        activeCategory={activeCategory}
+        onCategoryChange={handleCategoryChange}
+        flat={useFlatLayout}
+      />
+      {useFlatLayout ? (
+        <main className="relative flex min-h-0 flex-1 flex-col overflow-hidden bg-card text-card-foreground">
+          {content}
+        </main>
+      ) : (
+        <InsetSurface className="mr-2 mb-2">{content}</InsetSurface>
+      )}
     </SidebarProvider>
   )
 }


### PR DESCRIPTION
## Summary

- Follow-up to #670, which flattened `MainLayout` on Linux/Tauri but left `SettingsPage` still wrapped in `InsetSurface` with `mr-2 mb-2` — so the settings page kept the rounded inset panel under the system titlebar while the rest of the app went flat.
- `SettingsPage.tsx` now branches on `usePlatform()`: Linux/Tauri renders a plain `<main>` container (matches the Linux branch in `MainLayout`); macOS/Windows keep the existing `InsetSurface`.
- `SettingsSidebar` gains a `flat` prop; when set it swaps `bg-transparent border-none` for `border-r border-border/40 bg-background/80 dark:bg-background/60`, mirroring the bordered sidebar used by `LinuxMainLayout` so the sidebar still reads as a separate column without the inset surface around it.

## Test plan

- [x] `npx eslint src/pages/SettingsPage.tsx src/components/setting/SettingsSidebar.tsx`
- [x] `npx tsc --noEmit`
- [x] `bun run test -- src/layouts/__tests__/MainLayout.test.tsx --run` (no regression in the related layout tests)
- [ ] Visual check on a real Linux/Tauri build: open Settings, confirm no rounded inset around the content and the sidebar shows a right border consistent with the main page.
- [ ] Visual check on macOS and Windows: settings page still uses the rounded `InsetSurface` panel as before.