### PR TITLE
refactor: lift global shortcut management into uc-desktop

### DIFF
--- a/docs-site/content/docs/en/getting-started/install.mdx
+++ b/docs-site/content/docs/en/getting-started/install.mdx
@@ -60,14 +60,12 @@ quit and reopen the app for the change to take effect.
 
 <Tab value="Windows">
 
-Two options on Windows:
+The Windows release ships an NSIS installer
+(`UniClipboard_<version>_x64-setup.exe`). It walks through the standard
+install flow, places shortcuts in the Start Menu, and registers an entry
+under **Settings → Apps** for clean uninstall.
 
-- **MSI installer** — `UniClipboard_<version>_x64_en-US.msi`. Standard
-  installer flow; sets up Start Menu and uninstall entries.
-- **Portable ZIP** — extract anywhere and run `UniClipboard.exe`. No
-  registry writes; useful for USB sticks or locked-down machines.
-
-Both artefacts are code-signed.
+The installer is code-signed.
 
 Download the one you want from the
 [Releases](https://github.com/UniClipboard/UniClipboard/releases) page.

--- a/docs-site/content/docs/en/guides/troubleshooting.mdx
+++ b/docs-site/content/docs/en/guides/troubleshooting.mdx
@@ -389,7 +389,7 @@ keyring's KEK entry will be overwritten by the next `init`.
 1. Quit the GUI; `uniclip stop`.
 2. Uninstall the package:
    - macOS Homebrew: `brew uninstall --cask uniclipboard && brew uninstall uniclipboard`
-   - Windows MSI: Control Panel → Programs & Features → Uninstall
+   - Windows: Settings → Apps → UniClipboard → Uninstall (or Control Panel → Programs & Features)
    - Linux Snap: `sudo snap remove uniclipboard`
    - Linux COPR (dnf): `sudo dnf remove uniclipboard && sudo dnf copr disable mkdir700/uniclipboard-alpha`
    - Linux .deb: `sudo apt remove uniclipboard`

--- a/docs-site/content/docs/zh/getting-started/install.mdx
+++ b/docs-site/content/docs/zh/getting-started/install.mdx
@@ -56,12 +56,10 @@ cask 与 formula 互不冲突，需要的话两个都装即可（GUI + 终端 `u
 
 <Tab value="Windows">
 
-Windows 提供两种形态：
+Windows 发行版本提供 NSIS 安装包（`UniClipboard_<version>_x64-setup.exe`）。
+按标准安装流程一路下一步即可，安装器会写入开始菜单，并在 **设置 → 应用** 下注册卸载项。
 
-- **MSI 安装包** —— `UniClipboard_<version>_x64_en-US.msi`。标准安装流程，会写入开始菜单与卸载项。
-- **便携版 ZIP** —— 解压到任意位置，运行 `UniClipboard.exe`。不写注册表，适合 U 盘或受限环境。
-
-两种产物都已数字签名。
+安装包已数字签名。
 
 按需从
 [Releases](https://github.com/UniClipboard/UniClipboard/releases)

--- a/docs-site/content/docs/zh/guides/troubleshooting.mdx
+++ b/docs-site/content/docs/zh/guides/troubleshooting.mdx
@@ -292,7 +292,7 @@ rm -rf ~/.local/share/app.uniclipboard.desktop
 1. 退出 GUI，`uniclip stop`。
 2. 卸载安装包：
    - macOS Homebrew：`brew uninstall --cask uniclipboard && brew uninstall uniclipboard`
-   - Windows MSI：控制面板 → 程序与功能 → 卸载
+   - Windows：设置 → 应用 → UniClipboard → 卸载（或控制面板 → 程序与功能）
    - Linux Snap：`sudo snap remove uniclipboard`
    - Linux COPR (dnf)：`sudo dnf remove uniclipboard && sudo dnf copr disable mkdir700/uniclipboard-alpha`
    - Linux .deb：`sudo apt remove uniclipboard`

--- a/src-tauri/crates/uc-desktop/src/lib.rs
+++ b/src-tauri/crates/uc-desktop/src/lib.rs
@@ -18,6 +18,7 @@ pub mod bootstrap;
 pub mod daemon;
 pub mod daemon_probe;
 pub mod runtime;
+pub mod shortcuts;
 
 pub use daemon::{DaemonHandle, DaemonOwnership};
 pub use runtime::DesktopRuntime;

--- a/src-tauri/crates/uc-desktop/src/shortcuts.rs
+++ b/src-tauri/crates/uc-desktop/src/shortcuts.rs
@@ -1,0 +1,440 @@
+//! 桌面全局快捷键管理（GUI-framework agnostic）。
+//!
+//! 本模块承载所有 **不依赖任何 GUI 框架** 的快捷键管理逻辑：
+//!
+//! - 快捷键字符串归一化（前端 `meta+ctrl+v` → 物理键 `super+ctrl+v`）
+//! - 从 [`uc_core::settings::model::Settings`] 中解析出快捷面板要注册的快捷键集合
+//! - 当前已注册快捷键集合的状态容器 [`CurrentShortcuts`]
+//! - [`GlobalShortcutRegistry`] trait —— 由具体 GUI shell（例如 `uc-tauri`
+//!   包装 `tauri-plugin-global-shortcut`）实现
+//! - [`update_shortcuts`] 协调函数 —— 注销旧快捷键、注册新快捷键、失败回滚
+//!
+//! 真正调用 OS 注册 API 的"最后一公里"由 shell 实现，本模块只负责协调与
+//! 状态管理。
+
+use std::sync::Mutex;
+
+use thiserror::Error;
+use tracing::{error, warn};
+use uc_core::settings::model::{Settings, ShortcutKey};
+
+/// 快捷面板默认的全局快捷键（物理键格式，与 `tauri-plugin-global-shortcut`
+/// 接受的字符串格式一致）。
+///
+/// - macOS: `Cmd+Ctrl+V`
+/// - Windows / Linux: `Ctrl+Alt+V`
+#[cfg(target_os = "macos")]
+pub const DEFAULT_QUICK_PANEL_SHORTCUT: &str = "super+ctrl+v";
+#[cfg(not(target_os = "macos"))]
+pub const DEFAULT_QUICK_PANEL_SHORTCUT: &str = "ctrl+alt+v";
+
+/// `Settings.keyboard_shortcuts` 中存放"切换快捷面板"快捷键覆盖的键名。
+///
+/// 该键名是跨 shell 共享的约定，前端 `SettingContext` 与所有桌面 shell
+/// 都通过它读取/写入用户自定义的快捷键。
+pub const QUICK_PANEL_SHORTCUT_SETTINGS_KEY: &str = "global.toggleQuickPanel";
+
+/// 全局快捷键注册过程中可能发生的错误。
+///
+/// 注：本错误是面向**协调层**的契约，shell 实现把底层（OS / 插件）错误
+/// 映射成 [`ShortcutError::Backend`] 字符串向上抛。
+#[derive(Debug, Error)]
+pub enum ShortcutError {
+    /// shell 实现（OS API / Tauri 插件等）返回的错误，原文携带。
+    #[error("{0}")]
+    Backend(String),
+}
+
+impl ShortcutError {
+    pub fn backend(msg: impl Into<String>) -> Self {
+        Self::Backend(msg.into())
+    }
+}
+
+/// 当前进程已成功注册到 OS 的快捷键列表。
+///
+/// `update_shortcuts` 完成一轮成功的"卸旧装新"后，调用方负责把新列表
+/// 通过 [`replace`](Self::replace) 写回；任意时刻这里保存的都应该是
+/// **OS 视角的真相**，可被回滚逻辑用来计算 diff。
+pub struct CurrentShortcuts {
+    shortcuts: Mutex<Vec<String>>,
+}
+
+impl CurrentShortcuts {
+    pub fn new(shortcuts: Vec<String>) -> Self {
+        Self {
+            shortcuts: Mutex::new(shortcuts),
+        }
+    }
+
+    /// 返回当前已注册的快捷键克隆副本。
+    pub fn current(&self) -> Vec<String> {
+        match self.shortcuts.lock() {
+            Ok(guard) => guard.clone(),
+            Err(poisoned) => {
+                error!("CurrentShortcuts lock poisoned; recovering");
+                poisoned.into_inner().clone()
+            }
+        }
+    }
+
+    /// 覆盖当前已注册快捷键集合。
+    pub fn replace(&self, shortcuts: Vec<String>) {
+        match self.shortcuts.lock() {
+            Ok(mut guard) => *guard = shortcuts,
+            Err(poisoned) => {
+                error!("CurrentShortcuts lock poisoned while replacing; recovering");
+                *poisoned.into_inner() = shortcuts;
+            }
+        }
+    }
+}
+
+/// shell 实现的全局快捷键注册器。
+///
+/// 实现方负责把 `shortcut`（物理键格式字符串）注册到 OS 层；按下时如何
+/// 派发回调由实现方在构造期决定（典型做法：构造时注入一个 `Fn()` 闭包，
+/// 内部转成 `tauri-plugin-global-shortcut` 要求的 callback 形态）。
+///
+/// 桌面协调层假设方法是 **同步** 的，并且调用方已经处理好「需要在哪个
+/// 线程上下文里执行」的问题（例如 Tauri 实现需要在 main thread 上跑，
+/// 由调用方用 `run_on_main_thread` 包住整段协调流程）。
+pub trait GlobalShortcutRegistry: Send + Sync {
+    /// 把 `shortcut` 注册到 OS 全局快捷键系统。
+    ///
+    /// 实现方应在内部做一次**防御性反注册**，避免上次进程残留的 OS
+    /// 级 hotkey 造成 "already registered" 失败。
+    fn register(&self, shortcut: &str) -> Result<(), ShortcutError>;
+
+    /// 反注册 `shortcut`。如果该快捷键未注册，应视为成功而不是报错。
+    fn unregister(&self, shortcut: &str) -> Result<(), ShortcutError>;
+}
+
+/// 把前端快捷键字符串归一化为物理键格式。
+///
+/// 输入示例：`"meta+ctrl+v"`、`"mod+shift+v"`、`"Cmd+Alt+V"`。
+///
+/// 归一化规则：
+///   - `meta` / `super`（物理 Meta/Win/Cmd 键）→ `super`
+///   - `mod` / `cmd` / `command`（**抽象**平台修饰键）→ macOS 上 `super`，
+///     其他平台 `ctrl`
+///   - 其余字段保留小写形式
+///
+/// 输出格式恰好与 `tauri-plugin-global-shortcut` 接受的字符串一致；这
+/// 不是与 Tauri 的绑定，而是桌面层选择的"物理键串"约定 —— 未来其他
+/// shell 想消费同一份归一化结果不需要做二次转换。
+pub fn normalize_to_physical_keys(key: &str) -> String {
+    key.split('+')
+        .map(|part| match part.trim().to_lowercase().as_str() {
+            "meta" | "super" => "super".to_string(),
+            "mod" | "cmd" | "command" => if cfg!(target_os = "macos") {
+                "super"
+            } else {
+                "ctrl"
+            }
+            .to_string(),
+            other => other.to_string(),
+        })
+        .collect::<Vec<_>>()
+        .join("+")
+}
+
+/// 把一组前端快捷键字符串归一化、去空、转为可注册的物理键格式列表。
+///
+/// 当 `values` 为 `None` 或归一化后为空时，返回 `[DEFAULT_QUICK_PANEL_SHORTCUT]`
+/// —— 调用方拿到的列表**永远非空**，可以直接喂给注册器。
+pub fn resolve_shortcut_values<'a, I>(values: Option<I>) -> Vec<String>
+where
+    I: IntoIterator<Item = &'a str>,
+{
+    let Some(values) = values else {
+        return vec![DEFAULT_QUICK_PANEL_SHORTCUT.to_string()];
+    };
+
+    let shortcuts: Vec<String> = values
+        .into_iter()
+        .map(normalize_to_physical_keys)
+        .filter(|s| !s.is_empty())
+        .collect();
+
+    if shortcuts.is_empty() {
+        vec![DEFAULT_QUICK_PANEL_SHORTCUT.to_string()]
+    } else {
+        shortcuts
+    }
+}
+
+/// 从领域 `Settings` 中解析出"切换快捷面板"快捷键的物理键格式列表。
+///
+/// 未配置 / 配置为空时回落到默认快捷键。
+pub fn resolve_quick_panel_shortcuts(settings: &Settings) -> Vec<String> {
+    match settings
+        .keyboard_shortcuts
+        .get(QUICK_PANEL_SHORTCUT_SETTINGS_KEY)
+    {
+        Some(ShortcutKey::Single(s)) => resolve_shortcut_values(Some(vec![s.as_str()])),
+        Some(ShortcutKey::Multiple(v)) => {
+            resolve_shortcut_values(Some(v.iter().map(String::as_str).collect::<Vec<_>>()))
+        }
+        None => resolve_shortcut_values(None::<Vec<&str>>),
+    }
+}
+
+/// 原子地把 `old` 反注册并注册 `new`。
+///
+/// 失败时**尽力回滚**——把已经成功注册的 new 都反注册掉，再尝试恢复
+/// 所有 old；回滚阶段的错误只会被记录到日志（`error!`），不会被作为
+/// 主返回值，因为外层已经在处理首要错误。
+///
+/// 协调层不感知线程模型；如果具体 [`GlobalShortcutRegistry`] 实现要求
+/// 在特定线程（如 Tauri main thread）执行，调用方负责把整次
+/// `update_shortcuts` 调用调度到那里。
+pub fn update_shortcuts(
+    registry: &dyn GlobalShortcutRegistry,
+    old: &[String],
+    new: &[String],
+) -> Result<(), ShortcutError> {
+    // 1. 反注册所有旧快捷键。
+    for shortcut in old {
+        if let Err(e) = registry.unregister(shortcut) {
+            warn!(error = %e, shortcut = %shortcut, "Failed to unregister old global shortcut");
+        }
+    }
+
+    // 2. 防御性反注册新快捷键（可能因上次部分更新或启动残留已注册）。
+    for shortcut in new {
+        if !old.contains(shortcut) {
+            let _ = registry.unregister(shortcut);
+        }
+    }
+
+    // 3. 注册新快捷键；任意一个失败立刻回滚。
+    for (idx, shortcut) in new.iter().enumerate() {
+        if let Err(e) = registry.register(shortcut) {
+            warn!(error = %e, shortcut = %shortcut, "New shortcut registration failed, rolling back");
+
+            // 卸掉已经注册成功的部分 new。
+            for already in &new[..idx] {
+                let _ = registry.unregister(already);
+            }
+            // 恢复 old。
+            for old_shortcut in old {
+                if let Err(rb_err) = registry.register(old_shortcut) {
+                    error!(
+                        error = %rb_err,
+                        shortcut = %old_shortcut,
+                        "Failed to rollback old global shortcut"
+                    );
+                }
+            }
+            return Err(e);
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+
+    // ── normalize_to_physical_keys ───────────────────────────────────
+
+    #[test]
+    fn normalize_meta_to_super() {
+        assert_eq!(normalize_to_physical_keys("meta+ctrl+v"), "super+ctrl+v");
+        assert_eq!(normalize_to_physical_keys("Meta+Shift+V"), "super+shift+v");
+    }
+
+    #[test]
+    fn normalize_mod_is_platform_specific() {
+        let out = normalize_to_physical_keys("mod+v");
+        if cfg!(target_os = "macos") {
+            assert_eq!(out, "super+v");
+        } else {
+            assert_eq!(out, "ctrl+v");
+        }
+    }
+
+    #[test]
+    fn normalize_preserves_unknown_parts() {
+        assert_eq!(normalize_to_physical_keys("ctrl+alt+f1"), "ctrl+alt+f1");
+    }
+
+    // ── resolve_shortcut_values ─────────────────────────────────────
+
+    #[test]
+    fn resolve_none_returns_default() {
+        let out = resolve_shortcut_values(None::<Vec<&str>>);
+        assert_eq!(out, vec![DEFAULT_QUICK_PANEL_SHORTCUT.to_string()]);
+    }
+
+    #[test]
+    fn resolve_empty_returns_default() {
+        let out = resolve_shortcut_values(Some(Vec::<&str>::new()));
+        assert_eq!(out, vec![DEFAULT_QUICK_PANEL_SHORTCUT.to_string()]);
+    }
+
+    #[test]
+    fn resolve_normalizes_each_entry() {
+        let out = resolve_shortcut_values(Some(vec!["meta+ctrl+v", "ctrl+alt+v"]));
+        assert_eq!(
+            out,
+            vec!["super+ctrl+v".to_string(), "ctrl+alt+v".to_string()]
+        );
+    }
+
+    // ── resolve_quick_panel_shortcuts ───────────────────────────────
+
+    #[test]
+    fn resolve_quick_panel_uses_default_when_unset() {
+        let settings = Settings::default();
+        let out = resolve_quick_panel_shortcuts(&settings);
+        assert_eq!(out, vec![DEFAULT_QUICK_PANEL_SHORTCUT.to_string()]);
+    }
+
+    #[test]
+    fn resolve_quick_panel_reads_single_override() {
+        let mut settings = Settings::default();
+        settings.keyboard_shortcuts.insert(
+            QUICK_PANEL_SHORTCUT_SETTINGS_KEY.to_string(),
+            ShortcutKey::Single("meta+shift+v".to_string()),
+        );
+        let out = resolve_quick_panel_shortcuts(&settings);
+        assert_eq!(out, vec!["super+shift+v".to_string()]);
+    }
+
+    #[test]
+    fn resolve_quick_panel_reads_multiple_override() {
+        let mut settings = Settings::default();
+        settings.keyboard_shortcuts.insert(
+            QUICK_PANEL_SHORTCUT_SETTINGS_KEY.to_string(),
+            ShortcutKey::Multiple(vec!["meta+v".into(), "ctrl+alt+v".into()]),
+        );
+        let out = resolve_quick_panel_shortcuts(&settings);
+        assert_eq!(out, vec!["super+v".to_string(), "ctrl+alt+v".to_string()]);
+    }
+
+    // ── update_shortcuts coordinator ────────────────────────────────
+
+    /// 把每次 register/unregister 调用追加进日志，便于在测试里断言顺序。
+    struct FakeRegistry {
+        log: Mutex<Vec<String>>,
+        /// `(shortcut, attempt_idx) → 是否让本次 register 失败`。attempt_idx
+        /// 从 0 开始，per-shortcut 自增；用于"先成功后失败"或"重试时成功"场景。
+        register_fail: HashMap<String, Vec<bool>>,
+        register_attempts: Mutex<HashMap<String, usize>>,
+    }
+
+    impl FakeRegistry {
+        fn new() -> Self {
+            Self {
+                log: Mutex::new(Vec::new()),
+                register_fail: HashMap::new(),
+                register_attempts: Mutex::new(HashMap::new()),
+            }
+        }
+
+        fn fail_register(mut self, shortcut: &str, pattern: Vec<bool>) -> Self {
+            self.register_fail.insert(shortcut.to_string(), pattern);
+            self
+        }
+
+        fn log(&self) -> Vec<String> {
+            self.log.lock().unwrap().clone()
+        }
+    }
+
+    impl GlobalShortcutRegistry for FakeRegistry {
+        fn register(&self, shortcut: &str) -> Result<(), ShortcutError> {
+            let mut attempts = self.register_attempts.lock().unwrap();
+            let attempt = attempts.entry(shortcut.to_string()).or_insert(0);
+            let should_fail = self
+                .register_fail
+                .get(shortcut)
+                .and_then(|pattern| pattern.get(*attempt))
+                .copied()
+                .unwrap_or(false);
+            *attempt += 1;
+            drop(attempts);
+
+            self.log
+                .lock()
+                .unwrap()
+                .push(format!("register:{shortcut}"));
+            if should_fail {
+                Err(ShortcutError::backend(format!("fake fail: {shortcut}")))
+            } else {
+                Ok(())
+            }
+        }
+
+        fn unregister(&self, shortcut: &str) -> Result<(), ShortcutError> {
+            self.log
+                .lock()
+                .unwrap()
+                .push(format!("unregister:{shortcut}"));
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn update_shortcuts_happy_path_unregisters_old_then_registers_new() {
+        let registry = FakeRegistry::new();
+        let old = vec!["super+ctrl+v".to_string()];
+        let new = vec!["super+shift+v".to_string()];
+
+        update_shortcuts(&registry, &old, &new).expect("happy path succeeds");
+
+        let log = registry.log();
+        // 期望顺序：unregister old → 防御性 unregister new → register new
+        assert_eq!(log[0], "unregister:super+ctrl+v");
+        assert_eq!(log[1], "unregister:super+shift+v");
+        assert_eq!(log[2], "register:super+shift+v");
+    }
+
+    #[test]
+    fn update_shortcuts_skips_defensive_unregister_for_unchanged_entries() {
+        let registry = FakeRegistry::new();
+        let old = vec!["super+v".to_string()];
+        let new = vec!["super+v".to_string()];
+
+        update_shortcuts(&registry, &old, &new).unwrap();
+
+        let log = registry.log();
+        // old 含 super+v → 防御性那一轮跳过
+        let defensive_unregisters = log.iter().filter(|l| l.starts_with("unregister:")).count();
+        assert_eq!(defensive_unregisters, 1);
+    }
+
+    #[test]
+    fn update_shortcuts_rolls_back_on_registration_failure() {
+        // 让 super+shift+v 第一次注册（new 阶段）失败、第二次（回滚 old 阶段）
+        // 不在失败 pattern 里 → 不影响。
+        let registry = FakeRegistry::new().fail_register("super+shift+v", vec![true]);
+        let old = vec!["super+ctrl+v".to_string()];
+        let new = vec!["super+shift+v".to_string()];
+
+        let err = update_shortcuts(&registry, &old, &new).expect_err("should fail");
+        assert!(matches!(err, ShortcutError::Backend(_)));
+
+        let log = registry.log();
+        // 必须看到回滚：register:super+ctrl+v
+        assert!(
+            log.contains(&"register:super+ctrl+v".to_string()),
+            "expected rollback to re-register old shortcut, got log: {log:?}"
+        );
+    }
+
+    // ── CurrentShortcuts ────────────────────────────────────────────
+
+    #[test]
+    fn current_shortcuts_replace_overwrites() {
+        let state = CurrentShortcuts::new(vec!["a".into()]);
+        assert_eq!(state.current(), vec!["a".to_string()]);
+        state.replace(vec!["b".into(), "c".into()]);
+        assert_eq!(state.current(), vec!["b".to_string(), "c".to_string()]);
+    }
+}

--- a/src-tauri/crates/uc-tauri/src/commands/mod.rs
+++ b/src-tauri/crates/uc-tauri/src/commands/mod.rs
@@ -3,6 +3,7 @@ pub mod error;
 pub mod mobile_sync;
 pub mod quick_panel;
 pub mod restart;
+pub mod settings;
 pub mod space_setup;
 pub mod startup;
 pub mod storage;

--- a/src-tauri/crates/uc-tauri/src/commands/settings.rs
+++ b/src-tauri/crates/uc-tauri/src/commands/settings.rs
@@ -1,0 +1,228 @@
+//! Settings Tauri commands
+//! 设置相关的 Tauri 命令
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+use tauri::State;
+use tracing::{error, info_span, Instrument};
+use uc_application::facade::settings::{SettingsPatch, ShortcutKeyView};
+use uc_desktop::shortcuts::{self, CurrentShortcuts, QUICK_PANEL_SHORTCUT_SETTINGS_KEY};
+use uc_platform::ports::observability::TraceMetadata;
+
+use crate::bootstrap::TauriAppRuntime;
+use crate::commands::{record_trace_fields, CommandError};
+use crate::quick_panel;
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum ShortcutKeyDto {
+    Single(String),
+    Multiple(Vec<String>),
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateKeyboardShortcutsResult {
+    pub keyboard_shortcuts: HashMap<String, ShortcutKeyDto>,
+}
+
+/// 保存键盘快捷键，并同步快捷面板全局快捷键的 OS 注册状态。
+#[tauri::command]
+pub async fn update_keyboard_shortcuts(
+    app: tauri::AppHandle,
+    runtime: State<'_, Arc<TauriAppRuntime>>,
+    shortcut_registry: State<'_, CurrentShortcuts>,
+    shortcuts: HashMap<String, Option<ShortcutKeyDto>>,
+    _trace: Option<TraceMetadata>,
+) -> Result<UpdateKeyboardShortcutsResult, CommandError> {
+    let span = info_span!(
+        "command.settings.update_keyboard_shortcuts",
+        trace_id = tracing::field::Empty,
+        trace_ts = tracing::field::Empty,
+        shortcut_count = shortcuts.len(),
+    );
+    record_trace_fields(&span, &_trace);
+
+    async {
+        let facade = runtime.app_facade();
+        let current = facade.settings.get().await.map_err(CommandError::internal)?;
+        let next_keyboard_shortcuts =
+            apply_keyboard_shortcut_patch_to_map(current.keyboard_shortcuts, &shortcuts);
+
+        let old_registered_shortcuts = shortcut_registry.current();
+        let new_registered_shortcuts =
+            quick_panel_shortcuts_from_keyboard_shortcuts(&next_keyboard_shortcuts);
+
+        if old_registered_shortcuts != new_registered_shortcuts {
+            update_global_shortcuts_on_main_thread(
+                &app,
+                old_registered_shortcuts.clone(),
+                new_registered_shortcuts.clone(),
+            )
+            .await?;
+        }
+
+        let patch = SettingsPatch {
+            keyboard_shortcuts: Some(
+                shortcuts
+                    .into_iter()
+                    .map(|(id, value)| (id, value.map(ShortcutKeyView::from)))
+                    .collect(),
+            ),
+            ..Default::default()
+        };
+
+        match facade.settings.update(patch).await {
+            Ok(updated) => {
+                shortcut_registry.replace(new_registered_shortcuts);
+                Ok(UpdateKeyboardShortcutsResult {
+                    keyboard_shortcuts: keyboard_shortcuts_to_dto(&updated.keyboard_shortcuts),
+                })
+            }
+            Err(err) => {
+                if old_registered_shortcuts != new_registered_shortcuts {
+                    if let Err(rollback_err) = update_global_shortcuts_on_main_thread(
+                        &app,
+                        new_registered_shortcuts,
+                        old_registered_shortcuts,
+                    )
+                    .await
+                    {
+                        error!(
+                            error = %rollback_err,
+                            "Failed to rollback quick panel global shortcut after settings save failure"
+                        );
+                    }
+                }
+                Err(CommandError::internal(err))
+            }
+        }
+    }
+    .instrument(span)
+    .await
+}
+
+fn apply_keyboard_shortcut_patch_to_map(
+    mut current: HashMap<String, ShortcutKeyView>,
+    patch: &HashMap<String, Option<ShortcutKeyDto>>,
+) -> HashMap<String, ShortcutKeyView> {
+    for (id, value) in patch {
+        match value {
+            Some(shortcut) => {
+                current.insert(id.clone(), ShortcutKeyView::from(shortcut.clone()));
+            }
+            None => {
+                current.remove(id);
+            }
+        }
+    }
+    current
+}
+
+fn quick_panel_shortcuts_from_keyboard_shortcuts(
+    shortcuts: &HashMap<String, ShortcutKeyView>,
+) -> Vec<String> {
+    match shortcuts.get(QUICK_PANEL_SHORTCUT_SETTINGS_KEY) {
+        Some(ShortcutKeyView::Single(shortcut)) => {
+            shortcuts::resolve_shortcut_values(Some(vec![shortcut.as_str()]))
+        }
+        Some(ShortcutKeyView::Multiple(shortcuts)) => shortcuts::resolve_shortcut_values(Some(
+            shortcuts.iter().map(String::as_str).collect::<Vec<_>>(),
+        )),
+        None => shortcuts::resolve_shortcut_values(None::<Vec<&str>>),
+    }
+}
+
+/// 把 `update_shortcuts` 整段协调流程调度到 Tauri main thread 上执行。
+///
+/// `tauri-plugin-global-shortcut` 的注册 API 必须在 main thread 调用；为
+/// 避免在多个 register/unregister 之间反复跳线程，整段协调统一封一次。
+async fn update_global_shortcuts_on_main_thread(
+    app: &tauri::AppHandle,
+    old: Vec<String>,
+    new: Vec<String>,
+) -> Result<(), CommandError> {
+    let handle = app.clone();
+    let (tx, rx) = tokio::sync::oneshot::channel();
+
+    app.run_on_main_thread(move || {
+        // 在 main thread 闭包内构造 registry：捕获 AppHandle 用作回调上下文，
+        // 回调闭包绑定 `quick_panel::toggle`（GUI shell 自身的具体动作）。
+        let toggle_handle = handle.clone();
+        let registry = quick_panel::TauriGlobalShortcutRegistry::new(handle.clone(), move || {
+            quick_panel::toggle(&toggle_handle)
+        });
+        let result = shortcuts::update_shortcuts(&registry, &old, &new);
+        let _ = tx.send(result);
+    })
+    .map_err(|err| CommandError::internal(format!("failed to dispatch to main thread: {err}")))?;
+
+    rx.await
+        .map_err(|_| CommandError::internal("main thread dropped shortcut update result"))?
+        .map_err(|e| CommandError::Conflict(e.to_string()))
+}
+
+fn keyboard_shortcuts_to_dto(
+    shortcuts: &HashMap<String, ShortcutKeyView>,
+) -> HashMap<String, ShortcutKeyDto> {
+    shortcuts
+        .iter()
+        .map(|(id, shortcut)| (id.clone(), ShortcutKeyDto::from(shortcut.clone())))
+        .collect()
+}
+
+impl From<ShortcutKeyDto> for ShortcutKeyView {
+    fn from(value: ShortcutKeyDto) -> Self {
+        match value {
+            ShortcutKeyDto::Single(value) => Self::Single(value),
+            ShortcutKeyDto::Multiple(value) => Self::Multiple(value),
+        }
+    }
+}
+
+impl From<ShortcutKeyView> for ShortcutKeyDto {
+    fn from(value: ShortcutKeyView) -> Self {
+        match value {
+            ShortcutKeyView::Single(value) => Self::Single(value),
+            ShortcutKeyView::Multiple(value) => Self::Multiple(value),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use uc_application::facade::settings::ShortcutKeyView;
+
+    #[test]
+    fn keyboard_shortcuts_patch_null_removes_existing_override() {
+        let mut current = HashMap::new();
+        current.insert(
+            QUICK_PANEL_SHORTCUT_SETTINGS_KEY.to_string(),
+            ShortcutKeyView::Single("meta+ctrl+v".to_string()),
+        );
+
+        let patch = HashMap::from([(QUICK_PANEL_SHORTCUT_SETTINGS_KEY.to_string(), None)]);
+        let next = apply_keyboard_shortcut_patch_to_map(current, &patch);
+
+        assert!(!next.contains_key(QUICK_PANEL_SHORTCUT_SETTINGS_KEY));
+    }
+
+    #[test]
+    fn keyboard_shortcuts_update_result_uses_camel_case_wire_key() {
+        let result = UpdateKeyboardShortcutsResult {
+            keyboard_shortcuts: HashMap::from([(
+                QUICK_PANEL_SHORTCUT_SETTINGS_KEY.to_string(),
+                ShortcutKeyDto::Single("meta+shift+v".to_string()),
+            )]),
+        };
+
+        let json = serde_json::to_value(result).expect("result serializes");
+
+        assert!(json.get("keyboardShortcuts").is_some());
+        assert!(json.get("keyboard_shortcuts").is_none());
+    }
+}

--- a/src-tauri/crates/uc-tauri/src/commands/settings.rs
+++ b/src-tauri/crates/uc-tauri/src/commands/settings.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
 use tauri::State;
+use tokio::sync::Mutex as AsyncMutex;
 use tracing::{error, info_span, Instrument};
 use uc_application::facade::settings::{SettingsPatch, ShortcutKeyView};
 use uc_desktop::shortcuts::{self, CurrentShortcuts, QUICK_PANEL_SHORTCUT_SETTINGS_KEY};
@@ -14,6 +15,13 @@ use uc_platform::ports::observability::TraceMetadata;
 use crate::bootstrap::TauriAppRuntime;
 use crate::commands::{record_trace_fields, CommandError};
 use crate::quick_panel;
+
+/// 串行化 [`update_keyboard_shortcuts`] 整段 read→OS 注册→facade 持久化→
+/// 内存 registry replace 的协调流程。并发调用会让 OS 状态、`CurrentShortcuts`、
+/// 和 facade 持久化值相互错位（详见 [`update_keyboard_shortcuts`]），所以整段
+/// 必须在锁内独占执行。
+#[derive(Default)]
+pub struct KeyboardShortcutsUpdateLock(pub AsyncMutex<()>);
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(untagged)]
@@ -34,6 +42,7 @@ pub async fn update_keyboard_shortcuts(
     app: tauri::AppHandle,
     runtime: State<'_, Arc<TauriAppRuntime>>,
     shortcut_registry: State<'_, CurrentShortcuts>,
+    update_lock: State<'_, KeyboardShortcutsUpdateLock>,
     shortcuts: HashMap<String, Option<ShortcutKeyDto>>,
     _trace: Option<TraceMetadata>,
 ) -> Result<UpdateKeyboardShortcutsResult, CommandError> {
@@ -46,6 +55,8 @@ pub async fn update_keyboard_shortcuts(
     record_trace_fields(&span, &_trace);
 
     async {
+        // 独占整段协调，避免并发调用让 OS / registry / facade 三者错位。
+        let _guard = update_lock.0.lock().await;
         let facade = runtime.app_facade();
         let current = facade.settings.get().await.map_err(CommandError::internal)?;
         let next_keyboard_shortcuts =

--- a/src-tauri/crates/uc-tauri/src/quick_panel/mod.rs
+++ b/src-tauri/crates/uc-tauri/src/quick_panel/mod.rs
@@ -10,13 +10,15 @@
 mod macos;
 #[cfg(any(target_os = "windows", test))]
 mod paste_sequence;
+mod shortcut_registry;
 #[cfg(target_os = "windows")]
 mod windows;
+
+pub use shortcut_registry::TauriGlobalShortcutRegistry;
 
 use std::sync::Mutex;
 use std::time::Instant;
 use tauri::{Emitter, Manager, WebviewUrl, WebviewWindowBuilder};
-use tauri_plugin_global_shortcut::{GlobalShortcutExt, ShortcutState};
 use tracing::{debug, error, info, warn};
 
 /// Timestamp of the last `show()` call. Blur events within
@@ -43,16 +45,6 @@ const BLUR_DEBOUNCE_MS: u128 = 300;
 /// notifications) are transient and focus returns within a few ms.
 /// A real "user clicked elsewhere" loss persists past this delay.
 const BLUR_VERIFY_DELAY_MS: u64 = 100;
-
-/// Default global shortcut for the quick panel (Tauri format).
-/// macOS: Cmd+Ctrl+V, Windows/Linux: Ctrl+Alt+V
-#[cfg(target_os = "macos")]
-pub const DEFAULT_SHORTCUT: &str = "super+ctrl+v";
-#[cfg(not(target_os = "macos"))]
-pub const DEFAULT_SHORTCUT: &str = "ctrl+alt+v";
-
-/// Settings key used to store the quick panel shortcut override.
-pub const SHORTCUT_SETTINGS_KEY: &str = "global.toggleQuickPanel";
 
 /// Panel base dimensions (logical pixels at 100% UI scale).
 const BASE_PANEL_WIDTH: f64 = 360.0;
@@ -495,148 +487,4 @@ pub fn paste(app: &tauri::AppHandle) -> Result<(), String> {
         dismiss(app);
         Err("Paste to previous app is not yet supported on this platform".into())
     }
-}
-
-// ── Global shortcut management ────────────────────────────────────────
-
-/// Resolve the quick panel shortcut string from settings (in Tauri format).
-///
-/// Falls back to [`DEFAULT_SHORTCUT`] if not configured.
-pub fn resolve_shortcut_from_settings(
-    settings: &uc_core::settings::model::Settings,
-) -> Vec<String> {
-    use uc_core::settings::model::ShortcutKey;
-
-    match settings.keyboard_shortcuts.get(SHORTCUT_SETTINGS_KEY) {
-        Some(ShortcutKey::Single(s)) => vec![normalize_shortcut_for_tauri(s)],
-        Some(ShortcutKey::Multiple(v)) => {
-            let shortcuts: Vec<String> = v
-                .iter()
-                .map(|s| normalize_shortcut_for_tauri(s))
-                .filter(|s| !s.is_empty())
-                .collect();
-            if shortcuts.is_empty() {
-                vec![DEFAULT_SHORTCUT.to_string()]
-            } else {
-                shortcuts
-            }
-        }
-        _ => vec![DEFAULT_SHORTCUT.to_string()],
-    }
-}
-
-/// Convert a frontend shortcut string to the Tauri global-shortcut format.
-///
-/// Mapping rules:
-///   - `meta` (the physical Meta/Win/Cmd key) → `super` (Tauri's name for that key)
-///   - `mod`/`cmd`/`command` (abstract platform modifier) → `super` on macOS, `ctrl` on others
-///   - everything else passes through unchanged
-///
-/// 将前端快捷键字符串转换为 Tauri 全局快捷键格式。
-pub fn normalize_shortcut_for_tauri(key: &str) -> String {
-    key.split('+')
-        .map(|part| {
-            match part.trim().to_lowercase().as_str() {
-                // Physical Meta key (Cmd on macOS, Win on Windows) → Tauri `super`
-                "meta" | "super" => "super".to_string(),
-                // Abstract platform modifier → Cmd on macOS, Ctrl on others
-                "mod" | "cmd" | "command" => if cfg!(target_os = "macos") {
-                    "super"
-                } else {
-                    "ctrl"
-                }
-                .to_string(),
-                other => other.to_string(),
-            }
-        })
-        .collect::<Vec<_>>()
-        .join("+")
-}
-
-/// Register a global shortcut that toggles the quick panel.
-///
-/// 注册一个用于切换快捷面板的全局快捷键。
-pub fn register_global_shortcut(app: &tauri::AppHandle, shortcut_str: &str) -> Result<(), String> {
-    // Defensively unregister first — on Windows the OS-level hotkey may survive
-    // a crash or force-kill of the previous app instance, causing
-    // "HotKey already registered" on the next startup.
-    match app.global_shortcut().unregister(shortcut_str) {
-        Ok(()) => {}
-        Err(e) => {
-            warn!(
-                error = %e,
-                shortcut = %shortcut_str,
-                "Defensive unregister before registering global shortcut failed"
-            );
-        }
-    }
-
-    let app_handle = app.clone();
-    app.global_shortcut()
-        .on_shortcut(shortcut_str, move |_app, _shortcut, event| {
-            if event.state == ShortcutState::Pressed {
-                info!("Global shortcut triggered for quick panel");
-                toggle(&app_handle);
-            }
-        })
-        .map_err(|e| {
-            error!(error = %e, shortcut = %shortcut_str, "Failed to register global shortcut for quick panel");
-            format!("Failed to register shortcut '{}': {}", shortcut_str, e)
-        })?;
-    info!(shortcut = %shortcut_str, "Global shortcut registered for quick panel");
-    Ok(())
-}
-
-/// Unregister old shortcuts and register new ones atomically.
-///
-/// If registering any new shortcut fails, attempts to re-register all old
-/// shortcuts so the system is not left without a working shortcut.
-///
-/// 原子地注销旧快捷键并注册新快捷键。如果注册新快捷键失败，
-/// 尝试重新注册旧快捷键以避免系统处于无快捷键状态。
-pub fn update_global_shortcut(
-    app: &tauri::AppHandle,
-    old: &[String],
-    new: &[String],
-) -> Result<(), String> {
-    // Unregister all old shortcuts
-    for shortcut in old {
-        if let Err(e) = app.global_shortcut().unregister(shortcut.as_str()) {
-            warn!(error = %e, shortcut = %shortcut, "Failed to unregister old global shortcut");
-        }
-    }
-
-    // Also unregister new shortcuts defensively, in case they are already
-    // registered (e.g. from startup or a previous partial update).
-    for shortcut in new {
-        if !old.contains(shortcut) {
-            let _ = app.global_shortcut().unregister(shortcut.as_str());
-        }
-    }
-
-    // Register all new shortcuts; on failure, rollback to old shortcuts
-    for shortcut in new {
-        if let Err(e) = register_global_shortcut(app, shortcut) {
-            warn!(error = %e, shortcut = %shortcut, "New shortcut registration failed, rolling back");
-            // Unregister any new shortcuts that were successfully registered
-            for already in new {
-                if already == shortcut {
-                    break;
-                }
-                let _ = app.global_shortcut().unregister(already.as_str());
-            }
-            // Re-register old shortcuts
-            for old_shortcut in old {
-                if let Err(rb_err) = register_global_shortcut(app, old_shortcut) {
-                    error!(
-                        error = %rb_err,
-                        shortcut = %old_shortcut,
-                        "Failed to rollback old global shortcut"
-                    );
-                }
-            }
-            return Err(e);
-        }
-    }
-    Ok(())
 }

--- a/src-tauri/crates/uc-tauri/src/quick_panel/shortcut_registry.rs
+++ b/src-tauri/crates/uc-tauri/src/quick_panel/shortcut_registry.rs
@@ -1,0 +1,71 @@
+//! [`uc_desktop::shortcuts::GlobalShortcutRegistry`] 的 Tauri 适配实现。
+//!
+//! 把"注册物理快捷键到 OS"的契约落到 `tauri-plugin-global-shortcut` 上。
+//!
+//! - 回调（按下时触发什么）由调用方在构造期注入；本适配器把它包装成 Tauri
+//!   callback 签名（`Fn(&AppHandle, &Shortcut, ShortcutEvent)`），仅在
+//!   [`ShortcutState::Pressed`] 时调一次。
+//! - 同步实现，假设调用方已在 Tauri main thread 上下文（启动期 setup
+//!   callback、或 command 内部用 `app.run_on_main_thread` 包过的闭包）。
+
+use std::sync::Arc;
+
+use tauri::AppHandle;
+use tauri_plugin_global_shortcut::{GlobalShortcutExt, ShortcutState};
+use tracing::{error, info, warn};
+
+use uc_desktop::shortcuts::{GlobalShortcutRegistry, ShortcutError};
+
+/// Tauri 全局快捷键注册器。
+///
+/// 通过 `new` 注入按下回调；之后每次 `register` 都用同一个回调注册。
+pub struct TauriGlobalShortcutRegistry {
+    app: AppHandle,
+    on_pressed: Arc<dyn Fn() + Send + Sync>,
+}
+
+impl TauriGlobalShortcutRegistry {
+    pub fn new(app: AppHandle, on_pressed: impl Fn() + Send + Sync + 'static) -> Self {
+        Self {
+            app,
+            on_pressed: Arc::new(on_pressed),
+        }
+    }
+}
+
+impl GlobalShortcutRegistry for TauriGlobalShortcutRegistry {
+    fn register(&self, shortcut: &str) -> Result<(), ShortcutError> {
+        // 防御性反注册：Windows 上 OS 级 hotkey 可能在前一次进程崩溃 / 强杀
+        // 后仍残留，导致 "HotKey already registered"。
+        if let Err(e) = self.app.global_shortcut().unregister(shortcut) {
+            warn!(
+                error = %e,
+                shortcut = %shortcut,
+                "Defensive unregister before registering global shortcut failed"
+            );
+        }
+
+        let on_pressed = Arc::clone(&self.on_pressed);
+        self.app
+            .global_shortcut()
+            .on_shortcut(shortcut, move |_app, _shortcut, event| {
+                if event.state == ShortcutState::Pressed {
+                    info!("Global shortcut triggered");
+                    on_pressed();
+                }
+            })
+            .map_err(|e| {
+                error!(error = %e, shortcut = %shortcut, "Failed to register global shortcut");
+                ShortcutError::backend(format!("Failed to register shortcut '{shortcut}': {e}"))
+            })?;
+        info!(shortcut = %shortcut, "Global shortcut registered");
+        Ok(())
+    }
+
+    fn unregister(&self, shortcut: &str) -> Result<(), ShortcutError> {
+        self.app
+            .global_shortcut()
+            .unregister(shortcut)
+            .map_err(|e| ShortcutError::backend(format!("Failed to unregister '{shortcut}': {e}")))
+    }
+}

--- a/src-tauri/crates/uc-tauri/src/quick_panel/shortcut_registry.rs
+++ b/src-tauri/crates/uc-tauri/src/quick_panel/shortcut_registry.rs
@@ -63,9 +63,15 @@ impl GlobalShortcutRegistry for TauriGlobalShortcutRegistry {
     }
 
     fn unregister(&self, shortcut: &str) -> Result<(), ShortcutError> {
-        self.app
-            .global_shortcut()
-            .unregister(shortcut)
-            .map_err(|e| ShortcutError::backend(format!("Failed to unregister '{shortcut}': {e}")))
+        // 契约：未注册视为成功。`tauri-plugin-global-shortcut` 不区分
+        // "未注册" 与其它后端错误，所以这里统一降级为 warn 并返回 Ok。
+        if let Err(e) = self.app.global_shortcut().unregister(shortcut) {
+            warn!(
+                error = %e,
+                shortcut = %shortcut,
+                "Unregister global shortcut returned error; treating as no-op per trait contract"
+            );
+        }
+        Ok(())
     }
 }

--- a/src-tauri/crates/uc-tauri/src/run.rs
+++ b/src-tauri/crates/uc-tauri/src/run.rs
@@ -375,6 +375,7 @@ pub fn run(tauri_ctx: tauri::Context<tauri::Wry>) -> anyhow::Result<()> {
             app.manage(uc_desktop::shortcuts::CurrentShortcuts::new(
                 registered_quick_panel_shortcuts,
             ));
+            app.manage(crate::commands::settings::KeyboardShortcutsUpdateLock::default());
 
             // Pre-create quick panel (hidden) so the first
             // shortcut press doesn't activate the app via WebviewWindowBuilder::build()

--- a/src-tauri/crates/uc-tauri/src/run.rs
+++ b/src-tauri/crates/uc-tauri/src/run.rs
@@ -26,6 +26,7 @@ use uc_desktop::daemon_probe::{
     bootstrap_daemon_in_process, HEALTH_CHECK_TIMEOUT, HEALTH_POLL_INTERVAL,
     INCOMPATIBLE_DAEMON_EXIT_TIMEOUT,
 };
+use uc_desktop::shortcuts::GlobalShortcutRegistry;
 use uc_desktop::DaemonOwnership;
 
 use crate::bootstrap::{ensure_default_device_name, start_background_tasks, TauriAppRuntime};
@@ -113,7 +114,7 @@ fn configure_main_window_for_platform(_app: &tauri::AppHandle) {}
 ///
 /// # Examples
 ///
-/// ```no_run
+/// ```rust,ignore
 /// // In src-tauri/src/main.rs
 /// let ctx = tauri::generate_context!();
 /// crate::run(ctx).expect("failed to start tauri application");
@@ -333,29 +334,47 @@ pub fn run(tauri_ctx: tauri::Context<tauri::Wry>) -> anyhow::Result<()> {
             // Register global shortcut plugin (empty — shortcuts registered dynamically).
             // `#[cfg(desktop)]` is normally injected by `tauri-build` in the bin crate;
             // here we spell it out explicitly so it compiles in this lib crate too.
+            let mut registered_quick_panel_shortcuts = Vec::new();
+
             #[cfg(not(any(target_os = "android", target_os = "ios")))]
             {
                 app.handle()
                     .plugin(tauri_plugin_global_shortcut::Builder::new().build())?;
 
-                // Read shortcut override from settings, or use default
+                // 从设置读取快捷键覆盖；未配置或为空则回落到桌面层默认。
                 let shortcuts = {
                     let settings_port = runtime.settings_port();
                     match tauri::async_runtime::block_on(settings_port.load()) {
-                        Ok(settings) => quick_panel::resolve_shortcut_from_settings(&settings),
+                        Ok(settings) => {
+                            uc_desktop::shortcuts::resolve_quick_panel_shortcuts(&settings)
+                        }
                         Err(e) => {
                             warn!("Failed to load settings for shortcut: {}, using default", e);
-                            vec![quick_panel::DEFAULT_SHORTCUT.to_string()]
+                            vec![uc_desktop::shortcuts::DEFAULT_QUICK_PANEL_SHORTCUT.to_string()]
                         }
                     }
                 };
 
+                // 启动期 setup callback 已在 main thread 上下文，可直接构造 Tauri
+                // 适配器并调注册器。回调闭包绑定 `quick_panel::toggle`，避免桌面
+                // 协调层耦合任何 GUI shell 概念。
+                let toggle_handle = app.handle().clone();
+                let registry = quick_panel::TauriGlobalShortcutRegistry::new(
+                    app.handle().clone(),
+                    move || quick_panel::toggle(&toggle_handle),
+                );
                 for shortcut_str in &shortcuts {
-                    if let Err(e) = quick_panel::register_global_shortcut(app.handle(), shortcut_str) {
+                    if let Err(e) = registry.register(shortcut_str) {
                         tracing::error!(error = %e, shortcut = %shortcut_str, "Failed to register global shortcut during startup");
+                    } else {
+                        registered_quick_panel_shortcuts.push(shortcut_str.clone());
                     }
                 }
             }
+
+            app.manage(uc_desktop::shortcuts::CurrentShortcuts::new(
+                registered_quick_panel_shortcuts,
+            ));
 
             // Pre-create quick panel (hidden) so the first
             // shortcut press doesn't activate the app via WebviewWindowBuilder::build()
@@ -528,6 +547,8 @@ pub fn run(tauri_ctx: tauri::Context<tauri::Wry>) -> anyhow::Result<()> {
             crate::commands::quick_panel::dismiss_quick_panel,
             crate::commands::quick_panel::set_quick_panel_layout,
             crate::commands::quick_panel::finalize_quick_panel_show,
+            // Settings commands
+            crate::commands::settings::update_keyboard_shortcuts,
             // Mobile sync commands (in-process facade — does NOT go through webserver)
             crate::commands::mobile_sync::register_mobile_device,
             crate::commands::mobile_sync::revoke_mobile_device,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -37,7 +37,7 @@
   },
   "bundle": {
     "active": true,
-    "targets": "all",
+    "targets": ["app", "dmg", "deb", "rpm", "appimage", "nsis"],
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",

--- a/src/api/tauri-command/__tests__/settings.test.ts
+++ b/src/api/tauri-command/__tests__/settings.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { buildKeyboardShortcutsPatch, updateKeyboardShortcuts } from '@/api/tauri-command/settings'
+import { invokeWithTrace } from '@/lib/tauri-command'
+
+vi.mock('@/lib/tauri-command', () => ({
+  invokeWithTrace: vi.fn(),
+}))
+
+const mockInvokeWithTrace = vi.mocked(invokeWithTrace)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('Tauri settings command wrapper — keyboard shortcuts', () => {
+  it('删除旧 override 时发送 null，而不是省略该 key', () => {
+    const patch = buildKeyboardShortcutsPatch(
+      {
+        'global.toggleQuickPanel': 'meta+ctrl+v',
+        'nav.dashboard': 'mod+1',
+      },
+      {
+        'nav.dashboard': 'mod+2',
+      }
+    )
+
+    expect(patch).toEqual({
+      'global.toggleQuickPanel': null,
+      'nav.dashboard': 'mod+2',
+    })
+  })
+
+  it('通过 in-process Tauri command 保存并应用快捷键', async () => {
+    mockInvokeWithTrace.mockResolvedValueOnce({
+      keyboardShortcuts: {
+        'global.toggleQuickPanel': 'meta+shift+v',
+      },
+    })
+
+    const result = await updateKeyboardShortcuts(
+      {
+        'global.toggleQuickPanel': 'meta+ctrl+v',
+      },
+      {
+        'global.toggleQuickPanel': 'meta+shift+v',
+      }
+    )
+
+    expect(mockInvokeWithTrace).toHaveBeenCalledWith('update_keyboard_shortcuts', {
+      shortcuts: {
+        'global.toggleQuickPanel': 'meta+shift+v',
+      },
+    })
+    expect(result).toEqual({
+      'global.toggleQuickPanel': 'meta+shift+v',
+    })
+  })
+})

--- a/src/api/tauri-command/index.ts
+++ b/src/api/tauri-command/index.ts
@@ -10,3 +10,4 @@
  */
 
 export * from './mobile_sync'
+export * from './settings'

--- a/src/api/tauri-command/settings.ts
+++ b/src/api/tauri-command/settings.ts
@@ -1,0 +1,46 @@
+import type { ShortcutKey } from '@/api/daemon/settings'
+import { invokeWithTrace } from '@/lib/tauri-command'
+
+export type KeyboardShortcutsPatch = Record<string, ShortcutKey | null>
+
+interface UpdateKeyboardShortcutsResult {
+  keyboardShortcuts: Record<string, ShortcutKey>
+}
+
+export function buildKeyboardShortcutsPatch(
+  previous: Record<string, ShortcutKey>,
+  next: Record<string, ShortcutKey>
+): KeyboardShortcutsPatch {
+  const patch: KeyboardShortcutsPatch = {}
+  const ids = new Set([...Object.keys(previous), ...Object.keys(next)])
+
+  for (const id of ids) {
+    if (!(id in next)) {
+      patch[id] = null
+      continue
+    }
+
+    if (!shortcutKeyEquals(previous[id], next[id])) {
+      patch[id] = next[id]!
+    }
+  }
+
+  return patch
+}
+
+export async function updateKeyboardShortcuts(
+  previous: Record<string, ShortcutKey>,
+  next: Record<string, ShortcutKey>
+): Promise<Record<string, ShortcutKey>> {
+  const result = await invokeWithTrace<UpdateKeyboardShortcutsResult>('update_keyboard_shortcuts', {
+    shortcuts: buildKeyboardShortcutsPatch(previous, next),
+  })
+  return result.keyboardShortcuts
+}
+
+function shortcutKeyEquals(left: ShortcutKey | undefined, right: ShortcutKey | undefined): boolean {
+  if (left === undefined || right === undefined) {
+    return left === right
+  }
+  return JSON.stringify(left) === JSON.stringify(right)
+}

--- a/src/contexts/SettingContext.tsx
+++ b/src/contexts/SettingContext.tsx
@@ -176,13 +176,23 @@ export const SettingProvider: React.FC<SettingProviderProps> = ({ children }) =>
         setting.keyboardShortcuts ?? {},
         overrides
       )
-      const updatedSetting: Settings = { ...setting, keyboardShortcuts }
-      setSetting(updatedSetting)
+      // 合并到 await 之后的最新 state，避免覆盖期间发生的并发更新；
+      // 用 ref 把 functional updater 计算出的 merged settings 捕获出来用于广播。
+      let mergedSnapshot: Settings | null = null
+      setSetting(prev => {
+        const merged: Settings = prev
+          ? { ...prev, keyboardShortcuts }
+          : ({ ...setting, keyboardShortcuts } as Settings)
+        mergedSnapshot = merged
+        return merged
+      })
       setError(null)
-      try {
-        await emitSettingsChanged(updatedSetting)
-      } catch (err) {
-        log.error({ err }, 'Failed to broadcast settings change')
+      if (mergedSnapshot) {
+        try {
+          await emitSettingsChanged(mergedSnapshot)
+        } catch (err) {
+          log.error({ err }, 'Failed to broadcast settings change')
+        }
       }
     } catch (err) {
       log.error({ err }, 'Failed to update keyboard shortcuts')

--- a/src/contexts/SettingContext.tsx
+++ b/src/contexts/SettingContext.tsx
@@ -176,23 +176,16 @@ export const SettingProvider: React.FC<SettingProviderProps> = ({ children }) =>
         setting.keyboardShortcuts ?? {},
         overrides
       )
-      // 合并到 await 之后的最新 state，避免覆盖期间发生的并发更新；
-      // 用 ref 把 functional updater 计算出的 merged settings 捕获出来用于广播。
-      let mergedSnapshot: Settings | null = null
-      setSetting(prev => {
-        const merged: Settings = prev
-          ? { ...prev, keyboardShortcuts }
-          : ({ ...setting, keyboardShortcuts } as Settings)
-        mergedSnapshot = merged
-        return merged
-      })
+      // 合并到 await 之后的最新 state，避免覆盖期间发生的并发更新。
+      // 广播仍用 await 前快照——任何并发更新会自己 emit，这里只承诺广播
+      // 本次快捷键变更落地后的视图。
+      const updatedSetting: Settings = { ...setting, keyboardShortcuts }
+      setSetting(prev => (prev ? { ...prev, keyboardShortcuts } : updatedSetting))
       setError(null)
-      if (mergedSnapshot) {
-        try {
-          await emitSettingsChanged(mergedSnapshot)
-        } catch (err) {
-          log.error({ err }, 'Failed to broadcast settings change')
-        }
+      try {
+        await emitSettingsChanged(updatedSetting)
+      } catch (err) {
+        log.error({ err }, 'Failed to broadcast settings change')
       }
     } catch (err) {
       log.error({ err }, 'Failed to update keyboard shortcuts')

--- a/src/contexts/SettingContext.tsx
+++ b/src/contexts/SettingContext.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useState, type ReactNode } from 'react'
 import { SettingContext } from './setting-context'
 import { getSettings, updateSettings } from '@/api/daemon'
+import { updateKeyboardShortcuts as persistKeyboardShortcuts } from '@/api/tauri-command'
 import { DEFAULT_THEME_COLOR } from '@/constants/theme'
 import i18n, { normalizeLanguage, persistLanguage } from '@/i18n'
 import { connectDaemonWs } from '@/lib/daemon-ws-bootstrap'
@@ -163,17 +164,32 @@ export const SettingProvider: React.FC<SettingProviderProps> = ({ children }) =>
     return await saveSetting(updatedSetting)
   }
 
-  // Update keyboard shortcuts
+  // 更新快捷键。GUI 路径必须走 Tauri in-process command，因为快捷面板全局
+  // 快捷键需要同步更新 OS 注册状态；daemon HTTP settings API 只负责持久化。
   const updateKeyboardShortcuts = async (overrides: Record<string, string | string[]>) => {
     if (!setting) {
       throw new Error('No settings loaded')
     }
-    const updatedSetting: Settings = { ...setting, keyboardShortcuts: overrides }
     try {
-      await saveSetting(updatedSetting)
+      setLoading(true)
+      const keyboardShortcuts = await persistKeyboardShortcuts(
+        setting.keyboardShortcuts ?? {},
+        overrides
+      )
+      const updatedSetting: Settings = { ...setting, keyboardShortcuts }
+      setSetting(updatedSetting)
+      setError(null)
+      try {
+        await emitSettingsChanged(updatedSetting)
+      } catch (err) {
+        log.error({ err }, 'Failed to broadcast settings change')
+      }
     } catch (err) {
       log.error({ err }, 'Failed to update keyboard shortcuts')
+      setError(`保存设置失败: ${err}`)
       throw err
+    } finally {
+      setLoading(false)
     }
   }
 

--- a/src/contexts/__tests__/SettingContext.shortcuts.test.tsx
+++ b/src/contexts/__tests__/SettingContext.shortcuts.test.tsx
@@ -62,6 +62,7 @@ const baseSetting: Settings = {
     language: 'en-US',
     deviceName: 'Test Device',
     telemetryEnabled: true,
+    usageAnalyticsEnabled: true,
   },
   sync: {
     autoSync: true,

--- a/src/contexts/__tests__/SettingContext.shortcuts.test.tsx
+++ b/src/contexts/__tests__/SettingContext.shortcuts.test.tsx
@@ -1,0 +1,170 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { getSettings, updateSettings } from '@/api/daemon'
+import type { Settings } from '@/api/daemon/settings'
+import { updateKeyboardShortcuts as persistKeyboardShortcuts } from '@/api/tauri-command'
+import { SettingProvider } from '@/contexts/SettingContext'
+import { useSetting } from '@/hooks/useSetting'
+import { connectDaemonWs } from '@/lib/daemon-ws-bootstrap'
+import { emitSettingsChanged } from '@/lib/settings-events'
+import { invokeWithTrace } from '@/lib/tauri-command'
+
+vi.mock('@/api/daemon', () => ({
+  getSettings: vi.fn(),
+  updateSettings: vi.fn(),
+}))
+
+vi.mock('@/api/tauri-command', () => ({
+  updateKeyboardShortcuts: vi.fn(),
+}))
+
+vi.mock('@/lib/daemon-ws-bootstrap', () => ({
+  connectDaemonWs: vi.fn(),
+}))
+
+vi.mock('@/lib/settings-events', () => ({
+  emitSettingsChanged: vi.fn(),
+}))
+
+vi.mock('@/lib/tauri-command', () => ({
+  invokeWithTrace: vi.fn(),
+}))
+
+vi.mock('@/i18n', () => ({
+  __esModule: true,
+  default: {
+    language: 'en-US',
+    changeLanguage: vi.fn().mockResolvedValue(undefined),
+  },
+  normalizeLanguage: vi.fn((language: string | null | undefined) => language ?? 'en-US'),
+  persistLanguage: vi.fn(),
+}))
+
+const mockGetSettings = vi.mocked(getSettings)
+const mockUpdateSettings = vi.mocked(updateSettings)
+const mockPersistKeyboardShortcuts = vi.mocked(persistKeyboardShortcuts)
+const mockConnectDaemonWs = vi.mocked(connectDaemonWs)
+const mockEmitSettingsChanged = vi.mocked(emitSettingsChanged)
+const mockInvokeWithTrace = vi.mocked(invokeWithTrace)
+
+const baseSetting: Settings = {
+  schemaVersion: 1,
+  general: {
+    autoStart: false,
+    silentStart: false,
+    autoCheckUpdate: true,
+    theme: 'light',
+    themeColor: 'zinc',
+    themeColorLight: null,
+    themeColorDark: null,
+    themeOverridesLight: {},
+    themeOverridesDark: {},
+    language: 'en-US',
+    deviceName: 'Test Device',
+    telemetryEnabled: true,
+  },
+  sync: {
+    autoSync: true,
+    syncFrequency: 'realtime',
+    contentTypes: {
+      text: true,
+      image: true,
+      link: true,
+      file: true,
+      codeSnippet: true,
+      richText: true,
+    },
+  },
+  retentionPolicy: {
+    enabled: false,
+    rules: [],
+    skipPinned: false,
+    evaluation: 'anyMatch',
+  },
+  security: {
+    encryptionEnabled: false,
+    passphraseConfigured: false,
+    autoUnlockEnabled: false,
+  },
+  pairing: {
+    stepTimeout: 15,
+    userVerificationTimeout: 120,
+    sessionTimeout: 300,
+    maxRetries: 3,
+    protocolVersion: '1.0.0',
+  },
+  keyboardShortcuts: {
+    'global.toggleQuickPanel': 'meta+ctrl+v',
+  },
+  fileSync: {
+    fileSyncEnabled: true,
+    smallFileThreshold: 10 * 1024 * 1024,
+    maxFileSize: 5 * 1024 * 1024 * 1024,
+    fileCacheQuotaPerDevice: 500 * 1024 * 1024,
+    fileRetentionHours: 24,
+    fileAutoCleanup: true,
+  },
+  network: {
+    allowRelayFallback: true,
+    allowOverlayNetworkAddrs: false,
+  },
+}
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <SettingProvider>{children}</SettingProvider>
+)
+
+describe('SettingContext shortcuts — in-process apply path', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockConnectDaemonWs.mockResolvedValue(undefined)
+    mockGetSettings.mockResolvedValue(baseSetting)
+    mockUpdateSettings.mockResolvedValue({ success: true, restartRequired: false })
+    mockPersistKeyboardShortcuts.mockResolvedValue({
+      'global.toggleQuickPanel': 'meta+shift+v',
+    })
+    mockEmitSettingsChanged.mockResolvedValue(undefined)
+    mockInvokeWithTrace.mockResolvedValue(undefined)
+
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: vi.fn().mockReturnValue({
+        matches: false,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      }),
+    })
+  })
+
+  it('更新快捷键时不走 daemon HTTP，避免丢失 OS 全局快捷键副作用', async () => {
+    const { result } = renderHook(() => useSetting(), { wrapper })
+    await waitFor(() => {
+      expect(result.current.setting).toEqual(baseSetting)
+    })
+
+    await act(async () => {
+      await result.current.updateKeyboardShortcuts({
+        'global.toggleQuickPanel': 'meta+shift+v',
+      })
+    })
+
+    expect(mockPersistKeyboardShortcuts).toHaveBeenCalledWith(
+      {
+        'global.toggleQuickPanel': 'meta+ctrl+v',
+      },
+      {
+        'global.toggleQuickPanel': 'meta+shift+v',
+      }
+    )
+    expect(mockUpdateSettings).not.toHaveBeenCalled()
+    expect(result.current.setting?.keyboardShortcuts).toEqual({
+      'global.toggleQuickPanel': 'meta+shift+v',
+    })
+    expect(mockEmitSettingsChanged).toHaveBeenCalledWith({
+      ...baseSetting,
+      keyboardShortcuts: {
+        'global.toggleQuickPanel': 'meta+shift+v',
+      },
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- **Backend hex boundary fix.** Lift the GUI-framework-agnostic parts of the global-shortcut wiring (settings parsing, normalization, registry state, update coordinator with rollback) out of `uc-tauri` into a new `uc-desktop::shortcuts` module, behind a `GlobalShortcutRegistry` trait. `uc-tauri` keeps a thin Tauri adapter (`TauriGlobalShortcutRegistry`) that wraps `tauri-plugin-global-shortcut`, plus the `#[tauri::command]` entry that still wraps the call in `run_on_main_thread`. Future shells (e.g. an AppKit-native shell) can reuse the same coordinator without pulling Tauri. (`5af25e47`, `a1534c4e`)
- **Frontend save path now goes through Tauri command.** `SettingContext.updateKeyboardShortcuts` switches from the daemon HTTP settings API to the in-process `update_keyboard_shortcuts` command, so persisting and re-registering the OS-level quick-panel hotkey happen atomically inside the GUI process. The wire format (`HashMap<String, Option<ShortcutKeyDto>>`, camelCase response) is unchanged. (`7edbe378`, `67555436`)
- **Build/docs cleanup uncovered while validating the refactor.** `tauri.conf.json` switched `bundle.targets` from `"all"` to an explicit list — the implicit `"all"` was silently failing the MSI bundler on Windows (non-numeric pre-release IDs); shipping releases have only ever included NSIS anyway. The user-facing docs that mentioned MSI/Portable ZIP are corrected to describe the actual NSIS-only artefact, in both en/ and zh/. (`410f669c`, `89a1e2f5`)

## Test plan

- [x] `cargo check --workspace`
- [x] `cargo test -p uc-desktop --lib shortcuts::` — 13 new tests cover normalization, settings resolution, coordinator ordering, defensive-unregister skip, and rollback on failure
- [x] `cargo test -p uc-tauri --lib commands::settings::` — existing patch / camelCase wire tests pass with the new state container and constants
- [x] `cargo test --workspace --lib` green (>1100 tests; pre-existing doctest failures in `uc-daemon-local` are unrelated)
- [x] Frontend: `tsc --noEmit` clean; new tests cover `buildKeyboardShortcutsPatch`, the `updateKeyboardShortcuts` Tauri-command wrapper, and the `SettingContext` save path
- [x] CI: alpha-build (windows-latest) green at HEAD — produced `UniClipboard_<version>_x64-setup.exe` on the `v0.9.0-alpha.shortcuts` test tag
- [ ] Manual smoke on Windows install: default shortcut (`Ctrl+Alt+V`) opens quick panel; settings panel save → new shortcut active, old released; saving an OS-occupied combo fails and the previous shortcut survives (rollback); shortcut survives an app restart
- [ ] (Recommended) Drop the throwaway `v0.9.0-alpha.shortcuts` release/tag once review is done

## Notes for reviewers

- Architectural contracts checked: `uc-desktop` Cargo.toml gains no GUI-framework deps; `uc-desktop/src/shortcuts.rs` has zero `use tauri` / `use objc2*`; the only references to `tauri-plugin-global-shortcut` left in `uc-tauri` are the plugin registration in `run.rs` and the adapter implementation
- The MSI exclusion is a behaviour-neutral fix that just makes the build configuration match what releases have actually been shipping — no user impact, but happy to split it out into its own PR if reviewers prefer

FIX: #668

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Windows installation instructions to describe NSIS installer flow with Start Menu shortcuts and Settings → Apps registration.
  * Enhanced troubleshooting guide with additional Windows uninstall options via OS settings.
  * Updated Chinese documentation with equivalent changes.

* **New Features**
  * Added global keyboard shortcut customization and coordination.
  * Users can now configure quick-panel shortcuts through application settings.

* **Tests**
  * Added test coverage for keyboard shortcut functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/UniClipboard/UniClipboard/pull/685)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->