### PR TITLE
feat(clipboard/delivery): resolve device names from SpaceMember (Phase 3)

### DIFF
--- a/.planning/phases/097-entry-delivery-status/progress.md
+++ b/.planning/phases/097-entry-delivery-status/progress.md
@@ -8,6 +8,7 @@
 | 2026-05-14 | 决策逐一 review + plan 重写 | task_plan.md / findings.md 第二版，所有决策已敲定 |
 | 2026-05-14 | R1 写放大基准 | `bench/r1_delivery_write_amp.py` + findings R1 更新 (已量化，1000× 余量) |
 | 2026-05-14 | Phase 1 实施完成 | uc-core + uc-infra + uc-application + uc-bootstrap 端到端落地，workspace+tests 编译通过，uc-infra 6+ / uc-application 448 测试 pass |
+| 2026-05-15 | Phase 3 实施完成 (D6 策略调整，复用 SpaceMember) | uc-application view use case 注入 member_repo;facade/wiring 零改动;前端 deviceName fallback;workspace check 通过，uc-application 477/477,EntryDeliverySection 7/7 |
 
 ---
 
@@ -222,6 +223,63 @@ test result: ok. 448 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
 cargo check --workspace --tests
 Finished `dev` profile [unoptimized + debuginfo] target(s) in 28.16s
 ```
+
+---
+
+## 2026-05-15 · Phase 3 实施 (策略调整)
+
+### 上下文
+
+按原 plan D6 准备新建 `device_directory` 表 + `DeviceDirectoryPort`,在实施前用户挑战："为什么需要新建一个表，space member 中没有吗"。
+
+### 重新评估
+
+调研发现 plan D6/F6 漏看了既有事实：
+- `SpaceMember`(`uc-core/src/membership/member.rs:15`) 已经有 `device_name: String`
+- `MemberRepositoryPort.get(device_id)` / `list()` 已能按 id 取名
+- pairing 双方都会在 `redeem_invitation` / `pairing_inbound/orchestrator` 里把对端 name 写入 SpaceMember
+- `revoke_member` 同时清 member 与 trusted_peer → trusted_peer ⊆ space_member 恒成立
+
+结论：新建 device_directory 表是冗余的二号真相，违反"单一真相来源"原则。R4 提到的"仅接收过我方推送、从未推送过我方的 trusted peer 不出现在 directory" 在 SpaceMember 路径不存在。
+
+### 决策 (D6.v2)
+
+复用 `SpaceMember.device_name`,放弃新建 device_directory 表。已删除：
+- `uc-core/src/device_directory/`
+- `uc-core/src/ports/device_directory.rs`
+- `uc-infra/migrations/2026-05-15-000001_device_directory/`
+- `uc-infra/src/db/models/device_directory.rs`
+- `schema.rs` 中的 device_directory 表条目
+
+### 实施
+
+1. **`GetEntryDeliveryViewUseCase`** 注入 `Arc<dyn MemberRepositoryPort>`:
+   - execute 流程里 `member_repo.list()` 一次取全集，过滤空白名后建 `HashMap<DeviceId, String>` 索引
+   - `EntrySource::Remote` 加 `device_name: Option<String>`,从 index 取
+   - 每个 `EntryDeliveryTargetView` 加 `target_device_name: Option<String>`,从 index 取
+   - member_repo 故障降级为空 index,view 仍正常返回，前端 fallback 到 id
+2. **`ClipboardSyncFacade::new`** 把已有的 `deps.member_repo` 透传给 `view_uc`,无新增 dep,bootstrap 零改动
+3. **uc-tauri DTO** `EntrySourceDto::Remote` / `EntryDeliveryTargetDto` 加 `deviceName` / `targetDeviceName`,转换函数同步;`cargo test -p uc-tauri --test specta_export` 自动同步生成 `src/lib/ipc-bindings.generated.ts`
+4. **前端** `src/api/tauri-command/clipboard_delivery.ts` 加 `deviceName` / `targetDeviceName`;`EntryDeliverySection.tsx` + `EntryDeliveryBadge.tsx` 各引入 `deviceLabel(name, id)` 辅助函数 (空白等同缺失，fallback 到 id 截断，fallback 时保留 monospace 字体)
+5. 测试：
+   - uc-application 新增 3 个分支测试 (name 命中 / 空白 fallback / member_repo 故障降级),view use case 测试 10/10 通过
+   - EntryDeliverySection 新增"name 优先 + 空白 fallback"测试，7/7 通过
+
+### 校验
+
+- `cargo check --workspace --tests` → 通过
+- `cargo test -p uc-application --lib` → 477 / 477 通过
+- `cargo test -p uc-infra --lib db::repositories::entry_delivery_repo` → 6 / 6 通过 (无回归)
+- `bunx tsc --noEmit` → 无错误
+- `bun run test src/components/clipboard/__tests__/EntryDeliverySection.test.tsx` → 7 / 7 通过
+
+### 关键经验
+
+plan 的事实清单要先和现有代码核对一次再决策。D6/F6 当初只看了 `TrustedPeer`(确实没 device_name),漏掉 `SpaceMember` 已经有的字段，差点新建一张冗余表。用户的"为什么不复用"挑战直接命中根问题。
+
+### 下一步
+
+无，Phase 3 完结。Issue #704 可关闭。
 
 ## 错误日志
 

--- a/.planning/phases/097-entry-delivery-status/task_plan.md
+++ b/.planning/phases/097-entry-delivery-status/task_plan.md
@@ -404,7 +404,31 @@ pub trait DeviceDirectoryPort: Send + Sync {
 
 **依赖关系**:依赖 Phase 1 与 Phase 2。本 phase 是叠加增强，Phase 2 落地后 UI 已能用 fallback 跑通。
 
-**Status**: pending
+**Status**: complete (2026-05-15)
+
+**实施总结 (策略调整)**:
+
+实施前对 D6 做了重新评估，**复用 `SpaceMember.device_name`,放弃新建 `device_directory` 表**。理由：
+
+- `SpaceMember` 实体已经有 `device_name: String` 字段 (见 `uc-core/src/membership/member.rs:15`),由 pairing 流程在双方建立成员资格时写入 (`redeem_invitation.rs:151` / `pairing_inbound/orchestrator.rs:421`)
+- `MemberRepositoryPort.get(device_id)` / `list()` 已经能按 device_id 拿到名字
+- roster facade 的 `revoke_member`(`facade/roster/facade.rs:232`) 同时 remove `member_repo` 与 `trusted_peer_repo`,**trusted_peer ⊆ space_member** 在生命周期上始终成立
+- 视图层只需要"取 device_name"这一个动作，新建 `device_directory` 表会成为冗余的第二真相
+- R4 提到的"仅接收过我方推送、从未推送过我方的 trusted peer 不会出现在 directory" 风险，在复用 SpaceMember 路径不存在
+
+实际改动：
+
+1. **uc-application** · `GetEntryDeliveryViewUseCase` 注入 `MemberRepositoryPort`,执行时一次 `list()` 取全集建 `HashMap<DeviceId, String>`;`EntrySource::Remote` 加 `device_name: Option<String>`,`EntryDeliveryTargetView` 加 `target_device_name: Option<String>`;空白名按缺失处理;`member_repo.list` 故障降级为"无名字",不阻断视图。
+2. **uc-application** · 视图 use case 测试补 `FakeMemberRepo` + 3 个新分支：命中、空白 fallback、member_repo 故障降级。10/10 测试通过。
+3. **uc-application** · `ClipboardSyncFacade` 把已有的 `deps.member_repo` 传给 `view_uc`,无新增 dep 字段，wiring 零改动。
+4. **uc-tauri** · `EntrySourceDto::Remote` / `EntryDeliveryTargetDto` 加 `deviceName` / `targetDeviceName` 字段，生成 binding 自动同步。
+5. **前端** · `EntrySourceView.remote` / `EntryDeliveryTargetView` 加 `deviceName` / `targetDeviceName`;`EntryDeliverySection` 和 `EntryDeliveryBadge` 引入 `deviceLabel(name, id)` 辅助函数 (name 优先，空白/缺失时 fallback 到 id 截断，fallback 时保留 monospace 样式);测试补"name 命中" + "空白 fallback" 用例，7/7 通过。
+6. **校验** · `cargo check --workspace --tests` 通过;`cargo test -p uc-application --lib` 477/477 通过;`cargo test -p uc-infra ... entry_delivery_repo` 6/6 通过;`tsc --noEmit` 无错误;`EntryDeliverySection.test.tsx` 7/7 通过。
+
+**未做 (超出本期范围)**:
+
+- 入站 inbound ingest 不主动刷新 `SpaceMember.device_name`:配对完成那一刻的名字就是真相，对端改名不会自动回写。F4 提到的 `origin_device_name` 字段在 wire 上仍透传，但视图层不消费 (改名同步会改 member 表语义，留给后续如果产品需要再做)。
+- 不新增任何持久化结构，本期就是纯"接 wire 已有事实"的视图增强。
 
 ---
 
@@ -431,6 +455,7 @@ pub trait DeviceDirectoryPort: Send + Sync {
 | D4 | 列表批量 API | 失效 | 列表不展示，无需 |
 | D5 | facade vs webserver | facade | 既定事实 (in-process facade) |
 | D6 | 设备名解析层 | A · device_directory 表 + Port | 同时解决 source/target name，真相单点收口 |
+| D6.v2 | (Phase 3 实施前重审) 复用 SpaceMember.device_name 而不是新建 device_directory 表 | 复用 | `SpaceMember` 已有 `device_name`,由 pairing 双向写入;trusted_peer ⊆ space_member 在生命周期上恒成立;新建表会形成冗余二号真相，违反单一真相原则 |
 | D7 | 历史 entry 降级 | A1 · entry 表加 delivery_tracked 列 | per-entry 自带标志，不依赖全局变量 |
 | D8 | 离线 vs 在线失败区分 | 用现有 ClipboardDispatchError 五分类映射 | wire 层信号已足够细 |
 | D9 | trusted_peer 删除后 delivery 处理 | C · 保留行 + facade 默认不展示 | 不丢历史，UI 简洁，改动最小 |

--- a/src-tauri/crates/uc-application/src/facade/clipboard/facade.rs
+++ b/src-tauri/crates/uc-application/src/facade/clipboard/facade.rs
@@ -194,6 +194,7 @@ impl ClipboardSyncFacade {
             Arc::clone(&deps.trusted_peer_repo),
             Arc::clone(&deps.entry_delivery_repo),
             Arc::clone(&deps.device_identity),
+            Arc::clone(&deps.member_repo),
         ));
         Self {
             dispatch_uc,

--- a/src-tauri/crates/uc-application/src/usecases/clipboard_sync/get_entry_delivery_view.rs
+++ b/src-tauri/crates/uc-application/src/usecases/clipboard_sync/get_entry_delivery_view.rs
@@ -19,6 +19,7 @@ use uc_core::ports::{
     EntryDeliveryRepositoryPort,
 };
 use uc_core::trusted_peer::TrustedPeerRepositoryPort;
+use uc_core::MemberRepositoryPort;
 
 /// 视图模型:某条 entry 的"来源 + 对每个可信对端的同步状态"完整快照。
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -34,9 +35,12 @@ pub struct EntryDeliveryView {
 pub enum EntrySource {
     /// 本机捕获的 entry。
     Local,
-    /// 远端推送过来的 entry。device_id 是推送方,文本/可读名由视图层用
-    /// `DeviceDirectoryPort`(Phase 3 引入)解析,本期仅返回 id。
-    Remote { device_id: DeviceId },
+    /// 远端推送过来的 entry。`device_name` 取自空间成员目录中的人类可读名;
+    /// 不命中(例如已退出空间但仍存有历史 entry)时为 `None`,渲染层 fallback 到 `device_id`。
+    Remote {
+        device_id: DeviceId,
+        device_name: Option<String>,
+    },
     /// 新机制启用前已存在的老 entry,没有可信的投递信息可查。
     Historical,
 }
@@ -46,6 +50,8 @@ pub enum EntrySource {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EntryDeliveryTargetView {
     pub target_device_id: DeviceId,
+    /// 取自空间成员目录中的人类可读名;不命中时为 `None`,渲染层 fallback 到 `target_device_id`。
+    pub target_device_name: Option<String>,
     pub status: EntryDeliveryStatusView,
     pub reason_detail: Option<String>,
     /// `Pending` 时为 `None`(未发生过,没有时间可言)。
@@ -74,6 +80,7 @@ pub(crate) struct GetEntryDeliveryViewUseCase {
     trusted_peer_repo: Arc<dyn TrustedPeerRepositoryPort>,
     entry_delivery_repo: Arc<dyn EntryDeliveryRepositoryPort>,
     device_identity: Arc<dyn DeviceIdentityPort>,
+    member_repo: Arc<dyn MemberRepositoryPort>,
 }
 
 impl GetEntryDeliveryViewUseCase {
@@ -83,6 +90,7 @@ impl GetEntryDeliveryViewUseCase {
         trusted_peer_repo: Arc<dyn TrustedPeerRepositoryPort>,
         entry_delivery_repo: Arc<dyn EntryDeliveryRepositoryPort>,
         device_identity: Arc<dyn DeviceIdentityPort>,
+        member_repo: Arc<dyn MemberRepositoryPort>,
     ) -> Self {
         Self {
             entry_repo,
@@ -90,6 +98,7 @@ impl GetEntryDeliveryViewUseCase {
             trusted_peer_repo,
             entry_delivery_repo,
             device_identity,
+            member_repo,
         }
     }
 
@@ -134,11 +143,33 @@ impl GetEntryDeliveryViewUseCase {
         };
 
         let is_local = source_device == local_device;
+
+        // 名字索引:`SpaceMember.device_name` 由配对流程在双方建立成员资格时
+        // 写入,这里只读、不刷新。用一次 list 取全集再建 HashMap,避免对
+        // peer 集合做 N 次 get。member_repo 故障不阻断视图,降级为"无名字"。
+        let name_index: HashMap<DeviceId, String> = match self.member_repo.list().await {
+            Ok(members) => members
+                .into_iter()
+                .filter(|m| !m.device_name.trim().is_empty())
+                .map(|m| (m.device_id, m.device_name))
+                .collect(),
+            Err(err) => {
+                tracing::warn!(
+                    error = %err,
+                    entry_id = %entry_id,
+                    "delivery view: member_repo.list failed; falling back to id-only names",
+                );
+                HashMap::new()
+            }
+        };
+
         let source = if is_local {
             EntrySource::Local
         } else {
+            let device_name = name_index.get(&source_device).cloned();
             EntrySource::Remote {
                 device_id: source_device,
+                device_name,
             }
         };
 
@@ -180,10 +211,12 @@ impl GetEntryDeliveryViewUseCase {
         // 参数切换,而不是把 trusted_peer 集合外的也展示出来)。
         for peer in trusted {
             let target_id = peer.peer_device_id.clone();
+            let target_name = name_index.get(&target_id).cloned();
             match delivery_index.get(target_id.as_str()) {
                 Some(rec) => {
                     target_views.push(EntryDeliveryTargetView {
                         target_device_id: target_id,
+                        target_device_name: target_name,
                         status: map_status(&rec.status),
                         reason_detail: rec.reason_detail.clone(),
                         updated_at_ms: Some(rec.updated_at_ms),
@@ -193,6 +226,7 @@ impl GetEntryDeliveryViewUseCase {
                     // trusted peer 但没有 delivery 行 → 还没尝试投递。
                     target_views.push(EntryDeliveryTargetView {
                         target_device_id: target_id,
+                        target_device_name: target_name,
                         status: EntryDeliveryStatusView::Pending,
                         reason_detail: None,
                         updated_at_ms: None,
@@ -232,6 +266,7 @@ mod tests {
     use uc_core::trusted_peer::{TrustedPeer, TrustedPeerError};
     use uc_core::ClipboardSelectionDecision;
     use uc_core::ObservedClipboardRepresentation;
+    use uc_core::{MemberSyncPreferences, MembershipError, SpaceMember};
 
     // ── 测试 doubles ───────────────────────────────────────────────────
 
@@ -398,6 +433,63 @@ mod tests {
         }
     }
 
+    /// 简易 SpaceMember 仓储 fake。`list` 返回构造时给的 (device_id, name)
+    /// 列表;`fail_list = true` 时模拟 member_repo 故障,验证视图降级路径。
+    struct FakeMemberRepo {
+        members: Vec<SpaceMember>,
+        fail_list: bool,
+    }
+    impl FakeMemberRepo {
+        fn new(named: Vec<(DeviceId, &str)>) -> Self {
+            let fingerprint = IdentityFingerprint::from_raw_string("AAAABBBBCCCCDDDD")
+                .expect("test fingerprint must be valid");
+            let now = Utc::now();
+            let members = named
+                .into_iter()
+                .map(|(device_id, name)| SpaceMember {
+                    device_id,
+                    device_name: name.to_string(),
+                    identity_fingerprint: fingerprint.clone(),
+                    joined_at: now,
+                    sync_preferences: MemberSyncPreferences::default(),
+                })
+                .collect();
+            Self {
+                members,
+                fail_list: false,
+            }
+        }
+        fn failing() -> Self {
+            Self {
+                members: Vec::new(),
+                fail_list: true,
+            }
+        }
+    }
+    #[async_trait]
+    impl MemberRepositoryPort for FakeMemberRepo {
+        async fn get(&self, device_id: &DeviceId) -> Result<Option<SpaceMember>, MembershipError> {
+            Ok(self
+                .members
+                .iter()
+                .find(|m| &m.device_id == device_id)
+                .cloned())
+        }
+        async fn list(&self) -> Result<Vec<SpaceMember>, MembershipError> {
+            if self.fail_list {
+                Err(MembershipError::Repository("simulated".into()))
+            } else {
+                Ok(self.members.clone())
+            }
+        }
+        async fn save(&self, _member: &SpaceMember) -> Result<(), MembershipError> {
+            Ok(())
+        }
+        async fn remove(&self, _device_id: &DeviceId) -> Result<bool, MembershipError> {
+            Ok(false)
+        }
+    }
+
     // ── helpers ────────────────────────────────────────────────────────
 
     fn local_id() -> DeviceId {
@@ -445,12 +537,29 @@ mod tests {
         trusted_peer_repo: Arc<FakeTrustedPeerRepo>,
         delivery_repo: Arc<FakeDeliveryRepo>,
     ) -> GetEntryDeliveryViewUseCase {
+        build_uc_with_members(
+            entry_repo,
+            event_repo,
+            trusted_peer_repo,
+            delivery_repo,
+            Arc::new(FakeMemberRepo::new(vec![])),
+        )
+    }
+
+    fn build_uc_with_members(
+        entry_repo: Arc<FakeEntryRepo>,
+        event_repo: Arc<FakeEventRepo>,
+        trusted_peer_repo: Arc<FakeTrustedPeerRepo>,
+        delivery_repo: Arc<FakeDeliveryRepo>,
+        member_repo: Arc<FakeMemberRepo>,
+    ) -> GetEntryDeliveryViewUseCase {
         GetEntryDeliveryViewUseCase::new(
             entry_repo,
             event_repo,
             trusted_peer_repo,
             delivery_repo,
             Arc::new(FixedIdentity(local_id())),
+            member_repo,
         )
     }
 
@@ -525,7 +634,8 @@ mod tests {
         assert_eq!(
             view.source,
             EntrySource::Remote {
-                device_id: peer("origin-peer")
+                device_id: peer("origin-peer"),
+                device_name: None,
             }
         );
         assert!(
@@ -612,5 +722,109 @@ mod tests {
         let view = uc.execute(&entry_id("e1")).await.unwrap();
         assert_eq!(view.deliveries.len(), 1, "孤儿 target 应被丢弃");
         assert_eq!(view.deliveries[0].target_device_id, peer("p1"));
+    }
+
+    // ── 分支 8: device_name 解析 — 命中/未命中 fallback ─────────────────
+    //
+    // SpaceMember 表里 p1 有名字、p2 是空字符串(等同缺失)、p3 完全不在
+    // 表中。视图应分别填 Some("MacBook")、None、None,前端按 None 做截断
+    // device_id fallback,不要硬塞空字符串。
+
+    #[tokio::test]
+    async fn resolves_device_names_from_space_member_repo() {
+        let entries = Arc::new(FakeEntryRepo::new());
+        entries.insert(make_entry("e1", "ev1", true));
+        let events = Arc::new(FakeEventRepo::new());
+        events.set_source(&event_id("ev1"), Some(local_id()));
+        let trusted = Arc::new(FakeTrustedPeerRepo::new(vec![
+            peer("p1"),
+            peer("p2"),
+            peer("p3"),
+        ]));
+        let delivery = Arc::new(FakeDeliveryRepo::new(vec![delivered(
+            "e1",
+            peer("p1"),
+            100,
+        )]));
+        let members = Arc::new(FakeMemberRepo::new(vec![
+            (peer("p1"), "MacBook Pro"),
+            (peer("p2"), "   "), // 空白等同缺失
+        ]));
+
+        let uc = build_uc_with_members(entries, events, trusted, delivery, members);
+        let view = uc.execute(&entry_id("e1")).await.unwrap();
+
+        let by_target: HashMap<String, &EntryDeliveryTargetView> = view
+            .deliveries
+            .iter()
+            .map(|t| (t.target_device_id.to_string(), t))
+            .collect();
+        assert_eq!(
+            by_target["p1"].target_device_name.as_deref(),
+            Some("MacBook Pro")
+        );
+        assert!(
+            by_target["p2"].target_device_name.is_none(),
+            "空白名应被视为缺失"
+        );
+        assert!(
+            by_target["p3"].target_device_name.is_none(),
+            "member 表中没有 p3 → 视图层不应硬造名字"
+        );
+    }
+
+    // ── 分支 9: 远端 entry · source.device_name 命中 ────────────────────
+
+    #[tokio::test]
+    async fn remote_source_device_name_resolves_from_members() {
+        let entries = Arc::new(FakeEntryRepo::new());
+        entries.insert(make_entry("e1", "ev1", true));
+        let events = Arc::new(FakeEventRepo::new());
+        events.set_source(&event_id("ev1"), Some(peer("origin-peer")));
+        let members = Arc::new(FakeMemberRepo::new(vec![(
+            peer("origin-peer"),
+            "Sender Desktop",
+        )]));
+
+        let uc = build_uc_with_members(
+            entries,
+            events,
+            Arc::new(FakeTrustedPeerRepo::new(vec![])),
+            Arc::new(FakeDeliveryRepo::new(vec![])),
+            members,
+        );
+        let view = uc.execute(&entry_id("e1")).await.unwrap();
+        assert_eq!(
+            view.source,
+            EntrySource::Remote {
+                device_id: peer("origin-peer"),
+                device_name: Some("Sender Desktop".to_string()),
+            }
+        );
+    }
+
+    // ── 分支 10: member_repo 故障降级 — 不阻断视图,全部 fallback 到 id ──
+
+    #[tokio::test]
+    async fn member_repo_failure_falls_back_to_id_only_names() {
+        let entries = Arc::new(FakeEntryRepo::new());
+        entries.insert(make_entry("e1", "ev1", true));
+        let events = Arc::new(FakeEventRepo::new());
+        events.set_source(&event_id("ev1"), Some(local_id()));
+        let trusted = Arc::new(FakeTrustedPeerRepo::new(vec![peer("p1")]));
+        let delivery = Arc::new(FakeDeliveryRepo::new(vec![delivered(
+            "e1",
+            peer("p1"),
+            100,
+        )]));
+        let members = Arc::new(FakeMemberRepo::failing());
+
+        let uc = build_uc_with_members(entries, events, trusted, delivery, members);
+        let view = uc.execute(&entry_id("e1")).await.expect("仍应返回视图");
+        assert_eq!(view.deliveries.len(), 1);
+        assert!(
+            view.deliveries[0].target_device_name.is_none(),
+            "member_repo 故障时名字降级为 None,而不是阻断整个视图"
+        );
     }
 }

--- a/src-tauri/crates/uc-tauri/src/commands/clipboard_delivery.rs
+++ b/src-tauri/crates/uc-tauri/src/commands/clipboard_delivery.rs
@@ -43,10 +43,13 @@ pub struct EntryDeliveryViewDto {
 pub enum EntrySourceDto {
     /// 本机捕获。
     Local,
-    /// 远端推送。`deviceId` 是来源设备,Phase 3 起补 `deviceName`。
+    /// 远端推送。`deviceId` 是来源设备,`deviceName` 取自空间成员目录;
+    /// 不命中时为 `null`,前端 fallback 到 device_id 截断。
     Remote {
         #[serde(rename = "deviceId")]
         device_id: String,
+        #[serde(rename = "deviceName")]
+        device_name: Option<String>,
     },
     /// 追踪机制启用前已存在的老 entry,无可靠投递信息。
     Historical,
@@ -56,6 +59,9 @@ pub enum EntrySourceDto {
 #[serde(rename_all = "camelCase")]
 pub struct EntryDeliveryTargetDto {
     pub target_device_id: String,
+    /// 取自空间成员目录中的人类可读名;不命中时为 `null`,前端 fallback
+    /// 到 `targetDeviceId` 截断。
+    pub target_device_name: Option<String>,
     pub status: EntryDeliveryStatusDto,
     /// 失败时的 wire 层错误细节,供 UI tooltip / 详情展开使用。
     pub reason_detail: Option<String>,
@@ -105,8 +111,12 @@ impl From<EntrySource> for EntrySourceDto {
     fn from(source: EntrySource) -> Self {
         match source {
             EntrySource::Local => EntrySourceDto::Local,
-            EntrySource::Remote { device_id } => EntrySourceDto::Remote {
+            EntrySource::Remote {
+                device_id,
+                device_name,
+            } => EntrySourceDto::Remote {
                 device_id: device_id.as_str().to_string(),
+                device_name,
             },
             EntrySource::Historical => EntrySourceDto::Historical,
         }
@@ -117,6 +127,7 @@ impl From<EntryDeliveryTargetView> for EntryDeliveryTargetDto {
     fn from(target: EntryDeliveryTargetView) -> Self {
         Self {
             target_device_id: target.target_device_id.as_str().to_string(),
+            target_device_name: target.target_device_name,
             status: target.status.into(),
             reason_detail: target.reason_detail,
             updated_at_ms: target.updated_at_ms,

--- a/src/api/tauri-command/clipboard_delivery.ts
+++ b/src/api/tauri-command/clipboard_delivery.ts
@@ -23,7 +23,12 @@ import { commands } from '@/lib/ipc'
 /** entry 来源描述。 */
 export type EntrySourceView =
   | { tag: 'local' }
-  | { tag: 'remote'; deviceId: string }
+  | {
+      tag: 'remote'
+      deviceId: string
+      /** 取自空间成员目录;未命中时为 null,渲染层 fallback 到 device_id 截断。 */
+      deviceName: string | null
+    }
   | { tag: 'historical' }
 
 /** 失败原因细分,与 i18n key `delivery.failureReason.<variant>` 对应。 */
@@ -39,6 +44,8 @@ export type EntryDeliveryStatusView =
 /** 单个对端的当前同步状态。 */
 export interface EntryDeliveryTargetView {
   targetDeviceId: string
+  /** 取自空间成员目录;未命中时为 null,渲染层 fallback 到 device_id 截断。 */
+  targetDeviceName: string | null
   status: EntryDeliveryStatusView
   /** 失败时的 wire 层错误细节,可选;成功 / Pending 时为 null。 */
   reasonDetail: string | null

--- a/src/components/clipboard/EntryDeliveryBadge.tsx
+++ b/src/components/clipboard/EntryDeliveryBadge.tsx
@@ -58,6 +58,12 @@ function truncateDeviceId(deviceId: string): string {
   return `${deviceId.slice(0, 8)}…`
 }
 
+/** 名字优先于 id:后端解析到真实 name 就用,否则截断 device_id。 */
+function deviceLabel(name: string | null | undefined, deviceId: string): string {
+  if (name && name.trim().length > 0) return name
+  return truncateDeviceId(deviceId)
+}
+
 function summarize(targets: readonly EntryDeliveryTargetView[]): SyncSummary | null {
   if (targets.length === 0) return null
   let delivered = 0
@@ -123,7 +129,9 @@ const SourceBadge: React.FC<SourceBadgeProps> = ({ source }) => {
       case 'remote':
         return {
           Icon: Cloud,
-          label: t('delivery.source.remoteShort', { device: truncateDeviceId(source.deviceId) }),
+          label: t('delivery.source.remoteShort', {
+            device: deviceLabel(source.deviceName, source.deviceId),
+          }),
           tone: 'text-sky-500/80',
         }
       case 'historical':
@@ -256,8 +264,13 @@ const DeliveryRow: React.FC<DeliveryRowProps> = ({ target }) => {
       <span className={cn('shrink-0', tone.icon)} aria-hidden>
         {renderStatusIcon(target.status)}
       </span>
-      <span className="min-w-0 flex-1 truncate font-mono text-foreground/80">
-        {truncateDeviceId(target.targetDeviceId)}
+      <span
+        className={cn(
+          'min-w-0 flex-1 truncate text-foreground/80',
+          target.targetDeviceName && target.targetDeviceName.trim().length > 0 ? '' : 'font-mono'
+        )}
+      >
+        {deviceLabel(target.targetDeviceName, target.targetDeviceId)}
       </span>
       <span className={cn('shrink-0', tone.label)}>{renderStatusLabel(target.status, t)}</span>
     </li>

--- a/src/components/clipboard/EntryDeliverySection.tsx
+++ b/src/components/clipboard/EntryDeliverySection.tsx
@@ -10,8 +10,8 @@
  *   - Local + 无 deliveries: 显示"暂未配对任何设备"提示
  *   - delivery 为 null (loading / fetch failed): 渲染骨架或直接隐藏
  *
- * device 名暂用 device_id 前 8 字符 (Phase 3 起 `DeviceDirectoryPort` 落地后
- * 换成真实名称)。
+ * 设备显示名:优先用后端解析后的 `deviceName` / `targetDeviceName`(取自
+ * 空间成员目录),不命中时 fallback 到 device_id 前 8 字符截断。
  */
 
 import { Check, CircleDashed, X } from 'lucide-react'
@@ -44,6 +44,12 @@ const FAILURE_REASON_KEYS: Record<DeliveryFailureReason, string> = {
 function truncateDeviceId(deviceId: string): string {
   if (deviceId.length <= 10) return deviceId
   return `${deviceId.slice(0, 8)}…`
+}
+
+/** 名字优先于 id:后端解析到真实 name 就用,否则截断 device_id。 */
+function deviceLabel(name: string | null | undefined, deviceId: string): string {
+  if (name && name.trim().length > 0) return name
+  return truncateDeviceId(deviceId)
 }
 
 const EntryDeliverySection: React.FC<EntryDeliverySectionProps> = ({
@@ -93,7 +99,9 @@ const SourceLine: React.FC<SourceLineProps> = ({ source, className }) => {
       case 'local':
         return t('delivery.source.local')
       case 'remote':
-        return t('delivery.source.remote', { device: truncateDeviceId(source.deviceId) })
+        return t('delivery.source.remote', {
+          device: deviceLabel(source.deviceName, source.deviceId),
+        })
       case 'historical':
         return t('delivery.source.historical')
     }
@@ -164,8 +172,14 @@ const DeliveryRow: React.FC<DeliveryRowProps> = ({ target, rowPad, textSize }) =
       <span className={cn('shrink-0', tone.icon)} aria-hidden>
         {icon}
       </span>
-      <span className="min-w-0 flex-1 truncate font-mono text-foreground/80">
-        {truncateDeviceId(target.targetDeviceId)}
+      <span
+        className={cn(
+          'min-w-0 flex-1 truncate text-foreground/80',
+          // 用了真实名字时不再 monospace —— monospace 留给截断的 device_id。
+          target.targetDeviceName && target.targetDeviceName.trim().length > 0 ? '' : 'font-mono'
+        )}
+      >
+        {deviceLabel(target.targetDeviceName, target.targetDeviceId)}
       </span>
       <span className={cn('shrink-0', tone.label)}>{label}</span>
     </li>

--- a/src/components/clipboard/__tests__/EntryDeliverySection.test.tsx
+++ b/src/components/clipboard/__tests__/EntryDeliverySection.test.tsx
@@ -13,24 +13,28 @@ function mixedDelivery(): EntryDeliveryView {
     deliveries: [
       {
         targetDeviceId: 'did_a1b2c3d4e5',
+        targetDeviceName: null,
         status: { tag: 'delivered' },
         reasonDetail: null,
         updatedAtMs: 1_700_000_000_000,
       },
       {
         targetDeviceId: 'did_f6g7h8i9j0',
+        targetDeviceName: null,
         status: { tag: 'duplicate' },
         reasonDetail: null,
         updatedAtMs: 1_700_000_000_001,
       },
       {
         targetDeviceId: 'did_k1l2m3n4o5',
+        targetDeviceName: null,
         status: { tag: 'failed', reason: 'offline' },
         reasonDetail: 'no route to host',
         updatedAtMs: 1_700_000_000_002,
       },
       {
         targetDeviceId: 'did_p6q7r8s9t0',
+        targetDeviceName: null,
         status: { tag: 'pending' },
         reasonDetail: null,
         updatedAtMs: null,
@@ -98,13 +102,14 @@ describe('EntryDeliverySection', () => {
     expect(screen.getByText(i18n.t('delivery.list.noPeers'))).toBeInTheDocument()
   })
 
-  it('renders remote source with truncated device id', () => {
+  it('renders remote source with truncated device id when name is missing', () => {
     const delivery: EntryDeliveryView = {
       entryId: 'entry-remote',
-      source: { tag: 'remote', deviceId: 'did_sender_xyz' },
+      source: { tag: 'remote', deviceId: 'did_sender_xyz', deviceName: null },
       deliveries: [
         {
           targetDeviceId: 'did_peer_aaa',
+          targetDeviceName: null,
           status: { tag: 'delivered' },
           reasonDetail: null,
           updatedAtMs: 1_700_000_000_000,
@@ -113,8 +118,41 @@ describe('EntryDeliverySection', () => {
     }
     render(<EntryDeliverySection delivery={delivery} />)
 
-    // remote 来源行用截断 device id 替代 (Phase 3 起补真实 name)
+    // 名字缺失时 fallback 到 device_id 截断
     expect(screen.getByText('did_send…')).toBeInTheDocument()
+  })
+
+  it('prefers device names over device ids when resolved', () => {
+    const delivery: EntryDeliveryView = {
+      entryId: 'entry-named',
+      source: { tag: 'remote', deviceId: 'did_sender_xyz', deviceName: 'Mac Studio' },
+      deliveries: [
+        {
+          targetDeviceId: 'did_target_aaa',
+          targetDeviceName: 'iPad Pro',
+          status: { tag: 'delivered' },
+          reasonDetail: null,
+          updatedAtMs: 1_700_000_000_000,
+        },
+        {
+          // 空白名应被视为缺失,fallback 到 id 截断
+          targetDeviceId: 'did_target_bbb',
+          targetDeviceName: '   ',
+          status: { tag: 'pending' },
+          reasonDetail: null,
+          updatedAtMs: null,
+        },
+      ],
+    }
+    render(<EntryDeliverySection delivery={delivery} />)
+
+    // 来源用真实 name 而不是截断 id
+    expect(screen.getByText('Mac Studio')).toBeInTheDocument()
+    expect(screen.queryByText('did_send…')).not.toBeInTheDocument()
+
+    // 第一台 target 用真实名;第二台 fallback 到截断 id
+    expect(screen.getByText('iPad Pro')).toBeInTheDocument()
+    expect(screen.getByText('did_targ…')).toBeInTheDocument()
   })
 
   it('maps all five failure reasons to their i18n labels', () => {
@@ -124,6 +162,7 @@ describe('EntryDeliverySection', () => {
       source: { tag: 'local' },
       deliveries: reasons.map((reason, idx) => ({
         targetDeviceId: `did_peer_${idx}xxxxxxxx`,
+        targetDeviceName: null,
         status: { tag: 'failed', reason },
         reasonDetail: null,
         updatedAtMs: 1_700_000_000_000 + idx,

--- a/src/lib/ipc-bindings.generated.ts
+++ b/src/lib/ipc-bindings.generated.ts
@@ -423,6 +423,11 @@ export type EntryDeliveryStatusDto = { tag: "pending" } | { tag: "delivered" } |
 
 export type EntryDeliveryTargetDto = {
 	targetDeviceId: string,
+	/**
+	 *  取自空间成员目录中的人类可读名;不命中时为 `null`,前端 fallback
+	 *  到 `targetDeviceId` 截断。
+	 */
+	targetDeviceName: string | null,
 	status: EntryDeliveryStatusDto,
 	/**  失败时的 wire 层错误细节,供 UI tooltip / 详情展开使用。 */
 	reasonDetail: string | null,
@@ -449,8 +454,11 @@ export type EntryDeliveryViewDto = {
 export type EntrySourceDto = 
 /**  本机捕获。 */
 { tag: "local" } | 
-/**  远端推送。`deviceId` 是来源设备,Phase 3 起补 `deviceName`。 */
-{ tag: "remote"; deviceId: string } | 
+/**
+ *  远端推送。`deviceId` 是来源设备,`deviceName` 取自空间成员目录;
+ *  不命中时为 `null`,前端 fallback 到 device_id 截断。
+ */
+{ tag: "remote"; deviceId: string; deviceName: string | null } | 
 /**  追踪机制启用前已存在的老 entry,无可靠投递信息。 */
 { tag: "historical" };
 


### PR DESCRIPTION
## Summary

- Entry detail UI now shows human-readable device names (e.g. "Mac Studio") instead of the truncated `did_…` placeholder, by reading `SpaceMember.device_name` already written during pairing. `did_…` truncation remains as the fallback when the peer is not a current member or the name is blank (commit `f41ec470`).
- `GetEntryDeliveryViewUseCase` takes `MemberRepositoryPort` and does one `list()` per view to build a name index; `EntrySource::Remote` gains `device_name`, `EntryDeliveryTargetView` gains `target_device_name`. Tauri DTO + specta bindings + frontend types/components mirror the new field.
- Strategy revision vs. original plan D6: dropped the planned new `device_directory` table + port — `trusted_peer ⊆ space_member` holds across the roster lifecycle, so the dedicated directory would have been a redundant second source of truth (decision logged as D6.v2 in `findings.md` / `task_plan.md`).
- `member_repo.list` failure gracefully degrades to id-only fallback rather than blocking the view.
- No new persistent structures, no new migrations, no docs-site changes — Phase 3 was a pure consumer of facts already on the wire.

Closes #704.

## Test plan

- [x] \`cargo check --workspace --tests\` clean.
- [x] \`cargo test -p uc-application --lib\` → 477/477; the view use case suite (\`get_entry_delivery_view\`) is 10/10 including 3 new branches for name hit / blank fallback / member_repo failure.
- [x] \`cargo test -p uc-infra --lib db::repositories::entry_delivery_repo\` → 6/6 (no regression).
- [x] \`bunx tsc --noEmit\` clean.
- [x] \`bun run test src/components/clipboard/__tests__/EntryDeliverySection.test.tsx\` → 7/7 including the new "name preferred over id, blank fallback" case.
- [x] \`cargo test -p uc-tauri --test specta_export\` regenerated \`src/lib/ipc-bindings.generated.ts\` to include the new \`deviceName\` / \`targetDeviceName\` fields.
- [ ] Manual: pair two desktops, copy something on peer A, open the same entry's detail on peer B — confirm "来自 / From" shows the real device name (not \`did_…\`); same for the per-target rows on the sending side.
- [ ] Manual: pair, then revoke a peer that had received entries — confirm the older entries' delivery rows for that peer are now filtered out of the view (orphan filtering, already covered by Phase 1, just sanity check in this UI shape).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Clipboard delivery status now displays human-readable device names from the member directory, with automatic fallback to truncated device identifiers when names are not available.

* **Tests**
  * Added comprehensive test coverage for device name resolution, blank name handling, and graceful fallback when member data is unavailable.

* **Documentation**
  * Updated implementation strategy documentation and task planning to reflect Phase 3 completion.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/UniClipboard/UniClipboard/pull/736?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->