### PR TITLE
fix(ui): allow text selection in clipboard preview

### DIFF
--- a/src/components/clipboard/VirtualizedText.tsx
+++ b/src/components/clipboard/VirtualizedText.tsx
@@ -120,7 +120,7 @@ const WindowedLongText: React.FC<{ text: string; className?: string }> = ({ text
         <>
           <div style={{ height: renderData.topHeight }} />
           <div
-            className="whitespace-pre-wrap font-mono text-sm leading-relaxed text-foreground/90"
+            className="selectable whitespace-pre-wrap font-mono text-sm leading-relaxed text-foreground/90"
             style={{ wordBreak: 'break-all' }}
           >
             {renderData.visibleText}
@@ -158,7 +158,7 @@ const VirtualizedText: React.FC<VirtualizedTextProps> = ({ text, className }) =>
       className={className}
       itemContent={(_index, line) => (
         <div
-          className="whitespace-pre-wrap font-mono text-sm leading-relaxed text-foreground/90"
+          className="selectable whitespace-pre-wrap font-mono text-sm leading-relaxed text-foreground/90"
           style={{ wordBreak: 'break-all' }}
         >
           {line || '\u00A0'}

--- a/src/components/clipboard/preview-renderers/TextPreview.tsx
+++ b/src/components/clipboard/preview-renderers/TextPreview.tsx
@@ -17,7 +17,7 @@ const TextPreview: React.FC<TextPreviewProps> = ({ item, loading, preview }) => 
   const displayText = getTextPreviewContent(item, preview)
 
   if (!loading && displayText.length > LARGE_TEXT_THRESHOLD) {
-    return <VirtualizedText text={displayText} className="h-full" />
+    return <VirtualizedText text={displayText} className="selectable h-full" />
   }
 
   return (
@@ -28,7 +28,7 @@ const TextPreview: React.FC<TextPreviewProps> = ({ item, loading, preview }) => 
           <span className="text-sm font-medium">{t('clipboard.item.loading')}</span>
         </div>
       ) : (
-        <p className="break-all whitespace-pre-wrap font-mono text-sm leading-relaxed text-foreground/80">
+        <p className="selectable break-all whitespace-pre-wrap font-mono text-sm leading-relaxed text-foreground/80">
           {displayText}
         </p>
       )}


### PR DESCRIPTION
## Summary

- The clipboard preview pane sat under the global `body { user-select: none }` rule in `src/styles/globals.css:428`, which disables text selection everywhere unless a node opts in via the project's `.selectable` class. `TextPreview` and `VirtualizedText` never opted in, so users could not highlight or copy substrings from the preview pane (3a74b359).
- Add `selectable` to the small-text `<p>`, the Virtuoso per-line wrapper, and the windowed long-line container — matching the convention `ClipboardItem.tsx:381` already follows for the inline preview in the list.

No `docs-site/` updates: scanned `docs-site/content/docs/{en,zh}/` for any reference to selecting / copying text from the preview pane and found none. The user-visible contract documented elsewhere is unchanged.

## Test plan

- [x] `pnpm lint` via lint-staged on commit (eslint + prettier passed).
- [ ] Manual: open the app, select a text item, drag-select a substring inside the right-pane preview, copy with `Cmd/Ctrl+C`, paste elsewhere — verify the substring (not the whole entry) lands in the destination.
- [ ] Manual: repeat for a large text entry (>`LARGE_TEXT_THRESHOLD`) so the `VirtualizedText` Virtuoso path is exercised.
- [ ] Manual: repeat for a single >50K-char line so the `WindowedLongText` path is exercised.