### PR TITLE
fix(ci): strip incompatible libwayland from aarch64 AppImage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -268,6 +268,82 @@ jobs:
             bun run tauri build ${{ matrix.args }}
           fi
 
+      - name: Strip incompatible bundled libwayland from aarch64 AppImage
+        # Tauri 2 internally calls linuxdeploy + linuxdeploy-plugin-gtk to
+        # bundle the AppImage. linuxdeploy follows GTK's DT_NEEDED chain and
+        # ends up copying libwayland-{client,cursor,egl,server}.so* out of
+        # the Debian Bookworm build container. linuxdeploy's bundled exclude
+        # list — pinned by Tauri to a tauri-apps/binary-releases snapshot —
+        # excludes libEGL/libGL/libgbm/libdrm but NOT libwayland-*.
+        #
+        # On a modern aarch64 host running a Wayland session (e.g. Arch +
+        # mesa 26 in GNOME 50), WebKitWebProcess initializes EGL through
+        # libglvnd → libEGL_mesa, which talks to the bundled Bookworm
+        # libwayland (1.21) instead of the host's libwayland (0.25). The
+        # ABI mismatch surfaces as
+        #     "Could not create default EGL display: EGL_BAD_PARAMETER"
+        # and the renderer SIGABRTs immediately → white window.
+        #
+        # x86_64 hosts haven't hit this in the wild yet, but the same
+        # mismatch is latent there too. Keeping the patch aarch64-only for
+        # now to minimize blast radius; widen if/when a report lands.
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        shell: bash
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          BUNDLE_DIR="src-tauri/target/${{ matrix.target }}/release/bundle/appimage"
+          if ! compgen -G "$BUNDLE_DIR"/*.AppImage >/dev/null; then
+            echo "::warning::No AppImage found under $BUNDLE_DIR — skipping libwayland strip"
+            exit 0
+          fi
+
+          # appimagetool is used to repack the modified AppDir. We pin to the
+          # AppImageKit continuous build, which ships a FUSE-less repack path
+          # via --appimage-extract-and-run (the build container lacks FUSE).
+          APPIMAGETOOL=/tmp/appimagetool.AppImage
+          curl -fsSL -o "$APPIMAGETOOL" \
+            "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-aarch64.AppImage"
+          chmod +x "$APPIMAGETOOL"
+
+          for app in "$BUNDLE_DIR"/*.AppImage; do
+            echo "::group::Patching $(basename "$app")"
+            workdir="$(mktemp -d)"
+            (
+              cd "$workdir"
+              # The bundled AppRun supports extraction without FUSE.
+              "$app" --appimage-extract >/dev/null
+              if compgen -G "squashfs-root/usr/lib/libwayland-*.so*" >/dev/null; then
+                echo "Removing bundled libwayland-* (host-incompatible):"
+                ls squashfs-root/usr/lib/libwayland-*.so*
+                rm -f squashfs-root/usr/lib/libwayland-*.so*
+              else
+                echo "No bundled libwayland-* found — nothing to strip."
+              fi
+              # ARCH must be explicit; appimagetool refuses to guess for AppDirs
+              # produced by linuxdeploy.
+              ARCH=aarch64 "$APPIMAGETOOL" --appimage-extract-and-run \
+                squashfs-root "$app.patched"
+              mv "$app.patched" "$app"
+            )
+            rm -rf "$workdir"
+
+            # Re-sign so the updater .sig matches the repacked bytes. Tauri
+            # produced an .sig next to the original AppImage; replace it.
+            if [ -n "${TAURI_SIGNING_PRIVATE_KEY:-}" ]; then
+              rm -f "$app.sig"
+              bun run tauri signer sign \
+                --private-key "$TAURI_SIGNING_PRIVATE_KEY" \
+                --password "${TAURI_SIGNING_PRIVATE_KEY_PASSWORD:-}" \
+                "$app"
+            else
+              echo "::warning::TAURI_SIGNING_PRIVATE_KEY not set — leaving stale .sig in place"
+            fi
+            echo "::endgroup::"
+          done
+
       - name: Upload Sentry debug symbols
         # 把 release 编译出的 .dSYM (macOS) / .pdb (Windows) / DWARF (Linux)
         # 上传给 Sentry,后续 panic 上报时 Sentry 用 build-id 把地址翻译回


### PR DESCRIPTION
## Summary

- aarch64 Linux AppImage 在 Wayland session 上启动就白屏，WebKitWebProcess 立即 SIGABRT，报 `Could not create default EGL display: EGL_BAD_PARAMETER`。
- 根因：Tauri 2.11 内置的 linuxdeploy 把 build 容器（Debian Bookworm）里的 `libwayland-{client,cursor,egl,server}.so*` 一起捎进了 AppImage，linuxdeploy 那一版的 excludelist 只排除了 libEGL/libGL/libgbm/libdrm，**没排除 libwayland-***。host mesa 通过 libglvnd 调到 bundle 里旧版 libwayland，ABI 不匹配，WebKit 渲染进程崩溃。
- 这个 bug 是 PR #589（引入 aarch64 Linux build matrix entry）之后就一直存在的，跟 release/v0.10.1 本身无关；只是触发条件需要 host 是较新的发行版 + Wayland session，今天在 Arch + UTM + GNOME 50 上首次撞到。

## Fix

仅对 `aarch64-unknown-linux-gnu` build 新增一步 post-process：

1. `--appimage-extract` 提取 AppDir
2. 删 `usr/lib/libwayland-*.so*`
3. 用 `appimagetool` 重新打包
4. 用 `bun run tauri signer sign` 重新签名（updater .sig 必须匹配新 bytes）

x86_64 暂不动 —— 理论上也有同样隐患，但目前没有 in-the-wild 报告，先保住爆炸半径。

## Why not fix it upstream

更干净的修法是给 Tauri 加 `--exclude-library 'libwayland-*'` 默认，但要等 PR 走完 review/release 周期。这里是 release/v0.10.1 临时 unblock，不影响后续提 upstream PR。

## Test plan

- [ ] CI 跑 aarch64 build，确认 step 不报错
- [ ] 下载产物 AppImage，跑 `--appimage-extract` 后 `ls usr/lib/libwayland-*` 应为空
- [ ] 在 Arch + UTM + GNOME Wayland session 上跑新 AppImage，确认主窗口正常出来
- [ ] 验证新的 .sig 文件能被 updater 校验通过