### PR TITLE
fix(blob-sync): close BaoFileStorage::Poisoned panic paths

### DIFF
--- a/.github/workflows/alpha-build.yml
+++ b/.github/workflows/alpha-build.yml
@@ -70,6 +70,8 @@ jobs:
             xdg-utils
 
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: setup node
         uses: actions/setup-node@v4

--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -88,6 +88,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.branch || github.ref }}
+          submodules: recursive
 
       - name: setup node
         uses: actions/setup-node@v6

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,6 +105,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.branch || github.ref }}
+          submodules: recursive
 
       - name: setup node
         uses: actions/setup-node@v6

--- a/.github/workflows/cache-warmup.yml
+++ b/.github/workflows/cache-warmup.yml
@@ -31,6 +31,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          submodules: recursive
 
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
@@ -87,6 +89,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          submodules: recursive
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          submodules: recursive
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -40,6 +40,7 @@ jobs:
           # Use a PAT or the default token; for same-repo PRs GITHUB_TOKEN can push.
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
+          submodules: recursive
 
       - name: Install Rust stable (with rustfmt)
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -125,6 +125,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -44,6 +44,7 @@ jobs:
           ref: main
           token: ${{ secrets.REPO_BOT_TOKEN }}
           fetch-depth: 0
+          submodules: recursive
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,7 @@ jobs:
         with:
           ref: ${{ github.event_name == 'push' && github.ref || inputs.branch }}
           token: ${{ secrets.GITHUB_TOKEN }}
+          submodules: recursive
 
       - name: Setup Node.js
         if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -115,6 +115,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ steps.snap-meta.outputs.ref }}
+          submodules: recursive
 
       - name: Build snap
         id: build

--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,10 @@ __pycache__/
 venv/
 target/
 vendor/
+# `src-tauri/vendor/iroh-blobs` is a git submodule (see .gitmodules) pinning
+# our fork at github.com/UniClipboard/iroh-blobs. Negate the generic
+# `vendor/` rule so submodule state shows up in `git status`.
+!src-tauri/vendor/
 coverage/
 .cache/
 tmp/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "src-tauri/vendor/iroh-blobs"]
+	path = src-tauri/vendor/iroh-blobs
+	url = https://github.com/UniClipboard/iroh-blobs.git
+	branch = uniclipboard/0.100.0-patched

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,9 +91,17 @@ Optional but useful:
 ### Clone and Install
 
 ```bash
-git clone https://github.com/UniClipboard/UniClipboard.git
+# `--recurse-submodules` pulls our `iroh-blobs` fork under
+# `src-tauri/vendor/iroh-blobs/`; without it `cargo build` fails.
+git clone --recurse-submodules https://github.com/UniClipboard/UniClipboard.git
 cd UniClipboard
 bun install
+```
+
+Already cloned without submodules? Run:
+
+```bash
+git submodule update --init --recursive
 ```
 
 `bun install` triggers Husky hook installation via the `prepare` script. Pre-commit lint-staged checks will run automatically on `git commit`.

--- a/CONTRIBUTING_ZH.md
+++ b/CONTRIBUTING_ZH.md
@@ -91,9 +91,17 @@
 ### 克隆与安装
 
 ```bash
-git clone https://github.com/UniClipboard/UniClipboard.git
+# `--recurse-submodules` 会同步拉取 `src-tauri/vendor/iroh-blobs/`
+# 下的 iroh-blobs fork，缺这个 `cargo build` 会失败。
+git clone --recurse-submodules https://github.com/UniClipboard/UniClipboard.git
 cd UniClipboard
 bun install
+```
+
+如果克隆时漏了 `--recurse-submodules`：
+
+```bash
+git submodule update --init --recursive
 ```
 
 `bun install` 会通过 `prepare` 脚本自动安装 Husky 钩子，`git commit` 时会自动跑 lint-staged 检查。

--- a/README.md
+++ b/README.md
@@ -194,8 +194,9 @@ The cask and the formula can coexist — install both if you want the GUI plus t
 ### Build from Source
 
 ```bash
-# Clone the repository
-git clone https://github.com/UniClipboard/UniClipboard.git
+# Clone the repository (`--recurse-submodules` pulls the iroh-blobs fork
+# under src-tauri/vendor/iroh-blobs/; without it `cargo build` fails).
+git clone --recurse-submodules https://github.com/UniClipboard/UniClipboard.git
 cd UniClipboard
 
 # Install dependencies

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -194,8 +194,9 @@ GUI 和 CLI 互不冲突，需要的话两个都装即可。
 ### 从源码构建
 
 ```bash
-# 克隆仓库
-git clone https://github.com/UniClipboard/UniClipboard.git
+# 克隆仓库（`--recurse-submodules` 会同步拉取 src-tauri/vendor/iroh-blobs/
+# 下的 iroh-blobs fork，缺它 `cargo build` 会失败）
+git clone --recurse-submodules https://github.com/UniClipboard/UniClipboard.git
 cd UniClipboard
 
 # 安装依赖

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4169,8 +4169,6 @@ dependencies = [
 [[package]]
 name = "iroh-blobs"
 version = "0.100.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dd8da14b7c35d8c0e82a246939ee532ce4d9eb30b0e353a5a9470bc8f52b34"
 dependencies = [
  "arrayvec",
  "bao-tree",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -108,6 +108,11 @@ members = [
   "crates/uc-cli-macros",
   "crates/uc-daemon-client",
 ]
+# Submodule `vendor/iroh-blobs` is our fork of n0-computer/iroh-blobs
+# (branch `uniclipboard/0.100.0-patched`). It is consumed via
+# `[patch.crates-io]` below, NOT as a workspace member — exclude it so
+# cargo doesn't try to fold it into this workspace's resolver.
+exclude = ["vendor/iroh-blobs"]
 resolver = "2"
 
 [workspace.package]
@@ -122,3 +127,11 @@ license = "AGPL-3.0-only"
 # Cargo unification 强制把 specta 升到 rc.25，所以 tauri 也必须 ≥ 2.11。
 tauri = { version = "2.11", features = ["tray-icon", "macos-private-api"] }
 tauri-plugin-autostart = "2"
+
+# Vendor 替换 iroh-blobs 0.100.0：上游 HashContext::persist() 在非 Partial
+# 状态下会把 BaoFileStorage 永久污染为 Poisoned，下次 observe(hash) 触发
+# BaoFileStorage::bitfield() 的 panic 分支。修复见
+# vendor/iroh-blobs/src/store/fs.rs::HashContext::persist 与
+# vendor/iroh-blobs/src/store/fs/bao_file.rs::persist_regression 单元测试。
+[patch.crates-io]
+iroh-blobs = { path = "vendor/iroh-blobs" }

--- a/src-tauri/crates/uc-application/src/facade/clipboard_history/mod.rs
+++ b/src-tauri/crates/uc-application/src/facade/clipboard_history/mod.rs
@@ -23,8 +23,8 @@ use crate::usecases::clipboard_history::{
     compute_clipboard_stats, CleanupExpiredFilesUseCase, CleanupResult,
     ClearClipboardHistoryUseCase, DeleteClipboardEntryUseCase, EntryDetailResult,
     EntryProjectionDto, EntryResourceResult, GetEntryDetailUseCase, GetEntryResourceUseCase,
-    ListClipboardEntryProjectionsUseCase, ListProjectionsError,
-    ToggleFavoriteClipboardEntryUseCase,
+    ListClipboardEntryProjectionsUseCase, ListProjectionsError, ReconcileMissingFilesUseCase,
+    ReconcileResult, ToggleFavoriteClipboardEntryUseCase,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -99,6 +99,13 @@ pub struct CleanupResultView {
     pub errors: u32,
 }
 
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ReconcileResultView {
+    pub entries_scanned: u32,
+    pub entries_deleted: u32,
+    pub errors: u32,
+}
+
 #[derive(Debug, Clone, Error, PartialEq, Eq)]
 pub enum ClipboardHistoryError {
     #[error("entry not found")]
@@ -147,6 +154,7 @@ pub struct ClipboardHistoryFacade {
     delete_uc: DeleteClipboardEntryUseCase,
     clear_uc: ClearClipboardHistoryUseCase,
     cleanup_uc: Option<CleanupExpiredFilesUseCase>,
+    reconcile_uc: Option<ReconcileMissingFilesUseCase>,
     /// debug seed 路径需要的额外 ports，常态业务不直接消费。
     seed_event_writer: Arc<dyn ClipboardEventWriterPort>,
     seed_entry_repo: Arc<dyn ClipboardEntryRepositoryPort>,
@@ -241,11 +249,30 @@ impl ClipboardHistoryFacade {
             clear_uc = clear_uc.with_blob_transfer(bt);
         }
 
-        // cleanup 只在装配方传入了 file_cache_dir 时有意义 —— 没有 cache
-        // 目录就没有需要扫描的文件，构造 use case 也没用。
-        let cleanup_uc = file_cache_dir.map(|dir| {
+        // cleanup 与 reconcile 都只在装配方传入了 file_cache_dir 时才有
+        // 意义：没有 cache 目录就没有可扫描的文件 / 可消解的漂移条目。两者
+        // 共享同一组底层 ports，所以这里把 Arc clone 一份给 cleanup，原始
+        // ownership 留给 reconcile（后写入字段）。
+        let cleanup_uc = file_cache_dir.clone().map(|dir| {
             let mut uc = CleanupExpiredFilesUseCase::new(
                 settings,
+                dir,
+                entry_repo.clone(),
+                selection_repo.clone(),
+                event_writer.clone(),
+                representation_repo.clone(),
+            );
+            if let Some(idx) = search_index.clone() {
+                uc = uc.with_search_index(idx);
+            }
+            if let Some(bt) = blob_transfer.clone() {
+                uc = uc.with_blob_transfer(bt);
+            }
+            uc
+        });
+
+        let reconcile_uc = file_cache_dir.map(|dir| {
+            let mut uc = ReconcileMissingFilesUseCase::new(
                 dir,
                 entry_repo,
                 selection_repo,
@@ -269,6 +296,7 @@ impl ClipboardHistoryFacade {
             delete_uc,
             clear_uc,
             cleanup_uc,
+            reconcile_uc,
             seed_event_writer,
             seed_entry_repo,
             seed_device_identity,
@@ -444,6 +472,27 @@ impl ClipboardHistoryFacade {
         Ok(cleanup_to_view(result))
     }
 
+    /// Drop every DB entry whose cache-managed `file://` path no longer
+    /// exists on disk. Companion to [`Self::cleanup_expired_files`] —
+    /// cleanup walks the cache dir, reconcile walks the entry list, so
+    /// together they close both directions of cache↔DB drift. Should be
+    /// invoked once on startup before any code path observes a hash.
+    ///
+    /// Returns `Ok(default())` when the facade was assembled without a
+    /// `file_cache_dir` (headless / test contexts have nothing to drift).
+    pub async fn reconcile_missing_files(
+        &self,
+    ) -> Result<ReconcileResultView, ClipboardHistoryError> {
+        let Some(uc) = self.reconcile_uc.as_ref() else {
+            return Ok(ReconcileResultView::default());
+        };
+        let result = uc
+            .execute()
+            .await
+            .map_err(|e| ClipboardHistoryError::Internal(e.to_string()))?;
+        Ok(reconcile_to_view(result))
+    }
+
     pub async fn clear_history(&self) -> Result<ClearHistoryResultView, ClipboardHistoryError> {
         let result = self
             .clear_uc
@@ -512,6 +561,14 @@ fn cleanup_to_view(result: CleanupResult) -> CleanupResultView {
         bytes_reclaimed: result.bytes_reclaimed,
         entries_deleted: result.entries_deleted,
         orphans_removed: result.orphans_removed,
+        errors: result.errors,
+    }
+}
+
+fn reconcile_to_view(result: ReconcileResult) -> ReconcileResultView {
+    ReconcileResultView {
+        entries_scanned: result.entries_scanned,
+        entries_deleted: result.entries_deleted,
         errors: result.errors,
     }
 }

--- a/src-tauri/crates/uc-application/src/facade/clipboard_history/mod.rs
+++ b/src-tauri/crates/uc-application/src/facade/clipboard_history/mod.rs
@@ -9,9 +9,9 @@ use uc_core::ports::blob::BlobTransferPort;
 use uc_core::ports::clipboard::{ClipboardPayloadResolverPort, ThumbnailRepositoryPort};
 use uc_core::ports::search::search_index::SearchIndexPort;
 use uc_core::ports::{
-    ClipboardEntryRepositoryPort, ClipboardEventWriterPort, ClipboardRepresentationRepositoryPort,
-    ClipboardSelectionRepositoryPort, ClockPort, DeviceIdentityPort, FileTransferRepositoryPort,
-    SettingsPort,
+    CacheFsPort, ClipboardEntryRepositoryPort, ClipboardEventWriterPort,
+    ClipboardRepresentationRepositoryPort, ClipboardSelectionRepositoryPort, ClockPort,
+    DeviceIdentityPort, FileTransferRepositoryPort, SettingsPort,
 };
 use uc_core::{
     ClipboardEntry, ClipboardEvent, ClipboardSelection, ClipboardSelectionDecision, MimeType,
@@ -144,6 +144,10 @@ pub struct ClipboardHistoryFacadeDeps {
     pub device_identity: Arc<dyn DeviceIdentityPort>,
     /// `seed_text_entry` 用：构造 `captured_at_ms` / `created_at_ms`。
     pub clock: Arc<dyn ClockPort>,
+    /// `reconcile_missing_files` / `cleanup_expired_files` 等用例需要查询
+    /// cache 目录及其下路径是否真实存在；走 port 而不是 `std::fs`，让 uc-app
+    /// 保持基础设施无关。
+    pub cache_fs: Arc<dyn CacheFsPort>,
 }
 
 pub struct ClipboardHistoryFacade {
@@ -179,6 +183,7 @@ impl ClipboardHistoryFacade {
             settings,
             device_identity,
             clock,
+            cache_fs,
         } = deps;
         // seed 路径要在主 use case 装配之后单独留一份 Arc 引用——其它字段
         // 都被 move 进各 use case 内部，不能在外面继续 clone。
@@ -278,6 +283,7 @@ impl ClipboardHistoryFacade {
                 selection_repo,
                 event_writer,
                 representation_repo,
+                cache_fs,
             );
             if let Some(idx) = search_index {
                 uc = uc.with_search_index(idx);

--- a/src-tauri/crates/uc-application/src/facade/mod.rs
+++ b/src-tauri/crates/uc-application/src/facade/mod.rs
@@ -55,6 +55,7 @@ pub use clipboard_history::{
     ClearHistoryResultView as ClipboardClearHistoryResultView, ClipboardHistoryError,
     ClipboardHistoryFacade, ClipboardHistoryFacadeDeps, ClipboardListInput, ClipboardStatsView,
     EntryDetailView, EntryProjectionView, EntryResourceView,
+    ReconcileResultView as ClipboardReconcileResultView,
 };
 pub use clipboard_inbound::{
     InboundClipboardApplyError, InboundClipboardApplyInput, InboundClipboardApplyOutcome,

--- a/src-tauri/crates/uc-application/src/usecases/clipboard_history/mod.rs
+++ b/src-tauri/crates/uc-application/src/usecases/clipboard_history/mod.rs
@@ -11,6 +11,7 @@ pub(crate) mod delete_entry;
 pub(crate) mod get_entry_detail;
 pub(crate) mod get_entry_resource;
 pub(crate) mod list_entry_projections;
+pub(crate) mod reconcile_missing_files;
 pub(crate) mod toggle_favorite;
 
 pub(crate) use cleanup::{CleanupExpiredFilesUseCase, CleanupResult};
@@ -21,6 +22,7 @@ pub(crate) use get_entry_resource::{EntryResourceResult, GetEntryResourceUseCase
 pub(crate) use list_entry_projections::{
     EntryProjectionDto, ListClipboardEntryProjectionsUseCase, ListProjectionsError,
 };
+pub(crate) use reconcile_missing_files::{ReconcileMissingFilesUseCase, ReconcileResult};
 pub(crate) use toggle_favorite::ToggleFavoriteClipboardEntryUseCase;
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src-tauri/crates/uc-application/src/usecases/clipboard_history/reconcile_missing_files.rs
+++ b/src-tauri/crates/uc-application/src/usecases/clipboard_history/reconcile_missing_files.rs
@@ -27,8 +27,8 @@ use uc_core::ids::{EntryId, EventId};
 use uc_core::ports::blob::BlobTransferPort;
 use uc_core::ports::search::search_index::SearchIndexPort;
 use uc_core::ports::{
-    ClipboardEntryRepositoryPort, ClipboardEventWriterPort, ClipboardRepresentationRepositoryPort,
-    ClipboardSelectionRepositoryPort,
+    CacheFsPort, ClipboardEntryRepositoryPort, ClipboardEventWriterPort,
+    ClipboardRepresentationRepositoryPort, ClipboardSelectionRepositoryPort,
 };
 
 use super::delete_entry::DeleteClipboardEntryUseCase;
@@ -55,6 +55,7 @@ pub(crate) struct ReconcileMissingFilesUseCase {
     selection_repo: Arc<dyn ClipboardSelectionRepositoryPort>,
     event_writer: Arc<dyn ClipboardEventWriterPort>,
     representation_repo: Arc<dyn ClipboardRepresentationRepositoryPort>,
+    cache_fs: Arc<dyn CacheFsPort>,
     blob_transfer: Option<Arc<dyn BlobTransferPort>>,
     search_index: Option<Arc<dyn SearchIndexPort>>,
 }
@@ -66,6 +67,7 @@ impl ReconcileMissingFilesUseCase {
         selection_repo: Arc<dyn ClipboardSelectionRepositoryPort>,
         event_writer: Arc<dyn ClipboardEventWriterPort>,
         representation_repo: Arc<dyn ClipboardRepresentationRepositoryPort>,
+        cache_fs: Arc<dyn CacheFsPort>,
     ) -> Self {
         Self {
             file_cache_dir,
@@ -73,6 +75,7 @@ impl ReconcileMissingFilesUseCase {
             selection_repo,
             event_writer,
             representation_repo,
+            cache_fs,
             blob_transfer: None,
             search_index: None,
         }
@@ -90,7 +93,7 @@ impl ReconcileMissingFilesUseCase {
 
     #[tracing::instrument(name = "usecase.reconcile_missing_files.execute", skip(self))]
     pub(crate) async fn execute(&self) -> Result<ReconcileResult> {
-        if !self.file_cache_dir.exists() {
+        if !self.cache_fs.exists(&self.file_cache_dir).await {
             info!(
                 path = %self.file_cache_dir.display(),
                 "File cache directory does not exist, nothing to reconcile"
@@ -115,7 +118,11 @@ impl ReconcileMissingFilesUseCase {
         let mut result = ReconcileResult::default();
         let mut offset = 0usize;
         let mut handled: HashSet<EntryId> = HashSet::new();
+        let mut to_delete: Vec<EntryId> = Vec::new();
 
+        // Two-phase: scan first, delete second. Deleting during the scan
+        // shrinks the underlying table, which silently shifts later
+        // offset-based pages and skips entries adjacent to deletions.
         loop {
             let batch = self
                 .entry_repo
@@ -135,7 +142,7 @@ impl ReconcileMissingFilesUseCase {
             result.entries_scanned += batch_len as u32;
 
             for entry in &batch {
-                if handled.contains(&entry.entry_id) {
+                if !handled.insert(entry.entry_id.clone()) {
                     continue;
                 }
                 let missing = match self.entry_has_missing_cache_file(&entry.event_id).await {
@@ -149,32 +156,34 @@ impl ReconcileMissingFilesUseCase {
                         continue;
                     }
                 };
-                if !missing {
-                    continue;
-                }
-                handled.insert(entry.entry_id.clone());
-                match delete_uc.execute(&entry.entry_id).await {
-                    Ok(()) => {
-                        result.entries_deleted += 1;
-                        info!(
-                            entry_id = %entry.entry_id,
-                            "Reconcile: dropped entry whose cache file no longer exists"
-                        );
-                    }
-                    Err(e) => {
-                        warn!(
-                            entry_id = %entry.entry_id,
-                            error = %e,
-                            "Reconcile: delete_entry failed for stale entry"
-                        );
-                        result.errors += 1;
-                    }
+                if missing {
+                    to_delete.push(entry.entry_id.clone());
                 }
             }
 
             offset += batch_len;
             if batch_len < ENTRY_LIST_BATCH_SIZE {
                 break;
+            }
+        }
+
+        for entry_id in &to_delete {
+            match delete_uc.execute(entry_id).await {
+                Ok(()) => {
+                    result.entries_deleted += 1;
+                    info!(
+                        entry_id = %entry_id,
+                        "Reconcile: dropped entry whose cache file no longer exists"
+                    );
+                }
+                Err(e) => {
+                    warn!(
+                        entry_id = %entry_id,
+                        error = %e,
+                        "Reconcile: delete_entry failed for stale entry"
+                    );
+                    result.errors += 1;
+                }
             }
         }
 
@@ -207,7 +216,7 @@ impl ReconcileMissingFilesUseCase {
                 continue;
             };
             for path in extract_cache_paths(inline, &self.file_cache_dir) {
-                if !path.exists() {
+                if !self.cache_fs.exists(&path).await {
                     return Ok(true);
                 }
             }

--- a/src-tauri/crates/uc-application/src/usecases/clipboard_history/reconcile_missing_files.rs
+++ b/src-tauri/crates/uc-application/src/usecases/clipboard_history/reconcile_missing_files.rs
@@ -1,0 +1,322 @@
+//! Startup reconciliation: drop DB entries whose backing cache files have
+//! vanished.
+//!
+//! Companion to [`super::cleanup::CleanupExpiredFilesUseCase`]. Cleanup
+//! walks the file-cache directory to find files past their retention TTL
+//! and matches them back to entries. Reconcile walks the entry list and
+//! drops any entry whose cache-managed `file://` paths no longer exist on
+//! disk. The two passes together close both directions of cache↔DB drift.
+//!
+//! Why this exists: under iroh-blobs 0.100.0 a `Complete{External(path)}`
+//! entry whose path has been removed externally triggers
+//! `BaoFileStorage::open -> Err(_) -> Poisoned`, and a subsequent
+//! `observe(hash)` panics on `bao_file.rs:410` with
+//! "poisoned storage should not be used". Old uniclipboard releases ran a
+//! raw `tokio::fs::remove_file` cleanup that left exactly this drift behind;
+//! reconcile cleans up that historical mess on startup so the upstream
+//! crate never sees a stale External path.
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use anyhow::Result;
+use tracing::{info, info_span, warn, Instrument};
+
+use uc_core::ids::{EntryId, EventId};
+use uc_core::ports::blob::BlobTransferPort;
+use uc_core::ports::search::search_index::SearchIndexPort;
+use uc_core::ports::{
+    ClipboardEntryRepositoryPort, ClipboardEventWriterPort, ClipboardRepresentationRepositoryPort,
+    ClipboardSelectionRepositoryPort,
+};
+
+use super::delete_entry::DeleteClipboardEntryUseCase;
+
+/// Result of a reconcile pass.
+#[derive(Debug, Default, Clone)]
+pub struct ReconcileResult {
+    /// Number of entries scanned across every batch.
+    pub entries_scanned: u32,
+    /// Number of entries dropped because at least one of their cache files
+    /// was missing on disk.
+    pub entries_deleted: u32,
+    /// Number of entries that we *wanted* to drop but `delete_entry`
+    /// failed on. Surfaced separately so callers can decide whether to
+    /// alert vs. silently log.
+    pub errors: u32,
+}
+
+const ENTRY_LIST_BATCH_SIZE: usize = 1000;
+
+pub(crate) struct ReconcileMissingFilesUseCase {
+    file_cache_dir: PathBuf,
+    entry_repo: Arc<dyn ClipboardEntryRepositoryPort>,
+    selection_repo: Arc<dyn ClipboardSelectionRepositoryPort>,
+    event_writer: Arc<dyn ClipboardEventWriterPort>,
+    representation_repo: Arc<dyn ClipboardRepresentationRepositoryPort>,
+    blob_transfer: Option<Arc<dyn BlobTransferPort>>,
+    search_index: Option<Arc<dyn SearchIndexPort>>,
+}
+
+impl ReconcileMissingFilesUseCase {
+    pub(crate) fn new(
+        file_cache_dir: PathBuf,
+        entry_repo: Arc<dyn ClipboardEntryRepositoryPort>,
+        selection_repo: Arc<dyn ClipboardSelectionRepositoryPort>,
+        event_writer: Arc<dyn ClipboardEventWriterPort>,
+        representation_repo: Arc<dyn ClipboardRepresentationRepositoryPort>,
+    ) -> Self {
+        Self {
+            file_cache_dir,
+            entry_repo,
+            selection_repo,
+            event_writer,
+            representation_repo,
+            blob_transfer: None,
+            search_index: None,
+        }
+    }
+
+    pub(crate) fn with_blob_transfer(mut self, blob_transfer: Arc<dyn BlobTransferPort>) -> Self {
+        self.blob_transfer = Some(blob_transfer);
+        self
+    }
+
+    pub(crate) fn with_search_index(mut self, search_index: Arc<dyn SearchIndexPort>) -> Self {
+        self.search_index = Some(search_index);
+        self
+    }
+
+    #[tracing::instrument(name = "usecase.reconcile_missing_files.execute", skip(self))]
+    pub(crate) async fn execute(&self) -> Result<ReconcileResult> {
+        if !self.file_cache_dir.exists() {
+            info!(
+                path = %self.file_cache_dir.display(),
+                "File cache directory does not exist, nothing to reconcile"
+            );
+            return Ok(ReconcileResult::default());
+        }
+
+        let mut delete_uc = DeleteClipboardEntryUseCase::from_ports(
+            self.entry_repo.clone(),
+            self.selection_repo.clone(),
+            self.event_writer.clone(),
+            self.representation_repo.clone(),
+        )
+        .with_file_cache_dir(self.file_cache_dir.clone());
+        if let Some(idx) = self.search_index.clone() {
+            delete_uc = delete_uc.with_search_index(idx);
+        }
+        if let Some(bt) = self.blob_transfer.clone() {
+            delete_uc = delete_uc.with_blob_transfer(bt);
+        }
+
+        let mut result = ReconcileResult::default();
+        let mut offset = 0usize;
+        let mut handled: HashSet<EntryId> = HashSet::new();
+
+        loop {
+            let batch = self
+                .entry_repo
+                .list_entries(ENTRY_LIST_BATCH_SIZE, offset)
+                .instrument(info_span!(
+                    "list_entries_batch",
+                    batch_size = ENTRY_LIST_BATCH_SIZE,
+                    offset = offset
+                ))
+                .await
+                .map_err(|e| anyhow::anyhow!("list entries for reconcile: {e}"))?;
+
+            if batch.is_empty() {
+                break;
+            }
+            let batch_len = batch.len();
+            result.entries_scanned += batch_len as u32;
+
+            for entry in &batch {
+                if handled.contains(&entry.entry_id) {
+                    continue;
+                }
+                let missing = match self.entry_has_missing_cache_file(&entry.event_id).await {
+                    Ok(missing) => missing,
+                    Err(e) => {
+                        warn!(
+                            entry_id = %entry.entry_id,
+                            error = %e,
+                            "Failed to inspect representations while reconciling — skipping entry"
+                        );
+                        continue;
+                    }
+                };
+                if !missing {
+                    continue;
+                }
+                handled.insert(entry.entry_id.clone());
+                match delete_uc.execute(&entry.entry_id).await {
+                    Ok(()) => {
+                        result.entries_deleted += 1;
+                        info!(
+                            entry_id = %entry.entry_id,
+                            "Reconcile: dropped entry whose cache file no longer exists"
+                        );
+                    }
+                    Err(e) => {
+                        warn!(
+                            entry_id = %entry.entry_id,
+                            error = %e,
+                            "Reconcile: delete_entry failed for stale entry"
+                        );
+                        result.errors += 1;
+                    }
+                }
+            }
+
+            offset += batch_len;
+            if batch_len < ENTRY_LIST_BATCH_SIZE {
+                break;
+            }
+        }
+
+        info!(
+            entries_scanned = result.entries_scanned,
+            entries_deleted = result.entries_deleted,
+            errors = result.errors,
+            "Reconcile pass complete"
+        );
+        Ok(result)
+    }
+
+    /// Return `Ok(true)` when any cache-managed `file://` URI in the
+    /// entry's representations points at a path that doesn't exist on
+    /// disk. Paths outside `file_cache_dir` are ignored (user-owned
+    /// files we never managed).
+    async fn entry_has_missing_cache_file(&self, event_id: &EventId) -> Result<bool> {
+        let representations = self
+            .representation_repo
+            .get_representations_for_event(event_id)
+            .await
+            .map_err(|e| anyhow::anyhow!("get representations: {e}"))?;
+
+        for rep in &representations {
+            let mime = rep.mime_type.as_ref().map(|m| m.as_str()).unwrap_or("");
+            if !mime.contains("uri-list") {
+                continue;
+            }
+            let Some(inline) = rep.inline_data.as_ref() else {
+                continue;
+            };
+            for path in extract_cache_paths(inline, &self.file_cache_dir) {
+                if !path.exists() {
+                    return Ok(true);
+                }
+            }
+        }
+        Ok(false)
+    }
+}
+
+/// Decode a `text/uri-list` payload and return only those `file://` paths
+/// that fall under `cache_dir`. Lines that fail to parse, comments, and
+/// paths outside `cache_dir` are silently skipped — they are not the
+/// reconcile target. This mirrors the extraction logic in
+/// [`super::cleanup`] and [`super::delete_entry`], lifted into a pure
+/// helper so it can be unit-tested without a full use-case fixture.
+fn extract_cache_paths(uri_list: &[u8], cache_dir: &Path) -> Vec<PathBuf> {
+    let text = String::from_utf8_lossy(uri_list);
+    let mut out = Vec::new();
+    for line in text.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let parsed = if line.starts_with("file://") {
+            url::Url::parse(line)
+                .ok()
+                .and_then(|u| u.to_file_path().ok())
+        } else {
+            Some(PathBuf::from(line))
+        };
+        let Some(path) = parsed else { continue };
+        if path.starts_with(cache_dir) {
+            out.push(path);
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cache_dir() -> PathBuf {
+        PathBuf::from("/var/cache/uniclipboard")
+    }
+
+    #[test]
+    fn extracts_file_uri_inside_cache_dir() {
+        let uri = b"file:///var/cache/uniclipboard/abc/IMG.JPG\n";
+        let paths = extract_cache_paths(uri, &cache_dir());
+        assert_eq!(
+            paths,
+            vec![PathBuf::from("/var/cache/uniclipboard/abc/IMG.JPG")]
+        );
+    }
+
+    #[test]
+    fn skips_paths_outside_cache_dir() {
+        // user dropped a file from their Downloads folder — we never
+        // managed it, so it must not show up in the reconcile target set.
+        let uri = b"file:///Users/alice/Downloads/IMG.JPG\n";
+        let paths = extract_cache_paths(uri, &cache_dir());
+        assert!(paths.is_empty(), "user-owned path should be filtered out");
+    }
+
+    #[test]
+    fn skips_blank_lines_and_comments() {
+        let uri = b"# this is a comment\n\nfile:///var/cache/uniclipboard/a/b.txt\n\n";
+        let paths = extract_cache_paths(uri, &cache_dir());
+        assert_eq!(
+            paths,
+            vec![PathBuf::from("/var/cache/uniclipboard/a/b.txt")]
+        );
+    }
+
+    #[test]
+    fn accepts_bare_path_lines() {
+        // Some legacy representations carry plain paths instead of
+        // file:// URIs. The reverse-index loop in the original cleanup
+        // also handled this; keep parity.
+        let uri = b"/var/cache/uniclipboard/abc/file.bin\n";
+        let paths = extract_cache_paths(uri, &cache_dir());
+        assert_eq!(
+            paths,
+            vec![PathBuf::from("/var/cache/uniclipboard/abc/file.bin")]
+        );
+    }
+
+    #[test]
+    fn ignores_garbage_lines() {
+        let uri = b"not a url\nfile://?garbage\nfile:///var/cache/uniclipboard/ok.txt\n";
+        let paths = extract_cache_paths(uri, &cache_dir());
+        // The bare-path branch (`Some(PathBuf::from(line))`) means
+        // unparseable lines that aren't `file://`-prefixed still become
+        // a PathBuf and are filtered by the cache-dir prefix check.
+        // Only the legitimate cache path should survive.
+        assert_eq!(paths, vec![PathBuf::from("/var/cache/uniclipboard/ok.txt")]);
+    }
+
+    #[test]
+    fn returns_each_path_in_multi_file_payload() {
+        let uri =
+            b"file:///var/cache/uniclipboard/a/1.txt\nfile:///var/cache/uniclipboard/b/2.txt\n";
+        let paths = extract_cache_paths(uri, &cache_dir());
+        assert_eq!(
+            paths,
+            vec![
+                PathBuf::from("/var/cache/uniclipboard/a/1.txt"),
+                PathBuf::from("/var/cache/uniclipboard/b/2.txt"),
+            ]
+        );
+    }
+}

--- a/src-tauri/crates/uc-bootstrap/src/non_gui_runtime.rs
+++ b/src-tauri/crates/uc-bootstrap/src/non_gui_runtime.rs
@@ -377,6 +377,7 @@ pub fn build_app_facade_from_deps(
             settings: deps.settings.clone(),
             device_identity: deps.device.device_identity.clone(),
             clock: deps.system.clock.clone(),
+            cache_fs: deps.system.cache_fs.clone(),
         })),
         clipboard_sync: options.clipboard_sync,
         blob_transfer: options.blob_transfer,

--- a/src-tauri/crates/uc-desktop/src/background.rs
+++ b/src-tauri/crates/uc-desktop/src/background.rs
@@ -19,15 +19,31 @@ use tracing::{info, warn};
 use uc_application::facade::ClipboardHistoryFacade;
 use uc_bootstrap::TaskRegistry;
 
-/// Register the file cache cleanup task with `TaskRegistry`.
+/// Register the startup file-cache hygiene task with `TaskRegistry`.
 ///
-/// Cleanup goes through `ClipboardHistoryFacade::cleanup_expired_files`,
-/// which routes every expired file through the entry-aware delete path
-/// (untag iroh-blobs reference + remove cache file + drop sqlite rows
-/// in one shot). Pre-Phase-C this called a standalone use case that
-/// `tokio::fs::remove_file`-d cache files directly, leaving iroh-blobs
-/// metadata pointing at vanished files (the precursor to the Poisoned
-/// BaoFileStorage panic at `bao_file.rs:410`).
+/// Runs two passes back to back inside a single registry task:
+///
+/// 1. **Reconcile** (`ClipboardHistoryFacade::reconcile_missing_files`):
+///    drops any DB entry whose cache-managed `file://` path no longer
+///    exists on disk. This catches drift left over from older releases
+///    (pre-Phase-C raw `tokio::fs::remove_file` cleanup) and from any
+///    out-of-band cache deletion. **Reconcile must run first**, because
+///    a `Complete{External(missing_path)}` entry in the iroh-blobs
+///    metadata is exactly the precondition for the upstream panic at
+///    `bao_file.rs:410` "poisoned storage should not be used" — once any
+///    code path observes the hash, the actor task dies. Reconcile flushes
+///    those entries through the entry-aware delete path before the rest
+///    of the daemon starts servicing observe requests.
+///
+/// 2. **Cleanup** (`ClipboardHistoryFacade::cleanup_expired_files`):
+///    walks the cache directory for files past their retention TTL and
+///    routes each one through the same entry-aware delete path (untag
+///    iroh-blobs reference + remove cache file + drop sqlite rows in one
+///    shot).
+///
+/// The two passes are complementary: cleanup walks files → entries;
+/// reconcile walks entries → files. Together they keep cache↔DB in sync
+/// in both directions.
 ///
 /// Caller must drive this future inside a tokio runtime context (e.g.
 /// `tauri::async_runtime::spawn(async move { start_file_cache_cleanup(...).await })`).
@@ -36,7 +52,29 @@ pub async fn start_file_cache_cleanup(
     task_registry: &Arc<TaskRegistry>,
 ) {
     task_registry
-        .spawn("file_cache_cleanup", |_token| async move {
+        .spawn("file_cache_hygiene", |_token| async move {
+            // Phase 1: reconcile DB entries against disk. This must
+            // happen *before* anything in the daemon observes a hash
+            // whose External path may have vanished; otherwise the
+            // iroh-blobs actor panics with poisoned storage.
+            match history_facade.reconcile_missing_files().await {
+                Ok(result) => {
+                    if result.entries_deleted > 0 || result.errors > 0 {
+                        info!(
+                            entries_scanned = result.entries_scanned,
+                            entries_deleted = result.entries_deleted,
+                            errors = result.errors,
+                            "Startup reconcile dropped stale entries with missing cache files"
+                        );
+                    }
+                }
+                Err(e) => {
+                    warn!(error = %e, "Startup reconcile failed (non-fatal)");
+                }
+            }
+
+            // Phase 2: TTL-based cleanup of cache files that have
+            // outlived `file_sync.file_retention_hours`.
             match history_facade.cleanup_expired_files().await {
                 Ok(result) => {
                     if result.files_removed > 0 {

--- a/src/lib/ipc-bindings.generated.ts
+++ b/src/lib/ipc-bindings.generated.ts
@@ -270,12 +270,18 @@ export const commands = {
 	 *    3. 计算 desired OS 快捷键列表(开启时 = `resolve_quick_panel_shortcuts`,
 	 *       关闭时 = `[]`)。
 	 *    4. 在 main thread 上一次性完成:开启 → `pre_create` + `register`,
-	 *       关闭 → `unregister` + `destroy`。`tauri-plugin-global-shortcut`
+	 *       关闭 → 只 `unregister`,**不**销毁面板窗口。`tauri-plugin-global-shortcut`
 	 *       与 webview 创建都要求 main thread。
 	 *    5. 调 facade 持久化 patch。失败时反向回滚 OS 副作用,避免出现
 	 *       "OS 已生效但磁盘没存"或反过来的撕裂状态。
 	 *    6. 成功后 `shortcut_registry.replace(...)`,让后续 `update_keyboard_shortcuts`
 	 *       能算对 old/new diff。
+	 * 
+	 *  **关闭路径不彻底释放 webview**:macOS 上销毁 NSPanel 会与 ObjC 类替换 +
+	 *  on_window_event 异步任务发生 race 而崩溃。所以关闭只反注册 OS 快捷键,
+	 *  隐藏的 WKWebView / WebContent XPC 进程依旧存在,UI 会提示用户重启 GUI
+	 *  才能完全释放资源。下次启动期 `quick_panel.enabled = false` 会跳过
+	 *  `pre_create`,自然不会再有这些进程。
 	 */
 	setQuickPanelEnabled: (enabled: boolean, trace: {
 	trace_id: string,


### PR DESCRIPTION
## Summary

Inbound clipboard sync was crashing the `iroh-blob-store` worker task with `"poisoned storage should not be used"` (panic at iroh-blobs `bao_file.rs:410`) whenever the same file got synced twice or when the cache↔sqlite metadata had drifted out of step. Three defenses, layered:

- **iroh-blobs vendored as a git submodule** (`src-tauri/vendor/iroh-blobs`) pointing at our fork [`UniClipboard/iroh-blobs`](https://github.com/UniClipboard/iroh-blobs) on branch [`uniclipboard/0.100.0-patched`](https://github.com/UniClipboard/iroh-blobs/tree/uniclipboard/0.100.0-patched). The fork sits on top of upstream `v0.100.0` and carries two surgical patches: `persist()` no longer poisons non-`Partial` state, and `load()` maps `ErrorKind::NotFound` to `NonExisting` instead of `Poisoned` so an externally-deleted External data file is recoverable via the normal re-download path. Both patches ship with deterministic regression tests in the fork. (7b4ebded)

- **Application-layer reconciliation** — new `ReconcileMissingFilesUseCase` (`ClipboardHistoryFacade::reconcile_missing_files`) walks the entry list and routes any entry whose cache-managed `file://` path is missing through `DeleteClipboardEntryUseCase` (untag iroh-blobs reference + drop sqlite rows). Companion to the existing `cleanup_expired_files` pass; cleanup walks the cache dir, reconcile walks the entry list, together they close cache↔DB drift in both directions. (7b4ebded)

- **Startup hygiene task** runs reconcile *before* cleanup, so stale `Complete{External(missing_path)}` entries are flushed before any code path triggers an `observe(hash)`. Task renamed `file_cache_cleanup` → `file_cache_hygiene` to reflect the broader scope. (7b4ebded)

- **Docs** — README/CONTRIBUTING (both en + zh) updated to use `git clone --recurse-submodules`; a plain `git clone` now leaves `src-tauri/vendor/iroh-blobs/` empty and `cargo build` fails. (aab763e4)

## Test plan

- [x] `cargo build -p uc-application -p uc-desktop` passes
- [x] `cargo test -p uc-application --lib` — 503/503 (incl. 6 new `reconcile_missing_files` unit tests covering URI extraction edge cases)
- [x] In the fork repo: `cargo test --lib persist_regression` (2/2), `cargo test --lib load_regression` (2/2), `cargo test --lib try_reference_then_re_observe_smoke` (1/1)
- [x] `cargo tree -p uc-infra -i iroh-blobs` confirms the patch resolves to `src-tauri/vendor/iroh-blobs` (submodule path)
- [ ] Restart `bun tauri:dev`, copy a previously-synced file again, confirm no `"poisoned storage should not be used"` panic and the new `Startup reconcile dropped stale entries with missing cache files` log line fires when stale entries are present
- [ ] CI checkout step needs `submodules: recursive` — follow-up

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clipboard history reconciliation feature that automatically removes entries with missing cache files on startup.

* **Chores**
  * Updated build workflows to properly handle git submodules.
  * Updated development setup documentation for submodule initialization.
  * Integrated external dependency as a git submodule to improve build consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/UniClipboard/UniClipboard/pull/767?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->