### PR TITLE
backport: bring v0.10.1 fixes into main (abandoning 0.10.1 release)

### DIFF
--- a/.github/workflows/alpha-build.yml
+++ b/.github/workflows/alpha-build.yml
@@ -94,6 +94,20 @@ jobs:
         shell: bash
         run: echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> "$GITHUB_PATH"
 
+      - name: ensure darwin targets installed on pinned toolchain
+        # 见 build.yml 同名 step 注释:src-tauri/rust-toolchain.toml 把 cargo
+        # 锁到一个具体 channel(例如 1.95.0),与 dtolnay/rust-toolchain@stable
+        # 装的 stable 是两个独立 toolchain。在 src-tauri/ 下跑 cargo 时,
+        # target 必须装在 pinned channel,否则报 `Target ... is not installed`
+        # (alpha-build run 26074579386 因此挂掉,与 build.yml 早先修过的
+        # 25960898069 / 25961183688 同根因)。
+        if: matrix.platform == 'macos-latest'
+        shell: bash
+        run: |
+          TC=$(cd src-tauri && rustup show active-toolchain | awk '{print $1}')
+          echo "pinned toolchain: $TC"
+          rustup target add --toolchain "$TC" aarch64-apple-darwin x86_64-apple-darwin
+
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -28,6 +28,11 @@ on:
           - beta
           - rc
         default: stable
+      base_branch:
+        description: 'Branch to base the release off (default: main). Use release/vX.Y.Z when iterating prereleases on a release branch whose commits have not yet been merged back to main.'
+        required: false
+        type: string
+        default: 'main'
 
 jobs:
   prepare:
@@ -37,11 +42,12 @@ jobs:
       pull-requests: write
     env:
       CODEX_API_KEY: ${{ secrets.CODEX_API_KEY }}
+      BASE_BRANCH: ${{ inputs.base_branch || 'main' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: main
+          ref: ${{ inputs.base_branch || 'main' }}
           token: ${{ secrets.REPO_BOT_TOKEN }}
           fetch-depth: 0
           submodules: recursive
@@ -228,7 +234,7 @@ jobs:
             --body "$(cat <<EOF
           ## Release v${VERSION}
 
-          This PR prepares the release of v${VERSION}.
+          This PR prepares the release of v${VERSION} (base: \`${BASE_BRANCH}\`).
 
           ### Changes
           - Version bumped to ${VERSION} in package.json, tauri.conf.json, Cargo.toml, Cargo.lock
@@ -242,7 +248,7 @@ jobs:
           > **Do not manually create a tag.** Merging this PR handles everything.
           EOF
           )" \
-            --base main \
+            --base "${BASE_BRANCH}" \
             --head "release/v${VERSION}")
 
           echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/tag-on-merge.yml
+++ b/.github/workflows/tag-on-merge.yml
@@ -4,7 +4,10 @@ run-name: tag-${{ github.event.pull_request.head.ref }}
 on:
   pull_request:
     types: [closed]
-    branches: [main]
+    # 同时监听 main 和 release/v* 作为 PR base —— prepare-release.yml 支持
+    # 在已存在的 release branch(commits 尚未合回 main)上继续 bump 出下一个
+    # prerelease,这种 PR 的 base 是 release/vX.Y.Z 而不是 main。
+    branches: [main, 'release/v*']
 
 jobs:
   tag-release:

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -9915,6 +9915,7 @@ dependencies = [
  "chrono",
  "core-foundation 0.10.1",
  "core-graphics 0.24.0",
+ "libloading",
  "log",
  "mockall 0.13.1",
  "objc2",

--- a/src-tauri/crates/uc-bootstrap/src/tracing.rs
+++ b/src-tauri/crates/uc-bootstrap/src/tracing.rs
@@ -213,15 +213,27 @@ pub fn init_tracing_subscriber() -> anyhow::Result<()> {
                 // Tracing ERROR + WARN events are routed to Logs by the
                 // `event_filter` below; INFO stays as a breadcrumb only.
                 enable_logs: true,
-                // Runtime telemetry gate. Drops every outgoing event (incl.
-                // panics from the sentry-panic integration) when the user has
-                // telemetry off, without un-installing any global hook.
+                // Runtime telemetry gate + known-upstream-panic mute.
+                //
+                // Drops every outgoing event (incl. panics from the
+                // sentry-panic integration) when the user has telemetry off,
+                // without un-installing any global hook. After the gate we
+                // also drop the small set of panics we've already traced to
+                // open upstream issues (see `known_upstream_panic`) — they
+                // would otherwise dominate the fatal-issue board with crashes
+                // we can't fix from this codebase.
                 before_send: Some(Arc::new(|event| {
-                    if uc_observability::is_telemetry_enabled() {
-                        Some(event)
-                    } else {
-                        None
+                    if !uc_observability::is_telemetry_enabled() {
+                        return None;
                     }
+                    if let Some(tracker) = known_upstream_panic(&event) {
+                        ::tracing::debug!(
+                            tracker,
+                            "dropping known-upstream panic from Sentry event stream"
+                        );
+                        return None;
+                    }
+                    Some(event)
                 })),
                 // Same gate for the breadcrumb trail — when telemetry is off
                 // we drop them at capture time so re-enabling telemetry mid-
@@ -514,4 +526,113 @@ pub fn install_panic_logging_hook() {
     }));
 
     ::tracing::debug!("panic logging hook installed");
+}
+
+/// Identify Sentry panic events that match an upstream bug we've already
+/// filed but can't fix from this codebase. Returns the tracker tag when the
+/// event should be suppressed, or `None` to let it flow to Sentry.
+///
+/// Matching is two-step on purpose:
+/// 1. exception `type == "panic"` 且 `value == <字面量>` 是 hot path,99% 的
+///    panic 在这一步就被否决;
+/// 2. 再校验栈里出现了对应上游 crate 的具名 frame,避免我们或第三方代码
+///    碰巧 panic 了同样的字符串就被静默吞掉。
+///
+/// 每条规则都带一个 tracker tag(`<crate>#<issue>`),回收时直接 grep 它
+/// 找到对应 match arm。
+fn known_upstream_panic(event: &sentry::protocol::Event<'_>) -> Option<&'static str> {
+    for exc in event.exception.values.iter() {
+        if exc.ty != "panic" {
+            continue;
+        }
+        let value = exc.value.as_deref().unwrap_or("");
+        // tao#1180 / PR #1188 — Windows 退出时 EventLoop 已进入 Destroyed,
+        // 系统又派发一条 paint message,tao runner 状态机硬 panic。我们
+        // 已 graceful 关掉 daemon、记完 `Application exiting` 日志,功能
+        // 影响为零,纯噪音。等 tauri 升级到带 PR #1188 修复的 tao 后回收。
+        // Substring match because Sentry serializes the frame as
+        // `EventLoopRunner::move_state_to<T>` (with the generic), and the
+        // exact suffix could shift with future tao refactors. The fully
+        // qualified prefix `tao::platform_impl::platform::event_loop::runner`
+        // is specific enough to never collide with anything else.
+        if value == "cannot move state from Destroyed"
+            && exception_has_frame_containing(
+                exc,
+                "tao::platform_impl::platform::event_loop::runner::EventLoopRunner::move_state_to",
+            )
+        {
+            return Some("tao#1180");
+        }
+    }
+    None
+}
+
+fn exception_has_frame_containing(exc: &sentry::protocol::Exception, needle: &str) -> bool {
+    exc.stacktrace
+        .as_ref()
+        .map(|st| {
+            st.frames.iter().any(|f| {
+                f.function
+                    .as_deref()
+                    .is_some_and(|fn_| fn_.contains(needle))
+            })
+        })
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sentry::protocol::{Event, Exception, Frame, Stacktrace, Values};
+
+    fn make_panic_event(value: &str, frame_fn: Option<&str>) -> Event<'static> {
+        let stacktrace = frame_fn.map(|f| Stacktrace {
+            frames: vec![Frame {
+                function: Some(f.to_string()),
+                ..Default::default()
+            }],
+            ..Default::default()
+        });
+        Event {
+            exception: Values {
+                values: vec![Exception {
+                    ty: "panic".into(),
+                    value: Some(value.into()),
+                    stacktrace,
+                    ..Default::default()
+                }],
+            },
+            ..Default::default()
+        }
+    }
+
+    // Realistic frame string Sentry actually serializes — note the `<T>` suffix.
+    const TAO_DESTROYED_FRAME: &str =
+        "tao::platform_impl::platform::event_loop::runner::EventLoopRunner::move_state_to<T>";
+
+    #[test]
+    fn drops_tao_destroyed_panic_with_matching_frame() {
+        let ev = make_panic_event(
+            "cannot move state from Destroyed",
+            Some(TAO_DESTROYED_FRAME),
+        );
+        assert_eq!(known_upstream_panic(&ev), Some("tao#1180"));
+    }
+
+    #[test]
+    fn keeps_same_message_when_frame_is_unrelated() {
+        // Defense in depth: if some other crate panics with the same string
+        // (or a user does in their own code), we must NOT silently drop it.
+        let ev = make_panic_event(
+            "cannot move state from Destroyed",
+            Some("uc_app::some_module::do_thing"),
+        );
+        assert_eq!(known_upstream_panic(&ev), None);
+    }
+
+    #[test]
+    fn keeps_unrelated_panic_messages() {
+        let ev = make_panic_event("attempt to divide by zero", Some(TAO_DESTROYED_FRAME));
+        assert_eq!(known_upstream_panic(&ev), None);
+    }
 }

--- a/src-tauri/crates/uc-bootstrap/src/tracing.rs
+++ b/src-tauri/crates/uc-bootstrap/src/tracing.rs
@@ -563,6 +563,21 @@ fn known_upstream_panic(event: &sentry::protocol::Event<'_>) -> Option<&'static 
         {
             return Some("tao#1180");
         }
+        // libappindicator-rs / tauri tray-icon — Linux 用户的
+        // libayatana-appindicator3 没装,或者 libayatana-ido3 因为 glib
+        // 符号缺失加载失败。dlopen 失败被 panic 而不是 Err 返回,我们已
+        // 在 uc_tauri::tray 用 catch_unwind 兜住,app 继续启动只是少了
+        // tray 图标。catch_unwind 不会阻止 panic hook 触发,所以 Sentry
+        // 仍会收到一条事件 —— 在 sink 这边 drop 掉避免持续噪音。
+        //
+        // 用 starts_with 而不是精确匹配:实际 value 多行,前缀后面跟具体
+        // 的 .so 路径与 undefined symbol 名,因机器而异。这条 panic 的
+        // 栈帧大多是 system .so 的 `<unknown>`,所以这里不再校验 frame。
+        if value
+            .starts_with("Failed to load ayatana-appindicator3 or appindicator3 dynamic library")
+        {
+            return Some("libappindicator-rs#dlopen");
+        }
     }
     None
 }
@@ -634,5 +649,19 @@ mod tests {
     fn keeps_unrelated_panic_messages() {
         let ev = make_panic_event("attempt to divide by zero", Some(TAO_DESTROYED_FRAME));
         assert_eq!(known_upstream_panic(&ev), None);
+    }
+
+    #[test]
+    fn drops_libappindicator_dlopen_panic_with_distro_specific_suffix() {
+        // 真实 Sentry 上看到的多行 value(prefix + 具体 .so 路径与符号),
+        // starts_with 必须把整条吞掉。
+        let ev = make_panic_event(
+            "Failed to load ayatana-appindicator3 or appindicator3 dynamic library\n\
+             /lib/x86_64-linux-gnu/libayatana-ido3-0.4.so.0: undefined symbol: g_once_init_leave_pointer\n\
+             libayatana-appindicator3.so: 无法打开共享目标文件: 没有那个文件或目录\n\
+             libappindicator3.so: 无法打开共享目标文件: 没有那个文件或目录",
+            None, // frames 通常都是 <unknown>,栈不可用
+        );
+        assert_eq!(known_upstream_panic(&ev), Some("libappindicator-rs#dlopen"));
     }
 }

--- a/src-tauri/crates/uc-observability/src/profile.rs
+++ b/src-tauri/crates/uc-observability/src/profile.rs
@@ -53,6 +53,14 @@ const NOISE_FILTERS: &[&str] = &[
     // harmless because reachability still works over other interfaces,
     // but high-frequency, so cap at ERROR to keep Sentry Logs quiet.
     "noq_udp=error",
+    // netwatch 0.16/0.17/main 在 `UdpSocket::poll_recv_noq` 的 trace! 字段里
+    // 直接做 `meta.len / meta.stride`,而 `noq_udp::RecvMeta.stride` 在 GRO/GSO
+    // 边界(空 datagram、内核回退到非分段路径)允许为 0,触发 divide-by-zero
+    // panic —— 因为 panic 在第三方 crate 的 trace! 求值阶段,我们栈上没有任何
+    // uc_* 帧,只能在拿到 trace event 前就把该 target 截掉。上游尚未修复
+    // (net-tools 无对应 issue),在此用 EnvFilter 硬上限堵 trace。受影响:
+    // Sentry UNICLIPBOARD-RUST-18 (Windows) / -S (macOS),同根因被按 OS 拆组。
+    "netwatch::udp=debug",
     // QUIC connection state machine internals. Cap at WARN: silences the
     // ~40k DEBUG/INFO events per peer-hour of steady-state churn but keeps
     // the WARN/ERROR signals visible. The earlier `=off` here masked the
@@ -165,7 +173,14 @@ impl LogProfile {
     /// Check if `RUST_LOG` is set and return an override `EnvFilter`.
     fn rust_log_override() -> Option<EnvFilter> {
         if std::env::var("RUST_LOG").is_ok() {
-            EnvFilter::try_from_default_env().ok()
+            let filter = EnvFilter::try_from_default_env().ok()?;
+            // 即使用户主动开了 RUST_LOG=trace 也必须把 netwatch::udp 压回 debug,
+            // 否则会触发 netwatch udp.rs:436 的 divide-by-zero panic(详见
+            // NOISE_FILTERS 同名条目)。`add_directive` 会覆盖同 target 的更
+            // 宽松规则,放在用户 RUST_LOG 解析之后追加即可生效。
+            let filter =
+                filter.add_directive("netwatch::udp=debug".parse().expect("static directive"));
+            Some(filter)
         } else {
             None
         }

--- a/src-tauri/crates/uc-observability/src/profile.rs
+++ b/src-tauri/crates/uc-observability/src/profile.rs
@@ -57,9 +57,10 @@ const NOISE_FILTERS: &[&str] = &[
     // 直接做 `meta.len / meta.stride`,而 `noq_udp::RecvMeta.stride` 在 GRO/GSO
     // 边界(空 datagram、内核回退到非分段路径)允许为 0,触发 divide-by-zero
     // panic —— 因为 panic 在第三方 crate 的 trace! 求值阶段,我们栈上没有任何
-    // uc_* 帧,只能在拿到 trace event 前就把该 target 截掉。上游尚未修复
-    // (net-tools 无对应 issue),在此用 EnvFilter 硬上限堵 trace。受影响:
-    // Sentry UNICLIPBOARD-RUST-18 (Windows) / -S (macOS),同根因被按 OS 拆组。
+    // uc_* 帧,只能在拿到 trace event 前就把该 target 截掉。上游跟踪
+    // n0-computer/net-tools#148;在上游 release 修复前用 EnvFilter 硬上限堵
+    // trace。受影响 Sentry: UNICLIPBOARD-RUST-18 (Windows) / -S (macOS),
+    // 同根因被按 OS 拆组。
     "netwatch::udp=debug",
     // QUIC connection state machine internals. Cap at WARN: silences the
     // ~40k DEBUG/INFO events per peer-hour of steady-state churn but keeps

--- a/src-tauri/crates/uc-tauri/Cargo.toml
+++ b/src-tauri/crates/uc-tauri/Cargo.toml
@@ -69,6 +69,15 @@ chrono = { version = "0.4", features = ["serde"] }
 # Tracing support
 tracing = "0.1"
 
+[target.'cfg(target_os = "linux")'.dependencies]
+# Linux tray-icon 走 libappindicator-rs，后者用 once_cell::Lazy 包了
+# dlopen，找不到 libayatana-appindicator3 时直接 panic!()。我们的 binary
+# release profile = "abort"，catch_unwind 无法接住，所以必须在调用
+# TrayIconBuilder::build 之前用 libloading 自己探一遍 4 个候选 .so，
+# 没一个能加载就跳过 tray init 而不是让上游 panic 撂倒整个进程。
+# 版本钉到 0.7 — 与 Cargo.lock 现有的间接依赖对齐避免双版本膨胀。
+libloading = "0.7"
+
 [target.'cfg(target_os = "windows")'.dependencies]
 windows = { version = "0.61", features = [
     "Win32_Foundation",

--- a/src-tauri/crates/uc-tauri/src/tray.rs
+++ b/src-tauri/crates/uc-tauri/src/tray.rs
@@ -3,6 +3,7 @@
 //! This module provides [`TrayState`] which manages the system tray icon,
 //! its context menu, and language-dependent menu item labels.
 
+use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::sync::Mutex;
 
 use tauri::menu::{MenuBuilder, MenuItem};
@@ -123,7 +124,35 @@ impl TrayState {
             }
         }
 
-        let tray = builder.build(app)?;
+        // Linux 上 tauri 的 tray-icon → libappindicator-rs 在 dlopen 失败时
+        // 走 panic 而不是 Err —— 最常见的两种情况:
+        //   1. 用户系统缺 `libayatana-appindicator3-1`(deb)或 `libayatana-appindicator`
+        //      (rpm/pacman),Arch / CachyOS / 老 Ubuntu 上特别常见。
+        //   2. 系统有 libayatana-ido3 但版本太新,要的 glib 符号
+        //      (`g_once_init_leave_pointer`) 在用户的 libglib 里不存在 →
+        //      undefined symbol → 加载链断在 ido3 上。
+        //
+        // 这个 panic 沿 FFI/C 调用栈直接撂倒进程,run.rs 那一层的
+        // `if let Err(e)` 接不住。`catch_unwind` 把它兜成"启动正常,但没
+        // tray 图标" —— 比整个 app 启不起来好得多。`is_initialized()`
+        // 保持返回 false,所有依赖 tray 的菜单更新路径已经 noop。
+        //
+        // Sentry: UNICLIPBOARD-RUST-G / -10。同根因被按栈细节拆组。
+        let tray = match catch_unwind(AssertUnwindSafe(|| builder.build(app))) {
+            Ok(Ok(tray)) => tray,
+            Ok(Err(e)) => return Err(e),
+            Err(payload) => {
+                let msg = panic_payload_to_string(payload);
+                warn!(
+                    error = %msg,
+                    "System tray init panicked (likely libayatana-appindicator3 \
+                     missing or glib ABI skew); continuing without tray. \
+                     Install `libayatana-appindicator3-1` (apt) / \
+                     `libayatana-appindicator` (pacman/dnf) and restart to restore it."
+                );
+                return Ok(());
+            }
+        };
 
         info!(
             language = %language,
@@ -247,5 +276,18 @@ fn labels_for_language(language: &str) -> (&'static str, &'static str, &'static 
     match language {
         "zh-CN" => ("打开 UniClipboard", "设置", "退出"),
         _ => ("Open UniClipboard", "Settings", "Quit"),
+    }
+}
+
+/// Stringify a `catch_unwind` payload — panics carry either `&'static str`
+/// or `String`; anything else stays opaque to avoid re-panicking inside the
+/// formatter.
+fn panic_payload_to_string(payload: Box<dyn std::any::Any + Send>) -> String {
+    if let Some(s) = payload.downcast_ref::<&'static str>() {
+        (*s).to_string()
+    } else if let Some(s) = payload.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        "<non-string panic payload>".to_string()
     }
 }

--- a/src-tauri/crates/uc-tauri/src/tray.rs
+++ b/src-tauri/crates/uc-tauri/src/tray.rs
@@ -132,12 +132,30 @@ impl TrayState {
         //      (`g_once_init_leave_pointer`) 在用户的 libglib 里不存在 →
         //      undefined symbol → 加载链断在 ido3 上。
         //
-        // 这个 panic 沿 FFI/C 调用栈直接撂倒进程,run.rs 那一层的
-        // `if let Err(e)` 接不住。`catch_unwind` 把它兜成"启动正常,但没
-        // tray 图标" —— 比整个 app 启不起来好得多。`is_initialized()`
-        // 保持返回 false,所有依赖 tray 的菜单更新路径已经 noop。
+        // 这个 panic 沿 FFI/C 调用栈直接撂倒进程。原本想用 `catch_unwind`
+        // 兜底,但 release profile = "abort"(src-tauri/Cargo.toml),
+        // Rust 编译器在 abort 模式下根本不生成 unwind 表,catch_unwind 无法
+        // 接住任何 panic —— Sentry UNICLIPBOARD-RUST-G/-10 持续刷,0.10.1-alpha.2
+        // AppImage 在 Arch 上 `Aborted (core dumped)` 验证了这一点。
         //
-        // Sentry: UNICLIPBOARD-RUST-G / -10。同根因被按栈细节拆组。
+        // 正确做法:在调用 TrayIconBuilder::build **之前**预探 4 个候选 .so,
+        // 全部失败就跳过 build,让 libappindicator-sys 的 Lazy::new closure
+        // 根本不被触发。`is_initialized()` 保持返回 false,所有依赖 tray 的
+        // 菜单更新路径已经 noop。
+        #[cfg(target_os = "linux")]
+        if !appindicator_lib_available() {
+            warn!(
+                "libayatana-appindicator3 / appindicator3 not loadable on this \
+                 system; skipping system tray init to avoid libappindicator-rs \
+                 dlopen panic. Install `libayatana-appindicator3-1` (apt) / \
+                 `libayatana-appindicator` (pacman/dnf) and restart to enable it."
+            );
+            return Ok(());
+        }
+
+        // `catch_unwind` 仅作为 panic = unwind profile 下的额外兜底(目前 release
+        // = abort,这里实际不生效,但 dev/test profile 下仍可挡住非 dlopen 类
+        // panic);Linux 主防线是上面的预探。
         let tray = match catch_unwind(AssertUnwindSafe(|| builder.build(app))) {
             Ok(Ok(tray)) => tray,
             Ok(Err(e)) => return Err(e),
@@ -145,10 +163,8 @@ impl TrayState {
                 let msg = panic_payload_to_string(payload);
                 warn!(
                     error = %msg,
-                    "System tray init panicked (likely libayatana-appindicator3 \
-                     missing or glib ABI skew); continuing without tray. \
-                     Install `libayatana-appindicator3-1` (apt) / \
-                     `libayatana-appindicator` (pacman/dnf) and restart to restore it."
+                    "System tray init panicked during builder.build(); \
+                     continuing without tray."
                 );
                 return Ok(());
             }
@@ -277,6 +293,38 @@ fn labels_for_language(language: &str) -> (&'static str, &'static str, &'static 
         "zh-CN" => ("打开 UniClipboard", "设置", "退出"),
         _ => ("Open UniClipboard", "Settings", "Quit"),
     }
+}
+
+/// 探测 libappindicator-sys 加载链上的 4 个候选 .so 是否能 dlopen 成功。
+///
+/// 与上游 `libappindicator-sys-0.9.0/src/lib.rs` 的 `Lazy<LIB>` 探测顺序完全
+/// 一致(`.so.1` 后缀两条 + backcompat feature 启用时不带后缀两条),只要任
+/// 一条能加载就视为可用 —— 这跟上游 closure 在 `Library::new(...).is_ok()`
+/// 处直接 return 的逻辑等价。全部失败再返回 false,这时调用方应当跳过
+/// `TrayIconBuilder::build` 以避免触发上游 panic。
+///
+/// 注意:dlopen 成功并不等于 indicator 上 GTK 一定能跑(比如 libayatana-ido3
+/// 在用户机器上是装了但 glib 符号缺失),那种情况依旧会在 build 内部 panic。
+/// 但 Sentry 现网数据表明 RUST-G/-10 几乎都是"so 文件本身不在"这一类,
+/// 优先解决主流场景。glib ABI skew 那条路径如果再次浮上来,届时再叠加
+/// `dlsym` 探测关键符号。
+#[cfg(target_os = "linux")]
+fn appindicator_lib_available() -> bool {
+    const CANDIDATES: &[&str] = &[
+        "libayatana-appindicator3.so.1",
+        "libappindicator3.so.1",
+        "libayatana-appindicator3.so",
+        "libappindicator3.so",
+    ];
+    for name in CANDIDATES {
+        // SAFETY: `Library::new` 加载共享库是天然 unsafe(初始化 ctors 可能
+        // 有副作用),这里仅用于探测可加载性,Library handle 离开作用域时
+        // 自动 dlclose。
+        if unsafe { libloading::Library::new(*name) }.is_ok() {
+            return true;
+        }
+    }
+    false
 }
 
 /// Stringify a `catch_unwind` payload — panics carry either `&'static str`

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -45,6 +45,14 @@
       "icons/icon.icns",
       "icons/icon.ico"
     ],
+    "linux": {
+      "deb": {
+        "depends": ["libayatana-appindicator3-1"]
+      },
+      "rpm": {
+        "depends": ["libayatana-appindicator-gtk3"]
+      }
+    },
     "createUpdaterArtifacts": true
   },
   "plugins": {


### PR DESCRIPTION
## Summary

`release/v0.10.1` is being abandoned — its only headline fix (#812, AppImage libwayland strip on aarch64) was verified ineffective against the white-window symptom on Arch ARM + GNOME and has been reverted on the branch. The other fixes on that branch are still valuable but were never merged into `main`, so 0.11.0 currently regresses on them. This PR brings them across.

## What's picked (7 commits, in original chronological order)

| Original SHA | Subject |
|---|---|
| `d9dccfdf` | fix(observability): cap netwatch::udp at debug to avoid divide-by-zero panic |
| `0678e093` | docs(observability): link netwatch::udp mitigation to upstream issue #148 |
| `e38d53b7` | fix(observability): mute tao#1180 Destroyed-state panic in Sentry before_send |
| `664ac411` | fix(tray): survive libayatana-appindicator3 dlopen failure on Linux |
| `9be3a1c2` | ci(alpha-build): install darwin targets onto src-tauri's pinned toolchain |
| `255172c9` | ci(release): let prepare-release base off any branch |
| `3062d863` | fix(tray): pre-probe libappindicator3 with libloading before build |

All seven cherry-picked clean. The two auto-merges (`Cargo.lock` adding `libloading`, `tauri.conf.json` adding `libayatana-appindicator` to .deb/.rpm `depends`) are routine and reviewed.

## What's deliberately skipped

- `9e76963c`, `d74fb13a`, `60e50d23`, `aef9c427` — release version bumps for 0.10.1-alpha.{1,2,3,4}. Not applicable to main.
- `794e6546` (#812, libwayland AppImage strip) + `4eba22cf` (its revert) — the strip approach did not restore the renderer on real aarch64 Arch hardware. AppImage on aarch64 with modern GNOME / mesa 26 remains a known issue, **not addressed by this PR** and not on the 0.11.0 critical path.

## Known follow-ups not in this PR

While verifying the backport on Arch aarch64 + GNOME, two unrelated UX bugs surfaced. Both reproduce on main after this PR is merged, neither is regressed by it:

1. `tauri-plugin-single-instance` is registered with an empty callback (`src-tauri/crates/uc-tauri/src/run.rs:241`) — a second `uniclipboard` launch should `show()` + `set_focus()` the main window, but currently does nothing.
2. The Linux tray fallback (`src-tauri/crates/uc-tauri/src/tray.rs:145-154`) treats "libayatana-appindicator dlopen succeeds" as sufficient for `is_initialized() = true`, but on vanilla GNOME (no AppIndicator extension) the StatusNotifierWatcher is not present, so the tray icon never renders and the user cannot recover the window after closing it.

Both should be filed as separate issues (draft prepared at `~/.claude/jobs/51fc5c59/issue-gnome-tray-no-recovery.md` if useful).

## Test plan

- [ ] `cargo check -p uniclipboard` passes on linux + macOS + windows targets in CI
- [ ] `bun run tauri build --no-bundle` succeeds locally (ARM linux verified during backport investigation: yay-built `uniclipboard-git` from main + these fixes renders correctly on Arch aarch64 GNOME)
- [ ] No accidental version bump in `tauri.conf.json` / `package.json` — confirmed, only `linux.deb.depends` + `linux.rpm.depends` added
- [ ] CI workflow changes (`prepare-release.yml`, `alpha-build.yml`, `tag-on-merge.yml`) reviewed by release owner

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced tray icon stability on Linux to prevent initialization failures and crashes
  * Reduced excessive logging output during debug sessions

* **Chores**
  * Improved macOS build reliability with automatic Rust target detection
  * Enhanced release workflow to support multiple release branches
  * Updated tagging system to recognize releases from different branches
  * Added system dependencies for improved Linux package compatibility

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/UniClipboard/UniClipboard/pull/817?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->