### PR TITLE
fix(ci): install rust targets on the toolchain pinned by rust-toolchain.toml

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -107,6 +107,18 @@ jobs:
         shell: bash
         run: echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> "$GITHUB_PATH"
 
+      - name: ensure rust target installed
+        # 见 build.yml 同名 step:dtolnay/rust-toolchain 命中预装 stable toolchain
+        # 时会跳过 `rustup target add`,需要在这里幂等补装,否则 x86_64-apple-darwin
+        # 与各 musl target 都会缺失。Linux job 跑在容器里,rustup 也由 action 装。
+        shell: bash
+        run: |
+          if [ "${{ matrix.platform }}" = "macos-latest" ]; then
+            rustup target add aarch64-apple-darwin x86_64-apple-darwin
+          elif [ -n "${{ matrix.target }}" ] && [ "${{ matrix.target }}" != "x86_64-pc-windows-msvc" ]; then
+            rustup target add "${{ matrix.target }}"
+          fi
+
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -107,16 +107,20 @@ jobs:
         shell: bash
         run: echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> "$GITHUB_PATH"
 
-      - name: ensure rust target installed
-        # 见 build.yml 同名 step:dtolnay/rust-toolchain 命中预装 stable toolchain
-        # 时会跳过 `rustup target add`,需要在这里幂等补装,否则 x86_64-apple-darwin
-        # 与各 musl target 都会缺失。Linux job 跑在容器里,rustup 也由 action 装。
+      - name: ensure rust target installed on pinned toolchain
+        # src-tauri/rust-toolchain.toml 把 cargo 锁到一个具体 channel,
+        # 跟 dtolnay 装的 stable 是两个独立 toolchain。CLI build 也在
+        # src-tauri/ 下跑 cargo,必须把 target 装到 pinned channel,否则
+        # 与 build.yml 一样会报 `Target ... is not installed`。
+        # 见 dtolnay/rust-toolchain#75。Windows host=msvc 不用装。
         shell: bash
         run: |
+          TC=$(cd src-tauri && rustup show active-toolchain | awk '{print $1}')
+          echo "pinned toolchain: $TC"
           if [ "${{ matrix.platform }}" = "macos-latest" ]; then
-            rustup target add aarch64-apple-darwin x86_64-apple-darwin
+            rustup target add --toolchain "$TC" aarch64-apple-darwin x86_64-apple-darwin
           elif [ -n "${{ matrix.target }}" ] && [ "${{ matrix.target }}" != "x86_64-pc-windows-msvc" ]; then
-            rustup target add "${{ matrix.target }}"
+            rustup target add --toolchain "$TC" "${{ matrix.target }}"
           fi
 
       - name: Cache Rust dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -130,6 +130,15 @@ jobs:
         shell: bash
         run: echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> "$GITHUB_PATH"
 
+      - name: ensure darwin targets installed
+        # dtolnay/rust-toolchain 命中 runner 预装的 stable toolchain 时
+        # ("using existing install for stable-...") 会跳过 `rustup target add`,
+        # `targets:` 输入被静默忽略。25960898069 因此挂在 x86_64-apple-darwin。
+        # 这里幂等补一刀,已装则 no-op。
+        if: matrix.platform == 'macos-latest'
+        shell: bash
+        run: rustup target add aarch64-apple-darwin x86_64-apple-darwin
+
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -130,14 +130,20 @@ jobs:
         shell: bash
         run: echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> "$GITHUB_PATH"
 
-      - name: ensure darwin targets installed
-        # dtolnay/rust-toolchain 命中 runner 预装的 stable toolchain 时
-        # ("using existing install for stable-...") 会跳过 `rustup target add`,
-        # `targets:` 输入被静默忽略。25960898069 因此挂在 x86_64-apple-darwin。
-        # 这里幂等补一刀,已装则 no-op。
+      - name: ensure darwin targets installed on pinned toolchain
+        # src-tauri/rust-toolchain.toml 把 cargo 锁到一个具体 channel
+        # (例如 1.95.0),而 dtolnay/rust-toolchain@stable 装的是 stable —
+        # 这是两个独立的 toolchain。在 src-tauri/ 下跑 cargo 时,target 必须
+        # 已经装到 pinned channel,否则报 `Target ... is not installed`
+        # (25960898069 / 25961183688 的真因,见 dtolnay/rust-toolchain#75)。
+        # 这里先在 src-tauri/ 触发 rustup auto-install pinned toolchain,
+        # 再读出 channel 名,显式 `rustup target add --toolchain <channel>`。
         if: matrix.platform == 'macos-latest'
         shell: bash
-        run: rustup target add aarch64-apple-darwin x86_64-apple-darwin
+        run: |
+          TC=$(cd src-tauri && rustup show active-toolchain | awk '{print $1}')
+          echo "pinned toolchain: $TC"
+          rustup target add --toolchain "$TC" aarch64-apple-darwin x86_64-apple-darwin
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
## Summary

- alpha.6 release (run 25960898069) 在 darwin x86_64 build 阶段挂掉:
  `failed to build app: Target x86_64-apple-darwin is not installed (installed targets: aarch64-apple-darwin)`
- 真因: #728 引入 `src-tauri/rust-toolchain.toml` 把 cargo pin 到 `1.95.0`,
  跟 `dtolnay/rust-toolchain@stable` 装的 stable 是两个独立的 toolchain。
  tauri build 在 `src-tauri/` 下跑,cargo 读 toolchain file 切到 1.95.0,
  而 dtolnay 的 `targets:` 输入装到了 stable —— 1.95.0 那个 toolchain
  只有 host (aarch64) target,所以 x86_64 build 找不到 target。参考
  dtolnay/rust-toolchain#75 的官方解释。
- 修复: 在 dtolnay 步骤后追加一步,先在 `src-tauri/` 下用
  `rustup show active-toolchain` 读 pinned channel 名,再用
  `rustup target add --toolchain <channel>` 显式装到对的 toolchain。
  `build.yml` 装两个 darwin target,`build-cli.yml` 按 matrix 装对应 target。

## Why this slipped through alpha.5
`rust-toolchain.toml` 是 2026-05-15 才 merge 进 main 的 (#728),而 alpha.5
的 build 是在那之前跑的。alpha.6 是引入这个 pin 之后的第一次 release,
所以正好踩进去。GitHub macOS runner image 周更后 stable toolchain 被预装,
让 `dtolnay/rust-toolchain` 走 `using existing install` 路径,放大了这个
toolchain 错位 —— 但根因始终是 pinned channel 没装 cross target。

## Test plan
- [x] cache-warmup run 25961361226 上 `Build x86_64-apple-darwin` ✅
- [x] 同一 run 里 aarch64-apple-darwin / linux / windows 同样过
- [ ] merge 后重新触发 prepare-release,看真实 release pipeline 全绿