### PR TITLE
refactor(theme): semantic color tokens for devices page + Claude button contrast

### DIFF
--- a/src/components/setting/AboutSection.tsx
+++ b/src/components/setting/AboutSection.tsx
@@ -260,7 +260,7 @@ const AboutSection: React.FC = () => {
           </div>
           <button
             type="button"
-            className="inline-flex min-w-36 items-center justify-center gap-2 rounded-lg bg-secondary px-4 py-2 text-sm font-medium transition duration-200 hover:bg-secondary/80"
+            className="inline-flex min-w-36 items-center justify-center gap-2 rounded-lg border border-border bg-secondary px-4 py-2 text-sm font-medium text-secondary-foreground shadow-sm transition duration-200 hover:bg-secondary/80"
             onClick={handleCheckUpdate}
             disabled={isBusy || isCheckingUpdate}
             aria-busy={isCheckingUpdate}

--- a/src/pages/DevicesPage.tsx
+++ b/src/pages/DevicesPage.tsx
@@ -203,7 +203,7 @@ const HeroSection: React.FC = () => {
   return (
     <div className="grid grid-cols-1 gap-3 lg:grid-cols-[1fr_auto]">
       {/* ── 本机 hero (左) ────────────────────────────────────── */}
-      <div className="relative overflow-hidden rounded-2xl border border-border/60 bg-gradient-to-br from-emerald-500/10 via-card to-card px-6 py-6">
+      <div className="relative overflow-hidden rounded-2xl border border-border/60 bg-card px-6 py-6">
         <div
           aria-hidden
           className="pointer-events-none absolute inset-0 opacity-[0.04]"
@@ -213,7 +213,7 @@ const HeroSection: React.FC = () => {
           }}
         />
         <div className="relative flex items-center gap-5">
-          <div className="flex h-16 w-16 shrink-0 items-center justify-center rounded-2xl bg-emerald-500/15 text-emerald-600 shadow-sm ring-1 ring-emerald-500/20 dark:text-emerald-400">
+          <div className="flex h-16 w-16 shrink-0 items-center justify-center rounded-2xl bg-success/15 text-success shadow-sm ring-1 ring-success/20">
             {/* eslint-disable-next-line react-hooks/static-components -- `getDeviceIcon` returns a stable lucide icon reference keyed on deviceName, not a freshly-created component */}
             <Icon className="h-8 w-8" />
           </div>
@@ -222,7 +222,7 @@ const HeroSection: React.FC = () => {
               <span className="text-[11px] uppercase tracking-wider text-muted-foreground">
                 {t('devices.thisDevice.title')}
               </span>
-              <span className="inline-flex h-1.5 w-1.5 rounded-full bg-emerald-500" />
+              <span className="inline-flex h-1.5 w-1.5 rounded-full bg-success" />
             </div>
             <h2 className="mt-1 truncate text-xl font-semibold leading-tight text-foreground">
               {localDevice.deviceName}
@@ -299,12 +299,12 @@ interface StatPillProps {
 
 const STAT_ACCENT: Record<StatAccent, { icon: string; value: string }> = {
   emerald: {
-    icon: 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-400',
-    value: 'text-emerald-700 dark:text-emerald-300',
+    icon: 'bg-success/10 text-success',
+    value: 'text-success',
   },
   amber: {
-    icon: 'bg-amber-500/10 text-amber-600 dark:text-amber-400',
-    value: 'text-amber-700 dark:text-amber-300',
+    icon: 'bg-warning/10 text-warning',
+    value: 'text-warning',
   },
   muted: {
     icon: 'bg-muted text-muted-foreground',
@@ -678,15 +678,13 @@ const PeerCard: React.FC<PeerCardProps> = ({ peer, lanOnlyActive, onSelect }) =>
         <div
           className={cn(
             'relative flex h-12 w-12 items-center justify-center rounded-xl',
-            peer.connected
-              ? 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-400'
-              : 'bg-muted text-muted-foreground'
+            peer.connected ? 'bg-success/10 text-success' : 'bg-muted text-muted-foreground'
           )}
         >
           {/* eslint-disable-next-line react-hooks/static-components -- `getDeviceIcon` returns a stable lucide icon reference keyed on deviceName, not a freshly-created component */}
           <Icon className="h-6 w-6" />
           {peer.connected && (
-            <span className="absolute -bottom-0.5 -right-0.5 h-3 w-3 rounded-full bg-emerald-500 ring-2 ring-card" />
+            <span className="absolute -bottom-0.5 -right-0.5 h-3 w-3 rounded-full bg-success ring-2 ring-card" />
           )}
         </div>
         <ChevronRight className="h-4 w-4 text-muted-foreground/30 transition-all group-hover:translate-x-0.5 group-hover:text-muted-foreground" />
@@ -697,11 +695,7 @@ const PeerCard: React.FC<PeerCardProps> = ({ peer, lanOnlyActive, onSelect }) =>
           {peer.deviceName || t('devices.list.labels.unknownDevice')}
         </h4>
         <p className="mt-1 truncate text-xs text-muted-foreground">
-          <span
-            className={
-              peer.connected ? 'text-emerald-600 dark:text-emerald-400' : 'text-muted-foreground'
-            }
-          >
+          <span className={peer.connected ? 'text-success' : 'text-muted-foreground'}>
             {peer.connected
               ? `● ${t('devices.list.status.online')}`
               : `○ ${t('devices.list.status.offline')}`}
@@ -733,8 +727,8 @@ interface ChannelChipProps {
 }
 
 const CHANNEL_TONE: Record<ChannelTone, string> = {
-  emerald: 'bg-emerald-500/10 text-emerald-700 dark:text-emerald-300 ring-emerald-500/20',
-  amber: 'bg-amber-500/10 text-amber-700 dark:text-amber-300 ring-amber-500/20',
+  emerald: 'bg-success/10 text-success ring-success/20',
+  amber: 'bg-warning/10 text-warning ring-warning/20',
   muted: 'bg-muted text-muted-foreground ring-border',
 }
 
@@ -795,7 +789,7 @@ const MobileCard: React.FC<{
   return (
     <div className="group relative flex w-full flex-col gap-4 overflow-hidden rounded-2xl border border-border/60 bg-card p-5 text-left transition-all hover:border-border hover:shadow-sm">
       <div className="flex items-start justify-between">
-        <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-blue-500/10 text-blue-600 dark:text-blue-400">
+        <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-info/10 text-info">
           <Smartphone className="h-6 w-6" />
         </div>
         <div className="flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100">

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -77,6 +77,15 @@
 
   --destructive: oklch(0.58 0.22 27);
 
+  /* Semantic status tokens — global, do not switch with theme presets.
+     Override per preset with `[data-theme-preset=xxx] { --success: ... }`. */
+  --success: oklch(0.55 0.17 145);
+  --success-foreground: oklch(0.99 0 0);
+  --warning: oklch(0.72 0.17 75);
+  --warning-foreground: oklch(0.25 0.05 60);
+  --info: oklch(0.55 0.18 250);
+  --info-foreground: oklch(0.99 0 0);
+
   --border: oklch(0.922 0 0);
 
   --input: oklch(0.922 0 0);
@@ -239,6 +248,12 @@
   --color-border: var(--border);
   --color-destructive-foreground: var(--destructive-foreground);
   --color-destructive: var(--destructive);
+  --color-success-foreground: var(--success-foreground);
+  --color-success: var(--success);
+  --color-warning-foreground: var(--warning-foreground);
+  --color-warning: var(--warning);
+  --color-info-foreground: var(--info-foreground);
+  --color-info: var(--info);
   --color-accent-foreground: var(--accent-foreground);
   --color-accent: var(--accent);
   --color-muted-foreground: var(--muted-foreground);
@@ -505,6 +520,12 @@ html[data-uc-low-effects='true']::view-transition-new(root) {
   --accent: oklch(0.371 0 0);
   --accent-foreground: oklch(0.985 0 0);
   --destructive: oklch(0.704 0.191 22.216);
+  --success: oklch(0.78 0.16 145);
+  --success-foreground: oklch(0.18 0.05 145);
+  --warning: oklch(0.83 0.16 80);
+  --warning-foreground: oklch(0.18 0.05 60);
+  --info: oklch(0.72 0.17 245);
+  --info-foreground: oklch(0.15 0.04 250);
   --border: oklch(1 0 0 / 10%);
   --input: oklch(1 0 0 / 15%);
   --ring: oklch(0.556 0 0);


### PR DESCRIPTION
## Summary

- **Introduce `--success / --warning / --info` global semantic color tokens** (`refactor(theme)`, ed13563d). Defined once in `globals.css` `:root` / `.dark` and wired into `@theme inline`, so Tailwind generates `bg-success`, `text-warning`, `ring-info/20`, etc. Tokens are intentionally preset-independent — status colors stay stable across theme switches; per-preset overrides can later be added via `[data-theme-preset=xxx] { --success: ... }`.
- **Token-ify Devices page** (`refactor(theme)`, ed13563d). Replace every hardcoded `emerald-*` / `amber-*` / `blue-*` Tailwind palette usage on `DevicesPage.tsx` (status icons, online dots, channel chips, stat pills, mobile card icon) with the new semantic tokens.
- **Drop the green halo on the local-device hero card** (`refactor(theme)`, ed13563d). The `from-emerald-500/10 via-card to-card` gradient was specific to one color sense and read as a light-green wash; now plain `bg-card`.
- **Fix "Check update" button contrast under the Claude theme** (`fix(settings)`, 742a2153). Claude Light's `secondary` (oklch 0.9245) was too close to `card` (oklch 0.9818), so the bare `bg-secondary` button blended into the SettingGroup. Add `border`, `shadow-sm`, and explicit `text-secondary-foreground` — fix is local to that button and doesn't touch theme tokens or other secondary usages.

No docs-site updates: scan turned up nothing that depends on these purely visual / internal-token changes.

## Test plan

- [x] `npx tsc --noEmit` passes locally.
- [ ] Visually verify Devices page in **all** theme presets (zinc / blue / rose / orange / green / violet / amber / catppuccin / t3chat / claude / supabase / notebook), light + dark — online dot, "online" status text, channel chip (LAN / Relay / Offline), stat pills, mobile card icon, and the local-device hero card (no green halo).
- [ ] Visually verify the "Check update" button in About settings under the **Claude** theme (light + dark) — button should now have a visible border/shadow and not blend into the card; spot-check it still looks right in other themes (zinc / blue / catppuccin / notebook).
- [ ] Confirm no other page regressed by the new `bg-success` / `bg-warning` / `bg-info` utilities — these names are new, so collisions are unlikely, but quick smoke-check the rest of the app.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined the "Check for updates" button styling with a bordered design and enhanced visual feedback on interaction.
  * Upgraded device status colors and indicators across the devices interface for improved visual consistency and better user clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/UniClipboard/UniClipboard/pull/766?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->