### PR TITLE
fix(ci): make Format Check checkout work for fork PRs

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -36,7 +36,11 @@ jobs:
       - name: Checkout PR branch
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
+          # Fork PR 的 head_ref 在主仓库可能不存在(甚至与已删除的同名分支冲突,
+          # 例如 fork 上的 `dev` 在主仓库 dev 退役后会触发 "branch not found")。
+          # 显式指向 PR head 仓库 + sha,既兼容 same-repo 也兼容 fork。
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
           # Use a PAT or the default token; for same-repo PRs GITHUB_TOKEN can push.
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0


### PR DESCRIPTION
## Summary

- `.github/workflows/format.yml` used `ref: ${{ github.head_ref }}`, which `actions/checkout` resolves against the base repo. For fork PRs whose head branch happens to collide with a deleted/missing branch on the base repo, checkout fails with `A branch or tag with the name '<name>' could not be found` and every subsequent step is skipped. PR #775 hit this — its fork branch was named `dev`, and base-repo `dev` was retired on 2026-05-10. (cfc7110e)
- Pin checkout to `repository: github.event.pull_request.head.repo.full_name` + `ref: github.event.pull_request.head.sha`. Works for both same-repo and fork PRs.
- The same-repo auto-push step is unchanged: it pushes detached HEAD to `refs/heads/$PR_HEAD_REF` and is already guarded by `head.repo.full_name == github.repository`, so fork PRs still correctly skip it.

## Test plan

- [x] Diff inspected — only the `Checkout PR branch` step changes; auto-push path untouched.
- [ ] Open a same-repo PR with an intentional format issue; confirm Format Check checks out the PR head and auto-pushes a `style: auto-format` commit.
- [ ] Open a fork PR (or re-run #775 equivalent) where the fork's head branch name does **not** exist on the base repo; confirm Format Check now runs `cargo fmt` / `bun run format` and reports the diff instead of failing at checkout.