### PR TITLE
fix(ui/update): close update dialog when starting background download

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -215,13 +215,12 @@ const Sidebar: React.FC<SidebarProps> = ({ className }) => {
     }
   }
 
-  const handleStartBackgroundDownload = async () => {
-    try {
-      await downloadUpdate()
-    } catch (error) {
+  const handleStartBackgroundDownload = () => {
+    setUpdateDialogOpen(false)
+    downloadUpdate().catch(error => {
       log.error({ err: error }, '后台下载失败')
       toast.error(t('update.downloadFailed'))
-    }
+    })
   }
 
   const handleCancelDownload = async () => {
@@ -432,7 +431,7 @@ const Sidebar: React.FC<SidebarProps> = ({ className }) => {
                   <AlertDialogAction
                     onClick={event => {
                       event.preventDefault()
-                      void handleStartBackgroundDownload()
+                      handleStartBackgroundDownload()
                     }}
                     disabled={isInstalling}
                   >


### PR DESCRIPTION
## Summary

- 用户在更新对话框点「后台下载」后，对话框不再保持打开。之前 `handleStartBackgroundDownload` 走的是 `await downloadUpdate()`，而 `downloadUpdate` 直到整个下载完成才 resolve，所以即使下载已经在后台跑，UI 上的 modal 仍然在前面挡着。改成同步先 `setUpdateDialogOpen(false)` 再用 `.catch` 处理失败提示，下载逻辑保持不变（89f701fd）。
- 下载进度仍然由 `UpdateContext` 驱动：侧边栏图标会显示进度环，用户重新点开 dialog 也能看到 `downloading` 分支的进度条与「取消下载」按钮，所以可取消能力没有被牺牲。
- 仅触碰 `src/components/layout/Sidebar.tsx`，没有改 i18n / 设置 / 默认值；`docs-site/` 里关于「后台下载」的描述没有断言对话框的开/关行为，确认无需 docs 变更。

## Test plan

- [x] `git diff` 检查行为只有「点后台下载 → 关 dialog」一个变化，下载/取消/重开 dialog 的状态机仍由 `UpdateContext` + 事件订阅维护。
- [ ] 手动验证：在 `Available` 状态点更新图标 → 「后台下载」→ dialog 立即关闭；侧边栏图标转为带进度环；重新点图标，dialog 内进度条 + 「取消下载」可用。
- [ ] 手动验证下载失败路径：`downloadUpdate` reject 时仍弹 `toast.error(t('update.downloadFailed'))`，并且 `UpdateContext` 把 phase 回退到 `available`。