### PR TITLE
feat(packaging): support AUR uniclipboard-git build and auto-publish workflow

### DIFF
--- a/.github/workflows/aur.yml
+++ b/.github/workflows/aur.yml
@@ -88,9 +88,47 @@ jobs:
           # 在 ssh load 阶段触发 "invalid format"。printf 行为可预测。
           printf '%s\n' "$AUR_SSH_PRIVATE_KEY" > /home/builder/.ssh/aur
           chmod 600 /home/builder/.ssh/aur
-          # ssh-keyscan 提前 pin host key —— 跳过 "yes/no" 交互的同时防止 MITM。
-          # AUR 的 host key 长期稳定，pin 一次比 StrictHostKeyChecking=no 安全。
-          ssh-keyscan -H aur.archlinux.org > /home/builder/.ssh/known_hosts 2>/dev/null
+
+          # Host key pinning：
+          # ssh-keyscan 本身是 TOFU——它接受 scan 那一刻路径上拿到的任何 key，
+          # 包括 MITM 注入的 key。仅 keyscan 不算"防 MITM"。
+          # 真正的信任锚需要带外验证：把 AUR 官方公布的 host key fingerprint
+          # 存进 GH repository variable `AUR_HOST_FINGERPRINTS`（多算法用逗号
+          # 分隔，至少含 ed25519，格式 "SHA256:..."），来源：
+          #   https://wiki.archlinux.org/title/AUR_submission_guidelines
+          # 已配置 → scan 后比对，对不上 fail-fast（MITM 或 AUR 轮换了 key）。
+          # 未配置 → 退化为 keyscan + warning，保留首次部署可跑通。
+          ssh-keyscan -H aur.archlinux.org > /tmp/aur_known_hosts 2>/dev/null
+          EXPECTED_FPS='${{ vars.AUR_HOST_FINGERPRINTS }}'
+          if [ -n "$EXPECTED_FPS" ]; then
+            SCANNED_FPS=$(ssh-keygen -lf /tmp/aur_known_hosts | awk '{print $2}' | sort -u)
+            echo "Scanned fingerprints:"
+            printf '  %s\n' $SCANNED_FPS
+            MATCH=false
+            IFS=',' read -ra EXP_LIST <<< "$EXPECTED_FPS"
+            for fp in "${EXP_LIST[@]}"; do
+              fp="${fp// /}"
+              [ -z "$fp" ] && continue
+              if printf '%s\n' "$SCANNED_FPS" | grep -qxF "$fp"; then
+                echo "Matched pinned fingerprint: $fp"
+                MATCH=true
+              fi
+            done
+            if [ "$MATCH" != "true" ]; then
+              echo "::error::AUR host key fingerprint mismatch — possible MITM or AUR rotated its host key."
+              echo "::error::Expected one of: $EXPECTED_FPS"
+              echo "::error::Got: $(printf '%s,' $SCANNED_FPS)"
+              echo "::error::Verify via https://wiki.archlinux.org/title/AUR_submission_guidelines"
+              echo "::error::and update the AUR_HOST_FINGERPRINTS repo variable if AUR legitimately rotated."
+              exit 1
+            fi
+          else
+            echo "::warning::AUR_HOST_FINGERPRINTS repo variable not set — using TOFU keyscan."
+            echo "::warning::To pin, run: gh variable set AUR_HOST_FINGERPRINTS --body 'SHA256:...,SHA256:...'"
+            echo "::warning::Source the fingerprints from https://wiki.archlinux.org/title/AUR_submission_guidelines"
+          fi
+          cp /tmp/aur_known_hosts /home/builder/.ssh/known_hosts
+
           cat > /home/builder/.ssh/config <<'EOF'
           Host aur.archlinux.org
             IdentityFile ~/.ssh/aur

--- a/.github/workflows/aur.yml
+++ b/.github/workflows/aur.yml
@@ -1,0 +1,187 @@
+name: 'Publish to AUR (uniclipboard-git)'
+run-name: "aur-git-${{ github.run_number }}"
+
+# 触发场景：
+#   1. push to main 且影响 PKGBUILD 模板或本 workflow —— 这是主路径，确保
+#      AUR 上的 PKGBUILD 与仓库内 source of truth 同步。
+#   2. workflow_dispatch —— 手动重跑（比如想用某个分支的 PKGBUILD 验证 .SRCINFO
+#      生成、或在 AUR_SSH_PRIVATE_KEY rotated 后立即触发一次推送）。
+#
+# 不绑 release published：-git 包按定义追踪 main HEAD，pkgver 由 makepkg 在
+# 用户机器上从 git describe 重算，release 事件并不是它的"心跳"信号。强行绑
+# release 反而会在每个 alpha tag 引入无意义的空 commit（PKGBUILD 没变 + pkgver
+# 由 sed 替换后可能也没变）。
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'packaging/aur/uniclipboard-git/**'
+      - '.github/workflows/aur.yml'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: '只生成 PKGBUILD/.SRCINFO 作为 artifact，不 push 到 AUR'
+        required: false
+        type: boolean
+        default: false
+
+# AUR 是单分支 git remote，并发 push 会互踩。串行执行；cancel-in-progress=false
+# 让前一次跑完再排队，避免半道丢失 commit。
+concurrency:
+  group: aur-uniclipboard-git
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Sync PKGBUILD to AUR
+    runs-on: ubuntu-latest
+    # base-devel 已含 makepkg、namcap 依赖的 pacman 工具链。git/openssh 需要单装。
+    container: archlinux:base-devel
+    permissions:
+      contents: read
+    steps:
+      - name: Install runtime tools
+        shell: bash
+        run: |
+          # --needed 避免 base-devel 镜像里已有的包重装；-Sy 刷一次 db 即可，
+          # 不要 -Syu —— Arch partial upgrade 官方不支持，容器跑一次 full upgrade
+          # 在 GH runner 上要 2-3 min 且大概率因为 keyring 不同步报错。
+          pacman -Sy --noconfirm --needed git openssh sudo namcap
+
+      - name: Configure non-root builder user
+        shell: bash
+        run: |
+          # makepkg 拒绝 root 运行（保护 user，不让构建脚本以 root 写满文件系统）。
+          # 必须建一个普通用户跑 makepkg --printsrcinfo。NOPASSWD sudo 仅在 CI
+          # 一次性容器内有效，不会泄漏到 host。
+          useradd -m -G wheel -s /bin/bash builder
+          echo 'builder ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers.d/builder
+          chmod 440 /etc/sudoers.d/builder
+
+      - uses: actions/checkout@v4
+        with:
+          path: src
+
+      - name: Validate PKGBUILD with namcap
+        shell: bash
+        run: |
+          # 静态 lint：未声明的 depends、SPDX license 不规范、字段拼写错误等。
+          # namcap 对 PKGBUILD 阶段只能给 warning（看不到实际产物），但 fail-fast
+          # 抓 typo 还是值得的。这里不 fail on warning —— 有些条目（比如
+          # AGPL-3.0-only SPDX）namcap 老版本会误报。
+          namcap src/packaging/aur/uniclipboard-git/PKGBUILD || true
+
+      - name: Setup SSH for AUR
+        env:
+          AUR_SSH_PRIVATE_KEY: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+        shell: bash
+        run: |
+          if [ -z "${AUR_SSH_PRIVATE_KEY:-}" ]; then
+            echo "::error::AUR_SSH_PRIVATE_KEY secret missing."
+            echo "::error::Generate with: ssh-keygen -t ed25519 -C aur-uniclipboard -f aur"
+            echo "::error::Then upload aur.pub at https://aur.archlinux.org/account/<user>/edit/"
+            echo "::error::And put the private key (aur) into repo secret AUR_SSH_PRIVATE_KEY."
+            exit 1
+          fi
+          install -d -m700 -o builder -g builder /home/builder/.ssh
+          # printf '%s\n' 而不是 echo —— echo 在 ed25519 末尾换行处理诡异，曾
+          # 在 ssh load 阶段触发 "invalid format"。printf 行为可预测。
+          printf '%s\n' "$AUR_SSH_PRIVATE_KEY" > /home/builder/.ssh/aur
+          chmod 600 /home/builder/.ssh/aur
+          # ssh-keyscan 提前 pin host key —— 跳过 "yes/no" 交互的同时防止 MITM。
+          # AUR 的 host key 长期稳定，pin 一次比 StrictHostKeyChecking=no 安全。
+          ssh-keyscan -H aur.archlinux.org > /home/builder/.ssh/known_hosts 2>/dev/null
+          cat > /home/builder/.ssh/config <<'EOF'
+          Host aur.archlinux.org
+            IdentityFile ~/.ssh/aur
+            User aur
+            IdentitiesOnly yes
+          EOF
+          chown -R builder:builder /home/builder/.ssh
+
+      - name: Clone AUR repository
+        shell: bash
+        run: |
+          # AUR 的设计：clone 一个未注册的包名会成功（拿到空 repo），首次 push
+          # 时后端校验 PKGBUILD 并注册新包名。所以 clone 失败 = SSH 配置或账号问题，
+          # 不是"包名未注册"。直接 fail-fast。
+          sudo -u builder git clone ssh://aur@aur.archlinux.org/uniclipboard-git.git /home/builder/aur
+
+      - name: Render PKGBUILD with current pkgver snapshot
+        shell: bash
+        run: |
+          cd src
+          # git describe 输出形如 v0.10.1-alpha.2-3-g1234567，经 sed 变成
+          # 0.10.1.alpha.2.r3.g1234567，与 PKGBUILD 内 pkgver() 函数算法一致。
+          # CI 这步只更新 web 视图，用户 makepkg 时仍以 pkgver() 重算为准。
+          PKGVER=$(git describe --long --tags --abbrev=7 2>/dev/null \
+            | sed 's/^v//; s/\([^-]*-g\)/r\1/; s/-/./g' \
+            || printf "0.0.0.r%s.g%s" \
+                 "$(git rev-list --count HEAD)" \
+                 "$(git rev-parse --short=7 HEAD)")
+          echo "Computed pkgver=$PKGVER"
+          echo "PKGVER=$PKGVER" >> "$GITHUB_ENV"
+
+          install -m644 -o builder -g builder \
+            packaging/aur/uniclipboard-git/PKGBUILD /home/builder/aur/PKGBUILD
+          # sed 替换 pkgver= 那一行；用 # 作分隔符避免 $PKGVER 内任何 / 干扰。
+          sudo -u builder sed -i "s#^pkgver=.*#pkgver=$PKGVER#" /home/builder/aur/PKGBUILD
+
+      - name: Generate .SRCINFO
+        shell: bash
+        run: |
+          cd /home/builder/aur
+          # .SRCINFO 是 AUR web 索引读取的元数据；必须每次 PKGBUILD 变化时同步重生成。
+          sudo -u builder bash -c 'makepkg --printsrcinfo > .SRCINFO'
+
+      - name: Diff against AUR remote
+        id: diff
+        shell: bash
+        run: |
+          cd /home/builder/aur
+          sudo -u builder git config user.email "aur@uniclipboard.app"
+          sudo -u builder git config user.name "UniClipboard Bot"
+          sudo -u builder git add PKGBUILD .SRCINFO
+          if sudo -u builder git diff --cached --quiet; then
+            echo "No changes to push."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "=== staged diff ==="
+            sudo -u builder git --no-pager diff --cached
+            COMMIT_MSG="chore: sync from upstream main @ ${GITHUB_SHA::7} (pkgver=$PKGVER)"
+            sudo -u builder git commit -m "$COMMIT_MSG"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Push to AUR
+        if: ${{ steps.diff.outputs.changed == 'true' && inputs.dry_run != true }}
+        shell: bash
+        run: |
+          cd /home/builder/aur
+          # AUR 默认分支是 master（旧 git 默认），不要写 main。
+          sudo -u builder git push origin HEAD:master
+
+      - name: Upload rendered artifacts
+        # 不管推没推都上传，方便人工 review / dry_run 时下载。
+        uses: actions/upload-artifact@v4
+        with:
+          name: aur-uniclipboard-git
+          path: |
+            /home/builder/aur/PKGBUILD
+            /home/builder/aur/.SRCINFO
+          retention-days: 14
+          if-no-files-found: error
+
+      - name: Summary
+        shell: bash
+        run: |
+          {
+            echo "## AUR sync — uniclipboard-git :package:"
+            echo ""
+            echo "- **pkgver**: \`${PKGVER}\`"
+            echo "- **Source commit**: \`${GITHUB_SHA::7}\`"
+            echo "- **Changed**: ${{ steps.diff.outputs.changed }}"
+            echo "- **Pushed**: ${{ steps.diff.outputs.changed == 'true' && inputs.dry_run != true }}"
+            echo ""
+            echo "AUR page: https://aur.archlinux.org/packages/uniclipboard-git"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/packaging/AUR.md
+++ b/docs/packaging/AUR.md
@@ -1,0 +1,249 @@
+# AUR Packaging Plan for UniClipboard (Desktop)
+
+> Status:
+> - `uniclipboard-git` — **implemented** (2026-05-19). PKGBUILD lives at `packaging/aur/uniclipboard-git/PKGBUILD`; CI at `.github/workflows/aur.yml` syncs it to AUR on every relevant push.
+> - `uniclipboard` (stable source) — still planning, blocked on `v0.10.1` stable tag (§5).
+> - `uniclipboard-bin` — co-maintainer outreach to czyt (§10), no upstream-controlled PKGBUILD yet.
+>
+> Snapshot taken: 2026-05-19.
+> Target repo: this one (the desktop client at `github.com/UniClipboard/UniClipboard`).
+
+## 1. Background
+
+The UniClipboard desktop client ships `.deb` artifacts on GitHub releases (currently v0.10.0). On the Arch User Repository (AUR), a third-party packager `czyt` has been publishing `uniclipboard-bin`, which simply repackages our `.deb` releases. The upstream team (us) has no official presence on AUR.
+
+Goal of this doc: establish an official AUR presence under the upstream's control, without antagonizing the existing volunteer packager.
+
+## 2. Current AUR State
+
+| Package | Maintainer | Last update | Source |
+|---|---|---|---|
+| `uniclipboard-bin` | czyt | 2026-05-17 | repackages our `.deb` from GitHub releases |
+| `uniclipboard` | (vacant) | — | — |
+| `uniclipboard-git` | (vacant) | — | — |
+
+czyt's current PKGBUILD is clean: only downloads our official `.deb`, SHA256-verified, no install scripts, no sudo/suid, no extra network calls. czyt maintains 26 `-bin`-style packages overall — a typical Chinese-community AUR volunteer, not a malicious actor. Structural risk: a single compromised AUR account would affect all 26 packages simultaneously.
+
+## 3. Goals (priority order)
+
+1. **Claim the `uniclipboard` name.** Prevent squatting; create a clearly-official install path.
+2. **Add `uniclipboard-git` for development builds.** Standard practice for any non-trivial Arch project.
+3. **Become co-maintainer of `uniclipboard-bin`** without taking it over from czyt. Earns push access for emergencies (CVE, supply-chain incident) while preserving his active maintenance.
+4. **Sign release artifacts** so all three packages (including czyt's `-bin`) can eventually verify upstream signatures.
+
+## 4. Recommended Path
+
+Execute in this order:
+
+1. ~~**(15 min) Register official AUR account** and push `uniclipboard-git` to claim the name.~~ **Done 2026-05-19** — account registered; PKGBUILD + CI implemented (§6). First push happens automatically once `AUR_SSH_PRIVATE_KEY` secret is added and the workflow is triggered.
+2. **(5 min) Email czyt** requesting co-maintainer on `uniclipboard-bin` (template in §10).
+3. **(blocked on `v0.10.1` stable) Push `uniclipboard`** source-build package targeting the next non-alpha tag. Decided 2026-05-19 to wait rather than backfill `v0.10.0` — keeps the AUR repo aligned with the active release branch and avoids a same-week version bump. Until then, Arch users on stable either use `uniclipboard-bin` (czyt) or `uniclipboard-git`.
+4. **(next release pipeline change) Add `minisign` or `cosign` signatures** to GitHub release artifacts; publish the public key fingerprint in `SECURITY.md` and release notes.
+5. **(after signing lands) Update all three PKGBUILDs** to verify the signature. Coordinate the `-bin` update with czyt.
+
+## 5. Repo Facts (filled 2026-05-19 — verify before each push)
+
+These were collected by scanning the repo on 2026-05-19. The PKGBUILDs in §6/§7 already consume these values. Re-check anything marked **HUMAN** before pushing.
+
+### Build & runtime
+- [x] **Tech stack:** Tauri 2.11 + React 19 + TypeScript + Tailwind 4 (`src-tauri/Cargo.toml:136`, `package.json:92,113`).
+- [x] **Build command:** `bun run tauri build` (`.github/workflows/build.yml:268-269`).
+- [x] **Package manager:** **bun** (not pnpm). Lockfile is `bun.lock`. The `bun` package is in Arch `extra`.
+- [x] **`makedepends`:** `git rust nodejs bun pkgconf`. No `openssl-sys`/`libsqlite3-sys`-style sys crates spotted in workspace deps.
+- [x] **`depends`:** `webkit2gtk-4.1 gtk3 libayatana-appindicator libnotify` (mapped from `src-tauri/tauri.conf.json:48-54` .deb runtime deps).
+- [x] **Arches:** `x86_64 aarch64`. CI builds both for Linux (`.github/workflows/build.yml:71-86`).
+- [ ] **Minimum glibc:** **HUMAN** — CI builds in `debian:bookworm` (glibc 2.36) but no documented floor. Arch ships glibc ≥ 2.39, so practically a non-issue.
+
+### Distribution
+- [x] **License:** `AGPL-3.0-only` (`LICENSE` header; `src-tauri/Cargo.toml:4`). **Note:** the initial skeleton placeholder said MIT — that was wrong; §6/§7 are now corrected.
+- [x] **Release artifacts:** `.deb`, `.rpm`, `.AppImage` (Linux); `.dmg` (macOS); `.msi`/`.exe` (Windows). No upstream source tarball published — the `uniclipboard` AUR package pulls GitHub's auto-generated `archive/refs/tags/v$VER.tar.gz`.
+- [x] **Signatures:** Tauri **updater** already signs payloads with minisign (pubkey embedded at `src-tauri/tauri.conf.json:64`). **But** that key signs the in-app update bundle, not the release tarball or .deb — §11 (release-artifact signing) is still required for PKGBUILD-side verification.
+- [x] **Tag format:** `v$VERSION` (e.g. `v0.10.0`, `v0.10.1-alpha.1`). v-prefixed.
+- [x] **systemd user service:** none. App runs as a normal GUI process started by the user.
+- [x] **Desktop integration:** generic `.desktop` file lives at `packaging/linux/uniclipboard.desktop` (created 2026-05-19, content forked from `snap/local/uniclipboard.desktop`). Icons come from `src-tauri/icons/` (32/64/128/128@2x); PKGBUILD renames them into hicolor `apps/uniclipboard.png` at install. The two `.desktop` files (snap and packaging/linux) are independent copies for now — consolidate later if either drifts.
+- [x] **Config / data paths (Linux):** `$XDG_DATA_HOME/app.uniclipboard.desktop/` + `$XDG_CACHE_HOME/app.uniclipboard.desktop/` (`src-tauri/crates/uc-platform/src/app_dirs.rs:92-99`). Note the unusual `app.uniclipboard.desktop` dir name — matters for any future uninstall hook.
+
+### Project metadata
+- [x] **Homepage:** `https://www.uniclipboard.app` (confirmed in README).
+- [x] **Bug tracker:** `https://github.com/UniClipboard/UniClipboard/issues`.
+- [x] **Binary name:** `uniclipboard` (`src-tauri/Cargo.toml:2`). Product name `UniClipboard` is display-only.
+- [x] **AUR account:** **`uniclipboard`** — `aur@uniclipboard.app` (registered 2026-05-19). Org-owned, not tied to a personal AUR identity, so continuity survives maintainer turnover.
+
+### Version target for the `uniclipboard` (stable) AUR package
+- Latest stable tag: **`v0.10.0`**. Repo is currently at `0.10.1-alpha.1` (commit `9e76963c`).
+- `uniclipboard-git`: tracks `main`, version computed from `git describe`. Safe to push now.
+- `uniclipboard` (stable): **blocked on `v0.10.1` stable** (decided 2026-05-19, not backfilling `v0.10.0`). When the next non-alpha tag lands, fill `pkgver=` in §7 and push.
+
+## 6. PKGBUILD — `uniclipboard-git` (implemented)
+
+**Source of truth:** `packaging/aur/uniclipboard-git/PKGBUILD` (+ `.SRCINFO`).
+**Sync mechanism:** `.github/workflows/aur.yml` — runs on push to `main` that touches `packaging/aur/uniclipboard-git/**` or the workflow file itself, plus `workflow_dispatch` (with optional `dry_run`).
+
+How the sync works:
+1. Job runs in `archlinux:base-devel` container.
+2. Checks out this repo, computes `pkgver` from `git describe` (same algorithm as the in-PKGBUILD `pkgver()` function — keeps the AUR web snapshot in sync with current `main`).
+3. Clones `ssh://aur@aur.archlinux.org/uniclipboard-git.git` using the `AUR_SSH_PRIVATE_KEY` repo secret.
+4. Renders PKGBUILD, regenerates `.SRCINFO` via `makepkg --printsrcinfo` as a non-root `builder` user.
+5. Diffs against AUR HEAD — pushes only if something changed (no empty commits).
+6. Concurrency group `aur-uniclipboard-git` serializes pushes so two CI runs never race on the same remote.
+
+Required secret:
+- `AUR_SSH_PRIVATE_KEY` — ed25519 private key. Generate via `ssh-keygen -t ed25519 -C aur-uniclipboard -f aur`, upload `aur.pub` at `https://aur.archlinux.org/account/<user>/edit/`, paste the private key (`aur`) into repo secrets.
+
+Reference skeleton (kept here for documentation; the live file may have drifted):
+
+```bash
+# Maintainer: UniClipboard <aur@uniclipboard.app>
+
+pkgname=uniclipboard-git
+_pkgname=uniclipboard
+pkgver=0.10.1.alpha.1.r0.g0000000
+pkgrel=1
+pkgdesc="Real-time clipboard sync across macOS, Windows and Linux — local-first, peer-to-peer, and end-to-end encrypted"
+arch=('x86_64' 'aarch64')
+url="https://www.uniclipboard.app"
+license=('AGPL-3.0-only')
+depends=('webkit2gtk-4.1' 'gtk3' 'libayatana-appindicator' 'libnotify')
+makedepends=('git' 'rust' 'nodejs' 'bun' 'pkgconf')
+provides=("$_pkgname" "$_pkgname=$pkgver")
+conflicts=("$_pkgname")
+source=("$_pkgname::git+https://github.com/UniClipboard/UniClipboard.git")
+sha256sums=('SKIP')
+
+pkgver() {
+  cd "$_pkgname"
+  git describe --long --tags --abbrev=7 2>/dev/null \
+    | sed 's/^v//; s/\([^-]*-g\)/r\1/; s/-/./g' \
+    || printf "0.0.0.r%s.g%s" \
+         "$(git rev-list --count HEAD)" \
+         "$(git rev-parse --short=7 HEAD)"
+}
+
+prepare() {
+  cd "$_pkgname"
+  bun install --frozen-lockfile
+}
+
+build() {
+  cd "$_pkgname"
+  # --no-bundle skips .deb/.rpm/.AppImage generation; we only need the binary.
+  bun run tauri build --no-bundle
+}
+
+package() {
+  cd "$_pkgname"
+
+  install -Dm755 "src-tauri/target/release/uniclipboard" \
+                 "$pkgdir/usr/bin/uniclipboard"
+
+  install -Dm644 "packaging/linux/uniclipboard.desktop" \
+                 "$pkgdir/usr/share/applications/uniclipboard.desktop"
+
+  # Hicolor icons, renamed from Tauri's size-named source files.
+  install -Dm644 "src-tauri/icons/32x32.png"       "$pkgdir/usr/share/icons/hicolor/32x32/apps/uniclipboard.png"
+  install -Dm644 "src-tauri/icons/64x64.png"       "$pkgdir/usr/share/icons/hicolor/64x64/apps/uniclipboard.png"
+  install -Dm644 "src-tauri/icons/128x128.png"     "$pkgdir/usr/share/icons/hicolor/128x128/apps/uniclipboard.png"
+  install -Dm644 "src-tauri/icons/128x128@2x.png"  "$pkgdir/usr/share/icons/hicolor/256x256/apps/uniclipboard.png"
+
+  install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+}
+```
+
+## 7. PKGBUILD Skeleton — `uniclipboard` (release source)
+
+Same as `-git` with these differences:
+
+```bash
+pkgname=uniclipboard
+pkgver=0.10.0  # update on every stable release; do NOT track alpha tags here
+# Drop pkgver() function entirely.
+# Drop 'git' from makedepends.
+source=("$pkgname-$pkgver.tar.gz::https://github.com/UniClipboard/UniClipboard/archive/refs/tags/v$pkgver.tar.gz")
+sha256sums=('<fill in via: sha256sum the-downloaded-tarball>')
+# Once §11 signing lands:
+# source+=("$pkgname-$pkgver.tar.gz.sig::https://github.com/UniClipboard/UniClipboard/releases/download/v$pkgver/source.tar.gz.minisig")
+# validpgpkeys=()  # minisign uses sha256sums[]='SKIP' + a separate verify step, not validpgpkeys
+```
+
+GitHub's auto-generated tarball extracts to `UniClipboard-$pkgver/` (matches the repo name, `v` prefix stripped). So change every `cd "$_pkgname"` line to `cd "UniClipboard-$pkgver"` — confirm once with `tar tf` on the downloaded tarball before pushing.
+
+## 8. Validation Before Pushing
+
+```bash
+# Lint the PKGBUILD and the built package
+namcap PKGBUILD
+namcap *.pkg.tar.zst
+
+# Clean-room build — catches missing makedepends/depends
+# Requires the 'devtools' package; this runs inside a fresh chroot.
+extra-x86_64-build
+
+# Final smoke test
+sudo pacman -U uniclipboard-git-*-x86_64.pkg.tar.zst
+uniclipboard --version
+```
+
+Don't push until `namcap` is clean and the clean-room build succeeds. The clean-room is what catches "works on my laptop because I happen to have $library installed already".
+
+## 9. Push to AUR
+
+```bash
+# One-time, per AUR account
+ssh-keygen -t ed25519 -C "aur-uniclipboard" -f ~/.ssh/aur
+# Add ~/.ssh/aur.pub at https://aur.archlinux.org/account/\<username\>/edit/
+
+# In ~/.ssh/config:
+#   Host aur.archlinux.org
+#     IdentityFile ~/.ssh/aur
+#     User aur
+
+# Per package
+git clone ssh://aur@aur.archlinux.org/uniclipboard-git.git
+cd uniclipboard-git
+cp /path/to/PKGBUILD .
+makepkg --printsrcinfo > .SRCINFO
+git add PKGBUILD .SRCINFO
+git commit -m "Initial import: uniclipboard-git 0.10.0.r0.g..."
+git push
+```
+
+`.SRCINFO` must be committed alongside `PKGBUILD` on every change — AUR's web UI reads from it, not the PKGBUILD.
+
+## 10. Co-maintainer Request — Email Template
+
+Send to czyt (AUR profile email, or via GitHub @czyt). Replace placeholders before sending.
+
+> **Subject:** Co-maintainer request for `uniclipboard-bin`
+>
+> Hi czyt,
+>
+> I'm the upstream maintainer of UniClipboard desktop (`github.com/UniClipboard/UniClipboard`). First, thanks for keeping `uniclipboard-bin` up to date — you tracked 0.7 → 0.10 in nine days, which is great for our Linux users.
+>
+> I'd like to ask if you'd add me as co-maintainer on `uniclipboard-bin`. Goals:
+>
+> 1. Emergency push access (CVE, broken release artifact) so I can hotfix without waiting on you.
+> 2. We're about to start signing release artifacts (likely `minisign`); when that lands I can help update the PKGBUILD to verify the signature.
+> 3. I'll be publishing `uniclipboard` (source build) and `uniclipboard-git` under the upstream account. You'd remain primary on `-bin`; the three packages will share `provides`/`conflicts` cleanly.
+>
+> My AUR username: `uniclipboard`
+>
+> Upstream identity proof: I'll attach a signed message to the next GitHub release notes confirming this request.
+>
+> Thanks for the work!
+>
+> — mkdir700 (UniClipboard upstream)
+
+## 11. Supply Chain Hardening (deferred, post-launch)
+
+Out of scope for the initial AUR push, but plan for:
+
+- **Heads-up — there's already a minisign key in `src-tauri/tauri.conf.json:64`.** That key signs the Tauri **updater** payload (the in-app auto-update bundle), not the GitHub release tarball or .deb. For AUR verification we need a **separate** signing step over the release artifacts (or, debatably, repurpose the existing key — but mixing the two roles makes key rotation harder, so prefer a second key).
+- Add `minisign -S` to the GitHub Actions release workflow. Generate a dedicated release-artifact key (`minisign -G`), store the secret key encrypted in repo secrets, publish public key in `SECURITY.md`.
+- Update `uniclipboard` PKGBUILD to download `.sig` alongside tarball and verify in `prepare()`.
+- Coordinate the same change into `uniclipboard-bin` with czyt (he can verify the `.deb`'s `.sig` before extraction).
+- Once all three PKGBUILDs verify upstream signatures, a compromised AUR account alone is no longer enough to ship a malicious build — attacker also needs the upstream signing key.
+
+## 12. Open Questions
+
+- Do we want a Flatpak parallel to this AUR work? (Out of scope for this doc, but the answer affects how much we invest in Linux-native packaging.)
+- Once `uniclipboard` source build is published, do we also push to `[community]`/`[extra]` via a Trusted User? (Long timeline, requires sustained AUR votes first.)

--- a/docs/packaging/AUR.md
+++ b/docs/packaging/AUR.md
@@ -90,6 +90,9 @@ How the sync works:
 Required secret:
 - `AUR_SSH_PRIVATE_KEY` — ed25519 private key. Generate via `ssh-keygen -t ed25519 -C aur-uniclipboard -f aur`, upload `aur.pub` at `https://aur.archlinux.org/account/<user>/edit/`, paste the private key (`aur`) into repo secrets.
 
+Recommended repo variable (defense-in-depth against MITM on `ssh-keyscan`):
+- `AUR_HOST_FINGERPRINTS` — comma-separated list of pinned `SHA256:...` fingerprints for `aur.archlinux.org` host keys. Configure via `gh variable set AUR_HOST_FINGERPRINTS --body 'SHA256:...,SHA256:...'`. Source from `https://wiki.archlinux.org/title/AUR_submission_guidelines` (out-of-band verification — that's the whole point). When set, the workflow `ssh-keyscan`s and then verifies at least one scanned key matches a pinned fingerprint; mismatch → fail-fast. When unset, falls back to TOFU keyscan with a warning so first-time setup still works.
+
 Reference skeleton (kept here for documentation; the live file may have drifted):
 
 ```bash

--- a/packaging/aur/uniclipboard-git/.SRCINFO
+++ b/packaging/aur/uniclipboard-git/.SRCINFO
@@ -1,0 +1,25 @@
+pkgbase = uniclipboard-git
+	pkgdesc = Real-time clipboard sync across macOS, Windows and Linux — local-first, peer-to-peer, and end-to-end encrypted
+	pkgver = 0.10.1.alpha.2.r0.g0000000
+	pkgrel = 1
+	url = https://www.uniclipboard.app
+	arch = x86_64
+	arch = aarch64
+	license = AGPL-3.0-only
+	makedepends = git
+	makedepends = rust
+	makedepends = nodejs
+	makedepends = bun
+	makedepends = pkgconf
+	depends = webkit2gtk-4.1
+	depends = gtk3
+	depends = libayatana-appindicator
+	depends = libnotify
+	provides = uniclipboard
+	provides = uniclipboard=0.10.1.alpha.2.r0.g0000000
+	conflicts = uniclipboard
+	conflicts = uniclipboard-bin
+	source = uniclipboard::git+https://github.com/UniClipboard/UniClipboard.git
+	sha256sums = SKIP
+
+pkgname = uniclipboard-git

--- a/packaging/aur/uniclipboard-git/PKGBUILD
+++ b/packaging/aur/uniclipboard-git/PKGBUILD
@@ -1,0 +1,76 @@
+# Maintainer: UniClipboard <aur@uniclipboard.app>
+#
+# 源代码版本的 -git 包：直接从 main 分支 clone 并 cargo build。
+# 与 czyt 维护的 `uniclipboard-bin`（重打 .deb）互斥安装。
+#
+# 同步规则：本仓库内的 PKGBUILD 是 source of truth；CI（.github/workflows/aur.yml）
+# 在 main 推送或手动 dispatch 时把这份文件 + 重算后的 pkgver 推到 AUR。
+# 修改这个文件后 commit 即可，不要手动改 AUR 上的副本，否则会被 CI 覆盖。
+
+pkgname=uniclipboard-git
+_pkgname=uniclipboard
+# pkgver 是 AUR web 上展示用的 snapshot；makepkg 实际编译时调用下方 pkgver() 重算。
+# CI 在 push 前会用 git describe 的当前值 sed 替换，保持 web 视图不过期。
+pkgver=0.10.1.alpha.2.r0.g0000000
+pkgrel=1
+pkgdesc="Real-time clipboard sync across macOS, Windows and Linux — local-first, peer-to-peer, and end-to-end encrypted"
+arch=('x86_64' 'aarch64')
+url="https://www.uniclipboard.app"
+license=('AGPL-3.0-only')
+# Tauri 2 + webkit2gtk-4.1 运行链 + 系统托盘需要的 appindicator + 桌面通知。
+# tauri.conf.json 的 .deb depends 只列了 appindicator，是因为 .deb 工具会自动
+# 从 ELF 反查共享库依赖；PKGBUILD 不会，所以必须显式列全。
+depends=('webkit2gtk-4.1' 'gtk3' 'libayatana-appindicator' 'libnotify')
+# bun 在 Arch [extra]；rust 也在 [extra]（不要写 rustup，那是 AUR 包且需要再装 toolchain）。
+makedepends=('git' 'rust' 'nodejs' 'bun' 'pkgconf')
+provides=("$_pkgname" "$_pkgname=$pkgver")
+# 三个 AUR 包共享同一个可执行文件路径，互斥安装。-bin 由 czyt 维护，-git/源码版由 upstream 维护。
+conflicts=("$_pkgname" "${_pkgname}-bin")
+source=("$_pkgname::git+https://github.com/UniClipboard/UniClipboard.git")
+sha256sums=('SKIP')
+
+pkgver() {
+  cd "$_pkgname"
+  # 把 v0.10.1-alpha.2-3-g1234567 形如 → 0.10.1.alpha.2.r3.g1234567
+  # 1) sed 's/^v//'             去 v 前缀
+  # 2) 's/\([^-]*-g\)/r\1/'     把最后一段 "<count>-g<hash>" 前面补个 r
+  # 3) 's/-/./g'                所有 - 替换 . 满足 pacman 版本格式
+  ( git describe --long --tags --abbrev=7 2>/dev/null \
+      | sed 's/^v//; s/\([^-]*-g\)/r\1/; s/-/./g' ) \
+    || printf "0.0.0.r%s.g%s" \
+         "$(git rev-list --count HEAD)" \
+         "$(git rev-parse --short=7 HEAD)"
+}
+
+prepare() {
+  cd "$_pkgname"
+  # frozen-lockfile：lockfile 与 package.json 必须一致，否则 fail。
+  # 这能在用户机器上立即发现 main 分支推送了不一致的依赖（避免静默升级）。
+  bun install --frozen-lockfile
+}
+
+build() {
+  cd "$_pkgname"
+  # --no-bundle 跳过 .deb/.rpm/.AppImage 生成，PKGBUILD 自己负责安装路径。
+  # 这样不需要 dpkg/rpm-build/appimagetool 这些额外 makedepends。
+  bun run tauri build --no-bundle
+}
+
+package() {
+  cd "$_pkgname"
+
+  install -Dm755 "src-tauri/target/release/$_pkgname" \
+                 "$pkgdir/usr/bin/$_pkgname"
+
+  install -Dm644 "packaging/linux/$_pkgname.desktop" \
+                 "$pkgdir/usr/share/applications/$_pkgname.desktop"
+
+  # Hicolor 图标，从 Tauri 的 size-named 源文件重命名到标准 apps/ 路径。
+  # 128@2x 当成 256x256（@2x 是 macOS Retina 概念，Linux 用尺寸而非 DPI 区分）。
+  install -Dm644 "src-tauri/icons/32x32.png"       "$pkgdir/usr/share/icons/hicolor/32x32/apps/$_pkgname.png"
+  install -Dm644 "src-tauri/icons/64x64.png"       "$pkgdir/usr/share/icons/hicolor/64x64/apps/$_pkgname.png"
+  install -Dm644 "src-tauri/icons/128x128.png"     "$pkgdir/usr/share/icons/hicolor/128x128/apps/$_pkgname.png"
+  install -Dm644 "src-tauri/icons/128x128@2x.png"  "$pkgdir/usr/share/icons/hicolor/256x256/apps/$_pkgname.png"
+
+  install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+}

--- a/packaging/linux/uniclipboard.desktop
+++ b/packaging/linux/uniclipboard.desktop
@@ -1,0 +1,13 @@
+[Desktop Entry]
+Name=UniClipboard
+GenericName=Clipboard Sync
+Comment=Encrypted peer-to-peer clipboard sync between your devices
+Exec=uniclipboard %U
+Icon=uniclipboard
+Type=Application
+Categories=Network;Utility;
+Terminal=false
+StartupNotify=true
+StartupWMClass=UniClipboard
+X-GNOME-UsesNotifications=true
+Keywords=clipboard;sync;p2p;encrypted;


### PR DESCRIPTION
## Summary

- 新增 `packaging/aur/uniclipboard-git/PKGBUILD` + `.SRCINFO` 作为 AUR `-git` 源码包的 source of truth（ceae966e）。依赖、makedepends、icon/desktop 安装路径与 Tauri 配置和 `packaging/linux/uniclipboard.desktop` 对齐；`conflicts` 同时排除 `uniclipboard` 与 czyt 维护的 `uniclipboard-bin`。
- 新增 `.github/workflows/aur.yml`：在 `archlinux:base-devel` 容器内以非 root `builder` 用户跑 `makepkg --printsrcinfo`，从 `git describe` 计算 pkgver 替换 PKGBUILD snapshot，diff 后才推送到 `ssh://aur@aur.archlinux.org/uniclipboard-git.git`。触发条件：push to main 且仅改动 `packaging/aur/uniclipboard-git/**` 或 workflow 自身、或 `workflow_dispatch`（带 `dry_run`）。`concurrency` 串行化避免 AUR remote 竞争。
- 顺手把 `packaging/linux/uniclipboard.desktop` 入库（之前 worktree 里有但 untracked，是 PKGBUILD 的输入）。
- 把 `docs/packaging/AUR.md` 顶部 status 切到 implemented（仅 `-git` 包），§6 记录 source-of-truth/同步机制，§4 第 1 项打 strike-through。

合并后还需要一次性配置：
1. 生成 ed25519 SSH 密钥并把公钥贴到 AUR 账号
2. `gh secret set AUR_SSH_PRIVATE_KEY --repo UniClipboard/UniClipboard < ~/.ssh/aur_uniclipboard`
3. 手动 dispatch 一次 `Publish to AUR (uniclipboard-git)`（建议先 `dry_run=true` 看 artifact）

## Test plan

- [x] `yaml.parse` 通过：`triggers={push, workflow_dispatch}`、`jobs.publish.steps=12`、`concurrency.group=aur-uniclipboard-git`。
- [x] PKGBUILD 引用的所有文件存在：`packaging/linux/uniclipboard.desktop`、`src-tauri/icons/{32,64,128,128@2x}.png`、`LICENSE`。
- [x] 与 `docs/packaging/AUR.md` §5 列出的 license / depends / icon 路径事实一致；与当前 `src-tauri/Cargo.toml` + `tauri.conf.json` 重新核对过。
- [x] docs-site 影响扫描：本 PR 不改任何 CLI flag / 设置项 / 错误消息 / 默认值；`docs-site/` 无需更新。
- [ ] Reviewer：merge 前 `pacman -S namcap && namcap packaging/aur/uniclipboard-git/PKGBUILD`（如有 Arch 环境）。
- [ ] Reviewer：merge 后配置 `AUR_SSH_PRIVATE_KEY` secret，先用 `workflow_dispatch` + `dry_run=true` 跑一遍，下载 artifact 检查渲染后的 PKGBUILD/.SRCINFO；确认无误后再 `dry_run=false` 完成首次 AUR 注册推送。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Arch User Repository (AUR) package support for installation on Arch-based systems.
  * Added Linux desktop launcher entry for improved application discovery and integration.

* **Documentation**
  * Added comprehensive AUR packaging documentation.

* **Chores**
  * Configured automated CI/CD workflow for maintaining AUR package updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/UniClipboard/UniClipboard/pull/801?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->