### PR TITLE
fix(ci/aur): unshallow checkout so git describe finds tags for pkgver

### DIFF
--- a/.github/workflows/aur.yml
+++ b/.github/workflows/aur.yml
@@ -61,6 +61,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           path: src
+          # fetch-depth: 0 拉完整历史和所有 tags。默认 shallow (depth=1) 下
+          # `git describe --tags` 没有任何 tag 可参考会 fail，导致 pkgver
+          # 走 fallback `printf "0.0.0.r%s.g%s" $(rev-list --count) $(short hash)`
+          # 又因为 shallow 只能数到 1 commit → 推到 AUR 的 pkgver 变成
+          # `0.0.0.r1.gHASH`，web 上看着像个未发版项目。
+          fetch-depth: 0
 
       - name: Validate PKGBUILD with namcap
         shell: bash


### PR DESCRIPTION
## Summary

修复 #801 合并后 aur-git-1 暴露的 bug：AUR 上 PKGBUILD 的 pkgver 被推成 `0.0.0.r1.geab0b73`（fallback 格式，看着像未发版项目）。

**根因**：`actions/checkout@v4` 默认 `fetch-depth: 1`（shallow，且不拉 tags）→ `git describe --long --tags` 失败 → render 步骤走 `||` fallback `printf "0.0.0.r%s.g%s" $(rev-list --count) $(short hash)` → 但 shallow 下 `rev-list --count` 只能数到 1，于是 `r1`。

**修法**：`fetch-depth: 0` 拉完整历史+所有 tags。本地用当前 main 验证修复后会渲染成 `0.10.0.r8.geab0b73`（基于 `v0.10.0` tag），格式正确。

**对 AUR 的影响**：merge 后下一次 push 触发会自动用正确的 pkgver 覆盖 AUR 上的坏值，**不需要**手动清理 AUR 仓库。

## Test plan

- [x] 本地 `git describe --long --tags --abbrev=7 | sed 's/^v//; s/\([^-]*-g\)/r\1/; s/-/./g'` → `0.10.0.r8.geab0b73` ✓
- [x] YAML 解析通过、step 数不变
- [x] docs-site 影响扫描：纯 CI fix，无 user-facing surface 改动
- [ ] Reviewer：merge 后观察下一次自动 push 触发（应该被 path filter 命中），确认 AUR 上 pkgver 变成正确格式
- [ ] Reviewer：如果一直没有触发 path filter（极少有人改 packaging/aur/** 或 aur.yml），手动 `gh workflow run aur.yml --repo UniClipboard/UniClipboard` 跑一次确认