### PR TITLE
fix(ui): prevent tooltip auto-show after window refocus on Windows

### DIFF
--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -31,10 +31,22 @@ function Tooltip({
   const onOpenChange = isControlled ? onOpenChangeProp : setUncontrolledOpen
 
   React.useEffect(() => {
-    if (!open) return
-    const dismiss = () => onOpenChange?.(false)
-    window.addEventListener('blur', dismiss)
-    return () => window.removeEventListener('blur', dismiss)
+    const handleBlur = () => {
+      // 关闭已打开的 tooltip，避免切回窗口后旧的 tooltip 仍残留。
+      if (open) onOpenChange?.(false)
+      // 触发器在被点击后会保留 DOM 焦点。Windows 在窗口重新获焦时会向
+      // 上一次获焦的元素再分发一次 focus 事件，Radix Tooltip 的 onFocus
+      // 处理器随即 onOpen，导致 tooltip 在用户没有 hover 时自动展开。
+      // 这里在窗口失焦的同时主动 blur 当前获焦的 tooltip trigger，
+      // 让窗口切回时焦点不再回到触发器上，从而避免误触发；
+      // 选择器限定了仅作用于 tooltip trigger，不影响 input/textarea 等元素。
+      const active = document.activeElement
+      if (active instanceof HTMLElement && active.closest('[data-slot="tooltip-trigger"]')) {
+        active.blur()
+      }
+    }
+    window.addEventListener('blur', handleBlur)
+    return () => window.removeEventListener('blur', handleBlur)
   }, [open, onOpenChange])
 
   return (


### PR DESCRIPTION
## Summary

- 在 Windows 上，点击 sidebar 的导航项后切换窗口至后台、再切回时，tooltip 会"自动 hover"展开。根因是 Windows 在窗口重新获焦时会向上一次获焦的元素再分发一次 `focus` 事件，Radix Tooltip 的 `onFocus` 处理器（`@radix-ui/react-tooltip` 源码 `onFocus: ... if (!isPointerDownRef.current) context.onOpen()`）随即触发 `onOpen`。
- 修复方式：将 `Tooltip` 内已有的 `window blur` 监听器从"仅在 `open=true` 时挂载"改为常驻，并在 blur 时除了关闭已打开的 tooltip 外，再主动 `blur()` 当前获焦的 `[data-slot="tooltip-trigger"]`。窗口切回前焦点不会落回触发器，从而避免误触发。
- 选择器限定为 tooltip trigger，input/textarea/普通按钮的焦点不受影响；macOS/Linux 上没有 refocus 重发 focus 行为，对它们等价于一次无操作。
- docs-site 已扫描：未发现任何对 tooltip 行为的契约性描述需要同步更新。

## Test plan

- [x] `pnpm exec tsc --noEmit` 通过
- [ ] Windows：点击 sidebar 任一项 → 切换到其它窗口 → 切回，确认 tooltip 不再自动展开
- [ ] Windows：在输入框 / 设置项里切窗口再切回，确认输入框焦点保留正常
- [ ] Windows：使用键盘 Tab 到 sidebar item，hover 其它触发器，确认正常显示
- [ ] macOS：sidebar、设置页、剪贴板列表中的 tooltip 行为无回归