### PR TITLE
fix(repo): remove ghost submodule gitlink under .claude/worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ src-tauri/.app_data_a/
 src-tauri/.app_data_b/
 public/splashscreen.html
 .worktrees/
+.claude/worktrees/
 .env
 .seq-api-key
 target


### PR DESCRIPTION
## Summary

- Drop the stray gitlink at `.claude/worktrees/drop-discovery-port` (introduced in b416bd4d on 2026-04-18 with no corresponding `.gitmodules`). Local `git submodule update` was a no-op so nobody noticed, but Cloudflare's Workers Builds clones with submodule recursion and has been failing on every push to `main` since with `error occurred while updating repository submodules` (3f335cee).
- Add `.claude/worktrees/` to `.gitignore` so Claude Code worktrees can't be re-committed by accident (3f335cee).

No `docs-site/` changes — this is repo infrastructure only, no user-visible surface.

## Test plan

- [x] `git ls-files --stage | grep ^160000` returns empty after the commit (no remaining gitlinks).
- [x] Local clone still has `.claude/worktrees/drop-discovery-port` on disk (only the index entry was removed).
- [ ] After merge to `main`, the next push triggers Cloudflare **Workers Builds: uniclipboard-update-server** and it gets past the `Cloning repository...` step (previously failed at submodule update within ~2s of clone start).