### PR TITLE
fix(ui): remove web-style visual leaks from main window

### DIFF
--- a/src/components/clipboard/ClipboardActionBar.tsx
+++ b/src/components/clipboard/ClipboardActionBar.tsx
@@ -49,7 +49,7 @@ const ClipboardActionBar: React.FC<ClipboardActionBarProps> = ({
           className={cn(
             'flex items-center gap-2 px-2.5 py-1 rounded-md text-xs transition-colors duration-200',
             hasActiveItem && !isActiveItemTransferring
-              ? 'text-primary hover:bg-primary/5 cursor-pointer'
+              ? 'text-primary hover:bg-primary/5'
               : 'text-muted-foreground/30 cursor-default'
           )}
           onClick={hasActiveItem && !isActiveItemTransferring ? onSyncToClipboard : undefined}
@@ -72,7 +72,7 @@ const ClipboardActionBar: React.FC<ClipboardActionBarProps> = ({
           className={cn(
             'flex items-center gap-2 px-2.5 py-1 rounded-md text-xs transition-all duration-200 relative group',
             hasActiveItem && !isCopyBlocked
-              ? 'text-foreground hover:bg-muted cursor-pointer'
+              ? 'text-foreground hover:bg-muted'
               : 'text-muted-foreground/30 cursor-default'
           )}
           onClick={hasActiveItem && !isCopyBlocked ? onCopy : undefined}
@@ -127,7 +127,7 @@ const ClipboardActionBar: React.FC<ClipboardActionBarProps> = ({
         className={cn(
           'flex items-center gap-2 px-2.5 py-1 rounded-md text-xs transition-all duration-200 group',
           hasActiveItem
-            ? 'text-muted-foreground hover:text-destructive hover:bg-destructive/5 cursor-pointer'
+            ? 'text-muted-foreground hover:text-destructive hover:bg-destructive/5'
             : 'text-muted-foreground/30 cursor-default'
         )}
         onClick={hasActiveItem ? onDelete : undefined}

--- a/src/components/clipboard/ClipboardItem.tsx
+++ b/src/components/clipboard/ClipboardItem.tsx
@@ -378,7 +378,7 @@ const ClipboardItem: React.FC<ClipboardItemProps> = ({
       }}
     >
       {/* Main Content Area */}
-      <div className="select-text p-4">{renderContent()}</div>
+      <div className="selectable select-text p-4">{renderContent()}</div>
 
       {/* Footer Area */}
       <div className="flex items-center justify-between px-4 pb-2 pt-1 text-xs text-muted-foreground/60 select-none">
@@ -388,7 +388,7 @@ const ClipboardItem: React.FC<ClipboardItemProps> = ({
         {/* Center: Expand Button (仅在需要时显示) */}
         {shouldShowExpandButton() && (
           <div
-            className="flex items-center gap-1 cursor-pointer hover:text-foreground transition-colors px-2 py-1 rounded-md hover:bg-muted/50"
+            className="flex items-center gap-1 hover:text-foreground transition-colors px-2 py-1 rounded-md hover:bg-muted/50"
             onClick={e => {
               e.stopPropagation()
               void handleExpand() // Call async handler

--- a/src/components/clipboard/ClipboardItemRow.tsx
+++ b/src/components/clipboard/ClipboardItemRow.tsx
@@ -145,7 +145,7 @@ const ClipboardItemRow = React.forwardRef<HTMLDivElement, ClipboardItemRowProps>
         ref={elementRef ?? ref}
         {...rest}
         className={cn(
-          'flex flex-col gap-1 py-2.5 px-3 rounded-lg cursor-pointer select-none transition-colors shrink-0 overflow-hidden',
+          'flex flex-col gap-1 py-2.5 px-3 rounded-lg select-none transition-colors shrink-0 overflow-hidden',
           isActive ? 'bg-primary/10 text-foreground' : 'hover:bg-muted/50 text-foreground/80',
           extraClassName
         )}

--- a/src/components/device/DeviceStatus.tsx
+++ b/src/components/device/DeviceStatus.tsx
@@ -22,7 +22,7 @@ const DeviceStatus: React.FC<DeviceStatusProps> = () => {
           <div className="h-2 w-2 rounded-full bg-yellow-500 mr-2"></div>
           <span className="text-xs text-white">工作站</span>
         </div>
-        <div className="px-3 py-1 border border-dashed border-gray-600 rounded-full flex items-center cursor-pointer hover:bg-gray-700/60">
+        <div className="px-3 py-1 border border-dashed border-gray-600 rounded-full flex items-center hover:bg-gray-700/60">
           <svg
             xmlns="http://www.w3.org/2000/svg"
             className="h-3 w-3 text-gray-400 mr-1"

--- a/src/components/device/MobileSyncCredentialModal.tsx
+++ b/src/components/device/MobileSyncCredentialModal.tsx
@@ -225,7 +225,7 @@ const MobileSyncCredentialModal: React.FC<Props> = ({ payload, onClose }) => {
           <label
             ref={acknowledgeRef}
             className={cn(
-              'flex cursor-pointer items-start gap-2 rounded-md border bg-card p-3 transition-all',
+              'flex items-start gap-2 rounded-md border bg-card p-3 transition-all',
               hintActive
                 ? 'border-primary bg-primary/10 ring-4 ring-primary/30 shadow-md shadow-primary/20'
                 : 'border-border/60'

--- a/src/components/device/RotatedPasswordModal.tsx
+++ b/src/components/device/RotatedPasswordModal.tsx
@@ -124,7 +124,7 @@ const RotatedPasswordModal: React.FC<Props> = ({ payload, onClose }) => {
           <label
             ref={acknowledgeRef}
             className={cn(
-              'flex cursor-pointer items-start gap-2 rounded-md border bg-card p-3 transition-all',
+              'flex items-start gap-2 rounded-md border bg-card p-3 transition-all',
               hintActive
                 ? 'border-primary bg-primary/10 ring-4 ring-primary/30 shadow-md shadow-primary/20'
                 : 'border-border/60'

--- a/src/components/device/Rules.tsx
+++ b/src/components/device/Rules.tsx
@@ -44,7 +44,7 @@ const Rules: React.FC = () => {
                 <h5 className="text-sm font-medium text-white">自动同步</h5>
                 <p className="text-xs text-gray-400 mt-0.5">在设备解锁状态下自动同步剪贴板内容</p>
               </div>
-              <label className="flex items-center cursor-pointer">
+              <label className="flex items-center">
                 <div className="relative">
                   <input type="checkbox" className="sr-only" checked />
                   <div className="block bg-gray-600 w-10 h-5 rounded-full"></div>
@@ -59,7 +59,7 @@ const Rules: React.FC = () => {
                 <h5 className="text-sm font-medium text-white">同步文本</h5>
                 <p className="text-xs text-gray-400 mt-0.5">允许同步文本内容</p>
               </div>
-              <label className="flex items-center cursor-pointer">
+              <label className="flex items-center">
                 <div className="relative">
                   <input type="checkbox" className="sr-only" checked />
                   <div className="block bg-gray-600 w-10 h-5 rounded-full"></div>
@@ -76,7 +76,7 @@ const Rules: React.FC = () => {
                   允许同步图片内容 (可能会消耗更多流量)
                 </p>
               </div>
-              <label className="flex items-center cursor-pointer">
+              <label className="flex items-center">
                 <div className="relative">
                   <input type="checkbox" className="sr-only" checked />
                   <div className="block bg-gray-600 w-10 h-5 rounded-full"></div>
@@ -91,7 +91,7 @@ const Rules: React.FC = () => {
                 <h5 className="text-sm font-medium text-white">同步文件</h5>
                 <p className="text-xs text-gray-400 mt-0.5">允许同步文件内容 (最大10MB)</p>
               </div>
-              <label className="flex items-center cursor-pointer">
+              <label className="flex items-center">
                 <div className="relative">
                   <input type="checkbox" className="sr-only" />
                   <div className="block bg-gray-600 w-10 h-5 rounded-full"></div>

--- a/src/components/setting/AppearanceSection.tsx
+++ b/src/components/setting/AppearanceSection.tsx
@@ -162,7 +162,7 @@ function ThemeWindowPreview({ label, tokens, selected, hint, onSelect }: ThemeWi
       className={cn(
         'group relative h-full min-h-[6.625rem] rounded-xl border overflow-hidden p-0 text-left shadow-sm transition-all',
         selected ? 'border-primary/60 ring-2 ring-primary/30 shadow-md' : 'border-border/60',
-        'cursor-pointer hover:border-primary/40 hover:shadow-md'
+        'hover:border-primary/40 hover:shadow-md'
       )}
       style={{ backgroundColor: tokens.background }}
     >
@@ -280,7 +280,7 @@ function ThemeSystemPreview({
       className={cn(
         'group relative rounded-xl overflow-hidden p-0 text-left shadow-sm transition-all',
         selected ? 'shadow-md' : '',
-        'cursor-pointer hover:shadow-md'
+        'hover:shadow-md'
       )}
       style={{
         backgroundImage: `linear-gradient(90deg, ${lightTokens.background} 0%, ${lightTokens.background} 50%, ${darkTokens.background} 50%, ${darkTokens.background} 100%)`,

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -10,6 +10,25 @@ import { connectDaemonWs, registerDaemonShutdownListener } from '@/lib/daemon-ws
 import { initializeWindowUi } from '@/lib/window-ui'
 import { applyDeviceMetaToSentry, initSentry, Sentry } from '@/observability/sentry'
 
+// 屏蔽 WebKit/WebView2 默认右键菜单(Inspect / Reload / 拼写检查),否则用户右键
+// 任何文本都会暴露 webview 身份。需要原生右键的地方用 @radix-ui/react-context-menu opt-in。
+if (typeof window !== 'undefined') {
+  window.addEventListener('contextmenu', e => e.preventDefault())
+
+  // DevTools 用 ⌘⌥I (macOS) / Ctrl+Shift+I (Win/Linux) 打开,补偿被禁用的右键菜单。
+  window.addEventListener('keydown', e => {
+    const isMac = navigator.platform.toLowerCase().includes('mac')
+    const modifier = isMac ? e.metaKey && e.altKey : e.ctrlKey && e.shiftKey
+    if (modifier && e.key.toLowerCase() === 'i') {
+      e.preventDefault()
+      void import('@tauri-apps/api/webviewWindow').then(({ getCurrentWebviewWindow }) => {
+        const w = getCurrentWebviewWindow() as unknown as { openDevtools?: () => void }
+        w.openDevtools?.()
+      })
+    }
+  })
+}
+
 // Sentry init runs before React mounts so that the global ErrorBoundary,
 // the pino → Sentry.logger transmit hook, and breadcrumb capture are all
 // wired up by the time any module calls `createLogger()`. Whether logs

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -423,6 +423,22 @@ html[data-uc-low-effects='true']::view-transition-new(root) {
     overflow: hidden;
   }
 
+  /* 原生桌面应用约定:UI 文本默认不可框选,避免 WebKit 拖蓝选区暴露 webview。
+     输入控件、可编辑节点、显式标 .selectable 的剪贴板正文仍保留文本选择。 */
+  body {
+    user-select: none;
+    -webkit-user-select: none;
+  }
+
+  input,
+  textarea,
+  [contenteditable='true'],
+  [contenteditable=''],
+  .selectable {
+    user-select: text;
+    -webkit-user-select: text;
+  }
+
   /* Set default background based on system theme */
   /* This prevents white flash on startup before React/Tailwind loads */
   html {


### PR DESCRIPTION
## Summary

Closes #697. 三处具体 leak,让窗口不再像网页:

- **`cursor: pointer` 滥用(14 处)**:列表行、ActionBar 按钮、设备开关 label、外观/主题卡片、安全勾选 label,全部改用 hover 背景色表达可点。shadcn 内部的 `cursor-default` 保留不动。
- **WebKit/WebView2 默认右键菜单**:`src/main.tsx` 加 `contextmenu` 全局拦截。DevTools 改用 ⌘⌥I (macOS) / Ctrl+Shift+I (Win/Linux),通过 `getCurrentWebviewWindow().openDevtools()` 触发(devtools 在 `tauri.conf.json` 已开)。
- **业务文本默认可选中**:`globals.css` 加 `body { user-select: none }` + input/textarea/[contenteditable]/`.selectable` 显式可选;`ClipboardItem` 正文显式标 `.selectable` 保留剪贴板内容选择能力。

## Test plan

- [ ] macOS: 右键任意业务区域不再弹出 WebKit 菜单
- [ ] macOS: ⌘⌥I 能打开 DevTools
- [ ] Windows: 右键被拦截、Ctrl+Shift+I 能打开 DevTools
- [ ] Linux: 同上
- [ ] 业务面板列表项 hover 时光标保持默认箭头,但 hover 背景色仍然反馈可点
- [ ] 剪贴板正文(文本/代码)仍可框选复制
- [ ] 设备名/Tab 标签等 UI 文本不能被框选触发 WebKit 拖蓝选区
- [ ] shadcn dropdown/select/context-menu 项依旧显示原本的 `cursor-default`
- [ ] 找一名长期使用 macOS / Windows 原生应用的用户盲测 5 分钟,确认不会说"看着像网页"