### PR TITLE
fix(platform-clipboard): stop daemon crash on inbound image push

### DIFF
--- a/src-tauri/crates/uc-platform/src/clipboard/common.rs
+++ b/src-tauri/crates/uc-platform/src/clipboard/common.rs
@@ -1,38 +1,9 @@
-use anyhow::{anyhow, Context, Result};
+use super::payload::rep_bytes;
+use anyhow::{anyhow, Result};
 use clipboard_rs::{common::RustImage, Clipboard, ContentFormat};
-use std::borrow::Cow;
 use tracing::{debug, info, warn};
-use uc_core::clipboard::{
-    ClipboardPayloadSource, MimeType, ObservedClipboardRepresentation, SystemClipboardSnapshot,
-};
+use uc_core::clipboard::{MimeType, ObservedClipboardRepresentation, SystemClipboardSnapshot};
 use uc_core::ids::RepresentationId;
-
-/// 取 rep 字节，按 source 分流。
-///
-/// - `Inline` → 借用现有字节，零拷贝。
-/// - `LocalFile` → 同步读盘，返回 owned `Vec<u8>`。
-///
-/// 为什么需要这个 helper：入站 `apply_inbound::materializer` 会给图片 rep 合成
-/// `LocalFile` source（指向接收端 blob cache 中已 export 的文件），同一份 snapshot
-/// 在 `clipboard_capture` ingest 进 blob store 之后还会被 `ClipboardWriteCoordinator`
-/// 透传到 `SystemClipboardPort::write_snapshot` 往系统剪贴板写。如果继续直调
-/// `rep.expect_inline_bytes()`，对 `LocalFile` 会触发 panic（参见 `uc-core` 上
-/// `expect_inline_bytes` 的契约：仅 Inline 语境），daemon 整体崩溃。本 helper
-/// 显式按 source 分流，让 macOS / Windows / Linux 写入路径都能消化 `LocalFile` rep。
-///
-/// 同步读盘的代价：`SystemClipboardPort::write_snapshot` 本就是同步签名
-/// （`ClipboardWriteCoordinator` 在 tokio worker 里直调，NSPasteboard /
-/// Win32 OpenClipboard 等系统 API 本就阻塞），对端图片 blob 已由 iroh-blobs
-/// export 到本地 cache，读盘 = 顺序 IO，通常 < 几十 ms，与原系统 API 调用同量级。
-/// 如未来出现极大 payload 阻塞 worker 的证据再换 `spawn_blocking`，目前不预先优化。
-pub(crate) fn rep_bytes(rep: &ObservedClipboardRepresentation) -> Result<Cow<'_, [u8]>> {
-    match rep.source() {
-        ClipboardPayloadSource::Inline(b) => Ok(Cow::Borrowed(b.as_slice())),
-        ClipboardPayloadSource::LocalFile { path, .. } => std::fs::read(path)
-            .map(Cow::Owned)
-            .with_context(|| format!("read LocalFile rep payload at {}", path.display())),
-    }
-}
 
 /// 文件头魔数嗅探,返回桌面剪贴板能消费的 `image/*` mime 字符串。
 /// 无法识别返回 None。只读前 12 字节,无内存分配。

--- a/src-tauri/crates/uc-platform/src/clipboard/common.rs
+++ b/src-tauri/crates/uc-platform/src/clipboard/common.rs
@@ -1,8 +1,38 @@
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use clipboard_rs::{common::RustImage, Clipboard, ContentFormat};
+use std::borrow::Cow;
 use tracing::{debug, info, warn};
-use uc_core::clipboard::{MimeType, ObservedClipboardRepresentation, SystemClipboardSnapshot};
+use uc_core::clipboard::{
+    ClipboardPayloadSource, MimeType, ObservedClipboardRepresentation, SystemClipboardSnapshot,
+};
 use uc_core::ids::RepresentationId;
+
+/// 取 rep 字节，按 source 分流。
+///
+/// - `Inline` → 借用现有字节，零拷贝。
+/// - `LocalFile` → 同步读盘，返回 owned `Vec<u8>`。
+///
+/// 为什么需要这个 helper：入站 `apply_inbound::materializer` 会给图片 rep 合成
+/// `LocalFile` source（指向接收端 blob cache 中已 export 的文件），同一份 snapshot
+/// 在 `clipboard_capture` ingest 进 blob store 之后还会被 `ClipboardWriteCoordinator`
+/// 透传到 `SystemClipboardPort::write_snapshot` 往系统剪贴板写。如果继续直调
+/// `rep.expect_inline_bytes()`，对 `LocalFile` 会触发 panic（参见 `uc-core` 上
+/// `expect_inline_bytes` 的契约：仅 Inline 语境），daemon 整体崩溃。本 helper
+/// 显式按 source 分流，让 macOS / Windows / Linux 写入路径都能消化 `LocalFile` rep。
+///
+/// 同步读盘的代价：`SystemClipboardPort::write_snapshot` 本就是同步签名
+/// （`ClipboardWriteCoordinator` 在 tokio worker 里直调，NSPasteboard /
+/// Win32 OpenClipboard 等系统 API 本就阻塞），对端图片 blob 已由 iroh-blobs
+/// export 到本地 cache，读盘 = 顺序 IO，通常 < 几十 ms，与原系统 API 调用同量级。
+/// 如未来出现极大 payload 阻塞 worker 的证据再换 `spawn_blocking`，目前不预先优化。
+pub(crate) fn rep_bytes(rep: &ObservedClipboardRepresentation) -> Result<Cow<'_, [u8]>> {
+    match rep.source() {
+        ClipboardPayloadSource::Inline(b) => Ok(Cow::Borrowed(b.as_slice())),
+        ClipboardPayloadSource::LocalFile { path, .. } => std::fs::read(path)
+            .map(Cow::Owned)
+            .with_context(|| format!("read LocalFile rep payload at {}", path.display())),
+    }
+}
 
 /// 文件头魔数嗅探,返回桌面剪贴板能消费的 `image/*` mime 字符串。
 /// 无法识别返回 None。只读前 12 字节,无内存分配。
@@ -683,7 +713,11 @@ impl CommonClipboardImpl {
             (Some(m), Some(default))
                 if default.starts_with("image/") && !m.starts_with("image/") =>
             {
-                let recovered = sniff_image_magic(rep.expect_inline_bytes()).unwrap_or(default);
+                // sniff 路径罕见；rep 是 LocalFile source 读盘失败时退回 format_id 默认 mime。
+                let recovered = rep_bytes(rep)
+                    .ok()
+                    .and_then(|b| sniff_image_magic(&b))
+                    .unwrap_or(default);
                 warn!(
                     format_id = %rep.format_id,
                     wire_mime = m,
@@ -696,27 +730,27 @@ impl CommonClipboardImpl {
             (None, default) => default,
         };
 
+        // 把单 rep 的字节预读到 owned `Vec<u8>`（Inline 转 owned, LocalFile 同步读盘）。
+        // 后续各分支再从这份 owned 字节构造 String / RustImageData / set_buffer 输入,
+        // 保证 LocalFile rep 也能走完单 rep 快路径（避免 `expect_inline_bytes` panic,
+        // 见 `common::rep_bytes` 注释）。
+        let single_rep_bytes = rep_bytes(rep)?.into_owned();
+
         match effective_mime {
             Some("text/plain") => {
-                map_clipboard_err(
-                    ctx.set_text(String::from_utf8(rep.expect_inline_bytes().to_vec())?),
-                )?;
+                map_clipboard_err(ctx.set_text(String::from_utf8(single_rep_bytes)?))?;
             }
             Some("text/rtf") => {
-                map_clipboard_err(
-                    ctx.set_rich_text(String::from_utf8(rep.expect_inline_bytes().to_vec())?),
-                )?;
+                map_clipboard_err(ctx.set_rich_text(String::from_utf8(single_rep_bytes)?))?;
             }
             Some("text/html") => {
-                map_clipboard_err(
-                    ctx.set_html(String::from_utf8(rep.expect_inline_bytes().to_vec())?),
-                )?;
+                map_clipboard_err(ctx.set_html(String::from_utf8(single_rep_bytes)?))?;
             }
             Some("text/uri-list") | Some("file/uri-list") => {
                 // Convert file:// URIs back to raw OS paths for set_files(),
                 // which expects native paths. Also handle raw paths for compatibility
                 // with inbound cache paths that aren't URI-encoded.
-                let files: Vec<String> = String::from_utf8(rep.expect_inline_bytes().to_vec())?
+                let files: Vec<String> = String::from_utf8(single_rep_bytes)?
                     .lines()
                     .filter_map(|line| {
                         let line = line.trim();
@@ -752,29 +786,26 @@ impl CommonClipboardImpl {
                 #[cfg(target_os = "macos")]
                 {
                     if mime == "image/png" {
-                        map_clipboard_err(
-                            ctx.set_buffer("public.png", rep.expect_inline_bytes().to_vec()),
-                        )?;
+                        map_clipboard_err(ctx.set_buffer("public.png", single_rep_bytes))?;
                     } else {
                         // Non-PNG images still need format conversion via set_image
-                        let img =
-                            clipboard_rs::RustImageData::from_bytes(rep.expect_inline_bytes())
-                                .map_err(|e| {
-                                    warn!(
-                                        mime = mime,
-                                        data_size = rep.size_bytes(),
-                                        error = %e,
-                                        "write_snapshot: failed to decode image bytes"
-                                    );
-                                    anyhow!(e)
-                                })?;
+                        let img = clipboard_rs::RustImageData::from_bytes(&single_rep_bytes)
+                            .map_err(|e| {
+                                warn!(
+                                    mime = mime,
+                                    data_size = rep.size_bytes(),
+                                    error = %e,
+                                    "write_snapshot: failed to decode image bytes"
+                                );
+                                anyhow!(e)
+                            })?;
                         map_clipboard_err(ctx.set_image(img))?;
                     }
                 }
                 #[cfg(not(target_os = "macos"))]
                 {
-                    let img = clipboard_rs::RustImageData::from_bytes(rep.expect_inline_bytes())
-                        .map_err(|e| {
+                    let img = clipboard_rs::RustImageData::from_bytes(&single_rep_bytes).map_err(
+                        |e| {
                             warn!(
                                 mime = mime,
                                 data_size = rep.size_bytes(),
@@ -782,7 +813,8 @@ impl CommonClipboardImpl {
                                 "write_snapshot: failed to decode image bytes"
                             );
                             anyhow!(e)
-                        })?;
+                        },
+                    )?;
                     map_clipboard_err(ctx.set_image(img))?;
                 }
                 debug!(
@@ -823,9 +855,7 @@ impl CommonClipboardImpl {
                     bytes = rep.size_bytes(),
                     "write_snapshot: writing rep via raw set_buffer fallback (no recognized mime mapping)"
                 );
-                map_clipboard_err(
-                    ctx.set_buffer(&rep.format_id, rep.expect_inline_bytes().to_vec()),
-                )?;
+                map_clipboard_err(ctx.set_buffer(&rep.format_id, single_rep_bytes))?;
             }
         }
 

--- a/src-tauri/crates/uc-platform/src/clipboard/mod.rs
+++ b/src-tauri/crates/uc-platform/src/clipboard/mod.rs
@@ -7,6 +7,10 @@ pub mod event_loop;
 #[cfg(target_os = "windows")]
 pub mod image_convert;
 pub mod noop;
+// `payload.rs` 是跨平台 rep payload helper（按 source 分流读字节），三平台写入
+// 路径都依赖它来消化入站的 `LocalFile` source rep。它独立于 `clipboard-rs`，
+// 因此不与 `common` 共享 cfg gate（Linux Wayland / X11 写入器也调用它）。
+pub(crate) mod payload;
 pub mod platform;
 pub mod watcher;
 

--- a/src-tauri/crates/uc-platform/src/clipboard/payload.rs
+++ b/src-tauri/crates/uc-platform/src/clipboard/payload.rs
@@ -1,0 +1,99 @@
+//! 跨平台的 rep payload 读取 helper。
+//!
+//! 抽出来独立成 mod 是因为 `clipboard::common` 依赖 `clipboard-rs`，Phase 4 起被
+//! `#[cfg(any(target_os = "macos", target_os = "windows"))]` gate 住；Linux 的
+//! 原生 Wayland / x11rb 写入路径不引入 `clipboard-rs`，但同样需要按 `LocalFile`
+//! source 读盘以避免 `expect_inline_bytes` panic（见 `rep_bytes` 文档）。
+//!
+//! 本模块只依赖 `uc-core` + `std`，无 cfg gate，三平台均可使用。
+
+use anyhow::{Context, Result};
+use std::borrow::Cow;
+use uc_core::clipboard::{ClipboardPayloadSource, ObservedClipboardRepresentation};
+
+/// 取 rep 字节，按 source 分流。
+///
+/// - `Inline` → 借用现有字节，零拷贝。
+/// - `LocalFile` → 同步读盘，返回 owned `Vec<u8>`。
+///
+/// 为什么需要这个 helper：入站 `apply_inbound::materializer` 会给图片 rep 合成
+/// `LocalFile` source（指向接收端 blob cache 中已 export 的文件），同一份 snapshot
+/// 在 `clipboard_capture` ingest 进 blob store 之后还会被 `ClipboardWriteCoordinator`
+/// 透传到 `SystemClipboardPort::write_snapshot` 往系统剪贴板写。如果继续直调
+/// `rep.expect_inline_bytes()`，对 `LocalFile` 会触发 panic（参见 `uc-core` 上
+/// `expect_inline_bytes` 的契约：仅 Inline 语境），daemon 整体崩溃。本 helper
+/// 显式按 source 分流，让 macOS / Windows / Linux 写入路径都能消化 `LocalFile` rep。
+///
+/// 同步读盘的代价：`SystemClipboardPort::write_snapshot` 本就是同步签名
+/// （`ClipboardWriteCoordinator` 在 tokio worker 里直调，NSPasteboard /
+/// Win32 OpenClipboard 等系统 API 本就阻塞），对端图片 blob 已由 iroh-blobs
+/// export 到本地 cache，读盘 = 顺序 IO，通常 < 几十 ms，与原系统 API 调用同量级。
+/// 如未来出现极大 payload 阻塞 worker 的证据再换 `spawn_blocking`，目前不预先优化。
+pub(crate) fn rep_bytes(rep: &ObservedClipboardRepresentation) -> Result<Cow<'_, [u8]>> {
+    match rep.source() {
+        ClipboardPayloadSource::Inline(b) => Ok(Cow::Borrowed(b.as_slice())),
+        ClipboardPayloadSource::LocalFile { path, .. } => std::fs::read(path)
+            .map(Cow::Owned)
+            .with_context(|| format!("read LocalFile rep payload at {}", path.display())),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! `rep_bytes` 回归测试 —— 历史回归：远端推过来的图片走
+    //! `apply_inbound::materializer` 后会带一条 `LocalFile` source 的 image rep,
+    //! 旧版 OS 写入路径用 `expect_inline_bytes()` 强取 Inline 字节,对 LocalFile
+    //! 直接 panic,导致 daemon 整体崩溃。这里确保 helper 能消化两种 source、
+    //! 并在文件缺失时返回 Err 而非 panic。
+
+    use super::*;
+    use uc_core::clipboard::MimeType;
+    use uc_core::ids::{FormatId, RepresentationId};
+
+    #[test]
+    fn rep_bytes_borrows_inline_payload() {
+        let r = ObservedClipboardRepresentation::new(
+            RepresentationId::new(),
+            FormatId::from_str("public.png"),
+            Some(MimeType("image/png".to_string())),
+            vec![0xDE, 0xAD, 0xBE, 0xEF],
+        );
+        let bytes = rep_bytes(&r).expect("inline rep_bytes 必须返回 Ok");
+        assert_eq!(bytes.as_ref(), &[0xDE, 0xAD, 0xBE, 0xEF][..]);
+        assert!(matches!(bytes, Cow::Borrowed(_)));
+    }
+
+    #[test]
+    fn rep_bytes_reads_local_file_payload() {
+        let tmp = tempfile::NamedTempFile::new().expect("create tempfile");
+        let payload: &[u8] = b"\x89PNG\r\n\x1a\nfake-png-body";
+        std::fs::write(tmp.path(), payload).expect("write tempfile");
+        let r = ObservedClipboardRepresentation::new_local_file(
+            RepresentationId::new(),
+            FormatId::from_str("image-from-file"),
+            Some(MimeType("image/png".to_string())),
+            tmp.path().to_path_buf(),
+            payload.len() as u64,
+        );
+        let bytes = rep_bytes(&r).expect("LocalFile rep_bytes 必须返回 Ok");
+        assert_eq!(bytes.as_ref(), payload);
+        assert!(matches!(bytes, Cow::Owned(_)));
+    }
+
+    #[test]
+    fn rep_bytes_errors_when_local_file_missing() {
+        let r = ObservedClipboardRepresentation::new_local_file(
+            RepresentationId::new(),
+            FormatId::from_str("image-from-file"),
+            Some(MimeType("image/png".to_string())),
+            std::path::PathBuf::from("/nonexistent/uc-platform-payload-rep_bytes-test.png"),
+            0,
+        );
+        let err = rep_bytes(&r).expect_err("缺失文件必须返回 Err 而非 panic");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("/nonexistent/uc-platform-payload-rep_bytes-test.png"),
+            "错误信息应包含路径，便于排障；实际: {msg}"
+        );
+    }
+}

--- a/src-tauri/crates/uc-platform/src/clipboard/platform/linux/wayland/protocol/ext.rs
+++ b/src-tauri/crates/uc-platform/src/clipboard/platform/linux/wayland/protocol/ext.rs
@@ -674,8 +674,25 @@ fn handle_write(
             if payloads.contains_key(&mime) {
                 continue;
             }
+            // 用 `rep_bytes` 而非 `expect_inline_bytes`：远端 push 的 image rep 由
+            // `apply_inbound::materializer` 合成为 `LocalFile` source（指向 blob cache
+            // 文件），直接调 `expect_inline_bytes` 会 panic（见
+            // `clipboard::common::rep_bytes` 注释）。读盘失败时跳过该 rep + warn,
+            // 与 macOS / Windows 平台同语义。
+            let bytes = match crate::clipboard::common::rep_bytes(rep) {
+                Ok(b) => b.into_owned(),
+                Err(err) => {
+                    warn!(
+                        error = %err,
+                        format_id = %rep.format_id,
+                        mime = %mime,
+                        "ext-data-control write: read LocalFile rep failed; skipping this mime"
+                    );
+                    continue;
+                }
+            };
             source.offer(mime.clone());
-            payloads.insert(mime, Arc::new(rep.expect_inline_bytes().to_vec()));
+            payloads.insert(mime, Arc::new(bytes));
         }
     }
 

--- a/src-tauri/crates/uc-platform/src/clipboard/platform/linux/wayland/protocol/ext.rs
+++ b/src-tauri/crates/uc-platform/src/clipboard/platform/linux/wayland/protocol/ext.rs
@@ -677,9 +677,9 @@ fn handle_write(
             // 用 `rep_bytes` 而非 `expect_inline_bytes`：远端 push 的 image rep 由
             // `apply_inbound::materializer` 合成为 `LocalFile` source（指向 blob cache
             // 文件），直接调 `expect_inline_bytes` 会 panic（见
-            // `clipboard::common::rep_bytes` 注释）。读盘失败时跳过该 rep + warn,
+            // `clipboard::payload::rep_bytes` 注释）。读盘失败时跳过该 rep + warn,
             // 与 macOS / Windows 平台同语义。
-            let bytes = match crate::clipboard::common::rep_bytes(rep) {
+            let bytes = match crate::clipboard::payload::rep_bytes(rep) {
                 Ok(b) => b.into_owned(),
                 Err(err) => {
                     warn!(

--- a/src-tauri/crates/uc-platform/src/clipboard/platform/linux/wayland/protocol/wlr.rs
+++ b/src-tauri/crates/uc-platform/src/clipboard/platform/linux/wayland/protocol/wlr.rs
@@ -686,8 +686,25 @@ fn handle_write(
             if payloads.contains_key(&mime) {
                 continue;
             }
+            // 用 `rep_bytes` 而非 `expect_inline_bytes`：远端 push 的 image rep 由
+            // `apply_inbound::materializer` 合成为 `LocalFile` source（指向 blob cache
+            // 文件），直接调 `expect_inline_bytes` 会 panic（见
+            // `clipboard::common::rep_bytes` 注释）。读盘失败时跳过该 rep + warn,
+            // 与 macOS / Windows 平台同语义。
+            let bytes = match crate::clipboard::common::rep_bytes(rep) {
+                Ok(b) => b.into_owned(),
+                Err(err) => {
+                    warn!(
+                        error = %err,
+                        format_id = %rep.format_id,
+                        mime = %mime,
+                        "wlr-data-control write: read LocalFile rep failed; skipping this mime"
+                    );
+                    continue;
+                }
+            };
             source.offer(mime.clone());
-            payloads.insert(mime, Arc::new(rep.expect_inline_bytes().to_vec()));
+            payloads.insert(mime, Arc::new(bytes));
         }
     }
 

--- a/src-tauri/crates/uc-platform/src/clipboard/platform/linux/wayland/protocol/wlr.rs
+++ b/src-tauri/crates/uc-platform/src/clipboard/platform/linux/wayland/protocol/wlr.rs
@@ -689,9 +689,9 @@ fn handle_write(
             // 用 `rep_bytes` 而非 `expect_inline_bytes`：远端 push 的 image rep 由
             // `apply_inbound::materializer` 合成为 `LocalFile` source（指向 blob cache
             // 文件），直接调 `expect_inline_bytes` 会 panic（见
-            // `clipboard::common::rep_bytes` 注释）。读盘失败时跳过该 rep + warn,
+            // `clipboard::payload::rep_bytes` 注释）。读盘失败时跳过该 rep + warn,
             // 与 macOS / Windows 平台同语义。
-            let bytes = match crate::clipboard::common::rep_bytes(rep) {
+            let bytes = match crate::clipboard::payload::rep_bytes(rep) {
                 Ok(b) => b.into_owned(),
                 Err(err) => {
                     warn!(

--- a/src-tauri/crates/uc-platform/src/clipboard/platform/linux/x11/writer.rs
+++ b/src-tauri/crates/uc-platform/src/clipboard/platform/linux/x11/writer.rs
@@ -119,9 +119,9 @@ pub(super) fn install_snapshot(
         // 用 `rep_bytes` 而非 `expect_inline_bytes`：远端 push 的 image rep 由
         // `apply_inbound::materializer` 合成为 `LocalFile` source（指向 blob cache
         // 文件），直接调 `expect_inline_bytes` 会 panic（见
-        // `clipboard::common::rep_bytes` 注释）。读盘失败时跳过该 rep + warn,
+        // `clipboard::payload::rep_bytes` 注释）。读盘失败时跳过该 rep + warn,
         // 与 macOS / Windows / Wayland 平台同语义。
-        let bytes = match crate::clipboard::common::rep_bytes(rep) {
+        let bytes = match crate::clipboard::payload::rep_bytes(rep) {
             Ok(b) => Arc::new(b.into_owned()),
             Err(err) => {
                 warn!(

--- a/src-tauri/crates/uc-platform/src/clipboard/platform/linux/x11/writer.rs
+++ b/src-tauri/crates/uc-platform/src/clipboard/platform/linux/x11/writer.rs
@@ -115,7 +115,24 @@ pub(super) fn install_snapshot(
         // without the charset suffix still get bytes (mirrors what wlr /
         // ext data-control sources do via their multi-offer dance, and
         // what clipboard_rs's `file_uri_list_to_clipboard_data` did for X11).
-        let bytes = Arc::new(rep.expect_inline_bytes().to_vec());
+        //
+        // 用 `rep_bytes` 而非 `expect_inline_bytes`：远端 push 的 image rep 由
+        // `apply_inbound::materializer` 合成为 `LocalFile` source（指向 blob cache
+        // 文件），直接调 `expect_inline_bytes` 会 panic（见
+        // `clipboard::common::rep_bytes` 注释）。读盘失败时跳过该 rep + warn,
+        // 与 macOS / Windows / Wayland 平台同语义。
+        let bytes = match crate::clipboard::common::rep_bytes(rep) {
+            Ok(b) => Arc::new(b.into_owned()),
+            Err(err) => {
+                warn!(
+                    error = %err,
+                    format_id = %rep.format_id,
+                    mime = %mime,
+                    "x11 write: read LocalFile rep failed; skipping this mime"
+                );
+                continue;
+            }
+        };
         match mime.as_str() {
             "text/plain;charset=utf-8" | "text/plain;charset=UTF-8" => {
                 payloads.entry(atoms.UTF8_STRING).or_insert(bytes.clone());

--- a/src-tauri/crates/uc-platform/src/clipboard/platform/macos.rs
+++ b/src-tauri/crates/uc-platform/src/clipboard/platform/macos.rs
@@ -1,4 +1,4 @@
-use super::super::common::CommonClipboardImpl;
+use super::super::common::{rep_bytes, CommonClipboardImpl};
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use clipboard_rs::ClipboardContext;
@@ -93,7 +93,12 @@ fn resolve_multi_rep_mime(rep: &ObservedClipboardRepresentation) -> Option<&str>
 
     match (rep.mime.as_deref(), format_default) {
         (Some(m), Some(default)) if default.starts_with("image/") && !m.starts_with("image/") => {
-            let recovered = crate::clipboard::common::sniff_image_magic(rep.expect_inline_bytes())
+            // sniff 路径罕见（要求 image-like format_id + 显式 mime 不是 image/*）；
+            // 即便 rep 是 LocalFile source 读盘失败，也只是退回 format_id 默认 mime,
+            // 不影响后续 setData 分支的实际写入决策。
+            let recovered = rep_bytes(rep)
+                .ok()
+                .and_then(|b| crate::clipboard::common::sniff_image_magic(&b))
                 .unwrap_or(default);
             tracing::warn!(
                 format_id = %rep.format_id,
@@ -258,7 +263,20 @@ pub(crate) fn write_snapshot_multi_macos(snapshot: SystemClipboardSnapshot) -> R
             Some("text/plain") => {
                 // text/plain 的字节是 UTF-8，NSPasteboardTypeString 期望 UTF-8 字节，
                 // 直接写原始字节，不经 NSString 转换（避免对非法 UTF-8 误报）。
-                let data = make_nsdata(rep.expect_inline_bytes());
+                let bytes = match rep_bytes(rep) {
+                    Ok(b) => b,
+                    Err(err) => {
+                        warn!(
+                            error = %err,
+                            format_id = %rep.format_id,
+                            bytes = rep.size_bytes(),
+                            "macOS 多 rep 写入：读取 LocalFile text/plain rep 字节失败，跳过该 rep"
+                        );
+                        skipped.push(rep.format_id.as_str().to_string());
+                        continue;
+                    }
+                };
+                let data = make_nsdata(&bytes);
                 // NSPasteboardTypeString 是 extern "C" 静态变量，访问需要 unsafe 块。
                 // setData_forType 本身是 `pub fn`（安全方法）。
                 let ok = unsafe { text_item.setData_forType(&data, NSPasteboardTypeString) };
@@ -274,7 +292,20 @@ pub(crate) fn write_snapshot_multi_macos(snapshot: SystemClipboardSnapshot) -> R
                 }
             }
             Some("text/html") => {
-                let data = make_nsdata(rep.expect_inline_bytes());
+                let bytes = match rep_bytes(rep) {
+                    Ok(b) => b,
+                    Err(err) => {
+                        warn!(
+                            error = %err,
+                            format_id = %rep.format_id,
+                            bytes = rep.size_bytes(),
+                            "macOS 多 rep 写入：读取 LocalFile text/html rep 字节失败，跳过该 rep"
+                        );
+                        skipped.push(rep.format_id.as_str().to_string());
+                        continue;
+                    }
+                };
+                let data = make_nsdata(&bytes);
                 // NSPasteboardTypeHTML 是 extern "C" 静态变量，访问需要 unsafe 块。
                 let ok = unsafe { text_item.setData_forType(&data, NSPasteboardTypeHTML) };
                 if ok {
@@ -294,7 +325,20 @@ pub(crate) fn write_snapshot_multi_macos(snapshot: SystemClipboardSnapshot) -> R
                 // TextEdit 纯文本模式）继续用 NSPasteboardTypeString。原始 RTF 字节是
                 // ASCII 安全的（RTF 1.x 规范，非 ASCII 都做 \uN 转义），直接喂给 NSData。
                 // NSPasteboardTypeRTF 是 extern "C" 静态变量，访问需要 unsafe 块。
-                let data = make_nsdata(rep.expect_inline_bytes());
+                let bytes = match rep_bytes(rep) {
+                    Ok(b) => b,
+                    Err(err) => {
+                        warn!(
+                            error = %err,
+                            format_id = %rep.format_id,
+                            bytes = rep.size_bytes(),
+                            "macOS 多 rep 写入：读取 LocalFile text/rtf rep 字节失败，跳过该 rep"
+                        );
+                        skipped.push(rep.format_id.as_str().to_string());
+                        continue;
+                    }
+                };
+                let data = make_nsdata(&bytes);
                 let ok = unsafe { text_item.setData_forType(&data, NSPasteboardTypeRTF) };
                 if ok {
                     debug!(bytes = rep.size_bytes(), "写入 NSPasteboardTypeRTF 成功");
@@ -314,7 +358,20 @@ pub(crate) fn write_snapshot_multi_macos(snapshot: SystemClipboardSnapshot) -> R
                 // PNG 字节直接喂给 NSPasteboardTypePNG，AppKit 内部 lazy-decode，比
                 // 经 NSImage 中转更稳（避免 alpha / colorspace 翻译误差）。
                 let item: Retained<NSPasteboardItem> = NSPasteboardItem::new();
-                let data = make_nsdata(rep.expect_inline_bytes());
+                let bytes = match rep_bytes(rep) {
+                    Ok(b) => b,
+                    Err(err) => {
+                        warn!(
+                            error = %err,
+                            format_id = %rep.format_id,
+                            bytes = rep.size_bytes(),
+                            "macOS 多 rep 写入：读取 LocalFile image/png rep 字节失败，跳过该 rep"
+                        );
+                        skipped.push(rep.format_id.as_str().to_string());
+                        continue;
+                    }
+                };
+                let data = make_nsdata(&bytes);
                 // NSPasteboardTypePNG 是 extern "C" 静态变量，访问需要 unsafe 块。
                 let ok = unsafe { item.setData_forType(&data, NSPasteboardTypePNG) };
                 if ok {
@@ -332,7 +389,20 @@ pub(crate) fn write_snapshot_multi_macos(snapshot: SystemClipboardSnapshot) -> R
             }
             Some("image/tiff") => {
                 let item: Retained<NSPasteboardItem> = NSPasteboardItem::new();
-                let data = make_nsdata(rep.expect_inline_bytes());
+                let bytes = match rep_bytes(rep) {
+                    Ok(b) => b,
+                    Err(err) => {
+                        warn!(
+                            error = %err,
+                            format_id = %rep.format_id,
+                            bytes = rep.size_bytes(),
+                            "macOS 多 rep 写入：读取 LocalFile image/tiff rep 字节失败，跳过该 rep"
+                        );
+                        skipped.push(rep.format_id.as_str().to_string());
+                        continue;
+                    }
+                };
+                let data = make_nsdata(&bytes);
                 // NSPasteboardTypeTIFF 是 extern "C" 静态变量，访问需要 unsafe 块。
                 let ok = unsafe { item.setData_forType(&data, NSPasteboardTypeTIFF) };
                 if ok {
@@ -349,7 +419,20 @@ pub(crate) fn write_snapshot_multi_macos(snapshot: SystemClipboardSnapshot) -> R
                 }
             }
             Some("text/uri-list") => {
-                let uris = match parse_uri_list(rep.expect_inline_bytes()) {
+                let bytes = match rep_bytes(rep) {
+                    Ok(b) => b,
+                    Err(err) => {
+                        warn!(
+                            error = %err,
+                            format_id = %rep.format_id,
+                            bytes = rep.size_bytes(),
+                            "macOS 多 rep 写入：读取 LocalFile text/uri-list rep 字节失败，跳过该 rep"
+                        );
+                        skipped.push(rep.format_id.as_str().to_string());
+                        continue;
+                    }
+                };
+                let uris = match parse_uri_list(&bytes) {
                     Ok(list) => list,
                     Err(e) => {
                         warn!(
@@ -536,5 +619,59 @@ mod tests {
         assert_eq!(resolve_multi_rep_mime(&rep("DataObject", None)), None);
         assert_eq!(resolve_multi_rep_mime(&rep("PixPinData", None)), None);
         assert_eq!(resolve_multi_rep_mime(&rep("Ole Private Data", None)), None);
+    }
+
+    // —— rep_bytes（LocalFile 写入回归）——
+    //
+    // 历史回归：远端推过来的图片走 `apply_inbound::materializer` 后会带一条
+    // `LocalFile` source 的 image rep，旧版 macOS 写入路径用 `expect_inline_bytes()`
+    // 强取 Inline 字节，对 LocalFile 直接 panic，导致 daemon 整体崩溃。
+    // 这里的测试确保 helper 能消化两种 source、并在文件缺失时返回 Err 而非 panic。
+
+    #[test]
+    fn rep_bytes_borrows_inline_payload() {
+        let r = ObservedClipboardRepresentation::new(
+            RepresentationId::new(),
+            FormatId::from_str("public.png"),
+            Some(MimeType("image/png".to_string())),
+            vec![0xDE, 0xAD, 0xBE, 0xEF],
+        );
+        let bytes = rep_bytes(&r).expect("inline rep_bytes 必须返回 Ok");
+        assert_eq!(bytes.as_ref(), &[0xDE, 0xAD, 0xBE, 0xEF][..]);
+        assert!(matches!(bytes, std::borrow::Cow::Borrowed(_)));
+    }
+
+    #[test]
+    fn rep_bytes_reads_local_file_payload() {
+        let tmp = tempfile::NamedTempFile::new().expect("create tempfile");
+        let payload: &[u8] = b"\x89PNG\r\n\x1a\nfake-png-body";
+        std::fs::write(tmp.path(), payload).expect("write tempfile");
+        let r = ObservedClipboardRepresentation::new_local_file(
+            RepresentationId::new(),
+            FormatId::from_str("image-from-file"),
+            Some(MimeType("image/png".to_string())),
+            tmp.path().to_path_buf(),
+            payload.len() as u64,
+        );
+        let bytes = rep_bytes(&r).expect("LocalFile rep_bytes 必须返回 Ok");
+        assert_eq!(bytes.as_ref(), payload);
+        assert!(matches!(bytes, std::borrow::Cow::Owned(_)));
+    }
+
+    #[test]
+    fn rep_bytes_errors_when_local_file_missing() {
+        let r = ObservedClipboardRepresentation::new_local_file(
+            RepresentationId::new(),
+            FormatId::from_str("image-from-file"),
+            Some(MimeType("image/png".to_string())),
+            std::path::PathBuf::from("/nonexistent/uc-platform-macos-rep_bytes-test.png"),
+            0,
+        );
+        let err = rep_bytes(&r).expect_err("缺失文件必须返回 Err 而非 panic");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("/nonexistent/uc-platform-macos-rep_bytes-test.png"),
+            "错误信息应包含路径，便于排障；实际: {msg}"
+        );
     }
 }

--- a/src-tauri/crates/uc-platform/src/clipboard/platform/macos.rs
+++ b/src-tauri/crates/uc-platform/src/clipboard/platform/macos.rs
@@ -1,4 +1,5 @@
-use super::super::common::{rep_bytes, CommonClipboardImpl};
+use super::super::common::CommonClipboardImpl;
+use super::super::payload::rep_bytes;
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use clipboard_rs::ClipboardContext;
@@ -621,57 +622,7 @@ mod tests {
         assert_eq!(resolve_multi_rep_mime(&rep("Ole Private Data", None)), None);
     }
 
-    // —— rep_bytes（LocalFile 写入回归）——
-    //
-    // 历史回归：远端推过来的图片走 `apply_inbound::materializer` 后会带一条
-    // `LocalFile` source 的 image rep，旧版 macOS 写入路径用 `expect_inline_bytes()`
-    // 强取 Inline 字节，对 LocalFile 直接 panic，导致 daemon 整体崩溃。
-    // 这里的测试确保 helper 能消化两种 source、并在文件缺失时返回 Err 而非 panic。
-
-    #[test]
-    fn rep_bytes_borrows_inline_payload() {
-        let r = ObservedClipboardRepresentation::new(
-            RepresentationId::new(),
-            FormatId::from_str("public.png"),
-            Some(MimeType("image/png".to_string())),
-            vec![0xDE, 0xAD, 0xBE, 0xEF],
-        );
-        let bytes = rep_bytes(&r).expect("inline rep_bytes 必须返回 Ok");
-        assert_eq!(bytes.as_ref(), &[0xDE, 0xAD, 0xBE, 0xEF][..]);
-        assert!(matches!(bytes, std::borrow::Cow::Borrowed(_)));
-    }
-
-    #[test]
-    fn rep_bytes_reads_local_file_payload() {
-        let tmp = tempfile::NamedTempFile::new().expect("create tempfile");
-        let payload: &[u8] = b"\x89PNG\r\n\x1a\nfake-png-body";
-        std::fs::write(tmp.path(), payload).expect("write tempfile");
-        let r = ObservedClipboardRepresentation::new_local_file(
-            RepresentationId::new(),
-            FormatId::from_str("image-from-file"),
-            Some(MimeType("image/png".to_string())),
-            tmp.path().to_path_buf(),
-            payload.len() as u64,
-        );
-        let bytes = rep_bytes(&r).expect("LocalFile rep_bytes 必须返回 Ok");
-        assert_eq!(bytes.as_ref(), payload);
-        assert!(matches!(bytes, std::borrow::Cow::Owned(_)));
-    }
-
-    #[test]
-    fn rep_bytes_errors_when_local_file_missing() {
-        let r = ObservedClipboardRepresentation::new_local_file(
-            RepresentationId::new(),
-            FormatId::from_str("image-from-file"),
-            Some(MimeType("image/png".to_string())),
-            std::path::PathBuf::from("/nonexistent/uc-platform-macos-rep_bytes-test.png"),
-            0,
-        );
-        let err = rep_bytes(&r).expect_err("缺失文件必须返回 Err 而非 panic");
-        let msg = format!("{err:#}");
-        assert!(
-            msg.contains("/nonexistent/uc-platform-macos-rep_bytes-test.png"),
-            "错误信息应包含路径，便于排障；实际: {msg}"
-        );
-    }
+    // `rep_bytes` 自身的回归测试在 `crate::clipboard::payload::tests` 里（与 helper
+    // 同文件，三平台都跑），本测试模块只覆盖 macOS 多 rep 写入相关的
+    // `resolve_multi_rep_mime` 分派表。
 }

--- a/src-tauri/crates/uc-platform/src/clipboard/platform/windows.rs
+++ b/src-tauri/crates/uc-platform/src/clipboard/platform/windows.rs
@@ -1,4 +1,5 @@
-use super::super::common::{rep_bytes, CommonClipboardImpl};
+use super::super::common::CommonClipboardImpl;
+use super::super::payload::rep_bytes;
 use anyhow::Result;
 use async_trait::async_trait;
 use clipboard_rs::{Clipboard, ClipboardContext};

--- a/src-tauri/crates/uc-platform/src/clipboard/platform/windows.rs
+++ b/src-tauri/crates/uc-platform/src/clipboard/platform/windows.rs
@@ -1,4 +1,4 @@
-use super::super::common::CommonClipboardImpl;
+use super::super::common::{rep_bytes, CommonClipboardImpl};
 use anyhow::Result;
 use async_trait::async_trait;
 use clipboard_rs::{Clipboard, ClipboardContext};
@@ -38,7 +38,12 @@ fn resolve_multi_rep_mime(rep: &ObservedClipboardRepresentation) -> Option<&str>
     // image-like format_id 但显式 mime 非 image/*:见 `common.rs::write_snapshot` 同位置注释。
     match (rep.mime.as_deref(), format_default) {
         (Some(m), Some(default)) if default.starts_with("image/") && !m.starts_with("image/") => {
-            let recovered = crate::clipboard::common::sniff_image_magic(rep.expect_inline_bytes())
+            // sniff 路径罕见（要求 image-like format_id + 显式 mime 不是 image/*）；
+            // 即便 rep 是 LocalFile source 读盘失败，也只是退回 format_id 默认 mime,
+            // 不影响后续 setData 分支的实际写入决策。
+            let recovered = rep_bytes(rep)
+                .ok()
+                .and_then(|b| crate::clipboard::common::sniff_image_magic(&b))
                 .unwrap_or(default);
             tracing::warn!(
                 format_id = %rep.format_id,
@@ -344,27 +349,45 @@ pub(crate) fn write_snapshot_multi_windows(snapshot: SystemClipboardSnapshot) ->
         );
     }
 
-    // 预编码阶段 —— 在 OpenClipboard 会话**之外**完成耗时的 PNG→CF_DIBV5 转码。
-    // 和 `rep` 一一对应；None 表示该 rep 不走 CF_DIBV5 路径（非 image/png 或解码失败）。
-    // 不再按大小做阈值降级 —— CF_DIBV5 不走 GDI `CreateDIBitmap`，对大图稳定。
-    let dib_preencoded: Vec<Option<Vec<u8>>> = snapshot
+    // 预编码阶段 —— 在 OpenClipboard 会话**之外**完成两件事:
+    //   1) 把 image/png rep 的字节物化成 owned `Vec<u8>`（Inline 直接 to_vec, LocalFile
+    //      同步读盘）。在 OpenClipboard 会话内读盘会拉长持锁时间、增加 1418 风险,因此
+    //      所有 IO 都在会话外完成。
+    //   2) 把这份字节继续转码为 CF_DIBV5。失败时 `dib=None`,只写 "PNG" 自定义 format。
+    //
+    // 与 `rep` 一一对应；外层 `None` 表示该 rep 不走 image/png 路径（非 image/png 或读
+    // LocalFile 失败）。LocalFile 读盘失败会在这里 warn 并 None,主循环看到 None 时跳过。
+    let png_preencoded: Vec<Option<(Vec<u8>, Option<Vec<u8>>)>> = snapshot
         .representations
         .iter()
         .map(|rep| {
             if resolve_multi_rep_mime(rep) != Some("image/png") {
                 return None;
             }
-            match png_to_dibv5(rep.expect_inline_bytes()) {
+            let bytes = match rep_bytes(rep) {
+                Ok(b) => b.into_owned(),
+                Err(err) => {
+                    warn!(
+                        error = %err,
+                        format_id = %rep.format_id,
+                        size_bytes = rep.size_bytes(),
+                        "Windows 多 rep 写入：读取 LocalFile image/png rep 字节失败，跳过该 rep"
+                    );
+                    return None;
+                }
+            };
+            let dib = match png_to_dibv5(&bytes) {
                 Ok(dib) => Some(dib),
                 Err(e) => {
                     warn!(
                         error = %e,
-                        png_bytes = rep.expect_inline_bytes().len(),
+                        png_bytes = bytes.len(),
                         "PNG→CF_DIBV5 转码失败；仅写 \"PNG\" 自定义 format"
                     );
                     None
                 }
-            }
+            };
+            Some((bytes, dib))
         })
         .collect();
 
@@ -384,7 +407,7 @@ pub(crate) fn write_snapshot_multi_windows(snapshot: SystemClipboardSnapshot) ->
             ));
         }
 
-        match attempt_multi_write_inner(&snapshot, &dib_preencoded) {
+        match attempt_multi_write_inner(&snapshot, &png_preencoded) {
             Ok(skipped) => {
                 if !skipped.is_empty() {
                     debug!(
@@ -455,7 +478,7 @@ pub(crate) fn write_snapshot_multi_windows(snapshot: SystemClipboardSnapshot) ->
 /// 返回 None），不包含"整体尝试失败"的情况。
 fn attempt_multi_write_inner(
     snapshot: &SystemClipboardSnapshot,
-    dib_preencoded: &[Option<Vec<u8>>],
+    png_preencoded: &[Option<(Vec<u8>, Option<Vec<u8>>)>],
 ) -> Result<Vec<String>> {
     use clipboard_win::formats::{Html as HtmlFmt, CF_DIBV5};
     use clipboard_win::options::NoClear;
@@ -492,14 +515,24 @@ fn attempt_multi_write_inner(
             Some("text/plain") => {
                 // 必须使用 set_string_with::<NoClear>：
                 // set_string 内部调用 DoClear（EmptyClipboard），会把已写的其他 format 抹掉。
-                let text = String::from_utf8(rep.expect_inline_bytes().to_vec())
+                let bytes = match rep_bytes(rep) {
+                    Ok(b) => b,
+                    Err(err) => {
+                        warn!(
+                            error = %err,
+                            format_id = %rep.format_id,
+                            size_bytes = rep.size_bytes(),
+                            "Windows 多 rep 写入：读取 LocalFile text/plain rep 字节失败，跳过该 rep"
+                        );
+                        skipped.push(rep.format_id.as_str().to_string());
+                        continue;
+                    }
+                };
+                let text = String::from_utf8(bytes.into_owned())
                     .map_err(|e| anyhow::anyhow!("text/plain rep is not valid UTF-8: {}", e))?;
                 cb_raw::set_string_with::<NoClear>(&text, NoClear)
                     .map_err(|e| anyhow::anyhow!("set CF_UNICODETEXT failed: {}", e))?;
-                debug!(
-                    bytes = rep.expect_inline_bytes().len(),
-                    "写入 CF_UNICODETEXT 成功"
-                );
+                debug!(bytes = text.len(), "写入 CF_UNICODETEXT 成功");
                 wrote_any = true;
             }
             Some("text/html") => {
@@ -508,13 +541,26 @@ fn attempt_multi_write_inner(
                     skipped.push(rep.format_id.as_str().to_string());
                     continue;
                 };
-                let html = String::from_utf8(rep.expect_inline_bytes().to_vec())
+                let bytes = match rep_bytes(rep) {
+                    Ok(b) => b,
+                    Err(err) => {
+                        warn!(
+                            error = %err,
+                            format_id = %rep.format_id,
+                            size_bytes = rep.size_bytes(),
+                            "Windows 多 rep 写入：读取 LocalFile text/html rep 字节失败，跳过该 rep"
+                        );
+                        skipped.push(rep.format_id.as_str().to_string());
+                        continue;
+                    }
+                };
+                let html = String::from_utf8(bytes.into_owned())
                     .map_err(|e| anyhow::anyhow!("text/html rep is not valid UTF-8: {}", e))?;
                 // set_html 默认走 NoClear 分支，内部构造 "Version:0.9 / StartHTML / EndHTML /
                 // StartFragment / EndFragment" 头并包裹 BODY_HEADER/BODY_FOOTER，适合累加。
                 cb_raw::set_html(html_fmt, &html)
                     .map_err(|e| anyhow::anyhow!("set CF_HTML failed: {}", e))?;
-                debug!(bytes = rep.expect_inline_bytes().len(), "写入 CF_HTML 成功");
+                debug!(bytes = html.len(), "写入 CF_HTML 成功");
                 wrote_any = true;
             }
             Some("text/rtf") => {
@@ -527,12 +573,22 @@ fn attempt_multi_write_inner(
                     skipped.push(rep.format_id.as_str().to_string());
                     continue;
                 };
-                cb_raw::set_without_clear(rtf_fmt, rep.expect_inline_bytes())
+                let bytes = match rep_bytes(rep) {
+                    Ok(b) => b,
+                    Err(err) => {
+                        warn!(
+                            error = %err,
+                            format_id = %rep.format_id,
+                            size_bytes = rep.size_bytes(),
+                            "Windows 多 rep 写入：读取 LocalFile text/rtf rep 字节失败，跳过该 rep"
+                        );
+                        skipped.push(rep.format_id.as_str().to_string());
+                        continue;
+                    }
+                };
+                cb_raw::set_without_clear(rtf_fmt, &bytes)
                     .map_err(|e| anyhow::anyhow!("set Rich Text Format failed: {}", e))?;
-                debug!(
-                    bytes = rep.expect_inline_bytes().len(),
-                    "写入 Rich Text Format 成功"
-                );
+                debug!(bytes = bytes.len(), "写入 Rich Text Format 成功");
                 wrote_any = true;
             }
             Some("image/png") => {
@@ -544,17 +600,25 @@ fn attempt_multi_write_inner(
                 //     （合成路径覆盖所有认 CF_BITMAP / CF_DIB 的应用）
                 //   - "PNG"    ← Chrome、Firefox、Paint.NET、新版 Office、Google Docs
                 //
-                // CF_DIBV5 字节已在 OpenClipboard 会话外完成预编码（见 `png_to_dibv5`），
-                // 这里只做纯系统调用；任一 set_* 失败都 `?` 抛到外层由重试机制兜底。
+                // PNG owned 字节 + CF_DIBV5 字节都已在 OpenClipboard 会话外完成预编码
+                // （见 `png_preencoded` 构造），这里只做纯系统调用；任一 set_* 失败都 `?`
+                // 抛到外层由重试机制兜底。
+                //
+                // 外层 None 表示该 rep 在预编码阶段读 LocalFile 失败（已 warn）,直接跳过。
+                let Some((png_bytes, dib_opt)) = png_preencoded.get(idx).and_then(|o| o.as_ref())
+                else {
+                    skipped.push(rep.format_id.as_str().to_string());
+                    continue;
+                };
                 let mut wrote_dib = false;
                 let mut wrote_png = false;
 
-                if let Some(dib_bytes) = dib_preencoded.get(idx).and_then(|o| o.as_ref()) {
+                if let Some(dib_bytes) = dib_opt.as_ref() {
                     cb_raw::set_without_clear(CF_DIBV5, dib_bytes)
                         .map_err(|e| anyhow::anyhow!("set CF_DIBV5 failed: {}", e))?;
                     debug!(
                         dib_bytes = dib_bytes.len(),
-                        png_bytes = rep.expect_inline_bytes().len(),
+                        png_bytes = png_bytes.len(),
                         "写入 CF_DIBV5 成功"
                     );
                     wrote_dib = true;
@@ -562,12 +626,11 @@ fn attempt_multi_write_inner(
 
                 match cb_raw::register_format("PNG") {
                     Some(png_fmt) => {
-                        cb_raw::set_without_clear(png_fmt.get(), rep.expect_inline_bytes())
-                            .map_err(|e| {
-                                anyhow::anyhow!("set \"PNG\" custom format failed: {}", e)
-                            })?;
+                        cb_raw::set_without_clear(png_fmt.get(), png_bytes).map_err(|e| {
+                            anyhow::anyhow!("set \"PNG\" custom format failed: {}", e)
+                        })?;
                         debug!(
-                            png_bytes = rep.expect_inline_bytes().len(),
+                            png_bytes = png_bytes.len(),
                             "写入 \"PNG\" 自定义 format 成功"
                         );
                         wrote_png = true;
@@ -588,12 +651,25 @@ fn attempt_multi_write_inner(
                 // 已把 blob 落地到本机 iroh-blobs 缓存目录并改写为本机 URI）解析回本机
                 // 路径，打包成 DROPFILES + UTF-16 名字串，`SetClipboardData(CF_HDROP)`。
                 // 这是 Explorer / Office / 大多数桌面应用识别的文件拷贝语义。
-                let paths = match parse_uri_list_to_paths(rep.expect_inline_bytes()) {
+                let bytes = match rep_bytes(rep) {
+                    Ok(b) => b,
+                    Err(err) => {
+                        warn!(
+                            error = %err,
+                            format_id = %rep.format_id,
+                            size_bytes = rep.size_bytes(),
+                            "Windows 多 rep 写入：读取 LocalFile text/uri-list rep 字节失败，跳过该 rep"
+                        );
+                        skipped.push(rep.format_id.as_str().to_string());
+                        continue;
+                    }
+                };
+                let paths = match parse_uri_list_to_paths(&bytes) {
                     Ok(paths) => paths,
                     Err(e) => {
                         warn!(
                             error = %e,
-                            bytes = rep.expect_inline_bytes().len(),
+                            bytes = bytes.len(),
                             format_id = %rep.format_id,
                             "Windows 多 rep 写入：text/uri-list 解析失败，跳过该 rep"
                         );
@@ -626,10 +702,12 @@ fn attempt_multi_write_inner(
             // image/jpeg / image/tiff / image/webp / image/gif 等均未支持，
             // 未来在独立 phase 补齐（各自需要独立的编码转换 / format 注册）。
             other => {
+                // `rep.size_bytes()` 对 Inline / LocalFile 两种 source 都安全（LocalFile
+                // 返回构造时记录的 meta.len()），避免触发 expect_inline_bytes panic。
                 info!(
                     format_id = %rep.format_id,
                     mime = ?other,
-                    bytes = rep.expect_inline_bytes().len(),
+                    bytes = rep.size_bytes(),
                     "Windows 多 rep 写入：跳过不支持的 rep（当前支持 text/plain, text/html, text/rtf, image/png, text/uri-list）"
                 );
                 skipped.push(rep.format_id.as_str().to_string());
@@ -749,8 +827,22 @@ impl SystemClipboardPort for WindowsClipboard {
             };
             // Extract image bytes before passing snapshot to CommonClipboardImpl
             // (which consumes it by reference but we need the bytes for fallback).
+            // 用 `rep_bytes` 而非 `expect_inline_bytes`,后者对 LocalFile source panic
+            // （远端 push 单张图时 materializer 合成 `LocalFile` image-from-file rep,
+            // 一进这里就崩；见 `common::rep_bytes` 注释）。读盘失败时返回 None,fallback
+            // 路径自然降级走非 image 写入。
             let image_bytes = if image_fallback_eligible {
-                snapshot.representations.first().map(|rep| rep.expect_inline_bytes().to_vec())
+                snapshot.representations.first().and_then(|rep| match rep_bytes(rep) {
+                    Ok(b) => Some(b.into_owned()),
+                    Err(err) => {
+                        warn!(
+                            error = %err,
+                            format_id = %rep.format_id,
+                            "Windows 单 rep 写入：读取 LocalFile image rep 字节失败，image fallback 不可用"
+                        );
+                        None
+                    }
+                })
             } else {
                 None
             };
@@ -859,7 +951,12 @@ fn extract_text_plain_utf8(snapshot: &SystemClipboardSnapshot) -> Result<Option<
         return Ok(None);
     };
 
-    let text = String::from_utf8(text_rep.expect_inline_bytes().to_vec())
+    // 用 `rep_bytes` 而非 `expect_inline_bytes`：text/plain rep 当前不会被
+    // materializer 合成为 `LocalFile`，但 `expect_inline_bytes` 的契约已经在
+    // 出站路径被打破（见 `common::rep_bytes`），保持本函数对 LocalFile 安全
+    // 以免未来 materializer 扩展再次引入 panic。
+    let bytes = rep_bytes(text_rep)?;
+    let text = String::from_utf8(bytes.into_owned())
         .map_err(|err| anyhow::anyhow!("Failed to decode text/plain snapshot as UTF-8: {}", err))?;
     Ok(Some(text))
 }


### PR DESCRIPTION
## Summary

- `apply_inbound::materializer` synthesizes a `LocalFile` source image rep (pointing at the receiver-side blob-cache file) for every inbound image push. The same snapshot is then passed by `ClipboardWriteCoordinator` straight into `SystemClipboardPort::write_snapshot`. All platform write paths called `rep.expect_inline_bytes()`, whose `uc-core` contract panics on `LocalFile` — **daemon crashed on the first inbound image** (reproduced on macOS prod; user confirmed the same crash on Windows). (`f36b166e`)

- Introduce `common::rep_bytes(rep) -> Result<Cow<[u8]>>`: borrows for `Inline`, syncs from disk for `LocalFile`. Replace every `expect_inline_bytes()` call across the platform crate (15 sites). On read failure each branch now does `warn + skip` (matches existing "setData returned false / 1418 retry" semantics) instead of taking down the daemon.

- Windows PNG path is refactored: `dib_preencoded` → `png_preencoded: Vec<Option<(Vec<u8>, Option<Vec<u8>>)>>`, so PNG owned bytes **and** the CF_DIBV5 encoding are both materialized before `OpenClipboard`. No fs IO happens inside the clipboard session, keeping `ERROR_CLIPBOARD_NOT_OPEN (1418)` risk unchanged.

- Linux (`wlr-data-control`, `ext-data-control`, X11 selection owner) had the same `expect_inline_bytes` shape; same fix applied for consistency.

## Test plan

- [x] `cargo test -p uc-platform --lib` → 32 passed / 0 failed, including 3 new `rep_bytes_*` regression tests (Inline / LocalFile / missing file).
- [x] `cargo check -p uc-platform --tests` on macOS.
- [x] `cargo check -p uc-platform --tests --target x86_64-pc-windows-gnu` (clean, 3 pre-existing warnings only).
- [x] Clippy: no new warnings (the 3 pre-existing ones in `app_dirs.rs` / `capability.rs` / `common.rs:902` are untouched).
- [ ] **Reviewer / Windows user**: re-run the "remote pushes an image, receiver pastes" flow on Windows to confirm the daemon no longer crashes and the pasted image is intact.
- [ ] Linux CI build of `uc-platform` (couldn't cross-compile locally — `libdbus-1-dev` unavailable on the macOS host; the 3 Linux sites use the same `match rep_bytes(rep) { ... continue }` pattern as the verified macOS / Windows sites).
- [ ] **Reviewer**: spot-check the Windows PNG `png_preencoded` refactor reads correctly — particularly that the destructuring `let Some((png_bytes, dib_opt)) = png_preencoded.get(idx).and_then(|o| o.as_ref())` skips cleanly when LocalFile read failed during the pre-encode pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes & Improvements**
  * Enhanced clipboard write operations to support file-based clipboard sources in addition to inline data.
  * Improved error handling across all platforms to gracefully skip unsupported representations instead of crashing.
  * Better image format detection and recovery during clipboard operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/UniClipboard/UniClipboard/pull/772?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->