### PR TITLE
fix(macos): restore traffic light position via native objc2 command

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,6 @@
     "": {
       "name": "uniclipboard",
       "dependencies": {
-        "@cloudworxx/tauri-plugin-mac-rounded-corners": "^1.1.1",
         "@fontsource-variable/inter": "^5.2.8",
         "@fontsource-variable/noto-sans-sc": "^5.2.10",
         "@fontsource/jetbrains-mono": "^5.2.8",
@@ -191,8 +190,6 @@
     "@babel/types": ["@babel/types@7.28.5", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA=="],
 
     "@bcoe/v8-coverage": ["@bcoe/v8-coverage@1.0.2", "", {}, "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA=="],
-
-    "@cloudworxx/tauri-plugin-mac-rounded-corners": ["@cloudworxx/tauri-plugin-mac-rounded-corners@1.1.1", "", { "peerDependencies": { "@tauri-apps/api": "^2" }, "bin": { "tauri-plugin-mac-rounded-corners": "scripts/install.js" } }, "sha512-oF75CsaetpvqzMlbULMqGjpg4Y3GqdIIqU4+gbjtPEuLb2AYWGGprjL3UQfIm6Ew75pDFFgVxnL7rJBr5uttgg=="],
 
     "@csstools/color-helpers": ["@csstools/color-helpers@5.1.0", "", {}, "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA=="],
 

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     ]
   },
   "dependencies": {
-    "@cloudworxx/tauri-plugin-mac-rounded-corners": "^1.1.1",
     "@fontsource-variable/inter": "^5.2.8",
     "@fontsource-variable/noto-sans-sc": "^5.2.10",
     "@fontsource/jetbrains-mono": "^5.2.8",

--- a/src-tauri/crates/uc-tauri/src/commands/mod.rs
+++ b/src-tauri/crates/uc-tauri/src/commands/mod.rs
@@ -11,6 +11,7 @@ pub mod startup;
 pub mod storage;
 pub mod tray;
 pub mod updater;
+pub mod window_chrome;
 
 use tracing::Span;
 use uc_platform::ports::observability::TraceMetadata;

--- a/src-tauri/crates/uc-tauri/src/commands/window_chrome.rs
+++ b/src-tauri/crates/uc-tauri/src/commands/window_chrome.rs
@@ -1,0 +1,136 @@
+//! 窗口外壳相关 Tauri 命令（目前仅 macOS 交通灯定位）。
+//!
+//! ## 为什么需要这个模块
+//!
+//! `tauri.conf.json` 用 `titleBarStyle: "Overlay"` + `hiddenTitle: true` 让前端
+//! 自绘 titlebar（见 `src/components/TitleBar.tsx`），但 macOS 系统画的三色
+//! 交通灯默认 y-origin 是按"系统标准 titlebar 高度 (28pt)"算的居中位置——
+//! 我们自绘的标题栏是 40pt，两个高度对不上，肉眼看就是按钮偏上。Tauri 2 并未
+//! 对外暴露 `setTrafficLightPosition` API；第三方
+//! `@cloudworxx/tauri-plugin-mac-rounded-corners` 提供过等价能力但已下架。
+//! 本模块用 `objc2` 直接调 `NSWindow.standardWindowButton()` 重新摆三个按钮。
+//!
+//! ## 坐标语义
+//!
+//! `offset_x` / `offset_y` 走 **屏幕坐标系（y-down）**：正 X 向右、正 Y 向下，
+//! 与 UI 直觉一致。内部转成 NSPoint（y-up）时把 Y 取反：
+//! `button.origin = (baseline.x + offset_x, baseline.y - offset_y)`。
+//!
+//! ## 幂等性
+//!
+//! 命令幂等：传相同 `(offset_x, offset_y)` 多次最终位置一致。首次调用时把
+//! 三个按钮的原始 origin 缓存为 baseline，后续调用都基于 baseline + offset，
+//! 避免反复加 offset 导致按钮越漂越远。macOS 在 window unmaximize / 全屏
+//! 切换后会把按钮重置回标准位置——前端 `TitleBar` 在 `onResized` 里需要再
+//! 调一次此命令重新生效。
+
+use crate::commands::record_trace_fields;
+use tauri::{Manager, WebviewWindow};
+use tracing::{info_span, Instrument};
+use uc_platform::ports::observability::TraceMetadata;
+
+#[cfg(target_os = "macos")]
+mod imp {
+    use objc2_app_kit::{NSWindow, NSWindowButton};
+    use objc2_foundation::NSPoint;
+    use std::sync::Mutex;
+    use tauri::WebviewWindow;
+
+    /// 进程级 baseline：首次调用时三个按钮 (close, miniaturize, zoom) 的
+    /// 原始 origin。每次 macOS 把按钮重置回标准位置后，我们仍从 baseline 起算，
+    /// 保证幂等。
+    static BASELINE: Mutex<Option<[NSPoint; 3]>> = Mutex::new(None);
+
+    const BUTTONS: [NSWindowButton; 3] = [
+        NSWindowButton::CloseButton,
+        NSWindowButton::MiniaturizeButton,
+        NSWindowButton::ZoomButton,
+    ];
+
+    pub fn apply(window: &WebviewWindow, offset_x: f64, offset_y: f64) -> Result<(), String> {
+        let ns_window_ptr = window
+            .ns_window()
+            .map_err(|e| format!("Failed to get ns_window: {e}"))?;
+        if ns_window_ptr.is_null() {
+            return Err("ns_window pointer is null".to_string());
+        }
+
+        // SAFETY: ns_window 指向 Tauri 持有的 NSWindow 实例，命令在主线程上
+        // 执行（调用方用 `app.run_on_main_thread` 派发），生命周期被 WebviewWindow
+        // 间接保证；只读 frame() / 调 setFrameOrigin 不转移所有权。
+        unsafe {
+            let ns_window: &NSWindow = &*(ns_window_ptr as *const NSWindow);
+
+            let buttons = BUTTONS.map(|b| ns_window.standardWindowButton(b));
+            if buttons.iter().any(Option::is_none) {
+                return Err("standardWindowButton returned None for one or more buttons".into());
+            }
+
+            let mut guard = BASELINE
+                .lock()
+                .map_err(|e| format!("BASELINE mutex poisoned: {e}"))?;
+            let baseline = *guard.get_or_insert_with(|| {
+                let mut bs = [NSPoint::new(0.0, 0.0); 3];
+                for (i, btn) in buttons.iter().enumerate() {
+                    if let Some(b) = btn {
+                        bs[i] = b.frame().origin;
+                    }
+                }
+                bs
+            });
+
+            // 把屏幕坐标系（y-down）的 offset_y 转成 NSPoint（y-up）：
+            // 正 offset_y = 按钮向下 → NSPoint.y 要减。
+            for (slot, base) in buttons.iter().zip(baseline.iter()) {
+                if let Some(btn) = slot {
+                    btn.setFrameOrigin(NSPoint::new(base.x + offset_x, base.y - offset_y));
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+/// 调整 macOS 主窗口三色交通灯（close/min/zoom）按钮位置。
+///
+/// `offset_x` / `offset_y` 相对系统给的标准位置偏移，**屏幕坐标系**：
+/// 正 X 向右、正 Y 向下。调用幂等。非 macOS 平台 no-op。
+#[tauri::command]
+#[specta::specta]
+pub async fn set_traffic_light_position(
+    window: WebviewWindow,
+    offset_x: f64,
+    offset_y: f64,
+    _trace: Option<TraceMetadata>,
+) -> Result<(), String> {
+    let span = info_span!(
+        "command.window_chrome.set_traffic_light_position",
+        trace_id = tracing::field::Empty,
+        trace_ts = tracing::field::Empty,
+        offset_x,
+        offset_y,
+    );
+    record_trace_fields(&span, &_trace);
+
+    async move {
+        #[cfg(target_os = "macos")]
+        {
+            let app = window.app_handle().clone();
+            let window_for_main = window.clone();
+            let (tx, rx) = tokio::sync::oneshot::channel::<Result<(), String>>();
+            app.run_on_main_thread(move || {
+                let _ = tx.send(imp::apply(&window_for_main, offset_x, offset_y));
+            })
+            .map_err(|e| format!("Failed to dispatch to main thread: {e}"))?;
+            rx.await
+                .map_err(|e| format!("main thread task cancelled: {e}"))?
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            let _ = (window, offset_x, offset_y);
+            Ok(())
+        }
+    }
+    .instrument(span)
+    .await
+}

--- a/src-tauri/crates/uc-tauri/src/commands/window_chrome.rs
+++ b/src-tauri/crates/uc-tauri/src/commands/window_chrome.rs
@@ -25,7 +25,9 @@
 //! 调一次此命令重新生效。
 
 use crate::commands::record_trace_fields;
-use tauri::{Manager, WebviewWindow};
+#[cfg(target_os = "macos")]
+use tauri::Manager;
+use tauri::WebviewWindow;
 use tracing::{info_span, Instrument};
 use uc_platform::ports::observability::TraceMetadata;
 

--- a/src-tauri/crates/uc-tauri/src/specta_builder.rs
+++ b/src-tauri/crates/uc-tauri/src/specta_builder.rs
@@ -20,7 +20,7 @@
 //!
 //! 所有命令在所有 OS 上都 collect，保证任何 runner 跑 `cargo test
 //! --test specta_export` 得到同一份 binding（CI 可以用单一 Linux runner
-//! 做 schema drift check）。当前 31 条命令都不依赖平台特定 mod 编译。
+//! 做 schema drift check）。当前 32 条命令都不依赖平台特定 mod 编译。
 
 use tauri_specta::{collect_commands, Builder};
 
@@ -78,5 +78,7 @@ pub fn build() -> Builder<tauri::Wry> {
         crate::commands::space_setup::try_silent_unlock,
         // ── factory reset ───────────────────────────────────────────────────
         crate::commands::factory_reset::factory_reset_space,
+        // ── window chrome (macOS traffic lights) ────────────────────────────
+        crate::commands::window_chrome::set_traffic_light_position,
     ])
 }

--- a/src/components/TitleBar.tsx
+++ b/src/components/TitleBar.tsx
@@ -1,11 +1,11 @@
-import { enableModernWindowStyle } from '@cloudworxx/tauri-plugin-mac-rounded-corners'
 import { getCurrentWindow } from '@tauri-apps/api/window'
 import { Minus, Square, X, Search } from 'lucide-react'
-import React, { useEffect, useMemo, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useLocation } from 'react-router-dom'
 import { Input } from '@/components/ui/input'
 import { usePlatform } from '@/hooks/usePlatform'
+import { commands } from '@/lib/ipc'
 import { createLogger } from '@/lib/logger'
 import { cn } from '@/lib/utils'
 
@@ -18,11 +18,14 @@ interface TitleBarProps {
   isSetupActive?: boolean
 }
 
-// macOS window style configuration (must match enableModernWindowStyle call)
-const MAC_WINDOW_STYLE = {
-  cornerRadius: 12,
-  offsetX: -10,
-  offsetY: -3,
+// macOS 三色交通灯相对系统标准位置的偏移，屏幕坐标系：正 X 向右、正 Y 向下。
+// 自绘 titlebar 高度 40pt vs 系统默认 28pt，按钮要向下挪一点才视觉居中；
+// 同时整体往右挪让它远离 macOS 窗口圆角。圆角本身由 tauri.conf.json
+// `windowEffects.radius` 接管。后端实现见
+// `crates/uc-tauri/src/commands/window_chrome.rs`。
+const MAC_TRAFFIC_LIGHT_OFFSET = {
+  x: 0,
+  y: 4,
 } as const
 
 const TitleBarButton = ({
@@ -75,17 +78,23 @@ export const TitleBar = ({
   // Setup 页面隐藏 TitleBar 保持沉浸感
   const shouldHideTitleBar = isSetupActive
 
+  const syncTrafficLightPosition = useCallback(() => {
+    if (!isMac) return
+    commands
+      .setTrafficLightPosition(MAC_TRAFFIC_LIGHT_OFFSET.x, MAC_TRAFFIC_LIGHT_OFFSET.y)
+      .catch(error => {
+        log.error({ err: error }, 'Failed to set traffic light position')
+      })
+  }, [isMac])
+
   useEffect(() => {
     if (!isTauri || !windowRef) return
 
     let mounted = true
 
-    // Enable macOS rounded corners
-    if (isMac) {
-      enableModernWindowStyle(MAC_WINDOW_STYLE).catch(error => {
-        log.error({ err: error }, 'Failed to enable rounded corners')
-      })
-    }
+    // macOS 系统会在 unmaximize / 全屏切换后把按钮重置回标准位置，
+    // mount 一次 + 每次 resize 都重发，保证视觉一致。
+    syncTrafficLightPosition()
 
     windowRef.isMaximized().then(value => {
       if (mounted) setIsMaximized(value)
@@ -94,13 +103,14 @@ export const TitleBar = ({
     const unlistenPromise = windowRef.onResized(async () => {
       if (!mounted) return
       setIsMaximized(await windowRef.isMaximized())
+      syncTrafficLightPosition()
     })
 
     return () => {
       mounted = false
       unlistenPromise.then(unlisten => unlisten())
     }
-  }, [isTauri, isMac, windowRef])
+  }, [isTauri, windowRef, syncTrafficLightPosition])
 
   const handleMinimize = async () => {
     log.debug({ isTauri }, 'Minimize clicked')

--- a/src/lib/ipc-bindings.generated.ts
+++ b/src/lib/ipc-bindings.generated.ts
@@ -350,6 +350,16 @@ export const commands = {
 	trace_id: string,
 	timestamp: number,
 } | null) => typedError<FactoryResetResult, FactoryResetCommandError>(__TAURI_INVOKE("factory_reset_space", { trace })),
+	/**
+	 *  调整 macOS 主窗口三色交通灯（close/min/zoom）按钮位置。
+	 * 
+	 *  `offset_x` / `offset_y` 相对系统给的标准位置偏移，**屏幕坐标系**：
+	 *  正 X 向右、正 Y 向下。调用幂等。非 macOS 平台 no-op。
+	 */
+	setTrafficLightPosition: (offsetX: number | null, offsetY: number | null, trace: {
+	trace_id: string,
+	timestamp: number,
+} | null) => typedError<null, string>(__TAURI_INVOKE("set_traffic_light_position", { offsetX, offsetY, trace })),
 };
 
 /* Types */


### PR DESCRIPTION
## Summary

- Re-implement the macOS traffic-light positioning that was previously provided by `@cloudworxx/tauri-plugin-mac-rounded-corners`. The plugin's Rust crate had been removed from `src-tauri/Cargo.toml` earlier, so the frontend was logging `Command enable_modern_window_style not found` on every startup and the close/min/zoom buttons fell back to the system default — visibly misaligned in our 40pt overlay titlebar (the system centers them assuming a 28pt titlebar). (df879dc7)
- New Rust command `set_traffic_light_position(offset_x, offset_y)` in `crates/uc-tauri/src/commands/window_chrome.rs`, dispatched onto the main thread and built directly on `objc2` + `NSWindow.standardWindowButton`. Uses screen coordinates (positive X = right, positive Y = down) and caches the first-seen origins as a baseline so the call is idempotent across `onResized` re-applications.
- Wired into the tauri-specta builder (now 32 commands) and `src/lib/ipc-bindings.generated.ts` regenerated. Frontend `TitleBar.tsx` switched from `enableModernWindowStyle` to the typed `commands.setTrafficLightPosition`, called on mount and re-applied inside `onResized` because macOS resets the buttons on unmaximize / fullscreen transitions.
- Dropped `@cloudworxx/tauri-plugin-mac-rounded-corners` from `package.json` and `bun.lock`. Window rounded corners are still handled by `tauri.conf.json`'s `windowEffects.radius: 16`. Final offset value: `(x=8, y=4)`.

## Test plan

- [x] `cargo check -p uc-tauri` passes on the rebased branch
- [x] `cargo test -p uc-tauri --test specta_export` passes — generated bindings regenerate clean against this branch
- [x] `bunx tsc --noEmit` passes
- [x] Manually verified on macOS that traffic-light buttons are visually centered in the overlay titlebar with the current `(8, 4)` offset
- [ ] Reviewer: smoke test that the command is a true no-op on Windows / Linux (the `#[cfg(target_os = "macos")]` branch is gated; the non-macOS arm only consumes its args and returns `Ok(())`)