### PR TITLE
chore(coderabbit): enforce Chinese code comments in review rules

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -12,6 +12,16 @@ reviews:
         Do not nitpick or suggest any changes related to Markdown formatting, line length, list styles, table alignment, spacing, link syntax, heading styles, or any other pure formatting issues.
         Focus exclusively on whether the content is accurate, clear, logically structured, and uses professional technical wording.
         Ignore all formatting-only problems.
+    - path: '**/*.{rs,ts,tsx,js,jsx,vue,py,svelte,mjs,cjs}'
+      instructions: |
+        Code comments in this repository MUST be written in Chinese (applies to `//`, `///`, `/* */`, and doc comments).
+        This rule is defined in AGENTS.md and CONTRIBUTING.md.
+        Do NOT suggest translating Chinese comments to English, and do NOT flag Chinese comments as issues.
+        The following are intentionally kept in English and must not be flagged:
+          - identifiers (function, type, variable, module names)
+          - commit messages and PR titles/descriptions
+          - proper nouns from external specs (RFCs, stdlib APIs, third-party library names)
+        Focus reviews on logic, correctness, safety, and design — not on comment language.
   tools:
     markdownlint:
       enabled: false


### PR DESCRIPTION
## Summary

- `AGENTS.md` 与 `CONTRIBUTING.md` 已明确规定本仓库代码注释一律使用中文（`//`、`///`、`/* */`、doc comment 等），但 `.coderabbit.yaml` 从未把这条规则告诉 CodeRabbit。
- 结果：每个 PR（例如 #813）CodeRabbit 都会反复对中文注释提出"翻译成英文"的修改建议，制造审查噪音。
- 本次在 `.coderabbit.yaml` 的 `path_instructions` 中为常见源码后缀（`rs / ts / tsx / js / jsx / vue / py / svelte / mjs / cjs`）补充一条规则，显式声明：
  - 代码注释必须使用中文，不要建议翻译成英文，也不要把中文注释标记为问题。
  - 例外保留英文：标识符、commit message、PR 标题/描述、外部规范专有名词。
  - 审查精力放在逻辑、正确性、安全性与设计上，而不是注释语言。

## Test plan

- [ ] 合并后在新 PR 上观察 CodeRabbit 是否仍对中文注释提建议
- [ ] 如仍发生，回到 `.coderabbit.yaml` 调整 path glob 或在 CodeRabbit 控制台确认 `path_instructions` 已生效

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal code review configuration settings.

**Note:** This release contains no user-facing changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/UniClipboard/UniClipboard/pull/815?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->