### PR TITLE
ci(snap): build arm64 snap on ubuntu-22.04-arm runner

### DIFF
--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -62,14 +62,24 @@ jobs:
     # alpha 由 release.yml 在自动发布完成后显式 dispatch,这里的
     # release.published 入口只承接人工发布的 beta / rc / stable。
     if: ${{ github.event_name != 'release' || !contains(github.event.release.tag_name, '-alpha') }}
-    name: Build snap (amd64)
+    name: Build snap (${{ matrix.arch }})
     # snap build 必须在 Ubuntu host 上跑,snapcraft action 自带 LXD;
     # 我们用 22.04 跟 base=core22 对齐,snapcraft action-build 装的工具链
-    # 跟 base 一致避免 ABI 错位。
-    runs-on: ubuntu-22.04
+    # 跟 base 一致避免 ABI 错位。arm64 走 GitHub 公开仓库免费的
+    # ubuntu-22.04-arm hosted runner,不用 QEMU 交叉构建(原生构建 Rust +
+    # webkit2gtk 比 QEMU 快一个数量级)。
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 90
     permissions:
       contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-22.04
+          - arch: arm64
+            runner: ubuntu-22.04-arm
 
     steps:
       - name: Resolve snap metadata
@@ -118,7 +128,7 @@ jobs:
         # (`snap install --dangerous file.snap`)。retention 7 天够用。
         uses: actions/upload-artifact@v7
         with:
-          name: uniclipboard-amd64-snap
+          name: uniclipboard-${{ matrix.arch }}-snap
           path: ${{ steps.build.outputs.snap }}
           retention-days: 7
           if-no-files-found: error

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -32,6 +32,8 @@ confinement: strict
 architectures:
   - build-on: amd64
     build-for: amd64
+  - build-on: arm64
+    build-for: arm64
 
 apps:
   uniclipboard:


### PR DESCRIPTION
## Summary

- Adds `arm64` to `snap/snapcraft.yaml` architectures so the Snap Store can ingest aarch64 builds alongside the existing x86_64 ones. (1df254a)
- Matrices `.github/workflows/snap.yml` across `ubuntu-22.04` and `ubuntu-22.04-arm` GitHub-hosted runners — native arm64 build instead of QEMU cross-compile, ~1 order of magnitude faster. Artifact names are now arch-suffixed to prevent upload-artifact collision between the two matrix legs. (1df254a)
- Docs (`install.mdx`) intentionally **not** updated in this PR. `install.mdx:120` still enumerates only `.deb / .rpm / .AppImage` as the aarch64-capable formats. A follow-up PR will add Snap to that enumeration **after** the first release actually publishes the arm64 `.snap` to the Snap Store, to avoid documenting a format the store doesn't yet serve.

## Test plan

- [x] `workflow_dispatch` of `snap.yml` on this branch with `release=false` → both matrix legs (amd64, arm64) succeeded: https://github.com/UniClipboard/UniClipboard/actions/runs/25967366837
- [x] Both `.snap` artifacts produced (uniclipboard-amd64-snap 45.5 MB, uniclipboard-arm64-snap 43.3 MB).
- [ ] After merge, the next `release.published` event (or a manual `workflow_dispatch -f release=true`) should publish both archs to the chosen channel. Verify `snap info uniclipboard` lists both architectures.
- [ ] On an arm64 Linux box (Raspberry Pi, Apple Silicon Linux VM, or `multipass launch --cpus 2 noble`): `sudo snap install --dangerous ./uniclipboard_*_arm64.snap` from the artifact, launch the GUI, verify clipboard sync works.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for ARM64 architecture builds alongside existing AMD64 support, expanding platform compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/UniClipboard/UniClipboard/pull/768?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->