### PR TITLE
fix(ci): prepend cargo bin to PATH on macOS runners

### DIFF
--- a/.github/workflows/alpha-build.yml
+++ b/.github/workflows/alpha-build.yml
@@ -86,6 +86,12 @@ jobs:
         with:
           targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
 
+      - name: Prepend cargo bin to PATH
+        # 见 build.yml 同名 step 注释:绕开 macos-15-arm64 image 20260511+
+        # Homebrew rustup 多链导致 `cargo metadata` 落到 rustup-init 的问题。
+        shell: bash
+        run: echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> "$GITHUB_PATH"
+
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -101,6 +101,12 @@ jobs:
           # macOS 装两个 darwin target;Windows host=msvc 装 noop。
           targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || matrix.target }}
 
+      - name: Prepend cargo bin to PATH
+        # 见 build.yml 同名 step 注释:绕开 macos-15-arm64 image 20260511+
+        # Homebrew rustup 多链导致 `cargo` 落到 rustup-init 的问题。
+        shell: bash
+        run: echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> "$GITHUB_PATH"
+
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,6 +121,15 @@ jobs:
         with:
           targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
 
+      - name: Prepend cargo bin to PATH
+        # macos-15-arm64 runner image 20260511+ 预装了 Homebrew rustup
+        # formula,把 rustup-init multicall 软链到 /opt/homebrew/bin/cargo,
+        # 导致 `cargo metadata` 命中错误 binary 并吐 rustup-init 用法。
+        # dtolnay/rust-toolchain 检测到 rustup 已存在就跳过了 PATH 写入,
+        # 这里强制把 rustup 真 proxy 所在目录前置,覆盖 brew 那条。
+        shell: bash
+        run: echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> "$GITHUB_PATH"
+
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
         with:


### PR DESCRIPTION
## Summary

- macOS aarch64/x86_64 build jobs started failing on v0.10.0-alpha.1 with `cargo metadata: error: unexpected argument 'metadata' found` followed by `Usage: rustup-init[EXE] [OPTIONS]`. Run [25861431606](https://github.com/UniClipboard/UniClipboard/actions/runs/25861431606/job/75992108562) failed; the immediately preceding release run for v0.9.0 ([25846329956](https://github.com/UniClipboard/UniClipboard/actions/runs/25846329956)) succeeded 6 hours earlier.
- Root cause is a GitHub runner image bump, not our code: `macos-15-arm64` moved from **20260427.0018** → **20260511.0048** between the two runs. The new image preinstalls Homebrew's `rustup` formula, which is a `rustup-init` multicall symlinked as `rustup`, `cargo`, `rustc`, etc. under `/opt/homebrew/bin/`. `dtolnay/rust-toolchain@stable` sees `command -v rustup` succeed and **skips** appending `$CARGO_HOME/bin` to `$GITHUB_PATH`, so later steps resolve `cargo` to the Homebrew shim. When tauri-action runs `cargo metadata` to locate the workspace, that shim prints `rustup-init` usage and exits non-zero (d5fe78ee).
- Fix: add a single explicit step right after each `dtolnay/rust-toolchain@stable` invocation that writes `${CARGO_HOME:-$HOME/.cargo}/bin` to `$GITHUB_PATH`, forcing the real rustup proxy ahead of the Homebrew multicall. Applied in `build.yml`, `alpha-build.yml`, and `build-cli.yml`. `release.yml`'s rust-toolchain step runs on `ubuntu-latest` and is unaffected, so it is left alone (d5fe78ee).

## Test plan

- [ ] Re-run the failed v0.10.0-alpha.1 release (or trigger `alpha-build` with `macos-aarch64` as the cheapest probe) and confirm `cargo metadata` resolves and tauri-action completes its macOS bundle.
- [ ] Verify Linux container builds (`build / Build x86_64-unknown-linux-gnu`, `Build aarch64-unknown-linux-gnu`) and the Windows build still succeed — the new step runs everywhere but should be a no-op on those platforms.
- [ ] Spot-check `build-cli / Build CLI aarch64-apple-darwin` to ensure the CLI matrix gets the same fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD pipeline stability and reliability by enhancing build environment configuration across multiple workflows, ensuring better toolchain integration during automated builds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/UniClipboard/UniClipboard/pull/694)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->