### PR TITLE
feat(ui/windows): enable Mica window material (#699)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -9949,6 +9949,7 @@ dependencies = [
  "uc-observability",
  "uc-platform",
  "url",
+ "window-vibrancy",
  "windows 0.61.3",
 ]
 

--- a/src-tauri/crates/uc-tauri/Cargo.toml
+++ b/src-tauri/crates/uc-tauri/Cargo.toml
@@ -76,6 +76,9 @@ windows = { version = "0.61", features = [
     "Win32_UI_Input_KeyboardAndMouse",
     "Win32_System_Threading",
 ] }
+# Mica 装配 —— 见 `src/window_material.rs`。`window-vibrancy` 0.6 已经被
+# tauri 间接拉入 Cargo.lock，这里 promote 成显式依赖，不会引入新 crate。
+window-vibrancy = "0.6"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 core-foundation = "0.10"

--- a/src-tauri/crates/uc-tauri/src/commands/mod.rs
+++ b/src-tauri/crates/uc-tauri/src/commands/mod.rs
@@ -12,6 +12,7 @@ pub mod storage;
 pub mod tray;
 pub mod updater;
 pub mod window_chrome;
+pub mod window_material;
 
 use tracing::Span;
 use uc_platform::ports::observability::TraceMetadata;

--- a/src-tauri/crates/uc-tauri/src/commands/window_material.rs
+++ b/src-tauri/crates/uc-tauri/src/commands/window_material.rs
@@ -1,0 +1,32 @@
+//! `get_main_window_material` —— 前端拿主窗口当前实际生效的 DWM 材质。
+//!
+//! ## 为什么需要这个命令
+//!
+//! 主窗口透明背景 token 只有在 Mica 真的装上（Win 11 22H2+）时才该生效，
+//! 否则前端走透明 token → 用户看见的是桌面壁纸而不是应用 UI。Mica 是否成功
+//! 装配是 Rust 侧的运行期事实（依赖系统版本），前端无法自己判断，因此必须
+//! 通过这个 query 拿。
+//!
+//! 装配本身在 [`crate::run::configure_main_window_for_platform`] 里完成，
+//! 结果通过 `app.manage(MainWindowMaterial)` 共享；这个 command 只是把
+//! state 取出来回给 webview。
+
+use crate::commands::record_trace_fields;
+use crate::window_material::MainWindowMaterial;
+use tracing::{info_span, Instrument};
+use uc_platform::ports::observability::TraceMetadata;
+
+#[tauri::command]
+#[specta::specta]
+pub async fn get_main_window_material(
+    state: tauri::State<'_, MainWindowMaterial>,
+    _trace: Option<TraceMetadata>,
+) -> Result<MainWindowMaterial, crate::commands::CommandError> {
+    let span = info_span!(
+        "get_main_window_material",
+        trace_id = tracing::field::Empty,
+        trace_ts = tracing::field::Empty
+    );
+    record_trace_fields(&span, &_trace);
+    async move { Ok(*state) }.instrument(span).await
+}

--- a/src-tauri/crates/uc-tauri/src/lib.rs
+++ b/src-tauri/crates/uc-tauri/src/lib.rs
@@ -13,5 +13,6 @@ pub mod quick_panel;
 pub mod run;
 pub mod specta_builder;
 pub mod tray;
+pub mod window_material;
 
 pub use run::run;

--- a/src-tauri/crates/uc-tauri/src/run.rs
+++ b/src-tauri/crates/uc-tauri/src/run.rs
@@ -85,30 +85,25 @@ async fn wait_for_daemon_connection(
     }
 }
 
-#[cfg(target_os = "windows")]
 fn configure_main_window_for_platform(app: &tauri::AppHandle) {
     let Some(window) = app.get_webview_window("main") else {
-        warn!("Main window not found during Windows window configuration");
+        warn!("Main window not found during platform window configuration");
+        // `get_main_window_material` command 需要这个 state 存在才能响应；
+        // 拿不到 window 时按 `None` 兜底，等同于"没装材质"，前端走 opaque。
+        app.manage(crate::window_material::MainWindowMaterial::None);
         return;
     };
 
+    #[cfg(target_os = "windows")]
     if let Err(error) = window.set_decorations(false) {
         warn!(error = %error, "Failed to disable Windows main window decorations");
     }
 
-    // 装 Mica（仅 Win 11 22H2+ 会成功）。结果存进 app state 给前端查，决定
-    // background token 走透明还是 opaque。见 `window_material.rs` 头注。
+    // Windows: 装 Mica；macOS: tauri.conf 已装 hudWindow，这里只上报；
+    // Linux: 返回 None。结果存进 app state 给 `get_main_window_material`
+    // command 用。见 `window_material.rs` 头注。
     let material = crate::window_material::apply_to_main_window(&window);
     app.manage(material);
-}
-
-#[cfg(not(target_os = "windows"))]
-fn configure_main_window_for_platform(app: &tauri::AppHandle) {
-    // 非 Windows 也要 manage state，否则 `get_main_window_material` command
-    // 在 macOS / Linux 上拿不到 State 会 500。值固定为 `None`：macOS 走的是
-    // `windowEffects: ["hudWindow"]` 系统材质，前端不需要透明 token 切换；
-    // Linux 没有等价材质，保持现状 opaque。
-    app.manage(crate::window_material::MainWindowMaterial::None);
 }
 
 /// Builds the process runtime, starts background tasks and the in-process daemon as needed, and runs the Tauri event loop.

--- a/src-tauri/crates/uc-tauri/src/run.rs
+++ b/src-tauri/crates/uc-tauri/src/run.rs
@@ -95,10 +95,21 @@ fn configure_main_window_for_platform(app: &tauri::AppHandle) {
     if let Err(error) = window.set_decorations(false) {
         warn!(error = %error, "Failed to disable Windows main window decorations");
     }
+
+    // 装 Mica（仅 Win 11 22H2+ 会成功）。结果存进 app state 给前端查，决定
+    // background token 走透明还是 opaque。见 `window_material.rs` 头注。
+    let material = crate::window_material::apply_to_main_window(&window);
+    app.manage(material);
 }
 
 #[cfg(not(target_os = "windows"))]
-fn configure_main_window_for_platform(_app: &tauri::AppHandle) {}
+fn configure_main_window_for_platform(app: &tauri::AppHandle) {
+    // 非 Windows 也要 manage state，否则 `get_main_window_material` command
+    // 在 macOS / Linux 上拿不到 State 会 500。值固定为 `None`：macOS 走的是
+    // `windowEffects: ["hudWindow"]` 系统材质，前端不需要透明 token 切换；
+    // Linux 没有等价材质，保持现状 opaque。
+    app.manage(crate::window_material::MainWindowMaterial::None);
+}
 
 /// Builds the process runtime, starts background tasks and the in-process daemon as needed, and runs the Tauri event loop.
 ///

--- a/src-tauri/crates/uc-tauri/src/specta_builder.rs
+++ b/src-tauri/crates/uc-tauri/src/specta_builder.rs
@@ -93,5 +93,7 @@ pub fn build() -> Builder<tauri::Wry> {
             crate::commands::factory_reset::factory_reset_space,
             // ── window chrome (macOS traffic lights) ────────────────────────────
             crate::commands::window_chrome::set_traffic_light_position,
+            // ── window material (Windows Mica) ─────────────────────────────────
+            crate::commands::window_material::get_main_window_material,
         ])
 }

--- a/src-tauri/crates/uc-tauri/src/window_material.rs
+++ b/src-tauri/crates/uc-tauri/src/window_material.rs
@@ -1,0 +1,101 @@
+//! Windows 主窗口的 DWM 材质装配 + 状态查询。
+//!
+//! ## 为什么需要这个模块
+//!
+//! `tauri.conf.json` 的 `windowEffects: ["hudWindow"]` 是 macOS 专属字段（Tauri
+//! 在 Windows 下不读它）—— 结果就是 macOS 走 NSVisualEffectView 真透明，但
+//! Windows 端长期是不透明白底，与 macOS 主窗口并排放时有显眼的 native-vs-not
+//! 视觉差距。issue #699 / ship-readiness §D31 要求两端材质对齐。
+//!
+//! 我们用 `window-vibrancy` 0.6 仅装 Mica（Win 11 22H2+，build 22621+）。**不**
+//! 走 Acrylic 兜底：该 crate 自己警告 `apply_acrylic` 在 Win 10 v1903+ /
+//! Win 11 build 22000 上 resize/drag 时窗口卡顿（DWM 私有 API 的已知问题），
+//! 作为默认会把"白底"这点小事换成"拖动卡顿"这种新 bug。Win 10 / 早期 Win 11
+//! 保持原 opaque 行为，等后续做 settings 开关再让用户显式 opt-in Acrylic。
+//!
+//! ## 与前端的协议
+//!
+//! 装配结果通过 [`MainWindowMaterial`] state 暴露给 webview——前端 `main.tsx`
+//! 启动期调 [`crate::commands::window_material::get_main_window_material`]
+//! 命令拿状态，根据结果在 `<html>` 上设 `data-uc-window-material="mica" | "none"`，
+//! `globals.css` 据此切换 `--background` token 为透明 / 不透明。装失败 → 默认
+//! 不设 attr，CSS 走 opaque 路径，与现状完全一致（macOS / Linux 零回归）。
+//!
+//! ## 装配时机
+//!
+//! 必须在 `setup` callback 内、main window 已经存在但尚未被 `show()` 之前调
+//! [`apply_to_main_window`]：先装材质再 show，避免用户看到先白后透的闪烁。
+//! show/hide（hide-to-tray 路径）不会丢材质——DWM attribute 跟 HWND 走，所以
+//! 我们不需要在 `on_window_event` 里挂任何重新装配的逻辑。同理，active /
+//! inactive 的灰过渡也由 DWM 系统自动处理。
+
+use serde::Serialize;
+use specta::Type;
+
+/// 主窗口当前实际生效的 DWM 材质。
+///
+/// 这个 enum 是 Rust ↔ TypeScript 共享类型（specta 生成 binding），变体名直接
+/// 序列化成小写字符串，前端拿到的就是 `"mica"` / `"none"`。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Type)]
+#[serde(rename_all = "lowercase")]
+pub enum MainWindowMaterial {
+    /// Mica 装配成功（仅 Win 11 22H2+）。前端切到透明 background token。
+    Mica,
+    /// 未装材质：非 Windows，或 Mica 不可用（Win 10 / 早期 Win 11）。前端
+    /// 保持 opaque background。
+    None,
+}
+
+impl MainWindowMaterial {
+    /// 对应前端 CSS 的 `data-uc-window-material` attribute 值。
+    pub fn as_attr(self) -> &'static str {
+        match self {
+            Self::Mica => "mica",
+            Self::None => "none",
+        }
+    }
+}
+
+/// 进程级 main window 材质状态。setup 装完之后由 [`apply_to_main_window`]
+/// 写入；前端通过 specta command 读。Tauri 用 `tauri::State` 模式 share，
+/// 因为状态只在装配时写一次、之后只读，所以包一层 `std::sync::OnceLock` 不需要。
+/// 直接 `app.manage(MainWindowMaterial)` 由 Tauri 内部 Mutex 保护。
+pub type MainWindowMaterialState = MainWindowMaterial;
+
+/// 尝试为主窗口装 Mica，返回最终生效的材质。
+///
+/// 非 Windows / Win 10 / 早期 Win 11 → 返回 [`MainWindowMaterial::None`]，
+/// 调用方不需要做额外处理。失败时 `tracing::warn!` 记录原因，方便后续
+/// 核对实际命中率；这个失败是预期的（系统版本不够），不应该升级到 error。
+#[allow(unused_variables)] // window 在非 Windows 路径未使用
+pub fn apply_to_main_window(window: &tauri::WebviewWindow) -> MainWindowMaterial {
+    #[cfg(target_os = "windows")]
+    {
+        // dark=None 让 DWM 跟随系统外观偏好。我们前端的 light/dark 切换是
+        // CSS-driven 的，这里跟系统对齐就够了——如果用户系统是浅色，Mica
+        // 给浅色基色，反之亦然。如果将来前端要强制覆盖 dark 模式（而不
+        // 跟随系统），再考虑在 settings 改变时调 clear_mica → apply_mica。
+        match window_vibrancy::apply_mica(window, None) {
+            Ok(()) => {
+                tracing::info!("Mica window material applied to main window");
+                MainWindowMaterial::Mica
+            }
+            Err(error) => {
+                // 预期失败：Win 10、Win 11 22H2 之前、或运行在不支持的虚机里。
+                // 用 info 而不是 warn —— 这是常态，不是异常。
+                tracing::info!(
+                    error = %error,
+                    "Mica unavailable on this Windows version; main window stays opaque"
+                );
+                MainWindowMaterial::None
+            }
+        }
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        // macOS 走 tauri.conf 的 `windowEffects: ["hudWindow"]`（NSVisualEffectView）；
+        // Linux 没有等价系统材质。两边都不进这个函数。
+        MainWindowMaterial::None
+    }
+}

--- a/src-tauri/crates/uc-tauri/src/window_material.rs
+++ b/src-tauri/crates/uc-tauri/src/window_material.rs
@@ -1,48 +1,70 @@
-//! Windows 主窗口的 DWM 材质装配 + 状态查询。
+//! 主窗口系统材质装配 / 上报 + 状态查询。
 //!
 //! ## 为什么需要这个模块
 //!
-//! `tauri.conf.json` 的 `windowEffects: ["hudWindow"]` 是 macOS 专属字段（Tauri
-//! 在 Windows 下不读它）—— 结果就是 macOS 走 NSVisualEffectView 真透明，但
-//! Windows 端长期是不透明白底，与 macOS 主窗口并排放时有显眼的 native-vs-not
-//! 视觉差距。issue #699 / ship-readiness §D31 要求两端材质对齐。
+//! `tauri.conf.json` 配了 `windowEffects: ["hudWindow"]`（macOS 专属字段）+
+//! `transparent: true`，本意是让窗口透出 NSVisualEffectView——但前端
+//! `globals.css` 把 `html` 的 background 硬涂成 white、`body` 又走不透明的
+//! `--background` token，结果是 macOS 上 NSVisualEffectView 一直被完全遮住、
+//! 视觉无效；Windows 端则没有任何材质装配（windowEffects 不读）。两边事实上
+//! 都是白底，只是机制不同。
 //!
-//! 我们用 `window-vibrancy` 0.6 仅装 Mica（Win 11 22H2+，build 22621+）。**不**
-//! 走 Acrylic 兜底：该 crate 自己警告 `apply_acrylic` 在 Win 10 v1903+ /
+//! issue #699 / ship-readiness §D31 要求两端材质真正可见。修复思路是把
+//! "什么材质生效"作为运行期事实由后端报上来、前端据此切 background token
+//! 为透明，让底层材质透出来。
+//!
+//! ### Windows 侧
+//!
+//! 用 `window-vibrancy` 0.6 仅装 Mica（Win 11 22H2+，build 22621+）。**不**走
+//! Acrylic 兜底：该 crate 自己警告 `apply_acrylic` 在 Win 10 v1903+ /
 //! Win 11 build 22000 上 resize/drag 时窗口卡顿（DWM 私有 API 的已知问题），
 //! 作为默认会把"白底"这点小事换成"拖动卡顿"这种新 bug。Win 10 / 早期 Win 11
 //! 保持原 opaque 行为，等后续做 settings 开关再让用户显式 opt-in Acrylic。
+//!
+//! ### macOS 侧
+//!
+//! NSVisualEffectView 已经由 tauri.conf 的 `windowEffects: ["hudWindow"]` 装好，
+//! 不需要在 Rust 侧再调系统 API；本模块只负责"上报 Hud 已就绪"，让前端 CSS
+//! 跟 Mica 一样走透明 background。
+//!
+//! ### Linux 侧
+//!
+//! 没有等价系统材质，返回 [`MainWindowMaterial::None`]，前端走 opaque 兜底。
 //!
 //! ## 与前端的协议
 //!
 //! 装配结果通过 [`MainWindowMaterial`] state 暴露给 webview——前端 `main.tsx`
 //! 启动期调 [`crate::commands::window_material::get_main_window_material`]
-//! 命令拿状态，根据结果在 `<html>` 上设 `data-uc-window-material="mica" | "none"`，
-//! `globals.css` 据此切换 `--background` token 为透明 / 不透明。装失败 → 默认
-//! 不设 attr，CSS 走 opaque 路径，与现状完全一致（macOS / Linux 零回归）。
+//! 命令拿状态，根据结果在 `<html>` 上设 `data-uc-window-material="mica" | "hud" | "none"`，
+//! `globals.css` 据此切换 `--background` token 为透明 / 不透明。`mica` 与
+//! `hud` 在 CSS 层走同一组透明 token（视觉效果都是"系统模糊背景透出来"），
+//! `none` 保留 opaque，确保失败 / 不支持平台零回归。
 //!
 //! ## 装配时机
 //!
 //! 必须在 `setup` callback 内、main window 已经存在但尚未被 `show()` 之前调
 //! [`apply_to_main_window`]：先装材质再 show，避免用户看到先白后透的闪烁。
-//! show/hide（hide-to-tray 路径）不会丢材质——DWM attribute 跟 HWND 走，所以
-//! 我们不需要在 `on_window_event` 里挂任何重新装配的逻辑。同理，active /
-//! inactive 的灰过渡也由 DWM 系统自动处理。
+//! show/hide（hide-to-tray 路径）不会丢材质——DWM attribute / NSVisualEffectView
+//! 都跟窗口实例走，所以我们不需要在 `on_window_event` 里挂任何重新装配的逻辑。
+//! 同理，active / inactive 的灰过渡都由系统自动处理。
 
 use serde::Serialize;
 use specta::Type;
 
-/// 主窗口当前实际生效的 DWM 材质。
+/// 主窗口当前实际生效的系统材质。
 ///
 /// 这个 enum 是 Rust ↔ TypeScript 共享类型（specta 生成 binding），变体名直接
-/// 序列化成小写字符串，前端拿到的就是 `"mica"` / `"none"`。
+/// 序列化成小写字符串，前端拿到的就是 `"mica"` / `"hud"` / `"none"`。
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Type)]
 #[serde(rename_all = "lowercase")]
 pub enum MainWindowMaterial {
-    /// Mica 装配成功（仅 Win 11 22H2+）。前端切到透明 background token。
+    /// Windows 11 22H2+ 上 DWM Mica 装配成功。前端切到透明 background token。
     Mica,
-    /// 未装材质：非 Windows，或 Mica 不可用（Win 10 / 早期 Win 11）。前端
-    /// 保持 opaque background。
+    /// macOS NSVisualEffectView (`hudWindow`)。由 `tauri.conf.json` 在窗口
+    /// 创建时装好，Rust 侧只是上报。前端切到透明 background token。
+    Hud,
+    /// 未装材质：Linux，或 Windows 上 Mica 不可用（Win 10 / 早期 Win 11）。
+    /// 前端保持 opaque background，与历史行为一致。
     None,
 }
 
@@ -51,6 +73,7 @@ impl MainWindowMaterial {
     pub fn as_attr(self) -> &'static str {
         match self {
             Self::Mica => "mica",
+            Self::Hud => "hud",
             Self::None => "none",
         }
     }
@@ -62,11 +85,17 @@ impl MainWindowMaterial {
 /// 直接 `app.manage(MainWindowMaterial)` 由 Tauri 内部 Mutex 保护。
 pub type MainWindowMaterialState = MainWindowMaterial;
 
-/// 尝试为主窗口装 Mica，返回最终生效的材质。
+/// 主窗口系统材质的"装配 + 上报"统一入口。
 ///
-/// 非 Windows / Win 10 / 早期 Win 11 → 返回 [`MainWindowMaterial::None`]，
-/// 调用方不需要做额外处理。失败时 `tracing::warn!` 记录原因，方便后续
-/// 核对实际命中率；这个失败是预期的（系统版本不够），不应该升级到 error。
+/// - **Windows**：尝试装 Mica；成功返回 [`MainWindowMaterial::Mica`]，失败
+///   （Win 10 / 早期 Win 11）返回 [`MainWindowMaterial::None`]。
+/// - **macOS**：NSVisualEffectView 已经在 `tauri.conf.json` 的 `windowEffects:
+///   ["hudWindow"]` 里装好，本函数不调任何系统 API，只返回
+///   [`MainWindowMaterial::Hud`] 告诉前端"材质已就绪、可以走透明 token"。
+/// - **Linux**：没有等价系统材质，返回 [`MainWindowMaterial::None`]。
+///
+/// 调用方拿到结果后应该 `app.manage(...)` 让 `get_main_window_material`
+/// command 能读到。
 #[allow(unused_variables)] // window 在非 Windows 路径未使用
 pub fn apply_to_main_window(window: &tauri::WebviewWindow) -> MainWindowMaterial {
     #[cfg(target_os = "windows")]
@@ -92,10 +121,19 @@ pub fn apply_to_main_window(window: &tauri::WebviewWindow) -> MainWindowMaterial
         }
     }
 
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(target_os = "macos")]
     {
-        // macOS 走 tauri.conf 的 `windowEffects: ["hudWindow"]`（NSVisualEffectView）；
-        // Linux 没有等价系统材质。两边都不进这个函数。
+        // tauri.conf 里配的 `windowEffects: ["hudWindow"]` 在窗口创建时已经
+        // 装好 NSVisualEffectView，这里不需要再调系统 API。但需要把这一事实
+        // 上报给前端，否则前端走默认 opaque token 会把材质完全遮住——这是
+        // issue #699 引入这套机制前 macOS 上"hudWindow 一直没有视觉效果"
+        // 的根因。
+        MainWindowMaterial::Hud
+    }
+
+    #[cfg(not(any(target_os = "windows", target_os = "macos")))]
+    {
+        // Linux 没有等价的系统模糊背景；保持 opaque 与现状一致。
         MainWindowMaterial::None
     }
 }

--- a/src/__tests__/main.window-ui.test.ts
+++ b/src/__tests__/main.window-ui.test.ts
@@ -6,6 +6,7 @@ const mocks = vi.hoisted(() => {
   return {
     applyPlatformEffectPreferences: vi.fn(),
     applyPlatformTypographyScale: vi.fn(),
+    applyWindowMaterialFromBackend: vi.fn(() => Promise.resolve()),
     applyDeviceMetaToSentry: vi.fn(),
     attachConsole: vi.fn(() => Promise.resolve()),
     connectDaemonWs: vi.fn(() => Promise.resolve()),
@@ -39,6 +40,7 @@ vi.mock('@/lib/daemon-ws-bootstrap', () => ({
 vi.mock('@/lib/window-ui', () => ({
   applyPlatformEffectPreferences: mocks.applyPlatformEffectPreferences,
   applyPlatformTypographyScale: mocks.applyPlatformTypographyScale,
+  applyWindowMaterialFromBackend: mocks.applyWindowMaterialFromBackend,
   initializeWindowUi: mocks.initializeWindowUi,
 }))
 

--- a/src/api/runtime.ts
+++ b/src/api/runtime.ts
@@ -1,5 +1,5 @@
 import { commands } from '@/lib/ipc'
-import type { DeviceMeta as GeneratedDeviceMeta } from '@/lib/ipc'
+import type { DeviceMeta as GeneratedDeviceMeta, MainWindowMaterial } from '@/lib/ipc'
 
 export async function getDeviceId(): Promise<string> {
   return await commands.getDeviceId()
@@ -16,4 +16,10 @@ export type DeviceMeta = GeneratedDeviceMeta
 
 export async function getDeviceMeta(): Promise<DeviceMeta> {
   return await commands.getDeviceMeta()
+}
+
+export type { MainWindowMaterial }
+
+export async function getMainWindowMaterial(): Promise<MainWindowMaterial> {
+  return await commands.getMainWindowMaterial()
 }

--- a/src/lib/ipc-bindings.generated.ts
+++ b/src/lib/ipc-bindings.generated.ts
@@ -411,6 +411,10 @@ export const commands = {
 	trace_id: string,
 	timestamp: number,
 } | null) => typedError<null, string>(__TAURI_INVOKE("set_traffic_light_position", { offsetX, offsetY, trace })),
+	getMainWindowMaterial: (trace: {
+	trace_id: string,
+	timestamp: number,
+} | null) => typedError<MainWindowMaterial, CommandError>(__TAURI_INVOKE("get_main_window_material", { trace })),
 };
 
 /** Events */
@@ -590,6 +594,21 @@ export type LanInterfaceView = {
 	name: string,
 	ipv4: string,
 };
+
+/**
+ *  主窗口当前实际生效的 DWM 材质。
+ * 
+ *  这个 enum 是 Rust ↔ TypeScript 共享类型（specta 生成 binding），变体名直接
+ *  序列化成小写字符串，前端拿到的就是 `"mica"` / `"none"`。
+ */
+export type MainWindowMaterial = 
+/**  Mica 装配成功（仅 Win 11 22H2+）。前端切到透明 background token。 */
+"mica" | 
+/**
+ *  未装材质：非 Windows，或 Mica 不可用（Win 10 / 早期 Win 11）。前端
+ *  保持 opaque background。
+ */
+"none";
 
 /**
  *  `list_mobile_devices` 单条结果。来自 `MobileDeviceSummary`，不含

--- a/src/lib/ipc-bindings.generated.ts
+++ b/src/lib/ipc-bindings.generated.ts
@@ -596,17 +596,22 @@ export type LanInterfaceView = {
 };
 
 /**
- *  主窗口当前实际生效的 DWM 材质。
+ *  主窗口当前实际生效的系统材质。
  * 
  *  这个 enum 是 Rust ↔ TypeScript 共享类型（specta 生成 binding），变体名直接
- *  序列化成小写字符串，前端拿到的就是 `"mica"` / `"none"`。
+ *  序列化成小写字符串，前端拿到的就是 `"mica"` / `"hud"` / `"none"`。
  */
 export type MainWindowMaterial = 
-/**  Mica 装配成功（仅 Win 11 22H2+）。前端切到透明 background token。 */
+/**  Windows 11 22H2+ 上 DWM Mica 装配成功。前端切到透明 background token。 */
 "mica" | 
 /**
- *  未装材质：非 Windows，或 Mica 不可用（Win 10 / 早期 Win 11）。前端
- *  保持 opaque background。
+ *  macOS NSVisualEffectView (`hudWindow`)。由 `tauri.conf.json` 在窗口
+ *  创建时装好，Rust 侧只是上报。前端切到透明 background token。
+ */
+"hud" | 
+/**
+ *  未装材质：Linux，或 Windows 上 Mica 不可用（Win 10 / 早期 Win 11）。
+ *  前端保持 opaque background，与历史行为一致。
  */
 "none";
 

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -217,6 +217,7 @@ export type {
   FactoryResetResult,
   InstallKind,
   LanInterfaceView,
+  MainWindowMaterial,
   MobileDeviceView,
   MobileSyncError,
   MobileSyncSettingsViewDto,

--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -87,23 +87,27 @@ export const isLowEffectsEnabled = (): boolean =>
   typeof document !== 'undefined' && document.documentElement.dataset.ucLowEffects === 'true'
 
 /**
- * Windows 主窗口 DWM 材质状态 —— Rust 侧实际装配结果，由 webview 启动后
- * 通过 `commands.getMainWindowMaterial()` 异步取回，再 patch 到 `<html>`
- * 的 `data-uc-window-material` attribute 上。`globals.css` 据此决定
- * `--background` token 走透明还是 opaque：
+ * 主窗口当前实际生效的系统材质，与后端 `MainWindowMaterial` enum 同源。
+ * 不直接 import generated type 是为了避免 `platform.ts` 反向依赖 `@/lib/ipc`，
+ * 这里的 union 由 specta_export 测试保证两端 wire format 一致。
+ */
+export type WindowMaterial = 'mica' | 'hud' | 'none'
+
+/**
+ * 主窗口系统材质状态 —— Rust 侧通过 `commands.getMainWindowMaterial()` 异步
+ * 报告，写到 `<html>` 的 `data-uc-window-material`。`globals.css` 据此决定
+ * `--background`/`--sidebar`/`--card`/`--popover` 走透明还是 opaque：
  *
- *   `[data-uc-platform="windows"]` 默认 opaque（与现状一致）；
- *   `[data-uc-platform="windows"][data-uc-window-material="mica"]` 切透明。
+ *   `"mica"` (Win 11 22H2+) / `"hud"` (macOS NSVisualEffectView) → 透明，
+ *   让底层材质透出来；
+ *   `"none"` (Linux / Win 10 / 早期 Win 11 / 装配失败) → opaque 兜底。
  *
- * 这样 Win 10 / 早期 Win 11（Mica 装不上）不会出现"窗口先透明再变白"的
- * 反向闪烁；Win 11 22H2+ 会在装配完成后从 opaque 切到透明（短暂闪烁，
- * 方向是"看见内容 → 看见 Mica"，肉眼无感）。
- *
- * 非 Windows 平台 / material 为 'none' 时不设 attr（或显式设 'none'），
- * 不影响 macOS hudWindow / Linux opaque 的现有行为。
+ * 启动时先走 opaque（CSS 默认），invoke 拿到结果再 patch attribute —— Mica
+ * 装不上的情况下不会出现"先透明再变白"的反向闪烁；Mica/Hud 命中时是
+ * "看见内容 → 看见材质"的正向过渡，肉眼几乎无感。
  */
 export const applyWindowMaterial = (
-  material: 'mica' | 'none',
+  material: WindowMaterial,
   root: HTMLElement | null = typeof document === 'undefined' ? null : document.documentElement
 ): void => {
   if (!root) {

--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -85,3 +85,29 @@ export const applyPlatformEffectPreferences = (
 
 export const isLowEffectsEnabled = (): boolean =>
   typeof document !== 'undefined' && document.documentElement.dataset.ucLowEffects === 'true'
+
+/**
+ * Windows 主窗口 DWM 材质状态 —— Rust 侧实际装配结果，由 webview 启动后
+ * 通过 `commands.getMainWindowMaterial()` 异步取回，再 patch 到 `<html>`
+ * 的 `data-uc-window-material` attribute 上。`globals.css` 据此决定
+ * `--background` token 走透明还是 opaque：
+ *
+ *   `[data-uc-platform="windows"]` 默认 opaque（与现状一致）；
+ *   `[data-uc-platform="windows"][data-uc-window-material="mica"]` 切透明。
+ *
+ * 这样 Win 10 / 早期 Win 11（Mica 装不上）不会出现"窗口先透明再变白"的
+ * 反向闪烁；Win 11 22H2+ 会在装配完成后从 opaque 切到透明（短暂闪烁，
+ * 方向是"看见内容 → 看见 Mica"，肉眼无感）。
+ *
+ * 非 Windows 平台 / material 为 'none' 时不设 attr（或显式设 'none'），
+ * 不影响 macOS hudWindow / Linux opaque 的现有行为。
+ */
+export const applyWindowMaterial = (
+  material: 'mica' | 'none',
+  root: HTMLElement | null = typeof document === 'undefined' ? null : document.documentElement
+): void => {
+  if (!root) {
+    return
+  }
+  root.dataset.ucWindowMaterial = material
+}

--- a/src/lib/window-ui.ts
+++ b/src/lib/window-ui.ts
@@ -30,18 +30,14 @@ export const applyPlatformTypographyScale = () => {
 }
 
 /**
- * Windows 端：查 Rust 侧 Mica 装配结果并写 `data-uc-window-material`。
+ * 查 Rust 侧主窗口材质状态并写 `<html>` 的 `data-uc-window-material`。
  *
- * 非 Windows 直接 noop —— macOS 走 tauri.conf 的 `hudWindow`、Linux 没有
- * 等价材质，都不需要这个 attribute。失败时（Tauri runtime 未就绪 / IPC
- * 出错）静默走 opaque 兜底，与 issue #699 "Win10 旧版纯色背景" 行为一致。
+ * 后端按平台返回：Windows 装 Mica → `'mica'` 或 `'none'`；macOS 上报
+ * hudWindow → `'hud'`；Linux → `'none'`。前端无条件 invoke，让后端做平台
+ * 判断 —— 失败时（Tauri runtime 未就绪 / IPC 出错）静默走 opaque 兜底。
  */
 export const applyWindowMaterialFromBackend = async (): Promise<void> => {
   if (typeof document === 'undefined') {
-    return
-  }
-  const { isWindows } = detectPlatformInfo()
-  if (!isWindows) {
     return
   }
   try {

--- a/src/lib/window-ui.ts
+++ b/src/lib/window-ui.ts
@@ -1,4 +1,9 @@
-import { applyPlatformEffectPreferences, detectPlatformInfo } from '@/lib/platform'
+import { getMainWindowMaterial } from '@/api/runtime'
+import {
+  applyPlatformEffectPreferences,
+  applyWindowMaterial,
+  detectPlatformInfo,
+} from '@/lib/platform'
 import { initializeUiScale } from '@/lib/ui-scale'
 
 export { applyPlatformEffectPreferences } from '@/lib/platform'
@@ -22,6 +27,29 @@ export const applyPlatformTypographyScale = () => {
   root.style.setProperty('--font-size-body-lg', '0.875rem') /* 14px */
   root.style.setProperty('--font-size-section', '0.9375rem') /* 15px */
   root.style.setProperty('--font-size-title', '1.125rem') /* 18px */
+}
+
+/**
+ * Windows 端：查 Rust 侧 Mica 装配结果并写 `data-uc-window-material`。
+ *
+ * 非 Windows 直接 noop —— macOS 走 tauri.conf 的 `hudWindow`、Linux 没有
+ * 等价材质，都不需要这个 attribute。失败时（Tauri runtime 未就绪 / IPC
+ * 出错）静默走 opaque 兜底，与 issue #699 "Win10 旧版纯色背景" 行为一致。
+ */
+export const applyWindowMaterialFromBackend = async (): Promise<void> => {
+  if (typeof document === 'undefined') {
+    return
+  }
+  const { isWindows } = detectPlatformInfo()
+  if (!isWindows) {
+    return
+  }
+  try {
+    const material = await getMainWindowMaterial()
+    applyWindowMaterial(material)
+  } catch (err) {
+    console.warn('[window-ui] failed to fetch window material from backend:', err)
+  }
 }
 
 export const initializeWindowUi = (): (() => void) => {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,7 +5,7 @@ import { Provider } from 'react-redux'
 import './i18n'
 import { getDeviceMeta } from '@/api/runtime'
 import { connectDaemonWs, registerDaemonShutdownListener } from '@/lib/daemon-ws-bootstrap'
-import { initializeWindowUi } from '@/lib/window-ui'
+import { applyWindowMaterialFromBackend, initializeWindowUi } from '@/lib/window-ui'
 import { applyDeviceMetaToSentry, initSentry, Sentry } from '@/observability/sentry'
 import App from './App'
 import { store } from './store'
@@ -63,6 +63,13 @@ if (typeof window !== 'undefined') {
 }
 
 initializeWindowUi()
+
+// Windows-only: 异步从 Rust 拉 Mica 装配结果，patch 到 `<html>` 的
+// `data-uc-window-material` 让 `globals.css` 决定 background 走透明还是 opaque。
+// 与 `getDeviceMeta` 同模式 —— fire-and-forget，失败不阻塞渲染。
+applyWindowMaterialFromBackend().catch(err => {
+  console.warn('[main] window material setup failed:', err)
+})
 
 // 初始化日志系统：将后端日志输出到浏览器 DevTools
 const initLogging = async () => {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -429,30 +429,35 @@ html[data-uc-low-effects='true']::view-transition-new(root) {
   animation: none !important;
 }
 
-/* Windows DWM Mica（issue #699 / ship-readiness §D31）：Rust 侧 `apply_to_main_window`
-   装上 Mica 后，前端 `applyWindowMaterialFromBackend` 把 `data-uc-window-material="mica"`
-   写到 `<html>`。此时整个 webview 与窗口的 background 必须能"让光透过去"，
-   否则 Mica 被遮盖。Win10 / 早期 Win11 装不上 Mica 时 attribute 为 'none' 或缺省，
-   走默认 opaque 路径，与现状完全一致。 */
-html[data-uc-window-material='mica'] {
+/* 系统材质透出（issue #699 / ship-readiness §D31）：Rust 侧 `apply_to_main_window`
+   报告 Windows Mica 或 macOS hudWindow 已就绪后，前端 `applyWindowMaterialFromBackend`
+   把 `data-uc-window-material="mica" | "hud"` 写到 `<html>`。此时整个 webview
+   的 background 必须能"让光透过去"，否则 NSVisualEffectView / DWM Mica 被遮盖
+   (issue 之前 macOS 上配了 `windowEffects: ["hudWindow"]` 但视觉完全无效就是
+   这个原因)。Linux / Win10 / 早期 Win11 / 装配失败时 attribute 为 'none' 或缺省，
+   走默认 opaque 路径与现状一致。 */
+html[data-uc-window-material='mica'],
+html[data-uc-window-material='hud'] {
   background-color: transparent;
   --background: transparent;
   --sidebar: transparent;
-  /* 卡片 / popover 仍保持高 opacity，否则文本对比度不足 —— Win11 Settings
-     app 自身的 surface 大致也是 80%+ opacity 叠在 Mica 上。 */
+  /* 卡片 / popover 仍保持高 opacity，否则文本对比度不足 —— Win11 Settings app
+     与 macOS 系统 UI 自身的 surface 大致都是 70%+ opacity 叠在材质上。 */
   --card: oklch(1 0 0 / 0.7);
   --popover: oklch(1 0 0 / 0.92);
 }
 
-html[data-uc-window-material='mica'].dark {
+html[data-uc-window-material='mica'].dark,
+html[data-uc-window-material='hud'].dark {
   --card: oklch(0.205 0 0 / 0.7);
   --popover: oklch(0.205 0 0 / 0.92);
 }
 
 /* 兜底 React `.dark` class 还未挂上前的瞬间 —— html 默认 white / zinc-950
-   会遮住 Mica。 */
+   会遮住底层材质。 */
 @media (prefers-color-scheme: dark) {
-  html[data-uc-window-material='mica'] {
+  html[data-uc-window-material='mica'],
+  html[data-uc-window-material='hud'] {
     background-color: transparent;
   }
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -429,6 +429,34 @@ html[data-uc-low-effects='true']::view-transition-new(root) {
   animation: none !important;
 }
 
+/* Windows DWM Mica（issue #699 / ship-readiness §D31）：Rust 侧 `apply_to_main_window`
+   装上 Mica 后，前端 `applyWindowMaterialFromBackend` 把 `data-uc-window-material="mica"`
+   写到 `<html>`。此时整个 webview 与窗口的 background 必须能"让光透过去"，
+   否则 Mica 被遮盖。Win10 / 早期 Win11 装不上 Mica 时 attribute 为 'none' 或缺省，
+   走默认 opaque 路径，与现状完全一致。 */
+html[data-uc-window-material='mica'] {
+  background-color: transparent;
+  --background: transparent;
+  --sidebar: transparent;
+  /* 卡片 / popover 仍保持高 opacity，否则文本对比度不足 —— Win11 Settings
+     app 自身的 surface 大致也是 80%+ opacity 叠在 Mica 上。 */
+  --card: oklch(1 0 0 / 0.7);
+  --popover: oklch(1 0 0 / 0.92);
+}
+
+html[data-uc-window-material='mica'].dark {
+  --card: oklch(0.205 0 0 / 0.7);
+  --popover: oklch(0.205 0 0 / 0.92);
+}
+
+/* 兜底 React `.dark` class 还未挂上前的瞬间 —— html 默认 white / zinc-950
+   会遮住 Mica。 */
+@media (prefers-color-scheme: dark) {
+  html[data-uc-window-material='mica'] {
+    background-color: transparent;
+  }
+}
+
 @layer base {
   html,
   body,


### PR DESCRIPTION
## Summary
- Closes #699 —— Windows 主窗口启用 DWM Mica，让背景与 macOS hudWindow 视觉对齐
- Rust 侧用 `window-vibrancy` 0.6 装 Mica（Win 11 22H2+），装不上保持 opaque
- 前端 `<html>` 拿到 `data-uc-window-material="mica"` 时切 `--background`/`--sidebar` 透明、`--card`/`--popover` 半透明（light + dark 各一套）

## 与 issue 提议的偏差

issue 建议 Win 11 22H2+ Mica / 旧版 Acrylic / Win 10 纯色三级 fallback。本 PR **只装 Mica**，跳过 Acrylic 兜底：

`window-vibrancy` 0.6 的 `apply_acrylic` 文档明确警告"在 Win10 1903+ / Win11 22000 上 resize/drag 时窗口卡顿"（DWM 私有 API 已知问题，MS 大概不会修）。作为默认会把"白底"换成"拖动卡顿"——是新 bug、不是改进。issue 自己也说"Win 10 旧版纯色背景（不强行 blur，避免性能问题）"，所以早期 Win11 也按这个原则一起降级到 opaque。

Acrylic 留给后续 settings 开关让用户显式 opt-in（issue 已经标了"可让用户在 Settings 关"，反过来做 opt-in 是同一思路的实现）。

## 实现

### Rust 侧（commit 1）
- `src-tauri/crates/uc-tauri/Cargo.toml` `[target.'cfg(target_os = "windows")']` 加 `window-vibrancy = "0.6"`（之前已是 transitive，promote 不引入新 crate）
- `src-tauri/crates/uc-tauri/src/window_material.rs` 新建：`MainWindowMaterial { Mica, None }` enum + `apply_to_main_window(window)`
- `src-tauri/crates/uc-tauri/src/commands/window_material.rs` 新建：`get_main_window_material` specta command
- `src-tauri/crates/uc-tauri/src/run.rs` `configure_main_window_for_platform` 装 Mica 后 `app.manage(MainWindowMaterial)`；非 Windows 也 manage `None`，避免 macOS/Linux 上前端 invoke 时 state 不存在 500
- DWM active/inactive 灰过渡系统自动处理；hide-to-tray re-show 不会丢材质（attribute 跟 HWND 走），不需要重新装

### Frontend（commit 2）
- `src/api/runtime.ts` `getMainWindowMaterial()` wrapper
- `src/lib/platform.ts` `applyWindowMaterial(material, root)` 写 `<html>` 的 `data-uc-window-material`
- `src/lib/window-ui.ts` `applyWindowMaterialFromBackend()`（仅 Windows）异步查后端、patch dataset；失败静默兜底
- `src/main.tsx` fire-and-forget 调用（与 `getDeviceMeta` 同模式）
- `src/styles/globals.css` 加 `html[data-uc-window-material='mica']` selector + dark 变体；CSS 默认走 opaque，等 Mica 装配确认后才切透明，避免反向闪烁
- `src/lib/ipc-bindings.generated.ts` specta 重新跑后自动 regen

## Test plan

本地已跑：
- [x] `cargo check -p uc-tauri` macOS 通过
- [x] `cargo test -p uc-tauri` —— 34 unit + 1 specta_export integration 全过
- [x] `bunx tsc --noEmit` 通过
- [x] `bunx vitest run` —— 477 tests 全过
- [x] Cargo.lock diff 干净：仅 promote `window-vibrancy` 成 uc-tauri 直接 dep（无新 crate）

待验证：
- [ ] CI Windows MSVC 编译（本地无 toolchain）
- [ ] Windows peer 实测：Win 11 22H2+ 上 Mica 是否如期生效；Win 10 上 Mica 装不上时保持原 opaque 行为
- [ ] active/inactive 灰过渡视觉（DWM 自处理）

## 不在此 PR 范围
- 用户可见的 settings 开关让用户切换 Mica/Acrylic/None
- quick panel 窗口的材质对齐
- macOS 侧任何改动（cfg gated，与 macOS 路径零交集）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Windows Mica material support for enhanced visual integration with the desktop window manager, providing a modern frosted glass appearance on Windows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/UniClipboard/UniClipboard/pull/791?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->