### PR TITLE
fix(webserver): facade root-cause logging for all 5xx paths

### DIFF
--- a/src-tauri/crates/uc-webserver/src/api/blob.rs
+++ b/src-tauri/crates/uc-webserver/src/api/blob.rs
@@ -10,6 +10,7 @@ use axum::routing::get;
 use axum::Router;
 use uc_application::facade::ResourceFacadeError;
 
+use crate::api::dto::error::log_facade_failure;
 use crate::api::server::DaemonApiState;
 
 pub fn router() -> Router<DaemonApiState> {
@@ -46,16 +47,7 @@ async fn get_blob(
             )
                 .into_response()
         }
-        Err(err) => {
-            if !matches!(err, ResourceFacadeError::NotFound) {
-                tracing::error!(
-                    error = %err,
-                    blob_id = %blob_id,
-                    "Failed to resolve blob resource"
-                );
-            }
-            map_resource_error(err, "blob not found")
-        }
+        Err(err) => map_resource_error("get_blob", err, "blob not found", &blob_id),
     }
 }
 
@@ -87,27 +79,39 @@ async fn get_thumbnail(
             )
                 .into_response()
         }
-        Err(err) => {
-            if !matches!(err, ResourceFacadeError::NotFound) {
-                tracing::error!(
-                    error = %err,
-                    rep_id = %rep_id,
-                    "Failed to resolve thumbnail resource"
-                );
-            }
-            map_resource_error(err, "thumbnail not found")
-        }
+        Err(err) => map_resource_error("get_thumbnail", err, "thumbnail not found", &rep_id),
     }
 }
 
 fn map_resource_error(
+    op: &'static str,
     error: ResourceFacadeError,
     not_found_message: &'static str,
+    resource_id: &str,
 ) -> axum::response::Response {
-    match error {
-        ResourceFacadeError::NotFound => (StatusCode::NOT_FOUND, not_found_message).into_response(),
-        ResourceFacadeError::Mismatch(_) | ResourceFacadeError::Internal(_) => {
-            (StatusCode::INTERNAL_SERVER_ERROR, "internal error").into_response()
-        }
-    }
+    use ResourceFacadeError as E;
+    let (variant, status, message): (&'static str, StatusCode, String) = match error {
+        E::NotFound => (
+            "not_found",
+            StatusCode::NOT_FOUND,
+            not_found_message.to_string(),
+        ),
+        E::Mismatch(detail) => (
+            "mismatch",
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("resource {resource_id} mismatch: {detail}"),
+        ),
+        E::Internal(detail) => (
+            "internal",
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("resource {resource_id} internal: {detail}"),
+        ),
+    };
+    log_facade_failure("resource", op, variant, status, &message);
+    let body = if status == StatusCode::NOT_FOUND {
+        not_found_message
+    } else {
+        "internal error"
+    };
+    (status, body).into_response()
 }

--- a/src-tauri/crates/uc-webserver/src/api/clipboard.rs
+++ b/src-tauri/crates/uc-webserver/src/api/clipboard.rs
@@ -22,7 +22,7 @@ use crate::api::dto::clipboard::{
     GetEntryDetailResponse, GetEntryResourceResponse, ListEntriesResponse, ToggleFavoriteRequest,
     ToggleFavoriteResponse, ToggleFavoriteResultDto,
 };
-use crate::api::dto::error::ApiError;
+use crate::api::dto::error::{log_facade_failure, ApiError};
 use crate::api::server::DaemonApiState;
 
 #[derive(Deserialize)]
@@ -88,7 +88,7 @@ async fn list_entries(
             offset: params.offset,
         })
         .await
-        .map_err(map_clipboard_err)?;
+        .map_err(|e| map_clipboard_err("list_entries", e))?;
 
     let response_entries: Vec<EntryProjectionResponseDto> =
         entries.into_iter().map(entry_projection_to_dto).collect();
@@ -125,7 +125,7 @@ async fn get_entry(
     let detail = facade
         .get_entry(&entry_id)
         .await
-        .map_err(map_clipboard_err)?;
+        .map_err(|e| map_clipboard_err("get_entry", e))?;
 
     Ok(Json(GetEntryDetailResponse {
         data: entry_detail_to_dto(detail),
@@ -157,7 +157,7 @@ async fn delete_entry(
     facade
         .delete_entry(&entry_id)
         .await
-        .map_err(map_clipboard_err)?;
+        .map_err(|e| map_clipboard_err("delete_entry", e))?;
 
     Ok(StatusCode::NO_CONTENT)
 }
@@ -192,7 +192,7 @@ async fn toggle_favorite(
     let found = facade
         .toggle_favorite(&entry_id, body.is_favorited)
         .await
-        .map_err(map_clipboard_err)?;
+        .map_err(|e| map_clipboard_err("toggle_favorite", e))?;
 
     if !found {
         return Err(ApiError::not_found("entry not found"));
@@ -220,7 +220,10 @@ async fn get_stats(
     State(state): State<DaemonApiState>,
 ) -> Result<Json<GetClipboardStatsResponse>, ApiError> {
     let facade = require_facade(&state)?;
-    let stats = facade.stats().await.map_err(map_clipboard_err)?;
+    let stats = facade
+        .stats()
+        .await
+        .map_err(|e| map_clipboard_err("get_stats", e))?;
 
     Ok(Json(GetClipboardStatsResponse {
         data: clipboard_stats_to_dto(stats),
@@ -252,7 +255,7 @@ async fn get_entry_resource(
     let resource = facade
         .get_entry_resource(&entry_id)
         .await
-        .map_err(map_clipboard_err)?;
+        .map_err(|e| map_clipboard_err("get_entry_resource", e))?;
 
     Ok(Json(GetEntryResourceResponse {
         data: entry_resource_to_dto(resource),
@@ -277,7 +280,10 @@ async fn clear_history(
     State(state): State<DaemonApiState>,
 ) -> Result<Json<ClearHistoryResponse>, ApiError> {
     let facade = require_facade(&state)?;
-    let result = facade.clear_history().await.map_err(map_clipboard_err)?;
+    let result = facade
+        .clear_history()
+        .await
+        .map_err(|e| map_clipboard_err("clear_history", e))?;
 
     Ok(Json(ClearHistoryResponse {
         data: clear_history_to_dto(result),
@@ -285,16 +291,22 @@ async fn clear_history(
     }))
 }
 
-fn map_clipboard_err(err: ClipboardHistoryError) -> ApiError {
-    match err {
-        ClipboardHistoryError::NotFound => ApiError::not_found("entry not found"),
-        ClipboardHistoryError::UnsupportedContent => ApiError {
-            status: StatusCode::UNPROCESSABLE_ENTITY,
-            code: "unsupported_content".to_string(),
-            message: "entry is not text content".to_string(),
-        },
-        ClipboardHistoryError::Internal(message) => ApiError::internal(message),
-    }
+fn map_clipboard_err(op: &'static str, err: ClipboardHistoryError) -> ApiError {
+    use ClipboardHistoryError as E;
+    let (variant, api): (&'static str, ApiError) = match err {
+        E::NotFound => ("not_found", ApiError::not_found("entry not found")),
+        E::UnsupportedContent => (
+            "unsupported_content",
+            ApiError {
+                status: StatusCode::UNPROCESSABLE_ENTITY,
+                code: "unsupported_content".to_string(),
+                message: "entry is not text content".to_string(),
+            },
+        ),
+        E::Internal(message) => ("internal", ApiError::internal(message)),
+    };
+    log_facade_failure("clipboard_history", op, variant, api.status, &api.message);
+    api
 }
 
 fn entry_projection_to_dto(view: EntryProjectionView) -> EntryProjectionResponseDto {

--- a/src-tauri/crates/uc-webserver/src/api/device.rs
+++ b/src-tauri/crates/uc-webserver/src/api/device.rs
@@ -10,7 +10,7 @@ use axum::{Json, Router};
 use utoipa;
 
 use crate::api::dto::device::GetLocalDeviceInfoResponse;
-use crate::api::dto::error::ApiError;
+use crate::api::dto::error::{log_facade_failure, ApiError};
 use crate::api::server::DaemonApiState;
 
 pub fn router() -> Router<DaemonApiState> {
@@ -32,11 +32,17 @@ async fn get_local_device_info_handler(
     State(state): State<DaemonApiState>,
 ) -> Result<Json<GetLocalDeviceInfoResponse>, ApiError> {
     let app = state.app_facade_or_error()?;
-    let info = app
-        .device
-        .local_device_info()
-        .await
-        .map_err(|e| ApiError::internal(e.to_string()))?;
+    let info = app.device.local_device_info().await.map_err(|e| {
+        let api = ApiError::internal(e.to_string());
+        log_facade_failure(
+            "device",
+            "local_device_info",
+            "call_failed",
+            api.status,
+            &api.message,
+        );
+        api
+    })?;
 
     Ok(Json(GetLocalDeviceInfoResponse {
         data: crate::api::dto::device::LocalDeviceInfoDto {

--- a/src-tauri/crates/uc-webserver/src/api/dto/error.rs
+++ b/src-tauri/crates/uc-webserver/src/api/dto/error.rs
@@ -114,3 +114,34 @@ impl IntoResponse for ApiError {
         (self.status, Json(body)).into_response()
     }
 }
+
+// Emit the root-cause ERROR at the point we still have the original facade
+// enum variant. The webserver middleware only sees the final HTTP status by
+// the time the error has been flattened into a String, which is why earlier
+// Sentry Issues like "daemon http upstream unavailable" carried zero signal
+// — they were echoes of an error that had already been thrown away. Logging
+// here keeps `facade / op / error_variant` queryable in Sentry so distinct
+// failure modes (SponsorUnreachable, Timeout, ConnectionLost, etc.) don't
+// all collapse into one mega-group. Covers any 5xx (500 + 503) since both
+// share the same "cause chain compressed to a String" problem.
+pub fn log_facade_failure(
+    facade: &'static str,
+    op: &'static str,
+    variant: &'static str,
+    status: StatusCode,
+    message: &str,
+) {
+    if status.is_server_error() {
+        tracing::error!(
+            facade,
+            op,
+            error_variant = variant,
+            status = status.as_u16(),
+            "{} facade returned {} ({}): {}",
+            facade,
+            status.as_u16(),
+            variant,
+            message,
+        );
+    }
+}

--- a/src-tauri/crates/uc-webserver/src/api/dto/error.rs
+++ b/src-tauri/crates/uc-webserver/src/api/dto/error.rs
@@ -1,3 +1,59 @@
+//! HTTP error surface for daemon API handlers.
+//!
+//! # Why this module exists
+//!
+//! Every `facade::*Error` variant carries a specific cause (network not
+//! started, sponsor unreachable, storage write failure, …). By the time the
+//! webserver middleware sees the response it only has the final HTTP status —
+//! the cause chain has already been flattened into a `String` inside `ApiError`
+//! and the original variant is gone. Earlier Sentry Issues like
+//! "daemon http upstream unavailable" carried zero signal for exactly this
+//! reason: they were echoes of an error that had already been thrown away one
+//! layer deeper, in the handler's own `map_err`.
+//!
+//! [`log_facade_failure`] solves this by emitting the root-cause `ERROR` event
+//! at the **mapping point** — where the typed facade error is still in scope —
+//! with structured `facade / op / error_variant / status` fields. Sentry can
+//! then bucket distinct failure modes (SponsorUnreachable, Timeout,
+//! ConnectionLost, …) into distinct Issues instead of collapsing them into
+//! one mega-group keyed off the middleware's generic message.
+//!
+//! # Rule for new handlers
+//!
+//! **Any handler that maps a facade error onto a 5xx `ApiError` (or
+//! `(StatusCode::5xx, Json)`) MUST call [`log_facade_failure`] at the mapping
+//! point.** The helper itself filters out 4xx, so handlers can call it
+//! unconditionally on every variant.
+//!
+//! Concretely, prefer this shape:
+//!
+//! ```ignore
+//! fn map_foo_err(err: FooError) -> ApiError {
+//!     use FooError as E;
+//!     let (variant, api): (&'static str, ApiError) = match err {
+//!         E::NotFound        => ("not_found",        ApiError::not_found("...")),
+//!         E::ServiceDown(m)  => ("service_down",     ApiError::service_unavailable(m)),
+//!         E::Internal(m)     => ("internal",         ApiError::internal(m)),
+//!     };
+//!     log_facade_failure("foo", "do_thing", variant, api.status, &api.message);
+//!     api
+//! }
+//! ```
+//!
+//! # Anti-patterns
+//!
+//! - Calling `tracing::error!(error = %e, "X failed")` inside a `map_err`
+//!   closure or middleware: produces an ERROR event with no `facade / op /
+//!   error_variant`, which Sentry can only group by message — exactly the
+//!   "mega-group" failure mode this module was added to fix.
+//! - Logging the cause once in the handler AND once again in middleware: the
+//!   middleware path was already downgraded to `WARN` (see `api/server.rs`)
+//!   precisely so the in-handler `ERROR` is the single root-cause event.
+//! - Using `error_kind = "<some-string>"` as a fake root-cause attribute on a
+//!   middleware-level event: Sentry will index it as if it were a real bucket
+//!   key, producing the same collapse the structured `facade / op /
+//!   error_variant` triple is meant to prevent.
+
 use axum::{
     http::StatusCode,
     response::{IntoResponse, Response},

--- a/src-tauri/crates/uc-webserver/src/api/encryption.rs
+++ b/src-tauri/crates/uc-webserver/src/api/encryption.rs
@@ -12,9 +12,20 @@ use utoipa;
 use crate::api::dto::encryption::{
     EncryptionSessionReadyPayload, EncryptionStateResponse, KeychainAccessResponse,
 };
-use crate::api::dto::error::ApiError;
+use crate::api::dto::error::{log_facade_failure, ApiError};
 use crate::api::server::DaemonApiState;
 use crate::api::types::DaemonWsEvent;
+
+/// 把 encryption facade 的 anyhow 错误映射为 500 + 根因日志。
+///
+/// 与 `RosterError` / `SearchFacadeError` 不同，encryption facade 当前向 webserver
+/// 暴露 `anyhow::Error` 而非 enum，所以 `error_variant` 退化为 `"call_failed"`，
+/// 分桶由 `op` 维度承担（state / unlock / lock / verify_keychain_access）。
+fn map_encryption_internal(op: &'static str, message: String) -> ApiError {
+    let api = ApiError::internal(message);
+    log_facade_failure("encryption", op, "call_failed", api.status, &api.message);
+    api
+}
 
 pub fn router() -> Router<DaemonApiState> {
     Router::new()
@@ -47,7 +58,7 @@ async fn get_encryption_state_handler(
         .encryption
         .state()
         .await
-        .map_err(|e| ApiError::internal(e.to_string()))?;
+        .map_err(|e| map_encryption_internal("encryption_state", e.to_string()))?;
 
     let ts = chrono::Utc::now().timestamp_millis();
     Ok(Json(json!({
@@ -101,10 +112,10 @@ async fn unlock_handler(
             let ts = chrono::Utc::now().timestamp_millis();
             Ok(Json(json!({ "data": { "success": false }, "ts": ts })))
         }
-        Err(e) => {
-            warn!(error = %e, "keyring auto-unlock failed");
-            Err(ApiError::internal(format!("auto-unlock failed: {e}")))
-        }
+        Err(e) => Err(map_encryption_internal(
+            "encryption_unlock",
+            format!("auto-unlock failed: {e}"),
+        )),
     }
 }
 
@@ -124,10 +135,9 @@ async fn lock_handler(
     State(state): State<DaemonApiState>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
     let app = state.app_facade_or_error()?;
-    app.encryption
-        .lock()
-        .await
-        .map_err(|e| ApiError::internal(format!("failed to lock encryption: {e}")))?;
+    app.encryption.lock().await.map_err(|e| {
+        map_encryption_internal("encryption_lock", format!("failed to lock encryption: {e}"))
+    })?;
 
     info!("encryption session cleared (locked)");
     let ts = chrono::Utc::now().timestamp_millis();
@@ -151,11 +161,12 @@ async fn verify_keychain_access_handler(
     State(state): State<DaemonApiState>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
     let app = state.app_facade_or_error()?;
-    let granted = app
-        .encryption
-        .verify_keychain_access()
-        .await
-        .map_err(|e| ApiError::internal(format!("keychain access check failed: {e}")))?;
+    let granted = app.encryption.verify_keychain_access().await.map_err(|e| {
+        map_encryption_internal(
+            "verify_keychain_access",
+            format!("keychain access check failed: {e}"),
+        )
+    })?;
 
     let ts = chrono::Utc::now().timestamp_millis();
     Ok(Json(json!({

--- a/src-tauri/crates/uc-webserver/src/api/lifecycle.rs
+++ b/src-tauri/crates/uc-webserver/src/api/lifecycle.rs
@@ -74,7 +74,7 @@ async fn retry_lifecycle_handler(State(state): State<DaemonApiState>) -> impl In
     let span = tracing::info_span!("daemon.lifecycle.retry");
     async move {
         if let Err(error) = app.lifecycle.retry_to_ready().await {
-            return internal_error(anyhow::anyhow!("{}", error)).into_response();
+            return internal_error("lifecycle_retry", anyhow::anyhow!("{}", error)).into_response();
         }
 
         // Signal clipboard capture gate (if present) — same as /lifecycle/ready.

--- a/src-tauri/crates/uc-webserver/src/api/member.rs
+++ b/src-tauri/crates/uc-webserver/src/api/member.rs
@@ -6,13 +6,13 @@
 use axum::extract::{Path, State};
 use axum::routing::{get, patch};
 use axum::{Json, Router};
-use tracing::{info, instrument, warn};
+use tracing::{info, instrument};
 
 use uc_application::facade::{
     ContentTypesPatch, MemberSyncPreferencesPatch, MemberSyncPreferencesView, RosterError,
 };
 
-use crate::api::dto::error::ApiError;
+use crate::api::dto::error::{log_facade_failure, ApiError};
 use crate::api::dto::member::{
     GetMemberSyncPreferencesResponse, MemberSyncPreferencesPatchDto,
     UpdateMemberSyncPreferencesResponse,
@@ -190,31 +190,41 @@ fn member_sync_preferences_to_dto(
     }
 }
 
-/// 把 uc-app UseCase 的 anyhow 错误映射为 HTTP 状态。
+/// 把 `RosterError` 映射为 HTTP `ApiError`，并在 5xx 路径打根因日志。
 ///
-/// `MembershipApplicationError::NotFound` 在 uc-app 层被包成 anyhow 时保留了
-/// "not found" 文案（见 `GetMemberSyncPreferences::execute`），这里做字符串匹配
-/// 把它提升为 404；其余视为 500。
-fn map_member_error(device_id: &str, context: &str, err: RosterError) -> ApiError {
-    if matches!(err, RosterError::NotFound(_)) {
-        warn!(
-            error = %err,
-            device_id = %device_id,
-            context = context,
-            error_kind = "member_not_found",
-            "member handler rejected request: member not found"
-        );
-        ApiError::not_found(format!("member `{device_id}` not found"))
-    } else {
-        tracing::error!(
-            error = %err,
-            device_id = %device_id,
-            context = context,
-            error_kind = "roster_internal",
-            "member handler failed"
-        );
-        ApiError::internal(err.to_string())
-    }
+/// `NotFound` → 404（业务可见层面，由请求日志兜底，本函数不再单独打 warn）；
+/// `Unavailable` → 503；其余 repository / identity 故障 → 500。
+/// 5xx 路径统一由 [`log_facade_failure`] 输出 `facade / op / error_variant` 结构化字段。
+fn map_member_error(device_id: &str, op: &'static str, err: RosterError) -> ApiError {
+    use RosterError as E;
+    let (variant, api): (&'static str, ApiError) = match err {
+        E::NotFound(_) => (
+            "not_found",
+            ApiError::not_found(format!("member `{device_id}` not found")),
+        ),
+        E::MemberRepository(msg) => (
+            "member_repository",
+            ApiError::internal(format!("member repository failure: {msg}")),
+        ),
+        E::LocalIdentity(msg) => (
+            "local_identity",
+            ApiError::internal(format!("local identity failure: {msg}")),
+        ),
+        E::PeerAddressRepository(msg) => (
+            "peer_address_repository",
+            ApiError::internal(format!("peer address repository failure: {msg}")),
+        ),
+        E::TrustedPeerRepository(msg) => (
+            "trusted_peer_repository",
+            ApiError::internal(format!("trusted peer repository failure: {msg}")),
+        ),
+        E::Unavailable => (
+            "unavailable",
+            ApiError::service_unavailable("member roster facade unavailable"),
+        ),
+    };
+    log_facade_failure("roster", op, variant, api.status, &api.message);
+    api
 }
 
 #[cfg(test)]

--- a/src-tauri/crates/uc-webserver/src/api/pairing.rs
+++ b/src-tauri/crates/uc-webserver/src/api/pairing.rs
@@ -12,7 +12,7 @@ use utoipa;
 
 use uc_application::facade::RosterError;
 
-use crate::api::dto::error::ApiError;
+use crate::api::dto::error::{log_facade_failure, ApiError};
 use crate::api::dto::pairing::UnpairDeviceRequest;
 use crate::api::server::DaemonApiState;
 
@@ -48,15 +48,42 @@ pub(crate) async fn handle_unpair_device(
     // Slice 4 P5a-1: 取消配对 = 删除本机成员记录。libp2p 时代的
     // `PairingTransportPort::unpair_device` 通知对端的能力随 libp2p 一同下线；
     // 本地自治模型下不再广播给对端（对端发现后会自行清理）。
-    roster.revoke_member(peer_id.as_str()).await.map_err(|e| {
-        tracing::error!(error = %e, peer_id = %peer_id, "daemon unpair: revoke member failed");
-        match e {
-            RosterError::NotFound(_) => {
-                ApiError::not_found(format!("member `{peer_id}` not found"))
-            }
-            other => ApiError::internal(other.to_string()),
-        }
-    })?;
+    roster
+        .revoke_member(peer_id.as_str())
+        .await
+        .map_err(|e| map_unpair_err(e, peer_id.as_str()))?;
 
     Ok(StatusCode::NO_CONTENT)
+}
+
+fn map_unpair_err(err: RosterError, peer_id: &str) -> ApiError {
+    use RosterError as E;
+    let (variant, api): (&'static str, ApiError) = match err {
+        E::NotFound(_) => (
+            "not_found",
+            ApiError::not_found(format!("member `{peer_id}` not found")),
+        ),
+        E::MemberRepository(msg) => (
+            "member_repository",
+            ApiError::internal(format!("member repository failure: {msg}")),
+        ),
+        E::LocalIdentity(msg) => (
+            "local_identity",
+            ApiError::internal(format!("local identity failure: {msg}")),
+        ),
+        E::PeerAddressRepository(msg) => (
+            "peer_address_repository",
+            ApiError::internal(format!("peer address repository failure: {msg}")),
+        ),
+        E::TrustedPeerRepository(msg) => (
+            "trusted_peer_repository",
+            ApiError::internal(format!("trusted peer repository failure: {msg}")),
+        ),
+        E::Unavailable => (
+            "unavailable",
+            ApiError::service_unavailable("member roster facade unavailable"),
+        ),
+    };
+    log_facade_failure("roster", "unpair_device", variant, api.status, &api.message);
+    api
 }

--- a/src-tauri/crates/uc-webserver/src/api/routes.rs
+++ b/src-tauri/crates/uc-webserver/src/api/routes.rs
@@ -23,6 +23,7 @@ use serde_json::json;
 use uc_application::facade::ClipboardRestoreError;
 use uc_daemon_contract::constants::http_route;
 
+use crate::api::dto::error::log_facade_failure;
 use crate::api::server::DaemonApiState;
 use crate::security::middleware::{auth_extractor_middleware, rate_limit_middleware};
 
@@ -149,13 +150,19 @@ async fn restore_clipboard_entry_handler(
     let restore_facade = match app.clipboard_restore.as_ref() {
         Some(facade) => facade,
         None => {
-            return internal_error(anyhow::anyhow!(
-                "clipboard_restore facade unavailable in this entry point"
-            ))
+            return internal_error(
+                "restore_facade_check",
+                anyhow::anyhow!("clipboard_restore facade unavailable in this entry point"),
+            )
             .into_response();
         }
     };
 
+    let op: &'static str = if query.plain {
+        "restore_entry_as_plain_text"
+    } else {
+        "restore_entry"
+    };
     let result = if query.plain {
         restore_facade.restore_entry_as_plain_text(&entry_id).await
     } else {
@@ -171,7 +178,7 @@ async fn restore_clipboard_entry_handler(
             );
             restore_success_response().into_response()
         }
-        Err(error) => restore_error_to_response(error, &entry_id).into_response(),
+        Err(error) => restore_error_to_response(op, error, &entry_id).into_response(),
     }
 }
 
@@ -185,15 +192,17 @@ fn restore_success_response() -> (StatusCode, Json<serde_json::Value>) {
 /// spinning up an axum app or `DaemonApiState`. The handler above is a
 /// thin wrapper around this.
 fn restore_error_to_response(
+    op: &'static str,
     error: ClipboardRestoreError,
     entry_id: &str,
 ) -> (StatusCode, Json<serde_json::Value>) {
+    use ClipboardRestoreError as E;
     match error {
-        ClipboardRestoreError::NotFound => {
+        E::NotFound => {
             tracing::warn!(entry_id = %entry_id, "daemon restore: entry not found");
             (StatusCode::NOT_FOUND, Json(json!({"error": "not_found"})))
         }
-        ClipboardRestoreError::PayloadUnavailable {
+        E::PayloadUnavailable {
             entry_id: e_id,
             rep_id,
             state,
@@ -217,13 +226,18 @@ fn restore_error_to_response(
                 })),
             )
         }
-        ClipboardRestoreError::Internal(message) => {
-            tracing::error!(
-                entry_id = %entry_id,
-                error = %message,
-                "daemon restore failed (internal)"
+        E::Internal(message) => {
+            log_facade_failure(
+                "clipboard_restore",
+                op,
+                "internal",
+                StatusCode::INTERNAL_SERVER_ERROR,
+                &format!("entry {entry_id} restore failed: {message}"),
             );
-            internal_error(anyhow::anyhow!(message))
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": "internal_error"})),
+            )
         }
     }
 }
@@ -235,28 +249,41 @@ async fn status(State(state): State<DaemonApiState>) -> impl IntoResponse {
 async fn peers(State(state): State<DaemonApiState>) -> impl IntoResponse {
     match state.peer_snapshots().await {
         Ok(response) => Json(response).into_response(),
-        Err(error) => internal_error(error).into_response(),
+        Err(error) => internal_error("peers", error).into_response(),
     }
 }
 
 async fn paired_devices(State(state): State<DaemonApiState>) -> impl IntoResponse {
     match state.paired_devices().await {
         Ok(response) => Json(response).into_response(),
-        Err(error) => internal_error(error).into_response(),
+        Err(error) => internal_error("paired_devices", error).into_response(),
     }
 }
 
 async fn refresh_presence(State(state): State<DaemonApiState>) -> impl IntoResponse {
     match state.refresh_presence().await {
         Ok(response) => Json(response).into_response(),
-        Err(error) => internal_error(error).into_response(),
+        Err(error) => internal_error("refresh_presence", error).into_response(),
     }
 }
 
-/// NOTE: Individual API handlers now use `ApiError::unauthorized()` directly.
-/// This helper is kept for backward compatibility with the security middleware layer.
-pub(crate) fn internal_error(error: anyhow::Error) -> (StatusCode, Json<serde_json::Value>) {
-    tracing::error!(error = %error, "daemon API request failed");
+/// Legacy 500 兜底，供尚未迁到 `ApiError` 的 handler（peers / paired_devices /
+/// refresh_presence / storage / lifecycle / blob fallback 等）使用。
+///
+/// 每个调用点必须传入 `op` 名，以便 Sentry 按 `facade="daemon_api"` + op 分桶；
+/// 不要把这个 helper 当成"全场兜底"——新 handler 应直接用 `ApiError` 与
+/// 域 facade 的 `log_facade_failure` 调用。
+pub(crate) fn internal_error(
+    op: &'static str,
+    error: anyhow::Error,
+) -> (StatusCode, Json<serde_json::Value>) {
+    log_facade_failure(
+        "daemon_api",
+        op,
+        "internal",
+        StatusCode::INTERNAL_SERVER_ERROR,
+        &error.to_string(),
+    );
     (
         StatusCode::INTERNAL_SERVER_ERROR,
         Json(json!({"error": "internal_error"})),
@@ -280,7 +307,8 @@ mod tests {
 
     #[test]
     fn restore_not_found_returns_404() {
-        let (status, body) = restore_error_to_response(ClipboardRestoreError::NotFound, "entry-1");
+        let (status, body) =
+            restore_error_to_response("restore_entry", ClipboardRestoreError::NotFound, "entry-1");
         assert_eq!(status, StatusCode::NOT_FOUND);
         assert_eq!(body_value(body), json!({"error": "not_found"}));
     }
@@ -288,6 +316,7 @@ mod tests {
     #[test]
     fn restore_payload_unavailable_returns_410_with_full_context() {
         let (status, body) = restore_error_to_response(
+            "restore_entry",
             ClipboardRestoreError::PayloadUnavailable {
                 entry_id: "entry-1".to_string(),
                 rep_id: "rep-2".to_string(),
@@ -311,6 +340,7 @@ mod tests {
     #[test]
     fn restore_payload_unavailable_with_orphaned_state_uses_state_string_verbatim() {
         let (status, body) = restore_error_to_response(
+            "restore_entry",
             ClipboardRestoreError::PayloadUnavailable {
                 entry_id: "e".to_string(),
                 rep_id: "r".to_string(),
@@ -326,6 +356,7 @@ mod tests {
     #[test]
     fn restore_internal_returns_500_with_generic_body() {
         let (status, body) = restore_error_to_response(
+            "restore_entry",
             ClipboardRestoreError::Internal("write coordinator deadlocked".to_string()),
             "entry-3",
         );
@@ -336,7 +367,7 @@ mod tests {
 
     #[test]
     fn internal_error_returns_500_with_generic_body() {
-        let (status, body) = internal_error(anyhow::anyhow!("boom"));
+        let (status, body) = internal_error("test_op", anyhow::anyhow!("boom"));
         assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
         assert_eq!(body_value(body), json!({"error": "internal_error"}));
     }

--- a/src-tauri/crates/uc-webserver/src/api/search.rs
+++ b/src-tauri/crates/uc-webserver/src/api/search.rs
@@ -17,7 +17,7 @@ use uc_application::facade::{
 };
 use uc_daemon_contract::constants::http_route;
 
-use crate::api::dto::error::ApiError;
+use crate::api::dto::error::{log_facade_failure, ApiError};
 use crate::api::dto::search::{
     SearchQueryResponse, SearchRebuildAcceptedData, SearchRebuildAcceptedResponse, SearchResultDto,
     SearchStatusData, SearchStatusResponse,
@@ -89,11 +89,17 @@ fn search_input_from_params(params: SearchQueryParams) -> SearchQueryInput {
 /// Returns `Err(session_locked ApiError)` if the encryption session is not ready.
 async fn require_encryption_ready(state: &DaemonApiState) -> Result<(), ApiError> {
     let app_facade = state.app_facade_or_error()?;
-    let encryption_state = app_facade
-        .encryption
-        .state()
-        .await
-        .map_err(|e| ApiError::internal(format!("encryption state unavailable: {e}")))?;
+    let encryption_state = app_facade.encryption.state().await.map_err(|e| {
+        let api = ApiError::internal(format!("encryption state unavailable: {e}"));
+        log_facade_failure(
+            "encryption",
+            "encryption_state_probe",
+            "call_failed",
+            api.status,
+            &api.message,
+        );
+        api
+    })?;
     if !encryption_state.session_ready {
         return Err(ApiError {
             status: StatusCode::LOCKED,
@@ -140,7 +146,11 @@ async fn search_query_handler(
     let input = search_input_from_params(params);
     debug!(query = %input.query, "dispatching search query through app facade");
 
-    let page = app.search.query(input).await.map_err(map_search_error)?;
+    let page = app
+        .search
+        .query(input)
+        .await
+        .map_err(|e| map_search_error("search_query", e))?;
 
     let result_count = page.items.len();
     let total = page.total;
@@ -173,7 +183,11 @@ async fn search_status_handler(
     require_encryption_ready(&state).await?;
 
     let app = state.app_facade_or_error()?;
-    let view = app.search.status().await.map_err(map_search_error)?;
+    let view = app
+        .search
+        .status()
+        .await
+        .map_err(|e| map_search_error("search_status", e))?;
 
     debug!(
         state = %view.state,
@@ -203,7 +217,7 @@ async fn search_rebuild_handler(
         .search
         .request_rebuild()
         .await
-        .map_err(map_search_error)?;
+        .map_err(|e| map_search_error("search_rebuild", e))?;
 
     info!("manual search index rebuild accepted");
     Ok((
@@ -221,44 +235,68 @@ async fn search_rebuild_handler(
 // Error mapping
 // ---------------------------------------------------------------------------
 
-fn map_search_error(error: SearchFacadeError) -> ApiError {
-    match error {
-        SearchFacadeError::InvalidQuery(message) => ApiError {
-            status: StatusCode::BAD_REQUEST,
-            code: "invalid_query".to_string(),
-            message,
-        },
-        SearchFacadeError::BadRequest(message) => ApiError {
-            status: StatusCode::BAD_REQUEST,
-            code: "bad_request".to_string(),
-            message,
-        },
-        SearchFacadeError::SessionLocked => ApiError {
-            status: StatusCode::LOCKED,
-            code: "session_locked".to_string(),
-            message: "encryption session is locked".to_string(),
-        },
-        SearchFacadeError::IndexNotReady => ApiError {
-            status: StatusCode::SERVICE_UNAVAILABLE,
-            code: "index_not_ready".to_string(),
-            message: "search index not ready".to_string(),
-        },
-        SearchFacadeError::IndexUnavailable => ApiError {
-            status: StatusCode::SERVICE_UNAVAILABLE,
-            code: "index_unavailable".to_string(),
-            message: "search index unavailable".to_string(),
-        },
-        SearchFacadeError::ServiceUnavailable(message) => ApiError::service_unavailable(message),
-        SearchFacadeError::RebuildAlreadyRunning => {
-            debug!("manual rebuild rejected — already in progress");
+fn map_search_error(op: &'static str, error: SearchFacadeError) -> ApiError {
+    use SearchFacadeError as E;
+    let (variant, api): (&'static str, ApiError) = match error {
+        E::InvalidQuery(message) => (
+            "invalid_query",
             ApiError {
-                status: StatusCode::CONFLICT,
-                code: "rebuild_already_running".to_string(),
-                message: "a rebuild is already in progress".to_string(),
-            }
+                status: StatusCode::BAD_REQUEST,
+                code: "invalid_query".to_string(),
+                message,
+            },
+        ),
+        E::BadRequest(message) => (
+            "bad_request",
+            ApiError {
+                status: StatusCode::BAD_REQUEST,
+                code: "bad_request".to_string(),
+                message,
+            },
+        ),
+        E::SessionLocked => (
+            "session_locked",
+            ApiError {
+                status: StatusCode::LOCKED,
+                code: "session_locked".to_string(),
+                message: "encryption session is locked".to_string(),
+            },
+        ),
+        E::IndexNotReady => (
+            "index_not_ready",
+            ApiError {
+                status: StatusCode::SERVICE_UNAVAILABLE,
+                code: "index_not_ready".to_string(),
+                message: "search index not ready".to_string(),
+            },
+        ),
+        E::IndexUnavailable => (
+            "index_unavailable",
+            ApiError {
+                status: StatusCode::SERVICE_UNAVAILABLE,
+                code: "index_unavailable".to_string(),
+                message: "search index unavailable".to_string(),
+            },
+        ),
+        E::ServiceUnavailable(message) => (
+            "service_unavailable",
+            ApiError::service_unavailable(message),
+        ),
+        E::RebuildAlreadyRunning => {
+            debug!("manual rebuild rejected — already in progress");
+            (
+                "rebuild_already_running",
+                ApiError {
+                    status: StatusCode::CONFLICT,
+                    code: "rebuild_already_running".to_string(),
+                    message: "a rebuild is already in progress".to_string(),
+                },
+            )
         }
-        SearchFacadeError::Internal(message) => ApiError::internal(message),
-    }
+        E::Internal(message) => ("internal", ApiError::internal(message)),
+    };
+    log_facade_failure("search", op, variant, api.status, &api.message);
+    api
 }
 
 fn search_status_to_dto(view: SearchStatusView) -> SearchStatusData {

--- a/src-tauri/crates/uc-webserver/src/api/server.rs
+++ b/src-tauri/crates/uc-webserver/src/api/server.rs
@@ -242,49 +242,22 @@ pub(crate) async fn request_tracing_middleware(request: Request<Body>, next: Nex
     };
 
     match level_action {
-        // 5xx splitted by status — Sentry groups events by message template, so
-        // emitting a per-status static message+error_kind lets timeout, upstream-
-        // unavailable, and internal-error 5xx fingerprint into separate issues
-        // instead of drowning in one mega-group (see UNICLIPBOARD-RUST-5: 61
-        // events that turned out to mix 500 client bugs and 503 backend outage).
-        "server_error" => match status.as_u16() {
-            503 => tracing::error!(
-                request_id = %request_id,
-                method = %method,
-                path = %path,
-                status = 503u16,
-                elapsed_ms,
-                error_kind = "upstream_unavailable",
-                "daemon http upstream unavailable"
-            ),
-            504 => tracing::error!(
-                request_id = %request_id,
-                method = %method,
-                path = %path,
-                status = 504u16,
-                elapsed_ms,
-                error_kind = "gateway_timeout",
-                "daemon http gateway timeout"
-            ),
-            500 => tracing::error!(
-                request_id = %request_id,
-                method = %method,
-                path = %path,
-                status = 500u16,
-                elapsed_ms,
-                error_kind = "internal_error",
-                "daemon http handler internal error"
-            ),
-            code => tracing::error!(
-                request_id = %request_id,
-                method = %method,
-                path = %path,
-                status = code,
-                elapsed_ms,
-                error_kind = "server_error_other",
-                "daemon http server error (other 5xx)"
-            ),
-        },
+        // Access-log echo only — root cause lives in the handler that mapped
+        // the facade error to ApiError, not here. Earlier UNICLIPBOARD-RUST-5
+        // tried to fingerprint 5xx by status code, but a per-status static
+        // template ("daemon http upstream unavailable" etc.) is just a reskin
+        // of the HTTP status — it carries no signal beyond `status` itself
+        // and crowds out the real ERROR emitted upstream. Keep this at WARN
+        // so the Log channel still has a query handle for 5xx rate, but stop
+        // creating Sentry Issues from a layer that doesn't know the cause.
+        "server_error" => tracing::warn!(
+            request_id = %request_id,
+            method = %method,
+            path = %path,
+            status = status.as_u16(),
+            elapsed_ms,
+            "daemon http response 5xx"
+        ),
         "client_error" => tracing::warn!(
             request_id = %request_id,
             method = %method,

--- a/src-tauri/crates/uc-webserver/src/api/settings.rs
+++ b/src-tauri/crates/uc-webserver/src/api/settings.rs
@@ -12,7 +12,7 @@ use tracing::{info, instrument};
 use uc_application::facade::settings as app_settings;
 use utoipa;
 
-use crate::api::dto::error::ApiError;
+use crate::api::dto::error::{log_facade_failure, ApiError};
 use crate::api::dto::settings::{
     ContentTypesDto, ContentTypesPatchDto, FileSyncSettingsDto, GeneralSettingsDto,
     GetSettingsResponse, KeyboardShortcutsPatchDto, NetworkSettingsDto, PairingSettingsDto,
@@ -44,7 +44,11 @@ async fn get_settings_handler(
 ) -> Result<Json<GetSettingsResponse>, ApiError> {
     info!("get settings request received");
     let app = state.app_facade_or_error()?;
-    let settings = app.settings.get().await.map_err(settings_error_to_api)?;
+    let settings = app
+        .settings
+        .get()
+        .await
+        .map_err(|e| settings_error_to_api("get_settings", e))?;
 
     info!("get settings succeeded");
     Ok(Json(GetSettingsResponse {
@@ -119,7 +123,7 @@ async fn update_settings_handler(
         .settings
         .update(settings_patch_from_dto(payload))
         .await
-        .map_err(settings_error_to_api)?;
+        .map_err(|e| settings_error_to_api("update_settings", e))?;
 
     if let Some(enabled) = telemetry_update {
         uc_observability::set_telemetry_enabled(enabled);
@@ -137,9 +141,20 @@ async fn update_settings_handler(
     }))
 }
 
-fn settings_error_to_api(err: app_settings::SettingsFacadeError) -> ApiError {
-    tracing::error!(error = %err, "settings facade failed");
-    ApiError::internal(err.to_string())
+fn settings_error_to_api(op: &'static str, err: app_settings::SettingsFacadeError) -> ApiError {
+    use app_settings::SettingsFacadeError as E;
+    let (variant, api): (&'static str, ApiError) = match err {
+        E::Load(msg) => (
+            "load",
+            ApiError::internal(format!("failed to load settings: {msg}")),
+        ),
+        E::Save(msg) => (
+            "save",
+            ApiError::internal(format!("failed to save settings: {msg}")),
+        ),
+    };
+    log_facade_failure("settings", op, variant, api.status, &api.message);
+    api
 }
 
 #[doc(hidden)]

--- a/src-tauri/crates/uc-webserver/src/api/storage.rs
+++ b/src-tauri/crates/uc-webserver/src/api/storage.rs
@@ -64,8 +64,7 @@ async fn get_storage_stats_handler(State(state): State<DaemonApiState>) -> impl 
     let result = match app.storage.stats().await {
         Ok(r) => r,
         Err(e) => {
-            tracing::error!(error = %e, "Failed to compute storage stats");
-            return internal_error(anyhow::anyhow!("{}", e)).into_response();
+            return internal_error("storage_stats", anyhow::anyhow!("{}", e)).into_response();
         }
     };
 
@@ -138,9 +137,6 @@ async fn clear_cache_handler(
             )
             .into_response()
         }
-        Err(e) => {
-            tracing::error!(error = %e, "Failed to clear cache");
-            internal_error(anyhow::anyhow!("{}", e)).into_response()
-        }
+        Err(e) => internal_error("storage_clear_cache", anyhow::anyhow!("{}", e)).into_response(),
     }
 }

--- a/src-tauri/crates/uc-webserver/src/api/upgrade.rs
+++ b/src-tauri/crates/uc-webserver/src/api/upgrade.rs
@@ -21,7 +21,7 @@ use uc_daemon_contract::api::dto::upgrade::{
     AckUpgradePayload, AckUpgradeResponse, GetUpgradeStatusResponse, UpgradeStatusDto,
 };
 
-use crate::api::dto::error::ApiError;
+use crate::api::dto::error::{log_facade_failure, ApiError};
 use crate::api::server::DaemonApiState;
 
 /// Build version reported to the upgrade facade. Workspace-versioned and
@@ -105,11 +105,43 @@ fn status_to_dto(status: UpgradeStatus) -> UpgradeStatusDto {
 }
 
 fn detect_error_to_api(err: DetectUpgradeError) -> ApiError {
-    tracing::error!(error = %err, "upgrade detect failed");
-    ApiError::internal(err.to_string())
+    use DetectUpgradeError as E;
+    let (variant, api): (&'static str, ApiError) = match err {
+        E::CurrentVersionMalformed(msg) => (
+            "current_version_malformed",
+            ApiError::internal(format!("current build version malformed: {msg}")),
+        ),
+        E::ReadCursor(msg) => (
+            "read_cursor",
+            ApiError::internal(format!("read app version cursor failed: {msg}")),
+        ),
+        E::ReadSetupStatus(msg) => (
+            "read_setup_status",
+            ApiError::internal(format!("read setup status failed: {msg}")),
+        ),
+    };
+    log_facade_failure(
+        "upgrade",
+        "detect_on_startup",
+        variant,
+        api.status,
+        &api.message,
+    );
+    api
 }
 
 fn ack_error_to_api(err: AcknowledgeUpgradeError) -> ApiError {
-    tracing::error!(error = %err, "upgrade acknowledge failed");
-    ApiError::internal(err.to_string())
+    use AcknowledgeUpgradeError as E;
+    let (variant, api): (&'static str, ApiError) = match err {
+        E::CurrentVersionMalformed(msg) => (
+            "current_version_malformed",
+            ApiError::internal(format!("current build version malformed: {msg}")),
+        ),
+        E::WriteCursor(msg) => (
+            "write_cursor",
+            ApiError::internal(format!("write app version cursor failed: {msg}")),
+        ),
+    };
+    log_facade_failure("upgrade", "acknowledge", variant, api.status, &api.message);
+    api
 }

--- a/src-tauri/crates/uc-webserver/src/api/v2/setup.rs
+++ b/src-tauri/crates/uc-webserver/src/api/v2/setup.rs
@@ -29,7 +29,7 @@ use uc_daemon_contract::api::dto::v2::setup::{
 };
 use uc_daemon_contract::constants::http_route_v2;
 
-use crate::api::dto::error::ApiError;
+use crate::api::dto::error::{log_facade_failure, ApiError};
 use crate::api::server::DaemonApiState;
 
 pub fn router() -> Router<DaemonApiState> {
@@ -135,25 +135,45 @@ pub(crate) async fn issue_invitation(
     State(state): State<DaemonApiState>,
 ) -> Result<Json<IssueInvitationResponse>, ApiError> {
     let facade = require_facade(&state)?;
-    let out = facade.issue_pairing_invitation().await.map_err(|err| {
-        use uc_application::facade::IssuePairingInvitationError as E;
-        match err {
-            E::NetworkNotStarted => ApiError::service_unavailable("network is not started"),
-            E::ServiceUnavailable => {
-                ApiError::service_unavailable("pairing invitation service unavailable")
-            }
-            // `AddressNotAvailable` is only emitted by the dev-only
-            // `issue_pairing_invitation_for_address` path. The webserver
-            // never calls that path; collapse to Internal so a future
-            // regression surfaces in logs instead of being silently
-            // mapped to a misleading 400.
-            E::AddressNotAvailable(ip) => ApiError::internal(format!(
+    let out = facade
+        .issue_pairing_invitation()
+        .await
+        .map_err(map_issue_err)?;
+    Ok(Json(issue_to_dto(out)))
+}
+
+fn map_issue_err(err: uc_application::facade::IssuePairingInvitationError) -> ApiError {
+    use uc_application::facade::IssuePairingInvitationError as E;
+    let (variant, api): (&'static str, ApiError) = match err {
+        E::NetworkNotStarted => (
+            "network_not_started",
+            ApiError::service_unavailable("network is not started"),
+        ),
+        E::ServiceUnavailable => (
+            "service_unavailable",
+            ApiError::service_unavailable("pairing invitation service unavailable"),
+        ),
+        // `AddressNotAvailable` is only emitted by the dev-only
+        // `issue_pairing_invitation_for_address` path. The webserver
+        // never calls that path; collapse to Internal so a future
+        // regression surfaces in logs instead of being silently
+        // mapped to a misleading 400.
+        E::AddressNotAvailable(ip) => (
+            "address_not_available",
+            ApiError::internal(format!(
                 "unexpected AddressNotAvailable({ip}) on default path"
             )),
-            E::Internal(msg) => ApiError::internal(msg),
-        }
-    })?;
-    Ok(Json(issue_to_dto(out)))
+        ),
+        E::Internal(msg) => ("internal", ApiError::internal(msg)),
+    };
+    log_facade_failure(
+        "space_setup",
+        "issue_pairing_invitation",
+        variant,
+        api.status,
+        &api.message,
+    );
+    api
 }
 
 fn issue_to_dto(out: IssuePairingInvitationResult) -> IssueInvitationResponse {
@@ -198,26 +218,69 @@ pub(crate) async fn redeem(
 
 fn map_redeem_err(err: RedeemPairingInvitationError) -> ApiError {
     use RedeemPairingInvitationError as E;
-    match err {
-        E::InvitationNotFound => ApiError::not_found("invitation not found"),
-        E::InvitationExpired => ApiError::not_found("invitation has expired"),
-        E::SponsorUnreachable => ApiError::service_unavailable("sponsor is not reachable"),
-        E::ServiceUnavailable => {
-            ApiError::service_unavailable("pairing invitation service unavailable")
-        }
-        E::PassphraseMismatch => ApiError::bad_request("wrong passphrase"),
-        E::CorruptedKeyMaterial => ApiError::internal("space key material corrupted"),
-        E::DeviceNameRequired => ApiError::bad_request("device name is required"),
-        E::SponsorRejectedInvitation => {
-            ApiError::conflict("sponsor did not recognise the invitation code")
-        }
-        E::SponsorDeclined => ApiError::conflict("sponsor declined the pairing request"),
-        E::SponsorTimedOut => ApiError::service_unavailable("sponsor timed out the handshake"),
-        E::SponsorInternal(msg) => ApiError::internal(format!("sponsor internal error: {msg}")),
-        E::Timeout => ApiError::service_unavailable("pairing handshake timed out"),
-        E::ConnectionLost => ApiError::service_unavailable("connection lost mid-handshake"),
-        E::Internal(msg) => ApiError::internal(msg),
-    }
+    let (variant, api): (&'static str, ApiError) = match err {
+        E::InvitationNotFound => (
+            "invitation_not_found",
+            ApiError::not_found("invitation not found"),
+        ),
+        E::InvitationExpired => (
+            "invitation_expired",
+            ApiError::not_found("invitation has expired"),
+        ),
+        E::SponsorUnreachable => (
+            "sponsor_unreachable",
+            ApiError::service_unavailable("sponsor is not reachable"),
+        ),
+        E::ServiceUnavailable => (
+            "service_unavailable",
+            ApiError::service_unavailable("pairing invitation service unavailable"),
+        ),
+        E::PassphraseMismatch => (
+            "passphrase_mismatch",
+            ApiError::bad_request("wrong passphrase"),
+        ),
+        E::CorruptedKeyMaterial => (
+            "corrupted_key_material",
+            ApiError::internal("space key material corrupted"),
+        ),
+        E::DeviceNameRequired => (
+            "device_name_required",
+            ApiError::bad_request("device name is required"),
+        ),
+        E::SponsorRejectedInvitation => (
+            "sponsor_rejected_invitation",
+            ApiError::conflict("sponsor did not recognise the invitation code"),
+        ),
+        E::SponsorDeclined => (
+            "sponsor_declined",
+            ApiError::conflict("sponsor declined the pairing request"),
+        ),
+        E::SponsorTimedOut => (
+            "sponsor_timed_out",
+            ApiError::service_unavailable("sponsor timed out the handshake"),
+        ),
+        E::SponsorInternal(msg) => (
+            "sponsor_internal",
+            ApiError::internal(format!("sponsor internal error: {msg}")),
+        ),
+        E::Timeout => (
+            "timeout",
+            ApiError::service_unavailable("pairing handshake timed out"),
+        ),
+        E::ConnectionLost => (
+            "connection_lost",
+            ApiError::service_unavailable("connection lost mid-handshake"),
+        ),
+        E::Internal(msg) => ("internal", ApiError::internal(msg)),
+    };
+    log_facade_failure(
+        "space_setup",
+        "redeem_pairing_invitation",
+        variant,
+        api.status,
+        &api.message,
+    );
+    api
 }
 
 fn redeem_to_dto(out: RedeemPairingInvitationResult) -> RedeemResponse {
@@ -349,39 +412,89 @@ pub(crate) async fn switch_space(
 
 fn map_switch_space_err(err: SwitchSpaceError) -> ApiError {
     use SwitchSpaceError as E;
-    match err {
-        E::NotSetup => ApiError::conflict(
-            "this device has not completed first-time setup yet; use /v2/setup/initialize \
-             or /v2/setup/redeem first",
+    let (variant, api): (&'static str, ApiError) = match err {
+        E::NotSetup => (
+            "not_setup",
+            ApiError::conflict(
+                "this device has not completed first-time setup yet; use /v2/setup/initialize \
+                 or /v2/setup/redeem first",
+            ),
         ),
-        E::PendingMigration(_) => ApiError::conflict(
-            "a previous switch-space migration is still in flight; restart the daemon to \
-             auto-resume, or call /v2/setup/reset to abandon",
+        E::PendingMigration(_) => (
+            "pending_migration",
+            ApiError::conflict(
+                "a previous switch-space migration is still in flight; restart the daemon to \
+                 auto-resume, or call /v2/setup/reset to abandon",
+            ),
         ),
-        E::NotUnlocked => {
-            ApiError::conflict("space session is locked; unlock the current space before switching")
-        }
-        E::InvitationNotFound => ApiError::not_found("invitation not found"),
-        E::InvitationExpired => ApiError::not_found("invitation has expired"),
-        E::SponsorUnreachable => ApiError::service_unavailable("sponsor is not reachable"),
-        E::ServiceUnavailable => {
-            ApiError::service_unavailable("pairing invitation service unavailable")
-        }
-        E::PassphraseMismatch => ApiError::bad_request("wrong passphrase"),
-        E::CorruptedKeyMaterial => ApiError::internal("space key material corrupted"),
-        E::DeviceNameRequired => ApiError::bad_request("device name is required"),
-        E::SponsorRejectedInvitation => {
-            ApiError::conflict("sponsor did not recognise the invitation code")
-        }
-        E::SponsorDeclined => ApiError::conflict("sponsor declined the pairing request"),
-        E::Timeout => ApiError::service_unavailable("handshake timed out"),
-        E::ConnectionLost => ApiError::service_unavailable("connection lost mid-handshake"),
-        E::InvalidCiphertext => {
-            ApiError::internal("backup record decryption failed (corrupted ciphertext)")
-        }
-        E::Storage(msg) => ApiError::internal(format!("storage failure: {msg}")),
-        E::Internal(msg) => ApiError::internal(msg),
-    }
+        E::NotUnlocked => (
+            "not_unlocked",
+            ApiError::conflict(
+                "space session is locked; unlock the current space before switching",
+            ),
+        ),
+        E::InvitationNotFound => (
+            "invitation_not_found",
+            ApiError::not_found("invitation not found"),
+        ),
+        E::InvitationExpired => (
+            "invitation_expired",
+            ApiError::not_found("invitation has expired"),
+        ),
+        E::SponsorUnreachable => (
+            "sponsor_unreachable",
+            ApiError::service_unavailable("sponsor is not reachable"),
+        ),
+        E::ServiceUnavailable => (
+            "service_unavailable",
+            ApiError::service_unavailable("pairing invitation service unavailable"),
+        ),
+        E::PassphraseMismatch => (
+            "passphrase_mismatch",
+            ApiError::bad_request("wrong passphrase"),
+        ),
+        E::CorruptedKeyMaterial => (
+            "corrupted_key_material",
+            ApiError::internal("space key material corrupted"),
+        ),
+        E::DeviceNameRequired => (
+            "device_name_required",
+            ApiError::bad_request("device name is required"),
+        ),
+        E::SponsorRejectedInvitation => (
+            "sponsor_rejected_invitation",
+            ApiError::conflict("sponsor did not recognise the invitation code"),
+        ),
+        E::SponsorDeclined => (
+            "sponsor_declined",
+            ApiError::conflict("sponsor declined the pairing request"),
+        ),
+        E::Timeout => (
+            "timeout",
+            ApiError::service_unavailable("handshake timed out"),
+        ),
+        E::ConnectionLost => (
+            "connection_lost",
+            ApiError::service_unavailable("connection lost mid-handshake"),
+        ),
+        E::InvalidCiphertext => (
+            "invalid_ciphertext",
+            ApiError::internal("backup record decryption failed (corrupted ciphertext)"),
+        ),
+        E::Storage(msg) => (
+            "storage",
+            ApiError::internal(format!("storage failure: {msg}")),
+        ),
+        E::Internal(msg) => ("internal", ApiError::internal(msg)),
+    };
+    log_facade_failure(
+        "space_setup",
+        "switch_space",
+        variant,
+        api.status,
+        &api.message,
+    );
+    api
 }
 
 fn switch_space_to_dto(out: SwitchSpaceResult) -> SwitchSpaceResponse {

--- a/src-tauri/crates/uc-webserver/src/api/v2/setup.rs
+++ b/src-tauri/crates/uc-webserver/src/api/v2/setup.rs
@@ -91,22 +91,35 @@ pub(crate) async fn initialize(
 }
 
 fn map_init_err(err: InitializeSpaceError) -> ApiError {
-    match err {
-        InitializeSpaceError::PassphraseMismatch => {
-            ApiError::bad_request("passphrase and confirmation do not match")
-        }
-        InitializeSpaceError::DeviceNameRequired => {
-            ApiError::bad_request("device name is required")
-        }
-        InitializeSpaceError::AlreadyInitialized => {
-            ApiError::conflict("space is already initialised")
-        }
-        InitializeSpaceError::AlreadySetup => {
-            ApiError::conflict("setup has already been completed on this device")
-        }
-        InitializeSpaceError::StorageFailed(msg) => ApiError::internal(msg),
-        InitializeSpaceError::Internal(msg) => ApiError::internal(msg),
-    }
+    use InitializeSpaceError as E;
+    let (variant, api): (&'static str, ApiError) = match err {
+        E::PassphraseMismatch => (
+            "passphrase_mismatch",
+            ApiError::bad_request("passphrase and confirmation do not match"),
+        ),
+        E::DeviceNameRequired => (
+            "device_name_required",
+            ApiError::bad_request("device name is required"),
+        ),
+        E::AlreadyInitialized => (
+            "already_initialized",
+            ApiError::conflict("space is already initialised"),
+        ),
+        E::AlreadySetup => (
+            "already_setup",
+            ApiError::conflict("setup has already been completed on this device"),
+        ),
+        E::StorageFailed(msg) => ("storage_failed", ApiError::internal(msg)),
+        E::Internal(msg) => ("internal", ApiError::internal(msg)),
+    };
+    log_facade_failure(
+        "space_setup",
+        "initialize_space",
+        variant,
+        api.status,
+        &api.message,
+    );
+    api
 }
 
 fn initialize_to_dto(out: InitializeSpaceResult) -> InitializeSpaceResponse {
@@ -310,11 +323,27 @@ fn redeem_to_dto(out: RedeemPairingInvitationResult) -> RedeemResponse {
 )]
 pub(crate) async fn cancel(State(state): State<DaemonApiState>) -> Result<StatusCode, ApiError> {
     let facade = require_facade(&state)?;
-    facade.cancel_invitation().await.map_err(|err| match err {
-        CancelInvitationError::NotIssued => ApiError::conflict("no in-flight invitation to cancel"),
-        CancelInvitationError::Internal(msg) => ApiError::internal(msg),
-    })?;
+    facade.cancel_invitation().await.map_err(map_cancel_err)?;
     Ok(StatusCode::NO_CONTENT)
+}
+
+fn map_cancel_err(err: CancelInvitationError) -> ApiError {
+    use CancelInvitationError as E;
+    let (variant, api): (&'static str, ApiError) = match err {
+        E::NotIssued => (
+            "not_issued",
+            ApiError::conflict("no in-flight invitation to cancel"),
+        ),
+        E::Internal(msg) => ("internal", ApiError::internal(msg)),
+    };
+    log_facade_failure(
+        "space_setup",
+        "cancel_invitation",
+        variant,
+        api.status,
+        &api.message,
+    );
+    api
 }
 
 // ---------------------------------------------------------------------------
@@ -333,11 +362,18 @@ pub(crate) async fn cancel(State(state): State<DaemonApiState>) -> Result<Status
 )]
 pub(crate) async fn reset(State(state): State<DaemonApiState>) -> Result<StatusCode, ApiError> {
     let facade = require_facade(&state)?;
-    facade.reset().await.map_err(|err| match err {
-        ResetSpaceError::StorageFailed(msg) => ApiError::internal(msg),
-        ResetSpaceError::Internal(msg) => ApiError::internal(msg),
-    })?;
+    facade.reset().await.map_err(map_reset_err)?;
     Ok(StatusCode::NO_CONTENT)
+}
+
+fn map_reset_err(err: ResetSpaceError) -> ApiError {
+    use ResetSpaceError as E;
+    let (variant, api): (&'static str, ApiError) = match err {
+        E::StorageFailed(msg) => ("storage_failed", ApiError::internal(msg)),
+        E::Internal(msg) => ("internal", ApiError::internal(msg)),
+    };
+    log_facade_failure("space_setup", "reset", variant, api.status, &api.message);
+    api
 }
 
 // ---------------------------------------------------------------------------
@@ -358,11 +394,27 @@ pub(crate) async fn get_state(
     State(state): State<DaemonApiState>,
 ) -> Result<Json<SetupStateResponse>, ApiError> {
     let facade = require_facade(&state)?;
-    let view = facade.query_setup_state().await.map_err(|err| match err {
-        QuerySetupStateError::StorageFailed(msg) => ApiError::internal(msg),
-        QuerySetupStateError::Internal(msg) => ApiError::internal(msg),
-    })?;
+    let view = facade
+        .query_setup_state()
+        .await
+        .map_err(map_query_setup_state_err)?;
     Ok(Json(state_to_dto(view)))
+}
+
+fn map_query_setup_state_err(err: QuerySetupStateError) -> ApiError {
+    use QuerySetupStateError as E;
+    let (variant, api): (&'static str, ApiError) = match err {
+        E::StorageFailed(msg) => ("storage_failed", ApiError::internal(msg)),
+        E::Internal(msg) => ("internal", ApiError::internal(msg)),
+    };
+    log_facade_failure(
+        "space_setup",
+        "query_setup_state",
+        variant,
+        api.status,
+        &api.message,
+    );
+    api
 }
 
 fn state_to_dto(view: SetupStateView) -> SetupStateResponse {
@@ -529,11 +581,24 @@ pub(crate) async fn query_migration_progress(
     let progress = facade
         .query_migration_progress()
         .await
-        .map_err(|err| match err {
-            QueryMigrationProgressError::StorageFailed(msg) => ApiError::internal(msg),
-            QueryMigrationProgressError::Internal(msg) => ApiError::internal(msg),
-        })?;
+        .map_err(map_query_migration_progress_err)?;
     Ok(Json(migration_progress_to_dto(progress)))
+}
+
+fn map_query_migration_progress_err(err: QueryMigrationProgressError) -> ApiError {
+    use QueryMigrationProgressError as E;
+    let (variant, api): (&'static str, ApiError) = match err {
+        E::StorageFailed(msg) => ("storage_failed", ApiError::internal(msg)),
+        E::Internal(msg) => ("internal", ApiError::internal(msg)),
+    };
+    log_facade_failure(
+        "space_setup",
+        "query_migration_progress",
+        variant,
+        api.status,
+        &api.message,
+    );
+    api
 }
 
 fn migration_progress_to_dto(progress: MigrationProgress) -> MigrationProgressResponse {


### PR DESCRIPTION
## Summary

- **Before**: every 5xx surfaced in Sentry collapsed into one or two mega-groups (`daemon http upstream unavailable`, `daemon API request failed`) keyed off the middleware's generic message, because by the time the middleware saw the response the cause chain had already been flattened into a `String` inside `ApiError`.
- **After**: every webserver handler that maps a typed facade error onto a 5xx now emits a structured `ERROR` event at the **mapping point** with `facade / op / error_variant / status` attributes. Sentry can bucket distinct failure modes (`SponsorUnreachable`, `IndexUnavailable`, `StorageFailed`, …) into distinct Issues instead of collapsing them. (58333dfe, 93583d89)

**Handler coverage** — every facade `map_err` site now routes through `log_facade_failure`:
- pairing / member / search / encryption / clipboard / upgrade / settings / device
- `v2/setup` — all 8 ops (initialize / issue / redeem / cancel / reset / get_state / switch_space / query_migration_progress)

**Legacy `internal_error` cleanup** — the same fake-root-cause pattern existed in pre-`ApiError` handlers (routes / blob / storage / lifecycle). `internal_error(op, err)` now requires an op label; ad-hoc `tracing::error!` lines that produced unstructured ERROR events have been removed. (93583d89)

**Rule固化** — `api/dto/error.rs` gets a why-first module-level `//!` doc block explaining the cause-chain-flattening problem, the required mapper shape, and three anti-patterns (`error_kind` fake-attribute, double-logging, middleware fallback ERROR). New handlers see it on import. (93583d89)

**No docs-site impact** — scanned `docs-site/content/docs/{en,zh}/`; no doc lists HTTP error message wording, log field schema, or Sentry attribute names. Diagnostics privacy doc is unaffected (this PR doesn't change what gets sent, only how it's labelled).

## Test plan

- [x] `cargo test -p uc-webserver --lib` — 61/61 passing
- [x] `cargo check -p uc-webserver` — clean
- [x] sentry-tracing 0.48.1 source verified end-to-end: `FieldVisitor` captures all event KV, `log_from_event` copies `visitor.json_values` into `Log.attributes` with zero filtering, `enrich_log` only inserts namespaced correlation keys (no collision), `before_send_log` `is_sensitive_key` blocklist uses exact-match canonical folding — none of `facade / op / error_variant / status` are on it.
- [ ] **Reviewer sanity check**: skim one mapper per file (e.g. `map_unpair_err` in pairing.rs, `map_search_error` in search.rs) to confirm the `(variant, ApiError)` tuple shape and the `log_facade_failure` call at the end.
- [ ] **Post-merge**: trigger one real 5xx on alpha (e.g. call `/v2/setup/issue-invitation` before joining a network — emits `NetworkNotStarted`) and confirm `facade=space_setup, op=issue_pairing_invitation, error_variant=network_not_started` show up in the Sentry log entry's attributes panel. If `search bar` filtering by `facade:` doesn't work, that's a project-level indexed-attribute setting (Settings → Attribute Indexing), not a code issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized error handling and logging across API endpoints for improved consistency.
  * Standardized error-to-HTTP response mapping with structured logging for better diagnostics.
  * Improved server error logging to provide more consistent feedback on failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/UniClipboard/UniClipboard/pull/683)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->