### PR TITLE
feat(clipboard): ingest local image files into blob store

### DIFF
--- a/src-tauri/crates/uc-application/src/clipboard_capture/usecase.rs
+++ b/src-tauri/crates/uc-application/src/clipboard_capture/usecase.rs
@@ -23,13 +23,14 @@ use std::sync::Arc;
 use std::time::SystemTime;
 
 use anyhow::Result;
-use futures::future::try_join_all;
 use tracing::{debug, info, info_span, Instrument};
 use uc_observability::analytics::{
     AnalyticsPort, CaptureOrigin, Event, PayloadSizeBucket, PayloadType,
 };
 use uc_observability::{stages, FlowId};
 
+use uc_core::blob::ports::BlobWriterPort;
+use uc_core::clipboard::{ClipboardPayloadSource, PersistedClipboardRepresentation};
 use uc_core::ids::{EntryId, EventId};
 use uc_core::ports::clipboard::{RepresentationCachePort, SpoolQueuePort, SpoolRequest};
 use uc_core::ports::{
@@ -54,6 +55,11 @@ pub struct CaptureClipboardUseCase {
     device_identity: Arc<dyn DeviceIdentityPort>,
     representation_cache: Arc<dyn RepresentationCachePort>,
     spool_queue: Arc<dyn SpoolQueuePort>,
+    /// 用于把 path-backed `ObservedClipboardRepresentation` 同步物化进 blob 仓库。
+    /// 触发时机:capture 入口检测到 `ClipboardPayloadSource::LocalFile` 的 rep,
+    /// 调 `write_path_if_absent` 得到 `BlobId`,直接产出 `BlobReady` 状态的
+    /// `PersistedClipboardRepresentation`,绕过 normalizer / cache / spool 通路。
+    blob_writer: Arc<dyn BlobWriterPort>,
     /// schema doc §12.1 · outbound 同步链路源头流量信号。
     /// 仅在 `ClipboardChangeOrigin::{LocalCapture, LocalRestore}` 路径 emit；
     /// `RemotePush` 严禁 emit（红线：与入站同步双计会污染 DAU 信号）。
@@ -69,6 +75,7 @@ impl CaptureClipboardUseCase {
         device_identity: Arc<dyn DeviceIdentityPort>,
         representation_cache: Arc<dyn RepresentationCachePort>,
         spool_queue: Arc<dyn SpoolQueuePort>,
+        blob_writer: Arc<dyn BlobWriterPort>,
         analytics: Arc<dyn AnalyticsPort>,
     ) -> Self {
         Self {
@@ -79,6 +86,7 @@ impl CaptureClipboardUseCase {
             device_identity,
             representation_cache,
             spool_queue,
+            blob_writer,
             analytics,
         }
     }
@@ -169,14 +177,54 @@ impl CaptureClipboardUseCase {
                 snapshot_hash,
             );
 
-            // 3. Normalize representations
+            // 3. Normalize representations.
+            //
+            // 分流:Inline source 走 normalizer 既有逻辑(inline / staged / staged_with_preview
+            // 决策);LocalFile source 调 BlobWriter.write_path_if_absent 同步物化到 blob 仓库,
+            // 直接产出 BlobReady 状态的 PersistedRep —— 绕过 representation_cache / spool_queue,
+            // 因为它不需要"暂存字节等待异步物化"。
+            //
+            // LocalFile 在 capture 同步路径里物化(hardlink 时是 O(1),跨卷流式 copy 时是
+            // O(file_size) IO),让 dashboard 第一秒就能从 /clipboard/blobs/{blob_id} 取到真图。
             let normalized_reps = async {
-                let normalized_futures: Vec<_> = snapshot
-                    .representations
-                    .iter()
-                    .map(|rep| self.representation_normalizer.normalize(rep))
-                    .collect();
-                try_join_all(normalized_futures).await
+                let mut out: Vec<PersistedClipboardRepresentation> =
+                    Vec::with_capacity(snapshot.representations.len());
+                for observed in &snapshot.representations {
+                    match observed.source() {
+                        ClipboardPayloadSource::LocalFile { path, size_bytes } => {
+                            let blob_id =
+                                self.blob_writer.write_path_if_absent(path).await.map_err(
+                                    |err| {
+                                        anyhow::anyhow!(
+                                            "LocalFile rep ingest into blob store failed (path={}): {err}",
+                                            path.display()
+                                        )
+                                    },
+                                )?;
+                            info!(
+                                rep_id = %observed.id,
+                                blob_id = %blob_id,
+                                file_path = %path.display(),
+                                file_size = size_bytes,
+                                "Ingested LocalFile rep into blob store as BlobReady"
+                            );
+                            out.push(PersistedClipboardRepresentation::new(
+                                observed.id.clone(),
+                                observed.format_id.clone(),
+                                observed.mime.clone(),
+                                *size_bytes as i64,
+                                None,           // inline_data
+                                Some(blob_id),  // blob_id ⇒ payload_state=BlobReady
+                            ));
+                        }
+                        ClipboardPayloadSource::Inline(_) => {
+                            let persisted =
+                                self.representation_normalizer.normalize(observed).await?;
+                            out.push(persisted);
+                        }
+                    }
+                }
+                Ok::<Vec<PersistedClipboardRepresentation>, anyhow::Error>(out)
             }
             .instrument(info_span!(stages::NORMALIZE))
             .await?;
@@ -229,9 +277,14 @@ impl CaptureClipboardUseCase {
                         if let Some(observed) =
                             snapshot.representations.iter().find(|o| o.id == rep.id)
                         {
-                            self.representation_cache
-                                .put(&rep.id, observed.bytes.clone())
-                                .await;
+                            // Staged path 当前仍要求 Inline source —— LocalFile rep 在
+                            // 上游 BlobWriter ingest 阶段会被产出 BlobReady 状态,不会
+                            // 走到 Staged 分支。
+                            if let Some(bytes) = observed.inline_bytes() {
+                                self.representation_cache
+                                    .put(&rep.id, bytes.to_vec())
+                                    .await;
+                            }
                         }
                     }
                 }
@@ -280,14 +333,13 @@ impl CaptureClipboardUseCase {
                 .iter()
                 .filter(|rep| rep.payload_state() == PayloadAvailability::Staged)
                 .filter_map(|rep| {
-                    snapshot
-                        .representations
-                        .iter()
-                        .find(|o| o.id == rep.id)
-                        .map(|observed| SpoolRequest {
-                            rep_id: rep.id.clone(),
-                            bytes: observed.bytes.clone(),
-                        })
+                    let observed = snapshot.representations.iter().find(|o| o.id == rep.id)?;
+                    // Staged spool 仅承载 Inline 字节;LocalFile rep 不进 Staged。
+                    let bytes = observed.inline_bytes()?;
+                    Some(SpoolRequest {
+                        rep_id: rep.id.clone(),
+                        bytes: bytes.to_vec(),
+                    })
                 })
                 .collect();
 
@@ -369,7 +421,10 @@ impl CaptureClipboardUseCase {
                     || mime_str.eq_ignore_ascii_case("text/plain;charset=utf-8")
                     || mime_str.starts_with("text/")
                 {
-                    if let Ok(text) = std::str::from_utf8(&rep.bytes) {
+                    let Some(rep_bytes) = rep.inline_bytes() else {
+                        continue;
+                    };
+                    if let Ok(text) = std::str::from_utf8(rep_bytes) {
                         let trimmed = text.trim();
                         if !trimmed.is_empty() {
                             // Use char_indices() to find a safe character boundary

--- a/src-tauri/crates/uc-application/src/facade/clipboard_outbound/mod.rs
+++ b/src-tauri/crates/uc-application/src/facade/clipboard_outbound/mod.rs
@@ -8,6 +8,7 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use thiserror::Error;
 use tracing::{info, warn};
+use uc_core::clipboard::ClipboardPayloadSource;
 use uc_core::ids::EntryId;
 use uc_core::ports::SettingsPort;
 use uc_core::{ClipboardChangeOrigin, SystemClipboardSnapshot};
@@ -79,12 +80,42 @@ impl ClipboardOutboundDispatcher {
 impl ClipboardOutboundPort for ClipboardOutboundDispatcher {
     async fn dispatch_capture(
         &self,
-        input: ClipboardOutboundInput,
+        mut input: ClipboardOutboundInput,
     ) -> Result<ClipboardOutboundOutcome, ClipboardOutboundError> {
         if input.origin.is_remote_push() {
             return Ok(ClipboardOutboundOutcome::Skipped {
                 reason: "remote_push_echo".to_string(),
             });
+        }
+
+        // Strip `LocalFile` source reps before envelope construction.
+        //
+        // capture pipeline 已经把 LocalFile rep 物化到本机 blob 仓库(BlobReady 状态)。
+        // 对端无法从远端 path 读字节,LocalFile 在 wire 协议上无意义;且 V3 envelope
+        // BinaryRepresentation 只支持 inline 字节,若 LocalFile 留在 snapshot 里会触
+        // 发 encode 时的 expect_inline_bytes panic。
+        //
+        // 真正的"图片字节跨设备传输"路径:同一文件已在 files rep(uri-list)里以路径
+        // 形式存在,outbound 通过 publish_file_blob_refs 走 iroh-blobs add_path 流式
+        // 上传得到 V3BlobRef,对端 inbound materializer 用 BlobTransferFacade.fetch_blob
+        // 把真实文件落到本地 file-cache,完整字节恢复。
+        let stripped = input
+            .snapshot
+            .representations
+            .iter()
+            .filter(|rep| matches!(rep.source(), ClipboardPayloadSource::LocalFile { .. }))
+            .count();
+        if stripped > 0 {
+            input
+                .snapshot
+                .representations
+                .retain(|rep| !matches!(rep.source(), ClipboardPayloadSource::LocalFile { .. }));
+            info!(
+                entry_id = %input.entry_id,
+                stripped_count = stripped,
+                "outbound: stripped LocalFile reps before envelope construction (already in blob store; \
+                 peers receive bytes via files rep + iroh-blobs)"
+            );
         }
 
         // Phase timing: dispatch_capture 是 outbound 关键路径,从 capture
@@ -266,7 +297,13 @@ fn extract_file_paths_from_snapshot(snapshot: &SystemClipboardSnapshot) -> Vec<P
             continue;
         }
 
-        let text = match std::str::from_utf8(&rep.bytes) {
+        // outbound 路径的 rep 来自 DB reconstruct,必然 Inline source;LocalFile 不可能
+        // 出现。保守用 inline_bytes() 而非 expect_inline_bytes(),让契约违反时直接 skip
+        // 而不是 panic 在出站路径。
+        let Some(rep_bytes) = rep.inline_bytes() else {
+            continue;
+        };
+        let text = match std::str::from_utf8(rep_bytes) {
             Ok(text) => text,
             Err(_) => continue,
         };
@@ -324,7 +361,12 @@ async fn publish_oversized_inline_blob_refs(
     let mut blob_refs = Vec::new();
 
     for (idx, rep) in snapshot.representations.iter_mut().enumerate() {
-        if rep.bytes.len() <= OVERSIZED_REP_THRESHOLD_BYTES {
+        // outbound 路径的 rep 必然 Inline source;LocalFile 在 capture 阶段已物化到 blob,
+        // 不会进入 outbound dispatch。
+        let Some(rep_bytes) = rep.inline_bytes() else {
+            continue;
+        };
+        if rep_bytes.len() <= OVERSIZED_REP_THRESHOLD_BYTES {
             continue;
         }
         let mime_str = rep.mime.as_ref().map(|m| m.as_str().to_string());
@@ -342,8 +384,10 @@ async fn publish_oversized_inline_blob_refs(
         // to match.
         let _ = rep.content_hash();
 
-        let size_bytes = rep.bytes.len() as u64;
-        let plaintext = std::mem::take(&mut rep.bytes);
+        let size_bytes = rep_bytes.len() as u64;
+        let plaintext = rep
+            .take_inline_bytes()
+            .map_err(|err| ClipboardOutboundError::Internal(err.to_string()))?;
 
         let publish_start = Instant::now();
         let result = blob_transfer

--- a/src-tauri/crates/uc-application/src/facade/search/projection.rs
+++ b/src-tauri/crates/uc-application/src/facade/search/projection.rs
@@ -128,7 +128,7 @@ impl SearchProjectionBuilder {
                 .unwrap_or_default();
 
             if mime == "text/plain" || mime.starts_with("text/plain;") {
-                if let Ok(text) = std::str::from_utf8(&rep.bytes) {
+                if let Ok(text) = std::str::from_utf8(rep.inline_bytes().unwrap_or(&[])) {
                     let text = text.to_string();
                     if !text.is_empty() {
                         if rep.id == *preview_rep_id {
@@ -138,14 +138,14 @@ impl SearchProjectionBuilder {
                     }
                 }
             } else if mime == "text/html" {
-                if let Ok(text) = std::str::from_utf8(&rep.bytes) {
+                if let Ok(text) = std::str::from_utf8(rep.inline_bytes().unwrap_or(&[])) {
                     let text = text.to_string();
                     if !text.is_empty() {
                         html_text = Some(text);
                     }
                 }
             } else if mime == "text/uri-list" || mime == "file/uri-list" {
-                if let Ok(text) = std::str::from_utf8(&rep.bytes) {
+                if let Ok(text) = std::str::from_utf8(rep.inline_bytes().unwrap_or(&[])) {
                     for line in text.lines() {
                         let line = line.trim();
                         if !line.is_empty() && !line.starts_with('#') {

--- a/src-tauri/crates/uc-application/src/usecases/clipboard_restore/restore_as_plain_text.rs
+++ b/src-tauri/crates/uc-application/src/usecases/clipboard_restore/restore_as_plain_text.rs
@@ -174,7 +174,7 @@ impl RestoreClipboardEntryAsPlainTextUseCase {
                         entry_id = %entry_id,
                         event_id = %entry.event_id,
                         plain_rep_id = %rep.id,
-                        size_bytes = observed.bytes.len(),
+                        size_bytes = observed.size_bytes(),
                         "restore_plain.build_snapshot packed plain representation"
                     );
 
@@ -548,7 +548,7 @@ mod tests {
         let reps = &writes[0].representations;
         assert_eq!(reps.len(), 1, "snapshot must contain only the plain rep");
         assert_eq!(reps[0].id, plain.id);
-        assert_eq!(reps[0].bytes, b"hello world");
+        assert_eq!(reps[0].expect_inline_bytes(), b"hello world");
     }
 
     /// 条目根本没有 plain 表示（典型富文本场景：复制自 PDF 等）。用例应当

--- a/src-tauri/crates/uc-application/src/usecases/clipboard_restore/restore_selection.rs
+++ b/src-tauri/crates/uc-application/src/usecases/clipboard_restore/restore_selection.rs
@@ -261,7 +261,7 @@ impl RestoreClipboardSelectionUseCase {
             paste_rep_id = %paste_rep.id,
             packed_rep_count = representations.len(),
             packed_rep_ids = ?packed_rep_ids,
-            total_size_bytes = representations.iter().map(|r| r.bytes.len()).sum::<usize>(),
+            total_size_bytes = representations.iter().map(|r| r.size_bytes() as usize).sum::<usize>(),
             "restore.build_snapshot packed representations"
         );
 

--- a/src-tauri/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/materializer.rs
+++ b/src-tauri/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/materializer.rs
@@ -171,7 +171,8 @@ impl InboundBlobMaterializer for FileCacheBlobMaterializer {
                 )
             })?;
             let fetched_len = fetched.plaintext.len();
-            rep.bytes = fetched.plaintext.to_vec();
+            rep.set_inline_bytes(fetched.plaintext.to_vec())
+                .map_err(|err| anyhow!("materialize: failed to set inline bytes: {err}"))?;
             info!(
                 entry_id = %entry_id,
                 representation_index = idx,
@@ -274,7 +275,8 @@ impl InboundBlobMaterializer for FileCacheBlobMaterializer {
         let mut rewritten_rep_count = 0usize;
         for rep in &mut snapshot.representations {
             if is_file_list_representation(rep) {
-                rep.bytes = uri_list.as_bytes().to_vec();
+                rep.set_inline_bytes(uri_list.as_bytes().to_vec())
+                    .map_err(|err| anyhow!("materialize: failed to rewrite files rep: {err}"))?;
                 rewritten_rep_count += 1;
             }
         }
@@ -300,8 +302,74 @@ impl InboundBlobMaterializer for FileCacheBlobMaterializer {
             );
         }
 
+        // 接收端 image rep 合成:对 local_paths 中的图片文件追加一条 LocalFile source
+        // image rep,capture pipeline 会在 normalize 阶段同步通过 BlobWriterPort 把它
+        // 物化到接收端本机 blob 仓库,产出 BlobReady 状态的持久化 rep。
+        //
+        // 让接收端 dashboard 通过 /clipboard/blobs/{blob_id} 拿到真实图片字节预览,
+        // paste 时 OS pasteboard 同时含 file uri-list 与 image bytes —— 解决"对端粘贴
+        // 看到的是 macOS 文件图标缩略图"这条历史回归。仅对第一张图片合成 rep,多文件
+        // 选择不重复(对应发送端单 image rep 约定)。
+        let mut already_has_image_rep = snapshot.representations.iter().any(|rep| {
+            rep.mime
+                .as_ref()
+                .map(|m| m.as_str().to_ascii_lowercase().starts_with("image/"))
+                .unwrap_or(false)
+        });
+        if !already_has_image_rep {
+            for path in &local_paths {
+                let Some(image_mime) = image_file_mime_from_path(path) else {
+                    continue;
+                };
+                let Ok(meta) = std::fs::metadata(path) else {
+                    continue;
+                };
+                if meta.len() == 0 {
+                    continue;
+                }
+                snapshot
+                    .representations
+                    .push(ObservedClipboardRepresentation::new_local_file(
+                        RepresentationId::new(),
+                        FormatId::from("image-from-file"),
+                        Some(MimeType(image_mime.to_string())),
+                        path.clone(),
+                        meta.len(),
+                    ));
+                info!(
+                    path = %path.display(),
+                    size_bytes = meta.len(),
+                    mime = image_mime,
+                    "materialize: synthesized LocalFile image rep for inbound image file \
+                     (BlobWriter will ingest during capture)"
+                );
+                already_has_image_rep = true;
+                break;
+            }
+        }
+        let _ = already_has_image_rep;
+
         Ok(snapshot)
     }
+}
+
+/// 基于文件后缀推断常见图片 MIME。与 `uc-platform/clipboard/common.rs` 的同名 helper
+/// 表项保持一致(打开扩展时两边一起改);该函数刻意复制一份在 application 层,避免把
+/// 接收端的 image rep 合成逻辑硬连到 platform crate。
+fn image_file_mime_from_path(path: &std::path::Path) -> Option<&'static str> {
+    let ext = path
+        .extension()
+        .and_then(|e| e.to_str())?
+        .to_ascii_lowercase();
+    Some(match ext.as_str() {
+        "png" => "image/png",
+        "jpg" | "jpeg" => "image/jpeg",
+        "gif" => "image/gif",
+        "webp" => "image/webp",
+        "bmp" => "image/bmp",
+        "tif" | "tiff" => "image/tiff",
+        _ => return None,
+    })
 }
 
 fn is_file_list_representation(rep: &ObservedClipboardRepresentation) -> bool {

--- a/src-tauri/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/tests.rs
+++ b/src-tauri/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/tests.rs
@@ -726,16 +726,18 @@ async fn materializes_blob_refs_before_capture_and_write() {
         .expect_materialize()
         .times(1)
         .withf(move |_from_device, _receiver_entry_id, snapshot, refs| {
-            snapshot.representations[0].bytes == b"file:///sender/original.txt\n"
+            snapshot.representations[0].expect_inline_bytes() == b"file:///sender/original.txt\n"
                 && refs == &vec![blob_ref.clone()]
         })
         .returning(|_from_device, _receiver_entry_id, mut snapshot, _| {
-            snapshot.representations[0].bytes = b"file:///local/cache/original.txt\n".to_vec();
+            snapshot.representations[0]
+                .set_inline_bytes(b"file:///local/cache/original.txt\n".to_vec())
+                .unwrap();
             Ok(snapshot)
         });
 
     let assert_local_file = |snapshot: &SystemClipboardSnapshot| {
-        snapshot.representations[0].bytes == b"file:///local/cache/original.txt\n"
+        snapshot.representations[0].expect_inline_bytes() == b"file:///local/cache/original.txt\n"
     };
     let mut capture = MockCapture::new();
     capture
@@ -820,7 +822,7 @@ async fn file_cache_blob_materializer_writes_file_and_rewrites_file_uri_list() {
         .await
         .expect("materialize should succeed");
 
-    let uri_list = String::from_utf8(rewritten.representations[0].bytes.clone())
+    let uri_list = String::from_utf8(rewritten.representations[0].expect_inline_bytes().to_vec())
         .expect("uri-list should be UTF-8");
     assert!(uri_list.starts_with("file://"));
     assert!(uri_list.ends_with("/report.txt\n"));
@@ -889,7 +891,10 @@ async fn file_cache_blob_materializer_inlines_representation_bound_blob_into_rep
         .expect("representation-bound materialize should succeed");
 
     assert_eq!(materialized.representations.len(), 1);
-    assert_eq!(materialized.representations[0].bytes, b"\x89PNG\x0d");
+    assert_eq!(
+        materialized.representations[0].expect_inline_bytes(),
+        b"\x89PNG\x0d"
+    );
     assert_eq!(materialized.representations[0].format_id.as_ref(), "image");
 
     let mut entries = tokio::fs::read_dir(cache_dir.path())

--- a/src-tauri/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/usecase.rs
+++ b/src-tauri/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/usecase.rs
@@ -383,7 +383,7 @@ pub(super) fn format_rep_summary(snapshot: &SystemClipboardSnapshot) -> String {
                 "{}{}:{}",
                 rep.format_id.as_str(),
                 mime_suffix,
-                rep.bytes.len()
+                rep.size_bytes()
             )
         })
         .collect::<Vec<_>>()

--- a/src-tauri/crates/uc-application/src/usecases/clipboard_sync/payload_codec.rs
+++ b/src-tauri/crates/uc-application/src/usecases/clipboard_sync/payload_codec.rs
@@ -72,13 +72,17 @@ pub struct V3BlobRef {
 pub(crate) fn encode_snapshot_to_v3_bytes(
     snapshot: &SystemClipboardSnapshot,
 ) -> Result<(Bytes, String)> {
+    // V3 envelope BinaryRepresentation 仅承载 inline 字节;LocalFile source 必须在
+    // dispatch 之前由 capture pipeline 物化到 blob 仓库,outbound 通过 V3BlobRef
+    // 通道引用,因此 envelope 编码阶段 LocalFile 不应出现。这里用 expect_inline_bytes
+    // 让契约违反时立即 panic,而不是默默写空字节。
     let reps = snapshot
         .representations
         .iter()
         .map(|rep| BinaryRepresentation {
             format_id: rep.format_id.as_ref().to_string(),
             mime: rep.mime.as_ref().map(|m| m.as_str().to_string()),
-            data: rep.bytes.clone(),
+            data: rep.expect_inline_bytes().to_vec(),
         })
         .collect();
 
@@ -417,7 +421,7 @@ mod tests {
         let rep = &decoded.representations[0];
         assert_eq!(rep.format_id.as_ref(), "text");
         assert_eq!(rep.mime.as_ref().map(|m| m.as_str()), Some("text/plain"));
-        assert_eq!(rep.bytes, b"hello phase3");
+        assert_eq!(rep.expect_inline_bytes(), b"hello phase3");
     }
 
     /// Verdict 2 — roundtrip preserves byte-for-byte equality for
@@ -448,7 +452,7 @@ mod tests {
         assert_eq!(decoded.representations.len(), 2);
         assert_eq!(decoded.representations[0].format_id.as_ref(), "public.png");
         assert_eq!(
-            decoded.representations[0].bytes,
+            decoded.representations[0].expect_inline_bytes(),
             vec![0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A, 0xFF, 0x00]
         );
         assert_eq!(
@@ -514,11 +518,17 @@ mod tests {
 
         let legacy_decoded =
             decode_v3_bytes_to_snapshot(&bytes).expect("legacy snapshot decode should succeed");
-        assert_eq!(legacy_decoded.representations[0].bytes, b"file placeholder");
+        assert_eq!(
+            legacy_decoded.representations[0].expect_inline_bytes(),
+            b"file placeholder"
+        );
 
         let (decoded, refs) = decode_v3_bytes_to_snapshot_and_blob_refs(&bytes)
             .expect("decode with blob refs should succeed");
-        assert_eq!(decoded.representations[0].bytes, b"file placeholder");
+        assert_eq!(
+            decoded.representations[0].expect_inline_bytes(),
+            b"file placeholder"
+        );
         assert_eq!(refs, vec![blob_ref]);
         assert_eq!(refs[0].entry_id, entry_id);
     }
@@ -556,7 +566,10 @@ mod tests {
         let (bytes, _) = encode_snapshot_to_v3_bytes(&original).unwrap();
         let (decoded, refs) = decode_v3_bytes_to_snapshot_and_blob_refs(&bytes).unwrap();
 
-        assert_eq!(decoded.representations[0].bytes, b"plain text");
+        assert_eq!(
+            decoded.representations[0].expect_inline_bytes(),
+            b"plain text"
+        );
         assert!(refs.is_empty());
     }
 

--- a/src-tauri/crates/uc-application/src/usecases/mobile_sync/apply_incoming.rs
+++ b/src-tauri/crates/uc-application/src/usecases/mobile_sync/apply_incoming.rs
@@ -1366,7 +1366,7 @@ mod tests {
                     .as_ref()
                     .map(|m| m.as_str() == "text/uri-list")
                     .unwrap_or(false);
-                let body = std::str::from_utf8(&rep.bytes).unwrap_or("");
+                let body = std::str::from_utf8(rep.expect_inline_bytes()).unwrap_or("");
                 mime_ok
                     && body == "file:///C:/Users/mark/AppData/Local/uc/mobile_inbound/abc/My%20Photo.png\n"
             })

--- a/src-tauri/crates/uc-bootstrap/src/non_gui_runtime.rs
+++ b/src-tauri/crates/uc-bootstrap/src/non_gui_runtime.rs
@@ -144,6 +144,7 @@ fn build_fallback_apply_inbound(deps: &AppDeps) -> Arc<ApplyInboundClipboardUseC
         deps.device.device_identity.clone(),
         deps.clipboard.representation_cache.clone(),
         deps.clipboard.spool_queue.clone(),
+        deps.storage.blob_writer.clone(),
         deps.analytics.clone(),
     ));
     let capture: Arc<dyn ApplyInboundCapture> = capture_uc;

--- a/src-tauri/crates/uc-bootstrap/tests/slice2_phase2_clipboard_e2e.rs
+++ b/src-tauri/crates/uc-bootstrap/tests/slice2_phase2_clipboard_e2e.rs
@@ -707,7 +707,10 @@ async fn sponsor_dispatch_lands_on_joiner_within_2s() {
     let decoded = decode_v3_bytes_to_snapshot(&notice.plaintext)
         .expect("notice plaintext must decode as V3 envelope");
     assert_eq!(decoded.representations.len(), 1);
-    assert_eq!(decoded.representations[0].bytes, text.as_bytes());
+    assert_eq!(
+        decoded.representations[0].expect_inline_bytes(),
+        text.as_bytes()
+    );
     assert_eq!(
         decoded.representations[0].mime.as_ref().map(|m| m.as_str()),
         Some("text/plain")
@@ -802,7 +805,10 @@ async fn repeat_dispatch_lands_twice_phase2_no_dedup() {
     for notice in &received {
         let decoded = decode_v3_bytes_to_snapshot(&notice.plaintext)
             .expect("notice plaintext must decode as V3 envelope");
-        assert_eq!(decoded.representations[0].bytes, fixture_text.as_bytes());
+        assert_eq!(
+            decoded.representations[0].expect_inline_bytes(),
+            fixture_text.as_bytes()
+        );
     }
 
     sponsor.shutdown().await;

--- a/src-tauri/crates/uc-cli/src/commands/probe.rs
+++ b/src-tauri/crates/uc-cli/src/commands/probe.rs
@@ -230,7 +230,7 @@ fn run_restore(input: String, select: Option<usize>) -> Result<()> {
                 idx,
                 rep.format_id,
                 rep.mime,
-                rep.bytes.len()
+                rep.size_bytes()
             );
         }
 
@@ -274,17 +274,21 @@ fn print_snapshot(snapshot: &SystemClipboardSnapshot) {
 
 fn describe_representation(rep: &ObservedClipboardRepresentation) -> String {
     let mime = rep.mime.as_ref().map(|m| m.as_str()).unwrap_or("-");
+    // probe 只处理 JSON 反序列化产物 + 本机 watcher 当前 snapshot,均为 Inline source。
+    // LocalFile source 在 probe 路径上无法出现(JSON serialize 会失败、watcher 还没有
+    // 启用 LocalFile 模式)。退一步,即便 LocalFile 出现,展示空预览即可。
+    let bytes_view: &[u8] = rep.inline_bytes().unwrap_or(&[]);
     let preview = if is_text_representation(mime, &rep.format_id) {
-        format!("\"{}\"", text_preview(&rep.bytes, 160))
+        format!("\"{}\"", text_preview(bytes_view, 160))
     } else {
-        format!("hex:{}", hex_preview(&rep.bytes, 24))
+        format!("hex:{}", hex_preview(bytes_view, 24))
     };
 
     format!(
         "format_id={} mime={} bytes={} preview={}",
         rep.format_id,
         mime,
-        rep.bytes.len(),
+        rep.size_bytes(),
         preview
     )
 }
@@ -338,7 +342,7 @@ fn snapshot_fingerprint(snapshot: &SystemClipboardSnapshot) -> u64 {
     for rep in &snapshot.representations {
         rep.format_id.hash(&mut hasher);
         rep.mime.hash(&mut hasher);
-        rep.bytes.hash(&mut hasher);
+        rep.inline_bytes().unwrap_or(&[]).hash(&mut hasher);
     }
 
     hasher.finish()

--- a/src-tauri/crates/uc-cli/src/commands/watch.rs
+++ b/src-tauri/crates/uc-cli/src/commands/watch.rs
@@ -199,7 +199,7 @@ fn first_text_preview(snapshot: &SystemClipboardSnapshot) -> Option<String> {
         if !is_text {
             continue;
         }
-        if let Ok(s) = std::str::from_utf8(&rep.bytes) {
+        if let Ok(s) = std::str::from_utf8(rep.inline_bytes().unwrap_or(&[])) {
             return Some(s.to_string());
         }
     }
@@ -214,7 +214,7 @@ fn rep_summary_line(snapshot: &SystemClipboardSnapshot) -> String {
         .iter()
         .map(|rep| {
             let mime = rep.mime.as_ref().map(|m| m.as_str()).unwrap_or("?");
-            format!("{}/{}B", mime, rep.bytes.len())
+            format!("{}/{}B", mime, rep.size_bytes())
         })
         .collect();
     format!(

--- a/src-tauri/crates/uc-core/src/blob/ports/writer.rs
+++ b/src-tauri/crates/uc-core/src/blob/ports/writer.rs
@@ -1,12 +1,16 @@
 //! Blob Writer Port.
 //!
 //! Write-side abstraction for blob storage with content-hash deduplication.
-//! Callers pass plaintext bytes; encryption (if any) is handled by the
+//! Callers either pass plaintext bytes already in memory, or pass a path to a
+//! local file whose contents should be streamed into the store without loading
+//! the full payload into memory. Encryption (if any) is handled by the
 //! infrastructure layer via decorator.
 //!
 //! Lives in `uc-core` because the contract speaks only in domain types
-//! (`ContentHash` in, `BlobId` out). Concrete implementations live in
-//! `uc-infra`.
+//! (`ContentHash` in, `BlobId` out; or `Path` in, `BlobId` out). Concrete
+//! implementations live in `uc-infra`.
+
+use std::path::Path;
 
 use crate::{BlobId, ContentHash};
 
@@ -26,4 +30,23 @@ pub trait BlobWriterPort: Send + Sync {
         content_id: &ContentHash,
         plaintext_bytes: &[u8],
     ) -> anyhow::Result<BlobId>;
+
+    /// Ingest a file at `source_path` into the blob store, deduplicating by content hash.
+    ///
+    /// The implementation streams the file to compute its `ContentHash` without
+    /// loading the full payload into memory, so the call is suitable for
+    /// arbitrarily large files. Once the hash is known the behaviour matches
+    /// `write_if_absent`:
+    ///
+    /// # Atomic semantics
+    /// - If the computed `ContentHash` already maps to a blob → return that `BlobId`
+    /// - Otherwise materialise the file into storage and return the new `BlobId`
+    ///
+    /// # Idempotence guarantee
+    /// - Multiple concurrent calls with the same file content return the same `BlobId`
+    /// - Data is written only once per content hash, even across distinct source paths
+    ///
+    /// The source file is left untouched; the implementation must not mutate
+    /// the caller's file in place.
+    async fn write_path_if_absent(&self, source_path: &Path) -> anyhow::Result<BlobId>;
 }

--- a/src-tauri/crates/uc-core/src/clipboard/mod.rs
+++ b/src-tauri/crates/uc-core/src/clipboard/mod.rs
@@ -30,8 +30,8 @@ pub use policy::*;
 pub use selection::*;
 pub use snapshot::*;
 pub use system::{
-    is_file_mime_or_format, is_plain_text_mime_or_format, ObservedClipboardRepresentation,
-    RepresentationHash, SnapshotHash, SystemClipboardSnapshot,
+    is_file_mime_or_format, is_plain_text_mime_or_format, ClipboardPayloadSource,
+    ObservedClipboardRepresentation, RepresentationHash, SnapshotHash, SystemClipboardSnapshot,
 };
 
 pub use decision::{ClipboardContentActionDecision, DuplicationHint, RejectReason};

--- a/src-tauri/crates/uc-core/src/clipboard/policy/v1.rs
+++ b/src-tauri/crates/uc-core/src/clipboard/policy/v1.rs
@@ -141,7 +141,12 @@ impl SelectRepresentationPolicyV1 {
             return false;
         }
 
-        let bytes = match std::str::from_utf8(&rep.bytes) {
+        // file-list rep 的字节是 uri-list 文本,LocalFile source 不会出现在 file-list 类别
+        // (LocalFile 来自 image-from-file capture 路径,format_id 是 image-from-file 而非 files)。
+        let Some(rep_bytes) = rep.inline_bytes() else {
+            return false;
+        };
+        let bytes = match std::str::from_utf8(rep_bytes) {
             Ok(bytes) => bytes,
             Err(_) => return false,
         };

--- a/src-tauri/crates/uc-core/src/clipboard/system.rs
+++ b/src-tauri/crates/uc-core/src/clipboard/system.rs
@@ -1,3 +1,5 @@
+use std::io::Read;
+use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
 use crate::{
@@ -19,24 +21,30 @@ pub struct SystemClipboardSnapshot {
     pub representations: Vec<ObservedClipboardRepresentation>,
 }
 
-#[derive(Serialize, Deserialize)]
+/// 表示一条 rep 的负载来源。
+///
+/// `Inline` —— 字节已经在内存里(从系统剪贴板高层 API 一次读完、或从 wire 反序列化得到)。
+/// `LocalFile` —— 仅在 capture 入站短暂存在,指向用户本机文件路径(典型场景:macOS Finder
+/// 复制大图片,本地文件可能数十 MB)。此种 source **绝不允许进入 wire 序列化、spool 队列、
+/// envelope 构造**;capture pipeline 必须在持久化之前通过 `BlobWriterPort.write_path_if_absent`
+/// 把它物化到 blob 仓库,产出 `BlobReady` 状态的 `PersistedClipboardRepresentation`。
+#[derive(Debug, Clone)]
+pub enum ClipboardPayloadSource {
+    Inline(Vec<u8>),
+    LocalFile { path: PathBuf, size_bytes: u64 },
+}
+
 pub struct ObservedClipboardRepresentation {
-    pub id: RepresentationId, // 建议：uuid
+    pub id: RepresentationId,
     pub format_id: FormatId,
     pub mime: Option<MimeType>,
-    pub bytes: Vec<u8>,
-    /// Cached blake3 content hash — computed lazily on first access.
+    source: ClipboardPayloadSource,
+    /// blake3 content hash —— 首次访问时计算并缓存。
     ///
-    /// Cloning this type copies `cached_hash` as-is. If callers mutate the cloned
-    /// instance's public `bytes` after `content_hash()` has already populated the
-    /// cache, the cached hash can become stale. Current assumptions/mitigations:
-    /// - Deserialized instances start with an empty cache (`serde(skip)`).
-    /// - `DecryptingClipboardEventRepository` mutates bytes before hash access.
-    ///
-    /// Alternative designs if this trade-off changes:
-    /// - clear cache in `Clone`
-    /// - make `bytes` non-public and force controlled mutation paths
-    #[serde(skip)]
+    /// Clone 时直接拷贝(包括 `LocalFile` 上已算过的 hash),只要 path 指向的文件未变更
+    /// 即始终有效;若调用方就地替换字节(参见 `inline_bytes_mut`),必须确保替换后不再
+    /// 读取过时的 cached hash —— 当前 `DecryptingClipboardEventRepository` 在初始化
+    /// rep 后立即解密、再供下游读 hash,顺序安全。
     cached_hash: OnceLock<RepresentationHash>,
 }
 
@@ -57,6 +65,7 @@ impl std::ops::Deref for SnapshotHash {
 }
 
 impl ObservedClipboardRepresentation {
+    /// 构造一个内存字节 rep。
     pub fn new(
         id: RepresentationId,
         format_id: FormatId,
@@ -67,23 +76,176 @@ impl ObservedClipboardRepresentation {
             id,
             format_id,
             mime,
-            bytes,
+            source: ClipboardPayloadSource::Inline(bytes),
             cached_hash: OnceLock::new(),
         }
     }
 
-    pub fn size_bytes(&self) -> i64 {
-        self.bytes.len() as i64
+    /// 构造一个 path-backed rep。
+    ///
+    /// `size_bytes` 应来自调用方 `fs::metadata` 的 `len()`,作为 declared 字段;真正的 hash
+    /// 计算会在 `content_hash()` 调用时流式读取文件。
+    pub fn new_local_file(
+        id: RepresentationId,
+        format_id: FormatId,
+        mime: Option<MimeType>,
+        path: PathBuf,
+        size_bytes: u64,
+    ) -> Self {
+        Self {
+            id,
+            format_id,
+            mime,
+            source: ClipboardPayloadSource::LocalFile { path, size_bytes },
+            cached_hash: OnceLock::new(),
+        }
     }
 
-    /// Returns the blake3 content hash, computing it lazily and caching the result.
+    /// 获取负载来源(用于显式分流 Inline / LocalFile)。
+    pub fn source(&self) -> &ClipboardPayloadSource {
+        &self.source
+    }
+
+    /// 仅当 source 为 `Inline` 时返回字节切片;`LocalFile` 时返回 `None`。
+    pub fn inline_bytes(&self) -> Option<&[u8]> {
+        match &self.source {
+            ClipboardPayloadSource::Inline(b) => Some(b),
+            ClipboardPayloadSource::LocalFile { .. } => None,
+        }
+    }
+
+    /// 仅当 source 为 `Inline` 时返回可变字节;`LocalFile` 时返回 `None`。
+    pub fn inline_bytes_mut(&mut self) -> Option<&mut Vec<u8>> {
+        match &mut self.source {
+            ClipboardPayloadSource::Inline(b) => Some(b),
+            ClipboardPayloadSource::LocalFile { .. } => None,
+        }
+    }
+
+    /// 强制取 Inline 字节,`LocalFile` 时 panic。仅用于"必然 Inline"的语境
+    /// (如系统剪贴板 write_snapshot 出站路径、wire 解码后的 inbound 路径)。
+    pub fn expect_inline_bytes(&self) -> &[u8] {
+        self.inline_bytes().expect(
+            "ObservedClipboardRepresentation: LocalFile source not allowed in this code path; \
+             caller must handle path-backed reps explicitly via .source()",
+        )
+    }
+
+    /// 取走 Inline 字节,留下一个空 `Vec<u8>` 占位(仍为 Inline source);`LocalFile` 时
+    /// 返回 `Err`。用于 outbound 路径在把字节交给 blob ingest 后清空本地副本。
+    ///
+    /// **Note**: 调用方负责在 take 之前显式调用 `content_hash()` 让缓存命中,否则 take
+    /// 之后再读 hash 会拿到空字节的 blake3。缓存字段本身不被 take 清空,以便保留预计算
+    /// 的"原内容"hash 供后续 snapshot_hash 使用。
+    pub fn take_inline_bytes(&mut self) -> anyhow::Result<Vec<u8>> {
+        match &mut self.source {
+            ClipboardPayloadSource::Inline(b) => Ok(std::mem::take(b)),
+            ClipboardPayloadSource::LocalFile { .. } => Err(anyhow::anyhow!(
+                "take_inline_bytes not supported for LocalFile source"
+            )),
+        }
+    }
+
+    /// 替换 Inline 负载;`LocalFile` 时返回 `Err`(契约违反)。
+    pub fn set_inline_bytes(&mut self, bytes: Vec<u8>) -> anyhow::Result<()> {
+        match &mut self.source {
+            ClipboardPayloadSource::Inline(b) => {
+                *b = bytes;
+                self.cached_hash = OnceLock::new();
+                Ok(())
+            }
+            ClipboardPayloadSource::LocalFile { .. } => Err(anyhow::anyhow!(
+                "set_inline_bytes not supported for LocalFile source"
+            )),
+        }
+    }
+
+    pub fn size_bytes(&self) -> i64 {
+        match &self.source {
+            ClipboardPayloadSource::Inline(b) => b.len() as i64,
+            ClipboardPayloadSource::LocalFile { size_bytes, .. } => *size_bytes as i64,
+        }
+    }
+
+    /// blake3 content hash, computed lazily and cached.
+    ///
+    /// `Inline` source 直接对内存字节哈希;`LocalFile` source 流式读取文件计算哈希。
+    /// 若 `LocalFile` 路径不可读则 panic(此时 capture pipeline 上游应该已经处理过 stat 失败)。
     pub fn content_hash(&self) -> RepresentationHash {
         self.cached_hash
             .get_or_init(|| {
-                let hash = blake3::hash(&self.bytes);
+                let hash = match &self.source {
+                    ClipboardPayloadSource::Inline(b) => blake3::hash(b),
+                    ClipboardPayloadSource::LocalFile { path, .. } => stream_blake3(path)
+                        .unwrap_or_else(|err| {
+                            panic!(
+                                "ObservedClipboardRepresentation::content_hash: failed to stream-hash {} : {err}",
+                                path.display()
+                            )
+                        }),
+                };
                 RepresentationHash(ContentHash::from(hash.as_bytes()))
             })
             .clone()
+    }
+}
+
+/// 流式 blake3:对路径文件做分块哈希,常驻内存仅 64 KiB 缓冲。
+fn stream_blake3(path: &Path) -> std::io::Result<blake3::Hash> {
+    let mut file = std::fs::File::open(path)?;
+    let mut hasher = blake3::Hasher::new();
+    let mut buf = [0u8; 64 * 1024];
+    loop {
+        let n = file.read(&mut buf)?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+    }
+    Ok(hasher.finalize())
+}
+
+#[derive(Serialize, Deserialize)]
+struct ObservedRepProxy {
+    id: RepresentationId,
+    format_id: FormatId,
+    mime: Option<MimeType>,
+    bytes: Vec<u8>,
+}
+
+impl serde::Serialize for ObservedClipboardRepresentation {
+    fn serialize<S: serde::Serializer>(&self, ser: S) -> Result<S::Ok, S::Error> {
+        match &self.source {
+            ClipboardPayloadSource::Inline(bytes) => {
+                let proxy = ObservedRepProxy {
+                    id: self.id.clone(),
+                    format_id: self.format_id.clone(),
+                    mime: self.mime.clone(),
+                    bytes: bytes.clone(),
+                };
+                proxy.serialize(ser)
+            }
+            ClipboardPayloadSource::LocalFile { path, .. } => {
+                Err(serde::ser::Error::custom(format!(
+                    "ObservedClipboardRepresentation: LocalFile source cannot be serialized \
+                     (path={}); capture pipeline must materialize to blob storage first",
+                    path.display()
+                )))
+            }
+        }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for ObservedClipboardRepresentation {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        let proxy = ObservedRepProxy::deserialize(d)?;
+        Ok(Self {
+            id: proxy.id,
+            format_id: proxy.format_id,
+            mime: proxy.mime,
+            source: ClipboardPayloadSource::Inline(proxy.bytes),
+            cached_hash: OnceLock::new(),
+        })
     }
 }
 
@@ -208,10 +370,15 @@ pub(crate) fn is_link_content_representation(rep: &ObservedClipboardRepresentati
     if !(is_plain_text_representation(rep) || is_any_text_representation(rep)) {
         return false;
     }
-    if rep.bytes.is_empty() || rep.bytes.len() > LINK_HEURISTIC_BYTES_LIMIT {
+    // 仅纯文本/富文本 rep 走这条路径,LocalFile source 不应出现在文本类别里;
+    // 若上游 mis-classify 把 LocalFile 投到这里,直接当非链接处理(不 panic)。
+    let Some(bytes) = rep.inline_bytes() else {
+        return false;
+    };
+    if bytes.is_empty() || bytes.len() > LINK_HEURISTIC_BYTES_LIMIT {
         return false;
     }
-    let Ok(text) = std::str::from_utf8(&rep.bytes) else {
+    let Ok(text) = std::str::from_utf8(bytes) else {
         return false;
     };
     let trimmed = text.trim();
@@ -237,7 +404,7 @@ impl Clone for ObservedClipboardRepresentation {
             id: self.id.clone(),
             format_id: self.format_id.clone(),
             mime: self.mime.clone(),
-            bytes: self.bytes.clone(),
+            source: self.source.clone(),
             cached_hash: self.cached_hash.clone(),
         }
     }
@@ -245,12 +412,21 @@ impl Clone for ObservedClipboardRepresentation {
 
 impl std::fmt::Debug for ObservedClipboardRepresentation {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("ObservedClipboardRepresentation")
-            .field("id", &self.id)
+        let mut s = f.debug_struct("ObservedClipboardRepresentation");
+        s.field("id", &self.id)
             .field("format_id", &self.format_id)
-            .field("mime", &self.mime)
-            .field("bytes_len", &self.bytes.len())
-            .finish()
+            .field("mime", &self.mime);
+        match &self.source {
+            ClipboardPayloadSource::Inline(b) => {
+                s.field("source", &"Inline").field("bytes_len", &b.len());
+            }
+            ClipboardPayloadSource::LocalFile { path, size_bytes } => {
+                s.field("source", &"LocalFile")
+                    .field("path", &path.display().to_string())
+                    .field("size_bytes", size_bytes);
+            }
+        }
+        s.finish()
     }
 }
 

--- a/src-tauri/crates/uc-desktop/src/daemon/runtime_assembly.rs
+++ b/src-tauri/crates/uc-desktop/src/daemon/runtime_assembly.rs
@@ -87,6 +87,7 @@ pub fn build_daemon_runtime_workers(
         input.deps.device.device_identity.clone(),
         input.deps.clipboard.representation_cache.clone(),
         input.deps.clipboard.spool_queue.clone(),
+        input.deps.storage.blob_writer.clone(),
         input.deps.analytics.clone(),
     ));
     let blob_materializer = Arc::new(FileCacheBlobMaterializer::new(

--- a/src-tauri/crates/uc-infra/src/blob/blob_writer.rs
+++ b/src-tauri/crates/uc-infra/src/blob/blob_writer.rs
@@ -1,5 +1,7 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use async_trait::async_trait;
+use std::io::Read;
+use std::path::Path;
 use tracing::{debug, debug_span, Instrument};
 use uc_core::blob::ports::BlobWriterPort;
 use uc_core::ports::ClockPort;
@@ -89,4 +91,88 @@ where
         .instrument(span)
         .await
     }
+
+    async fn write_path_if_absent(&self, source_path: &Path) -> Result<BlobId> {
+        let span = debug_span!(
+            "infra.blob.write_path_if_absent",
+            source_path = %source_path.display(),
+        );
+        let source = source_path.to_path_buf();
+
+        async move {
+            // 1. 流式读取源文件计算 ContentHash —— 不把整文件载入内存,以支持任意大小。
+            let hash_source = source.clone();
+            let (content_id, file_size) =
+                tokio::task::spawn_blocking(move || stream_hash_file(&hash_source))
+                    .await
+                    .context("hash join failed")??;
+            debug!(
+                content_hash = %content_id,
+                file_size,
+                "Computed content hash for path-backed ingest"
+            );
+
+            // 2. 已有同 hash blob → 直接复用,不再做盘 IO。
+            if let Some(existing) = self.blob_repo.find_by_hash(&content_id).await? {
+                debug!(
+                    content_hash = %content_id,
+                    blob_id = %existing.blob_id,
+                    "Path ingest: dedup hit, reusing existing blob"
+                );
+                return Ok(existing.blob_id);
+            }
+
+            // 3. 未命中 → 走 BlobStorePort.put_from_path(hardlink 优先,跨卷 fallback copy;
+            //    加密 decorator 会 override 为读 → 加密 → 写)。
+            let blob_id = BlobId::new();
+            let (storage_path, compressed_size) =
+                self.blob_store.put_from_path(&blob_id, &source).await?;
+
+            let created_at_ms = self.clock.now_ms();
+            let blob_storage_locator = BlobStorageLocator::new_local_fs(storage_path);
+            let record = Blob::new(
+                blob_id.clone(),
+                blob_storage_locator,
+                file_size as i64,
+                content_id.clone(),
+                created_at_ms,
+                compressed_size,
+            );
+
+            if let Err(err) = self.blob_repo.insert_blob(&record).await {
+                if let Some(existing) = self.blob_repo.find_by_hash(&content_id).await? {
+                    debug!(
+                        error = %err,
+                        content_hash = %content_id,
+                        "Path ingest insert raced with existing blob; returning existing record",
+                    );
+                    return Ok(existing.blob_id);
+                }
+                return Err(err);
+            }
+            Ok(blob_id)
+        }
+        .instrument(span)
+        .await
+    }
+}
+
+/// 对 `path` 流式做 blake3 哈希,返回 (ContentHash, file_size_bytes)。
+/// 64 KiB 缓冲,常驻内存与文件大小无关。
+fn stream_hash_file(path: &Path) -> Result<(ContentHash, u64)> {
+    let mut file = std::fs::File::open(path)
+        .with_context(|| format!("failed to open {} for hashing", path.display()))?;
+    let mut hasher = blake3::Hasher::new();
+    let mut buf = [0u8; 64 * 1024];
+    let mut total: u64 = 0;
+    loop {
+        let n = file.read(&mut buf).context("read failed during hashing")?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+        total = total.saturating_add(n as u64);
+    }
+    let hash = hasher.finalize();
+    Ok((ContentHash::from(hash.as_bytes()), total))
 }

--- a/src-tauri/crates/uc-infra/src/blob/filesystem_store.rs
+++ b/src-tauri/crates/uc-infra/src/blob/filesystem_store.rs
@@ -2,7 +2,8 @@
 //! 基于文件系统的 blob 存储。
 
 use anyhow::{Context, Result};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use tracing::{debug, warn};
 use uc_core::blob::ports::BlobReaderPort;
 use uc_core::BlobId;
 
@@ -52,6 +53,67 @@ impl BlobStorePort for FilesystemBlobStore {
 
     async fn get(&self, blob_id: &BlobId) -> Result<Vec<u8>> {
         <Self as BlobReaderPort>::get(self, blob_id).await
+    }
+
+    async fn put_from_path(
+        &self,
+        blob_id: &BlobId,
+        source_path: &Path,
+    ) -> Result<(PathBuf, Option<i64>)> {
+        self.ensure_dir().await?;
+        let dest = self.blob_path(blob_id);
+        let source = source_path.to_path_buf();
+
+        // 优先 hardlink:同卷下 O(1) 完成 ingest,无额外磁盘占用、无 byte copy。
+        // 跨卷(EXDEV)或某些文件系统(SMB/NFS 部分配置)不支持 hardlink,回退到 copy。
+        let link_dest = dest.clone();
+        let link_source = source.clone();
+        match tokio::task::spawn_blocking(move || std::fs::hard_link(&link_source, &link_dest))
+            .await
+            .context("hardlink join failed")?
+        {
+            Ok(()) => {
+                debug!(
+                    blob_id = %blob_id,
+                    source = %source.display(),
+                    dest = %dest.display(),
+                    "Hardlinked source file into blob store"
+                );
+                return Ok((dest, None));
+            }
+            Err(err) => {
+                warn!(
+                    blob_id = %blob_id,
+                    source = %source.display(),
+                    dest = %dest.display(),
+                    error = %err,
+                    "Hardlink failed; falling back to streaming copy (likely EXDEV or unsupported FS)"
+                );
+            }
+        }
+
+        // 流式 copy 回退:tokio::fs::copy 内部按块读写,常驻内存极小。
+        let copied = tokio::fs::copy(&source, &dest).await.with_context(|| {
+            format!("failed to copy {} -> {}", source.display(), dest.display())
+        })?;
+        debug!(
+            blob_id = %blob_id,
+            source = %source.display(),
+            dest = %dest.display(),
+            bytes = copied,
+            "Copied source file into blob store"
+        );
+
+        // 与 put() 行为对齐:确保字节真正落盘后再返回。
+        let dest_file = tokio::fs::File::open(&dest)
+            .await
+            .context("failed to reopen blob file for sync")?;
+        dest_file
+            .sync_all()
+            .await
+            .context("failed to sync blob file after copy")?;
+
+        Ok((dest, None))
     }
 }
 

--- a/src-tauri/crates/uc-infra/src/blob/store_port.rs
+++ b/src-tauri/crates/uc-infra/src/blob/store_port.rs
@@ -10,7 +10,7 @@
 
 use anyhow::Result;
 use async_trait::async_trait;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use uc_core::BlobId;
 
@@ -24,6 +24,20 @@ pub trait BlobStorePort: Send + Sync {
 
     /// Read bytes from blob storage.
     async fn get(&self, blob_id: &BlobId) -> Result<Vec<u8>>;
+
+    /// 把 `source_path` 上的本地文件登记进 blob 存储。
+    ///
+    /// 推荐实现策略:先尝试 `hard_link`(O(1) 不占额外磁盘),失败(典型 EXDEV — 跨卷 /
+    /// 跨文件系统)再回退到流式 copy。返回 `(storage_path, compressed_size)`,语义与
+    /// `put` 一致。
+    ///
+    /// 实现不得改动 source 文件;若 store 是带加密 decorator,该接口会被 decorator
+    /// 重写为"读 → 加密 → 写新文件",而不是直接 hardlink(因为加密产物字节不同)。
+    async fn put_from_path(
+        &self,
+        blob_id: &BlobId,
+        source_path: &Path,
+    ) -> Result<(PathBuf, Option<i64>)>;
 }
 
 #[async_trait]
@@ -34,5 +48,13 @@ impl<T: BlobStorePort + ?Sized> BlobStorePort for Arc<T> {
 
     async fn get(&self, blob_id: &BlobId) -> Result<Vec<u8>> {
         (**self).get(blob_id).await
+    }
+
+    async fn put_from_path(
+        &self,
+        blob_id: &BlobId,
+        source_path: &Path,
+    ) -> Result<(PathBuf, Option<i64>)> {
+        (**self).put_from_path(blob_id, source_path).await
     }
 }

--- a/src-tauri/crates/uc-infra/src/clipboard/normalizer.rs
+++ b/src-tauri/crates/uc-infra/src/clipboard/normalizer.rs
@@ -82,7 +82,11 @@ impl ClipboardRepresentationNormalizerPort for ClipboardRepresentationNormalizer
         observed: &ObservedClipboardRepresentation,
     ) -> Result<PersistedClipboardRepresentation> {
         let inline_threshold_bytes = self.config.inline_threshold_bytes;
-        let size_bytes = observed.bytes.len() as i64;
+        let size_bytes = observed.size_bytes();
+        // Normalizer 仅处理 Inline source rep —— LocalFile rep 必须在更上游的 capture
+        // 流水线里通过 BlobWriterPort.write_path_if_absent 物化到 blob 仓库,直接产出
+        // BlobReady 状态的 PersistedClipboardRepresentation,不应进入此路径。
+        let bytes = observed.expect_inline_bytes();
 
         // Decision: inline, preview, or staged for blob materialization
         // 决策：内联、预览还是为 blob 物化创建暂存状态
@@ -101,7 +105,7 @@ impl ClipboardRepresentationNormalizerPort for ClipboardRepresentationNormalizer
                 observed.format_id.clone(),
                 observed.mime.clone(),
                 size_bytes,
-                Some(observed.bytes.clone()),
+                Some(bytes.to_vec()),
                 None, // blob_id
             ))
         } else {
@@ -123,7 +127,7 @@ impl ClipboardRepresentationNormalizerPort for ClipboardRepresentationNormalizer
                     observed.format_id.clone(),
                     observed.mime.clone(),
                     size_bytes,
-                    Some(truncate_to_preview(&observed.bytes)),
+                    Some(truncate_to_preview(bytes)),
                     None, // blob_id
                     PayloadAvailability::Staged,
                     None,

--- a/src-tauri/crates/uc-infra/src/security/decrypting_clipboard_event_repo.rs
+++ b/src-tauri/crates/uc-infra/src/security/decrypting_clipboard_event_repo.rs
@@ -45,14 +45,17 @@ impl ClipboardEventRepositoryPort for DecryptingClipboardEventRepository {
             .get_representation(event_id, representation_id)
             .await?;
 
-        if !observed.bytes.is_empty() {
+        // Inline source 才需要解密;LocalFile source 不应在这条路径出现 —— 仓库读出的
+        // ObservedClipboardRepresentation 必然由 inline_data 解出(走 wire / DB 字节)。
+        let inline_len = observed.inline_bytes().map(|b| b.len()).unwrap_or(0);
+        if inline_len > 0 {
             // BlobCipherAdapter 内部 wire format 与 4 个 decorator 历史 inline_data
             // 字节布局 (serde_json::to_vec(&EncryptedBlob)) 一致——既有数据可
             // 直接被新 port 解开,不需要数据迁移。
             let aad = aad::for_inline(event_id, &RepresentationId::from(representation_id));
             // 单空间模型下用占位 ActiveSpace,adapter 当前不按 SpaceId 路由。
             let active = ActiveSpace::new(SpaceId::from("space"));
-            let ciphertext = Ciphertext::new(observed.bytes.clone());
+            let ciphertext = Ciphertext::new(observed.expect_inline_bytes().to_vec());
             let plaintext = self
                 .blob_cipher
                 .decrypt(&active, &ciphertext, &Aad::from(aad.as_slice()))
@@ -65,7 +68,9 @@ impl ClipboardEventRepositoryPort for DecryptingClipboardEventRepository {
                 "Decrypted representation bytes via BlobCipherPort"
             );
 
-            observed.bytes = plaintext.into_bytes();
+            observed
+                .set_inline_bytes(plaintext.into_bytes())
+                .context("set decrypted bytes back to observed rep")?;
         }
 
         Ok(observed)

--- a/src-tauri/crates/uc-infra/src/security/encrypted_blob_store.rs
+++ b/src-tauri/crates/uc-infra/src/security/encrypted_blob_store.rs
@@ -141,6 +141,21 @@ impl BlobStorePort for EncryptedBlobStore {
         Ok((path, Some(on_disk_size)))
     }
 
+    async fn put_from_path(
+        &self,
+        blob_id: &BlobId,
+        source_path: &std::path::Path,
+    ) -> Result<(PathBuf, Option<i64>)> {
+        // AEAD wire format(v1_aead::encrypt_blob_xchacha)是 one-shot,目前不支持流式
+        // 加密。这里先把源文件整文件读进内存再走 put() —— 与 capture-side 调用方约定:
+        // 加密 store 启用时,path-backed ingest 的"任意大小"语义降级为"内存里能放得下",
+        // 流式 AEAD 重构属于独立 phase。
+        let bytes = tokio::fs::read(source_path)
+            .await
+            .with_context(|| format!("failed to read {} for encryption", source_path.display()))?;
+        self.put(blob_id, &bytes).await
+    }
+
     async fn get(&self, blob_id: &BlobId) -> Result<Vec<u8>> {
         <Self as BlobReaderPort>::get(self, blob_id).await
     }

--- a/src-tauri/crates/uc-platform/examples/wayland_clipboard_test.rs
+++ b/src-tauri/crates/uc-platform/examples/wayland_clipboard_test.rs
@@ -89,15 +89,13 @@ fn main() -> anyhow::Result<()> {
     let snap = clipboard.read_snapshot()?;
     eprintln!("    snapshot: {} reps", snap.representations.len());
     for rep in &snap.representations {
-        let preview: String = String::from_utf8_lossy(&rep.bytes)
-            .chars()
-            .take(80)
-            .collect();
+        let bytes = rep.inline_bytes().unwrap_or(&[]);
+        let preview: String = String::from_utf8_lossy(bytes).chars().take(80).collect();
         eprintln!(
             "      - format={} mime={:?} bytes={} preview={:?}",
             rep.format_id,
             rep.mime.as_ref().map(|m| m.0.as_str()),
-            rep.bytes.len(),
+            bytes.len(),
             preview
         );
     }

--- a/src-tauri/crates/uc-platform/examples/wayland_watch.rs
+++ b/src-tauri/crates/uc-platform/examples/wayland_watch.rs
@@ -76,12 +76,13 @@ async fn main() -> anyhow::Result<()> {
                             snapshot.representations.len()
                         );
                         for rep in &snapshot.representations {
-                            let preview = preview_bytes(&rep.bytes);
+                            let bytes = rep.inline_bytes().unwrap_or(&[]);
+                            let preview = preview_bytes(bytes);
                             println!(
                                 "  - format={} mime={:?} bytes={} preview={:?}",
                                 rep.format_id,
                                 rep.mime.as_ref().map(|m| m.0.as_str()),
-                                rep.bytes.len(),
+                                bytes.len(),
                                 preview
                             );
                         }

--- a/src-tauri/crates/uc-platform/examples/x11_clipboard_test.rs
+++ b/src-tauri/crates/uc-platform/examples/x11_clipboard_test.rs
@@ -98,15 +98,13 @@ fn main() -> anyhow::Result<()> {
     let snap = clipboard.read_snapshot()?;
     eprintln!("    snapshot: {} reps", snap.representations.len());
     for rep in &snap.representations {
-        let preview: String = String::from_utf8_lossy(&rep.bytes)
-            .chars()
-            .take(80)
-            .collect();
+        let bytes = rep.inline_bytes().unwrap_or(&[]);
+        let preview: String = String::from_utf8_lossy(bytes).chars().take(80).collect();
         eprintln!(
             "      - format={} mime={:?} bytes={} preview={:?}",
             rep.format_id,
             rep.mime.as_ref().map(|m| m.0.as_str()),
-            rep.bytes.len(),
+            bytes.len(),
             preview
         );
     }

--- a/src-tauri/crates/uc-platform/examples/x11_watch.rs
+++ b/src-tauri/crates/uc-platform/examples/x11_watch.rs
@@ -76,12 +76,13 @@ async fn main() -> anyhow::Result<()> {
                             snapshot.representations.len()
                         );
                         for rep in &snapshot.representations {
-                            let preview = preview_bytes(&rep.bytes);
+                            let bytes = rep.inline_bytes().unwrap_or(&[]);
+                            let preview = preview_bytes(bytes);
                             println!(
                                 "  - format={} mime={:?} bytes={} preview={:?}",
                                 rep.format_id,
                                 rep.mime.as_ref().map(|m| m.0.as_str()),
-                                rep.bytes.len(),
+                                bytes.len(),
                                 preview
                             );
                         }

--- a/src-tauri/crates/uc-platform/src/clipboard/common.rs
+++ b/src-tauri/crates/uc-platform/src/clipboard/common.rs
@@ -28,6 +28,24 @@ pub(crate) fn sniff_image_magic(body: &[u8]) -> Option<&'static str> {
     None
 }
 
+/// 基于文件后缀推断常见图片 MIME。仅用于 `image-from-file` LocalFile rep 的 mime 标注;
+/// 与 `sniff_image_magic` 字节嗅探互补 —— 这里在抓取阶段不读字节,所以只能凭扩展名。
+fn image_file_mime_from_path(path: &std::path::Path) -> Option<&'static str> {
+    let ext = path
+        .extension()
+        .and_then(|e| e.to_str())?
+        .to_ascii_lowercase();
+    Some(match ext.as_str() {
+        "png" => "image/png",
+        "jpg" | "jpeg" => "image/jpeg",
+        "gif" => "image/gif",
+        "webp" => "image/webp",
+        "bmp" => "image/bmp",
+        "tif" | "tiff" => "image/tiff",
+        _ => return None,
+    })
+}
+
 /// Known TIFF UTI aliases on macOS pasteboard.
 /// When the image has already been captured via the fast raw-TIFF path,
 /// these formats must be skipped in the raw fallback loop to avoid
@@ -323,11 +341,34 @@ impl CommonClipboardImpl {
             }
         }
 
+        // macOS Finder thumbnail pollution guard.
+        //
+        // 当 captured_file_paths 含图片扩展名时,ContentFormat::Image 99% 是 Finder 在
+        // "复制文件"时注入的文件图标缩略图(128/256 px),而不是用户复制的图片内容本身。
+        // 跳过 ContentFormat::Image 分支,让下面的 image-from-file fallback 用 LocalFile
+        // source 引用真实文件 —— 这样 dashboard / 跨设备同步看到的都是真图,不是缩略图。
+        //
+        // 不在 captured_file_paths 含图片扩展名时退化:即使 Image 与 Files 共存,Files 也
+        // 可能是其他类型(PDF/ZIP)且 Image 真是用户复制的截图,不能误杀。所以仅当 file 列表
+        // 里至少一个文件是图片扩展名才 suppress。
+        #[cfg(target_os = "macos")]
+        let suppress_image_due_to_file_thumbnail = captured_file_paths
+            .iter()
+            .any(|p| image_file_mime_from_path(p).is_some());
+        #[cfg(not(target_os = "macos"))]
+        let suppress_image_due_to_file_thumbnail = false;
+
         // Track whether we successfully read image data via the high-level path.
         // Used to skip TIFF aliases in the raw fallback loop on macOS.
         let mut image_already_read = false;
 
-        if ctx.has(ContentFormat::Image) {
+        if ctx.has(ContentFormat::Image) && suppress_image_due_to_file_thumbnail {
+            info!(
+                captured_files = captured_file_paths.len(),
+                "macOS: ContentFormat::Image suppressed (looks like Finder file thumbnail); \
+                 deferring to image-from-file LocalFile rep below"
+            );
+        } else if ctx.has(ContentFormat::Image) {
             debug!("clipboard-rs reports ContentFormat::Image available");
 
             // macOS fast path: read raw TIFF directly via get_buffer, avoiding
@@ -475,52 +516,22 @@ impl CommonClipboardImpl {
             debug!("clipboard-rs reports no ContentFormat::Image available");
         }
 
-        // If the clipboard carried file references (but no image bytes were
-        // captured above) and any of those files look like image files, this
-        // fallback may load their bytes as inline `image-from-file` reps so
-        // that screenshot tools (which copy a temp PNG path) render as a real
-        // image preview in the UI rather than showing only a filename.
+        // 当 clipboard 携带文件引用且至少有一个是图片文件,produce 一条 `image-from-file`
+        // rep —— 这条 rep 走 `ClipboardPayloadSource::LocalFile` 路径,**不读字节、不占内存**,
+        // 由 capture pipeline 在 normalize 阶段同步调 `BlobWriter.write_path_if_absent` 物化
+        // 到 blob 仓库(hardlink 优先,跨卷 fallback 流式 copy)。
         //
-        // Contract (post 260426-1gz quick task):
-        // - Only "small" image files (< MAX_INLINE_IMAGE_BYTES) become inline
-        //   `image-from-file` reps for immediate UI preview. Daily screenshots
-        //   from system tools are typically well under this threshold.
-        // - Large image files are intentionally NOT inlined here. Locally the
-        //   UI still has the `files` rep (filename / file list) and the
-        //   `BackgroundBlobWorker.try_generate_thumbnail` path will populate
-        //   `clipboard_representation_thumbnail` asynchronously, so the
-        //   history list still gets a thumbnail. Cross-device transfer of the
-        //   actual pixels is the responsibility of the file transfer / blob
-        //   ref path, not this fallback.
-        // - This guarantees that no single rep produced by capture exceeds
-        //   the V3 envelope budget, preventing the
-        //   `peer rejected: payload ... exceeds local maximum 2097152`
-        //   dispatch failure observed when a >= 2 MiB PNG file URI is copied.
+        // 任意大小的图片文件都能被收纳:dashboard 通过 `/clipboard/blobs/{blob_id}` 拿真实
+        // 字节预览,跨设备同步通过 V3BlobRef + iroh-blobs 流式拉取。256 KiB 与 2 MiB envelope
+        // 预算只约束 wire 路径的 inline rep,跟 LocalFile 物化路径无关。
         if !image_already_read && !captured_file_paths.is_empty() {
-            // Hard upper safety cap: never read an image file larger than this
-            // even if the inline-budget check below were somehow bypassed.
-            const MAX_IMAGE_FILE_BYTES: u64 = 20 * 1024 * 1024; // 20 MB
-                                                                // Conservative inline budget: stays well under the 2 MiB envelope
-                                                                // (`MAX_PAYLOAD_SIZE` in `clipboard_wire.rs`) so that even after
-                                                                // V3 header + AEAD tag + co-existing reps (plain text, files,
-                                                                // html, ...) the encrypted envelope fits with ~8x headroom.
-                                                                // 256 KiB still covers typical screenshot-tool PNGs (usually
-                                                                // < 200 KiB), so the immediate inline preview UX does not regress.
-            const MAX_INLINE_IMAGE_BYTES: u64 = 256 * 1024; // 256 KiB
+            // Sanity cap:超过此阈值的图片文件视为异常(可能用户误把磁盘镜像复制了),
+            // 跳过登记,让 files rep 仍然能传文件本体。100 MB 对桌面截图场景留充裕空间。
+            const MAX_IMAGE_FILE_BYTES: u64 = 100 * 1024 * 1024;
 
             for path in &captured_file_paths {
-                let ext = match path.extension().and_then(|e| e.to_str()) {
-                    Some(e) => e.to_ascii_lowercase(),
-                    None => continue,
-                };
-                let mime = match ext.as_str() {
-                    "png" => "image/png",
-                    "jpg" | "jpeg" => "image/jpeg",
-                    "gif" => "image/gif",
-                    "webp" => "image/webp",
-                    "bmp" => "image/bmp",
-                    "tif" | "tiff" => "image/tiff",
-                    _ => continue,
+                let Some(mime) = image_file_mime_from_path(path) else {
+                    continue;
                 };
                 let meta = match std::fs::metadata(path) {
                     Ok(m) => m,
@@ -537,55 +548,26 @@ impl CommonClipboardImpl {
                     debug!(
                         path = %path.display(),
                         size_bytes = meta.len(),
-                        "Skipping clipboard image file (size out of range)"
+                        threshold = MAX_IMAGE_FILE_BYTES,
+                        "Skipping clipboard image file (size out of safe range)"
                     );
                     continue;
                 }
-                if meta.len() > MAX_INLINE_IMAGE_BYTES {
-                    // Intentionally do NOT read or push an inline rep here.
-                    // The downstream `files` rep + BackgroundBlobWorker
-                    // thumbnail path covers local UI; cross-device pixel
-                    // transfer is handled by file transfer / blob ref. This
-                    // prevents the snapshot from carrying a multi-MiB inline
-                    // rep that would blow the V3 envelope budget.
-                    //
-                    // Note (per uc-platform AGENTS §12.3): only path/size/
-                    // mime/threshold are logged — never any file bytes.
-                    debug!(
-                        path = %path.display(),
-                        size_bytes = meta.len(),
-                        mime = mime,
-                        threshold = MAX_INLINE_IMAGE_BYTES,
-                        "Skipping inline image-from-file rep (too large for envelope); files rep + background thumbnail will handle it"
-                    );
-                    break;
-                }
-                match std::fs::read(path) {
-                    Ok(bytes) => {
-                        debug!(
-                            path = %path.display(),
-                            size_bytes = bytes.len(),
-                            mime = mime,
-                            "Loaded image bytes from clipboard file path"
-                        );
-                        reps.push(ObservedClipboardRepresentation::new(
-                            RepresentationId::new(),
-                            "image-from-file".into(),
-                            Some(MimeType(mime.to_string())),
-                            bytes,
-                        ));
-                        // One image representation is enough to drive the
-                        // preview; avoid duplicating for multi-file selections.
-                        break;
-                    }
-                    Err(err) => {
-                        warn!(
-                            error = %err,
-                            path = %path.display(),
-                            "Failed to read clipboard image file"
-                        );
-                    }
-                }
+                debug!(
+                    path = %path.display(),
+                    size_bytes = meta.len(),
+                    mime = mime,
+                    "Captured image-from-file rep as LocalFile source (no inline read; blob ingest happens during normalize)"
+                );
+                reps.push(ObservedClipboardRepresentation::new_local_file(
+                    RepresentationId::new(),
+                    "image-from-file".into(),
+                    Some(MimeType(mime.to_string())),
+                    path.clone(),
+                    meta.len(),
+                ));
+                // 一个图片 rep 足以驱动 dashboard 预览;多文件选择时不重复产 rep。
+                break;
             }
         }
 
@@ -701,7 +683,7 @@ impl CommonClipboardImpl {
             (Some(m), Some(default))
                 if default.starts_with("image/") && !m.starts_with("image/") =>
             {
-                let recovered = sniff_image_magic(&rep.bytes).unwrap_or(default);
+                let recovered = sniff_image_magic(rep.expect_inline_bytes()).unwrap_or(default);
                 warn!(
                     format_id = %rep.format_id,
                     wire_mime = m,
@@ -716,19 +698,25 @@ impl CommonClipboardImpl {
 
         match effective_mime {
             Some("text/plain") => {
-                map_clipboard_err(ctx.set_text(String::from_utf8(rep.bytes.clone())?))?;
+                map_clipboard_err(
+                    ctx.set_text(String::from_utf8(rep.expect_inline_bytes().to_vec())?),
+                )?;
             }
             Some("text/rtf") => {
-                map_clipboard_err(ctx.set_rich_text(String::from_utf8(rep.bytes.clone())?))?;
+                map_clipboard_err(
+                    ctx.set_rich_text(String::from_utf8(rep.expect_inline_bytes().to_vec())?),
+                )?;
             }
             Some("text/html") => {
-                map_clipboard_err(ctx.set_html(String::from_utf8(rep.bytes.clone())?))?;
+                map_clipboard_err(
+                    ctx.set_html(String::from_utf8(rep.expect_inline_bytes().to_vec())?),
+                )?;
             }
             Some("text/uri-list") | Some("file/uri-list") => {
                 // Convert file:// URIs back to raw OS paths for set_files(),
                 // which expects native paths. Also handle raw paths for compatibility
                 // with inbound cache paths that aren't URI-encoded.
-                let files: Vec<String> = String::from_utf8(rep.bytes.clone())?
+                let files: Vec<String> = String::from_utf8(rep.expect_inline_bytes().to_vec())?
                     .lines()
                     .filter_map(|line| {
                         let line = line.trim();
@@ -752,7 +740,7 @@ impl CommonClipboardImpl {
             Some(mime) if mime.starts_with("image/") => {
                 debug!(
                     mime = mime,
-                    data_size = rep.bytes.len(),
+                    data_size = rep.size_bytes(),
                     format_id = %rep.format_id,
                     "write_snapshot: writing image to clipboard"
                 );
@@ -764,33 +752,37 @@ impl CommonClipboardImpl {
                 #[cfg(target_os = "macos")]
                 {
                     if mime == "image/png" {
-                        map_clipboard_err(ctx.set_buffer("public.png", rep.bytes.clone()))?;
+                        map_clipboard_err(
+                            ctx.set_buffer("public.png", rep.expect_inline_bytes().to_vec()),
+                        )?;
                     } else {
                         // Non-PNG images still need format conversion via set_image
                         let img =
-                            clipboard_rs::RustImageData::from_bytes(&rep.bytes).map_err(|e| {
-                                warn!(
-                                    mime = mime,
-                                    data_size = rep.bytes.len(),
-                                    error = %e,
-                                    "write_snapshot: failed to decode image bytes"
-                                );
-                                anyhow!(e)
-                            })?;
+                            clipboard_rs::RustImageData::from_bytes(rep.expect_inline_bytes())
+                                .map_err(|e| {
+                                    warn!(
+                                        mime = mime,
+                                        data_size = rep.size_bytes(),
+                                        error = %e,
+                                        "write_snapshot: failed to decode image bytes"
+                                    );
+                                    anyhow!(e)
+                                })?;
                         map_clipboard_err(ctx.set_image(img))?;
                     }
                 }
                 #[cfg(not(target_os = "macos"))]
                 {
-                    let img = clipboard_rs::RustImageData::from_bytes(&rep.bytes).map_err(|e| {
-                        warn!(
-                            mime = mime,
-                            data_size = rep.bytes.len(),
-                            error = %e,
-                            "write_snapshot: failed to decode image bytes"
-                        );
-                        anyhow!(e)
-                    })?;
+                    let img = clipboard_rs::RustImageData::from_bytes(rep.expect_inline_bytes())
+                        .map_err(|e| {
+                            warn!(
+                                mime = mime,
+                                data_size = rep.size_bytes(),
+                                error = %e,
+                                "write_snapshot: failed to decode image bytes"
+                            );
+                            anyhow!(e)
+                        })?;
                     map_clipboard_err(ctx.set_image(img))?;
                 }
                 debug!(
@@ -828,10 +820,12 @@ impl CommonClipboardImpl {
                 warn!(
                     format_id = %rep.format_id,
                     mime = ?rep.mime,
-                    bytes = rep.bytes.len(),
+                    bytes = rep.size_bytes(),
                     "write_snapshot: writing rep via raw set_buffer fallback (no recognized mime mapping)"
                 );
-                map_clipboard_err(ctx.set_buffer(&rep.format_id, rep.bytes.clone()))?;
+                map_clipboard_err(
+                    ctx.set_buffer(&rep.format_id, rep.expect_inline_bytes().to_vec()),
+                )?;
             }
         }
 

--- a/src-tauri/crates/uc-platform/src/clipboard/platform/linux/wayland/protocol/ext.rs
+++ b/src-tauri/crates/uc-platform/src/clipboard/platform/linux/wayland/protocol/ext.rs
@@ -675,7 +675,7 @@ fn handle_write(
                 continue;
             }
             source.offer(mime.clone());
-            payloads.insert(mime, Arc::new(rep.bytes.clone()));
+            payloads.insert(mime, Arc::new(rep.expect_inline_bytes().to_vec()));
         }
     }
 

--- a/src-tauri/crates/uc-platform/src/clipboard/platform/linux/wayland/protocol/wlr.rs
+++ b/src-tauri/crates/uc-platform/src/clipboard/platform/linux/wayland/protocol/wlr.rs
@@ -687,7 +687,7 @@ fn handle_write(
                 continue;
             }
             source.offer(mime.clone());
-            payloads.insert(mime, Arc::new(rep.bytes.clone()));
+            payloads.insert(mime, Arc::new(rep.expect_inline_bytes().to_vec()));
         }
     }
 

--- a/src-tauri/crates/uc-platform/src/clipboard/platform/linux/x11/writer.rs
+++ b/src-tauri/crates/uc-platform/src/clipboard/platform/linux/x11/writer.rs
@@ -115,7 +115,7 @@ pub(super) fn install_snapshot(
         // without the charset suffix still get bytes (mirrors what wlr /
         // ext data-control sources do via their multi-offer dance, and
         // what clipboard_rs's `file_uri_list_to_clipboard_data` did for X11).
-        let bytes = Arc::new(rep.bytes.clone());
+        let bytes = Arc::new(rep.expect_inline_bytes().to_vec());
         match mime.as_str() {
             "text/plain;charset=utf-8" | "text/plain;charset=UTF-8" => {
                 payloads.entry(atoms.UTF8_STRING).or_insert(bytes.clone());

--- a/src-tauri/crates/uc-platform/src/clipboard/platform/macos.rs
+++ b/src-tauri/crates/uc-platform/src/clipboard/platform/macos.rs
@@ -93,8 +93,8 @@ fn resolve_multi_rep_mime(rep: &ObservedClipboardRepresentation) -> Option<&str>
 
     match (rep.mime.as_deref(), format_default) {
         (Some(m), Some(default)) if default.starts_with("image/") && !m.starts_with("image/") => {
-            let recovered =
-                crate::clipboard::common::sniff_image_magic(&rep.bytes).unwrap_or(default);
+            let recovered = crate::clipboard::common::sniff_image_magic(rep.expect_inline_bytes())
+                .unwrap_or(default);
             tracing::warn!(
                 format_id = %rep.format_id,
                 wire_mime = m,
@@ -258,31 +258,31 @@ pub(crate) fn write_snapshot_multi_macos(snapshot: SystemClipboardSnapshot) -> R
             Some("text/plain") => {
                 // text/plain 的字节是 UTF-8，NSPasteboardTypeString 期望 UTF-8 字节，
                 // 直接写原始字节，不经 NSString 转换（避免对非法 UTF-8 误报）。
-                let data = make_nsdata(&rep.bytes);
+                let data = make_nsdata(rep.expect_inline_bytes());
                 // NSPasteboardTypeString 是 extern "C" 静态变量，访问需要 unsafe 块。
                 // setData_forType 本身是 `pub fn`（安全方法）。
                 let ok = unsafe { text_item.setData_forType(&data, NSPasteboardTypeString) };
                 if ok {
-                    debug!(bytes = rep.bytes.len(), "写入 NSPasteboardTypeString 成功");
+                    debug!(bytes = rep.size_bytes(), "写入 NSPasteboardTypeString 成功");
                     wrote_any = true;
                 } else {
                     warn!(
-                        bytes = rep.bytes.len(),
+                        bytes = rep.size_bytes(),
                         "setData_forType(NSPasteboardTypeString) 返回 false"
                     );
                     skipped.push(rep.format_id.as_str().to_string());
                 }
             }
             Some("text/html") => {
-                let data = make_nsdata(&rep.bytes);
+                let data = make_nsdata(rep.expect_inline_bytes());
                 // NSPasteboardTypeHTML 是 extern "C" 静态变量，访问需要 unsafe 块。
                 let ok = unsafe { text_item.setData_forType(&data, NSPasteboardTypeHTML) };
                 if ok {
-                    debug!(bytes = rep.bytes.len(), "写入 NSPasteboardTypeHTML 成功");
+                    debug!(bytes = rep.size_bytes(), "写入 NSPasteboardTypeHTML 成功");
                     wrote_any = true;
                 } else {
                     warn!(
-                        bytes = rep.bytes.len(),
+                        bytes = rep.size_bytes(),
                         "setData_forType(NSPasteboardTypeHTML) 返回 false"
                     );
                     skipped.push(rep.format_id.as_str().to_string());
@@ -294,14 +294,14 @@ pub(crate) fn write_snapshot_multi_macos(snapshot: SystemClipboardSnapshot) -> R
                 // TextEdit 纯文本模式）继续用 NSPasteboardTypeString。原始 RTF 字节是
                 // ASCII 安全的（RTF 1.x 规范，非 ASCII 都做 \uN 转义），直接喂给 NSData。
                 // NSPasteboardTypeRTF 是 extern "C" 静态变量，访问需要 unsafe 块。
-                let data = make_nsdata(&rep.bytes);
+                let data = make_nsdata(rep.expect_inline_bytes());
                 let ok = unsafe { text_item.setData_forType(&data, NSPasteboardTypeRTF) };
                 if ok {
-                    debug!(bytes = rep.bytes.len(), "写入 NSPasteboardTypeRTF 成功");
+                    debug!(bytes = rep.size_bytes(), "写入 NSPasteboardTypeRTF 成功");
                     wrote_any = true;
                 } else {
                     warn!(
-                        bytes = rep.bytes.len(),
+                        bytes = rep.size_bytes(),
                         "setData_forType(NSPasteboardTypeRTF) 返回 false"
                     );
                     skipped.push(rep.format_id.as_str().to_string());
@@ -314,17 +314,17 @@ pub(crate) fn write_snapshot_multi_macos(snapshot: SystemClipboardSnapshot) -> R
                 // PNG 字节直接喂给 NSPasteboardTypePNG，AppKit 内部 lazy-decode，比
                 // 经 NSImage 中转更稳（避免 alpha / colorspace 翻译误差）。
                 let item: Retained<NSPasteboardItem> = NSPasteboardItem::new();
-                let data = make_nsdata(&rep.bytes);
+                let data = make_nsdata(rep.expect_inline_bytes());
                 // NSPasteboardTypePNG 是 extern "C" 静态变量，访问需要 unsafe 块。
                 let ok = unsafe { item.setData_forType(&data, NSPasteboardTypePNG) };
                 if ok {
-                    debug!(bytes = rep.bytes.len(), "写入 NSPasteboardTypePNG 成功");
+                    debug!(bytes = rep.size_bytes(), "写入 NSPasteboardTypePNG 成功");
                     wrote_any = true;
                     image_total += 1;
                     image_items.push(item);
                 } else {
                     warn!(
-                        bytes = rep.bytes.len(),
+                        bytes = rep.size_bytes(),
                         "setData_forType(NSPasteboardTypePNG) 返回 false"
                     );
                     skipped.push(rep.format_id.as_str().to_string());
@@ -332,29 +332,29 @@ pub(crate) fn write_snapshot_multi_macos(snapshot: SystemClipboardSnapshot) -> R
             }
             Some("image/tiff") => {
                 let item: Retained<NSPasteboardItem> = NSPasteboardItem::new();
-                let data = make_nsdata(&rep.bytes);
+                let data = make_nsdata(rep.expect_inline_bytes());
                 // NSPasteboardTypeTIFF 是 extern "C" 静态变量，访问需要 unsafe 块。
                 let ok = unsafe { item.setData_forType(&data, NSPasteboardTypeTIFF) };
                 if ok {
-                    debug!(bytes = rep.bytes.len(), "写入 NSPasteboardTypeTIFF 成功");
+                    debug!(bytes = rep.size_bytes(), "写入 NSPasteboardTypeTIFF 成功");
                     wrote_any = true;
                     image_total += 1;
                     image_items.push(item);
                 } else {
                     warn!(
-                        bytes = rep.bytes.len(),
+                        bytes = rep.size_bytes(),
                         "setData_forType(NSPasteboardTypeTIFF) 返回 false"
                     );
                     skipped.push(rep.format_id.as_str().to_string());
                 }
             }
             Some("text/uri-list") => {
-                let uris = match parse_uri_list(&rep.bytes) {
+                let uris = match parse_uri_list(rep.expect_inline_bytes()) {
                     Ok(list) => list,
                     Err(e) => {
                         warn!(
                             error = %e,
-                            bytes = rep.bytes.len(),
+                            bytes = rep.size_bytes(),
                             format_id = %rep.format_id,
                             "macOS 多 rep 写入：text/uri-list 解析失败，跳过该 rep"
                         );
@@ -392,7 +392,7 @@ pub(crate) fn write_snapshot_multi_macos(snapshot: SystemClipboardSnapshot) -> R
                 info!(
                     format_id = %rep.format_id,
                     mime = ?other,
-                    bytes = rep.bytes.len(),
+                    bytes = rep.size_bytes(),
                     "macOS 多 rep 写入：跳过不支持的 rep（当前支持 text/plain, text/html, text/rtf, text/uri-list, image/png, image/tiff）"
                 );
                 skipped.push(rep.format_id.as_str().to_string());

--- a/src-tauri/crates/uc-platform/src/clipboard/platform/windows.rs
+++ b/src-tauri/crates/uc-platform/src/clipboard/platform/windows.rs
@@ -38,8 +38,8 @@ fn resolve_multi_rep_mime(rep: &ObservedClipboardRepresentation) -> Option<&str>
     // image-like format_id 但显式 mime 非 image/*:见 `common.rs::write_snapshot` 同位置注释。
     match (rep.mime.as_deref(), format_default) {
         (Some(m), Some(default)) if default.starts_with("image/") && !m.starts_with("image/") => {
-            let recovered =
-                crate::clipboard::common::sniff_image_magic(&rep.bytes).unwrap_or(default);
+            let recovered = crate::clipboard::common::sniff_image_magic(rep.expect_inline_bytes())
+                .unwrap_or(default);
             tracing::warn!(
                 format_id = %rep.format_id,
                 wire_mime = m,
@@ -354,12 +354,12 @@ pub(crate) fn write_snapshot_multi_windows(snapshot: SystemClipboardSnapshot) ->
             if resolve_multi_rep_mime(rep) != Some("image/png") {
                 return None;
             }
-            match png_to_dibv5(&rep.bytes) {
+            match png_to_dibv5(rep.expect_inline_bytes()) {
                 Ok(dib) => Some(dib),
                 Err(e) => {
                     warn!(
                         error = %e,
-                        png_bytes = rep.bytes.len(),
+                        png_bytes = rep.expect_inline_bytes().len(),
                         "PNG→CF_DIBV5 转码失败；仅写 \"PNG\" 自定义 format"
                     );
                     None
@@ -492,11 +492,14 @@ fn attempt_multi_write_inner(
             Some("text/plain") => {
                 // 必须使用 set_string_with::<NoClear>：
                 // set_string 内部调用 DoClear（EmptyClipboard），会把已写的其他 format 抹掉。
-                let text = String::from_utf8(rep.bytes.clone())
+                let text = String::from_utf8(rep.expect_inline_bytes().to_vec())
                     .map_err(|e| anyhow::anyhow!("text/plain rep is not valid UTF-8: {}", e))?;
                 cb_raw::set_string_with::<NoClear>(&text, NoClear)
                     .map_err(|e| anyhow::anyhow!("set CF_UNICODETEXT failed: {}", e))?;
-                debug!(bytes = rep.bytes.len(), "写入 CF_UNICODETEXT 成功");
+                debug!(
+                    bytes = rep.expect_inline_bytes().len(),
+                    "写入 CF_UNICODETEXT 成功"
+                );
                 wrote_any = true;
             }
             Some("text/html") => {
@@ -505,13 +508,13 @@ fn attempt_multi_write_inner(
                     skipped.push(rep.format_id.as_str().to_string());
                     continue;
                 };
-                let html = String::from_utf8(rep.bytes.clone())
+                let html = String::from_utf8(rep.expect_inline_bytes().to_vec())
                     .map_err(|e| anyhow::anyhow!("text/html rep is not valid UTF-8: {}", e))?;
                 // set_html 默认走 NoClear 分支，内部构造 "Version:0.9 / StartHTML / EndHTML /
                 // StartFragment / EndFragment" 头并包裹 BODY_HEADER/BODY_FOOTER，适合累加。
                 cb_raw::set_html(html_fmt, &html)
                     .map_err(|e| anyhow::anyhow!("set CF_HTML failed: {}", e))?;
-                debug!(bytes = rep.bytes.len(), "写入 CF_HTML 成功");
+                debug!(bytes = rep.expect_inline_bytes().len(), "写入 CF_HTML 成功");
                 wrote_any = true;
             }
             Some("text/rtf") => {
@@ -524,9 +527,12 @@ fn attempt_multi_write_inner(
                     skipped.push(rep.format_id.as_str().to_string());
                     continue;
                 };
-                cb_raw::set_without_clear(rtf_fmt, &rep.bytes)
+                cb_raw::set_without_clear(rtf_fmt, rep.expect_inline_bytes())
                     .map_err(|e| anyhow::anyhow!("set Rich Text Format failed: {}", e))?;
-                debug!(bytes = rep.bytes.len(), "写入 Rich Text Format 成功");
+                debug!(
+                    bytes = rep.expect_inline_bytes().len(),
+                    "写入 Rich Text Format 成功"
+                );
                 wrote_any = true;
             }
             Some("image/png") => {
@@ -548,7 +554,7 @@ fn attempt_multi_write_inner(
                         .map_err(|e| anyhow::anyhow!("set CF_DIBV5 failed: {}", e))?;
                     debug!(
                         dib_bytes = dib_bytes.len(),
-                        png_bytes = rep.bytes.len(),
+                        png_bytes = rep.expect_inline_bytes().len(),
                         "写入 CF_DIBV5 成功"
                     );
                     wrote_dib = true;
@@ -556,11 +562,12 @@ fn attempt_multi_write_inner(
 
                 match cb_raw::register_format("PNG") {
                     Some(png_fmt) => {
-                        cb_raw::set_without_clear(png_fmt.get(), &rep.bytes).map_err(|e| {
-                            anyhow::anyhow!("set \"PNG\" custom format failed: {}", e)
-                        })?;
+                        cb_raw::set_without_clear(png_fmt.get(), rep.expect_inline_bytes())
+                            .map_err(|e| {
+                                anyhow::anyhow!("set \"PNG\" custom format failed: {}", e)
+                            })?;
                         debug!(
-                            png_bytes = rep.bytes.len(),
+                            png_bytes = rep.expect_inline_bytes().len(),
                             "写入 \"PNG\" 自定义 format 成功"
                         );
                         wrote_png = true;
@@ -581,12 +588,12 @@ fn attempt_multi_write_inner(
                 // 已把 blob 落地到本机 iroh-blobs 缓存目录并改写为本机 URI）解析回本机
                 // 路径，打包成 DROPFILES + UTF-16 名字串，`SetClipboardData(CF_HDROP)`。
                 // 这是 Explorer / Office / 大多数桌面应用识别的文件拷贝语义。
-                let paths = match parse_uri_list_to_paths(&rep.bytes) {
+                let paths = match parse_uri_list_to_paths(rep.expect_inline_bytes()) {
                     Ok(paths) => paths,
                     Err(e) => {
                         warn!(
                             error = %e,
-                            bytes = rep.bytes.len(),
+                            bytes = rep.expect_inline_bytes().len(),
                             format_id = %rep.format_id,
                             "Windows 多 rep 写入：text/uri-list 解析失败，跳过该 rep"
                         );
@@ -622,7 +629,7 @@ fn attempt_multi_write_inner(
                 info!(
                     format_id = %rep.format_id,
                     mime = ?other,
-                    bytes = rep.bytes.len(),
+                    bytes = rep.expect_inline_bytes().len(),
                     "Windows 多 rep 写入：跳过不支持的 rep（当前支持 text/plain, text/html, text/rtf, image/png, text/uri-list）"
                 );
                 skipped.push(rep.format_id.as_str().to_string());
@@ -743,7 +750,7 @@ impl SystemClipboardPort for WindowsClipboard {
             // Extract image bytes before passing snapshot to CommonClipboardImpl
             // (which consumes it by reference but we need the bytes for fallback).
             let image_bytes = if image_fallback_eligible {
-                snapshot.representations.first().map(|rep| rep.bytes.clone())
+                snapshot.representations.first().map(|rep| rep.expect_inline_bytes().to_vec())
             } else {
                 None
             };
@@ -852,7 +859,7 @@ fn extract_text_plain_utf8(snapshot: &SystemClipboardSnapshot) -> Result<Option<
         return Ok(None);
     };
 
-    let text = String::from_utf8(text_rep.bytes.clone())
+    let text = String::from_utf8(text_rep.expect_inline_bytes().to_vec())
         .map_err(|err| anyhow::anyhow!("Failed to decode text/plain snapshot as UTF-8: {}", err))?;
     Ok(Some(text))
 }


### PR DESCRIPTION
## Summary

Eliminate macOS Finder thumbnail pollution and let any-size image files copied via Finder be previewed locally and synced cross-device without inline-byte budget constraints. (aa4199cc)

- **Capture path**: macOS capture drops the Finder-injected image thumbnail when captured file paths contain image extensions, and switches image-from-file representations to a new `ClipboardPayloadSource::LocalFile` so capture no longer reads bytes during clipboard observation. The 256 KiB inline cap for image-from-file is removed; the 100 MB sanity cap remains.
- **Ingest pipeline**: New `BlobWriterPort::write_path_if_absent` stream-hashes a local file and ingests it via `BlobStorePort::put_from_path` (hardlink with EXDEV fallback to streaming copy). `LocalFile` reps are normalized into `BlobReady` `PersistedRep` ahead of `representation_cache` / `spool_queue`, so the heavy bytes never go through inline pathways.
- **Wire safety**: `LocalFile` is hard-blocked from envelope serialization; outbound dispatch strips it before encode. The paired files rep already carries the path and peers fetch real bytes via iroh-blobs.
- **Receiver symmetry**: Inbound materializer synthesizes a `LocalFile` image rep after the files rep is materialized, so the receiver's capture pipeline also produces a `BlobReady` image rep — enabling dashboard preview and image-aware paste on the receiving end.
- **Selection policy v1**: Image-from-file reps above `INLINE_PREVIEW_MAX_BYTES` lose the `UiPreview` boost as a safety net; capture-time guard is primary.

No `docs-site/` changes — there is no documented user-facing contract that this PR alters. The "inline-size threshold" / "Small-file threshold (MB)" docs describe a generic file-size split that is unchanged; this PR fixes a broken capture path for macOS Finder images that the docs already implicitly promised would work.

## Test plan

- [x] `cargo test -p uc-application -p uc-core -p uc-infra -p uc-platform` (touched crates)
- [ ] Manual: on macOS, copy a multi-MB PNG from Finder → dashboard preview shows the real image (not the Finder icon); paired peer receives the file via iroh-blobs and the peer's dashboard also shows the real image
- [ ] Manual: copy an oversized image file (>100 MB) → rejected with a clear reason rather than ingested
- [ ] Manual: copy a small text snippet → still rides the inline path unchanged
- [ ] Verify `LocalFile` source never appears in wire envelopes (assertion in payload_codec; covered by `apply_inbound/tests.rs`)