### PR TITLE
feat(clipboard/delivery): entry detail source + per-device sync (Phase 2)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -17,6 +17,7 @@
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
+        "@radix-ui/react-hover-card": "^1.1.15",
         "@radix-ui/react-label": "^2.1.8",
         "@radix-ui/react-navigation-menu": "^1.2.14",
         "@radix-ui/react-popover": "^1.1.15",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@radix-ui/react-collapsible": "^1.1.12",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
+    "@radix-ui/react-hover-card": "^1.1.15",
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-navigation-menu": "^1.2.14",
     "@radix-ui/react-popover": "^1.1.15",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -411,6 +411,9 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "as-slice"
@@ -10053,6 +10056,7 @@ name = "uc-core"
 version = "0.10.0-alpha.3"
 dependencies = [
  "anyhow",
+ "arrayvec",
  "async-trait",
  "base64 0.22.1",
  "blake3",

--- a/src-tauri/crates/uc-application/src/clipboard_capture/usecase.rs
+++ b/src-tauri/crates/uc-application/src/clipboard_capture/usecase.rs
@@ -141,7 +141,17 @@ impl CaptureClipboardUseCase {
 
             let event_id = EventId::new();
             let captured_at_ms = snapshot.ts_ms;
-            let source_device = self.device_identity.current_device_id();
+            // `RemotePush { from_device: Some(_) }` 路径走的是 apply_inbound:
+            // 这次 capture 把对端推过来的 snapshot 落库,事件源就是对端,
+            // 否则 delivery view 会把这条远端推送进来的 entry 误识别为
+            // 本机产生,详情页显示"来自本机 + 等待同步"。
+            // 守卫路径(`from_device: None`)与本地路径一样,按本机 id 记录。
+            let source_device = match origin {
+                ClipboardChangeOrigin::RemotePush {
+                    from_device: Some(d),
+                } => d,
+                _ => self.device_identity.current_device_id(),
+            };
             let snapshot_hash = {
                 let _guard = info_span!(
                     "clipboard.snapshot_hash",
@@ -445,7 +455,7 @@ fn telemetry_capture_origin(origin: ClipboardChangeOrigin) -> Option<CaptureOrig
         ClipboardChangeOrigin::LocalRestore => Some(CaptureOrigin::ManualRestore),
         // 入站同步写本地剪贴板路径——必须过滤，否则 outbound capture
         // 与入站事件双计。
-        ClipboardChangeOrigin::RemotePush => None,
+        ClipboardChangeOrigin::RemotePush { .. } => None,
     }
 }
 

--- a/src-tauri/crates/uc-application/src/clipboard_write/coordinator.rs
+++ b/src-tauri/crates/uc-application/src/clipboard_write/coordinator.rs
@@ -332,7 +332,10 @@ impl ClipboardWriteCoordinator {
                     // the re-encoded content, so we set a one-shot origin override: the NEXT clipboard
                     // change will be treated as RemotePush regardless of hash.
                     self.clipboard_change_origin
-                        .set_next_origin(ClipboardChangeOrigin::RemotePush, Duration::from_secs(60))
+                        .set_next_origin(
+                            ClipboardChangeOrigin::remote_push_anonymous(),
+                            Duration::from_secs(60),
+                        )
                         .await;
                 }
                 ClipboardWriteIntent::LocalCapture => {}

--- a/src-tauri/crates/uc-application/src/facade/app_facade.rs
+++ b/src-tauri/crates/uc-application/src/facade/app_facade.rs
@@ -415,6 +415,20 @@ impl AppFacade {
             })
     }
 
+    /// 取一条 entry 的"来源 + 每个对端同步状态"完整视图。GUI detail
+    /// 面板用它渲染"来自哪台设备 / 同步到了哪些设备 / 哪台失败"。
+    pub async fn get_entry_delivery_view(
+        &self,
+        entry_id: &uc_core::ids::EntryId,
+    ) -> Result<crate::facade::EntryDeliveryView, crate::facade::GetEntryDeliveryViewError> {
+        let facade = self.clipboard_sync.get().cloned().ok_or_else(|| {
+            crate::facade::GetEntryDeliveryViewError::Storage(
+                "clipboard sync facade unavailable".to_string(),
+            )
+        })?;
+        facade.get_entry_delivery_view(entry_id).await
+    }
+
     /// 发布 blob。
     pub async fn publish_blob(
         &self,

--- a/src-tauri/crates/uc-application/src/facade/clipboard_outbound/mod.rs
+++ b/src-tauri/crates/uc-application/src/facade/clipboard_outbound/mod.rs
@@ -81,7 +81,7 @@ impl ClipboardOutboundPort for ClipboardOutboundDispatcher {
         &self,
         input: ClipboardOutboundInput,
     ) -> Result<ClipboardOutboundOutcome, ClipboardOutboundError> {
-        if input.origin == ClipboardChangeOrigin::RemotePush {
+        if input.origin.is_remote_push() {
             return Ok(ClipboardOutboundOutcome::Skipped {
                 reason: "remote_push_echo".to_string(),
             });

--- a/src-tauri/crates/uc-application/src/facade/mobile_sync/facade.rs
+++ b/src-tauri/crates/uc-application/src/facade/mobile_sync/facade.rs
@@ -630,6 +630,7 @@ mod tests {
     use uc_core::ports::{EndpointInfoError, LanInterfaceProbeError, PasswordHasherError};
     use uc_core::settings::model::Settings;
     use uc_core::BlobId;
+    use uc_core::DeviceId;
 
     use crate::usecases::clipboard_sync::apply_inbound::{InboundCapture, InboundWrite};
     use uc_core::blob::ports::BlobReaderPort;
@@ -889,6 +890,7 @@ mod tests {
         async fn capture(
             &self,
             _: EntryId,
+            _: DeviceId,
             _: SystemClipboardSnapshot,
         ) -> AnyResult<Option<EntryId>> {
             unimplemented!()

--- a/src-tauri/crates/uc-application/src/facade/mod.rs
+++ b/src-tauri/crates/uc-application/src/facade/mod.rs
@@ -42,7 +42,9 @@ pub use blob_transfer::{
 };
 pub use clipboard::{
     ClipboardSyncDeps, ClipboardSyncError, ClipboardSyncFacade, DispatchEntryInput,
-    DispatchEntryOutcome, DispatchEntryPerTarget, InboundAction, InboundNotice, IngestHandle,
+    DispatchEntryOutcome, DispatchEntryPerTarget, EntryDeliveryStatusView, EntryDeliveryTargetView,
+    EntryDeliveryView, EntrySource, GetEntryDeliveryViewError, InboundAction, InboundNotice,
+    IngestHandle,
 };
 pub use clipboard_capture::{
     CapturedClipboardEntryView, ClipboardCaptureFacade, ClipboardCaptureFacadeError,

--- a/src-tauri/crates/uc-application/src/sync_planner/planner.rs
+++ b/src-tauri/crates/uc-application/src/sync_planner/planner.rs
@@ -51,7 +51,7 @@ impl OutboundSyncPlanner {
         extracted_paths_count: usize,
     ) -> OutboundSyncPlan {
         // Guard: RemotePush is never re-synced outbound.
-        if origin == ClipboardChangeOrigin::RemotePush {
+        if origin.is_remote_push() {
             return OutboundSyncPlan {
                 clipboard: None,
                 files: vec![],

--- a/src-tauri/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/ports.rs
+++ b/src-tauri/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/ports.rs
@@ -7,7 +7,7 @@
 use anyhow::Result;
 use async_trait::async_trait;
 use uc_core::ids::EntryId;
-use uc_core::{ClipboardChangeOrigin, SystemClipboardSnapshot};
+use uc_core::{ClipboardChangeOrigin, DeviceId, SystemClipboardSnapshot};
 
 use crate::clipboard_capture::CaptureClipboardUseCase;
 use crate::clipboard_write::{ClipboardWriteCoordinator, ClipboardWriteIntent};
@@ -25,6 +25,9 @@ pub trait InboundCapture: Send + Sync {
     /// card on this id and let it be replaced by the real entry without a
     /// transfer_id → entry_id remap step.
     ///
+    /// `from_device` 是推送方 device id,落库时会写入 `ClipboardEvent.source_device`
+    /// 让上层视图(delivery view)正确识别来源为远端而非本机。
+    ///
     /// Returns `Ok(Some(entry_id))` on success, `Ok(None)` only in the
     /// legitimate "no supported representation" / `LocalRestore`
     /// short-circuit cases (which `RemotePush` never hits in practice —
@@ -32,6 +35,7 @@ pub trait InboundCapture: Send + Sync {
     async fn capture(
         &self,
         preset_entry_id: EntryId,
+        from_device: DeviceId,
         snapshot: SystemClipboardSnapshot,
     ) -> Result<Option<EntryId>>;
 }
@@ -41,11 +45,14 @@ impl InboundCapture for CaptureClipboardUseCase {
     async fn capture(
         &self,
         preset_entry_id: EntryId,
+        from_device: DeviceId,
         snapshot: SystemClipboardSnapshot,
     ) -> Result<Option<EntryId>> {
         self.execute_with_origin(
             snapshot,
-            ClipboardChangeOrigin::RemotePush,
+            ClipboardChangeOrigin::RemotePush {
+                from_device: Some(from_device),
+            },
             Some(preset_entry_id),
         )
         .await

--- a/src-tauri/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/tests.rs
+++ b/src-tauri/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/tests.rs
@@ -92,6 +92,7 @@ mockall::mock! {
         async fn capture(
             &self,
             preset_entry_id: EntryId,
+            from_device: DeviceId,
             snapshot: SystemClipboardSnapshot,
         ) -> Result<Option<EntryId>>;
     }
@@ -246,7 +247,7 @@ async fn applied_on_new_content() {
     capture
         .expect_capture()
         .times(1)
-        .returning(|_, _| Ok(Some(EntryId::from("entry-new"))));
+        .returning(|_, _, _| Ok(Some(EntryId::from("entry-new"))));
 
     let mut write = MockWrite::new();
     write.expect_write().times(1).returning(|_| Ok(()));
@@ -259,6 +260,35 @@ async fn applied_on_new_content() {
             entry_id: EntryId::from("entry-new")
         }
     );
+}
+
+/// 回归:apply_inbound 必须把 `input.from_device`(推送方)透传给
+/// `InboundCapture::capture` 的第二参数,持久化层才能把
+/// `ClipboardEvent.source_device` 写成对端 id —— 不然 delivery view 会
+/// 把远端推送进来的 entry 误识别为本机产生,详情页显示"来自本机 +
+/// 等待同步"(detail 顶部 EntryDeliveryBadge)。
+#[tokio::test]
+async fn from_device_is_forwarded_to_capture() {
+    let (input, _hash) = fixture_input("trace-source");
+    let expected_from_device = input.from_device.clone();
+
+    let mut repo = MockEntryRepo::new();
+    repo.expect_find_entry_id_by_snapshot_hash()
+        .times(1)
+        .returning(|_| Ok(None));
+
+    let mut capture = MockCapture::new();
+    capture
+        .expect_capture()
+        .withf(move |_preset, from_device, _snapshot| from_device == &expected_from_device)
+        .times(1)
+        .returning(|_, _, _| Ok(Some(EntryId::from("entry-remote"))));
+
+    let mut write = MockWrite::new();
+    write.expect_write().times(1).returning(|_| Ok(()));
+
+    let uc = build(repo, capture, write);
+    uc.execute(input).await.expect("forwarding path ok");
 }
 
 /// Verdict 2 — dedup hit: returns `DuplicateSkipped` and **does
@@ -305,7 +335,7 @@ async fn rapid_duplicate_skipped_even_when_repo_has_not_caught_up() {
     capture
         .expect_capture()
         .times(1)
-        .returning(|_, _| Ok(Some(EntryId::from("entry-first"))));
+        .returning(|_, _, _| Ok(Some(EntryId::from("entry-first"))));
 
     let mut write = MockWrite::new();
     write.expect_write().times(1).returning(|_| Ok(()));
@@ -383,7 +413,7 @@ async fn visible_duplicate_skipped_across_channel_representation_expansion() {
     capture
         .expect_capture()
         .times(1)
-        .returning(|_, _| Ok(Some(EntryId::from("entry-visible"))));
+        .returning(|_, _, _| Ok(Some(EntryId::from("entry-visible"))));
 
     let mut write = MockWrite::new();
     write.expect_write().times(1).returning(|_| Ok(()));
@@ -447,7 +477,7 @@ async fn visible_duplicate_window_expires() {
     capture
         .expect_capture()
         .times(2)
-        .returning(|_, _| Ok(Some(EntryId::new())));
+        .returning(|_, _, _| Ok(Some(EntryId::new())));
 
     let mut write = MockWrite::new();
     write.expect_write().times(2).returning(|_| Ok(()));
@@ -550,7 +580,10 @@ async fn capture_returning_none_maps_to_internal_error() {
         .returning(|_| Ok(None));
 
     let mut capture = MockCapture::new();
-    capture.expect_capture().times(1).returning(|_, _| Ok(None));
+    capture
+        .expect_capture()
+        .times(1)
+        .returning(|_, _, _| Ok(None));
 
     // Zero expectations on write.
     let write = MockWrite::new();
@@ -593,7 +626,7 @@ async fn write_failure_does_not_surface_after_capture_commits() {
     capture
         .expect_capture()
         .times(1)
-        .returning(|_, _| Ok(Some(EntryId::from("entry-committed"))));
+        .returning(|_, _, _| Ok(Some(EntryId::from("entry-committed"))));
 
     // Deterministic synchronization:让 mock 在被调用时 signal,test 主体
     // await 这个 signal,确保 `.times(1)` 期望在 mock Drop 之前一定满足,
@@ -707,9 +740,9 @@ async fn materializes_blob_refs_before_capture_and_write() {
     let mut capture = MockCapture::new();
     capture
         .expect_capture()
-        .withf(move |_preset_entry_id, snapshot| assert_local_file(snapshot))
+        .withf(move |_preset_entry_id, _from_device, snapshot| assert_local_file(snapshot))
         .times(1)
-        .returning(|_, _| Ok(Some(EntryId::from("entry-new"))));
+        .returning(|_, _, _| Ok(Some(EntryId::from("entry-new"))));
 
     let mut write = MockWrite::new();
     write
@@ -944,7 +977,7 @@ async fn happy_path_emits_incoming_pending_then_new_content() {
     capture
         .expect_capture()
         .times(1)
-        .returning(|preset, _| Ok(Some(preset)));
+        .returning(|preset, _, _| Ok(Some(preset)));
 
     let mut write = MockWrite::new();
     write.expect_write().times(1).returning(|_| Ok(()));

--- a/src-tauri/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/usecase.rs
+++ b/src-tauri/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/usecase.rs
@@ -267,7 +267,7 @@ impl ApplyInboundClipboardUseCase {
         let snapshot_for_write = snapshot.clone();
         let entry_id = self
             .capture
-            .capture(receiver_entry_id.clone(), snapshot)
+            .capture(receiver_entry_id.clone(), input.from_device, snapshot)
             .await
             .map_err(|e| ApplyInboundError::Capture(e.to_string()))?
             .ok_or_else(|| {

--- a/src-tauri/crates/uc-application/src/usecases/mobile_sync/apply_incoming.rs
+++ b/src-tauri/crates/uc-application/src/usecases/mobile_sync/apply_incoming.rs
@@ -901,6 +901,7 @@ mod tests {
             async fn capture(
                 &self,
                 preset_entry_id: EntryId,
+                from_device: DeviceId,
                 snapshot: SystemClipboardSnapshot,
             ) -> AnyResult<Option<EntryId>>;
         }
@@ -935,7 +936,7 @@ mod tests {
         capture
             .expect_capture()
             .times(1)
-            .returning(move |_, _| Ok(Some(id_for_capture.clone())));
+            .returning(move |_, _, _| Ok(Some(id_for_capture.clone())));
 
         let mut write = MockWrite::new();
         write.expect_write().times(1).returning(|_| Ok(()));
@@ -990,7 +991,7 @@ mod tests {
         capture
             .expect_capture()
             .times(1)
-            .returning(move |_, _| Ok(Some(id_for_capture.clone())));
+            .returning(move |_, _, _| Ok(Some(id_for_capture.clone())));
 
         let mut write = MockWrite::new();
         write.expect_write().times(1).returning(|_| Ok(()));
@@ -1026,7 +1027,7 @@ mod tests {
         capture
             .expect_capture()
             .times(1)
-            .returning(move |_, _| Ok(Some(id_for_capture.clone())));
+            .returning(move |_, _, _| Ok(Some(id_for_capture.clone())));
         let mut write = MockWrite::new();
         write.expect_write().times(1).returning(|_| Ok(()));
 
@@ -1354,7 +1355,7 @@ mod tests {
         let mut capture = MockCapture::new();
         capture
             .expect_capture()
-            .withf(|_id, snapshot| {
+            .withf(|_id, _from_device, snapshot| {
                 let rep = snapshot
                     .representations
                     .iter()
@@ -1370,7 +1371,7 @@ mod tests {
                     && body == "file:///C:/Users/mark/AppData/Local/uc/mobile_inbound/abc/My%20Photo.png\n"
             })
             .times(1)
-            .returning(|_, _| Ok(Some(EntryId::from("entry-file-win"))));
+            .returning(|_, _, _| Ok(Some(EntryId::from("entry-file-win"))));
 
         let mut write = MockWrite::new();
         write.expect_write().times(1).returning(|_| Ok(()));
@@ -1516,7 +1517,7 @@ mod tests {
         capture
             .expect_capture()
             .times(1)
-            .returning(|_, _| Ok(Some(EntryId::from("entry-fanout-1"))));
+            .returning(|_, _, _| Ok(Some(EntryId::from("entry-fanout-1"))));
         let mut write = MockWrite::new();
         write.expect_write().times(1).returning(|_| Ok(()));
         let inbound =
@@ -1693,9 +1694,9 @@ mod tests {
         let mut capture = MockCapture::new();
         capture
             .expect_capture()
-            .withf(|_id, snapshot| snapshot.ts_ms == 1_700_000_000_000)
+            .withf(|_id, _from_device, snapshot| snapshot.ts_ms == 1_700_000_000_000)
             .times(1)
-            .returning(|_, _| Ok(Some(EntryId::from("entry-clock"))));
+            .returning(|_, _, _| Ok(Some(EntryId::from("entry-clock"))));
 
         let mut write = MockWrite::new();
         write.expect_write().times(1).returning(|_| Ok(()));
@@ -1739,7 +1740,7 @@ mod tests {
         capture
             .expect_capture()
             .times(1)
-            .returning(move |_, _| Ok(Some(id_for_capture.clone())));
+            .returning(move |_, _, _| Ok(Some(id_for_capture.clone())));
         let mut write = MockWrite::new();
         write.expect_write().times(1).returning(|_| Ok(()));
         let inbound =

--- a/src-tauri/crates/uc-core/Cargo.toml
+++ b/src-tauri/crates/uc-core/Cargo.toml
@@ -40,6 +40,10 @@ url = "2"
 
 uuid = { version = "1", features = ["v4", "fast-rng", "serde"] }
 
+# Stack-string for `Copy`-able device ids (固定 64 字节上限,详见
+# `ids/device_id.rs`)。
+arrayvec = { version = "0.7", features = ["serde"] }
+
 # Optional: domain layer only records events (facts)
 tracing = { version = "0.1", optional = true }
 zeroize = "1.8.2"

--- a/src-tauri/crates/uc-core/src/clipboard/change.rs
+++ b/src-tauri/crates/uc-core/src/clipboard/change.rs
@@ -1,10 +1,41 @@
 use super::SystemClipboardSnapshot;
+use crate::DeviceId;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ClipboardChangeOrigin {
     LocalCapture,
     LocalRestore,
-    RemotePush,
+    /// 由远端推送写入本机剪贴板的入站事件。
+    ///
+    /// `from_device` 携带的是推送方 device id,持久化路径(把这次入站事件
+    /// 转成 `ClipboardEvent` 落库)需要它才能给 `ClipboardEvent.source_device`
+    /// 填正确的对端;若不带,持久化层会把入站记录的来源错记为本机,
+    /// 上层视图就会把"远端推送进来的 entry"展示成"本机产生"。
+    ///
+    /// 守卫路径(OS 回写后让 watcher 短路忽略回声)只关心"这次变化属于
+    /// 远端推送"这个 tag,不关心是哪个对端,故为 `Option`:守卫端构造时
+    /// 传 `None`,持久化端构造时传 `Some(from_device)`。
+    RemotePush {
+        from_device: Option<DeviceId>,
+    },
+}
+
+impl ClipboardChangeOrigin {
+    /// 是否为远端推送来源,忽略 `from_device` 字段。
+    ///
+    /// 用于守卫路径 / 出站过滤等仅关心 tag、不关心具体对端的比较场景。
+    pub fn is_remote_push(&self) -> bool {
+        matches!(self, Self::RemotePush { .. })
+    }
+
+    /// 构造"匿名"远端推送 origin。
+    ///
+    /// 守卫路径在 OS 回写后只想标记"下一次剪贴板变化属于远端推送的回声",
+    /// 此时并不需要追溯具体对端 —— 用本构造器表达"我知道是远端推送,但
+    /// 来源对此处不重要"的意图。
+    pub fn remote_push_anonymous() -> Self {
+        Self::RemotePush { from_device: None }
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/src-tauri/crates/uc-core/src/clipboard/change.rs
+++ b/src-tauri/crates/uc-core/src/clipboard/change.rs
@@ -1,38 +1,36 @@
 use super::SystemClipboardSnapshot;
 use crate::DeviceId;
 
+/// 一次剪贴板变化的领域来源。
+///
+/// 同一份剪贴板内容可能来自本机用户操作,也可能来自远端推送写入本机;
+/// 该来源是后续业务判定(归属、去重、过滤等)的依据,而非传输/持久化路径。
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ClipboardChangeOrigin {
+    /// 本机捕获到的新剪贴板内容。
     LocalCapture,
+    /// 本机内部对剪贴板的回填/恢复写入。
     LocalRestore,
-    /// 由远端推送写入本机剪贴板的入站事件。
+    /// 来源于远端设备的剪贴板变化。
     ///
-    /// `from_device` 携带的是推送方 device id,持久化路径(把这次入站事件
-    /// 转成 `ClipboardEvent` 落库)需要它才能给 `ClipboardEvent.source_device`
-    /// 填正确的对端;若不带,持久化层会把入站记录的来源错记为本机,
-    /// 上层视图就会把"远端推送进来的 entry"展示成"本机产生"。
+    /// `from_device` 表示这次变化所归属的远端来源对端:
+    /// - `Some(device_id)` —— 已知具体对端;
+    /// - `None` —— 已知属于远端推送但来源对端未知或对当前消费者无关。
     ///
-    /// 守卫路径(OS 回写后让 watcher 短路忽略回声)只关心"这次变化属于
-    /// 远端推送"这个 tag,不关心是哪个对端,故为 `Option`:守卫端构造时
-    /// 传 `None`,持久化端构造时传 `Some(from_device)`。
-    RemotePush {
-        from_device: Option<DeviceId>,
-    },
+    /// 消费者据此区分"远端推送"与"本机产生",并在需要追溯归属时取用
+    /// `from_device`。
+    RemotePush { from_device: Option<DeviceId> },
 }
 
 impl ClipboardChangeOrigin {
     /// 是否为远端推送来源,忽略 `from_device` 字段。
-    ///
-    /// 用于守卫路径 / 出站过滤等仅关心 tag、不关心具体对端的比较场景。
     pub fn is_remote_push(&self) -> bool {
         matches!(self, Self::RemotePush { .. })
     }
 
-    /// 构造"匿名"远端推送 origin。
+    /// 构造一个不携带具体来源对端的远端推送 origin。
     ///
-    /// 守卫路径在 OS 回写后只想标记"下一次剪贴板变化属于远端推送的回声",
-    /// 此时并不需要追溯具体对端 —— 用本构造器表达"我知道是远端推送,但
-    /// 来源对此处不重要"的意图。
+    /// 用于"已知本次变化属于远端推送,但来源对端在当前语境无意义"的场景。
     pub fn remote_push_anonymous() -> Self {
         Self::RemotePush { from_device: None }
     }

--- a/src-tauri/crates/uc-core/src/ids/device_id.rs
+++ b/src-tauri/crates/uc-core/src/ids/device_id.rs
@@ -1,20 +1,113 @@
-use serde::{Deserialize, Serialize};
+//! `DeviceId` —— `Copy`-able 设备身份。
+//!
+//! 为什么是 `Copy`:
+//! 设备 id 出现在大量值传递路径(`ClipboardChangeOrigin::RemotePush`
+//! 携带的 `from_device`、各 use case 的入参、tracing field、跨 span 的
+//! 闭包捕获 …)。如果它只是 `String` wrapper,每条流水线都要散布
+//! `.clone()` 才能在多次借用之间复用,可读性与维护成本都被 hit。把
+//! `DeviceId` 设计为 `Copy`,核心业务代码就能像传 `Uuid` 一样自然传值。
+//!
+//! 为什么用 `ArrayString<64>` 而不是 `String`:
+//! `String` 拥有堆分配,无法实现 `Copy`。项目里见到的最长 device_id
+//! 形态是 `mobile_sync:<MobileDeviceId>` ≈ 48 字节,留出 64 字节余量
+//! 把存储改成栈上定长数组,从而获得 `Copy` 能力。超长输入会在 `new()`
+//! 与反序列化路径上显式拒绝(panic / serde error),不被静默截断 ——
+//! 默契是"device_id 是有限规模的稳定标识,不是任意长度字符串"。
+//!
+//! Wire / DB 兼容:`Serialize`/`Deserialize` 仍以裸字符串往返,不变更
+//! 任何外部存档或协议格式。
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct DeviceId(String);
+use arrayvec::ArrayString;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+/// 单个 device_id 允许的最大字节数(UTF-8 字节,非字符数)。
+///
+/// 选 64 是因为见到的最长 device_id 形态约 48 字节
+/// (`mobile_sync:<MobileDeviceId>`),64 字节给可预见的 prefix 留余量,
+/// 同时维持栈占用合理。需要超过该上限时应优先重构 device_id 命名,
+/// 而非提高该常量。
+pub const DEVICE_ID_MAX_BYTES: usize = 64;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct DeviceId(ArrayString<DEVICE_ID_MAX_BYTES>);
 
 impl std::fmt::Display for DeviceId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
+        write!(f, "{}", self.0.as_str())
     }
 }
 
 impl DeviceId {
-    pub fn new(id: impl Into<String>) -> Self {
-        Self(id.into())
+    /// 构造 `DeviceId`。超过 `DEVICE_ID_MAX_BYTES` 字节会 panic ——
+    /// 这是契约违反,代表上游生成 device_id 的代码出 bug 或命名规则
+    /// 突破假设,需要修正,而非静默截断。
+    pub fn new(id: impl AsRef<str>) -> Self {
+        let s = id.as_ref();
+        let arr = ArrayString::from(s).unwrap_or_else(|_| {
+            panic!(
+                "device id exceeds {DEVICE_ID_MAX_BYTES} bytes (got {} bytes): {s:?}",
+                s.len()
+            )
+        });
+        Self(arr)
     }
 
     pub fn as_str(&self) -> &str {
-        &self.0
+        self.0.as_str()
+    }
+}
+
+impl Serialize for DeviceId {
+    fn serialize<S: Serializer>(&self, ser: S) -> Result<S::Ok, S::Error> {
+        self.0.as_str().serialize(ser)
+    }
+}
+
+impl<'de> Deserialize<'de> for DeviceId {
+    fn deserialize<D: Deserializer<'de>>(de: D) -> Result<Self, D::Error> {
+        let s: std::borrow::Cow<'de, str> = Deserialize::deserialize(de)?;
+        ArrayString::from(s.as_ref()).map(DeviceId).map_err(|_| {
+            serde::de::Error::custom(format!(
+                "device id exceeds {DEVICE_ID_MAX_BYTES} bytes (got {} bytes)",
+                s.len()
+            ))
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trip_short_id() {
+        let id = DeviceId::new("a3a88f53-e2b8-4503-87bb-c91844e16a6f");
+        assert_eq!(id.as_str(), "a3a88f53-e2b8-4503-87bb-c91844e16a6f");
+        // 反复 copy 不需要 .clone()
+        let copies: [DeviceId; 3] = [id, id, id];
+        assert!(copies.iter().all(|c| c.as_str() == id.as_str()));
+    }
+
+    #[test]
+    fn round_trip_mobile_sync_prefix() {
+        // 项目里见到的最长 device_id 形态。
+        let id = DeviceId::new("mobile_sync:did_0123456789abcdef0123456789abcdef");
+        assert!(id.as_str().len() <= DEVICE_ID_MAX_BYTES);
+    }
+
+    #[test]
+    #[should_panic(expected = "device id exceeds")]
+    fn rejects_overlong_id() {
+        let too_long = "x".repeat(DEVICE_ID_MAX_BYTES + 1);
+        let _ = DeviceId::new(too_long);
+    }
+
+    #[test]
+    fn serde_round_trip_matches_plain_string() {
+        let id = DeviceId::new("peer-x");
+        let json = serde_json::to_string(&id).unwrap();
+        assert_eq!(json, "\"peer-x\"");
+        let back: DeviceId = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, id);
     }
 }

--- a/src-tauri/crates/uc-core/src/ids/device_id.rs
+++ b/src-tauri/crates/uc-core/src/ids/device_id.rs
@@ -1,31 +1,22 @@
-//! `DeviceId` —— `Copy`-able 设备身份。
+//! `DeviceId` —— 设备身份的值对象。
 //!
-//! 为什么是 `Copy`:
-//! 设备 id 出现在大量值传递路径(`ClipboardChangeOrigin::RemotePush`
-//! 携带的 `from_device`、各 use case 的入参、tracing field、跨 span 的
-//! 闭包捕获 …)。如果它只是 `String` wrapper,每条流水线都要散布
-//! `.clone()` 才能在多次借用之间复用,可读性与维护成本都被 hit。把
-//! `DeviceId` 设计为 `Copy`,核心业务代码就能像传 `Uuid` 一样自然传值。
+//! `DeviceId` 是一个 `Copy` 值对象,代表系统中某台设备的稳定标识。
+//! 设计为 `Copy` 是为了让该标识能像普通值一样被传递、复制、比较,
+//! 而不必在每个使用点散布 `.clone()`。
 //!
-//! 为什么用 `ArrayString<64>` 而不是 `String`:
-//! `String` 拥有堆分配,无法实现 `Copy`。项目里见到的最长 device_id
-//! 形态是 `mobile_sync:<MobileDeviceId>` ≈ 48 字节,留出 64 字节余量
-//! 把存储改成栈上定长数组,从而获得 `Copy` 能力。超长输入会在 `new()`
-//! 与反序列化路径上显式拒绝(panic / serde error),不被静默截断 ——
-//! 默契是"device_id 是有限规模的稳定标识,不是任意长度字符串"。
+//! 内部以 `ArrayString<DEVICE_ID_MAX_BYTES>` 存储,从而在不进行堆分配的
+//! 前提下获得 `Copy` 能力;超过该上限的输入在 `new()` 与反序列化路径上
+//! 被显式拒绝(panic / serde error),不会被静默截断 —— 契约是
+//! "device_id 是有限规模的稳定标识,不是任意长度字符串"。
 //!
-//! Wire / DB 兼容:`Serialize`/`Deserialize` 仍以裸字符串往返,不变更
-//! 任何外部存档或协议格式。
+//! `Serialize` / `Deserialize` 以裸字符串往返,等价于一个等长字符串值。
 
 use arrayvec::ArrayString;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-/// 单个 device_id 允许的最大字节数(UTF-8 字节,非字符数)。
+/// 单个 `DeviceId` 允许的最大字节数(UTF-8 字节,非字符数)。
 ///
-/// 选 64 是因为见到的最长 device_id 形态约 48 字节
-/// (`mobile_sync:<MobileDeviceId>`),64 字节给可预见的 prefix 留余量,
-/// 同时维持栈占用合理。需要超过该上限时应优先重构 device_id 命名,
-/// 而非提高该常量。
+/// 超出该上限的输入在 `DeviceId::new` 与反序列化路径上被显式拒绝。
 pub const DEVICE_ID_MAX_BYTES: usize = 64;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/src-tauri/crates/uc-desktop/src/daemon/workers/clipboard_watcher.rs
+++ b/src-tauri/crates/uc-desktop/src/daemon/workers/clipboard_watcher.rs
@@ -136,7 +136,7 @@ impl ClipboardChangeHandler for DaemonClipboardChangeHandler {
         // 同一份内容出现两份。直接短路返回，与 LocalRestore 在功能效果上对称
         // （LocalRestore 在 usecase 内部短路，RemotePush 因 apply_inbound 也
         // 走同一 usecase 入口，必须在 watcher 层短路才不会破坏入站落库路径）。
-        if origin == ClipboardChangeOrigin::RemotePush {
+        if origin.is_remote_push() {
             debug!(
                 origin_guard_key = %origin_guard_key,
                 flow_id = %flow_id,
@@ -148,7 +148,7 @@ impl ClipboardChangeHandler for DaemonClipboardChangeHandler {
         // 3. Determine the origin string for the WS event payload.
         let origin_str = match origin {
             ClipboardChangeOrigin::LocalCapture | ClipboardChangeOrigin::LocalRestore => "local",
-            ClipboardChangeOrigin::RemotePush => "remote",
+            ClipboardChangeOrigin::RemotePush { .. } => "remote",
         };
 
         // 4. Clone snapshot before capture consumes it.

--- a/src-tauri/crates/uc-infra/src/clipboard/change_origin.rs
+++ b/src-tauri/crates/uc-infra/src/clipboard/change_origin.rs
@@ -125,7 +125,11 @@ impl ClipboardChangeOriginPort for InMemoryClipboardChangeOrigin {
         Self::remember_snapshot_origin(
             &mut state,
             snapshot_hash,
-            ClipboardChangeOrigin::RemotePush,
+            // 守卫路径只关心"这次回声属于远端推送"这个 tag,不关心对端 id;
+            // 用 `remote_push_anonymous` 显式表达,避免 `from_device` 字段
+            // 进入 dedup 比较(`s.origin == origin`)语义,导致同一 snapshot
+            // 因 from_device 不同被视为两条。
+            ClipboardChangeOrigin::remote_push_anonymous(),
             expires_at,
         );
     }

--- a/src-tauri/crates/uc-tauri/src/commands/clipboard_delivery.rs
+++ b/src-tauri/crates/uc-tauri/src/commands/clipboard_delivery.rs
@@ -1,0 +1,190 @@
+//! Entry delivery view —— GUI detail 面板的"来源 + 每对端同步状态"查询命令。
+//!
+//! 为什么需要这个模块:
+//! Phase 1 已经把"投递事实"沉到 `EntryDeliveryRepositoryPort` + view use case,
+//! `ClipboardSyncFacade::get_entry_delivery_view` 在 in-process facade 上透出
+//! 完整视图。前端要在 quick-panel 与主窗口两套 detail 上挂"来自哪台设备 /
+//! 同步到了哪些设备 / 哪台失败"区域,只需要一个跨 IPC 的薄读命令。
+//!
+//! 命令走 in-process facade(`runtime.app_facade()`),不经 HTTP/webserver。
+//! DTO 在本文件就地定义、camelCase 序列化,语义与 use case 输出 1:1 对应;
+//! 不进 `uc-daemon-contract`,因为这是 GUI-only 路径,没有 LAN/mobile 协议。
+
+use std::sync::Arc;
+
+use serde::Serialize;
+use tracing::{info_span, Instrument};
+
+use uc_application::facade::{
+    EntryDeliveryStatusView, EntryDeliveryTargetView, EntryDeliveryView, EntrySource,
+    GetEntryDeliveryViewError,
+};
+use uc_core::clipboard::DeliveryFailureReason;
+use uc_core::ids::EntryId;
+use uc_platform::ports::observability::TraceMetadata;
+
+use crate::bootstrap::TauriAppRuntime;
+use crate::commands::error::CommandError;
+use crate::commands::record_trace_fields;
+
+/// `EntryDeliveryView` 的前端可序列化镜像。字段命名与领域模型保持一致,
+/// 只在序列化时改写成 camelCase。
+#[derive(Debug, Serialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct EntryDeliveryViewDto {
+    pub entry_id: String,
+    pub source: EntrySourceDto,
+    pub deliveries: Vec<EntryDeliveryTargetDto>,
+}
+
+/// entry 来源描述。`tag` 字段供前端 discriminated union 直接 switch。
+#[derive(Debug, Serialize, specta::Type)]
+#[serde(tag = "tag", rename_all = "camelCase")]
+pub enum EntrySourceDto {
+    /// 本机捕获。
+    Local,
+    /// 远端推送。`deviceId` 是来源设备,Phase 3 起补 `deviceName`。
+    Remote {
+        #[serde(rename = "deviceId")]
+        device_id: String,
+    },
+    /// 追踪机制启用前已存在的老 entry,无可靠投递信息。
+    Historical,
+}
+
+#[derive(Debug, Serialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct EntryDeliveryTargetDto {
+    pub target_device_id: String,
+    pub status: EntryDeliveryStatusDto,
+    /// 失败时的 wire 层错误细节,供 UI tooltip / 详情展开使用。
+    pub reason_detail: Option<String>,
+    /// `Pending` 时为 `None`(从未尝试过)。`#[specta(type = ...)]` 告诉 specta
+    /// 这是个 ms 精度的 epoch,实际值不会超过 JS Number 安全整数范围 (~285 万年),
+    /// 用 `Number<i64>` 包装绕过 BigInt 禁用规则,与 mobile_sync.rs 的 `last_seen_at_ms`
+    /// 同源。
+    #[specta(type = Option<specta_typescript::Number<i64>>)]
+    pub updated_at_ms: Option<i64>,
+}
+
+/// 状态枚举:`tag` + `reason` 形式,便于前端区分四档与失败子分类。
+#[derive(Debug, Serialize, specta::Type)]
+#[serde(tag = "tag", rename_all = "camelCase")]
+pub enum EntryDeliveryStatusDto {
+    Pending,
+    Delivered,
+    Duplicate,
+    Failed {
+        #[serde(rename = "reason")]
+        reason: DeliveryFailureReasonDto,
+    },
+}
+
+/// 失败原因。i18n key 命名约定:`delivery.failureReason.<variant 小驼峰>`。
+#[derive(Debug, Serialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub enum DeliveryFailureReasonDto {
+    Offline,
+    LocalPolicy,
+    PeerRejected,
+    Io,
+    Internal,
+}
+
+impl From<EntryDeliveryView> for EntryDeliveryViewDto {
+    fn from(view: EntryDeliveryView) -> Self {
+        Self {
+            entry_id: view.entry_id.as_str().to_string(),
+            source: view.source.into(),
+            deliveries: view.deliveries.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl From<EntrySource> for EntrySourceDto {
+    fn from(source: EntrySource) -> Self {
+        match source {
+            EntrySource::Local => EntrySourceDto::Local,
+            EntrySource::Remote { device_id } => EntrySourceDto::Remote {
+                device_id: device_id.as_str().to_string(),
+            },
+            EntrySource::Historical => EntrySourceDto::Historical,
+        }
+    }
+}
+
+impl From<EntryDeliveryTargetView> for EntryDeliveryTargetDto {
+    fn from(target: EntryDeliveryTargetView) -> Self {
+        Self {
+            target_device_id: target.target_device_id.as_str().to_string(),
+            status: target.status.into(),
+            reason_detail: target.reason_detail,
+            updated_at_ms: target.updated_at_ms,
+        }
+    }
+}
+
+impl From<EntryDeliveryStatusView> for EntryDeliveryStatusDto {
+    fn from(status: EntryDeliveryStatusView) -> Self {
+        match status {
+            EntryDeliveryStatusView::Pending => EntryDeliveryStatusDto::Pending,
+            EntryDeliveryStatusView::Delivered => EntryDeliveryStatusDto::Delivered,
+            EntryDeliveryStatusView::Duplicate => EntryDeliveryStatusDto::Duplicate,
+            EntryDeliveryStatusView::Failed { reason } => EntryDeliveryStatusDto::Failed {
+                reason: reason.into(),
+            },
+        }
+    }
+}
+
+impl From<DeliveryFailureReason> for DeliveryFailureReasonDto {
+    fn from(reason: DeliveryFailureReason) -> Self {
+        match reason {
+            DeliveryFailureReason::Offline => DeliveryFailureReasonDto::Offline,
+            DeliveryFailureReason::LocalPolicy => DeliveryFailureReasonDto::LocalPolicy,
+            DeliveryFailureReason::PeerRejected => DeliveryFailureReasonDto::PeerRejected,
+            DeliveryFailureReason::Io => DeliveryFailureReasonDto::Io,
+            DeliveryFailureReason::Internal => DeliveryFailureReasonDto::Internal,
+        }
+    }
+}
+
+impl From<GetEntryDeliveryViewError> for CommandError {
+    fn from(err: GetEntryDeliveryViewError) -> Self {
+        match err {
+            GetEntryDeliveryViewError::EntryNotFound(id) => {
+                CommandError::NotFound(format!("entry not found: {id}"))
+            }
+            GetEntryDeliveryViewError::Storage(msg) => CommandError::InternalError(msg),
+        }
+    }
+}
+
+/// 拉一条 entry 的同步状态视图。
+///
+/// 前端 detail 面板在 entry 切换时调用,失败时(facade 未装配 / DB 故障)
+/// 返回 `InternalError`;entry 不存在返回 `NotFound`,前端据此降级渲染。
+#[tauri::command]
+#[specta::specta]
+pub async fn clipboard_entry_delivery_view(
+    runtime: tauri::State<'_, Arc<TauriAppRuntime>>,
+    entry_id: String,
+    _trace: Option<TraceMetadata>,
+) -> Result<EntryDeliveryViewDto, CommandError> {
+    let span = info_span!(
+        "command.clipboard.entry_delivery_view",
+        entry_id = %entry_id,
+        trace_id = tracing::field::Empty,
+        trace_ts = tracing::field::Empty,
+    );
+    record_trace_fields(&span, &_trace);
+
+    let runtime = runtime.inner().clone();
+    async move {
+        let entry = EntryId::from_string(entry_id);
+        let view = runtime.app_facade().get_entry_delivery_view(&entry).await?;
+        Ok(EntryDeliveryViewDto::from(view))
+    }
+    .instrument(span)
+    .await
+}

--- a/src-tauri/crates/uc-tauri/src/commands/mod.rs
+++ b/src-tauri/crates/uc-tauri/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod autostart;
+pub mod clipboard_delivery;
 pub mod error;
 pub mod factory_reset;
 pub mod mobile_sync;

--- a/src-tauri/crates/uc-tauri/src/specta_builder.rs
+++ b/src-tauri/crates/uc-tauri/src/specta_builder.rs
@@ -20,7 +20,7 @@
 //!
 //! 所有命令在所有 OS 上都 collect，保证任何 runner 跑 `cargo test
 //! --test specta_export` 得到同一份 binding（CI 可以用单一 Linux runner
-//! 做 schema drift check）。当前 30 条命令都不依赖平台特定 mod 编译。
+//! 做 schema drift check）。当前 31 条命令都不依赖平台特定 mod 编译。
 
 use tauri_specta::{collect_commands, Builder};
 
@@ -56,6 +56,8 @@ pub fn build() -> Builder<tauri::Wry> {
         crate::commands::updater::install_update,
         // ── storage ─────────────────────────────────────────────────────────
         crate::commands::storage::open_data_directory,
+        // ── clipboard delivery view (entry detail "源 + 同步状态") ──────────
+        crate::commands::clipboard_delivery::clipboard_entry_delivery_view,
         // ── quick panel ─────────────────────────────────────────────────────
         crate::commands::quick_panel::paste_to_previous_app,
         crate::commands::quick_panel::dismiss_quick_panel,

--- a/src-tauri/crates/uc-webserver/src/mobile_lan/test_support.rs
+++ b/src-tauri/crates/uc-webserver/src/mobile_lan/test_support.rs
@@ -52,7 +52,7 @@ use uc_core::ports::{
     PasswordHasherError, PasswordHasherPort, SettingsPort,
 };
 use uc_core::settings::model::Settings;
-use uc_core::{BlobId, SystemClipboardSnapshot};
+use uc_core::{BlobId, DeviceId, SystemClipboardSnapshot};
 
 /// 构造一份只装 1 台已登记设备的 [`MobileSyncFacade`], 凭据是
 /// `(username, password)`, PHC 形态固定为 `phc:{password}`。
@@ -354,7 +354,12 @@ impl BlobReaderPort for NoopBlobReader {
 struct NoopInboundCapture;
 #[async_trait]
 impl ApplyInboundCapture for NoopInboundCapture {
-    async fn capture(&self, _: EntryId, _: SystemClipboardSnapshot) -> AnyResult<Option<EntryId>> {
+    async fn capture(
+        &self,
+        _: EntryId,
+        _: DeviceId,
+        _: SystemClipboardSnapshot,
+    ) -> AnyResult<Option<EntryId>> {
         Err(anyhow!(
             "test_support: NoOp InboundCapture should not be reached"
         ))

--- a/src/api/tauri-command/clipboard_delivery.ts
+++ b/src/api/tauri-command/clipboard_delivery.ts
@@ -1,6 +1,5 @@
 /**
- * Entry delivery view — wrapper for the `clipboard_entry_delivery_view`
- * Tauri command.
+ * Entry 投递视图 —— `clipboard_entry_delivery_view` Tauri 命令的前端薄封装。
  *
  * 为什么需要这个模块:
  * 在 entry detail 面板上要渲染"这条剪贴板内容来自哪台设备 / 已经同步到了
@@ -8,10 +7,10 @@
  * `ClipboardSyncFacade::get_entry_delivery_view` 上,这里只是一个跨 IPC 的
  * 薄读封装,供 quick-panel 与主窗口两套 detail 共享调用。
  *
- * 走 in-process facade (Tauri command 直调 `runtime.app_facade()`),不
- * 经 daemon webserver —— GUI 业务一律走 facade 是项目原则。
+ * 走 in-process facade (Tauri 命令直接通过 `runtime.app_facade()` 调用),
+ * 不经 daemon webserver —— GUI 业务一律走 facade 是项目原则。
  *
- * Backend: `src-tauri/crates/uc-tauri/src/commands/clipboard_delivery.rs`
+ * 后端入口: `src-tauri/crates/uc-tauri/src/commands/clipboard_delivery.rs`
  */
 
 import { commands } from '@/lib/ipc'
@@ -55,7 +54,7 @@ export interface EntryDeliveryView {
 }
 
 // ============================================================================
-// Invocation
+// 调用入口
 // ============================================================================
 
 /**

--- a/src/api/tauri-command/clipboard_delivery.ts
+++ b/src/api/tauri-command/clipboard_delivery.ts
@@ -1,0 +1,78 @@
+/**
+ * Entry delivery view — wrapper for the `clipboard_entry_delivery_view`
+ * Tauri command.
+ *
+ * 为什么需要这个模块:
+ * 在 entry detail 面板上要渲染"这条剪贴板内容来自哪台设备 / 已经同步到了
+ * 哪些可信对端 / 哪些设备失败"。Phase 1 已经把这些视图组装动作沉到
+ * `ClipboardSyncFacade::get_entry_delivery_view` 上,这里只是一个跨 IPC 的
+ * 薄读封装,供 quick-panel 与主窗口两套 detail 共享调用。
+ *
+ * 走 in-process facade (Tauri command 直调 `runtime.app_facade()`),不
+ * 经 daemon webserver —— GUI 业务一律走 facade 是项目原则。
+ *
+ * Backend: `src-tauri/crates/uc-tauri/src/commands/clipboard_delivery.rs`
+ */
+
+import { commands } from '@/lib/ipc'
+
+// ============================================================================
+// 视图类型 — 与 Rust 侧 DTO 一一对应。变体名保持小驼峰 (Rust 端 serde
+// rename_all = "camelCase"),前端按 `tag` 字段做 discriminated union。
+// ============================================================================
+
+/** entry 来源描述。 */
+export type EntrySourceView =
+  | { tag: 'local' }
+  | { tag: 'remote'; deviceId: string }
+  | { tag: 'historical' }
+
+/** 失败原因细分,与 i18n key `delivery.failureReason.<variant>` 对应。 */
+export type DeliveryFailureReason = 'offline' | 'localPolicy' | 'peerRejected' | 'io' | 'internal'
+
+/** 单条投递状态。`Pending` 来自视图层合成 (trusted_peer ∖ 已尝试)。 */
+export type EntryDeliveryStatusView =
+  | { tag: 'pending' }
+  | { tag: 'delivered' }
+  | { tag: 'duplicate' }
+  | { tag: 'failed'; reason: DeliveryFailureReason }
+
+/** 单个对端的当前同步状态。 */
+export interface EntryDeliveryTargetView {
+  targetDeviceId: string
+  status: EntryDeliveryStatusView
+  /** 失败时的 wire 层错误细节,可选;成功 / Pending 时为 null。 */
+  reasonDetail: string | null
+  /** `Pending` 时为 null (从未尝试)。 */
+  updatedAtMs: number | null
+}
+
+/** 完整视图:来源 + 每个可信对端的最新状态。 */
+export interface EntryDeliveryView {
+  entryId: string
+  source: EntrySourceView
+  deliveries: EntryDeliveryTargetView[]
+}
+
+// ============================================================================
+// Invocation
+// ============================================================================
+
+/**
+ * 取一条 entry 的"来源 + 每对端同步状态"完整视图。
+ *
+ * 失败语义:
+ * - entry 不存在 (例如刚被删) → Tauri 返回 `NotFound` code,被 reject;
+ *   调用方应当把 detail 区域降级为"无投递信息"或直接隐藏 section
+ * - facade 未装配 / DB 故障 → `InternalError`,调用方可上报 Sentry +
+ *   退化渲染
+ *
+ * @param entryId 要查询的 entry id (字符串形式,与列表/详情其他 API 一致)
+ */
+export async function getEntryDeliveryView(entryId: string): Promise<EntryDeliveryView> {
+  // tauri-specta 生成的 `EntryDeliveryViewDto` 与本文件手写的 `EntryDeliveryView`
+  // 结构同形（字段名 / discriminated union tag literal 完全一致），TS 结构归并
+  // 会让它们互通；保留手写类型作为本模块对上层的稳定 API 名称，避免上层
+  // (useEntryDelivery / EntryDeliverySection / 测试) 跟随生成文件改名。
+  return (await commands.clipboardEntryDeliveryView(entryId)) as EntryDeliveryView
+}

--- a/src/components/clipboard/ClipboardPreview.tsx
+++ b/src/components/clipboard/ClipboardPreview.tsx
@@ -3,7 +3,6 @@ import React from 'react'
 import { useTranslation } from 'react-i18next'
 import type { DisplayClipboardItem } from './ClipboardContent'
 import ClipboardPreviewInfo from './ClipboardPreviewInfo'
-import EntryDeliverySection from './EntryDeliverySection'
 import CodePreview from './preview-renderers/CodePreview'
 import FilePreview from './preview-renderers/FilePreview'
 import ImagePreview from './preview-renderers/ImagePreview'
@@ -99,9 +98,12 @@ const ClipboardPreview: React.FC<ClipboardPreviewProps> = ({ item, actions }) =>
 
   return (
     <div className="flex flex-1 min-h-0 flex-col bg-background/20 backdrop-blur-sm">
-      <ClipboardPreviewInfo item={item} preview={preview} imageDimensions={imageDimensions} />
-
-      <EntryDeliverySection delivery={delivery} />
+      <ClipboardPreviewInfo
+        item={item}
+        preview={preview}
+        imageDimensions={imageDimensions}
+        delivery={delivery}
+      />
 
       <div className="relative flex-1 min-h-0">
         {isLargeText ? (

--- a/src/components/clipboard/ClipboardPreview.tsx
+++ b/src/components/clipboard/ClipboardPreview.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import { useTranslation } from 'react-i18next'
 import type { DisplayClipboardItem } from './ClipboardContent'
 import ClipboardPreviewInfo from './ClipboardPreviewInfo'
+import EntryDeliverySection from './EntryDeliverySection'
 import CodePreview from './preview-renderers/CodePreview'
 import FilePreview from './preview-renderers/FilePreview'
 import ImagePreview from './preview-renderers/ImagePreview'
@@ -18,6 +19,7 @@ import {
 } from '@/api/clipboardItems'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { useClipboardPreviewState } from '@/hooks/useClipboardPreviewState'
+import { useEntryDelivery } from '@/hooks/useEntryDelivery'
 
 interface ClipboardPreviewProps {
   item: DisplayClipboardItem | null
@@ -35,6 +37,7 @@ const ClipboardPreview: React.FC<ClipboardPreviewProps> = ({ item, actions }) =>
     setImageDimensions,
     transfer,
   } = useClipboardPreviewState(item)
+  const { delivery } = useEntryDelivery(item?.id ?? null)
 
   if (!item) {
     return (
@@ -97,6 +100,8 @@ const ClipboardPreview: React.FC<ClipboardPreviewProps> = ({ item, actions }) =>
   return (
     <div className="flex flex-1 min-h-0 flex-col bg-background/20 backdrop-blur-sm">
       <ClipboardPreviewInfo item={item} preview={preview} imageDimensions={imageDimensions} />
+
+      <EntryDeliverySection delivery={delivery} />
 
       <div className="relative flex-1 min-h-0">
         {isLargeText ? (

--- a/src/components/clipboard/ClipboardPreviewInfo.tsx
+++ b/src/components/clipboard/ClipboardPreviewInfo.tsx
@@ -2,6 +2,7 @@ import { Database, Files, Globe, Hash, Layers, Maximize, Type } from 'lucide-rea
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 import type { DisplayClipboardItem } from './ClipboardContent'
+import EntryDeliveryBadge from './EntryDeliveryBadge'
 import type {
   ClipboardCodeItem,
   ClipboardFileItem,
@@ -9,6 +10,7 @@ import type {
   ClipboardLinkItem,
   ClipboardTextItem,
 } from '@/api/clipboardItems'
+import type { EntryDeliveryView } from '@/api/tauri-command/clipboard_delivery'
 import type { ClipboardPreviewData } from '@/lib/clipboard-preview-cache'
 import { formatFileSize } from '@/utils'
 
@@ -16,6 +18,7 @@ interface ClipboardPreviewInfoProps {
   imageDimensions: { width: number; height: number } | null
   item: DisplayClipboardItem | null
   preview: ClipboardPreviewData | null
+  delivery: EntryDeliveryView | null
 }
 
 interface InfoRow {
@@ -92,6 +95,7 @@ const ClipboardPreviewInfo: React.FC<ClipboardPreviewInfoProps> = ({
   imageDimensions,
   item,
   preview,
+  delivery,
 }) => {
   const { t } = useTranslation()
 
@@ -99,7 +103,7 @@ const ClipboardPreviewInfo: React.FC<ClipboardPreviewInfoProps> = ({
 
   const rows = buildInfoRows(item, preview, imageDimensions, t)
 
-  if (rows.length === 0) return null
+  if (rows.length === 0 && !delivery) return null
 
   return (
     <div className="shrink-0 overflow-hidden bg-muted/10 px-6 py-3">
@@ -112,6 +116,11 @@ const ClipboardPreviewInfo: React.FC<ClipboardPreviewInfoProps> = ({
             </span>
           </div>
         ))}
+        {delivery && (
+          <div className="ml-auto">
+            <EntryDeliveryBadge delivery={delivery} />
+          </div>
+        )}
       </div>
     </div>
   )

--- a/src/components/clipboard/EntryDeliveryBadge.tsx
+++ b/src/components/clipboard/EntryDeliveryBadge.tsx
@@ -1,0 +1,315 @@
+/**
+ * Entry delivery badge —— ClipboardPreviewInfo 行尾的紧凑展示。
+ *
+ * 为什么需要这个组件:
+ * 原 EntryDeliverySection 是一个独占一行的灰条 (来源 + 设备表),在主窗口
+ * detail 顶部显得笨重。本组件把这份信息压成两枚 icon (来源 + 同步聚合)
+ * + 一句话状态,真正的设备明细放进 hover popover,detail 区域顶部恢复
+ * 清爽。quick-panel 仍走 EntryDeliverySection (空间紧、显示明细更有用)。
+ *
+ * 渲染契约:
+ * - 来源 icon: Local / Remote / Historical 三档,tooltip 显示完整文案
+ * - 同步聚合 icon + 文字: synced / syncing / partial / failed / pending
+ *   - historical 来源 或 无 trusted peer → 不渲染同步部分
+ * - popover (hover/click on 同步部分): 列出每个对端 status,复用与
+ *   EntryDeliverySection 一致的图标 / 颜色编码
+ */
+
+import {
+  AlertCircle,
+  Check,
+  CheckCircle2,
+  CircleDashed,
+  Cloud,
+  History,
+  Laptop,
+  LoaderCircle,
+  X,
+} from 'lucide-react'
+import React, { useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+import type {
+  DeliveryFailureReason,
+  EntryDeliveryStatusView,
+  EntryDeliveryTargetView,
+  EntryDeliveryView,
+  EntrySourceView,
+} from '@/api/tauri-command/clipboard_delivery'
+import { HoverCard, HoverCardContent, HoverCardTrigger } from '@/components/ui/hover-card'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
+import { cn } from '@/lib/utils'
+
+interface EntryDeliveryBadgeProps {
+  delivery: EntryDeliveryView | null
+}
+
+type SyncSummary = 'synced' | 'syncing' | 'partial' | 'failed' | 'pending'
+
+const FAILURE_REASON_KEYS: Record<DeliveryFailureReason, string> = {
+  offline: 'delivery.failureReason.offline',
+  localPolicy: 'delivery.failureReason.localPolicy',
+  peerRejected: 'delivery.failureReason.peerRejected',
+  io: 'delivery.failureReason.io',
+  internal: 'delivery.failureReason.internal',
+}
+
+function truncateDeviceId(deviceId: string): string {
+  if (deviceId.length <= 10) return deviceId
+  return `${deviceId.slice(0, 8)}…`
+}
+
+function summarize(targets: readonly EntryDeliveryTargetView[]): SyncSummary | null {
+  if (targets.length === 0) return null
+  let delivered = 0
+  let failed = 0
+  let pending = 0
+  for (const t of targets) {
+    switch (t.status.tag) {
+      case 'delivered':
+      case 'duplicate':
+        delivered += 1
+        break
+      case 'failed':
+        failed += 1
+        break
+      case 'pending':
+        pending += 1
+        break
+    }
+  }
+  if (failed === targets.length) return 'failed'
+  if (failed > 0) return 'partial'
+  if (delivered === targets.length) return 'synced'
+  if (delivered > 0 && pending > 0) return 'syncing'
+  return 'pending'
+}
+
+const EntryDeliveryBadge: React.FC<EntryDeliveryBadgeProps> = ({ delivery }) => {
+  const { t } = useTranslation()
+
+  if (!delivery) return null
+
+  const { source, deliveries } = delivery
+  // historical 来源 + 空列表 是 legacy entry 的典型形态,展示来源 icon 即可
+  // (legacy 无追踪意义)。其它来源即便列表为空也保留来源信息,符合"一眼
+  // 看出这条从哪里来"的设计目标。
+  const summary = source.tag === 'historical' ? null : summarize(deliveries)
+
+  return (
+    <TooltipProvider delayDuration={150}>
+      <div className="flex shrink-0 items-center gap-3">
+        <SourceBadge source={source} />
+        {summary && <SyncBadge summary={summary} deliveries={deliveries} t={t} />}
+      </div>
+    </TooltipProvider>
+  )
+}
+
+interface SourceBadgeProps {
+  source: EntrySourceView
+}
+
+const SourceBadge: React.FC<SourceBadgeProps> = ({ source }) => {
+  const { t } = useTranslation()
+
+  const { Icon, label, tone } = useMemo(() => {
+    switch (source.tag) {
+      case 'local':
+        return {
+          Icon: Laptop,
+          label: t('delivery.source.localShort'),
+          tone: 'text-muted-foreground/60',
+        }
+      case 'remote':
+        return {
+          Icon: Cloud,
+          label: t('delivery.source.remoteShort', { device: truncateDeviceId(source.deviceId) }),
+          tone: 'text-sky-500/80',
+        }
+      case 'historical':
+        return {
+          Icon: History,
+          label: t('delivery.source.historicalShort'),
+          tone: 'text-muted-foreground/50',
+        }
+    }
+  }, [source, t])
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span
+          className="group inline-flex items-center gap-1.5"
+          aria-label={label}
+          data-source={source.tag}
+        >
+          <Icon
+            className={cn('h-3.5 w-3.5 transition-colors group-hover:text-foreground/80', tone)}
+          />
+          <span className="text-[11px] font-semibold tabular-nums text-muted-foreground/60 transition-colors group-hover:text-foreground/80">
+            {label}
+          </span>
+        </span>
+      </TooltipTrigger>
+      <TooltipContent side="top">{label}</TooltipContent>
+    </Tooltip>
+  )
+}
+
+interface SyncBadgeProps {
+  summary: SyncSummary
+  deliveries: readonly EntryDeliveryTargetView[]
+  t: (key: string, opts?: Record<string, unknown>) => string
+}
+
+const SyncBadge: React.FC<SyncBadgeProps> = ({ summary, deliveries, t }) => {
+  const { Icon, label, tone, spin } = useMemo(() => {
+    switch (summary) {
+      case 'synced':
+        return {
+          Icon: CheckCircle2,
+          label: t('delivery.summary.synced'),
+          tone: 'text-emerald-500',
+          spin: false,
+        }
+      case 'syncing':
+        return {
+          Icon: LoaderCircle,
+          label: t('delivery.summary.syncing'),
+          tone: 'text-sky-500',
+          spin: true,
+        }
+      case 'partial':
+        return {
+          Icon: AlertCircle,
+          label: t('delivery.summary.partial'),
+          tone: 'text-amber-500',
+          spin: false,
+        }
+      case 'failed':
+        return {
+          Icon: AlertCircle,
+          label: t('delivery.summary.failed'),
+          tone: 'text-destructive',
+          spin: false,
+        }
+      case 'pending':
+        return {
+          Icon: CircleDashed,
+          label: t('delivery.summary.pending'),
+          tone: 'text-muted-foreground/70',
+          spin: false,
+        }
+    }
+  }, [summary, t])
+
+  // HoverCard 原生处理 hover 行为:trigger ↔ content 互相 hover 时不会进入
+  // 关闭流程,跨越间隙也不会触发 close → open 的闪烁。
+  return (
+    <HoverCard>
+      <HoverCardTrigger asChild>
+        <button
+          type="button"
+          aria-label={t('delivery.popover.ariaTrigger')}
+          className="group inline-flex items-center gap-1.5 rounded outline-none focus-visible:ring-2 focus-visible:ring-ring/60"
+          data-summary={summary}
+        >
+          <Icon className={cn('h-3.5 w-3.5 transition-colors', tone, spin && 'animate-spin')} />
+          <span
+            className={cn(
+              'text-[11px] font-semibold tabular-nums transition-colors',
+              tone,
+              'opacity-80 group-hover:opacity-100'
+            )}
+          >
+            {label}
+          </span>
+        </button>
+      </HoverCardTrigger>
+      <HoverCardContent align="end" side="bottom" sideOffset={6} className="w-64 p-2">
+        <div className="mb-1 px-1 text-[11px] font-medium uppercase tracking-wide text-muted-foreground/80">
+          {t('delivery.popover.title')}
+        </div>
+        <ul className="flex flex-col">
+          {deliveries.map(target => (
+            <DeliveryRow key={target.targetDeviceId} target={target} />
+          ))}
+        </ul>
+      </HoverCardContent>
+    </HoverCard>
+  )
+}
+
+interface DeliveryRowProps {
+  target: EntryDeliveryTargetView
+}
+
+const DeliveryRow: React.FC<DeliveryRowProps> = ({ target }) => {
+  const { t } = useTranslation()
+  const tone = renderStatusTone(target.status)
+
+  return (
+    <li
+      className="flex items-center gap-2 px-1 py-1 text-[11px] leading-tight"
+      data-status={target.status.tag}
+    >
+      <span className={cn('shrink-0', tone.icon)} aria-hidden>
+        {renderStatusIcon(target.status)}
+      </span>
+      <span className="min-w-0 flex-1 truncate font-mono text-foreground/80">
+        {truncateDeviceId(target.targetDeviceId)}
+      </span>
+      <span className={cn('shrink-0', tone.label)}>{renderStatusLabel(target.status, t)}</span>
+    </li>
+  )
+}
+
+function renderStatusIcon(status: EntryDeliveryStatusView) {
+  switch (status.tag) {
+    case 'delivered':
+    case 'duplicate':
+      return <Check className="h-3 w-3" />
+    case 'pending':
+      return <CircleDashed className="h-3 w-3" />
+    case 'failed':
+      return <X className="h-3 w-3" />
+  }
+}
+
+function renderStatusLabel(
+  status: EntryDeliveryStatusView,
+  t: (key: string, opts?: Record<string, unknown>) => string
+): string {
+  switch (status.tag) {
+    case 'delivered':
+      return t('delivery.status.delivered')
+    case 'duplicate':
+      return t('delivery.status.duplicate')
+    case 'pending':
+      return t('delivery.status.pending')
+    case 'failed':
+      return t('delivery.status.failedWithReason', {
+        reason: t(FAILURE_REASON_KEYS[status.reason]),
+      })
+  }
+}
+
+interface StatusTone {
+  icon: string
+  label: string
+}
+
+function renderStatusTone(status: EntryDeliveryStatusView): StatusTone {
+  switch (status.tag) {
+    case 'delivered':
+      return { icon: 'text-emerald-500', label: 'text-foreground/80' }
+    case 'duplicate':
+      return { icon: 'text-emerald-500/70', label: 'text-muted-foreground' }
+    case 'pending':
+      return { icon: 'text-muted-foreground/60', label: 'text-muted-foreground' }
+    case 'failed':
+      return { icon: 'text-destructive', label: 'text-destructive' }
+  }
+}
+
+export default EntryDeliveryBadge

--- a/src/components/clipboard/EntryDeliverySection.tsx
+++ b/src/components/clipboard/EntryDeliverySection.tsx
@@ -1,0 +1,224 @@
+/**
+ * Entry delivery 区段 —— quick-panel 与主窗口 detail 共享渲染。
+ *
+ * 渲染契约:
+ * - "来源" 行: Local / Remote { deviceId } / Historical 三档
+ * - "同步状态" 列表: 按 trusted_peer 全集列出每个对端,状态四档 (Delivered /
+ *   Duplicate / Pending / Failed),失败附 reason
+ * - 边界态:
+ *   - Historical: 显示"机制启用前的老 entry,无投递记录" 提示,**不**列设备
+ *   - Local + 无 deliveries: 显示"暂未配对任何设备"提示
+ *   - delivery 为 null (loading / fetch failed): 渲染骨架或直接隐藏
+ *
+ * device 名暂用 device_id 前 8 字符 (Phase 3 起 `DeviceDirectoryPort` 落地后
+ * 换成真实名称)。
+ */
+
+import { Check, CircleDashed, X } from 'lucide-react'
+import React, { useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+import type {
+  DeliveryFailureReason,
+  EntryDeliveryStatusView,
+  EntryDeliveryTargetView,
+  EntryDeliveryView,
+  EntrySourceView,
+} from '@/api/tauri-command/clipboard_delivery'
+import { cn } from '@/lib/utils'
+
+interface EntryDeliverySectionProps {
+  delivery: EntryDeliveryView | null
+  /** 紧凑模式:quick-panel 空间窄,字号 / padding 收紧。 */
+  compact?: boolean
+  className?: string
+}
+
+const FAILURE_REASON_KEYS: Record<DeliveryFailureReason, string> = {
+  offline: 'delivery.failureReason.offline',
+  localPolicy: 'delivery.failureReason.localPolicy',
+  peerRejected: 'delivery.failureReason.peerRejected',
+  io: 'delivery.failureReason.io',
+  internal: 'delivery.failureReason.internal',
+}
+
+function truncateDeviceId(deviceId: string): string {
+  if (deviceId.length <= 10) return deviceId
+  return `${deviceId.slice(0, 8)}…`
+}
+
+const EntryDeliverySection: React.FC<EntryDeliverySectionProps> = ({
+  delivery,
+  compact = false,
+  className,
+}) => {
+  const { t } = useTranslation()
+
+  // delivery 还没拉回来 / 报错时直接不渲染,避免占位 + 跳动。组件调用者
+  // 自己决定要不要给个 loading 骨架。
+  if (!delivery) return null
+
+  const isCompact = compact
+  const textSize = isCompact ? 'text-[11px]' : 'text-xs'
+  const titleSize = isCompact ? 'text-[11px]' : 'text-xs'
+  const rowPad = isCompact ? 'py-0.5' : 'py-1'
+
+  return (
+    <section
+      aria-label={t('delivery.section.aria')}
+      className={cn(
+        'flex flex-col gap-1.5 border-t border-border/40 px-3 py-2',
+        textSize,
+        className
+      )}
+    >
+      {/* Source 行 */}
+      <SourceLine source={delivery.source} className={titleSize} />
+
+      {/* Deliveries 列表 / Historical / 无 peer 文案 */}
+      <DeliveryList delivery={delivery} rowPad={rowPad} textSize={textSize} titleSize={titleSize} />
+    </section>
+  )
+}
+
+interface SourceLineProps {
+  source: EntrySourceView
+  className?: string
+}
+
+const SourceLine: React.FC<SourceLineProps> = ({ source, className }) => {
+  const { t } = useTranslation()
+
+  const label = useMemo(() => {
+    switch (source.tag) {
+      case 'local':
+        return t('delivery.source.local')
+      case 'remote':
+        return t('delivery.source.remote', { device: truncateDeviceId(source.deviceId) })
+      case 'historical':
+        return t('delivery.source.historical')
+    }
+  }, [source, t])
+
+  return (
+    <div className={cn('flex items-baseline gap-1.5', className)}>
+      <span className="shrink-0 text-muted-foreground">{t('delivery.source.label')}</span>
+      <span className="min-w-0 truncate font-medium text-foreground">{label}</span>
+    </div>
+  )
+}
+
+interface DeliveryListProps {
+  delivery: EntryDeliveryView
+  rowPad: string
+  textSize: string
+  titleSize: string
+}
+
+const DeliveryList: React.FC<DeliveryListProps> = ({ delivery, rowPad, textSize, titleSize }) => {
+  const { t } = useTranslation()
+
+  // Historical: 老 entry,delivery 表里也是空,显示统一的"无追踪信息"提示。
+  if (delivery.source.tag === 'historical') {
+    return <p className={cn('text-muted-foreground', textSize)}>{t('delivery.list.historical')}</p>
+  }
+
+  // 本机 / 远端 entry,但没有任何 trusted peer (单设备场景)。
+  if (delivery.deliveries.length === 0) {
+    return <p className={cn('text-muted-foreground', textSize)}>{t('delivery.list.noPeers')}</p>
+  }
+
+  return (
+    <div className="flex flex-col gap-0.5">
+      <span className={cn('text-muted-foreground', titleSize)}>{t('delivery.list.title')}</span>
+      <ul className="flex flex-col">
+        {delivery.deliveries.map(target => (
+          <DeliveryRow
+            key={target.targetDeviceId}
+            target={target}
+            rowPad={rowPad}
+            textSize={textSize}
+          />
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+interface DeliveryRowProps {
+  target: EntryDeliveryTargetView
+  rowPad: string
+  textSize: string
+}
+
+const DeliveryRow: React.FC<DeliveryRowProps> = ({ target, rowPad, textSize }) => {
+  const { t } = useTranslation()
+  const icon = renderStatusIcon(target.status)
+  const label = renderStatusLabel(target.status, t)
+  const tone = renderStatusTone(target.status)
+
+  return (
+    <li
+      className={cn('flex items-center gap-2 leading-tight', rowPad, textSize)}
+      data-status={target.status.tag}
+    >
+      <span className={cn('shrink-0', tone.icon)} aria-hidden>
+        {icon}
+      </span>
+      <span className="min-w-0 flex-1 truncate font-mono text-foreground/80">
+        {truncateDeviceId(target.targetDeviceId)}
+      </span>
+      <span className={cn('shrink-0', tone.label)}>{label}</span>
+    </li>
+  )
+}
+
+function renderStatusIcon(status: EntryDeliveryStatusView) {
+  switch (status.tag) {
+    case 'delivered':
+    case 'duplicate':
+      return <Check className="h-3 w-3" />
+    case 'pending':
+      return <CircleDashed className="h-3 w-3" />
+    case 'failed':
+      return <X className="h-3 w-3" />
+  }
+}
+
+function renderStatusLabel(
+  status: EntryDeliveryStatusView,
+  t: (key: string, opts?: Record<string, unknown>) => string
+): string {
+  switch (status.tag) {
+    case 'delivered':
+      return t('delivery.status.delivered')
+    case 'duplicate':
+      return t('delivery.status.duplicate')
+    case 'pending':
+      return t('delivery.status.pending')
+    case 'failed':
+      return t('delivery.status.failedWithReason', {
+        reason: t(FAILURE_REASON_KEYS[status.reason]),
+      })
+  }
+}
+
+interface StatusTone {
+  icon: string
+  label: string
+}
+
+function renderStatusTone(status: EntryDeliveryStatusView): StatusTone {
+  switch (status.tag) {
+    case 'delivered':
+      return { icon: 'text-emerald-500', label: 'text-foreground/80' }
+    case 'duplicate':
+      // 已被对端持有但走的是另一路径,弱化展示避免抢眼。
+      return { icon: 'text-emerald-500/70', label: 'text-muted-foreground' }
+    case 'pending':
+      return { icon: 'text-muted-foreground/60', label: 'text-muted-foreground' }
+    case 'failed':
+      return { icon: 'text-destructive', label: 'text-destructive' }
+  }
+}
+
+export default EntryDeliverySection

--- a/src/components/clipboard/__tests__/ClipboardPreviewInfo.test.tsx
+++ b/src/components/clipboard/__tests__/ClipboardPreviewInfo.test.tsx
@@ -19,7 +19,14 @@ function createFileItem(): DisplayClipboardItem {
 
 describe('ClipboardPreviewInfo', () => {
   it('renders file count and combined size for file entries', () => {
-    render(<ClipboardPreviewInfo item={createFileItem()} preview={null} imageDimensions={null} />)
+    render(
+      <ClipboardPreviewInfo
+        item={createFileItem()}
+        preview={null}
+        imageDimensions={null}
+        delivery={null}
+      />
+    )
 
     expect(screen.getByText(i18n.t('header.filters.file'))).toBeInTheDocument()
     expect(
@@ -30,7 +37,7 @@ describe('ClipboardPreviewInfo', () => {
 
   it('renders nothing when no item is selected', () => {
     const { container } = render(
-      <ClipboardPreviewInfo item={null} preview={null} imageDimensions={null} />
+      <ClipboardPreviewInfo item={null} preview={null} imageDimensions={null} delivery={null} />
     )
 
     expect(container).toBeEmptyDOMElement()

--- a/src/components/clipboard/__tests__/EntryDeliverySection.test.tsx
+++ b/src/components/clipboard/__tests__/EntryDeliverySection.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, within } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
-import EntryDeliverySection from '../EntryDeliverySection'
 import type { EntryDeliveryView } from '@/api/tauri-command/clipboard_delivery'
+import EntryDeliverySection from '@/components/clipboard/EntryDeliverySection'
 import i18n from '@/i18n'
 
 /** "正常本地 entry,N 个对端混合状态" 是 detail 区域最常见也最容易回归的形态,

--- a/src/components/clipboard/__tests__/EntryDeliverySection.test.tsx
+++ b/src/components/clipboard/__tests__/EntryDeliverySection.test.tsx
@@ -1,0 +1,141 @@
+import { render, screen, within } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import EntryDeliverySection from '../EntryDeliverySection'
+import type { EntryDeliveryView } from '@/api/tauri-command/clipboard_delivery'
+import i18n from '@/i18n'
+
+/** "正常本地 entry,N 个对端混合状态" 是 detail 区域最常见也最容易回归的形态,
+ * 用它做基线确保 source/list/status/reason 四块文案都能拼对。 */
+function mixedDelivery(): EntryDeliveryView {
+  return {
+    entryId: 'entry-001',
+    source: { tag: 'local' },
+    deliveries: [
+      {
+        targetDeviceId: 'did_a1b2c3d4e5',
+        status: { tag: 'delivered' },
+        reasonDetail: null,
+        updatedAtMs: 1_700_000_000_000,
+      },
+      {
+        targetDeviceId: 'did_f6g7h8i9j0',
+        status: { tag: 'duplicate' },
+        reasonDetail: null,
+        updatedAtMs: 1_700_000_000_001,
+      },
+      {
+        targetDeviceId: 'did_k1l2m3n4o5',
+        status: { tag: 'failed', reason: 'offline' },
+        reasonDetail: 'no route to host',
+        updatedAtMs: 1_700_000_000_002,
+      },
+      {
+        targetDeviceId: 'did_p6q7r8s9t0',
+        status: { tag: 'pending' },
+        reasonDetail: null,
+        updatedAtMs: null,
+      },
+    ],
+  }
+}
+
+describe('EntryDeliverySection', () => {
+  it('returns null when delivery view is unavailable', () => {
+    const { container } = render(<EntryDeliverySection delivery={null} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders local source + four-status row mix', () => {
+    render(<EntryDeliverySection delivery={mixedDelivery()} />)
+
+    // Source 行: "来自: 本地"
+    expect(screen.getByText(i18n.t('delivery.source.label'))).toBeInTheDocument()
+    expect(screen.getByText(i18n.t('delivery.source.local'))).toBeInTheDocument()
+
+    // 四行设备截断展示 (前 8 字符 + …)
+    expect(screen.getByText('did_a1b2…')).toBeInTheDocument()
+    expect(screen.getByText('did_f6g7…')).toBeInTheDocument()
+    expect(screen.getByText('did_k1l2…')).toBeInTheDocument()
+    expect(screen.getByText('did_p6q7…')).toBeInTheDocument()
+
+    // 四档状态文案,失败要带 reason
+    expect(screen.getByText(i18n.t('delivery.status.delivered'))).toBeInTheDocument()
+    expect(screen.getByText(i18n.t('delivery.status.duplicate'))).toBeInTheDocument()
+    expect(screen.getByText(i18n.t('delivery.status.pending'))).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        i18n.t('delivery.status.failedWithReason', {
+          reason: i18n.t('delivery.failureReason.offline'),
+        })
+      )
+    ).toBeInTheDocument()
+
+    const list = screen.getByRole('list')
+    expect(within(list).getAllByRole('listitem')).toHaveLength(4)
+  })
+
+  it('shows historical hint and hides device list for legacy entries', () => {
+    const delivery: EntryDeliveryView = {
+      entryId: 'entry-old',
+      source: { tag: 'historical' },
+      deliveries: [],
+    }
+    render(<EntryDeliverySection delivery={delivery} />)
+
+    expect(screen.getByText(i18n.t('delivery.source.historical'))).toBeInTheDocument()
+    expect(screen.getByText(i18n.t('delivery.list.historical'))).toBeInTheDocument()
+    expect(screen.queryByRole('list')).not.toBeInTheDocument()
+  })
+
+  it('shows "no peers" hint for local entry without trusted peers', () => {
+    const delivery: EntryDeliveryView = {
+      entryId: 'entry-solo',
+      source: { tag: 'local' },
+      deliveries: [],
+    }
+    render(<EntryDeliverySection delivery={delivery} />)
+
+    expect(screen.getByText(i18n.t('delivery.list.noPeers'))).toBeInTheDocument()
+  })
+
+  it('renders remote source with truncated device id', () => {
+    const delivery: EntryDeliveryView = {
+      entryId: 'entry-remote',
+      source: { tag: 'remote', deviceId: 'did_sender_xyz' },
+      deliveries: [
+        {
+          targetDeviceId: 'did_peer_aaa',
+          status: { tag: 'delivered' },
+          reasonDetail: null,
+          updatedAtMs: 1_700_000_000_000,
+        },
+      ],
+    }
+    render(<EntryDeliverySection delivery={delivery} />)
+
+    // remote 来源行用截断 device id 替代 (Phase 3 起补真实 name)
+    expect(screen.getByText('did_send…')).toBeInTheDocument()
+  })
+
+  it('maps all five failure reasons to their i18n labels', () => {
+    const reasons = ['offline', 'localPolicy', 'peerRejected', 'io', 'internal'] as const
+    const delivery: EntryDeliveryView = {
+      entryId: 'entry-failures',
+      source: { tag: 'local' },
+      deliveries: reasons.map((reason, idx) => ({
+        targetDeviceId: `did_peer_${idx}xxxxxxxx`,
+        status: { tag: 'failed', reason },
+        reasonDetail: null,
+        updatedAtMs: 1_700_000_000_000 + idx,
+      })),
+    }
+    render(<EntryDeliverySection delivery={delivery} />)
+
+    for (const reason of reasons) {
+      const label = i18n.t('delivery.status.failedWithReason', {
+        reason: i18n.t(`delivery.failureReason.${reason}`),
+      })
+      expect(screen.getByText(label)).toBeInTheDocument()
+    }
+  })
+})

--- a/src/components/ui/hover-card.tsx
+++ b/src/components/ui/hover-card.tsx
@@ -1,0 +1,77 @@
+/**
+ * Hover-driven popover primitive —— Radix HoverCard 的项目级包装。
+ *
+ * 为什么需要这个组件:
+ * Popover 走 click;鼠标从 trigger 经"空隙"移入 content 期间会触发
+ * close → open,导致弹窗闪烁。HoverCard 原生为 hover 场景设计,自带
+ * openDelay / closeDelay,trigger 与 content 互相 hover 时不会进入
+ * 关闭流程,正好解决这个问题。HoverCard 本身不接管焦点,也就不会出现
+ * Popover 那种关闭后焦点还回 trigger 导致 `:focus-visible` 残留 ring
+ * 的桌面端问题。
+ *
+ * 默认值:
+ * - `openDelay = 80ms`:鼠标停留即可弹出,不至于划过 trigger 就闪一下
+ * - `closeDelay = 120ms`:覆盖 trigger ↔ content 间的空隙跨越时间
+ */
+
+import * as HoverCardPrimitive from '@radix-ui/react-hover-card'
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+interface HoverCardRootProps extends React.ComponentPropsWithoutRef<
+  typeof HoverCardPrimitive.Root
+> {
+  children?: React.ReactNode
+}
+
+function HoverCard({ openDelay = 80, closeDelay = 120, ...props }: HoverCardRootProps) {
+  return <HoverCardPrimitive.Root openDelay={openDelay} closeDelay={closeDelay} {...props} />
+}
+
+const HoverCardTrigger = HoverCardPrimitive.Trigger
+
+const HoverCardContent = React.forwardRef<
+  React.ElementRef<typeof HoverCardPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof HoverCardPrimitive.Content>
+>(({ className, align = 'center', sideOffset = 8, style, onMouseDown, ...props }, ref) => (
+  <HoverCardPrimitive.Portal>
+    <HoverCardPrimitive.Content
+      ref={ref}
+      align={align}
+      sideOffset={sideOffset}
+      // HoverCard 走桌面 UI "默认不可框选" 约定 (globals.css#L428):
+      // 这是一个 hover 详情面板,不是剪贴板正文,被拖蓝会让 webview 看起来
+      // 像浏览器。
+      //
+      // 为什么用 inline style + onMouseDown 双保险,而不是 Tailwind class:
+      // 1. 实测 `select-none` class 在某些上下文下未生效 (可能 JIT 漏扫
+      //    或 cascade 被 ancestor 打破),用 inline style 直绕。
+      // 2. webkit 的 `user-select: none` 不阻止从外部 drag 进来扩展选区,
+      //    `onMouseDown.preventDefault()` 在 content 内启动 drag 时直接
+      //    阻止选区起点,再加上 user-select: none 防止外部 drag 扩展进来
+      //    时高亮 content 内文字。
+      style={{ userSelect: 'none', WebkitUserSelect: 'none', ...style }}
+      onMouseDown={e => {
+        // 只在不是表单/可输入控件上抑制,避免误伤未来可能放进 hover 卡的
+        // 复制按钮 (click 仍可触发,因 click 走 mouseup→click 链,
+        // preventDefault on mousedown 不阻断 click)。
+        const target = e.target as HTMLElement
+        if (!target.closest('input, textarea, [contenteditable=""], [contenteditable="true"]')) {
+          e.preventDefault()
+        }
+        onMouseDown?.(e)
+      }}
+      className={cn(
+        'z-50 w-72 rounded-xl border bg-popover p-3 text-popover-foreground shadow-lg ring-1 ring-foreground/10 outline-none',
+        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+        'data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+        className
+      )}
+      {...props}
+    />
+  </HoverCardPrimitive.Portal>
+))
+
+HoverCardContent.displayName = HoverCardPrimitive.Content.displayName
+
+export { HoverCard, HoverCardTrigger, HoverCardContent }

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -6,15 +6,28 @@ const Popover = PopoverPrimitive.Root
 const PopoverTrigger = PopoverPrimitive.Trigger
 const PopoverAnchor = PopoverPrimitive.Anchor
 
+// 桌面应用默认阻止 Radix 在关闭时把焦点还回 trigger。
+// 为什么:这是个 Tauri WebView 应用,鼠标 hover/click 关闭弹窗后焦点回到
+// trigger 会被 WebKit 的 :focus-visible 启发式命中,继续渲染 ring,看起来
+// 像一圈残留的 border。桌面端用户对键盘焦点回流无感知诉求,而鼠标流程下
+// 的视觉残留体感很差。键盘 tab 进入 trigger 时仍正常显示 ring (那条路径
+// 不经过 close → returnFocus),无障碍未被破坏。
+// 调用方仍可显式传 `onCloseAutoFocus` 覆盖此默认 (例如一个必须把焦点送回
+// 表单字段的下拉)。
+const defaultCloseAutoFocus = (event: Event) => {
+  event.preventDefault()
+}
+
 const PopoverContent = React.forwardRef<
   React.ElementRef<typeof PopoverPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
->(({ className, align = 'center', sideOffset = 8, ...props }, ref) => (
+>(({ className, align = 'center', sideOffset = 8, onCloseAutoFocus, ...props }, ref) => (
   <PopoverPrimitive.Portal>
     <PopoverPrimitive.Content
       ref={ref}
       align={align}
       sideOffset={sideOffset}
+      onCloseAutoFocus={onCloseAutoFocus ?? defaultCloseAutoFocus}
       className={cn(
         'z-50 w-72 rounded-xl border bg-popover p-3 text-popover-foreground shadow-lg ring-1 ring-foreground/10 outline-none',
         'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',

--- a/src/hooks/useEntryDelivery.ts
+++ b/src/hooks/useEntryDelivery.ts
@@ -1,0 +1,71 @@
+/**
+ * Entry delivery view fetch hook —— quick-panel 与主窗口两套 detail 共享。
+ *
+ * 为什么需要这个 hook:
+ * detail 区域要展示"来自哪台设备 + 每个可信对端的同步状态"。这份数据
+ * 跟现有 `useClipboardPreview` / `useClipboardPreviewState` 拉的"内容
+ * 预览"是两条独立通路 (一条是 `clipboardPreviewCache`,一条是新的
+ * `clipboard_entry_delivery_view` Tauri command),把 fetch 抽到独立
+ * hook,组件可以让它和 preview 并发执行 —— React 在同一组件里调用
+ * 两个 useEffect 是天然并发的。
+ *
+ * 不缓存:detail 重开 (entryId 切换 / 同 entryId 再次打开) 要重新拉,
+ * 以反映"这一瞬间"的同步快照。Phase 2 不监听 dispatch 完成事件,detail
+ * 打开期间不动态刷新 (见 task_plan.md Phase 2 · "触发刷新")。
+ */
+
+import { useEffect, useRef, useState } from 'react'
+import {
+  type EntryDeliveryView,
+  getEntryDeliveryView,
+} from '@/api/tauri-command/clipboard_delivery'
+import { createLogger } from '@/lib/logger'
+
+const log = createLogger('entry-delivery')
+
+export interface EntryDeliveryHookResult {
+  delivery: EntryDeliveryView | null
+  loading: boolean
+  /** entry 不存在 / facade 不可用 等 fetch 失败的标记,组件据此降级渲染。 */
+  error: string | null
+}
+
+export function useEntryDelivery(entryId: string | null): EntryDeliveryHookResult {
+  const [delivery, setDelivery] = useState<EntryDeliveryView | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const requestIdRef = useRef(0)
+
+  useEffect(() => {
+    if (!entryId) {
+      requestIdRef.current++
+      setDelivery(null)
+      setLoading(false)
+      setError(null)
+      return
+    }
+
+    const currentRequestId = ++requestIdRef.current
+    setLoading(true)
+    setError(null)
+    setDelivery(null)
+
+    void (async () => {
+      try {
+        const next = await getEntryDeliveryView(entryId)
+        if (currentRequestId !== requestIdRef.current) return
+        setDelivery(next)
+      } catch (err) {
+        if (currentRequestId !== requestIdRef.current) return
+        log.warn({ err, entryId }, 'failed to load entry delivery view')
+        setError(err instanceof Error ? err.message : String(err))
+      } finally {
+        if (currentRequestId === requestIdRef.current) {
+          setLoading(false)
+        }
+      }
+    })()
+  }, [entryId])
+
+  return { delivery, loading, error }
+}

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -1210,7 +1210,10 @@
       "label": "From:",
       "local": "this device",
       "remote": "{{device}}",
-      "historical": "local history (legacy)"
+      "historical": "local history (legacy)",
+      "localShort": "This device",
+      "remoteShort": "From {{device}}",
+      "historicalShort": "Legacy entry"
     },
     "list": {
       "title": "Sync status",
@@ -1222,6 +1225,17 @@
       "duplicate": "delivered (duplicate)",
       "pending": "not attempted",
       "failedWithReason": "failed · {{reason}}"
+    },
+    "summary": {
+      "synced": "Synced",
+      "partial": "Partially synced",
+      "syncing": "Syncing",
+      "failed": "Sync failed",
+      "pending": "Awaiting sync"
+    },
+    "popover": {
+      "title": "Sync status",
+      "ariaTrigger": "View per-device sync details"
     },
     "failureReason": {
       "offline": "peer offline",

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -1202,6 +1202,35 @@
     "imageAlt": "Clipboard image",
     "deleteHint": "{{modifier}}⌫ delete"
   },
+  "delivery": {
+    "section": {
+      "aria": "Entry sync status"
+    },
+    "source": {
+      "label": "From:",
+      "local": "this device",
+      "remote": "{{device}}",
+      "historical": "local history (legacy)"
+    },
+    "list": {
+      "title": "Sync status",
+      "historical": "Created before sync tracking; no delivery records",
+      "noPeers": "No paired devices yet"
+    },
+    "status": {
+      "delivered": "delivered",
+      "duplicate": "delivered (duplicate)",
+      "pending": "not attempted",
+      "failedWithReason": "failed · {{reason}}"
+    },
+    "failureReason": {
+      "offline": "peer offline",
+      "localPolicy": "blocked by local policy",
+      "peerRejected": "peer rejected",
+      "io": "network error",
+      "internal": "internal error"
+    }
+  },
   "quickPanel": {
     "loading": "Connecting clipboard history...",
     "unavailable": "Clipboard history is unavailable right now.",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -1201,7 +1201,10 @@
       "label": "来自:",
       "local": "本地",
       "remote": "{{device}}",
-      "historical": "本机历史条目"
+      "historical": "本机历史条目",
+      "localShort": "本机",
+      "remoteShort": "来自 {{device}}",
+      "historicalShort": "历史条目"
     },
     "list": {
       "title": "同步状态",
@@ -1213,6 +1216,17 @@
       "duplicate": "已接收(去重)",
       "pending": "未尝试",
       "failedWithReason": "失败 · {{reason}}"
+    },
+    "summary": {
+      "synced": "已同步",
+      "partial": "部分同步",
+      "syncing": "同步中",
+      "failed": "同步失败",
+      "pending": "等待同步"
+    },
+    "popover": {
+      "title": "同步状态",
+      "ariaTrigger": "查看每台设备的同步详情"
     },
     "failureReason": {
       "offline": "对端离线",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -1193,6 +1193,35 @@
     "imageAlt": "剪贴板图片",
     "deleteHint": "{{modifier}}⌫ 删除"
   },
+  "delivery": {
+    "section": {
+      "aria": "条目同步状态"
+    },
+    "source": {
+      "label": "来自:",
+      "local": "本地",
+      "remote": "{{device}}",
+      "historical": "本机历史条目"
+    },
+    "list": {
+      "title": "同步状态",
+      "historical": "此条目在同步追踪启用前创建,无投递记录",
+      "noPeers": "暂未配对任何设备"
+    },
+    "status": {
+      "delivered": "已接收",
+      "duplicate": "已接收(去重)",
+      "pending": "未尝试",
+      "failedWithReason": "失败 · {{reason}}"
+    },
+    "failureReason": {
+      "offline": "对端离线",
+      "localPolicy": "本地策略阻断",
+      "peerRejected": "对端拒收",
+      "io": "网络错误",
+      "internal": "内部错误"
+    }
+  },
   "quickPanel": {
     "loading": "正在连接剪贴板历史...",
     "unavailable": "当前无法使用剪贴板历史。",

--- a/src/lib/ipc-bindings.generated.ts
+++ b/src/lib/ipc-bindings.generated.ts
@@ -203,6 +203,16 @@ export const commands = {
 	timestamp: number,
 } | null) => typedError<null, CommandError>(__TAURI_INVOKE("open_data_directory", { trace })),
 	/**
+	 *  拉一条 entry 的同步状态视图。
+	 * 
+	 *  前端 detail 面板在 entry 切换时调用,失败时(facade 未装配 / DB 故障)
+	 *  返回 `InternalError`;entry 不存在返回 `NotFound`,前端据此降级渲染。
+	 */
+	clipboardEntryDeliveryView: (entryId: string, trace: {
+	trace_id: string,
+	timestamp: number,
+} | null) => typedError<EntryDeliveryViewDto, CommandError>(__TAURI_INVOKE("clipboard_entry_delivery_view", { entryId, trace })),
+	/**
 	 *  Hide the quick panel, re-activate the previous app, and paste.
 	 * 
 	 *  隐藏快捷面板，重新激活之前的应用，并粘贴。
@@ -356,6 +366,9 @@ export type DaemonConnectionPayload = {
 	token: string,
 };
 
+/**  失败原因。i18n key 命名约定:`delivery.failureReason.<variant 小驼峰>`。 */
+export type DeliveryFailureReasonDto = "offline" | "localPolicy" | "peerRejected" | "io" | "internal";
+
 /**
  *  暴露给 webview 的设备和应用元数据，用于补齐前端 Sentry scope。
  * 
@@ -404,6 +417,42 @@ export type DownloadProgressSnapshot = {
 	total: number | null,
 	version: string | null,
 };
+
+/**  状态枚举:`tag` + `reason` 形式,便于前端区分四档与失败子分类。 */
+export type EntryDeliveryStatusDto = { tag: "pending" } | { tag: "delivered" } | { tag: "duplicate" } | { tag: "failed"; reason: DeliveryFailureReasonDto };
+
+export type EntryDeliveryTargetDto = {
+	targetDeviceId: string,
+	status: EntryDeliveryStatusDto,
+	/**  失败时的 wire 层错误细节,供 UI tooltip / 详情展开使用。 */
+	reasonDetail: string | null,
+	/**
+	 *  `Pending` 时为 `None`(从未尝试过)。`#[specta(type = ...)]` 告诉 specta
+	 *  这是个 ms 精度的 epoch,实际值不会超过 JS Number 安全整数范围 (~285 万年),
+	 *  用 `Number<i64>` 包装绕过 BigInt 禁用规则,与 mobile_sync.rs 的 `last_seen_at_ms`
+	 *  同源。
+	 */
+	updatedAtMs: number | null,
+};
+
+/**
+ *  `EntryDeliveryView` 的前端可序列化镜像。字段命名与领域模型保持一致,
+ *  只在序列化时改写成 camelCase。
+ */
+export type EntryDeliveryViewDto = {
+	entryId: string,
+	source: EntrySourceDto,
+	deliveries: EntryDeliveryTargetDto[],
+};
+
+/**  entry 来源描述。`tag` 字段供前端 discriminated union 直接 switch。 */
+export type EntrySourceDto = 
+/**  本机捕获。 */
+{ tag: "local" } | 
+/**  远端推送。`deviceId` 是来源设备,Phase 3 起补 `deviceName`。 */
+{ tag: "remote"; deviceId: string } | 
+/**  追踪机制启用前已存在的老 entry,无可靠投递信息。 */
+{ tag: "historical" };
 
 /**
  *  前端可 `error.code` switch 的 typed 错误。序列化形态:

--- a/src/quick-panel/ClipboardPreviewPane.tsx
+++ b/src/quick-panel/ClipboardPreviewPane.tsx
@@ -2,6 +2,7 @@ import { File, Loader2 } from 'lucide-react'
 import React, { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useClipboardPreview } from './useClipboardPreview'
+import EntryDeliverySection from '@/components/clipboard/EntryDeliverySection'
 import VirtualizedText from '@/components/clipboard/VirtualizedText'
 
 interface ClipboardPreviewPaneProps {
@@ -16,7 +17,7 @@ function formatBytes(bytes: number): string {
 
 const ClipboardPreviewPane: React.FC<ClipboardPreviewPaneProps> = ({ entryId }) => {
   const { t } = useTranslation(undefined, { keyPrefix: 'previewPanel' })
-  const { preview, loading, error } = useClipboardPreview(entryId)
+  const { preview, loading, error, delivery } = useClipboardPreview(entryId)
   const isMac = useMemo(() => navigator.platform.toUpperCase().includes('MAC'), [])
 
   const isLargeText =
@@ -83,6 +84,8 @@ const ClipboardPreviewPane: React.FC<ClipboardPreviewPaneProps> = ({ entryId }) 
           </div>
         )}
       </div>
+
+      <EntryDeliverySection delivery={delivery} compact />
 
       <div className="flex items-center justify-start border-t border-border/50 px-3 py-1.5 text-[11px] text-muted-foreground">
         <span>{t('deleteHint', { modifier: isMac ? '⌥' : 'Alt+' })}</span>

--- a/src/quick-panel/useClipboardPreview.ts
+++ b/src/quick-panel/useClipboardPreview.ts
@@ -1,4 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
+import type { EntryDeliveryView } from '@/api/tauri-command/clipboard_delivery'
+import { useEntryDelivery } from '@/hooks/useEntryDelivery'
 import { clipboardPreviewCache, type ClipboardPreviewData } from '@/lib/clipboard-preview-cache'
 
 export type ClipboardPreviewState = ClipboardPreviewData
@@ -7,6 +9,10 @@ export interface ClipboardPreviewResult {
   preview: ClipboardPreviewState | null
   loading: boolean
   error: string | null
+  /** entry delivery 视图 (来源 + 每对端同步状态);未就绪 / fetch 失败时为 null。 */
+  delivery: EntryDeliveryView | null
+  /** delivery 单独的 loading 标记,不与 preview loading 合并,二者并发独立。 */
+  deliveryLoading: boolean
 }
 
 export function useClipboardPreview(entryId: string | null): ClipboardPreviewResult {
@@ -52,5 +58,7 @@ export function useClipboardPreview(entryId: string | null): ClipboardPreviewRes
     })()
   }, [entryId])
 
-  return { preview, loading, error }
+  const { delivery, loading: deliveryLoading } = useEntryDelivery(entryId)
+
+  return { preview, loading, error, delivery, deliveryLoading }
 }


### PR DESCRIPTION
## Summary

Entry delivery Phase 2 — 让"这条 entry 从哪里来,同步到了哪里"在 detail 顶部一眼可见,并修复入站 entry 来源被错记为本机的 bug。

- **`45122f31` Phase 2 UI 初版**:新增 detail 顶部行内 EntryDeliverySection,展示来源(本机 / 远端 / 历史)+ 每台可信对端的投递状态(delivered / pending / failed / duplicate),数据由 `AppFacade::get_entry_delivery_view` 提供。
- **`d4f4f0f5` UI 紧凑化**:行内灰条占据 detail 太显眼,改成 EntryDeliveryBadge —— 两枚 icon(来源 + 同步聚合)+ 一行状态,设备明细放进 hover popover(新增 shadcn HoverCard)。quick-panel 沿用原 Section(空间紧、明细更有用)。
- **`5d1963a2` 修复 source_device bug**:入站同步走 capture pipeline 持久化 ClipboardEvent 时,`source_device` 被无差别填成本机 id,detail badge 把"远端推过来的 entry"误识别为"来自本机 + 等待同步"。`ClipboardChangeOrigin::RemotePush` 改为携带 `from_device: Option<DeviceId>`,apply_inbound 把对端 id 透传到持久化层;顺手把 `DeviceId` 内部从 `String` 换成 `arrayvec::ArrayString<64>`,获得 `Copy`,清掉一批 `.clone()` / 抽变量,wire/db serde 形态不变。

## Test plan

- [x] `cargo test --workspace --lib` 全绿(uc-core 104 / uc-application 474 / uc-infra 297 / uc-desktop+webserver 等 1200+,0 失败)
- [x] 新增 `apply_inbound::tests::from_device_is_forwarded_to_capture` 用 mockall withf 锁定"input.from_device 透传给 capture"
- [x] 新增 `device_id` 4 个单测:short id round-trip / `mobile_sync:` 长 prefix / 超长拒绝 / serde 与 String 形态等价
- [x] `cargo test -p uc-bootstrap --tests` slice2 phase2 E2E 通过(`sponsor_dispatch_lands_on_joiner_within_2s`、`repeat_dispatch_lands_twice_phase2_no_dedup`)
- [ ] 手动:本机 + 远端 peer 各推一条,确认 detail 顶部 EntryDeliveryBadge 分别显示"This device"/"From <peer-id>",且远端那条不再出现"等待同步"
- [ ] 手动:hover 同步 icon 弹出 popover,逐条 peer 状态(delivered/pending/failed)一致
- [ ] 手动:quick-panel 沿用 EntryDeliverySection 不变,布局未受波及

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clipboard entry delivery view showing sync status across devices with source and per-target delivery information
  * Added entry delivery badge and section components displaying sync status, device information, and failure reasons

* **Dependencies**
  * Added `@radix-ui/react-hover-card` for UI popover interactions
  * Added `arrayvec` for device ID stack allocation

* **Bug Fixes**
  * Improved remote clipboard change tracking to preserve originating device identity

* **Tests**
  * Updated test suites to match internal signature changes for device tracking

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/UniClipboard/UniClipboard/pull/732?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->