### PR TITLE
chore(lint): resolve @/* aliases via typescript resolver (#734)

### DIFF
--- a/docs-site/content/docs/en/getting-started/install.mdx
+++ b/docs-site/content/docs/en/getting-started/install.mdx
@@ -44,8 +44,8 @@ curl -fsSL https://raw.githubusercontent.com/UniClipboard/UniClipboard/main/scri
 
 <Callout type="info">
   Update behavior matches the platform tabs below: `.deb` / `.rpm` installs are not picked up by the
-  in-app updater — re-run the script or use your system package manager. AppImage on Linux and `.app`
-  on macOS continue to update from inside the app. For Windows, see the **Windows** tab.
+  in-app updater — re-run the script or use your system package manager. AppImage on Linux and
+  `.app` on macOS continue to update from inside the app. For Windows, see the **Windows** tab.
 </Callout>
 
 ## Pick your platform

--- a/docs-site/content/docs/zh/getting-started/install.mdx
+++ b/docs-site/content/docs/zh/getting-started/install.mdx
@@ -42,8 +42,9 @@ curl -fsSL https://raw.githubusercontent.com/UniClipboard/UniClipboard/main/scri
 ```
 
 <Callout type="info">
-  更新策略与下方各平台一致：`.deb` / `.rpm` 不会从 App 内更新器升级，请重跑安装脚本或走系统包管理器；
-  AppImage（Linux）与 `.app`（macOS）仍由 App 内更新器接管。Windows 安装请参见下方 **Windows** 标签页。
+  更新策略与下方各平台一致：`.deb` / `.rpm` 不会从 App
+  内更新器升级，请重跑安装脚本或走系统包管理器； AppImage（Linux）与 `.app`（macOS）仍由 App
+  内更新器接管。Windows 安装请参见下方 **Windows** 标签页。
 </Callout>
 
 ## 选择平台

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,6 +3,7 @@ import { fileURLToPath } from 'node:url'
 import { includeIgnoreFile } from '@eslint/compat'
 import js from '@eslint/js'
 import prettier from 'eslint-config-prettier'
+import { createTypeScriptImportResolver } from 'eslint-import-resolver-typescript'
 import importX from 'eslint-plugin-import-x'
 import reactX from 'eslint-plugin-react'
 import reactHooks from 'eslint-plugin-react-hooks'
@@ -54,6 +55,11 @@ export default tseslint.config(
   {
     plugins: {
       'import-x': importX,
+    },
+    settings: {
+      // 让 @/* 别名被解析成 src/* 真实路径,从而归入 import-x/order 的 internal 组。
+      // 没有这个 resolver 时,@/* 会被当成 unknown,与 AGENTS.md 文档约定的顺序不一致。
+      'import-x/resolver-next': [createTypeScriptImportResolver({ project: './tsconfig.json' })],
     },
     rules: {
       'import-x/order': [

--- a/scripts/verify-direct-daemon-ws.mjs
+++ b/scripts/verify-direct-daemon-ws.mjs
@@ -34,8 +34,8 @@
  * 5  Malformed response (bad JSON, unexpected envelope shape)
  */
 
-import { WebSocketServer } from 'ws'
 import http from 'http'
+import { WebSocketServer } from 'ws'
 
 // ── Helpers ────────────────────────────────────────────────────
 

--- a/src/__tests__/api/daemon/settings.test.ts
+++ b/src/__tests__/api/daemon/settings.test.ts
@@ -9,6 +9,10 @@
  */
 
 import { describe, expect, it, beforeEach, afterEach } from 'vitest'
+// `./_test-helpers` 必须先于 `@/api/daemon/*` 加载: 它在 top-level 注册了
+// `vi.mock('@/api/daemon/client', ...)`,只有先跑过才能保证 storage/settings
+// 拿到的是被 mock 的 client; 一旦顺序反了,真实 client 会先进 ESM 缓存。
+// eslint-disable-next-line import-x/order
 import {
   makeSettingsDto,
   setupMockClient,

--- a/src/__tests__/api/daemon/storage.test.ts
+++ b/src/__tests__/api/daemon/storage.test.ts
@@ -9,6 +9,10 @@
  */
 
 import { describe, expect, it, beforeEach, afterEach } from 'vitest'
+// `./_test-helpers` 必须先于 `@/api/daemon/*` 加载: 它在 top-level 注册了
+// `vi.mock('@/api/daemon/client', ...)`,只有先跑过才能保证 storage/settings
+// 拿到的是被 mock 的 client; 一旦顺序反了,真实 client 会先进 ESM 缓存。
+// eslint-disable-next-line import-x/order
 import {
   mockDaemonClient,
   setupMockClient,

--- a/src/api/daemon/client.ts
+++ b/src/api/daemon/client.ts
@@ -14,10 +14,10 @@
  * - `destroy()` clears the keep-alive timer.
  */
 
+import { createLogger } from '@/lib/logger'
 import { DaemonApiError, DaemonErrorCode, mapStatusToErrorCode } from './errors'
 import type { DaemonConfig, SessionToken } from './types'
 import { isSessionExpired } from './types'
-import { createLogger } from '@/lib/logger'
 
 const log = createLogger('daemon-client')
 

--- a/src/api/daemon/lifecycle.ts
+++ b/src/api/daemon/lifecycle.ts
@@ -7,8 +7,8 @@
  * - `POST /lifecycle/retry` → retry lifecycle initialization
  */
 
-import { daemonClient } from './client'
 import type { LifecycleStatusDto } from '@/api/types'
+import { daemonClient } from './client'
 
 interface LifecycleReadyResponse {
   data?: { success: boolean }

--- a/src/api/security.ts
+++ b/src/api/security.ts
@@ -19,6 +19,7 @@
  * webserver. Existing call sites do not need to change.
  */
 
+import { createLogger } from '@/lib/logger'
 import {
   getEncryptionState as daemonGetEncryptionState,
   verifyKeychainAccess as daemonVerifyKeychainAccess,
@@ -33,7 +34,6 @@ import {
   trySilentUnlock as tauriTrySilentUnlock,
   unlockSpaceWithPassphrase as tauriUnlockSpaceWithPassphrase,
 } from './tauri-command/space_setup'
-import { createLogger } from '@/lib/logger'
 
 const log = createLogger('security')
 

--- a/src/components/StartupModals.tsx
+++ b/src/components/StartupModals.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useState } from 'react'
-import TelemetryNotice from './TelemetryNotice'
-import UpgradeNotice from './UpgradeNotice'
 import { getUpgradeStatus, type UpgradeStatus } from '@/api/daemon'
 import { connectDaemonWs } from '@/lib/daemon-ws-bootstrap'
 import { createLogger } from '@/lib/logger'
+import TelemetryNotice from './TelemetryNotice'
+import UpgradeNotice from './UpgradeNotice'
 
 const log = createLogger('startup-modals')
 

--- a/src/components/__tests__/StartupModals.test.tsx
+++ b/src/components/__tests__/StartupModals.test.tsx
@@ -13,9 +13,9 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import StartupModals from '../StartupModals'
 import { getUpgradeStatus, type UpgradeStatus } from '@/api/daemon'
 import { connectDaemonWs } from '@/lib/daemon-ws-bootstrap'
+import StartupModals from '../StartupModals'
 
 const mockUpdateGeneralSetting = vi.hoisted(() => vi.fn().mockResolvedValue(undefined))
 

--- a/src/components/clipboard/ClipboardContent.tsx
+++ b/src/components/clipboard/ClipboardContent.tsx
@@ -2,11 +2,6 @@ import { Inbox, Loader2, Search } from 'lucide-react'
 import React, { useMemo, useState, useEffect, useCallback, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useDefaultLayout } from 'react-resizable-panels'
-import ClipboardActionBar from './ClipboardActionBar'
-import ClipboardItemRow from './ClipboardItemRow'
-import ClipboardPreview from './ClipboardPreview'
-import DeleteConfirmDialog from './DeleteConfirmDialog'
-import FileContextMenu from './FileContextMenu'
 import {
   getDisplayType,
   ClipboardItemResponse,
@@ -40,6 +35,11 @@ import {
 } from '@/store/slices/clipboardSlice'
 import { linkTransferToEntry } from '@/store/slices/fileTransferSlice'
 import { selectEntryTransferStatus } from '@/store/slices/fileTransferSlice'
+import ClipboardActionBar from './ClipboardActionBar'
+import ClipboardItemRow from './ClipboardItemRow'
+import ClipboardPreview from './ClipboardPreview'
+import DeleteConfirmDialog from './DeleteConfirmDialog'
+import FileContextMenu from './FileContextMenu'
 
 const log = createLogger('clipboard-content')
 

--- a/src/components/clipboard/ClipboardItem.tsx
+++ b/src/components/clipboard/ClipboardItem.tsx
@@ -9,7 +9,6 @@ import {
 } from 'lucide-react'
 import React, { useMemo, useState, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
-import VirtualizedText from './VirtualizedText'
 import {
   ClipboardTextItem,
   ClipboardImageItem,
@@ -24,6 +23,7 @@ import { toast } from '@/components/ui/toast'
 import { createLogger } from '@/lib/logger'
 import { cn } from '@/lib/utils'
 import { formatFileSize } from '@/utils'
+import VirtualizedText from './VirtualizedText'
 
 const log = createLogger('clipboard-item')
 

--- a/src/components/clipboard/ClipboardItemRow.tsx
+++ b/src/components/clipboard/ClipboardItemRow.tsx
@@ -15,7 +15,6 @@ import {
 } from 'lucide-react'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
-import type { DisplayClipboardItem } from './ClipboardContent'
 import {
   ClipboardCodeItem,
   ClipboardFileItem,
@@ -32,6 +31,7 @@ import {
   selectTransferByTransferIds,
   selectTransferByEntryId,
 } from '@/store/slices/fileTransferSlice'
+import type { DisplayClipboardItem } from './ClipboardContent'
 
 interface ClipboardItemRowProps extends React.HTMLAttributes<HTMLDivElement> {
   item: DisplayClipboardItem

--- a/src/components/clipboard/ClipboardPreview.tsx
+++ b/src/components/clipboard/ClipboardPreview.tsx
@@ -1,15 +1,6 @@
 import { Clipboard } from 'lucide-react'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
-import type { DisplayClipboardItem } from './ClipboardContent'
-import ClipboardPreviewInfo from './ClipboardPreviewInfo'
-import CodePreview from './preview-renderers/CodePreview'
-import FilePreview from './preview-renderers/FilePreview'
-import ImagePreview from './preview-renderers/ImagePreview'
-import LinkPreview from './preview-renderers/LinkPreview'
-import TextPreview from './preview-renderers/TextPreview'
-import { isLargeTextPreview } from './preview-renderers/textPreviewUtils'
-import TransferProgressBar from './TransferProgressBar'
 import {
   ClipboardCodeItem,
   ClipboardImageItem,
@@ -19,6 +10,15 @@ import {
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { useClipboardPreviewState } from '@/hooks/useClipboardPreviewState'
 import { useEntryDelivery } from '@/hooks/useEntryDelivery'
+import type { DisplayClipboardItem } from './ClipboardContent'
+import ClipboardPreviewInfo from './ClipboardPreviewInfo'
+import CodePreview from './preview-renderers/CodePreview'
+import FilePreview from './preview-renderers/FilePreview'
+import ImagePreview from './preview-renderers/ImagePreview'
+import LinkPreview from './preview-renderers/LinkPreview'
+import TextPreview from './preview-renderers/TextPreview'
+import { isLargeTextPreview } from './preview-renderers/textPreviewUtils'
+import TransferProgressBar from './TransferProgressBar'
 
 interface ClipboardPreviewProps {
   item: DisplayClipboardItem | null

--- a/src/components/clipboard/ClipboardPreviewInfo.tsx
+++ b/src/components/clipboard/ClipboardPreviewInfo.tsx
@@ -1,8 +1,6 @@
 import { Database, Files, Globe, Hash, Layers, Maximize, Type } from 'lucide-react'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
-import type { DisplayClipboardItem } from './ClipboardContent'
-import EntryDeliveryBadge from './EntryDeliveryBadge'
 import type {
   ClipboardCodeItem,
   ClipboardFileItem,
@@ -13,6 +11,8 @@ import type {
 import type { EntryDeliveryView } from '@/api/tauri-command/clipboard_delivery'
 import type { ClipboardPreviewData } from '@/lib/clipboard-preview-cache'
 import { formatFileSize } from '@/utils'
+import type { DisplayClipboardItem } from './ClipboardContent'
+import EntryDeliveryBadge from './EntryDeliveryBadge'
 
 interface ClipboardPreviewInfoProps {
   imageDimensions: { width: number; height: number } | null

--- a/src/components/clipboard/FileContextMenu.tsx
+++ b/src/components/clipboard/FileContextMenu.tsx
@@ -1,7 +1,6 @@
 import { Copy, Download, FolderOpen, Loader2, Trash2 } from 'lucide-react'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
-import type { DisplayClipboardItem } from './ClipboardContent'
 import {
   ContextMenu,
   ContextMenuContent,
@@ -16,6 +15,7 @@ import {
   selectEntryTransferStatus,
   selectTransferByEntryId,
 } from '@/store/slices/fileTransferSlice'
+import type { DisplayClipboardItem } from './ClipboardContent'
 
 interface FileContextMenuProps {
   children: React.ReactNode

--- a/src/components/clipboard/__tests__/ClipboardPreviewInfo.test.tsx
+++ b/src/components/clipboard/__tests__/ClipboardPreviewInfo.test.tsx
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
+import i18n from '@/i18n'
 import type { DisplayClipboardItem } from '../ClipboardContent'
 import ClipboardPreviewInfo from '../ClipboardPreviewInfo'
-import i18n from '@/i18n'
 
 function createFileItem(): DisplayClipboardItem {
   return {

--- a/src/components/clipboard/__tests__/useClipboardPreviewState.test.tsx
+++ b/src/components/clipboard/__tests__/useClipboardPreviewState.test.tsx
@@ -1,8 +1,8 @@
 import { renderHook, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import type { DisplayClipboardItem } from '../ClipboardContent'
 import { useClipboardPreviewState } from '@/hooks/useClipboardPreviewState'
 import type { ClipboardPreviewData } from '@/lib/clipboard-preview-cache'
+import type { DisplayClipboardItem } from '../ClipboardContent'
 
 const useAppSelectorMock = vi.fn()
 const cacheGetMock = vi.fn()

--- a/src/components/clipboard/preview-renderers/FilePreview.tsx
+++ b/src/components/clipboard/preview-renderers/FilePreview.tsx
@@ -12,10 +12,10 @@ import {
 } from 'lucide-react'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
-import type { DisplayClipboardItem } from '../ClipboardContent'
 import { cn } from '@/lib/utils'
 import type { EntryTransferStatus, TransferProgressInfo } from '@/store/slices/fileTransferSlice'
 import { formatFileSize } from '@/utils'
+import type { DisplayClipboardItem } from '../ClipboardContent'
 
 interface FilePreviewProps {
   effectiveStatus: EntryTransferStatus['status'] | undefined

--- a/src/components/clipboard/preview-renderers/TextPreview.tsx
+++ b/src/components/clipboard/preview-renderers/TextPreview.tsx
@@ -1,10 +1,10 @@
 import { Loader2 } from 'lucide-react'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
-import VirtualizedText from '../VirtualizedText'
-import { getTextPreviewContent, LARGE_TEXT_THRESHOLD } from './textPreviewUtils'
 import type { ClipboardTextItem } from '@/api/clipboardItems'
 import type { ClipboardPreviewData } from '@/lib/clipboard-preview-cache'
+import VirtualizedText from '../VirtualizedText'
+import { getTextPreviewContent, LARGE_TEXT_THRESHOLD } from './textPreviewUtils'
 
 interface TextPreviewProps {
   item: ClipboardTextItem

--- a/src/components/setting/AboutSection.tsx
+++ b/src/components/setting/AboutSection.tsx
@@ -2,8 +2,6 @@ import { getVersion } from '@tauri-apps/api/app'
 import { Loader2, TriangleAlert } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { SettingGroup } from './SettingGroup'
-import { SettingRow } from './SettingRow'
 import {
   AlertDialog,
   AlertDialogAction,
@@ -33,6 +31,8 @@ import { useUpdate } from '@/hooks/useUpdate'
 import { createLogger } from '@/lib/logger'
 import { cn } from '@/lib/utils'
 import type { UpdateChannel } from '@/types/setting'
+import { SettingGroup } from './SettingGroup'
+import { SettingRow } from './SettingRow'
 
 const log = createLogger('about-section')
 

--- a/src/components/setting/AppearanceSection.tsx
+++ b/src/components/setting/AppearanceSection.tsx
@@ -2,7 +2,6 @@ import { Minus, Plus, RotateCcw, X } from 'lucide-react'
 import { useEffect, useState, type MouseEvent } from 'react'
 import { HexColorPicker } from 'react-colorful'
 import { useTranslation } from 'react-i18next'
-import { SettingGroup } from './SettingGroup'
 import {
   Button,
   Popover,
@@ -27,6 +26,7 @@ import {
 } from '@/lib/theme-engine'
 import { setTransitionOrigin } from '@/lib/theme-transition'
 import { cn } from '@/lib/utils'
+import { SettingGroup } from './SettingGroup'
 
 const log = createLogger('appearance-section')
 

--- a/src/components/setting/GeneralSection.tsx
+++ b/src/components/setting/GeneralSection.tsx
@@ -1,7 +1,5 @@
 import { useState, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
-import { SettingGroup } from './SettingGroup'
-import { SettingRow } from './SettingRow'
 import {
   Select,
   SelectContent,
@@ -14,6 +12,8 @@ import {
 import { useSetting } from '@/hooks/useSetting'
 import { SUPPORTED_LANGUAGES, type SupportedLanguage, getInitialLanguage } from '@/i18n'
 import { createLogger } from '@/lib/logger'
+import { SettingGroup } from './SettingGroup'
+import { SettingRow } from './SettingRow'
 
 const log = createLogger('general-section')
 

--- a/src/components/setting/NetworkSection.tsx
+++ b/src/components/setting/NetworkSection.tsx
@@ -1,15 +1,15 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { AllowOverlayAddrsDisclosure } from './AllowOverlayAddrsDisclosure'
-import { LanOnlyDisclosure } from './LanOnlyDisclosure'
-import { RestartBanner } from './RestartBanner'
-import { SettingGroup } from './SettingGroup'
-import { SettingRow } from './SettingRow'
 import { Switch } from '@/components/ui'
 import { useDebounce } from '@/hooks/useDebounce'
 import { useSetting } from '@/hooks/useSetting'
 import { commands } from '@/lib/ipc'
 import { createLogger } from '@/lib/logger'
+import { AllowOverlayAddrsDisclosure } from './AllowOverlayAddrsDisclosure'
+import { LanOnlyDisclosure } from './LanOnlyDisclosure'
+import { RestartBanner } from './RestartBanner'
+import { SettingGroup } from './SettingGroup'
+import { SettingRow } from './SettingRow'
 
 const log = createLogger('network-section')
 

--- a/src/components/setting/SecuritySection.tsx
+++ b/src/components/setting/SecuritySection.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { SettingGroup } from './SettingGroup'
-import { SettingRow } from './SettingRow'
 import { Switch } from '@/components/ui'
 import { useSetting } from '@/hooks/useSetting'
+import { SettingGroup } from './SettingGroup'
+import { SettingRow } from './SettingRow'
 
 const SecuritySection: React.FC = () => {
   const { t } = useTranslation()

--- a/src/components/setting/SettingRow.tsx
+++ b/src/components/setting/SettingRow.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react'
+import { cn } from '@/lib/utils'
 import { isExperimentalFeature } from './experimental-features'
 import { ExperimentalBadge } from './ExperimentalBadge'
-import { cn } from '@/lib/utils'
 
 interface SettingRowProps {
   label?: string

--- a/src/components/setting/StorageSection.tsx
+++ b/src/components/setting/StorageSection.tsx
@@ -1,9 +1,6 @@
 import { Database, FolderOpen, HardDrive, RefreshCw } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import ClearHistoryDialog from './ClearHistoryDialog'
-import { SettingGroup } from './SettingGroup'
-import { SettingRow } from './SettingRow'
 import { getSearchStatus, triggerSearchRebuild } from '@/api/daemon'
 import type { SearchStatusData } from '@/api/daemon'
 import * as storageApi from '@/api/storage'
@@ -24,6 +21,9 @@ import { createLogger } from '@/lib/logger'
 import { useAppDispatch } from '@/store/hooks'
 import { resetItems } from '@/store/slices/clipboardSlice'
 import type { RetentionRule } from '@/types/setting'
+import ClearHistoryDialog from './ClearHistoryDialog'
+import { SettingGroup } from './SettingGroup'
+import { SettingRow } from './SettingRow'
 
 const log = createLogger('storage-section')
 

--- a/src/components/setting/SyncSection.tsx
+++ b/src/components/setting/SyncSection.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { SettingGroup } from './SettingGroup'
-import { SettingRow } from './SettingRow'
 import { Switch, Input, Badge } from '@/components/ui'
 import { useSetting } from '@/hooks/useSetting'
+import { SettingGroup } from './SettingGroup'
+import { SettingRow } from './SettingRow'
 
 const MB = 1024 * 1024
 

--- a/src/components/setting/settings-config.ts
+++ b/src/components/setting/settings-config.ts
@@ -10,6 +10,7 @@ import {
   type LucideIcon,
 } from 'lucide-react'
 import type { ComponentType } from 'react'
+import ShortcutsSection from '@/components/setting/ShortcutsSection'
 import AboutSection from './AboutSection'
 import AppearanceSection from './AppearanceSection'
 import GeneralSection from './GeneralSection'
@@ -17,7 +18,6 @@ import NetworkSection from './NetworkSection'
 import SecuritySection from './SecuritySection'
 import StorageSection from './StorageSection'
 import SyncSection from './SyncSection'
-import ShortcutsSection from '@/components/setting/ShortcutsSection'
 
 export interface SettingsCategory {
   id: string

--- a/src/contexts/SettingContext.tsx
+++ b/src/contexts/SettingContext.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback, useEffect, useState, type ReactNode } from 'react'
-import { SettingContext } from './setting-context'
 import { getSettings, updateSettings } from '@/api/daemon'
 import { updateKeyboardShortcuts as persistKeyboardShortcuts } from '@/api/tauri-command'
 import { DEFAULT_THEME_COLOR } from '@/constants/theme'
@@ -12,6 +11,7 @@ import { applyThemeOverrides, applyThemePreset } from '@/lib/theme-engine'
 import { startThemeTransition } from '@/lib/theme-transition'
 import { setFrontendSentryEnabled } from '@/observability/sentry'
 import type { SettingContextType, Settings } from '@/types/setting'
+import { SettingContext } from './setting-context'
 
 const log = createLogger('setting-context')
 

--- a/src/contexts/ShortcutContext.tsx
+++ b/src/contexts/ShortcutContext.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useMemo, useRef, useState, type ReactNode } from 'react'
-import { ShortcutContext } from './shortcut-context'
 import { ShortcutScope } from '@/shortcuts/definitions'
 import { ShortcutLayer, LAYER_ORDER } from '@/shortcuts/layers'
+import { ShortcutContext } from './shortcut-context'
 
 type LayerEntry = {
   token: string

--- a/src/contexts/UpdateContext.tsx
+++ b/src/contexts/UpdateContext.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { UpdateContext, type UpdateState } from './update-context'
 import {
   cancelDownload as apiCancelDownload,
   checkForUpdate,
@@ -16,6 +15,7 @@ import { toast } from '@/components/ui/toast'
 import { useSetting } from '@/hooks/useSetting'
 import { createLogger } from '@/lib/logger'
 import type { UpdateChannel } from '@/types/setting'
+import { UpdateContext, type UpdateState } from './update-context'
 
 const log = createLogger('update-context')
 
@@ -178,6 +178,41 @@ export const UpdateProvider: React.FC<UpdateProviderProps> = ({ children }) => {
     }
   }, [])
 
+  const handleDownloadEvent = useCallback((event: DownloadEvent) => {
+    switch (event.event) {
+      case 'Started':
+        setState(prev => ({
+          ...prev,
+          phase: prev.phase === 'installing' ? 'installing' : 'downloading',
+          downloaded: 0,
+          total: event.data.contentLength,
+        }))
+        break
+      case 'Progress':
+        setState(prev => ({
+          ...prev,
+          phase: prev.phase === 'installing' ? 'installing' : 'downloading',
+          downloaded: prev.downloaded + event.data.chunkLength,
+        }))
+        break
+      case 'Finished':
+        setState(prev => ({
+          ...prev,
+          phase: prev.phase === 'installing' ? 'installing' : 'ready',
+          total: prev.total ?? prev.downloaded,
+        }))
+        break
+      case 'Failed':
+        setState(prev => ({
+          ...prev,
+          phase: prev.info ? 'available' : 'idle',
+          downloaded: 0,
+          total: null,
+        }))
+        break
+    }
+  }, [])
+
   // Mount-time: sync backend snapshot, then attach broadcast listener.
   useEffect(() => {
     let cancelled = false
@@ -228,42 +263,7 @@ export const UpdateProvider: React.FC<UpdateProviderProps> = ({ children }) => {
       cancelled = true
       if (unlisten) unlisten()
     }
-  }, [])
-
-  const handleDownloadEvent = useCallback((event: DownloadEvent) => {
-    switch (event.event) {
-      case 'Started':
-        setState(prev => ({
-          ...prev,
-          phase: prev.phase === 'installing' ? 'installing' : 'downloading',
-          downloaded: 0,
-          total: event.data.contentLength,
-        }))
-        break
-      case 'Progress':
-        setState(prev => ({
-          ...prev,
-          phase: prev.phase === 'installing' ? 'installing' : 'downloading',
-          downloaded: prev.downloaded + event.data.chunkLength,
-        }))
-        break
-      case 'Finished':
-        setState(prev => ({
-          ...prev,
-          phase: prev.phase === 'installing' ? 'installing' : 'ready',
-          total: prev.total ?? prev.downloaded,
-        }))
-        break
-      case 'Failed':
-        setState(prev => ({
-          ...prev,
-          phase: prev.info ? 'available' : 'idle',
-          downloaded: 0,
-          total: null,
-        }))
-        break
-    }
-  }, [])
+  }, [handleDownloadEvent])
 
   // Startup auto-check (gated by `autoCheckUpdate`).
   useEffect(() => {

--- a/src/hooks/__tests__/useEncryptionSessionState.test.tsx
+++ b/src/hooks/__tests__/useEncryptionSessionState.test.tsx
@@ -1,8 +1,8 @@
 import { act, renderHook, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { useEncryptionSessionState } from '../useEncryptionSessionState'
 import { getEncryptionState } from '@/api/daemon'
 import { getEncryptionSessionStatus as _getEncryptionSessionStatus } from '@/api/security'
+import { useEncryptionSessionState } from '../useEncryptionSessionState'
 
 // Mock daemonWs (hook now uses daemonWs.subscribe instead of Tauri listen)
 let capturedEncryptionHandler: ((event: { eventType: string }) => void) | null = null

--- a/src/hooks/__tests__/useEntryDelivery.test.tsx
+++ b/src/hooks/__tests__/useEntryDelivery.test.tsx
@@ -14,8 +14,8 @@
 
 import { act, renderHook, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { useEntryDelivery } from '../useEntryDelivery'
 import { getEntryDeliveryView } from '@/api/tauri-command/clipboard_delivery'
+import { useEntryDelivery } from '../useEntryDelivery'
 
 // ── mock 事件总线 ─────────────────────────────────────────────────────
 //

--- a/src/hooks/__tests__/useThemeSync.test.tsx
+++ b/src/hooks/__tests__/useThemeSync.test.tsx
@@ -1,9 +1,9 @@
 import { listen } from '@tauri-apps/api/event'
 import { renderHook, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { useThemeSync } from '../useThemeSync'
 import { getSettings } from '@/api/daemon'
 import { applyThemePreset } from '@/lib/theme-engine'
+import { useThemeSync } from '../useThemeSync'
 
 vi.mock('@tauri-apps/api/event', () => ({
   listen: vi.fn(),

--- a/src/hooks/__tests__/useTransferProgress.test.tsx
+++ b/src/hooks/__tests__/useTransferProgress.test.tsx
@@ -3,8 +3,8 @@ import { act, renderHook, waitFor } from '@testing-library/react'
 import React from 'react'
 import { Provider } from 'react-redux'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { useTransferProgress } from '../useTransferProgress'
 import fileTransferReducer from '@/store/slices/fileTransferSlice'
+import { useTransferProgress } from '../useTransferProgress'
 
 // ── Mock daemon WS ────────────────────────────────────────────
 

--- a/src/hooks/useClipboardCollection.ts
+++ b/src/hooks/useClipboardCollection.ts
@@ -1,10 +1,10 @@
 import { useCallback, useEffect, useState } from 'react'
-import { useClipboardEventStream } from './useClipboardEventStream'
-import { useEncryptionSessionState } from './useEncryptionSessionState'
 import type { ClipboardItemResponse } from '@/api/clipboardItems'
 import { getClipboardEntries } from '@/api/daemon/clipboard'
 import { transformDaemonDtoToItemResponse } from '@/lib/clipboard-transform'
 import { createLogger } from '@/lib/logger'
+import { useClipboardEventStream } from './useClipboardEventStream'
+import { useEncryptionSessionState } from './useEncryptionSessionState'
 
 const log = createLogger('use-clipboard-collection')
 

--- a/src/hooks/useClipboardEvents.ts
+++ b/src/hooks/useClipboardEvents.ts
@@ -1,7 +1,5 @@
 import { useEffect, useRef, useState, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useClipboardEventStream } from './useClipboardEventStream'
-import { useEncryptionSessionState } from './useEncryptionSessionState'
 import { Filter, OrderBy } from '@/api/clipboardItems'
 import { toast } from '@/components/ui/toast'
 import { createLogger } from '@/lib/logger'
@@ -12,6 +10,8 @@ import {
   prependItem,
   removeItem,
 } from '@/store/slices/clipboardSlice'
+import { useClipboardEventStream } from './useClipboardEventStream'
+import { useEncryptionSessionState } from './useEncryptionSessionState'
 
 const log = createLogger('use-clipboard-events')
 const PAGE_SIZE = 20

--- a/src/lib/__tests__/clipboard-utils.test.ts
+++ b/src/lib/__tests__/clipboard-utils.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { formatRelativeTime, getItemPreview, resolveItemType } from '../clipboard-utils'
 import type { ClipboardItemResponse } from '@/api/clipboardItems'
+import { formatRelativeTime, getItemPreview, resolveItemType } from '../clipboard-utils'
 
 function createItemResponse(
   partial: Partial<ClipboardItemResponse['item']>

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -37,10 +37,10 @@
  * The wrapper transparently injects trace + redacts logs + bubbles errors.
  */
 
-import { commands as raw, events as rawEvents } from './ipc-bindings.generated'
 import { redactSensitiveArgs } from '@/observability/redaction'
 import { Sentry } from '@/observability/sentry'
 import { traceManager } from '@/observability/trace'
+import { commands as raw, events as rawEvents } from './ipc-bindings.generated'
 
 /** Wire shape of the trace metadata Tauri commands accept. */
 type TraceArg = { trace_id: string; timestamp: number } | null

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,13 +2,13 @@ import { attachConsole } from '@tauri-apps/plugin-log'
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { Provider } from 'react-redux'
-import App from './App'
 import './i18n'
-import { store } from './store'
 import { getDeviceMeta } from '@/api/runtime'
 import { connectDaemonWs, registerDaemonShutdownListener } from '@/lib/daemon-ws-bootstrap'
 import { initializeWindowUi } from '@/lib/window-ui'
 import { applyDeviceMetaToSentry, initSentry, Sentry } from '@/observability/sentry'
+import App from './App'
+import { store } from './store'
 
 // 屏蔽 WebKit/WebView2 默认右键菜单(Inspect / Reload / 拼写检查),否则用户右键
 // 任何文本都会暴露 webview 身份。需要原生右键的地方用 @radix-ui/react-context-menu opt-in。

--- a/src/pages/DevicesPage.tsx
+++ b/src/pages/DevicesPage.tsx
@@ -955,7 +955,7 @@ const useMobileDevices = (): UseMobileDevicesReturn => {
       return
     }
     setAddDialogOpen(true)
-  }, [settings?.enabled, settings?.lanListenEnabled, settings?.lanListenerError, t])
+  }, [settings, t])
 
   const handleEnableSuccess = useCallback(() => {
     setAddDialogOpen(true)

--- a/src/quick-panel/ClipboardHistoryPanel.tsx
+++ b/src/quick-panel/ClipboardHistoryPanel.tsx
@@ -1,10 +1,5 @@
 import { listen } from '@tauri-apps/api/event'
 import React, { useCallback, useEffect, useMemo, useReducer, useRef, useState } from 'react'
-import ClipboardPreviewPane from './ClipboardPreviewPane'
-import HistoryPane from './components/HistoryPane'
-import { PREVIEW_OPEN_DELAY_MS, PREVIEW_SWITCH_DELAY_MS } from './constants'
-import { useHistorySearch } from './hooks/useHistorySearch'
-import type { DisplayItem, PreviewAction, PreviewState, TimeRangePreset } from './types'
 import { Filter } from '@/api/clipboardItems'
 import { deleteClipboardEntry, restoreClipboardEntry } from '@/api/daemon'
 import { unlockEncryptionSession } from '@/api/security'
@@ -16,6 +11,11 @@ import { commands } from '@/lib/ipc'
 import { createLogger } from '@/lib/logger'
 import { readStoredUiScale, subscribeUiScaleChanges } from '@/lib/ui-scale'
 import { cn } from '@/lib/utils'
+import ClipboardPreviewPane from './ClipboardPreviewPane'
+import HistoryPane from './components/HistoryPane'
+import { PREVIEW_OPEN_DELAY_MS, PREVIEW_SWITCH_DELAY_MS } from './constants'
+import { useHistorySearch } from './hooks/useHistorySearch'
+import type { DisplayItem, PreviewAction, PreviewState, TimeRangePreset } from './types'
 
 const log = createLogger('clipboard-history-panel')
 

--- a/src/quick-panel/ClipboardPreviewPane.tsx
+++ b/src/quick-panel/ClipboardPreviewPane.tsx
@@ -1,9 +1,9 @@
 import { File, Loader2 } from 'lucide-react'
 import React, { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useClipboardPreview } from './useClipboardPreview'
 import EntryDeliveryBadge from '@/components/clipboard/EntryDeliveryBadge'
 import VirtualizedText from '@/components/clipboard/VirtualizedText'
+import { useClipboardPreview } from './useClipboardPreview'
 
 interface ClipboardPreviewPaneProps {
   entryId: string | null

--- a/src/quick-panel/QuickPanelApp.tsx
+++ b/src/quick-panel/QuickPanelApp.tsx
@@ -1,8 +1,8 @@
 import React, { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import ClipboardHistoryPanel from './ClipboardHistoryPanel'
 import { daemonClient } from '@/api/daemon/client'
 import { connectDaemonWs } from '@/lib/daemon-ws-bootstrap'
+import ClipboardHistoryPanel from './ClipboardHistoryPanel'
 
 const loadingClassName =
   'flex h-screen w-screen items-center justify-center bg-transparent text-[13px] text-muted-foreground'

--- a/src/quick-panel/__tests__/useClipboardPreview.test.tsx
+++ b/src/quick-panel/__tests__/useClipboardPreview.test.tsx
@@ -1,7 +1,7 @@
 import { renderHook, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { useClipboardPreview } from '../useClipboardPreview'
 import { clearClipboardPreviewCache } from '@/lib/clipboard-preview-cache'
+import { useClipboardPreview } from '../useClipboardPreview'
 
 vi.mock('@/api/daemon/clipboard', () => ({
   getClipboardEntryResource: vi.fn(),

--- a/src/quick-panel/components/HistoryPane.tsx
+++ b/src/quick-panel/components/HistoryPane.tsx
@@ -15,9 +15,6 @@ import {
 } from 'lucide-react'
 import React, { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
-import { quickCardClassName } from '../constants'
-import type { DisplayItem, TimeRangePreset } from '../types'
-import PanelItem from './PanelItem'
 import { Filter } from '@/api/clipboardItems'
 import AdvancedSearch from '@/components/search/AdvancedSearch'
 import {
@@ -27,6 +24,9 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 import { cn } from '@/lib/utils'
+import { quickCardClassName } from '../constants'
+import type { DisplayItem, TimeRangePreset } from '../types'
+import PanelItem from './PanelItem'
 
 interface HistoryPaneProps {
   filteredItems: DisplayItem[]

--- a/src/quick-panel/components/PanelItem.tsx
+++ b/src/quick-panel/components/PanelItem.tsx
@@ -1,8 +1,8 @@
 import { FileText } from 'lucide-react'
 import React from 'react'
+import { formatRelativeTime } from '@/lib/clipboard-utils'
 import { isMac, typeIcons } from '../constants'
 import type { DisplayItem } from '../types'
-import { formatRelativeTime } from '@/lib/clipboard-utils'
 
 interface PanelItemProps {
   item: DisplayItem

--- a/src/quick-panel/hooks/useHistorySearch.ts
+++ b/src/quick-panel/hooks/useHistorySearch.ts
@@ -1,9 +1,9 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import type { DisplayItem, TimeRangePreset } from '../types'
 import { Filter } from '@/api/clipboardItems'
 import { querySearch } from '@/api/daemon/search'
 import type { SearchResultDto, SearchParams } from '@/api/daemon/search'
 import { createLogger } from '@/lib/logger'
+import type { DisplayItem, TimeRangePreset } from '../types'
 
 const log = createLogger('use-history-search')
 

--- a/src/quick-panel/main.tsx
+++ b/src/quick-panel/main.tsx
@@ -1,11 +1,11 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { Provider } from 'react-redux'
-import QuickPanelApp from './QuickPanelApp'
 import '@/i18n'
 import { initializeWindowUi } from '@/lib/window-ui'
 import { store } from '@/store'
 import '@/styles/globals.css'
+import QuickPanelApp from './QuickPanelApp'
 
 initializeWindowUi()
 

--- a/src/shortcuts/definitions.ts
+++ b/src/shortcuts/definitions.ts
@@ -2,8 +2,8 @@
  * Shortcut action types
  * Union type of all shortcut actions
  */
-import { ShortcutLayer } from './layers'
 import { isMac } from '@/lib/shortcut-format'
+import { ShortcutLayer } from './layers'
 
 export type ShortcutAction =
   | 'global.zoomIn'

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,11 +1,11 @@
 import { configureStore } from '@reduxjs/toolkit'
+import { redactSensitiveArgs } from '@/observability/redaction'
+import { Sentry, sentryEnabled } from '@/observability/sentry'
 import { appApi } from './api'
 import clipboardReducer from './slices/clipboardSlice'
 import devicesReducer from './slices/devicesSlice'
 import fileTransferReducer from './slices/fileTransferSlice'
 import statsReducer from './slices/statsSlice'
-import { redactSensitiveArgs } from '@/observability/redaction'
-import { Sentry, sentryEnabled } from '@/observability/sentry'
 
 const sentryReduxEnhancer = sentryEnabled
   ? Sentry.createReduxEnhancer({

--- a/src/store/slices/__tests__/clipboardSlice.test.ts
+++ b/src/store/slices/__tests__/clipboardSlice.test.ts
@@ -1,8 +1,8 @@
 import { configureStore } from '@reduxjs/toolkit'
 import { describe, it, expect } from 'vitest'
+import type { ClipboardItemResponse, ClipboardItemsResult } from '@/api/clipboardItems'
 import clipboardReducer, { prependItem, removeItem } from '../clipboardSlice'
 import fileTransferReducer from '../fileTransferSlice'
-import type { ClipboardItemResponse, ClipboardItemsResult } from '@/api/clipboardItems'
 
 function makeItem(id: string, overrides?: Partial<ClipboardItemResponse>): ClipboardItemResponse {
   return {

--- a/src/store/slices/clipboardSlice.ts
+++ b/src/store/slices/clipboardSlice.ts
@@ -1,5 +1,4 @@
 import { createSlice, createAsyncThunk, PayloadAction } from '@reduxjs/toolkit'
-import { hydrateEntryTransferStatuses } from './fileTransferSlice'
 import type { ClipboardItemResponse, ClipboardItemsResult } from '@/api/clipboardItems'
 import { OrderBy, Filter } from '@/api/clipboardItems'
 import {
@@ -9,6 +8,7 @@ import {
   toggleFavorite,
 } from '@/api/daemon'
 import { transformDaemonDtoToItemResponse } from '@/lib/clipboard-transform'
+import { hydrateEntryTransferStatuses } from './fileTransferSlice'
 
 // ── State ────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Closes #734.

## Summary

为 `eslint-plugin-import-x` 接入 `eslint-import-resolver-typescript`,让 `@/*` 按 tsconfig 路径映射归入 `import-x/order` 的 `internal` 组——与 `src/AGENTS.md` 约定的顺序 `builtin → external → internal → parent → sibling → index` 真正对齐。

之前因为缺少 resolver,`@/*` 被识别成 `unknown` 而非 `internal`,实际生效的顺序是 `builtin → external → parent → sibling → @/* (unknown)`,导致文档与 lint 拒收同时存在,每次 PR 都靠人肉手改。

## 改动范围

- **`eslint.config.js`**: 加 `createTypeScriptImportResolver({ project: './tsconfig.json' })` 到 `import-x/resolver-next`。
- **50 个 src 文件**: `eslint --fix` 一次性收敛,纯 import 顺序漂移,无逻辑改动。
- **`src/quick-panel/main.tsx`**: 手工调一处——side-effect import 让 fixer 保守不动,人工把 sibling 挪到最后。
- **`src/__tests__/api/daemon/settings.test.ts` / `storage.test.ts`**: 加 `eslint-disable-next-line import-x/order` + 注释,WHY 写在代码里——`_test-helpers.ts` 在 top-level 调 `vi.mock('@/api/daemon/client', ...)`,必须先于 `@/api/daemon/*` 加载,否则真实 client 会先进 ESM 缓存导致 mock 失效。

## 顺手修的两个 react-hooks bug

`eslint-plugin-react-hooks 7.1.1`(本周 `f95a8038` 依赖 bump 引入)给 main 留了两个 react-hooks 错误,任何重新 lint 这两个文件的 commit 都过不了 pre-commit:

- **`UpdateContext.tsx`** (`react-hooks/immutability`): `handleDownloadEvent` 的 `useCallback` 声明上移到使用它的 `useEffect` 之前(JS 函数提升让运行时不出错,但 React Compiler 不能追踪这种时序依赖),顺带把它补进依赖列表。
- **`DevicesPage.tsx`** (`react-hooks/preserve-manual-memoization`): `handleAddClick` 的 deps 由 `settings?.enabled / lanListenEnabled / lanListenerError` 拆细写法改成 `settings` 整体,跟 Compiler 推断对齐,memoization 才能保留。

## 验收

- [x] 步骤 1:resolver 配置完成,`bunx eslint 'src/**/*.{ts,tsx,js,jsx}'` 全过,无 `import-x/order` 错误
- [x] 步骤 2:pre-commit 钩子复用已有 husky + lint-staged 配置,新提交自动维持顺序(本 PR 自身就走了一遍)
- [x] `bunx tsc --noEmit` 通过
- [x] `bunx vitest run` —— 76 个测试文件,476/476 通过
- [ ] 步骤 3(强制 alias,no-relative-import-paths):本 PR 不做,可单独跟进
- [ ] 步骤 4(中文注释 CI 脚本):可选,本 PR 不做

## Test plan

- [x] `bunx eslint 'src/**/*.{ts,tsx,js,jsx}'` — 0 import-order 错误(剩余 1 个 `no-useless-assignment` 在 `AddDeviceDialog.tsx`,与本 PR 无关、main 上预先存在)
- [x] `bunx tsc --noEmit`
- [x] `bunx vitest run` — 476/476 通过
- [ ] manual: `bun run tauri:dev` 启动主窗口、设置页、quick-panel,验证 UI 行为无回归(纯顺序调整,理论上不影响运行时)