### PR TITLE
feat(settings): add open logs directory in general settings

### DIFF
--- a/src-tauri/crates/uc-tauri/src/commands/storage.rs
+++ b/src-tauri/crates/uc-tauri/src/commands/storage.rs
@@ -42,3 +42,39 @@ pub async fn open_data_directory(
     .instrument(span)
     .await
 }
+
+/// Open the application logs directory in the system file manager.
+/// 在系统文件管理器中打开应用日志目录。
+#[tauri::command]
+#[specta::specta]
+pub async fn open_logs_directory(
+    app: tauri::AppHandle,
+    runtime: tauri::State<'_, std::sync::Arc<crate::bootstrap::TauriAppRuntime>>,
+    _trace: Option<TraceMetadata>,
+) -> Result<(), CommandError> {
+    let span = info_span!(
+        "command.storage.open_logs_dir",
+        trace_id = tracing::field::Empty,
+        trace_ts = tracing::field::Empty,
+    );
+    record_trace_fields(&span, &_trace);
+
+    async move {
+        let dir = runtime.storage_paths().logs_dir.clone();
+        std::fs::create_dir_all(&dir).map_err(|e| {
+            CommandError::InternalError(format!(
+                "Failed to create logs directory {}: {e}",
+                dir.display()
+            ))
+        })?;
+
+        app.opener()
+            .open_path(dir.to_string_lossy(), None::<&str>)
+            .map_err(|e| CommandError::InternalError(e.to_string()))?;
+
+        tracing::info!(dir = %dir.display(), "Opened logs directory");
+        Ok(())
+    }
+    .instrument(span)
+    .await
+}

--- a/src-tauri/crates/uc-tauri/src/specta_builder.rs
+++ b/src-tauri/crates/uc-tauri/src/specta_builder.rs
@@ -67,6 +67,7 @@ pub fn build() -> Builder<tauri::Wry> {
             crate::commands::updater::get_install_kind,
             // ── storage ─────────────────────────────────────────────────────────
             crate::commands::storage::open_data_directory,
+            crate::commands::storage::open_logs_directory,
             // ── clipboard delivery view (entry detail "源 + 同步状态") ──────────
             crate::commands::clipboard_delivery::clipboard_entry_delivery_view,
             // ── quick panel ─────────────────────────────────────────────────────

--- a/src/api/storage.ts
+++ b/src/api/storage.ts
@@ -76,6 +76,16 @@ export async function openDataDirectory(): Promise<void> {
   await commands.openDataDirectory()
 }
 
+/**
+ * Open the platform logs directory in the system file explorer.
+ *
+ * 打开平台日志目录的系统文件浏览器。
+ */
+export async function openLogsDirectory(): Promise<void> {
+  const { commands } = await import('@/lib/ipc')
+  await commands.openLogsDirectory()
+}
+
 // Re-export clipboard history clearance from daemon clipboard API.
 // This is used by StorageSection for the "clear all history" action.
 export { clearClipboardHistory as clearAllClipboardHistory } from './daemon/clipboard'

--- a/src/components/setting/GeneralSection.tsx
+++ b/src/components/setting/GeneralSection.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
+import * as storageApi from '@/api/storage'
 import {
   Select,
   SelectContent,
@@ -8,6 +9,7 @@ import {
   SelectValue,
   Switch,
   Input,
+  Button,
 } from '@/components/ui'
 import { useSetting } from '@/hooks/useSetting'
 import { SUPPORTED_LANGUAGES, type SupportedLanguage, getInitialLanguage } from '@/i18n'
@@ -132,6 +134,14 @@ export default function GeneralSection() {
     }
   }
 
+  const handleOpenLogsDir = async () => {
+    try {
+      await storageApi.openLogsDirectory()
+    } catch (error) {
+      log.error({ err: error }, '打开日志目录失败')
+    }
+  }
+
   return (
     <>
       <SettingGroup title={t('settings.sections.general.startupTitle')}>
@@ -212,6 +222,17 @@ export default function GeneralSection() {
             onCheckedChange={handleUsageAnalyticsChange}
             disabled={isBusy}
           />
+        </SettingRow>
+      </SettingGroup>
+
+      <SettingGroup title={t('settings.sections.general.logsDirectory.title')}>
+        <SettingRow
+          label={t('settings.sections.general.logsDirectory.label')}
+          description={t('settings.sections.general.logsDirectory.description')}
+        >
+          <Button variant="outline" size="sm" onClick={handleOpenLogsDir}>
+            {t('settings.sections.general.logsDirectory.button')}
+          </Button>
         </SettingRow>
       </SettingGroup>
     </>

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -119,6 +119,12 @@
             "accept": "OK",
             "optOut": "Disable"
           }
+        },
+        "logsDirectory": {
+          "title": "Logs",
+          "label": "Log directory",
+          "description": "Open the folder where application logs are stored",
+          "button": "Open in file manager"
         }
       },
       "appearance": {

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -119,6 +119,12 @@
             "accept": "好的",
             "optOut": "关闭"
           }
+        },
+        "logsDirectory": {
+          "title": "日志",
+          "label": "日志目录",
+          "description": "在文件管理器中打开当前应用的日志文件夹",
+          "button": "在文件管理器中打开"
         }
       },
       "appearance": {

--- a/src/lib/ipc-bindings.generated.ts
+++ b/src/lib/ipc-bindings.generated.ts
@@ -216,6 +216,14 @@ export const commands = {
 	timestamp: number,
 } | null) => typedError<null, CommandError>(__TAURI_INVOKE("open_data_directory", { trace })),
 	/**
+	 *  Open the application logs directory in the system file manager.
+	 *  在系统文件管理器中打开应用日志目录。
+	 */
+	openLogsDirectory: (trace: {
+	trace_id: string,
+	timestamp: number,
+} | null) => typedError<null, CommandError>(__TAURI_INVOKE("open_logs_directory", { trace })),
+	/**
 	 *  拉一条 entry 的同步状态视图。
 	 * 
 	 *  前端 detail 面板在 entry 切换时调用,失败时(facade 未装配 / DB 故障)


### PR DESCRIPTION
Expose open_logs_directory via Tauri so users can open the runtime logs folder from Settings > General on all platforms.