### PR TITLE
docs(changelog): require PR number on each entry

### DIFF
--- a/.claude/commands/gen-changelog.md
+++ b/.claude/commands/gen-changelog.md
@@ -16,22 +16,26 @@ Generate a user-facing changelog for the current release.
    git log <base>..HEAD --oneline
    ```
 
-   Also inspect full commit messages (`git show <hash>`) when needed to understand the scope of changes.
+   Squash-merge commits look like `feat(scope): summary (#778)` — the trailing `(#778)` is the PR number you must capture for each entry. Also inspect full commit messages (`git show <hash>`) when needed to understand the scope of changes. Skip `release:` commits (the merge commit that cuts the version itself); their PR is the release PR, not a user-visible change.
 
-4. **Consolidate changes by PR/intent**: Multiple commits from the same PR or addressing the same issue should be merged into a single changelog entry. Do NOT list each commit separately — describe the user-visible outcome.
+4. **Consolidate changes by PR/intent**: Multiple commits from the same PR or addressing the same issue MUST be merged into a single changelog entry. Do NOT list each commit separately and do NOT let the same `(#PR)` appear twice in the same section — describe the user-visible outcome once.
 
-5. **Classify** each entry by conventional commit type per the template rules (feat→Features, fix→Fixes, etc.). Skip `chore:` commits.
+5. **Classify** each entry by conventional commit type per the template rules (feat→Features, fix→Fixes, etc.). Skip `chore:`, `ci:`, `test:`, `refactor:`, `docs:` commits unless they produce a user-visible change.
 
-6. **Write the changelog** in English to `docs/changelog/{version}.md`, and in Chinese to `docs/changelog/{version}.zh.md`. Follow the template format exactly:
+6. **Append the PR number** to every entry in the form ` (#123)` at the end of the line. Take the number from the squash commit's trailing `(#NNN)`. Do NOT add contributor handles — New Contributors are surfaced in a separate GitHub Release section.
+
+7. **Write the changelog** in English to `docs/changelog/{version}.md`, and in Chinese to `docs/changelog/{version}.zh.md`. Follow the template format exactly:
    - Only include sections that have content
    - Use today's date (YYYY-MM-DD)
    - Descriptions should be concise and user-facing (explain the impact, not the implementation)
+   - Each entry ends with ` (#PR)`
 
-7. **Show the user** the generated content for review before finishing.
+8. **Show the user** the generated content for review before finishing.
 
 ## Key Rules
 
-- One PR / one logical fix = one changelog entry, even if it contains multiple commits
+- One PR = one changelog entry per section, even if it contains multiple commits
+- Every bullet ends with ` (#PR)`; never duplicate the same `(#PR)` within a section
 - Write from the user's perspective: what was broken, what's new, what improved
 - Keep descriptions concise but informative
 - Chinese version should be natural Chinese, not a literal translation

--- a/docs/CHANGELOG_TEMPLATE.md
+++ b/docs/CHANGELOG_TEMPLATE.md
@@ -13,30 +13,32 @@
 
 ### Breaking Changes
 
-- {仅在确有用户可感知的不兼容变化时保留}
+- {仅在确有用户可感知的不兼容变化时保留} (#PR)
 
 ### Features
 
-- {描述用户能直接感受到的新增或改进，每条一行}
+- {描述用户能直接感受到的新增或改进，每条一行} (#PR)
 
 ### Fixes
 
-- {描述用户遇到的问题被如何修复，每条一行}
+- {描述用户遇到的问题被如何修复，每条一行} (#PR)
 ```
 
 ## 规则
 
-1. **默认统计范围**是“上一个已发布版本 -> 当前版本”
-2. **预发布版本**默认只写本次增量，不合并更早的 alpha / beta / rc 日志
-3. **正式版本**默认也只写给定范围，不自动汇总整段预发布历史；若需要整段汇总，必须在提示词中明确说明
+1. **默认统计范围** 是“上一个已发布版本 -> 当前版本”
+2. **预发布版本** 默认只写本次增量，不合并更早的 alpha / beta / rc 日志
+3. **正式版本** 默认也只写给定范围，不自动汇总整段预发布历史；若需要整段汇总，必须在提示词中明确说明
 4. **仅包含有内容的分类**，空分类整段省略；`### Breaking Changes` 只在确有用户可感知的不兼容变化时保留
 5. **只写用户可感知的变化**，不写重构、日志、CI、测试、依赖升级、架构调整等内部内容
 6. **写结果，不写实现**；避免内部模块名、协议名、算法名、状态管理细节等术语
 7. **拿不准就不写**；不能确认用户是否能感知到，就省略
-8. **同类内容合并**为一条，避免把同一件事拆成多条重复描述
-9. **每条一句话**，短、清楚、自然；英文版与中文版都遵循同一结构
-10. **版本号**取自 `package.json` / `Cargo.toml` / `tauri.conf.json`
-11. **日期**使用发布当天，格式 `YYYY-MM-DD`
+8. **每条末尾标注 PR 编号**，格式为 `(#123)`；PR 编号来自 squash commit 信息（`feat: xxx (#123)`）
+9. **一个 PR 一条记录**：同一个 PR 内的多条改动必须合并为一条用户视角的总结，**不要** 让同一个 `(#PR)` 在同一分类里出现多次；如果一个 PR 的改动确实跨分类（如同时含 feature 与 fix），可以分类各保留一条
+10. **每条一句话**，短、清楚、自然；英文版与中文版都遵循同一结构
+11. **版本号** 取自 `package.json` / `Cargo.toml` / `tauri.conf.json`
+12. **日期** 使用发布当天，格式 `YYYY-MM-DD`
+13. **贡献者** 不在条目里标注；GitHub Release 会单独生成 New Contributors 区域，无需在 changelog 里重复
 
 ## 示例
 
@@ -45,10 +47,10 @@
 
 ### Features
 
-- Improve setup and pairing progress messages so it is clearer what the app is waiting for
-- Make image and file previews more reliable across supported surfaces
+- Improve setup and pairing progress messages so it is clearer what the app is waiting for (#612)
+- Make image and file previews more reliable across supported surfaces (#615)
 
 ### Fixes
 
-- Prevent lag when previewing very large text content
+- Prevent lag when previewing very large text content (#618)
 ```


### PR DESCRIPTION
## Summary

- Release notes embed `docs/changelog/{version}.md` verbatim, but entries have no link back to the PR that produced them — users reading a release page have no fast path to *what actually changed*. (915ccc7c)
- Update `docs/CHANGELOG_TEMPLATE.md` so the template, rules, and example all require every bullet to end with ` (#PR)`, taken from the squash commit's trailing `(#NNN)`. Reinforce that multiple commits from the same PR must collapse into one entry per section — no duplicate `(#PR)` within a section.
- Update `.claude/commands/gen-changelog.md` in lockstep: tell the skill to extract PR numbers from `git log --oneline`, skip `release:` / pure `chore|ci|test|refactor|docs` commits, and append ` (#PR)` to each entry.
- Contributor handles are intentionally left out — the New Contributors section added in #780 already covers attribution, and inline `by @handle` would just duplicate that.

No `docs-site/` changes: both files are developer-facing (release maintainer template + Claude Code skill); they don't describe any user-visible CLI flag, setting, or behavior.

## Test plan

- [x] Reviewed rendered template and skill files for internal consistency (every example bullet now ends with `(#PR)`; the "one PR = one entry" rule is stated in both files).
- [ ] Next time `/gen-changelog` runs (i.e. when cutting `0.10.0-alpha.11`), verify the generated `docs/changelog/{version}.md` follows the new format end-to-end.