### PR TITLE
fix(clipboard-restore): map missing local source to 410 and scrub paths from logs

### DIFF
--- a/src-tauri/crates/uc-application/src/usecases/clipboard_restore/restore_selection.rs
+++ b/src-tauri/crates/uc-application/src/usecases/clipboard_restore/restore_selection.rs
@@ -318,22 +318,24 @@ impl RestoreClipboardSelectionUseCase {
                 continue;
             }
             if line.starts_with("file://") {
+                // 错误消息只暴露 entry_id / rep_id —— `line` 是 `file://...` URI，
+                // 含完整文件路径，属于用户私有 payload，禁止写入错误链 / 日志。
                 match url::Url::parse(line) {
                     Ok(url) => {
                         let path = url.to_file_path().map_err(|_| {
                             anyhow::anyhow!(
-                                "Failed to convert URI to file path for entry {}: {}",
+                                "Failed to convert URI to file path for entry {} (rep {})",
                                 entry_id,
-                                line
+                                rep.id
                             )
                         })?;
                         file_paths.push(path);
                     }
                     Err(e) => {
                         bail!(
-                            "Failed to parse file URI for entry {}: {} (error: {})",
+                            "Failed to parse file URI for entry {} (rep {}): {}",
                             entry_id,
-                            line,
+                            rep.id,
                             e
                         );
                     }
@@ -347,10 +349,20 @@ impl RestoreClipboardSelectionUseCase {
             bail!("No valid file paths found in entry {}", entry_id);
         }
 
-        for path in &file_paths {
-            if !path.exists() {
-                bail!("File deleted: {}", path.display());
-            }
+        // 本地源文件不存在 → 通过 PayloadResolveError::Lost 让 facade 映射为
+        // PayloadUnavailable（HTTP 410 Gone）+ warn 级日志，避免被当成服务端
+        // 5xx 上报到 Sentry。reason 严禁携带文件路径或文件名——属于用户私有
+        // payload（uc-application §16.3）。
+        let missing_count = file_paths.iter().filter(|p| !p.exists()).count();
+        if missing_count > 0 {
+            return Err(anyhow::Error::new(PayloadResolveError::Lost {
+                rep_id: rep.id.clone(),
+                reason: format!(
+                    "{} of {} referenced file(s) no longer exist on disk",
+                    missing_count,
+                    file_paths.len()
+                ),
+            }));
         }
 
         let snapshot = build_file_snapshot(&build_path_list(&file_paths));

--- a/src/components/clipboard/ClipboardContent.tsx
+++ b/src/components/clipboard/ClipboardContent.tsx
@@ -537,11 +537,21 @@ const ClipboardContent: React.FC<ClipboardContentProps> = ({
             setTimeout(() => setCopySuccess(false), 1500)
             return true
           } catch (err) {
-            // If copy fails (e.g. cache file deleted), mark entry as stale
-            const errMsg = err instanceof Error ? err.message : String(err)
+            // 410 Gone (PAYLOAD_UNAVAILABLE) 表示后端识别出"内容不可用"——对文件类
+            // entry,几乎专属于"用户已把本地源文件删除或移动"。把后端原始字面值
+            // `payload_unavailable` 透传给用户毫无信息量,这里改成面向用户的明确
+            // 文案;其他错误保留原始 message 用于排障。
+            const { DaemonApiError, DaemonErrorCode } = await import('@/api/daemon/errors')
+            const isPayloadUnavailable =
+              err instanceof DaemonApiError && err.code === DaemonErrorCode.PAYLOAD_UNAVAILABLE
+            const description = isPayloadUnavailable
+              ? t('clipboard.errors.fileSourceMissing')
+              : err instanceof Error
+                ? err.message
+                : String(err)
             dispatch(markEntryStale(itemId))
             toast.error(t('clipboard.errors.copyFailed'), {
-              description: errMsg,
+              description,
             })
             return false
           }

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -601,7 +601,8 @@
       "loadDetailFailed": "Failed to load details",
       "unknown": "An unknown error occurred",
       "unavailableBadge": "Content unavailable",
-      "unavailableTooltip": "This content is no longer available (bytes lost). Cannot paste. Consider deleting it from history."
+      "unavailableTooltip": "This content is no longer available (bytes lost). Cannot paste. Consider deleting it from history.",
+      "fileSourceMissing": "The source file is no longer at its original location — it may have been deleted or moved. Restore it to retry."
     },
     "item": {
       "characters": "characters",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -592,7 +592,8 @@
       "loadDetailFailed": "加载详情失败",
       "unknown": "发生未知错误",
       "unavailableBadge": "内容已不可用",
-      "unavailableTooltip": "该内容已不可用（数据已丢失），无法粘贴。建议从历史中删除。"
+      "unavailableTooltip": "该内容已不可用（数据已丢失），无法粘贴。建议从历史中删除。",
+      "fileSourceMissing": "源文件已不在原位置，可能被删除或移动；放回原位置后可重试。"
     },
     "item": {
       "characters": "字符",


### PR DESCRIPTION
## Summary

- **Backend (`uc-application`)**: when restoring a file-type entry, the
  user-side deletion of the source file was being turned into HTTP 500
  + ERROR log + Sentry upload, with the full filesystem path written
  into the log line. Now it's mapped to `PayloadResolveError::Lost` →
  `PayloadUnavailable` (410 Gone) + warn-level log; the `reason`
  carries only counts (`N of M referenced file(s) no longer exist on
  disk`), never paths or filenames. (bfbbb70e)
- **Backend privacy follow-through**: two adjacent `bail!` sites used
  to inline the raw `file://...` URI into their error messages —
  replaced with `(rep <id>)` so URI strings can't propagate up the
  anyhow chain. (bfbbb70e)
- **Frontend**: `copyFileToClipboard` bypasses the `copyToClipboard`
  thunk, so the 410 localization branch there never fired for file
  entries — the toast description was the raw `payload_unavailable`
  literal. `ClipboardContent` now detects
  `DaemonApiError + PAYLOAD_UNAVAILABLE` in the file-restore catch and
  renders the new i18n key `clipboard.errors.fileSourceMissing`
  ("源文件已不在原位置，可能被删除或移动；放回原位置后可重试。" /
  "The source file is no longer at its original location — it may
  have been deleted or moved. Restore it to retry."). (bfbbb70e)

## Test plan

- [x] `cargo check -p uc-application` clean.
- [x] `cargo test -p uc-application clipboard_restore` — 14/14 pass;
      `maps_lost_payload_to_payload_unavailable_with_lost_state`
      already covers the new mapping path.
- [x] `bunx tsc --noEmit` clean; `bunx eslint` clean on touched files.
- [x] `docs-site/` scanned for `payload_unavailable / 410 / Gone /
      restore / 内容不可用 / source file / cache deleted` — no user
      docs depend on this surface area, no docs commit needed.
- [ ] Manual repro on macOS dev profile: copy a file → delete the
      source file from disk → click restore on that entry. Expect
      toast "复制到剪贴板失败 / 源文件已不在原位置 …", 410 in
      daemon log at `warn` level, and **no** path or filename in any
      log line / Sentry event.
- [ ] Same flow on Windows (file URI path-handling differs).