### PR TITLE
perf(clipboard-sync): eager flush each deferred peer's delivery record

### DIFF
--- a/src-tauri/crates/uc-application/src/usecases/clipboard_sync/dispatch_entry.rs
+++ b/src-tauri/crates/uc-application/src/usecases/clipboard_sync/dispatch_entry.rs
@@ -609,11 +609,15 @@ impl DispatchClipboardEntryUseCase {
             tokio::spawn(
                 async move {
                     let bg_started = Instant::now();
-                    let mut bg_records: Vec<EntryDeliveryRecord> = Vec::new();
                     let mut bg_accepted = 0usize;
                     let mut bg_duplicate = 0usize;
                     let mut bg_offline = 0usize;
                     let mut bg_errored = 0usize;
+                    // 每个 peer task join 完就立刻把它那条 delivery record
+                    // 写盘 + emit,不再累成一笔等所有 deferred peer 跑完再
+                    // flush。否则一个 staggered retry 拖尾的离线 peer 会
+                    // 把前面早就 ack 的 peer 的 badge 刷新也一起卡 15s,
+                    // 与注释里"按 peer 真实完成时刻陆续刷新"的承诺相违背。
                     while let Some(joined) = set.join_next().await {
                         let processed = classify_dispatch_result(
                             joined,
@@ -629,15 +633,14 @@ impl DispatchClipboardEntryUseCase {
                             }
                         }
                         if let Some(rec) = processed.delivery_record {
-                            bg_records.push(rec);
+                            flush_delivery_records(
+                                std::slice::from_ref(&rec),
+                                entry_delivery_repo_bg.as_ref(),
+                                &host_event_bus_bg,
+                            )
+                            .await;
                         }
                     }
-                    flush_delivery_records(
-                        &bg_records,
-                        entry_delivery_repo_bg.as_ref(),
-                        &host_event_bus_bg,
-                    )
-                    .await;
                     info!(
                         content_hash = %content_hash_bg,
                         deferred_count = total_pending,


### PR DESCRIPTION
## Summary

- Inside the deferred fan-out background task (`dispatch_entry.rs`, introduced in #787), records were accumulated into a `Vec<EntryDeliveryRecord>` and only flushed after the whole `JoinSet` drained. A single staggered-retry tail (an offline peer the `FAN_OUT_DEADLINE` punted to the background) therefore held the persistence + `DeliveryHostEvent::StatusChanged` of every faster peer in the same batch — entry-detail badges refreshed in one synchronized late burst rather than per-peer as each ack arrived (277c0b31).
- Move the flush inside the `join_next()` loop and pass each record through `std::slice::from_ref(&rec)` so the existing `flush_delivery_records` helper (which preserves write-then-emit order) runs once per peer. Accumulator removed; the trailing summary `info!` keeps its counters.
- The surrounding comment already promised "按 peer 真实完成时刻陆续刷新" — this PR makes the code match.

No `docs-site/` updates: scanned `content/docs/{en,zh}/` against the changed surface area (`delivery`, `badge`, `detail view`, `per-peer`, `fan-out`, `已同步`) — none of the user docs describe the per-peer delivery-record refresh cadence, so there is nothing to bring in line.

## Test plan

- [x] `cargo test -p uc-application --lib usecases::clipboard_sync::dispatch_entry` — 23 passing, including `fan_out_deadline_defers_slow_peers_to_background`.
- [ ] Manual: pair three peers, take one offline, send a clipboard entry on the host. Verify the entry detail badge for the online peers updates as each ack arrives (well before the 15s staggered-retry deadline on the offline peer), instead of all three flipping together late.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved responsiveness of clipboard synchronization by processing delivery status updates incrementally as each peer completes, instead of waiting for all operations to finish before displaying updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/UniClipboard/UniClipboard/pull/790?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->