### PR TITLE
fix(quick-panel): restore inner focus HWND for Windows paste

### DIFF
--- a/src-tauri/crates/uc-tauri/src/quick_panel/windows.rs
+++ b/src-tauri/crates/uc-tauri/src/quick_panel/windows.rs
@@ -20,8 +20,8 @@ use windows::Win32::UI::Input::KeyboardAndMouse::{
     VK_MENU,
 };
 use windows::Win32::UI::WindowsAndMessaging::{
-    GetForegroundWindow, GetWindowThreadProcessId, IsIconic, IsWindow, SetForegroundWindow,
-    ShowWindow, SW_RESTORE,
+    GetForegroundWindow, GetGUIThreadInfo, GetWindowThreadProcessId, IsIconic, IsWindow,
+    SetForegroundWindow, ShowWindow, GUITHREADINFO, SW_RESTORE,
 };
 
 /// How long to wait after re-activating the previous app before sending Ctrl+V.
@@ -29,10 +29,22 @@ const RESTORE_SETTLE_MS: Duration = Duration::from_millis(40);
 const ALT_RELEASE_WAIT_MS: Duration = Duration::from_millis(120);
 const ALT_RELEASE_POLL_MS: Duration = Duration::from_millis(10);
 
-/// The last foreground window before the quick panel claimed focus.
+/// 之前的前台窗口（顶层 HWND）以及它内部真正持有键盘焦点的子 HWND。
 ///
-/// Stored as `isize` because `HWND` contains `*mut c_void` which is not `Send+Sync`.
-static PREVIOUS_FOREGROUND_WINDOW: Mutex<Option<isize>> = Mutex::new(None);
+/// Electron / WebView2 / Chromium 类应用（如 Microsoft Teams、Slack、Discord、
+/// VS Code、Chrome）的顶层窗口下嵌套着 `Chrome_RenderWidgetHostHWND` 之类的
+/// 子窗口，真正接收 `WM_KEYDOWN` 的是内层子窗口。仅靠 `SetForegroundWindow`
+/// 顶层窗口并不会自动把键盘焦点下沉到子窗口，于是合成的 Ctrl+V 落到了顶层
+/// 窗口本身而不是输入框上 —— 这正是 quick window 自动粘贴对 Teams 失效的
+/// 直接原因。
+///
+/// 这里同时保存顶层 HWND 与 `GetGUIThreadInfo` 拿到的 `hwndFocus`，恢复时
+/// 先把顶层窗口拉回前台，再用 `AttachThreadInput` + `SetFocus` 把焦点重新
+/// 下沉到内层子窗口。
+///
+/// 两个值都以 `isize` 存放，因为 `HWND` 内部是 `*mut c_void`，不实现
+/// `Send + Sync`；用 0 表示"未捕获到内层焦点窗口，退化为只恢复顶层窗口"。
+static PREVIOUS_FOREGROUND_WINDOW: Mutex<Option<(isize, isize)>> = Mutex::new(None);
 
 /// Force the given Tauri window to the foreground on Windows.
 ///
@@ -45,7 +57,8 @@ pub fn force_foreground(window: &tauri::WebviewWindow) {
         return;
     };
 
-    let _ = activate_window(hwnd, "quick panel");
+    // quick panel 自身没有需要单独下沉的内层焦点窗口，传 null 即可走顶层激活路径。
+    let _ = activate_window(hwnd, HWND(std::ptr::null_mut()), "quick panel");
 }
 
 /// Remember the foreground window before the quick panel claims focus.
@@ -61,11 +74,28 @@ pub fn remember_previous_foreground(window: &tauri::WebviewWindow) {
             return;
         }
 
+        // 顺手取该窗口所在 GUI 线程当前真正持有键盘焦点的子 HWND。
+        // `GetGUIThreadInfo` 可以查询任意线程的 GUI 状态，不需要 AttachThreadInput；
+        // 拿不到时（线程已退出 / 顶层窗口本身就是焦点）就退化为 null。
+        let target_thread = GetWindowThreadProcessId(foreground_hwnd, None);
+        let focus_hwnd = if target_thread != 0 {
+            let mut info: GUITHREADINFO = std::mem::zeroed();
+            info.cbSize = std::mem::size_of::<GUITHREADINFO>() as u32;
+            if GetGUIThreadInfo(target_thread, &mut info).is_ok() {
+                info.hwndFocus
+            } else {
+                HWND(std::ptr::null_mut())
+            }
+        } else {
+            HWND(std::ptr::null_mut())
+        };
+
         match PREVIOUS_FOREGROUND_WINDOW.lock() {
             Ok(mut guard) => {
-                *guard = Some(foreground_hwnd.0 as isize);
+                *guard = Some((foreground_hwnd.0 as isize, focus_hwnd.0 as isize));
                 debug!(
                     ?foreground_hwnd,
+                    ?focus_hwnd,
                     "Captured previous foreground window for quick panel"
                 );
             }
@@ -76,14 +106,19 @@ pub fn remember_previous_foreground(window: &tauri::WebviewWindow) {
 
 /// Restore focus to the previously active window.
 pub fn restore_previous_foreground() -> Result<(), String> {
-    let hwnd = match PREVIOUS_FOREGROUND_WINDOW.lock() {
+    let (top_hwnd, focus_hwnd) = match PREVIOUS_FOREGROUND_WINDOW.lock() {
         Ok(mut guard) => guard.take(),
         Err(_) => return Err("Previous foreground window lock poisoned".into()),
     }
-    .map(|ptr| HWND(ptr as *mut std::ffi::c_void))
+    .map(|(top, focus)| {
+        (
+            HWND(top as *mut std::ffi::c_void),
+            HWND(focus as *mut std::ffi::c_void),
+        )
+    })
     .ok_or_else(|| "No previous foreground window captured".to_string())?;
 
-    activate_window(hwnd, "previous app")
+    activate_window(top_hwnd, focus_hwnd, "previous app")
 }
 
 /// Simulate a global Ctrl+V keystroke.
@@ -146,29 +181,29 @@ fn keyboard_inputs_for_events(events: &[SimulatedKeyEvent]) -> Vec<INPUT> {
         .collect()
 }
 
-fn activate_window(hwnd: HWND, label: &str) -> Result<(), String> {
+fn activate_window(top_hwnd: HWND, focus_hwnd: HWND, label: &str) -> Result<(), String> {
     unsafe {
-        if !IsWindow(Some(hwnd)).as_bool() {
+        if !IsWindow(Some(top_hwnd)).as_bool() {
             return Err(format!("Stored {label} window handle is no longer valid"));
         }
 
-        if IsIconic(hwnd).as_bool() {
-            let _ = ShowWindow(hwnd, SW_RESTORE);
+        if IsIconic(top_hwnd).as_bool() {
+            let _ = ShowWindow(top_hwnd, SW_RESTORE);
         }
 
         let foreground_hwnd = GetForegroundWindow();
         let foreground_thread = GetWindowThreadProcessId(foreground_hwnd, None);
         let current_thread = GetCurrentThreadId();
-        let attached = foreground_thread != 0 && foreground_thread != current_thread;
+        let attached_fg = foreground_thread != 0 && foreground_thread != current_thread;
 
-        if attached {
+        if attached_fg {
             let _ = AttachThreadInput(foreground_thread, current_thread, true);
         }
 
-        let result = SetForegroundWindow(hwnd);
-        let _ = SetFocus(Some(hwnd));
+        let result = SetForegroundWindow(top_hwnd);
+        let _ = SetFocus(Some(top_hwnd));
 
-        if attached {
+        if attached_fg {
             let _ = AttachThreadInput(foreground_thread, current_thread, false);
         }
 
@@ -178,7 +213,28 @@ fn activate_window(hwnd: HWND, label: &str) -> Result<(), String> {
             ));
         }
 
-        debug!(?hwnd, label, "Activated window via AttachThreadInput");
+        // 顶层窗口已经回到前台。如果先前捕获到了真正持有键盘焦点的内层
+        // 子窗口（Electron / WebView2 / Chromium 类应用的常见情况），再用
+        // 一次 `AttachThreadInput` 把输入焦点下沉回那个子窗口，这样合成的
+        // Ctrl+V 才会落到真正的输入框上 —— 这是修复 Teams 等应用自动粘贴
+        // 失败的关键。`focus_hwnd` 为 null 或等于顶层窗口时跳过即可。
+        if !focus_hwnd.is_invalid()
+            && focus_hwnd != top_hwnd
+            && IsWindow(Some(focus_hwnd)).as_bool()
+        {
+            let target_thread = GetWindowThreadProcessId(focus_hwnd, None);
+            let attached_focus = target_thread != 0 && target_thread != current_thread;
+            if attached_focus {
+                let _ = AttachThreadInput(target_thread, current_thread, true);
+            }
+            let _ = SetFocus(Some(focus_hwnd));
+            if attached_focus {
+                let _ = AttachThreadInput(target_thread, current_thread, false);
+            }
+            debug!(?focus_hwnd, label, "Restored inner keyboard focus HWND");
+        }
+
+        debug!(?top_hwnd, label, "Activated window via AttachThreadInput");
     }
 
     Ok(())


### PR DESCRIPTION
## Summary

- 修复 quick window 自动粘贴在 Microsoft Teams、Slack、Discord、VS Code 等 Electron / WebView2 / Chromium 内核应用中**完全失效**的问题——Ctrl+V 没有落到输入框。
- 根因（`src-tauri/crates/uc-tauri/src/quick_panel/windows.rs`）：捕获/恢复"上一个前台应用"时只存了 `GetForegroundWindow()` 顶层 HWND。Chromium 类应用真正接收 `WM_KEYDOWN` 的是顶层窗口内部的 `Chrome_RenderWidgetHostHWND` 子窗口；`SetForegroundWindow` 顶层并不会把键盘焦点下沉到子窗口，于是 `SendInput` 出来的 Ctrl+V 落到了空地。
- 修复：`remember_previous_foreground` 同时用 `GetGUIThreadInfo` 取该窗口所在线程的 `hwndFocus`，存为 `(top_hwnd, focus_hwnd)` 二元组；`activate_window` 在原有 `AttachThreadInput + SetForegroundWindow(top_hwnd)` 之后，再做一次 `AttachThreadInput + SetFocus(focus_hwnd)` 把键盘焦点重新下沉回内层子窗口。
- 退化路径：`GetGUIThreadInfo` 失败 / `focus_hwnd` 为空或等于顶层窗口 / 已失效 → 跳过下沉步骤，行为与旧逻辑一致；Notepad、纯 Win32 输入框这类原本就能工作的场景没有回归风险。

Docs left as-is — no user-facing surface (settings, defaults, error messages, hotkeys) changed; the existing `quick-panel.mdx` claim "Enter 粘贴回上一个应用 / Enter simulates a system paste" was already correct and now actually holds on more apps.

## Test plan

- [x] `cargo check -p uc-tauri --target x86_64-pc-windows-gnu` 通过，触改文件无新增 warning。
- [x] `cargo fmt` 干净（commit 时 lint-staged 自动跑过）。
- [ ] **Windows 手测核心目标：** quick window → 选条目 → `Enter` → 粘贴到 Microsoft Teams 聊天输入框成功落入。
- [ ] **Windows 回归手测：** Notepad、Chrome 地址栏、VS Code 编辑器、Slack 输入框、Discord 输入框 — 全部仍能正常粘贴。
- [ ] 若 Teams 仍失败，开启 trace 日志：
  - 确认 `Captured previous foreground window for quick panel` 的 `focus_hwnd` 字段非 `0x0`；
  - 确认 `Restored inner keyboard focus HWND` 是否被打印。

  以此判断是焦点 HWND 没捕获到（根因 1 没解决），还是焦点回去了但仍丢键（需要进一步加大 `RESTORE_SETTLE_MS` 或改用 scancode-based `SendInput`）。