### PR TITLE
fix: secure-storage / daemon bootstrap resilience on Linux snap

### DIFF
--- a/docs-site/content/docs/en/getting-started/install.mdx
+++ b/docs-site/content/docs/en/getting-started/install.mdx
@@ -140,8 +140,19 @@ See the [COPR deployment notes](https://github.com/UniClipboard/UniClipboard/blo
 The Snap is built with strict confinement on `core22` and bundles its own GTK + WebKit stack, so it runs the same on Ubuntu 20.04+, Debian 11+, RHEL 9, openSUSE Leap, and similar.
 
 ```bash
-sudo snap install uniclipboard
+# While UniClipboard is in alpha, only the edge channel publishes builds.
+sudo snap install uniclipboard --edge
 ```
+
+After installing, grant the snap permission to read/write the system keyring (GNOME Keyring / KWallet), so the daemon can store its long-lived identity key there:
+
+```bash
+sudo snap connect uniclipboard:password-manager-service
+```
+
+Skipping this step is not fatal — the daemon falls back to a file-based Key Encryption Key under the snap's data directory and will start either way (look for `System secure storage probe failed; falling back to file-based KEK` in the logs). Connecting the plug just moves the KEK into the OS-managed keyring, which is what other system applications already use.
+
+`password-manager-service` is not auto-connect at install time; once the auto-connect request lands on the snap store this command will become unnecessary for new installs.
 
 Don't have `snapd`? See the [Snapcraft install guide](https://snapcraft.io/docs/installing-snapd) for your distribution.
 

--- a/docs-site/content/docs/en/guides/troubleshooting.mdx
+++ b/docs-site/content/docs/en/guides/troubleshooting.mdx
@@ -79,8 +79,8 @@ sudo snap connect uniclipboard:password-manager-service
 On older revisions (pre-r118) the same situation crashed the daemon
 with `Daemon startup/probe failed during Tauri bootstrap`. `sudo snap
 refresh uniclipboard --edge` to a current revision fixes that on its
-own; connecting the plug is then only about *where* the KEK is stored,
-not *whether* the daemon starts.
+own; connecting the plug is then only about _where_ the KEK is stored,
+not _whether_ the daemon starts.
 
 ## Pairing failures
 

--- a/docs-site/content/docs/en/guides/troubleshooting.mdx
+++ b/docs-site/content/docs/en/guides/troubleshooting.mdx
@@ -62,6 +62,26 @@ A common cause is the keyslot file being held by another process —
 typically the GUI and `uniclip` racing on the default profile. Adding
 `--profile dev` on the CLI side keeps them out of each other's way.
 
+### Snap install: "System secure storage probe failed; falling back to file-based KEK"
+
+This WARN means the snap could not reach the freedesktop Secret Service
+(GNOME Keyring / KWallet) — AppArmor refused the D-Bus call because the
+`password-manager-service` plug is not connected. The daemon still
+starts; the Key Encryption Key is just written to disk under the snap's
+data directory instead of into the system keyring. To move it back into
+the system keyring:
+
+```bash
+sudo snap connect uniclipboard:password-manager-service
+# then restart the app
+```
+
+On older revisions (pre-r118) the same situation crashed the daemon
+with `Daemon startup/probe failed during Tauri bootstrap`. `sudo snap
+refresh uniclipboard --edge` to a current revision fixes that on its
+own; connecting the plug is then only about *where* the KEK is stored,
+not *whether* the daemon starts.
+
 ## Pairing failures
 
 ### Invite says "invalid or expired"

--- a/docs-site/content/docs/zh/getting-started/install.mdx
+++ b/docs-site/content/docs/zh/getting-started/install.mdx
@@ -133,8 +133,19 @@ sudo dnf install uniclipboard
 Snap 包基于 `core22` 严格沙箱构建，自带 GTK + WebKit 运行时，因此在 Ubuntu 20.04+、Debian 11+、RHEL 9、openSUSE Leap 等老发行版上都能正常运行。
 
 ```bash
-sudo snap install uniclipboard
+# 当前仍处于 alpha 阶段，仅 edge 通道有包。
+sudo snap install uniclipboard --edge
 ```
+
+安装后再授权 snap 访问系统钥匙串（GNOME Keyring / KWallet），让守护进程把长期身份密钥放进系统密钥环：
+
+```bash
+sudo snap connect uniclipboard:password-manager-service
+```
+
+不接这一步也能跑——守护进程会降级到文件 KEK，存放在 snap 数据目录下（日志里能看到 `System secure storage probe failed; falling back to file-based KEK`）。接上 plug 只是把 KEK 搬进 OS 管理的钥匙串，跟其他系统应用走同一套机制。
+
+`password-manager-service` 当前不是 auto-connect interface；等 snap store 的 auto-connect 申请通过后，新安装就不再需要手动执行这条命令。
 
 没有 `snapd`？请参考 [Snapcraft 安装指南](https://snapcraft.io/docs/installing-snapd) 查看你所用发行版的安装方式。
 

--- a/docs-site/content/docs/zh/guides/troubleshooting.mdx
+++ b/docs-site/content/docs/zh/guides/troubleshooting.mdx
@@ -50,6 +50,17 @@ uniclip start --foreground -v
 
 常见原因是 keyslot 文件被另一份进程占着（典型场景：GUI 与 `uniclip` 用了同一个默认 profile 同时跑）。在 CLI 端加 `--profile dev` 让二者分家即可。
 
+### Snap 安装：日志里出现 "System secure storage probe failed; falling back to file-based KEK"
+
+这条 WARN 说明 snap 沙箱无法访问 freedesktop Secret Service（GNOME Keyring / KWallet）—— AppArmor 拒绝了 D-Bus 调用，原因是 `password-manager-service` plug 没接上。守护进程不会因此崩，只是 Key Encryption Key 落到了 snap 数据目录的文件里，而不是系统钥匙串。把它搬回系统钥匙串：
+
+```bash
+sudo snap connect uniclipboard:password-manager-service
+# 接好之后重启应用
+```
+
+更早的版本（r118 之前）遇到同样情况会直接 `Daemon startup/probe failed during Tauri bootstrap` 崩溃。`sudo snap refresh uniclipboard --edge` 升到最新 edge 就好；这种情况下 plug 只决定 KEK *存在哪里*，不再决定守护进程能不能起。
+
 ## 配对失败
 
 ### 邀请码报"invalid or expired"

--- a/docs-site/content/docs/zh/guides/troubleshooting.mdx
+++ b/docs-site/content/docs/zh/guides/troubleshooting.mdx
@@ -59,7 +59,7 @@ sudo snap connect uniclipboard:password-manager-service
 # 接好之后重启应用
 ```
 
-更早的版本（r118 之前）遇到同样情况会直接 `Daemon startup/probe failed during Tauri bootstrap` 崩溃。`sudo snap refresh uniclipboard --edge` 升到最新 edge 就好；这种情况下 plug 只决定 KEK *存在哪里*，不再决定守护进程能不能起。
+更早的版本（r118 之前）遇到同样情况会直接 `Daemon startup/probe failed during Tauri bootstrap` 崩溃。`sudo snap refresh uniclipboard --edge` 升到最新 edge 就好；这种情况下 plug 只决定 KEK _存在哪里_，不再决定守护进程能不能起。
 
 ## 配对失败
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -45,6 +45,16 @@ apps:
     # 文件传输场景。剪贴板事件从 GTK clipboard API 取,strict snap 通过
     # wayland / x11 plug 拿到 host compositor selection;daemon 监听
     # 系统剪贴板变化跟原生 .deb 行为一致。
+    #
+    # `password-manager-service`: daemon 启动期通过 secret-service D-Bus
+    # API (org.freedesktop.Secret.Service / GNOME Keyring / KWallet 等)
+    # 取本地身份的 KEK。该 plug **不会** auto-connect,首装后需要 manual
+    # `snap connect uniclipboard:password-manager-service`;未连接时
+    # uc-platform::capability 仍会探测到 desktop 然后走 system keyring,
+    # DBus 被 AppArmor 拒后直接 daemon 启动失败 ——
+    # uc-platform::secure_storage 的 file-based fallback 仅在 "no desktop
+    # detected" 路径触发。要在 snap store 启用 auto-connect 需在 snapcraft
+    # forum 提 request。
     plugs:
       - desktop
       - desktop-legacy
@@ -56,6 +66,7 @@ apps:
       - home
       - removable-media
       - mount-observe
+      - password-manager-service
 
 parts:
   uniclipboard:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -129,8 +129,14 @@ parts:
       # 2) 后端构建 —— 直接 cargo build,绕过 tauri-cli (不需要 .deb /
       # AppImage / updater signing 这些 snap 用不到的逻辑)。binary 名字
       # 由 src-tauri/Cargo.toml 的 [package].name 决定 = "uniclipboard"。
+      #
+      # `--features custom-protocol` 必传：开了 Tauri 才走 `tauri://localhost`
+      # 协议从嵌入的 frontendDist 加载 webview;不开的话 release binary 仍
+      # 尝试 devUrl (http://localhost:1420) → 用户看到 "Could not connect
+      # to localhost: Connection refused"。`bun run tauri build` 默认会开
+      # 它,我们绕过 tauri-cli 所以必须手动加。
       cd src-tauri
-      cargo build --release --locked --bin uniclipboard
+      cargo build --release --locked --bin uniclipboard --features custom-protocol
       cd ..
 
       # 3) 安装到 snap install 目录。strict snap 启动时 mount 这个目录

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -42,6 +42,14 @@ cargo-clippy = []
 # 启用后默认使用 "dev" profile（数据目录后缀 `-dev`、keychain service 后缀 `-dev`）。
 # 仅供 `bun tauri:build:dev` 使用，避免本地 dev 构建产物覆盖 prod 安装的数据。
 dev-profile = ["uc-tauri/dev-profile"]
+# Tauri 的 production webview 加载开关：开了才会用 `tauri://localhost` 协议从
+# 嵌入的 `frontendDist` 读 index.html / assets；关掉的话即便 cargo `--release`
+# 也仍走 `devUrl`（tauri.conf.json 里是 http://localhost:1420），结果是 snap
+# 包跑出来 webview 显示 "Could not connect to localhost: Connection refused"。
+# `tauri-cli`（`bun run tauri build`）会自动把这个 feature 打开，但 snap.yml
+# 绕过 tauri-cli 直接 cargo build，因此必须在这里手动通过
+# `--features custom-protocol` 启用。
+custom-protocol = ["tauri/custom-protocol"]
 
 # dev profile:用 line-tables-only 替代完整 dwarf,大幅缩短 link 阶段。
 # 实测 inner-loop 11s → 4s(-65%),target 体积 46GB → 4.4GB(-91%)。

--- a/src-tauri/crates/uc-platform/src/secure_storage.rs
+++ b/src-tauri/crates/uc-platform/src/secure_storage.rs
@@ -11,6 +11,11 @@ use crate::{
     system_secure_storage::SystemSecureStorage,
 };
 
+/// Sentinel key used to probe whether the platform secret service is actually
+/// reachable from this process. Picked so it's clearly internal and unlikely
+/// to ever collide with a real keyring entry.
+const SYSTEM_STORAGE_PROBE_KEY: &str = "__uc_secure_storage_probe__";
+
 #[derive(Debug, thiserror::Error)]
 pub enum SecureStorageFactoryError {
     #[error("secure storage unsupported: {capability:?}")]
@@ -18,6 +23,22 @@ pub enum SecureStorageFactoryError {
 
     #[error("failed to initialize file-based secure storage: {0}")]
     FileBasedInit(#[from] std::io::Error),
+}
+
+/// Probe whether `SystemSecureStorage` can actually round-trip a call to the
+/// platform secret service. `Ok` means `get` succeeded — including the "no
+/// such entry" case, which is the expected outcome for the sentinel key.
+/// `Err` means the secret service is reachable in principle (env says we have
+/// a desktop + DBus) but the real call was rejected at runtime: snap AppArmor
+/// blocking `org.freedesktop.Secret.Service.OpenSession`, gnome-keyring
+/// locked and unable to prompt in this context, KWallet disabled, etc. Those
+/// failures used to crash daemon bootstrap; callers can now degrade
+/// gracefully to file-based KEK instead.
+fn probe_system_storage_reachable(storage: &SystemSecureStorage) -> Result<(), String> {
+    storage
+        .get(SYSTEM_STORAGE_PROBE_KEY)
+        .map(|_| ())
+        .map_err(|e| e.to_string())
 }
 
 fn secure_storage_from_capability(
@@ -167,8 +188,32 @@ pub fn create_default_secure_storage_in_app_data_root(
 
     match capability {
         SecureStorageCapability::SystemKeyring => {
-            info!("Using system secure storage");
-            secure_storage_from_capability(capability)
+            // capability detection is env-only (DISPLAY + DBUS_SESSION_BUS_ADDRESS),
+            // it cannot tell whether the secret service actually accepts our calls.
+            // snap AppArmor refusing OpenSession is the canonical failure we hit
+            // (see `password-manager-service` plug in snapcraft.yaml). Round-trip
+            // a probe before committing to system keyring; on failure degrade to
+            // FileSecureStorage so daemon bootstrap can still complete instead of
+            // crashing the GUI with an opaque "in-process daemon start failed".
+            let system_storage = SystemSecureStorage::new();
+            match probe_system_storage_reachable(&system_storage) {
+                Ok(()) => {
+                    info!("Using system secure storage");
+                    Ok(Arc::new(system_storage) as Arc<dyn SecureStoragePort>)
+                }
+                Err(probe_err) => {
+                    warn!(
+                        probe_error = %probe_err,
+                        "System secure storage probe failed; falling back to file-based KEK. \
+                         Check snap interface connections (e.g. password-manager-service) or \
+                         keyring daemon availability."
+                    );
+                    Ok(
+                        Arc::new(FileSecureStorage::new_in_app_data_root(app_data_root)?)
+                            as Arc<dyn SecureStoragePort>,
+                    )
+                }
+            }
         }
         SecureStorageCapability::FileBasedKeystore => {
             warn!("Using file-based secure storage (insecure dev fallback for WSL/headless environments)");

--- a/src-tauri/crates/uc-tauri/src/run.rs
+++ b/src-tauri/crates/uc-tauri/src/run.rs
@@ -328,7 +328,13 @@ pub fn run(tauri_ctx: tauri::Context<tauri::Wry>) -> anyhow::Result<()> {
                         // 也由 CLI 负责重新拉起。
                     }
                     Err(error) => {
-                        error!(error = %error, "Daemon startup/probe failed during Tauri bootstrap");
+                        // Display 只暴露 thiserror 外层 message，会把 anyhow source chain
+                        // 截掉 —— root cause 全丢；用 Debug 把整条 chain 一起打出来。
+                        error!(
+                            error = %error,
+                            error_chain = ?error,
+                            "Daemon startup/probe failed during Tauri bootstrap"
+                        );
                     }
                 }
             });


### PR DESCRIPTION
## Summary

Five commits that together fix the **"Daemon startup/probe failed during Tauri bootstrap"** crash and the **"Could not connect to localhost: Connection refused"** white-screen on Linux snap installs, plus a docs update covering the resulting first-run experience.

- `b65963fe` **fix(daemon-bootstrap)** — `run.rs:331` was logging `error = %error`, which only renders the outermost `thiserror` message. The actual `anyhow` source chain (where the root cause lives) was silently dropped. Add `error_chain = ?error` alongside the Display string so both the console and structured JSON sink carry the full chain.
- `b82bfc37` **fix(snap)** — Declare the `password-manager-service` plug in `snap/snapcraft.yaml` so users *can* connect to the freedesktop Secret Service / GNOME Keyring. The plug is not auto-connect; long term we'll request auto-connect via the snapcraft forum.
- `6945983d` **fix(secure-storage)** — Add a runtime probe in `create_default_secure_storage_in_app_data_root`; on failure (AppArmor refusal, keyring locked, KWallet disabled, …) degrade to `FileSecureStorage` rooted at `app_data_root` and log a WARN pointing the operator at snap interface connections / keyring daemon health. This converts the previous hard crash into a graceful, observable fallback.
- `b54c3cec` **fix(snap)** — Enable Tauri's `custom-protocol` feature for snap builds. Without it the Tauri runtime ignores its `frontendDist` and falls back to `devUrl` (`http://localhost:1420`) even for `cargo build --release` binaries — that's the "Could not connect to localhost" white-screen. `bun run tauri build` (alpha-build / build.yml) auto-enables this; snap.yml bypasses tauri-cli and now has to opt in by hand.
- `ceea1f02` **docs(snap)** — Install guide (en + zh) calls out `--edge` (alpha only publishes there today) and the one-shot `sudo snap connect uniclipboard:password-manager-service` post-install step. Troubleshooting guide (en + zh) gets a section decoding the `System secure storage probe failed; falling back to file-based KEK` WARN, plus the pre-r118 crash variant.

## Test plan

- [x] `cargo check -p uc-tauri` (b65963fe)
- [x] `cargo check -p uc-platform` (6945983d)
- [x] `cargo check -p uniclipboard --features custom-protocol` (b54c3cec)
- [x] Snap build with all four code commits (r118, Ubuntu 22.04 arm64):
  - **plug connected** — `Using system secure storage` (no fallback WARN), `backend_ready`, webview URL = `tauri://localhost`, main window loads.
  - **plug disconnected** — `System secure storage probe failed; falling back to file-based KEK` WARN with full DBus/AppArmor `probe_error`, `backend_ready`, webview URL = `tauri://localhost`, main window loads.
- [ ] `bun run docs-site:dev` and eyeball the install / troubleshooting pages render cleanly (ceea1f02).

## Notes

- Plug declaration is still required even with the fallback. The fallback only triggers on probe failure; the SystemKeyring path stays the default and preferred branch.
- Behaviour change for snap users who never `snap connect` the plug: identity KEK lives on disk under `app_data_root` instead of refusing to boot. Connecting the plug + restarting moves it back into the system keyring on next launch.
- Follow-up: open a forum thread to request `password-manager-service` auto-connect for the `uniclipboard` snap so the manual `snap connect` step disappears for end users. Once that lands, the install guide should drop the `snap connect` paragraph.
- Follow-up: audit other release pipelines for the same `custom-protocol` blind spot — copr.yml and any future packaging recipes that don't go through `tauri-cli` need the same flag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added password-manager-service plug support for snap installations with automatic fallback to file-based storage when system keyring is unavailable.

* **Documentation**
  * Updated snap installation instructions for alpha releases via edge channel.
  * Added troubleshooting guides for snap-specific setup and keyring connectivity.

* **Improvements**
  * Enhanced daemon startup error reporting with full diagnostic information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/UniClipboard/UniClipboard/pull/774?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->