### PR TITLE
feat(release): include New Contributors section in release notes

### DIFF
--- a/.github/release-notes/release.md.tmpl
+++ b/.github/release-notes/release.md.tmpl
@@ -14,3 +14,4 @@
 ## Verification
 
 All releases are signed. `.sig` files are provided for verification.
+{{NEW_CONTRIBUTORS_SECTION}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -269,6 +269,31 @@ jobs:
           git tag -a "v${{ needs.validate.outputs.version }}" -m "Release v${{ needs.validate.outputs.version }}"
           git push origin "v${{ needs.validate.outputs.version }}"
 
+      - name: Fetch GitHub generated notes
+        id: gh-generated-notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true
+        run: |
+          VERSION="${{ needs.validate.outputs.version }}"
+          PREV_TAG="${{ needs.validate.outputs.previous_tag }}"
+
+          # 仅当 previous_tag 是真实 tag (以 v 开头) 时才传给 API；
+          # 首发场景下 previous_tag 会是 commit hash，让 GitHub 自行回退。
+          ARGS=(-X POST "/repos/${{ github.repository }}/releases/generate-notes"
+                -f "tag_name=v${VERSION}")
+          if [[ "$PREV_TAG" == v* ]]; then
+            ARGS+=(-f "previous_tag_name=${PREV_TAG}")
+          fi
+
+          if ! gh api "${ARGS[@]}" --jq '.body' > generated-notes.md; then
+            echo "Warning: gh api generate-notes failed; New Contributors section will be omitted"
+            : > generated-notes.md
+          fi
+
+          echo "Preview of GitHub-generated notes:"
+          head -80 generated-notes.md || true
+
       - name: Generate release notes
         id: release-notes
         run: |
@@ -280,6 +305,7 @@ jobs:
             --is-prerelease "${{ needs.validate.outputs.is_prerelease }}" \
             --artifacts-dir "release-assets" \
             --template ".github/release-notes/release.md.tmpl" \
+            --generated-notes-file "generated-notes.md" \
             --output "release-notes.md"
 
       - name: Create GitHub Release

--- a/scripts/generate-release-notes.js
+++ b/scripts/generate-release-notes.js
@@ -15,6 +15,7 @@ function parseArgs(argv = process.argv.slice(2)) {
     template: null,
     output: null,
     docsBaseUrl: null,
+    generatedNotesFile: null,
   }
 
   for (let index = 0; index < argv.length; index += 1) {
@@ -47,6 +48,9 @@ function parseArgs(argv = process.argv.slice(2)) {
       index += 1
     } else if (arg === '--docs-base-url' && next) {
       options.docsBaseUrl = next
+      index += 1
+    } else if (arg === '--generated-notes-file' && next) {
+      options.generatedNotesFile = next
       index += 1
     }
   }
@@ -227,6 +231,42 @@ function buildChangelogLinks({ version, docsBaseUrl, englishExists, chineseExist
   return `\n**Changelog Files**\n\n${lines.join('\n')}`
 }
 
+function buildNewContributorsSection(generatedNotesFile) {
+  if (!generatedNotesFile) {
+    return ''
+  }
+  if (!fs.existsSync(generatedNotesFile)) {
+    emitWarning(
+      `Generated notes file not found, skipping New Contributors section`,
+      generatedNotesFile
+    )
+    return ''
+  }
+
+  const content = fs.readFileSync(generatedNotesFile, 'utf8')
+  const lines = content.split('\n')
+  const headerIndex = lines.findIndex(line => /^##+\s+New Contributors\s*$/.test(line))
+  if (headerIndex === -1) {
+    return ''
+  }
+
+  const bodyLines = []
+  for (let i = headerIndex + 1; i < lines.length; i += 1) {
+    const line = lines[i]
+    if (/^##+\s/.test(line) || /^\*\*Full Changelog\*\*/.test(line)) {
+      break
+    }
+    bodyLines.push(line)
+  }
+
+  const body = bodyLines.join('\n').trim()
+  if (!body) {
+    return ''
+  }
+
+  return `\n## New Contributors\n\n${body}\n`
+}
+
 function buildPrereleaseWarning(isPrerelease, channel) {
   if (!isPrerelease) {
     return ''
@@ -289,6 +329,7 @@ export function generateReleaseNotes(options) {
       IS_PRERELEASE_WARNING: buildPrereleaseWarning(options.isPrerelease, options.channel),
       INSTALLER_TABLE: installerTable,
       CLI_INSTALLER_TABLE: cliInstallerTable,
+      NEW_CONTRIBUTORS_SECTION: buildNewContributorsSection(options.generatedNotesFile),
     }).trim() + '\n'
 
   fs.writeFileSync(outputPath, rendered, 'utf8')


### PR DESCRIPTION
## Summary

- Append a `## New Contributors` section to the auto-generated GitHub release body, surfacing first-time contributors alongside the existing changelog/installer tables (8c29802c).
- Wire the release workflow to call GitHub's `POST /repos/.../releases/generate-notes` API right after the tag is created; only pass `previous_tag_name` when it's a real `v*` tag, so first-release / commit-hash fallbacks don't break the call.
- Make the section opt-in via a new `--generated-notes-file` flag on `scripts/generate-release-notes.js` and a `{{NEW_CONTRIBUTORS_SECTION}}` slot in `.github/release-notes/release.md.tmpl`. If the API call fails, the file is missing, or the response has no `## New Contributors` segment, the slot renders empty and the rest of the release body is unaffected.

## Test plan

- [x] Local smoke test of `generateReleaseNotes` with a synthetic generated-notes file containing a `## New Contributors` block — section appears at the end of the release body, after `Verification`.
- [x] Local smoke test with a generated-notes file lacking the block — body ends cleanly at `Verification`, no stray heading.
- [x] Local smoke test with a missing generated-notes file path — script emits a GHA warning annotation and renders the body without the section.
- [ ] On the next `release.yml` run (alpha or stable), verify the GitHub release body shows the `## New Contributors` segment when first-time contributors exist between the previous tag and HEAD.
- [ ] On a release where the `gh api generate-notes` call errors (e.g. transient API failure), verify the workflow continues and the release body just omits the section.