### PR TITLE
fix(pairing): disable multipath QUIC to avoid noq#512 race

### DIFF
--- a/src-tauri/crates/uc-infra/src/network/iroh/node.rs
+++ b/src-tauri/crates/uc-infra/src/network/iroh/node.rs
@@ -304,18 +304,35 @@ fn build_transport_config() -> QuicTransportConfig {
         // because the iroh `QuicTransportConfigBuilder` already pre-sets a
         // sane default — calling this setter just overrides it.
         .keep_alive_interval(Duration::from_secs(15))
-        // iroh#4124 workaround: every QUIC connection has a monotonic
-        // PathId budget; the iroh default is `MAX_MULTIPATH_PATHS + 1 =
-        // 13`. With mDNS + pkarr + dual-relay + call-me-maybe + STUN
-        // hairpin all feeding candidates into the same connection, plus
-        // path abandonment not releasing the ID slot, we burn through 13
-        // in seconds. Once exhausted, every blob transfer that needs to
-        // open a new path fails with `Error::Io` and `remote_state` spams
-        // `MaxPathIdReached` WARN forever (no upstream back-off yet).
-        // Bumping to 64 gives ~5× headroom; each path costs a small
-        // amount of state-machine memory, well bounded by typical 2-peer
-        // workloads.
-        .max_concurrent_multipath_paths(64)
+        // Multipath QUIC extension is *not* enabled — we deliberately leave
+        // `max_concurrent_multipath_paths` at the noq-proto default of
+        // `None` (i.e. don't call the setter). Rationale:
+        //
+        // 1. Our shape is 2-peer P2P. Multipath QUIC is designed for hosts
+        //    with multiple ISPs simultaneously; we have one functional
+        //    path between any two devices.
+        //
+        // 2. Empirically, enabling multipath (any value ≥ 1) triggers
+        //    upstream bug noq#512 ("PTO fires when unset for an abandoned
+        //    path") whenever the cross-peer link has more than one
+        //    candidate (Tailscale + LAN + vmnet etc) and one of those
+        //    candidates gets abandoned during handshake. The race
+        //    manifests as: incoming connection arrives at the iroh
+        //    endpoint, ALPN routes to `/uniclipboard/pairing/1`,
+        //    `noq_proto::connection` silently swallows the PTO timer,
+        //    handshake never makes progress, and `iroh::protocol`
+        //    eventually 60s-timeouts at the router.accept ALPN deadline.
+        //    We observed this at ~50% under release build with multipath
+        //    enabled across 10 mac↔fedora rounds, but 0% on fedora
+        //    self-pair (localhost UDP, no path abandonment).
+        //
+        // 3. iroh#4124 (the old reason this setter existed at all —
+        //    PathId-budget exhaustion at 13) was about ramping the budget
+        //    up. Since we're not enabling multipath, there is no PathId
+        //    budget to exhaust.
+        //
+        // Revisit only after upstream noq#512 is fixed AND we have a
+        // real product need for multipath (e.g. mobile multi-radio).
         .build()
 }
 

--- a/src-tauri/crates/uc-observability/src/profile.rs
+++ b/src-tauri/crates/uc-observability/src/profile.rs
@@ -53,14 +53,18 @@ const NOISE_FILTERS: &[&str] = &[
     // harmless because reachability still works over other interfaces,
     // but high-frequency, so cap at ERROR to keep Sentry Logs quiet.
     "noq_udp=error",
-    // QUIC connection state machine internals. These show up at WARN /
-    // ERROR but are documented protocol noise:
-    //   - "PTO expired while unset" — probe timer on an unactivated path
-    //   - "failed closing path" — multipath graceful-close race
-    // iroh's higher layers re-emit real connection failures as their own
-    // structured events, so silencing this module loses no actionable
-    // signal — we just stop burning quota on QUIC steady-state churn.
-    "noq_proto::connection=off",
+    // QUIC connection state machine internals. Cap at WARN: silences the
+    // ~40k DEBUG/INFO events per peer-hour of steady-state churn but keeps
+    // the WARN/ERROR signals visible. The earlier `=off` here masked the
+    // exact symptoms ("PTO expired while unset", "failed closing path
+    // err=MultipathNotNegotiated") of upstream noq#512, which made a
+    // multipath-pairing failure invisible at the prod log level — every
+    // diagnosis had to override RUST_LOG to even see the root cause.
+    // Higher layers do re-emit *some* real failures, but for QUIC state
+    // machine races they only re-emit a generic "router.accept timed out"
+    // 60s after the fact, with no path/PTO context. Keeping WARN/ERROR
+    // through preserves that context cheaply.
+    "noq_proto::connection=warn",
     // magicsock multipath state machine. The remote_state submodule is
     // also where iroh#4124 spams `Opening path failed` on every event
     // once the per-connection PathId budget is exhausted; cap that one


### PR DESCRIPTION
## Summary

- **Stop calling `.max_concurrent_multipath_paths(64)` in `build_transport_config`** so iroh's QUIC transport falls back to noq-proto's default (`None` = multipath disabled). Empirically this was the root cause of the intermittent ~50% pairing failures users hit on multi-candidate links (Tailscale + LAN + UTM vmnet, etc.) (`a4d9051f`).
- **Lift the prod log filter on `noq_proto::connection` from `=off` to `=warn`** so the upstream race signals stay visible at the prod log level instead of forcing every future diagnosis to override `RUST_LOG` (`c69c3b67`).

## Root cause: upstream [noq#512][noq-512] (still open)

When multipath QUIC is enabled, every handshake on a link with more than one candidate IP eventually trips this upstream race during NAT-traversal:

1. iroh sends initial packets on path 0 and arms `set_loss_detection_timer()`.
2. The path is abandoned mid-handshake (vmnet bridge / Clash TUN / Tailscale path probing).
3. Path-abandonment removes the in-flight packets but **doesn't clear the PTO timer** (this is the noq#512 bug).
4. Timer fires; `pto_time_and_space()` returns `None` (no in-flight space to retransmit on).
5. `noq_proto::connection` silently logs `PTO expired while unset path_id=0` and returns. **No retransmit happens.** Handshake never completes.
6. 60 seconds later `iroh::protocol::router.accept` times out at the ALPN-bound deadline with the unhelpful message `Accepting incoming connection ended with error: timed out`.

User-visible: pairing succeeds the first time, then fails ~50–100% of the time on subsequent attempts. The mac sponsor log at INFO shows every inbound pairing arriving at iroh, ALPN being correctly routed to `/uniclipboard/pairing/1`, then **complete silence for 60 seconds**.

The race only fires when multipath is actively enabled and the path set churns — fedora self-pair on localhost UDP (single path, no abandonment) succeeds 100% of the time even with multipath enabled, confirming the trigger.

## Why this setter existed in the first place

The original 64-path budget was a workaround for [iroh#4124][iroh-4124] (per-connection PathId budget exhaustion at the default 13). #4124 only happens when multipath is enabled and many candidates churn through the same connection — itself a downstream consequence of enabling multipath. With multipath disabled there is no PathId budget to exhaust, so #4124's trigger goes away too. (Upstream confirmed this by closing #4124 manually without merging a fix.)

## Why we don't need multipath

Our shape is 2-peer P2P clipboard sync. Multipath QUIC is designed for hosts with multiple ISPs simultaneously (mobile Wi-Fi + cellular, dual-ISP bonding). Every device in our deployment has exactly one functional path to any given peer at a time. Iroh's hole-punching, relay fallback, mDNS / DNS / pkarr address-lookup all happen *before* connection establishment and are unaffected by this change — pairing across NAT, across Tailscale, across LAN all keep working exactly as before.

## When to revisit

Re-enable when **both** of these are true:

1. Upstream noq#512 closes with a real fix (still open as of 2026-05-14)
2. We have a real product need for multipath (mobile multi-radio, dual-ISP bonding). Desktop P2P clipboard does not need this.

The `default = None` posture means we'll automatically follow upstream once they decide multipath is stable — re-enabling later is a one-line `.max_concurrent_multipath_paths(N)` add-back.

## Test plan

- [x] 10 GUI pairing rounds mac↔fedora (UTM VM, 192.168.64/24 vmnet bridge): **100% success**, handshake latency 444ms – 750ms (vs 60s timeout previously)
- [x] Mac sponsor log clean: 0 occurrences of `MultipathNotNegotiated`, 0 occurrences of `PTO expired while unset`, 0 `router.accept` timeouts
- [x] Verified the second commit's filter change makes the race signals visible at prod log level (no `RUST_LOG` override needed)
- [ ] **Reviewer**: spot-check that no other call site re-enables multipath via `set_max_concurrent_multipath_paths` or similar. There shouldn't be one — the deleted line was the only reference in the repo.
- [ ] **Reviewer**: confirm the docs-site scan was correct (no user-facing surface change). This PR's diff doesn't touch any CLI flag, GUI setting, error message, or default visible to end users; multipath is purely an internal QUIC transport knob.

[noq-512]: https://github.com/n0-computer/noq/issues/512
[iroh-4124]: https://github.com/n0-computer/iroh/issues/4124

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted QUIC protocol configuration to address upstream compatibility issues and improve network stability.

* **Chores**
  * Enhanced QUIC logging visibility at production log levels for improved diagnostics and system observability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/UniClipboard/UniClipboard/pull/696)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->