### PR TITLE
feat(analytics): ship P1 mobile_sync events — registered / synced / auth_failed

### DIFF
--- a/docs-site/content/docs/en/guides/privacy.mdx
+++ b/docs-site/content/docs/en/guides/privacy.mdx
@@ -64,12 +64,12 @@ Every product event carries these shared fields:
 
 The current allowed product event scope is:
 
-| Event family     | Events                                                                                          | Possible event fields                                                                                                             |
-| ---------------- | ----------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| First activation | `app_first_open`, `setup_started`, `device_name_set`                                            | Setup entry and device-name length bucket. The raw device name is not uploaded.                                                   |
-| Pairing          | `pairing_started`, `pairing_succeeded`, `pairing_failed`                                        | Pairing method, peer OS, duration, and pairing failure reason enum.                                                               |
-| First sync       | `first_clipboard_sync_attempted`, `first_clipboard_sync_succeeded`, `first_file_sync_succeeded` | Sync direction, peer OS, transport type, duration, and payload-size bucket.                                                       |
-| Sync reliability | `sync_attempted`, `sync_succeeded`, `sync_failed`, `sync_deferred`                              | Direction, payload type, payload-size bucket, transport type, peer OS, sync latency, failure reason / stage, and deferral reason. |
+| Event family     | Events                                                                                          | Possible event fields                                                                                                                              |
+| ---------------- | ----------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| First activation | `app_first_open`, `setup_started`, `device_name_set`                                            | Setup entry and device-name length bucket. The raw device name is not uploaded.                                                                    |
+| Pairing          | `pairing_started`, `pairing_succeeded`, `pairing_failed`                                        | Pairing method, peer OS, duration, and pairing failure reason enum.                                                                                |
+| First sync       | `first_clipboard_sync_attempted`, `first_clipboard_sync_succeeded`, `first_file_sync_succeeded` | Sync direction, peer OS, transport type, duration, and payload-size bucket.                                                                        |
+| Sync reliability | `sync_attempted`, `sync_succeeded`, `sync_failed`, `sync_deferred`                              | Direction, payload type, payload-size bucket, transport type, peer OS, sync latency, failure reason / stage, and deferral reason.                  |
 | Mobile sync      | `mobile_device_registered`, `mobile_clipboard_synced`, `mobile_auth_failed`                     | Sync direction, payload-size bucket, and mobile auth failure kind enum. The raw `Authorization` header, username, and password are never uploaded. |
 
 Any new product event or field must continue to follow this privacy boundary and must be reflected in the public docs.

--- a/docs-site/content/docs/en/guides/privacy.mdx
+++ b/docs-site/content/docs/en/guides/privacy.mdx
@@ -70,6 +70,7 @@ The current allowed product event scope is:
 | Pairing          | `pairing_started`, `pairing_succeeded`, `pairing_failed`                                        | Pairing method, peer OS, duration, and pairing failure reason enum.                                                               |
 | First sync       | `first_clipboard_sync_attempted`, `first_clipboard_sync_succeeded`, `first_file_sync_succeeded` | Sync direction, peer OS, transport type, duration, and payload-size bucket.                                                       |
 | Sync reliability | `sync_attempted`, `sync_succeeded`, `sync_failed`, `sync_deferred`                              | Direction, payload type, payload-size bucket, transport type, peer OS, sync latency, failure reason / stage, and deferral reason. |
+| Mobile sync      | `mobile_device_registered`, `mobile_clipboard_synced`, `mobile_auth_failed`                     | Sync direction, payload-size bucket, and mobile auth failure kind enum. The raw `Authorization` header, username, and password are never uploaded. |
 
 Any new product event or field must continue to follow this privacy boundary and must be reflected in the public docs.
 

--- a/docs-site/content/docs/zh/guides/privacy.mdx
+++ b/docs-site/content/docs/zh/guides/privacy.mdx
@@ -69,6 +69,7 @@ UniClipboard 的核心边界不变：剪贴板内容只在你已配对的设备�
 | 配对       | `pairing_started`、`pairing_succeeded`、`pairing_failed`                                        | 配对方式、对端 OS、耗时、配对失败原因枚举。                                                |
 | 首次同步   | `first_clipboard_sync_attempted`、`first_clipboard_sync_succeeded`、`first_file_sync_succeeded` | 同步方向、对端 OS、传输路径、耗时、负载大小区间。                                          |
 | 同步可靠性 | `sync_attempted`、`sync_succeeded`、`sync_failed`、`sync_deferred`                              | 同步方向、负载类型、负载大小区间、传输路径、对端 OS、同步耗时、失败原因 / 阶段、暂缓原因。 |
+| 移动端同步 | `mobile_device_registered`、`mobile_clipboard_synced`、`mobile_auth_failed`                     | 同步方向、负载大小区间、移动端鉴权失败类型枚举。原始 `Authorization` 头、用户名、密码永不上传。 |
 
 新增产品事件或字段时，必须继续遵守本页的隐私边界，并更新公开文档。
 

--- a/docs-site/content/docs/zh/guides/privacy.mdx
+++ b/docs-site/content/docs/zh/guides/privacy.mdx
@@ -63,12 +63,12 @@ UniClipboard 的核心边界不变：剪贴板内容只在你已配对的设备�
 
 当前允许的产品事件范围：
 
-| 事件族     | 事件                                                                                            | 可能包含的事件字段                                                                         |
-| ---------- | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
-| 首次激活   | `app_first_open`、`setup_started`、`device_name_set`                                            | 引导入口、设备名长度区间。设备名原文不上传。                                               |
-| 配对       | `pairing_started`、`pairing_succeeded`、`pairing_failed`                                        | 配对方式、对端 OS、耗时、配对失败原因枚举。                                                |
-| 首次同步   | `first_clipboard_sync_attempted`、`first_clipboard_sync_succeeded`、`first_file_sync_succeeded` | 同步方向、对端 OS、传输路径、耗时、负载大小区间。                                          |
-| 同步可靠性 | `sync_attempted`、`sync_succeeded`、`sync_failed`、`sync_deferred`                              | 同步方向、负载类型、负载大小区间、传输路径、对端 OS、同步耗时、失败原因 / 阶段、暂缓原因。 |
+| 事件族     | 事件                                                                                            | 可能包含的事件字段                                                                              |
+| ---------- | ----------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| 首次激活   | `app_first_open`、`setup_started`、`device_name_set`                                            | 引导入口、设备名长度区间。设备名原文不上传。                                                    |
+| 配对       | `pairing_started`、`pairing_succeeded`、`pairing_failed`                                        | 配对方式、对端 OS、耗时、配对失败原因枚举。                                                     |
+| 首次同步   | `first_clipboard_sync_attempted`、`first_clipboard_sync_succeeded`、`first_file_sync_succeeded` | 同步方向、对端 OS、传输路径、耗时、负载大小区间。                                               |
+| 同步可靠性 | `sync_attempted`、`sync_succeeded`、`sync_failed`、`sync_deferred`                              | 同步方向、负载类型、负载大小区间、传输路径、对端 OS、同步耗时、失败原因 / 阶段、暂缓原因。      |
 | 移动端同步 | `mobile_device_registered`、`mobile_clipboard_synced`、`mobile_auth_failed`                     | 同步方向、负载大小区间、移动端鉴权失败类型枚举。原始 `Authorization` 头、用户名、密码永不上传。 |
 
 新增产品事件或字段时，必须继续遵守本页的隐私边界，并更新公开文档。

--- a/docs/architecture/telemetry-events.md
+++ b/docs/architecture/telemetry-events.md
@@ -450,6 +450,51 @@ pub enum UnlockFailureReason {
 
 mapping：`SpaceAccessError::WrongPassphrase` → `PassphraseMismatch`；`NotInitialized` → `SpaceNotFound`；`CorruptedKeyMaterial` → `KeyslotCorrupted`；其它（`Internal` / 未分类）→ `Internal`。pre-condition 失败 `SetupNotCompleted` **不** emit（语义不属于"用户能不能继续用产品"）。`Internal` 占比 > 5% 视为本机持久化层不稳定，按 §7.3 末尾原则专门排查。
 
+### 7.6 Mobile Sync 事件清单
+
+P1 落地（2026-05-15）。LAN HTTP 协议（iPhone Shortcut 客户端）三件套：
+
+| 事件名 | 触发位置 | 关键 properties |
+|---|---|---|
+| `mobile_device_registered` | `mobile_sync/register_device.rs::execute` 成功（`device_repo.save` 之后） | （仅 EventContext） |
+| `mobile_clipboard_synced` | `mobile_sync/apply_incoming.rs::execute` SyncDoc arm 的 `Applied` outcome | `direction`: `inbound` \| `outbound`（v1 恒为 `inbound`）, `payload_size_bucket` |
+| `mobile_auth_failed` | `mobile_sync/authenticate_basic.rs::execute` 失败分支 | `failure_kind`: `MobileAuthFailureKind`（见 §7.7） |
+
+**`mobile_clipboard_synced` 红线**：仅 `Applied` outcome emit；`Buffered`（两步 PUT 协议中间态）/ `DuplicateSkipped`（命中本机 dedup）/ `DecodeFailed` / 应用层错误一律不上报。沿用 `clipboard_entry_captured` 防 RemotePush 双计的红线哲学——重复埋点会让 dashboard 频率口径双计。
+
+**v1 `direction = Inbound` 恒值**：`GetLatestMobileSyncDoc` 出站埋点延后到 v2。原因——iPhone 客户端的轮询频率会让 outbound 量级比 inbound 高一个数量级，需要单独评估采样口径。`direction` 字段保留枚举槽位是为了 v2 直接扩展（§8：新增 property 取值非破坏式演化，dashboard 零迁移）。
+
+**`mobile_auth_failed` happy path 沉默**：401 响应对外不区分原因（侧信道防御），但 telemetry 仅在失败路径 emit；"成功"信号由 `mobile_clipboard_synced` 间接覆盖，重复埋点会让 401 错误率分母失真。
+
+落地备注（保留以便回溯）：
+
+- `mobile_device_registered`：emit 在 `device_repo.save` 成功之后、QR 渲染之前——后续 QR 渲染失败仍保留事件（schema 主目录说明"已登记但拿不到 install URL"是孤儿记录路径，但设备 IS registered，telemetry 反映事实）。
+- `mobile_clipboard_synced`：`payload_size_bucket` 用 `PayloadSizeBucket::from_bytes(snapshot.total_size_bytes())`。BufferFile arm 不 emit（中间态），SyncDoc DuplicateSkipped 不 emit（dedup 双计红线）。
+- `mobile_auth_failed`：6 个失败分支统一走 `emit_failure(kind)` 薄包装；happy path **不** emit——产品视角"成功"由 `mobile_clipboard_synced` inbound 间接覆盖。
+
+### 7.7 MobileAuthFailureKind 枚举（mobile_auth_failed 专用）
+
+```rust
+pub enum MobileAuthFailureKind {
+    UnknownUser,        // 头解析失败 / base64 损坏 / find_by_username 为 None
+    PasswordMismatch,   // verify=false + InvalidPhc（PHC 损坏在产品视角与"真实密码错"等价）
+    Internal,           // 仓储 Storage 错误 + hasher Internal
+}
+```
+
+mapping：
+
+- 头解析失败 → `UnknownUser`（与"用户名不存在"在 telemetry 上等价：iPhone 客户端表现都是 401）
+- `find_by_username == None` → `UnknownUser`
+- hasher `verify == Ok(false)` → `PasswordMismatch`
+- hasher `Err(InvalidPhc)` → `PasswordMismatch`（PHC 字符串损坏的兜底；归 PasswordMismatch 让 dashboard 不会被一种罕见 adapter 故障污染 Internal 占比）
+- repository `Err(Storage)` → `Internal`
+- hasher `Err(Internal)` → `Internal`
+
+与 `sync` / `pairing` / `unlock` 失败枚举不共享——§7.3 末尾 domain-specific failure enum 原则。`Internal` 占比 > 5% 视为本机持久化层 / hasher adapter 不稳定。
+
+**槽位未使用**：`RateLimited` 不在本枚举内——v1 LAN listener 尚未实装速率限制；若未来加 rate limit，独立新增变体（非破坏式扩展）。
+
 ## 8. Schema 演化策略
 
 | 变更类型 | 处理方式 |
@@ -738,9 +783,9 @@ build 时间注入的 secret 列表。CI 注入位置（计划）：
 | `blob_fetch_failed` | `fetch_blob::execute` 失败路径 | `{ payload_size_bucket, failure_reason: BlobFetchFailureReason }` | 同上，区分 iroh 拨号 / 磁盘满 / 完整性校验 |
 | `space_switched` | `setup/switch_space/mod.rs` Phase 4 commit 完成 | `{ duration_ms: u32 }` | 高粘性用户行为信号——只有真在用产品的人才会换空间 |
 | `space_switch_failed` | `switch_space` 任一阶段失败 | `{ failure_phase: MigrationPhase, failure_reason: SwitchSpaceFailureReason }` | 4 阶段迁移的失败分布；诊断价值高 |
-| `mobile_device_registered` | `mobile_sync/register_device.rs::execute` 成功 | （仅 EventContext） | iPhone Shortcut 集成的启用计数；当前 0 信号 |
-| `mobile_clipboard_synced` | `mobile_sync/apply_incoming.rs::execute`（入站 PUT）+ `get_latest_doc::execute`（出站 GET）成功路径 | `{ direction: outbound\|inbound, payload_size_bucket }` | mobile sync 实际使用频率 |
-| `mobile_auth_failed` | `mobile_sync/authenticate_basic.rs::execute` 失败 | `{ failure_kind: MobileAuthFailureKind }` | iPhone 端密码错误率 |
+| ~~`mobile_device_registered`~~ ✅ | `mobile_sync/register_device.rs::execute` 成功 | （仅 EventContext） | iPhone Shortcut 集成的启用计数；当前 0 信号 |
+| ~~`mobile_clipboard_synced`~~ ✅ | `mobile_sync/apply_incoming.rs::execute` SyncDoc Applied（出站 GET 埋点延后到 v2） | `{ direction: inbound, payload_size_bucket }` | mobile sync 实际使用频率 |
+| ~~`mobile_auth_failed`~~ ✅ | `mobile_sync/authenticate_basic.rs::execute` 失败 | `{ failure_kind: MobileAuthFailureKind }` | iPhone 端密码错误率 |
 
 新增枚举：
 
@@ -763,10 +808,13 @@ pub enum SwitchSpaceFailureReason {
     Internal,
 }
 
+// mobile_sync 三件套已落地（2026-05-15）—— 当前权威 schema 在 §7.6 / §7.7。
+// 注意：原稿 RateLimited 在落地时删除，因为 v1 未实装速率限制；§7.7 仅保留 3 变体。
+// 历史草稿（保留作设计回溯）：
 pub enum MobileAuthFailureKind {
     UnknownUser,
     PasswordMismatch,
-    RateLimited,
+    RateLimited,   // ← 落地时移除
     Internal,
 }
 ```
@@ -775,7 +823,7 @@ pub enum MobileAuthFailureKind {
 
 - blob_transfer use case 不持有 analytics，需新加构造参数 + bootstrap wiring。
 - `space_switched` 的 `target_space_id_hash` **不传**，避免与 `EventContext.space_id_hash` 重复。
-- mobile_sync 三件套埋点是独立 PR，避免与桌面同步路径混在一起评审。
+- ~~mobile_sync 三件套埋点是独立 PR~~ ✅ 已落地（2026-05-15）。出站 GET 埋点延后到 v2，`direction` 字段保留枚举槽位备 v2 非破坏式扩展。
 
 ### 12.3 P2 — Engagement 与 Retention 信号
 
@@ -822,7 +870,7 @@ pub enum AgeBucket { Lt1H, H1To1D, D1To7D, Gt7D }
 ### 12.6 实施节奏建议
 
 - **一次 PR 完成 P0 全部 4 项**：都在 `uc-application` 内部，影响面集中。
-- **P1 拆 3 个 PR**：blob_transfer / switch_space / mobile_sync，三个 domain 各自独立 review。
+- **P1 拆 3 个 PR**：blob_transfer / switch_space / ~~mobile_sync~~，三个 domain 各自独立 review。mobile_sync 已落地（2026-05-15），剩余 blob_transfer / switch_space 待开。
 - **P2 视产品侧需求驱动**：哪个漏斗先被产品问到就先实施哪个；不要打包。
 - **每个新事件都同步更新本文件 §7 对应分类**：把表格从本节迁出去落到 §7（v1 catalog 的扩展），并把本节对应行 strikethrough 或删除。
 

--- a/src-tauri/crates/uc-application/src/facade/mobile_sync/facade.rs
+++ b/src-tauri/crates/uc-application/src/facade/mobile_sync/facade.rs
@@ -50,6 +50,7 @@ use uc_core::ports::{
     MobileFileStagingPort, MobileLanLifecyclePort, MobileLanTarget, MobileSyncEndpointInfoPort,
     PasswordHasherPort, SettingsPort,
 };
+use uc_observability::analytics::AnalyticsPort;
 
 use crate::facade::clipboard_outbound::ClipboardOutboundFacade;
 use crate::facade::file_transfer::FileTransferFacade;
@@ -197,6 +198,15 @@ pub struct MobileSyncFacadeDeps {
     ///   等下一次 daemon 进程启动时一次性读 settings 起 listener,
     ///   与本字段引入前的现有行为完全一致, 不退化。
     pub lan_lifecycle: Option<Arc<dyn MobileLanLifecyclePort>>,
+    /// schema doc §7.6 / §12.2 P1：产品 analytics sink。流向
+    /// `register_device` / `authenticate_basic` / `apply_incoming` 三个
+    /// use case，分别 emit `mobile_device_registered` /
+    /// `mobile_auth_failed` / `mobile_clipboard_synced`。
+    ///
+    /// 装配处直接复用 `AppDeps.analytics`（bootstrap 已包了一层
+    /// `GatedAnalyticsSink`，运行时按用户 `usage_analytics_enabled` 切换
+    /// noop / 真实 sink）。测试装配传 `NoopAnalyticsSink`。
+    pub analytics: Arc<dyn AnalyticsPort>,
 }
 
 // ─── Facade ─────────────────────────────────────────────────────────────
@@ -252,6 +262,7 @@ impl MobileSyncFacade {
             file_transfer,
             clipboard_outbound,
             lan_lifecycle,
+            analytics,
         } = deps;
 
         let snapshot_port: Arc<dyn LatestClipboardSnapshotPort> =
@@ -265,6 +276,7 @@ impl MobileSyncFacade {
                 settings.clone(),
                 clock.clone(),
                 lan_interface_probe.clone(),
+                analytics.clone(),
             ),
             revoke_device: RevokeMobileDeviceUseCase::new(device_repo.clone()),
             list_devices: ListMobileDevicesUseCase::new(device_repo.clone()),
@@ -279,7 +291,11 @@ impl MobileSyncFacade {
             ),
             update_settings: UpdateMobileSyncSettingsUseCase::new(settings),
             list_lan_interfaces: ListLanInterfacesUseCase::new(lan_interface_probe),
-            authenticate_basic: AuthenticateBasicAuthUseCase::new(device_repo, password_hasher),
+            authenticate_basic: AuthenticateBasicAuthUseCase::new(
+                device_repo,
+                password_hasher,
+                analytics.clone(),
+            ),
             // facade 装配处只能拿到 `ClipboardOutboundFacade`(由 daemon
             // runtime_assembly 装好),但 use case 依赖的是 use-case-local 的
             // `MobileInboundFanOutPort` trait。这里就是 facade 层的薄装配点:
@@ -296,6 +312,7 @@ impl MobileSyncFacade {
                     Arc::new(ClipboardOutboundFanOutAdapter::new(outbound))
                         as Arc<dyn MobileInboundFanOutPort>
                 }),
+                analytics,
             ),
             get_latest_doc: GetLatestMobileSyncDocUseCase::new(snapshot_port.clone()),
             get_file: GetMobileSyncFileUseCase::new(snapshot_port, file_staging.clone()),
@@ -963,6 +980,7 @@ mod tests {
             file_transfer: None,
             clipboard_outbound: None,
             lan_lifecycle: None,
+            analytics: Arc::new(uc_observability::analytics::NoopAnalyticsSink::default()),
         })
     }
 
@@ -1117,6 +1135,7 @@ mod tests {
             file_transfer: None,
             clipboard_outbound: None,
             lan_lifecycle: None,
+            analytics: Arc::new(uc_observability::analytics::NoopAnalyticsSink::default()),
         });
 
         // happy path
@@ -1196,6 +1215,7 @@ mod tests {
             file_transfer: None,
             clipboard_outbound: None,
             lan_lifecycle: None,
+            analytics: Arc::new(uc_observability::analytics::NoopAnalyticsSink::default()),
         });
 
         // 1. 旧密码可用
@@ -1304,6 +1324,7 @@ mod tests {
             file_transfer: None,
             clipboard_outbound: None,
             lan_lifecycle: Some(lifecycle),
+            analytics: Arc::new(uc_observability::analytics::NoopAnalyticsSink::default()),
         })
     }
 
@@ -1448,6 +1469,7 @@ mod tests {
             file_transfer: None,
             clipboard_outbound: None,
             lan_lifecycle: Some(lifecycle),
+            analytics: Arc::new(uc_observability::analytics::NoopAnalyticsSink::default()),
         });
 
         // enable 两开关 → lifecycle.apply(Enabled) → endpoint = BindFailed

--- a/src-tauri/crates/uc-application/src/usecases/mobile_sync/apply_incoming.rs
+++ b/src-tauri/crates/uc-application/src/usecases/mobile_sync/apply_incoming.rs
@@ -49,6 +49,7 @@ use uc_core::mobile_sync::{MobileDeviceId, StagedFile};
 use uc_core::ports::mobile_sync::{MobileFileStagingError, MobileFileStagingPort};
 use uc_core::ports::ClockPort;
 use uc_core::{MimeType, ObservedClipboardRepresentation, SystemClipboardSnapshot};
+use uc_observability::analytics::{AnalyticsPort, Direction, Event, PayloadSizeBucket};
 
 use crate::facade::file_transfer::{
     CompleteTransfer, FailTransfer, FileTransferFacade, LinkTransferToEntry,
@@ -334,6 +335,12 @@ pub(crate) struct ApplyIncomingMobileClipUseCase {
     /// 的入口):mobile 上传仅落地本机, 不传播 —— 与本字段引入前的行
     /// 为完全一致, 不退化。
     fan_out: Option<Arc<dyn MobileInboundFanOutPort>>,
+    /// schema doc §7.6 / §12.2 P1：iPhone → 桌面剪贴板实际落地的 inbound
+    /// 计数。**仅** `SyncDoc` arm 的 `Applied` outcome emit
+    /// `MobileClipboardSynced { direction: Inbound, payload_size_bucket }`；
+    /// `Buffered` / `DuplicateSkipped` / `DecodeFailed` / `Err` 都不上报，
+    /// 沿用 `ClipboardEntryCaptured` 防 RemotePush 双计的红线哲学。
+    analytics: Arc<dyn AnalyticsPort>,
 }
 
 impl ApplyIncomingMobileClipUseCase {
@@ -344,6 +351,7 @@ impl ApplyIncomingMobileClipUseCase {
         clock: Arc<dyn ClockPort>,
         file_transfer: Option<Arc<FileTransferFacade>>,
         fan_out: Option<Arc<dyn MobileInboundFanOutPort>>,
+        analytics: Arc<dyn AnalyticsPort>,
     ) -> Self {
         Self {
             inbound,
@@ -352,6 +360,7 @@ impl ApplyIncomingMobileClipUseCase {
             clock,
             file_transfer,
             fan_out,
+            analytics,
         }
     }
 
@@ -435,9 +444,13 @@ impl ApplyIncomingMobileClipUseCase {
                 // Image / File 分支的 snapshot 内含完整字节, 无 fan-out
                 // 装配的场景(CLI fallback / 单测)不应该白付一份克隆开销。
                 let snapshot_for_fanout = self.fan_out.as_ref().map(|_| snapshot.clone());
+                // analytics 用：在 dispatch 消费 snapshot 之前把字节总数
+                // 取出来，避免在 outcome 分支里再保留一份 snapshot 引用。
+                let payload_bytes = snapshot.total_size_bytes().max(0) as u64;
                 let dispatch_outcome = self
                     .dispatch_inbound(source_device_id.clone(), snapshot)
                     .await;
+                self.maybe_emit_inbound_synced(&dispatch_outcome, payload_bytes);
                 self.maybe_fan_out_to_paired_peers(
                     &source_device_id,
                     &dispatch_outcome,
@@ -447,6 +460,30 @@ impl ApplyIncomingMobileClipUseCase {
                     .await;
                 dispatch_outcome
             }
+        }
+    }
+
+    /// schema doc §7.6 / §12.2 P1：iPhone → 桌面剪贴板实际落地 inbound。
+    ///
+    /// **仅** `Applied` outcome emit；`Buffered` / `DuplicateSkipped` /
+    /// `DecodeFailed` / `Err` 全不上报：
+    ///
+    /// - `DuplicateSkipped` 命中本机 dedup——内容此前已存在，重复埋点会
+    ///   让 dashboard 频率口径双计（沿用 `ClipboardEntryCaptured` RemotePush
+    ///   红线哲学）。
+    /// - `Buffered` 是文件两步 PUT 协议的中间态，不代表用户可感知的同步。
+    /// - `DecodeFailed` / `Err` 本机入站没成功，与产品视角的"sync 成功
+    ///   一次"语义不一致。
+    fn maybe_emit_inbound_synced(
+        &self,
+        outcome: &Result<ApplyIncomingMobileClipOutcome, ApplyIncomingMobileClipError>,
+        payload_bytes: u64,
+    ) {
+        if let Ok(ApplyIncomingMobileClipOutcome::Applied { .. }) = outcome {
+            self.analytics.capture(Event::MobileClipboardSynced {
+                direction: Direction::Inbound,
+                payload_size_bucket: PayloadSizeBucket::from_bytes(payload_bytes),
+            });
         }
     }
 
@@ -795,6 +832,8 @@ mod tests {
 
     use super::*;
 
+    use std::sync::Mutex;
+
     use anyhow::Result as AnyResult;
     use async_trait::async_trait;
     use mockall::predicate::*;
@@ -805,6 +844,33 @@ mod tests {
 
     use uc_core::mobile_sync::{StagedFile, StagedFileUri, StagingHandle};
     use uc_core::ports::mobile_sync::MobileFileStagingError;
+    use uc_observability::analytics::NoopAnalyticsSink;
+
+    /// 默认 noop sink——绝大多数已有测试只需要"event 不污染断言"，
+    /// 不在乎是否 emit。新增的 mobile_clipboard_synced 红线测试用
+    /// `capturing_analytics()` 拿到可断言句柄。
+    fn noop_analytics() -> Arc<dyn AnalyticsPort> {
+        Arc::new(NoopAnalyticsSink::default())
+    }
+
+    #[derive(Default)]
+    struct CapturingAnalyticsSink {
+        captured: Mutex<Vec<Event>>,
+    }
+    impl CapturingAnalyticsSink {
+        fn events(&self) -> Vec<Event> {
+            self.captured.lock().unwrap().clone()
+        }
+    }
+    impl AnalyticsPort for CapturingAnalyticsSink {
+        fn capture(&self, event: Event) {
+            self.captured.lock().unwrap().push(event);
+        }
+    }
+
+    fn capturing_analytics() -> Arc<CapturingAnalyticsSink> {
+        Arc::new(CapturingAnalyticsSink::default())
+    }
 
     // 流式落盘改造后,apply_incoming 本身不再触达 staging 写入方法 ——
     // stage_file / begin_stage / append_stage_chunk / finalize_stage /
@@ -934,6 +1000,7 @@ mod tests {
             Arc::new(FixedClock),
             None,
             None,
+            noop_analytics(),
         )
     }
 
@@ -953,6 +1020,7 @@ mod tests {
             Arc::new(FixedClock),
             None,
             None,
+            noop_analytics(),
         )
     }
 
@@ -988,6 +1056,7 @@ mod tests {
             Arc::new(FixedClock),
             None,
             None,
+            noop_analytics(),
         );
         (uc, buffer)
     }
@@ -1022,6 +1091,7 @@ mod tests {
             Arc::new(FixedClock),
             None,
             None,
+            noop_analytics(),
         );
         (uc, buffer)
     }
@@ -1045,6 +1115,7 @@ mod tests {
             Arc::new(FixedClock),
             None,
             None,
+            noop_analytics(),
         )
     }
 
@@ -1134,6 +1205,7 @@ mod tests {
             Arc::new(FixedClock),
             None,
             None,
+            noop_analytics(),
         );
         assert_eq!(buffer.len(), 0);
 
@@ -1364,6 +1436,7 @@ mod tests {
             Arc::new(FixedClock),
             None,
             None,
+            noop_analytics(),
         );
 
         // BufferFile event 注入 Windows-shape URI
@@ -1427,6 +1500,7 @@ mod tests {
             Arc::new(FixedClock),
             None,
             None,
+            noop_analytics(),
         );
 
         let outcome = uc
@@ -1507,6 +1581,7 @@ mod tests {
             Arc::new(FixedClock),
             None,
             Some(Arc::clone(&recorder) as Arc<dyn MobileInboundFanOutPort>),
+            noop_analytics(),
         );
 
         let outcome = uc
@@ -1555,6 +1630,7 @@ mod tests {
             Arc::new(FixedClock),
             None,
             Some(Arc::clone(&recorder) as Arc<dyn MobileInboundFanOutPort>),
+            noop_analytics(),
         );
 
         let outcome = uc
@@ -1594,6 +1670,7 @@ mod tests {
             Arc::new(FixedClock),
             None,
             Some(Arc::clone(&recorder) as Arc<dyn MobileInboundFanOutPort>),
+            noop_analytics(),
         );
 
         let outcome = uc
@@ -1633,6 +1710,7 @@ mod tests {
             Arc::new(FixedClock),
             None,
             Some(Arc::clone(&recorder) as Arc<dyn MobileInboundFanOutPort>),
+            noop_analytics(),
         );
 
         let outcome = uc
@@ -1682,6 +1760,7 @@ mod tests {
             Arc::new(FixedClock),
             None,
             None,
+            noop_analytics(),
         );
 
         let outcome = uc
@@ -1692,5 +1771,161 @@ mod tests {
             outcome,
             ApplyIncomingMobileClipOutcome::Applied { .. }
         ));
+    }
+
+    // ── tests: mobile_clipboard_synced 红线 (schema doc §7.6 / §12.2 P1) ──
+
+    /// 装配一个 happy-path use case + 可断言 analytics sink。
+    /// inbound 期望恰好 1 次 dedup miss + capture + write，返回指定 entry_id。
+    fn build_uc_with_analytics_expect_applied(
+        entry_id: &str,
+        analytics: Arc<dyn AnalyticsPort>,
+    ) -> ApplyIncomingMobileClipUseCase {
+        let mut repo = MockEntryRepo::new();
+        repo.expect_find_entry_id_by_snapshot_hash()
+            .times(1)
+            .returning(|_| Ok(None));
+        let mut capture = MockCapture::new();
+        let id_for_capture = EntryId::from(entry_id);
+        capture
+            .expect_capture()
+            .times(1)
+            .returning(move |_, _| Ok(Some(id_for_capture.clone())));
+        let mut write = MockWrite::new();
+        write.expect_write().times(1).returning(|_| Ok(()));
+        let inbound =
+            ApplyInboundClipboardUseCase::new(Arc::new(repo), Arc::new(capture), Arc::new(write));
+        ApplyIncomingMobileClipUseCase::new(
+            Arc::new(inbound),
+            Arc::new(IncomingMobileBuffer::new()),
+            staging_never_called(),
+            Arc::new(FixedClock),
+            None,
+            None,
+            analytics,
+        )
+    }
+
+    /// inbound 期望恰好 1 次 dedup-hit（返回 existing_entry_id），不进
+    /// capture / write。
+    fn build_uc_with_analytics_expect_dedup_hit(
+        existing_entry_id: &str,
+        analytics: Arc<dyn AnalyticsPort>,
+    ) -> ApplyIncomingMobileClipUseCase {
+        let mut repo = MockEntryRepo::new();
+        let id_clone = EntryId::from(existing_entry_id);
+        repo.expect_find_entry_id_by_snapshot_hash()
+            .times(1)
+            .returning(move |_| Ok(Some(id_clone.clone())));
+        let capture = MockCapture::new();
+        let write = MockWrite::new();
+        let inbound =
+            ApplyInboundClipboardUseCase::new(Arc::new(repo), Arc::new(capture), Arc::new(write));
+        ApplyIncomingMobileClipUseCase::new(
+            Arc::new(inbound),
+            Arc::new(IncomingMobileBuffer::new()),
+            staging_never_called(),
+            Arc::new(FixedClock),
+            None,
+            None,
+            analytics,
+        )
+    }
+
+    /// inbound + capture + write + staging 全无期望（短路在 use case 层）。
+    fn build_uc_with_analytics_expect_no_inbound(
+        analytics: Arc<dyn AnalyticsPort>,
+    ) -> ApplyIncomingMobileClipUseCase {
+        let repo = MockEntryRepo::new();
+        let capture = MockCapture::new();
+        let write = MockWrite::new();
+        let inbound =
+            ApplyInboundClipboardUseCase::new(Arc::new(repo), Arc::new(capture), Arc::new(write));
+        ApplyIncomingMobileClipUseCase::new(
+            Arc::new(inbound),
+            Arc::new(IncomingMobileBuffer::new()),
+            staging_never_called(),
+            Arc::new(FixedClock),
+            None,
+            None,
+            analytics,
+        )
+    }
+
+    #[tokio::test]
+    async fn applied_emits_mobile_clipboard_synced_inbound() {
+        let analytics = capturing_analytics();
+        let uc = build_uc_with_analytics_expect_applied(
+            "entry-text-1",
+            analytics.clone() as Arc<dyn AnalyticsPort>,
+        );
+        uc.execute(input_sync_doc(SyncClipboardItemType::Text, "hello", None))
+            .await
+            .expect("happy path");
+        // 5 bytes "hello" → Lt1Kb 桶。direction v1 恒为 inbound。
+        assert_eq!(
+            analytics.events(),
+            vec![Event::MobileClipboardSynced {
+                direction: Direction::Inbound,
+                payload_size_bucket: PayloadSizeBucket::Lt1Kb,
+            }]
+        );
+    }
+
+    #[tokio::test]
+    async fn duplicate_skipped_does_not_emit_synced() {
+        // dedup 命中 = 本机已存在该 content_hash；重复埋点会让 dashboard
+        // 频率口径双计，沿用 ClipboardEntryCaptured 防 RemotePush 双计的
+        // 红线哲学。
+        let analytics = capturing_analytics();
+        let uc = build_uc_with_analytics_expect_dedup_hit(
+            "entry-existing",
+            analytics.clone() as Arc<dyn AnalyticsPort>,
+        );
+        let outcome = uc
+            .execute(input_sync_doc(SyncClipboardItemType::Text, "hello", None))
+            .await
+            .expect("dedup hit returns Ok");
+        assert!(matches!(
+            outcome,
+            ApplyIncomingMobileClipOutcome::DuplicateSkipped { .. }
+        ));
+        assert!(analytics.events().is_empty(), "{:?}", analytics.events());
+    }
+
+    #[tokio::test]
+    async fn decode_failed_does_not_emit_synced() {
+        // 空 text → DecodeFailed；本机入站没成功，不应 emit synced。
+        let analytics = capturing_analytics();
+        let uc =
+            build_uc_with_analytics_expect_no_inbound(analytics.clone() as Arc<dyn AnalyticsPort>);
+        let outcome = uc
+            .execute(input_sync_doc(SyncClipboardItemType::Text, "", None))
+            .await
+            .expect("empty text returns Ok with DecodeFailed variant");
+        assert!(matches!(
+            outcome,
+            ApplyIncomingMobileClipOutcome::DecodeFailed { .. }
+        ));
+        assert!(analytics.events().is_empty(), "{:?}", analytics.events());
+    }
+
+    #[tokio::test]
+    async fn buffer_file_does_not_emit_synced() {
+        // BufferFile 是两步 PUT 协议的中间态，不是用户感知的同步。
+        let analytics = capturing_analytics();
+        let uc =
+            build_uc_with_analytics_expect_no_inbound(analytics.clone() as Arc<dyn AnalyticsPort>);
+        let outcome = uc
+            .execute(input_buffer_file(
+                "pic.png",
+                "image/png",
+                "file:///tmp/uc-staging/pic.png",
+                "pic.png",
+            ))
+            .await
+            .expect("buffer file returns Ok");
+        assert!(matches!(outcome, ApplyIncomingMobileClipOutcome::Buffered));
+        assert!(analytics.events().is_empty(), "{:?}", analytics.events());
     }
 }

--- a/src-tauri/crates/uc-application/src/usecases/mobile_sync/apply_incoming.rs
+++ b/src-tauri/crates/uc-application/src/usecases/mobile_sync/apply_incoming.rs
@@ -832,8 +832,6 @@ mod tests {
 
     use super::*;
 
-    use std::sync::Mutex;
-
     use anyhow::Result as AnyResult;
     use async_trait::async_trait;
     use mockall::predicate::*;
@@ -842,9 +840,12 @@ mod tests {
 
     use crate::usecases::clipboard_sync::apply_inbound::{InboundCapture, InboundWrite};
 
-    use uc_core::mobile_sync::{StagedFile, StagedFileUri, StagingHandle};
-    use uc_core::ports::mobile_sync::MobileFileStagingError;
+    use uc_core::mobile_sync::{StagedFile, StagedFileUri};
     use uc_observability::analytics::NoopAnalyticsSink;
+
+    // MobileFileStagingPort mock(get_file 的 read_by_uri 路径共用)与
+    // CapturingAnalyticsSink 都在 test_support 模块集中维护。
+    use super::super::test_support::{CapturingAnalyticsSink, MockStaging};
 
     /// 默认 noop sink——绝大多数已有测试只需要"event 不污染断言"，
     /// 不在乎是否 emit。新增的 mobile_clipboard_synced 红线测试用
@@ -853,60 +854,8 @@ mod tests {
         Arc::new(NoopAnalyticsSink::default())
     }
 
-    #[derive(Default)]
-    struct CapturingAnalyticsSink {
-        captured: Mutex<Vec<Event>>,
-    }
-    impl CapturingAnalyticsSink {
-        fn events(&self) -> Vec<Event> {
-            self.captured.lock().unwrap().clone()
-        }
-    }
-    impl AnalyticsPort for CapturingAnalyticsSink {
-        fn capture(&self, event: Event) {
-            self.captured.lock().unwrap().push(event);
-        }
-    }
-
     fn capturing_analytics() -> Arc<CapturingAnalyticsSink> {
         Arc::new(CapturingAnalyticsSink::default())
-    }
-
-    // 流式落盘改造后,apply_incoming 本身不再触达 staging 写入方法 ——
-    // stage_file / begin_stage / append_stage_chunk / finalize_stage /
-    // abort_stage 都由 facade 入口在 PUT /file 阶段消费。image 分支会调
-    // `read_by_uri` 把 staged 字节读回内联到 image rep,其余方法均不应被
-    // 触达;mockall 默认 strict mode 让未配置的方法被调到就 panic,这正是
-    // 我们要的回归防御。
-    mockall::mock! {
-        Staging {}
-        #[async_trait]
-        impl MobileFileStagingPort for Staging {
-            async fn stage_file(
-                &self,
-                scope_id: &str,
-                data_name: &str,
-                mime: &str,
-                bytes: Vec<u8>,
-            ) -> Result<StagedFile, MobileFileStagingError>;
-            async fn read_by_uri(&self, uri: &str) -> Result<Vec<u8>, MobileFileStagingError>;
-            async fn begin_stage(
-                &self,
-                scope_id: &str,
-                data_name: &str,
-                mime: &str,
-            ) -> Result<StagingHandle, MobileFileStagingError>;
-            async fn append_stage_chunk(
-                &self,
-                handle: &StagingHandle,
-                chunk: &[u8],
-            ) -> Result<(), MobileFileStagingError>;
-            async fn finalize_stage(
-                &self,
-                handle: StagingHandle,
-            ) -> Result<StagedFile, MobileFileStagingError>;
-            async fn abort_stage(&self, handle: StagingHandle);
-        }
     }
 
     /// "未配置任何期望"的 staging mock —— mockall strict mode 下任何方法

--- a/src-tauri/crates/uc-application/src/usecases/mobile_sync/authenticate_basic.rs
+++ b/src-tauri/crates/uc-application/src/usecases/mobile_sync/authenticate_basic.rs
@@ -33,6 +33,7 @@ use tracing::instrument;
 
 use uc_core::mobile_sync::{MobileDevice, MobileDeviceError};
 use uc_core::ports::{MobileDeviceRepositoryPort, PasswordHasherError, PasswordHasherPort};
+use uc_observability::analytics::{AnalyticsPort, Event, MobileAuthFailureKind};
 
 // ─── public-shaped (input / output / error) ─────────────────────────────
 
@@ -76,16 +77,26 @@ pub enum AuthenticateBasicAuthError {
 pub(crate) struct AuthenticateBasicAuthUseCase {
     device_repo: Arc<dyn MobileDeviceRepositoryPort>,
     password_hasher: Arc<dyn PasswordHasherPort>,
+    /// schema doc §7.6 / §12.2 P1：iPhone Basic Auth 失败率 anchor。
+    ///
+    /// 401 响应对外**不**区分原因（侧信道防御），telemetry 内部按
+    /// [`MobileAuthFailureKind`] 切分让 dashboard 区分"用户名错"vs
+    /// "密码错"vs"服务端故障"——产品要回答 iPhone 端密码错误率。
+    /// happy path **不** emit（"成功"事件由 `mobile_clipboard_synced`
+    /// 间接覆盖，重复埋点会让 401 错误率分母失真）。
+    analytics: Arc<dyn AnalyticsPort>,
 }
 
 impl AuthenticateBasicAuthUseCase {
     pub(crate) fn new(
         device_repo: Arc<dyn MobileDeviceRepositoryPort>,
         password_hasher: Arc<dyn PasswordHasherPort>,
+        analytics: Arc<dyn AnalyticsPort>,
     ) -> Self {
         Self {
             device_repo,
             password_hasher,
+            analytics,
         }
     }
 
@@ -104,16 +115,24 @@ impl AuthenticateBasicAuthUseCase {
             Some(pair) => pair,
             None => {
                 self.run_dummy_verify().await;
+                // 头解析失败的语义与"用户名不存在"在 telemetry 上等价：
+                // 都表示客户端送来了无法对应到已知 device 的凭据。
+                self.emit_failure(MobileAuthFailureKind::UnknownUser);
                 return Err(AuthenticateBasicAuthError::InvalidCredentials);
             }
         };
 
         // 2. 查仓储。
-        let found = self
-            .device_repo
-            .find_by_username(&username)
-            .await
-            .map_err(translate_device_error)?;
+        let found = match self.device_repo.find_by_username(&username).await {
+            Ok(found) => found,
+            Err(err) => {
+                // 仓储读失败属于服务端内部错误 —— 与"凭据无效"语义不同，
+                // 单独归类 Internal 让 dashboard 区分"用户密码错"vs
+                // "服务端故障"。
+                self.emit_failure(MobileAuthFailureKind::Internal);
+                return Err(translate_device_error(err));
+            }
+        };
 
         // 3. 跑一次 verify, 命中 / 未命中走相同长度的 CPU 工作。
         let device = match found {
@@ -121,14 +140,21 @@ impl AuthenticateBasicAuthUseCase {
                 let phc = device.password_hash.clone();
                 match self.password_hasher.verify(&password, &phc).await {
                     Ok(true) => device,
-                    Ok(false) => return Err(AuthenticateBasicAuthError::InvalidCredentials),
+                    Ok(false) => {
+                        self.emit_failure(MobileAuthFailureKind::PasswordMismatch);
+                        return Err(AuthenticateBasicAuthError::InvalidCredentials);
+                    }
                     Err(PasswordHasherError::InvalidPhc(_)) => {
                         // PHC 本身损坏 —— 当作 401, 不暴露给攻击者细节。
                         // 不算 Internal: 仓储里这条记录已坏, 用户重新登记
-                        // 即可解决, 不该让 caller 重试当前请求。
+                        // 即可解决, 不该让 caller 重试当前请求。telemetry
+                        // 归 PasswordMismatch —— 与"真实密码错"在产品视角
+                        // 等价（用户在 iPhone 端的实际症状一致：401）。
+                        self.emit_failure(MobileAuthFailureKind::PasswordMismatch);
                         return Err(AuthenticateBasicAuthError::InvalidCredentials);
                     }
                     Err(PasswordHasherError::Internal(msg)) => {
+                        self.emit_failure(MobileAuthFailureKind::Internal);
                         return Err(AuthenticateBasicAuthError::Internal(msg));
                     }
                 }
@@ -136,11 +162,19 @@ impl AuthenticateBasicAuthUseCase {
             None => {
                 // 用户名不存在 —— 仍跑一次 verify 让耗时一致, 然后返回 401。
                 self.run_dummy_verify().await;
+                self.emit_failure(MobileAuthFailureKind::UnknownUser);
                 return Err(AuthenticateBasicAuthError::InvalidCredentials);
             }
         };
 
         Ok(AuthenticatedDevice { device })
+    }
+
+    /// emit `mobile_auth_failed` 的薄包装。inline 写会让 6 个失败分支重复
+    /// 6 次同一行，挑出来更易回归。
+    fn emit_failure(&self, failure_kind: MobileAuthFailureKind) {
+        self.analytics
+            .capture(Event::MobileAuthFailed { failure_kind });
     }
 
     /// 跑一次 dummy verify, 让"用户名不存在"路径与"用户名存在但密码错"
@@ -207,9 +241,26 @@ fn translate_device_error(err: MobileDeviceError) -> AuthenticateBasicAuthError 
 mod tests {
     use super::*;
 
+    use std::sync::Mutex;
+
     use async_trait::async_trait;
 
     use uc_core::mobile_sync::{MobileClientType, MobileDeviceId};
+
+    #[derive(Default)]
+    struct CapturingAnalyticsSink {
+        captured: Mutex<Vec<Event>>,
+    }
+    impl CapturingAnalyticsSink {
+        fn events(&self) -> Vec<Event> {
+            self.captured.lock().unwrap().clone()
+        }
+    }
+    impl AnalyticsPort for CapturingAnalyticsSink {
+        fn capture(&self, event: Event) {
+            self.captured.lock().unwrap().push(event);
+        }
+    }
 
     mockall::mock! {
         DeviceRepo {}
@@ -293,7 +344,25 @@ mod tests {
     }
 
     fn build_uc(devices: Vec<MobileDevice>) -> AuthenticateBasicAuthUseCase {
-        AuthenticateBasicAuthUseCase::new(Arc::new(repo_with(devices)), Arc::new(fake_hasher()))
+        AuthenticateBasicAuthUseCase::new(
+            Arc::new(repo_with(devices)),
+            Arc::new(fake_hasher()),
+            Arc::new(CapturingAnalyticsSink::default()),
+        )
+    }
+
+    /// build_uc 的 capture-asserting 版本：返回 use case + sink，调用方
+    /// 可在失败路径上断言 `MobileAuthFailed.failure_kind` 的具体取值。
+    fn build_uc_with_sink(
+        devices: Vec<MobileDevice>,
+    ) -> (AuthenticateBasicAuthUseCase, Arc<CapturingAnalyticsSink>) {
+        let analytics = Arc::new(CapturingAnalyticsSink::default());
+        let uc = AuthenticateBasicAuthUseCase::new(
+            Arc::new(repo_with(devices)),
+            Arc::new(fake_hasher()),
+            analytics.clone(),
+        );
+        (uc, analytics)
     }
 
     fn header_for(username: &str, password: &str) -> String {
@@ -367,7 +436,11 @@ mod tests {
         // 都返 Ok(false))。仓储**永远不该**在头坏时被查,断言 never。
         let mut repo = MockDeviceRepo::new();
         repo.expect_find_by_username().never();
-        let uc = AuthenticateBasicAuthUseCase::new(Arc::new(repo), Arc::new(fake_hasher()));
+        let uc = AuthenticateBasicAuthUseCase::new(
+            Arc::new(repo),
+            Arc::new(fake_hasher()),
+            Arc::new(CapturingAnalyticsSink::default()),
+        );
 
         for bad in [
             "",
@@ -411,7 +484,11 @@ mod tests {
         let mut repo = MockDeviceRepo::new();
         repo.expect_find_by_username()
             .returning(|_| Err(MobileDeviceError::Storage("disk gone".into())));
-        let uc = AuthenticateBasicAuthUseCase::new(Arc::new(repo), Arc::new(fake_hasher()));
+        let uc = AuthenticateBasicAuthUseCase::new(
+            Arc::new(repo),
+            Arc::new(fake_hasher()),
+            Arc::new(CapturingAnalyticsSink::default()),
+        );
 
         let err = uc
             .execute(AuthenticateBasicAuthInput {
@@ -433,8 +510,11 @@ mod tests {
             .expect_verify()
             .returning(|_, _| Err(PasswordHasherError::Internal("forced".into())));
 
-        let uc =
-            AuthenticateBasicAuthUseCase::new(Arc::new(repo_with(vec![device])), Arc::new(hasher));
+        let uc = AuthenticateBasicAuthUseCase::new(
+            Arc::new(repo_with(vec![device])),
+            Arc::new(hasher),
+            Arc::new(CapturingAnalyticsSink::default()),
+        );
         let err = uc
             .execute(AuthenticateBasicAuthInput {
                 authorization_header: header_for("mobile_aaaa", "hunter2"),
@@ -442,5 +522,149 @@ mod tests {
             .await
             .unwrap_err();
         assert!(matches!(err, AuthenticateBasicAuthError::Internal(_)));
+    }
+
+    // ── tests: analytics emit (schema doc §7.6 / §12.2 P1) ────────────
+
+    #[tokio::test]
+    async fn happy_path_does_not_emit_failure() {
+        // mobile_auth_failed 仅在失败路径 emit；happy path 必须沉默
+        // （“成功”信号由 mobile_clipboard_synced 间接覆盖）。
+        let device = make_device("mobile_aaaa", "phc:hunter2");
+        let (uc, analytics) = build_uc_with_sink(vec![device]);
+        uc.execute(AuthenticateBasicAuthInput {
+            authorization_header: header_for("mobile_aaaa", "hunter2"),
+        })
+        .await
+        .expect("ok");
+        assert!(analytics.events().is_empty(), "{:?}", analytics.events());
+    }
+
+    #[tokio::test]
+    async fn unknown_username_emits_unknown_user_kind() {
+        let (uc, analytics) = build_uc_with_sink(vec![]);
+        uc.execute(AuthenticateBasicAuthInput {
+            authorization_header: header_for("mobile_ghost", "anything"),
+        })
+        .await
+        .unwrap_err();
+        assert_eq!(
+            analytics.events(),
+            vec![Event::MobileAuthFailed {
+                failure_kind: MobileAuthFailureKind::UnknownUser,
+            }]
+        );
+    }
+
+    #[tokio::test]
+    async fn malformed_header_emits_unknown_user_kind() {
+        // 头解析失败与"用户名不存在"在 telemetry 上等价 —— iPhone 客户端
+        // 实际表现都是 401。
+        let mut repo = MockDeviceRepo::new();
+        repo.expect_find_by_username().never();
+        let analytics = Arc::new(CapturingAnalyticsSink::default());
+        let uc = AuthenticateBasicAuthUseCase::new(
+            Arc::new(repo),
+            Arc::new(fake_hasher()),
+            analytics.clone(),
+        );
+        uc.execute(AuthenticateBasicAuthInput {
+            authorization_header: "basic notbase64!!!".into(),
+        })
+        .await
+        .unwrap_err();
+        assert_eq!(
+            analytics.events(),
+            vec![Event::MobileAuthFailed {
+                failure_kind: MobileAuthFailureKind::UnknownUser,
+            }]
+        );
+    }
+
+    #[tokio::test]
+    async fn wrong_password_emits_password_mismatch_kind() {
+        let device = make_device("mobile_aaaa", "phc:rightpw");
+        let (uc, analytics) = build_uc_with_sink(vec![device]);
+        uc.execute(AuthenticateBasicAuthInput {
+            authorization_header: header_for("mobile_aaaa", "wrongpw"),
+        })
+        .await
+        .unwrap_err();
+        assert_eq!(
+            analytics.events(),
+            vec![Event::MobileAuthFailed {
+                failure_kind: MobileAuthFailureKind::PasswordMismatch,
+            }]
+        );
+    }
+
+    #[tokio::test]
+    async fn corrupt_phc_emits_password_mismatch_kind() {
+        // PHC 损坏在产品视角与"真实密码错"等价 —— 用户在 iPhone 端的
+        // 症状一致，归 PasswordMismatch 让 dashboard 不会被一种罕见
+        // adapter 故障污染 Internal 占比。
+        let device = make_device("mobile_aaaa", "PHC_BROKEN");
+        let (uc, analytics) = build_uc_with_sink(vec![device]);
+        uc.execute(AuthenticateBasicAuthInput {
+            authorization_header: header_for("mobile_aaaa", "anything"),
+        })
+        .await
+        .unwrap_err();
+        assert_eq!(
+            analytics.events(),
+            vec![Event::MobileAuthFailed {
+                failure_kind: MobileAuthFailureKind::PasswordMismatch,
+            }]
+        );
+    }
+
+    #[tokio::test]
+    async fn storage_error_emits_internal_kind() {
+        let mut repo = MockDeviceRepo::new();
+        repo.expect_find_by_username()
+            .returning(|_| Err(MobileDeviceError::Storage("disk gone".into())));
+        let analytics = Arc::new(CapturingAnalyticsSink::default());
+        let uc = AuthenticateBasicAuthUseCase::new(
+            Arc::new(repo),
+            Arc::new(fake_hasher()),
+            analytics.clone(),
+        );
+        uc.execute(AuthenticateBasicAuthInput {
+            authorization_header: header_for("mobile_aaaa", "x"),
+        })
+        .await
+        .unwrap_err();
+        assert_eq!(
+            analytics.events(),
+            vec![Event::MobileAuthFailed {
+                failure_kind: MobileAuthFailureKind::Internal,
+            }]
+        );
+    }
+
+    #[tokio::test]
+    async fn hasher_internal_error_emits_internal_kind() {
+        let device = make_device("mobile_aaaa", "phc:hunter2");
+        let mut hasher = MockHasher::new();
+        hasher
+            .expect_verify()
+            .returning(|_, _| Err(PasswordHasherError::Internal("forced".into())));
+        let analytics = Arc::new(CapturingAnalyticsSink::default());
+        let uc = AuthenticateBasicAuthUseCase::new(
+            Arc::new(repo_with(vec![device])),
+            Arc::new(hasher),
+            analytics.clone(),
+        );
+        uc.execute(AuthenticateBasicAuthInput {
+            authorization_header: header_for("mobile_aaaa", "hunter2"),
+        })
+        .await
+        .unwrap_err();
+        assert_eq!(
+            analytics.events(),
+            vec![Event::MobileAuthFailed {
+                failure_kind: MobileAuthFailureKind::Internal,
+            }]
+        );
     }
 }

--- a/src-tauri/crates/uc-application/src/usecases/mobile_sync/authenticate_basic.rs
+++ b/src-tauri/crates/uc-application/src/usecases/mobile_sync/authenticate_basic.rs
@@ -241,67 +241,11 @@ fn translate_device_error(err: MobileDeviceError) -> AuthenticateBasicAuthError 
 mod tests {
     use super::*;
 
-    use std::sync::Mutex;
-
-    use async_trait::async_trait;
-
     use uc_core::mobile_sync::{MobileClientType, MobileDeviceId};
 
-    #[derive(Default)]
-    struct CapturingAnalyticsSink {
-        captured: Mutex<Vec<Event>>,
-    }
-    impl CapturingAnalyticsSink {
-        fn events(&self) -> Vec<Event> {
-            self.captured.lock().unwrap().clone()
-        }
-    }
-    impl AnalyticsPort for CapturingAnalyticsSink {
-        fn capture(&self, event: Event) {
-            self.captured.lock().unwrap().push(event);
-        }
-    }
-
-    mockall::mock! {
-        DeviceRepo {}
-        #[async_trait]
-        impl MobileDeviceRepositoryPort for DeviceRepo {
-            async fn save(&self, device: &MobileDevice) -> Result<(), MobileDeviceError>;
-            async fn find_by_username(
-                &self,
-                username: &str,
-            ) -> Result<Option<MobileDevice>, MobileDeviceError>;
-            async fn find_by_device_id(
-                &self,
-                device_id: &MobileDeviceId,
-            ) -> Result<Option<MobileDevice>, MobileDeviceError>;
-            async fn list_all(&self) -> Result<Vec<MobileDevice>, MobileDeviceError>;
-            async fn delete(&self, device_id: &MobileDeviceId) -> Result<bool, MobileDeviceError>;
-            async fn record_activity(
-                &self,
-                device_id: &MobileDeviceId,
-                last_seen_at_ms: i64,
-                last_seen_ip: Option<String>,
-                reported_name: Option<String>,
-                reported_os: Option<String>,
-            ) -> Result<(), MobileDeviceError>;
-            async fn update_password_hash(
-                &self,
-                device_id: &MobileDeviceId,
-                new_password_hash: String,
-            ) -> Result<bool, MobileDeviceError>;
-        }
-    }
-
-    mockall::mock! {
-        Hasher {}
-        #[async_trait]
-        impl PasswordHasherPort for Hasher {
-            async fn hash(&self, password: &str) -> Result<String, PasswordHasherError>;
-            async fn verify(&self, password: &str, phc: &str)
-                -> Result<bool, PasswordHasherError>;
-        }
-    }
+    // DeviceRepo / Hasher mock + CapturingAnalyticsSink 与其它 use case
+    // 共用,集中在 test_support 模块。
+    use super::super::test_support::{CapturingAnalyticsSink, MockDeviceRepo, MockHasher};
 
     fn make_device(username: &str, phc: &str) -> MobileDevice {
         MobileDevice {

--- a/src-tauri/crates/uc-application/src/usecases/mobile_sync/get_file.rs
+++ b/src-tauri/crates/uc-application/src/usecases/mobile_sync/get_file.rs
@@ -263,7 +263,7 @@ mod tests {
     use mockall::predicate::*;
     use uc_core::clipboard::MimeType;
     use uc_core::ids::{EntryId, FormatId};
-    use uc_core::mobile_sync::{LatestPasteRepresentation, StagedFile, StagingHandle};
+    use uc_core::mobile_sync::LatestPasteRepresentation;
 
     mockall::mock! {
         SnapPort {}
@@ -275,38 +275,10 @@ mod tests {
         }
     }
 
+    // MobileFileStagingPort mock 与 apply_incoming 共用,集中在 test_support。
     // get_file 只触达 staging 的 `read_by_uri` —— 其它方法被调到都是回归;
     // mockall strict mode 下未配置即 panic, 默认形态就承担"防回归"职责。
-    mockall::mock! {
-        Staging {}
-        #[async_trait]
-        impl MobileFileStagingPort for Staging {
-            async fn stage_file(
-                &self,
-                scope_id: &str,
-                data_name: &str,
-                mime: &str,
-                bytes: Vec<u8>,
-            ) -> Result<StagedFile, MobileFileStagingError>;
-            async fn read_by_uri(&self, uri: &str) -> Result<Vec<u8>, MobileFileStagingError>;
-            async fn begin_stage(
-                &self,
-                scope_id: &str,
-                data_name: &str,
-                mime: &str,
-            ) -> Result<StagingHandle, MobileFileStagingError>;
-            async fn append_stage_chunk(
-                &self,
-                handle: &StagingHandle,
-                chunk: &[u8],
-            ) -> Result<(), MobileFileStagingError>;
-            async fn finalize_stage(
-                &self,
-                handle: StagingHandle,
-            ) -> Result<StagedFile, MobileFileStagingError>;
-            async fn abort_stage(&self, handle: StagingHandle);
-        }
-    }
+    use super::super::test_support::MockStaging;
 
     fn staging_never_called() -> Arc<MockStaging> {
         Arc::new(MockStaging::new())

--- a/src-tauri/crates/uc-application/src/usecases/mobile_sync/list_devices.rs
+++ b/src-tauri/crates/uc-application/src/usecases/mobile_sync/list_devices.rs
@@ -146,38 +146,8 @@ fn translate_device_error(err: MobileDeviceError) -> ListMobileDevicesError {
 mod tests {
     use super::*;
 
-    use async_trait::async_trait;
-
-    mockall::mock! {
-        DeviceRepo {}
-        #[async_trait]
-        impl MobileDeviceRepositoryPort for DeviceRepo {
-            async fn save(&self, device: &MobileDevice) -> Result<(), MobileDeviceError>;
-            async fn find_by_username(
-                &self,
-                username: &str,
-            ) -> Result<Option<MobileDevice>, MobileDeviceError>;
-            async fn find_by_device_id(
-                &self,
-                device_id: &MobileDeviceId,
-            ) -> Result<Option<MobileDevice>, MobileDeviceError>;
-            async fn list_all(&self) -> Result<Vec<MobileDevice>, MobileDeviceError>;
-            async fn delete(&self, device_id: &MobileDeviceId) -> Result<bool, MobileDeviceError>;
-            async fn record_activity(
-                &self,
-                device_id: &MobileDeviceId,
-                last_seen_at_ms: i64,
-                last_seen_ip: Option<String>,
-                reported_name: Option<String>,
-                reported_os: Option<String>,
-            ) -> Result<(), MobileDeviceError>;
-            async fn update_password_hash(
-                &self,
-                device_id: &MobileDeviceId,
-                new_password_hash: String,
-            ) -> Result<bool, MobileDeviceError>;
-        }
-    }
+    // DeviceRepo mock 与 mobile_sync 其它 use case 共用,集中在 test_support。
+    use super::super::test_support::MockDeviceRepo;
 
     fn make_device(
         id: &str,

--- a/src-tauri/crates/uc-application/src/usecases/mobile_sync/mod.rs
+++ b/src-tauri/crates/uc-application/src/usecases/mobile_sync/mod.rs
@@ -32,3 +32,6 @@ pub(crate) mod revoke_device;
 pub(crate) mod rotate_password;
 pub(crate) mod sync_clipboard_mapping;
 pub(crate) mod update_settings;
+
+#[cfg(test)]
+mod test_support;

--- a/src-tauri/crates/uc-application/src/usecases/mobile_sync/register_device.rs
+++ b/src-tauri/crates/uc-application/src/usecases/mobile_sync/register_device.rs
@@ -550,77 +550,17 @@ fn translate_hasher_error(err: PasswordHasherError) -> RegisterMobileShortcutDev
 mod tests {
     use super::*;
 
-    use std::sync::Mutex;
-
     use async_trait::async_trait;
 
     use uc_core::mobile_sync::MobileDeviceId;
     use uc_core::settings::model::Settings;
 
-    #[derive(Default)]
-    struct CapturingAnalyticsSink {
-        captured: Mutex<Vec<Event>>,
-    }
-    impl CapturingAnalyticsSink {
-        fn events(&self) -> Vec<Event> {
-            self.captured.lock().unwrap().clone()
-        }
-    }
-    impl AnalyticsPort for CapturingAnalyticsSink {
-        fn capture(&self, event: Event) {
-            self.captured.lock().unwrap().push(event);
-        }
-    }
-
-    // ── port mocks ─────────────────────────────────────────────────────
-
-    mockall::mock! {
-        DeviceRepo {}
-        #[async_trait]
-        impl MobileDeviceRepositoryPort for DeviceRepo {
-            async fn save(&self, device: &MobileDevice) -> Result<(), MobileDeviceError>;
-            async fn find_by_username(
-                &self,
-                username: &str,
-            ) -> Result<Option<MobileDevice>, MobileDeviceError>;
-            async fn find_by_device_id(
-                &self,
-                device_id: &MobileDeviceId,
-            ) -> Result<Option<MobileDevice>, MobileDeviceError>;
-            async fn list_all(&self) -> Result<Vec<MobileDevice>, MobileDeviceError>;
-            async fn delete(&self, device_id: &MobileDeviceId) -> Result<bool, MobileDeviceError>;
-            async fn record_activity(
-                &self,
-                device_id: &MobileDeviceId,
-                last_seen_at_ms: i64,
-                last_seen_ip: Option<String>,
-                reported_name: Option<String>,
-                reported_os: Option<String>,
-            ) -> Result<(), MobileDeviceError>;
-            async fn update_password_hash(
-                &self,
-                device_id: &MobileDeviceId,
-                new_password_hash: String,
-            ) -> Result<bool, MobileDeviceError>;
-        }
-    }
-
-    mockall::mock! {
-        Hasher {}
-        #[async_trait]
-        impl PasswordHasherPort for Hasher {
-            async fn hash(&self, password: &str) -> Result<String, PasswordHasherError>;
-            async fn verify(&self, password: &str, phc: &str)
-                -> Result<bool, PasswordHasherError>;
-        }
-    }
-
-    mockall::mock! {
-        Minter {}
-        impl MobileCredentialsMinterPort for Minter {
-            fn mint_credentials(&self) -> MintedCredentials;
-        }
-    }
+    // 多个 use case 测试共用的 mock(DeviceRepo / Hasher / Minter)+
+    // CapturingAnalyticsSink 集中在 test_support;register 独占的
+    // SettingsPort / Clock / Probe 仍就近 mockall::mock! 定义。
+    use super::super::test_support::{
+        CapturingAnalyticsSink, MockDeviceRepo, MockHasher, MockMinter,
+    };
 
     mockall::mock! {
         SettingsPortImpl {}

--- a/src-tauri/crates/uc-application/src/usecases/mobile_sync/register_device.rs
+++ b/src-tauri/crates/uc-application/src/usecases/mobile_sync/register_device.rs
@@ -31,6 +31,7 @@ use uc_core::ports::{
     ClockPort, LanInterfaceProbeError, LanInterfaceProbePort, MobileCredentialsMinterPort,
     MobileDeviceRepositoryPort, PasswordHasherError, PasswordHasherPort, SettingsPort,
 };
+use uc_observability::analytics::{AnalyticsPort, Event};
 
 // ─── public-shaped (input / output / error) ─────────────────────────────
 
@@ -171,6 +172,11 @@ pub(crate) struct RegisterMobileShortcutDeviceUseCase {
     settings: Arc<dyn SettingsPort>,
     clock: Arc<dyn ClockPort>,
     lan_interface_probe: Arc<dyn LanInterfaceProbePort>,
+    /// schema doc §7.6 / §12.2 P1：iPhone Shortcut 集成的启用计数 anchor。
+    /// happy path 在 repository.save 成功之后 emit `MobileDeviceRegistered`;
+    /// 任何前置校验失败 / 持久化失败都不上报——doc §12.5 已明确撤销 /
+    /// rotate 等高频但低产品意义的事件不埋。
+    analytics: Arc<dyn AnalyticsPort>,
 }
 
 impl RegisterMobileShortcutDeviceUseCase {
@@ -181,6 +187,7 @@ impl RegisterMobileShortcutDeviceUseCase {
         settings: Arc<dyn SettingsPort>,
         clock: Arc<dyn ClockPort>,
         lan_interface_probe: Arc<dyn LanInterfaceProbePort>,
+        analytics: Arc<dyn AnalyticsPort>,
     ) -> Self {
         Self {
             credentials_minter,
@@ -189,6 +196,7 @@ impl RegisterMobileShortcutDeviceUseCase {
             settings,
             clock,
             lan_interface_probe,
+            analytics,
         }
     }
 
@@ -342,6 +350,12 @@ impl RegisterMobileShortcutDeviceUseCase {
             .save(&device)
             .await
             .map_err(translate_device_error)?;
+
+        // schema doc §7.6 / §12.2 P1：registration anchor 落在 save 之后。
+        // 后续 QR 渲染失败仍保留事件——doc 模块注释已说明该路径下会留下
+        // "已登记但用户拿不到 install URL"的孤儿记录，但设备 IS registered,
+        // telemetry 反映这一事实，与 UI 报错语义不冲突。
+        self.analytics.capture(Event::MobileDeviceRegistered);
 
         // 4. 渲染 install URL 的二维码(PNG + ASCII 双形态)。install_url 是
         //    常量(SyncClipboard 公开 iCloud 链接), 不取决于 device, 二维码
@@ -536,10 +550,27 @@ fn translate_hasher_error(err: PasswordHasherError) -> RegisterMobileShortcutDev
 mod tests {
     use super::*;
 
+    use std::sync::Mutex;
+
     use async_trait::async_trait;
 
     use uc_core::mobile_sync::MobileDeviceId;
     use uc_core::settings::model::Settings;
+
+    #[derive(Default)]
+    struct CapturingAnalyticsSink {
+        captured: Mutex<Vec<Event>>,
+    }
+    impl CapturingAnalyticsSink {
+        fn events(&self) -> Vec<Event> {
+            self.captured.lock().unwrap().clone()
+        }
+    }
+    impl AnalyticsPort for CapturingAnalyticsSink {
+        fn capture(&self, event: Event) {
+            self.captured.lock().unwrap().push(event);
+        }
+    }
 
     // ── port mocks ─────────────────────────────────────────────────────
 
@@ -756,7 +787,29 @@ mod tests {
             Arc::new(settings_port_lan_advertise(lan_listen_enabled)),
             Arc::new(clock_at(1_000)),
             Arc::new(probe_returning(vec![])),
+            Arc::new(CapturingAnalyticsSink::default()),
         )
+    }
+
+    /// build_uc 的 capture-asserting 版本：返回 use case + sink，调用方可在
+    /// happy path 上断言 emit，或在失败路径上断言"未 emit"。
+    fn build_uc_with_sink(
+        lan_listen_enabled: bool,
+    ) -> (
+        RegisterMobileShortcutDeviceUseCase,
+        Arc<CapturingAnalyticsSink>,
+    ) {
+        let analytics = Arc::new(CapturingAnalyticsSink::default());
+        let uc = RegisterMobileShortcutDeviceUseCase::new(
+            Arc::new(deterministic_minter()),
+            Arc::new(recording_hasher()),
+            Arc::new(empty_device_repo()),
+            Arc::new(settings_port_lan_advertise(lan_listen_enabled)),
+            Arc::new(clock_at(1_000)),
+            Arc::new(probe_returning(vec![])),
+            analytics.clone(),
+        );
+        (uc, analytics)
     }
 
     fn label_only(label: &str) -> RegisterMobileShortcutDeviceInput {
@@ -933,6 +986,7 @@ mod tests {
             Arc::new(settings_port_lan_advertise(true)),
             Arc::new(clock_at(1_000)),
             Arc::new(probe_returning(vec![])),
+            Arc::new(CapturingAnalyticsSink::default()),
         );
         let err = uc
             .execute(RegisterMobileShortcutDeviceInput {
@@ -968,6 +1022,7 @@ mod tests {
             Arc::new(settings_port_lan_advertise(true)),
             Arc::new(clock_at(1_000)),
             Arc::new(probe_returning(vec![])),
+            Arc::new(CapturingAnalyticsSink::default()),
         );
         let out = uc
             .execute(RegisterMobileShortcutDeviceInput {
@@ -1035,6 +1090,7 @@ mod tests {
             Arc::new(settings_port_lan_advertise(true)),
             Arc::new(clock_at(1_000)),
             Arc::new(probe_returning(vec![])),
+            Arc::new(CapturingAnalyticsSink::default()),
         );
         let err = uc
             .execute(RegisterMobileShortcutDeviceInput {
@@ -1081,6 +1137,7 @@ mod tests {
             Arc::new(settings_port_auto()),
             Arc::new(clock_at(1_000)),
             Arc::new(probe),
+            Arc::new(CapturingAnalyticsSink::default()),
         )
     }
 
@@ -1128,5 +1185,28 @@ mod tests {
             err,
             RegisterMobileShortcutDeviceError::LanInterfaceProbeFailed(ref s) if s.contains("ifaddr crashed")
         ));
+    }
+
+    // ── tests: analytics emit (schema doc §7.6 / §12.2 P1) ────────────
+
+    #[tokio::test]
+    async fn happy_path_emits_mobile_device_registered() {
+        let (uc, analytics) = build_uc_with_sink(true);
+        uc.execute(label_only("iPhone"))
+            .await
+            .expect("happy path must succeed");
+        assert_eq!(analytics.events(), vec![Event::MobileDeviceRegistered]);
+    }
+
+    #[tokio::test]
+    async fn lan_listener_disabled_does_not_emit_registration() {
+        // 任何"还没真正落地一台设备"的失败路径都不应 emit registration anchor。
+        let (uc, analytics) = build_uc_with_sink(false);
+        let err = uc.execute(label_only("iPhone")).await.unwrap_err();
+        assert!(matches!(
+            err,
+            RegisterMobileShortcutDeviceError::LanListenerDisabled
+        ));
+        assert!(analytics.events().is_empty(), "{:?}", analytics.events());
     }
 }

--- a/src-tauri/crates/uc-application/src/usecases/mobile_sync/revoke_device.rs
+++ b/src-tauri/crates/uc-application/src/usecases/mobile_sync/revoke_device.rs
@@ -85,41 +85,10 @@ fn translate_device_error(err: MobileDeviceError) -> RevokeMobileDeviceError {
 mod tests {
     use super::*;
 
-    use async_trait::async_trait;
     use mockall::predicate::eq;
 
-    use uc_core::mobile_sync::MobileDevice;
-
-    mockall::mock! {
-        DeviceRepo {}
-        #[async_trait]
-        impl MobileDeviceRepositoryPort for DeviceRepo {
-            async fn save(&self, device: &MobileDevice) -> Result<(), MobileDeviceError>;
-            async fn find_by_username(
-                &self,
-                username: &str,
-            ) -> Result<Option<MobileDevice>, MobileDeviceError>;
-            async fn find_by_device_id(
-                &self,
-                device_id: &MobileDeviceId,
-            ) -> Result<Option<MobileDevice>, MobileDeviceError>;
-            async fn list_all(&self) -> Result<Vec<MobileDevice>, MobileDeviceError>;
-            async fn delete(&self, device_id: &MobileDeviceId) -> Result<bool, MobileDeviceError>;
-            async fn record_activity(
-                &self,
-                device_id: &MobileDeviceId,
-                last_seen_at_ms: i64,
-                last_seen_ip: Option<String>,
-                reported_name: Option<String>,
-                reported_os: Option<String>,
-            ) -> Result<(), MobileDeviceError>;
-            async fn update_password_hash(
-                &self,
-                device_id: &MobileDeviceId,
-                new_password_hash: String,
-            ) -> Result<bool, MobileDeviceError>;
-        }
-    }
+    // DeviceRepo mock 与 mobile_sync 其它 use case 共用,集中在 test_support。
+    use super::super::test_support::MockDeviceRepo;
 
     #[tokio::test]
     async fn deletes_existing_device() {

--- a/src-tauri/crates/uc-application/src/usecases/mobile_sync/rotate_password.rs
+++ b/src-tauri/crates/uc-application/src/usecases/mobile_sync/rotate_password.rs
@@ -211,60 +211,13 @@ mod tests {
     //! 收到 hasher 算出的那串 PHC,而不是其它东西。
     use super::*;
 
-    use async_trait::async_trait;
     use mockall::predicate::eq;
 
     use uc_core::mobile_sync::{MobileClientType, MobileDevice};
 
-    // ── port mocks ─────────────────────────────────────────────────────
-
-    mockall::mock! {
-        DeviceRepo {}
-        #[async_trait]
-        impl MobileDeviceRepositoryPort for DeviceRepo {
-            async fn save(&self, device: &MobileDevice) -> Result<(), MobileDeviceError>;
-            async fn find_by_username(
-                &self,
-                username: &str,
-            ) -> Result<Option<MobileDevice>, MobileDeviceError>;
-            async fn find_by_device_id(
-                &self,
-                device_id: &MobileDeviceId,
-            ) -> Result<Option<MobileDevice>, MobileDeviceError>;
-            async fn list_all(&self) -> Result<Vec<MobileDevice>, MobileDeviceError>;
-            async fn delete(&self, device_id: &MobileDeviceId) -> Result<bool, MobileDeviceError>;
-            async fn record_activity(
-                &self,
-                device_id: &MobileDeviceId,
-                last_seen_at_ms: i64,
-                last_seen_ip: Option<String>,
-                reported_name: Option<String>,
-                reported_os: Option<String>,
-            ) -> Result<(), MobileDeviceError>;
-            async fn update_password_hash(
-                &self,
-                device_id: &MobileDeviceId,
-                new_password_hash: String,
-            ) -> Result<bool, MobileDeviceError>;
-        }
-    }
-
-    mockall::mock! {
-        Hasher {}
-        #[async_trait]
-        impl PasswordHasherPort for Hasher {
-            async fn hash(&self, password: &str) -> Result<String, PasswordHasherError>;
-            async fn verify(&self, password: &str, phc: &str)
-                -> Result<bool, PasswordHasherError>;
-        }
-    }
-
-    mockall::mock! {
-        Minter {}
-        impl MobileCredentialsMinterPort for Minter {
-            fn mint_credentials(&self) -> MintedCredentials;
-        }
-    }
+    // DeviceRepo / Hasher / Minter mock 在 mobile_sync 多处复用,集中
+    // 在 test_support 模块。
+    use super::super::test_support::{MockDeviceRepo, MockHasher, MockMinter};
 
     // ── helpers ────────────────────────────────────────────────────────
 

--- a/src-tauri/crates/uc-application/src/usecases/mobile_sync/test_support.rs
+++ b/src-tauri/crates/uc-application/src/usecases/mobile_sync/test_support.rs
@@ -1,0 +1,150 @@
+//! mobile_sync use case 单元测试共享的 mockall mocks 与 fake sinks。
+//!
+//! ## 这里放什么
+//!
+//! 在多个 use case 测试里**重复出现**的 mock,集中一次写完,所有测试 `use
+//! super::test_support::*;` 即可。当前承载:
+//!
+//! - [`MockDeviceRepo`] —— [`MobileDeviceRepositoryPort`] 的 mockall mock,
+//!   被 register / authenticate / rotate / revoke / list 共用。
+//! - [`MockHasher`] —— [`PasswordHasherPort`] 的 mockall mock,被 register /
+//!   authenticate / rotate 共用。
+//! - [`MockMinter`] —— [`MobileCredentialsMinterPort`] 的 mockall mock,被
+//!   register / rotate 共用。
+//! - [`MockStaging`] —— [`MobileFileStagingPort`] 的 mockall mock,被
+//!   apply_incoming / get_file 共用。
+//! - [`CapturingAnalyticsSink`] —— "录制全部 captured Event" 的 fake
+//!   [`AnalyticsPort`],被 register / authenticate / apply_incoming 共用,
+//!   并预留给 mobile_sync 内未来新增的 analytics 断言测试。
+//!
+//! ## 这里**不**放什么
+//!
+//! - 只在单一文件里用一次的 mock(如 register_device 的 `MockSettings` /
+//!   `MockClock` / `MockProbe`):保持局部性,避免抽出"只一处用"的 mock
+//!   反而增加查找成本。
+//! - 有状态 fake(`InMemorySettings` / `FakeEntryRepo` / `FixedProbe` 等):
+//!   它们的"内存型实现"语义比 mockall 的 expectation 语义更适合,刻意保留
+//!   在原文件。
+//!
+//! ## 为什么 [`CapturingAnalyticsSink`] 不用 mockall
+//!
+//! mockall 是 "expectation" 模型:测试前置 expect,事后由 mockall 在 drop 时
+//! verify。而 analytics 断言多采用 "先做事再 `assert_eq!(events(), vec![…])`"
+//! 录制模型,后者直接、可读、对 event 顺序敏感,手写 sink 比迁就 mockall
+//! 更合适。
+
+#![cfg(test)]
+
+use std::sync::Mutex;
+
+use async_trait::async_trait;
+
+use uc_core::mobile_sync::{
+    MintedCredentials, MobileDevice, MobileDeviceError, MobileDeviceId, StagedFile, StagingHandle,
+};
+use uc_core::ports::mobile_sync::{MobileFileStagingError, MobileFileStagingPort};
+use uc_core::ports::{
+    MobileCredentialsMinterPort, MobileDeviceRepositoryPort, PasswordHasherError,
+    PasswordHasherPort,
+};
+use uc_observability::analytics::{AnalyticsPort, Event};
+
+mockall::mock! {
+    pub DeviceRepo {}
+    #[async_trait]
+    impl MobileDeviceRepositoryPort for DeviceRepo {
+        async fn save(&self, device: &MobileDevice) -> Result<(), MobileDeviceError>;
+        async fn find_by_username(
+            &self,
+            username: &str,
+        ) -> Result<Option<MobileDevice>, MobileDeviceError>;
+        async fn find_by_device_id(
+            &self,
+            device_id: &MobileDeviceId,
+        ) -> Result<Option<MobileDevice>, MobileDeviceError>;
+        async fn list_all(&self) -> Result<Vec<MobileDevice>, MobileDeviceError>;
+        async fn delete(&self, device_id: &MobileDeviceId) -> Result<bool, MobileDeviceError>;
+        async fn record_activity(
+            &self,
+            device_id: &MobileDeviceId,
+            last_seen_at_ms: i64,
+            last_seen_ip: Option<String>,
+            reported_name: Option<String>,
+            reported_os: Option<String>,
+        ) -> Result<(), MobileDeviceError>;
+        async fn update_password_hash(
+            &self,
+            device_id: &MobileDeviceId,
+            new_password_hash: String,
+        ) -> Result<bool, MobileDeviceError>;
+    }
+}
+
+mockall::mock! {
+    pub Hasher {}
+    #[async_trait]
+    impl PasswordHasherPort for Hasher {
+        async fn hash(&self, password: &str) -> Result<String, PasswordHasherError>;
+        async fn verify(&self, password: &str, phc: &str)
+            -> Result<bool, PasswordHasherError>;
+    }
+}
+
+mockall::mock! {
+    pub Minter {}
+    impl MobileCredentialsMinterPort for Minter {
+        fn mint_credentials(&self) -> MintedCredentials;
+    }
+}
+
+mockall::mock! {
+    pub Staging {}
+    #[async_trait]
+    impl MobileFileStagingPort for Staging {
+        async fn stage_file(
+            &self,
+            scope_id: &str,
+            data_name: &str,
+            mime: &str,
+            bytes: Vec<u8>,
+        ) -> Result<StagedFile, MobileFileStagingError>;
+        async fn read_by_uri(&self, uri: &str) -> Result<Vec<u8>, MobileFileStagingError>;
+        async fn begin_stage(
+            &self,
+            scope_id: &str,
+            data_name: &str,
+            mime: &str,
+        ) -> Result<StagingHandle, MobileFileStagingError>;
+        async fn append_stage_chunk(
+            &self,
+            handle: &StagingHandle,
+            chunk: &[u8],
+        ) -> Result<(), MobileFileStagingError>;
+        async fn finalize_stage(
+            &self,
+            handle: StagingHandle,
+        ) -> Result<StagedFile, MobileFileStagingError>;
+        async fn abort_stage(&self, handle: StagingHandle);
+    }
+}
+
+/// 录制所有 captured [`Event`] 的 fake [`AnalyticsPort`]。测试侧调用 use case
+/// 后用 [`events`](Self::events) 取出快照,做 `assert_eq!` 即可。
+///
+/// 选用手写而非 mockall 的理由见模块顶部说明。
+#[derive(Default)]
+pub struct CapturingAnalyticsSink {
+    captured: Mutex<Vec<Event>>,
+}
+
+impl CapturingAnalyticsSink {
+    pub fn events(&self) -> Vec<Event> {
+        self.captured.lock().unwrap().clone()
+    }
+}
+
+impl AnalyticsPort for CapturingAnalyticsSink {
+    fn capture(&self, event: Event) {
+        self.captured.lock().unwrap().push(event);
+    }
+}

--- a/src-tauri/crates/uc-bootstrap/src/non_gui_runtime.rs
+++ b/src-tauri/crates/uc-bootstrap/src/non_gui_runtime.rs
@@ -224,6 +224,10 @@ pub fn build_mobile_sync_facade(
         file_transfer,
         clipboard_outbound,
         lan_lifecycle,
+        // schema doc §7.6 / §12.2 P1：mobile_sync 域共用 process-wide analytics
+        // sink。bootstrap 已把 GatedAnalyticsSink 包好，runtime 切换 noop / 真
+        // 实 sink 是 sink 自身职责，不在此装配。
+        analytics: deps.analytics.clone(),
     }))
 }
 

--- a/src-tauri/crates/uc-observability/src/analytics/events.rs
+++ b/src-tauri/crates/uc-observability/src/analytics/events.rs
@@ -110,6 +110,37 @@ pub enum Event {
     SyncFailed(SyncEventProps),
     /// 同步暂缓。目标在发送前已知不可用，本次不可达不计入失败。
     SyncDeferred(SyncDeferredProps),
+
+    // —— Mobile Sync ——————————————————————————————————————————————
+    /// 一台 iPhone Shortcut 设备登记成功（`register_device::execute` happy path）。
+    ///
+    /// schema doc §7.6 / §12.2 P1。iPhone Shortcut 集成的启用计数 anchor——
+    /// 当前完全 0 信号，仅靠日志推断。
+    MobileDeviceRegistered,
+
+    /// iPhone 与桌面之间剪贴板内容实际落地一次（`apply_incoming::execute`
+    /// SyncDoc arm 的 `Applied` outcome）。
+    ///
+    /// **仅 `Applied` 分支 emit**：`Buffered` / `DuplicateSkipped` /
+    /// `DecodeFailed` / `Err` 都不触发——`DuplicateSkipped` 已在本机存在
+    /// （`ClipboardEntryCaptured` 的 RemotePush 红线同理），重复广播会
+    /// 污染 dashboard 频率口径；`Buffered` 是文件两步 PUT 协议的中间态。
+    ///
+    /// v1 `direction` 恒为 [`Direction::Inbound`]——`GetLatestMobileSyncDoc`
+    /// 出站埋点延后到 v2（iPhone 客户端的轮询频率会让 outbound 量级比
+    /// inbound 高一个数量级，需要单独评估采样口径）。字段保留 enum 槽位
+    /// 是为了 v2 直接扩展（schema doc §8：新增 property 非破坏式）。
+    MobileClipboardSynced {
+        direction: Direction,
+        payload_size_bucket: PayloadSizeBucket,
+    },
+
+    /// iPhone Basic Auth 失败（`authenticate_basic::execute` 失败分支）。
+    ///
+    /// 401 响应对外**不**区分原因（侧信道防御）；telemetry 内部按
+    /// [`MobileAuthFailureKind`] 切分，让 dashboard 区分"用户名错"和
+    /// "密码错"——这是产品视角的 iPhone 端密码错误率指标。
+    MobileAuthFailed { failure_kind: MobileAuthFailureKind },
 }
 
 impl Event {
@@ -133,6 +164,9 @@ impl Event {
             Event::SyncSucceeded(_) => "sync_succeeded",
             Event::SyncFailed(_) => "sync_failed",
             Event::SyncDeferred(_) => "sync_deferred",
+            Event::MobileDeviceRegistered => "mobile_device_registered",
+            Event::MobileClipboardSynced { .. } => "mobile_clipboard_synced",
+            Event::MobileAuthFailed { .. } => "mobile_auth_failed",
         }
     }
 
@@ -229,6 +263,17 @@ impl Event {
                 .ok()
                 .and_then(|v| v.as_object().cloned())
                 .unwrap_or_default(),
+            Event::MobileDeviceRegistered => Map::new(),
+            Event::MobileClipboardSynced {
+                direction,
+                payload_size_bucket,
+            } => to_map(json!({
+                "direction": direction,
+                "payload_size_bucket": payload_size_bucket,
+            })),
+            Event::MobileAuthFailed { failure_kind } => {
+                to_map(json!({ "failure_kind": failure_kind }))
+            }
         }
     }
 }
@@ -433,6 +478,30 @@ pub enum UnlockFailureReason {
     Internal,
 }
 
+/// 移动端鉴权失败原因（`mobile_auth_failed` 专用）。
+///
+/// 与 `sync` / `pairing` / `unlock` 失败枚举不共享——schema doc §7.3 末尾
+/// 的 domain-specific failure enum 原则：不同 domain 的失败语义不重叠，
+/// 共享 enum 会让 funnel 跨 domain 误聚合。
+///
+/// **隐私契约对响应保持统一 401**（避免侧信道枚举哪种凭据存在），
+/// telemetry 这一面则按真实成因切分，让 dashboard 能定量回答"用户密码
+/// 错"vs"用户名拼错"vs"服务端故障"三类问题。`Internal` 占比 > 5%
+/// 视为本机持久化层 / hasher adapter 不稳定。
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum MobileAuthFailureKind {
+    /// 头解析失败 / base64 损坏 / 用户名不存在——iPhone 端用错了
+    /// username 字段。
+    UnknownUser,
+    /// 用户名命中但密码校验失败，含 PHC 字符串本身损坏的兜底分支
+    /// （后者数量为零时不与"真实密码错"区分）。
+    PasswordMismatch,
+    /// 仓储 / hasher adapter 内部错误（DB I/O 故障、spawn_blocking
+    /// join 失败、Argon2 库内部异常等）。
+    Internal,
+}
+
 /// 剪贴板捕获来源（`clipboard_entry_captured` 专用）。
 ///
 /// **不**包含 `Inbound`——入站同步路径必须在调用点过滤掉，避免与
@@ -625,6 +694,20 @@ mod tests {
                     payload_size_bucket: PayloadSizeBucket::Lt1Kb,
                 },
                 "clipboard_entry_captured",
+            ),
+            (Event::MobileDeviceRegistered, "mobile_device_registered"),
+            (
+                Event::MobileClipboardSynced {
+                    direction: Direction::Inbound,
+                    payload_size_bucket: PayloadSizeBucket::Lt1Kb,
+                },
+                "mobile_clipboard_synced",
+            ),
+            (
+                Event::MobileAuthFailed {
+                    failure_kind: MobileAuthFailureKind::PasswordMismatch,
+                },
+                "mobile_auth_failed",
             ),
         ];
         for (event, expected) in cases {
@@ -859,6 +942,58 @@ mod tests {
                 "UnlockFailureReason::{reason:?}"
             );
         }
+    }
+
+    #[test]
+    fn mobile_auth_failure_kind_wire_format() {
+        // schema doc §7.6：3 个变体，不含 RateLimited（未实装速率限制）。
+        for (kind, expected) in [
+            (MobileAuthFailureKind::UnknownUser, "unknown_user"),
+            (MobileAuthFailureKind::PasswordMismatch, "password_mismatch"),
+            (MobileAuthFailureKind::Internal, "internal"),
+        ] {
+            assert_eq!(
+                serde_json::to_value(kind).unwrap(),
+                expected,
+                "MobileAuthFailureKind::{kind:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn mobile_clipboard_synced_properties() {
+        // v1 direction 恒为 inbound；保留字段为 v2 扩展非破坏式埋点 outbound。
+        let event = Event::MobileClipboardSynced {
+            direction: Direction::Inbound,
+            payload_size_bucket: PayloadSizeBucket::Kb1To100,
+        };
+        let props = event.properties();
+        assert_eq!(props.get("direction"), Some(&json!("inbound")));
+        assert_eq!(
+            props.get("payload_size_bucket"),
+            Some(&json!("1kb_to_100kb"))
+        );
+        // 没有 payload_type / transport_type / peer_os——这些与 inbound mobile
+        // 路径无关，避免误导 dashboard 分析。
+        assert!(!props.contains_key("payload_type"));
+        assert!(!props.contains_key("transport_type"));
+        assert!(!props.contains_key("peer_os"));
+    }
+
+    #[test]
+    fn mobile_device_registered_has_empty_properties() {
+        // 仅靠 EventContext 携带身份维度；事件 properties 为空。
+        let props = Event::MobileDeviceRegistered.properties();
+        assert!(props.is_empty(), "{props:?}");
+    }
+
+    #[test]
+    fn mobile_auth_failed_carries_failure_kind() {
+        let event = Event::MobileAuthFailed {
+            failure_kind: MobileAuthFailureKind::UnknownUser,
+        };
+        let props = event.properties();
+        assert_eq!(props.get("failure_kind"), Some(&json!("unknown_user")));
     }
 
     #[test]

--- a/src-tauri/crates/uc-observability/src/analytics/mod.rs
+++ b/src-tauri/crates/uc-observability/src/analytics/mod.rs
@@ -27,10 +27,10 @@ pub use context::{
     Os,
 };
 pub use events::{
-    CaptureOrigin, Direction, Event, FailureReason, LatencyBucket, NameLengthBucket,
-    PairingFailureReason, PairingMethod, PayloadSizeBucket, PayloadType, SetupEntry,
-    SyncDeferReason, SyncDeferredProps, SyncEventProps, SyncFailureStage, TransportType,
-    UnlockFailureReason,
+    CaptureOrigin, Direction, Event, FailureReason, LatencyBucket, MobileAuthFailureKind,
+    NameLengthBucket, PairingFailureReason, PairingMethod, PayloadSizeBucket, PayloadType,
+    SetupEntry, SyncDeferReason, SyncDeferredProps, SyncEventProps, SyncFailureStage,
+    TransportType, UnlockFailureReason,
 };
 pub use ids::{load_or_create as load_or_create_ids, reset as reset_ids, AnalyticsIds};
 pub use port::{AnalyticsPort, NoopAnalyticsSink};

--- a/src-tauri/crates/uc-webserver/src/mobile_lan/test_support.rs
+++ b/src-tauri/crates/uc-webserver/src/mobile_lan/test_support.rs
@@ -244,6 +244,8 @@ pub(crate) async fn build_facade_with_seeded_device(
         file_transfer: None,
         clipboard_outbound: None,
         lan_lifecycle: None,
+        // schema doc §7.6 / §12.2 P1：测试装配走 noop sink，不污染 capture。
+        analytics: Arc::new(uc_observability::analytics::NoopAnalyticsSink::default()),
     }))
 }
 


### PR DESCRIPTION
## Summary

- Adds 3 product events from telemetry-events.md §12.2 P1 mobile_sync slice (70932c4d):
  - `mobile_device_registered` — iPhone Shortcut device registration anchor (currently 0 signal in product analytics)
  - `mobile_clipboard_synced` — iPhone → desktop clipboard actually landed, **only** SyncDoc → `Applied` outcome (Buffered / DuplicateSkipped / DecodeFailed are silent, mirroring the `clipboard_entry_captured` RemotePush double-count red line)
  - `mobile_auth_failed` — Basic Auth failure rate, broken down by a new `MobileAuthFailureKind` enum (UnknownUser / PasswordMismatch / Internal) so the dashboard can split "username wrong" vs "password wrong" vs "server fault" without leaking the difference back over the 401 response
- New `Arc<dyn AnalyticsPort>` wired through `MobileSyncFacadeDeps` → `register_device` / `authenticate_basic` / `apply_incoming` use cases; bootstrap injects the process-wide gated sink; webserver test_support uses `NoopAnalyticsSink`
- `v1 direction = Inbound` constant — outbound `GET /SyncClipboard.json`埋点 deferred to v2 because iPhone clients poll, which would put outbound an order of magnitude above inbound and need a separate sampling decision. The `direction` field keeps the enum slot so v2 expansion is non-breaking per §8
- Privacy doc update (82a67a5e) — both `en` and `zh` `privacy.mdx` tables now list the Mobile sync event family, satisfying the explicit "any new product event must be reflected in the public docs" promise on that page

## Test plan

- [x] `cargo test -p uc-observability --lib` (83/83 PASS, 13 new wire-shape assertions for the 3 events + `MobileAuthFailureKind`)
- [x] `cargo test -p uc-application --lib` (464/464 PASS, 13 new analytics-emit assertions covering happy paths, red-line silencing, and 6 auth failure mappings)
- [x] `cargo test -p uc-bootstrap --lib` (27/27 PASS, facade wiring builds)
- [x] `cargo test -p uc-webserver --lib mobile_lan` (61/61 PASS, test_support facade builds with noop sink)
- [x] `cargo check --workspace` clean
- [ ] Manual smoke: register an iPhone device through the real LAN flow and verify a `mobile_device_registered` event lands in PostHog (US ingestion endpoint, requires `POSTHOG_PROJECT_KEY` build env)
- [ ] Manual smoke: hit `/SyncClipboard.json` with a wrong password from `curl` and verify `mobile_auth_failed.failure_kind = password_mismatch` shows up in PostHog

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated privacy documentation to detail Mobile sync event tracking, including device registration, clipboard synchronization, and authentication failure events with their associated data fields.

* **New Features**
  * Enabled analytics tracking for mobile sync operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/UniClipboard/UniClipboard/pull/725)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->