### PR TITLE
refactor(shortcuts): remove unimplemented definitions from settings

### DIFF
--- a/src/components/setting/ShortcutsSection.tsx
+++ b/src/components/setting/ShortcutsSection.tsx
@@ -14,7 +14,7 @@ import {
 const log = createLogger('shortcuts-section')
 
 /** Display order for shortcut scopes */
-const SCOPE_ORDER: ShortcutScope[] = ['global', 'clipboard', 'settings', 'devices', 'modal']
+const SCOPE_ORDER: ShortcutScope[] = ['global']
 
 const ShortcutsSection: React.FC = () => {
   const { t } = useTranslation()

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -390,15 +390,7 @@
           "modal": "Modal"
         },
         "actions": {
-          "clearSelection": "Clear selection",
-          "selectAll": "Select all",
-          "delete": "Delete selected",
-          "favorite": "Toggle favorite",
-          "goClipboard": "Go to clipboard",
-          "goDevices": "Go to devices",
           "goSettings": "Go to settings",
-          "focusSearch": "Focus search",
-          "closeModal": "Close modal",
           "toggleQuickPanel": "Toggle quick panel",
           "zoomIn": "Zoom in",
           "zoomOut": "Zoom out"

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -381,15 +381,7 @@
           "modal": "模态框"
         },
         "actions": {
-          "clearSelection": "取消选择",
-          "selectAll": "全选",
-          "delete": "删除选中项",
-          "favorite": "收藏/取消收藏",
-          "goClipboard": "前往剪贴板",
-          "goDevices": "前往设备",
           "goSettings": "前往设置",
-          "focusSearch": "聚焦搜索框",
-          "closeModal": "关闭模态框",
           "toggleQuickPanel": "切换快捷面板",
           "zoomIn": "放大界面",
           "zoomOut": "缩小界面"

--- a/src/shortcuts/definitions.ts
+++ b/src/shortcuts/definitions.ts
@@ -6,18 +6,10 @@ import { ShortcutLayer } from './layers'
 import { isMac } from '@/lib/shortcut-format'
 
 export type ShortcutAction =
-  | 'clipboard.clearSelection'
-  | 'clipboard.selectAll'
-  | 'clipboard.delete'
-  | 'clipboard.favorite'
-  | 'clipboard.copy'
   | 'global.zoomIn'
   | 'global.zoomOut'
-  | 'navigation.dashboard'
-  | 'navigation.devices'
+  | 'global.toggleQuickPanel'
   | 'navigation.settings'
-  | 'search.focus'
-  | 'modal.close'
   | string
 
 /**
@@ -61,68 +53,20 @@ export interface ShortcutDefinition {
 
 /**
  * Central shortcut definitions
+ *
+ * 仅收录"在前端/后端真正被实装"的快捷键。
+ * 历史上这里还有 clipboard.{esc,selectAll,delete,favorite}、nav.{dashboard,devices}、
+ * search.focus、modal.close —— 它们只在设置页面"看起来可定制",但没有 handler 读取
+ * override,改了也不生效,因此从设置面板里下掉,避免对用户产生误导。
  */
 export const SHORTCUT_DEFINITIONS: ShortcutDefinition[] = [
-  // ===== Clipboard actions =====
-  {
-    id: 'clipboard.esc',
-    key: 'esc',
-    action: 'clipboard.clearSelection',
-    scope: 'clipboard',
-    description: 'settings.sections.shortcuts.actions.clearSelection',
-  },
-  {
-    id: 'clipboard.selectAll',
-    key: 'mod+a',
-    action: 'clipboard.selectAll',
-    scope: 'clipboard',
-    description: 'settings.sections.shortcuts.actions.selectAll',
-  },
-  {
-    id: 'clipboard.delete',
-    key: 'backspace',
-    action: 'clipboard.delete',
-    scope: 'clipboard',
-    description: 'settings.sections.shortcuts.actions.delete',
-  },
-  {
-    id: 'clipboard.favorite',
-    key: 'mod+f',
-    action: 'clipboard.favorite',
-    scope: 'clipboard',
-    description: 'settings.sections.shortcuts.actions.favorite',
-  },
-
   // ===== Navigation =====
-  {
-    id: 'nav.dashboard',
-    key: 'mod+1',
-    action: 'navigation.dashboard',
-    scope: 'global',
-    description: 'settings.sections.shortcuts.actions.goClipboard',
-  },
-  {
-    id: 'nav.devices',
-    key: 'mod+2',
-    action: 'navigation.devices',
-    scope: 'global',
-    description: 'settings.sections.shortcuts.actions.goDevices',
-  },
   {
     id: 'nav.settings',
     key: 'mod+comma',
     action: 'navigation.settings',
     scope: 'global',
     description: 'settings.sections.shortcuts.actions.goSettings',
-  },
-
-  // ===== Search =====
-  {
-    id: 'search.focus',
-    key: 'mod+/',
-    action: 'search.focus',
-    scope: 'global',
-    description: 'settings.sections.shortcuts.actions.focusSearch',
   },
 
   // ===== Global (OS-level) =====
@@ -146,14 +90,5 @@ export const SHORTCUT_DEFINITIONS: ShortcutDefinition[] = [
     action: 'global.zoomOut',
     scope: 'global',
     description: 'settings.sections.shortcuts.actions.zoomOut',
-  },
-
-  // ===== Modal =====
-  {
-    id: 'modal.close',
-    key: 'esc',
-    action: 'modal.close',
-    scope: 'modal',
-    description: 'settings.sections.shortcuts.actions.closeModal',
   },
 ]


### PR DESCRIPTION
## Summary

- Remove 8 unimplemented shortcut definitions that appeared customizable but had no effect when changed: clipboard scope actions (esc, selectAll, delete, favorite), navigation (dashboard mod+1, devices mod+2), search focus (mod+/), and modal close
- Keep only 4 implemented shortcuts: nav.settings, global.toggleQuickPanel, global.zoomIn/Out
- Removes misleading UI entries that confused users into customizing non-functional settings
- ClipboardContent's hardcoded c/d/up/down navigation shortcuts remain internal, not exposed in settings

## Test plan

- [x] TypeScript compilation passes
- [x] Shortcut-related tests pass (SettingContext.shortcuts, GlobalShortcuts.zoom)
- [ ] Reviewer: verify settings > shortcuts panel only shows 4 shortcut groups after merge