### PR TITLE
chore(observability): cut Sentry span quota burn

### DIFF
--- a/src-tauri/crates/uc-application/src/facade/encryption/mod.rs
+++ b/src-tauri/crates/uc-application/src/facade/encryption/mod.rs
@@ -39,7 +39,12 @@ impl EncryptionFacade {
         Self { deps }
     }
 
-    #[instrument(skip_all)]
+    // 故意不挂 `#[instrument]`:`state()` 是高频只读查询(前端轮询 +
+    // CLI / daemon 每个请求都会读一次),自身不做 I/O,也不推进流程。
+    // 给它开 span 会被 sentry-tracing 上报成 transaction —— 14 天观测到
+    // 96 万次,占 span 配额 ~27%。如要排障,出错路径用 `tracing::warn!`
+    // / `error!` 即可,无需 root span。其他写动作(initialize / unlock /
+    // lock / verify_keychain_access)仍保留 instrument。
     pub async fn state(&self) -> Result<EncryptionStateView, EncryptionFacadeError> {
         let initialized = self
             .deps

--- a/src-tauri/crates/uc-bootstrap/src/tracing.rs
+++ b/src-tauri/crates/uc-bootstrap/src/tracing.rs
@@ -33,6 +33,7 @@ use sentry::integrations::tracing::{
     breadcrumb_from_event, event_from_event, log_from_event, CombinedEventMapping, EventFilter,
     EventMapping,
 };
+use tracing_subscriber::filter::{filter_fn, FilterExt};
 use tracing_subscriber::prelude::*;
 
 use crate::correlation::{self, CorrelationLayer};
@@ -206,9 +207,12 @@ pub fn init_tracing_subscriber() -> anyhow::Result<()> {
                 environment: option_env!("APP_ENV")
                     .filter(|s| !s.is_empty())
                     .map(Into::into),
-                // ERROR / Exception 全采样;performance trace 降到 10% 控制 quota。
+                // ERROR / Exception 全采样;performance trace 紧急下调至 2%
+                // 控制 quota —— 2026-05 月底配额已用 80%,经诊断 iroh
+                // poll_send 与 presence 链路占 81%,在加上下方 iroh
+                // target 过滤后,2% 仍能保留可观测性。
                 sample_rate: 1.0,
-                traces_sample_rate: 0.1,
+                traces_sample_rate: 0.02,
                 // Enable Sentry Logs (replaces the legacy OTLP→Seq pipeline).
                 // Tracing ERROR + WARN events are routed to Logs by the
                 // `event_filter` below; INFO stays as a breadcrumb only.
@@ -385,7 +389,23 @@ pub fn init_tracing_subscriber() -> anyhow::Result<()> {
                         _ => EventMapping::Combined(CombinedEventMapping::from(out)),
                     }
                 })
-                .with_filter(profile.json_filter()),
+                // 紧急止血:屏蔽 iroh / iroh_* / noq_* 系列 target 进 Sentry。
+                //
+                // 诊断显示 `iroh::socket::transports::poll_send`(QUIC UDP
+                // 发包) 单一 op 占 14 天 span 配额 54%,加上 `iroh::endpoint
+                // ::connect` 与 noq_proto 链路合计 ~70%。这些来自第三方
+                // crate 的 instrument,我们无法直接精简注解,只能在喂给
+                // Sentry 的入口处整体过滤。本地 jsonl / console 不受影响
+                // (它们各自挂的是独立的 layer + filter),离线排障仍可见。
+                //
+                // 与上游 sample_rate 下调到 0.02 协同:两者乘积保证剩余配额
+                // 能撑到月底,同时保留 uc_* / clipboard 主流程 span 的可观
+                // 测性。回收条件:upstream iroh 减少自身 trace span 后,或
+                // 我们在 sentry 上开了 op-级别配额管理后,可放开本过滤。
+                .with_filter(profile.json_filter().and(filter_fn(|meta| {
+                    let t = meta.target();
+                    !(t.starts_with("iroh") || t.starts_with("noq_"))
+                }))),
         )
     } else {
         // No eprintln here -- it pollutes CLI output. Absence of a DSN is a

--- a/src-tauri/crates/uc-bootstrap/src/tracing.rs
+++ b/src-tauri/crates/uc-bootstrap/src/tracing.rs
@@ -213,6 +213,25 @@ pub fn init_tracing_subscriber() -> anyhow::Result<()> {
                 // target 过滤后,2% 仍能保留可观测性。
                 sample_rate: 1.0,
                 traces_sample_rate: 0.02,
+                // 兜底过滤:对一组已知"高频且无业务价值"的 transaction
+                // 名直接返回 0.0,确保即使有人后续加 instrument 也不会再
+                // 烧配额。对其他 transaction 退回 traces_sample_rate
+                // 的 0.02。`traces_sampler` 一旦设置就完全取代
+                // `traces_sample_rate`,所以必须显式在这里复述基线值
+                // (sentry-rust 行为详见 performance::sample_rate)。
+                //
+                // 命中表来自 2026-05 月度配额诊断 —— 这几个名字对应
+                // iroh / noq_proto 的 root transaction(虽然上方 layer
+                // filter 已经按 target 屏蔽,但 sentry-tracing 也可能
+                // 在某些路径下用更短的 transaction name,这里加一道。
+                traces_sampler: Some(Arc::new(|ctx| {
+                    matches!(
+                        ctx.name(),
+                        "poll_send" | "connect" | "QADv4" | "tx" | "state"
+                    )
+                    .then_some(0.0)
+                    .unwrap_or(0.02)
+                })),
                 // Enable Sentry Logs (replaces the legacy OTLP→Seq pipeline).
                 // Tracing ERROR + WARN events are routed to Logs by the
                 // `event_filter` below; INFO stays as a breadcrumb only.

--- a/src-tauri/crates/uc-infra/src/network/iroh/presence_adapter.rs
+++ b/src-tauri/crates/uc-infra/src/network/iroh/presence_adapter.rs
@@ -551,7 +551,12 @@ impl PresencePort for IrohPresenceAdapter {
         Ok(result)
     }
 
-    #[instrument(skip_all, fields(device = %device.as_str()))]
+    // 故意不挂 `#[instrument]`:`current_state()` 仅做 in-memory map
+    // lookup(`last_state` / `peers`),没有外部 I/O,但被 roster /
+    // list_with_presence / ensure_reachable_all 在热路径上反复调用,
+    // 14 天观测到 ~20 万次 span 落到 Sentry。`ensure_reachable` /
+    // `verify_reachable` 真做拨号,继续保留 instrument(uc-infra §10.1
+    // 强制要求关键 adapter 有 tracing)。
     async fn current_state(&self, device: &DeviceId) -> ReachabilityState {
         let key = device.as_str();
         // Prefer the last-observed snapshot — it's authoritative for


### PR DESCRIPTION
## Summary

- 月度 Sentry span 配额本月已用 80%,剩两周大概率超支。诊断(14 天 trace explorer)显示前两个 op 吃掉 81% 配额:`iroh::socket::transports::poll_send` ~54%(QUIC 底层 UDP 发包逐包 instrument),`uc_application::facade::encryption::state` ~27%(前端 / CLI 轮询的纯只读查询)。
- **紧急止血** (`16aa4284`):在 sentry-tracing layer 上叠加 target 过滤,丢弃 `iroh` / `iroh_*` / `noq_*` 系列 target 的 span;同时把 `traces_sample_rate` 从 0.1 下调到 0.02。本地 jsonl / console 不受影响,离线排障仍可见全部信息。
- **读路径瘦身 + sampler 兜底** (`b023eb5b`):去掉 `EncryptionFacade::state` 与 `IrohPresenceAdapter::current_state` 两个纯内存只读查询的 `#[instrument]`(写动作 / 拨号路径全部保留);再加一个 `traces_sampler`,对 `poll_send` / `connect` / `QADv4` / `tx` / `state` 这几个高频 transaction 名直接 0.0 采样,防止未来通过其他模块路径再次引入。

预期日均 spans 从 ~26 万降到 ~5k–15k,本月可平稳落地,主流程(clipboard / pairing / setup / 网络 I/O)观测性不受影响。

## Test plan

- [x] `cargo check -p uc-bootstrap -p uc-application -p uc-infra` 通过
- [x] `cargo fmt` 通过(pre-commit hook)
- [ ] 部署后 24h 观察 Sentry `https://mkdir700.sentry.io/explore/traces/?project=4511335726120960` 的 span 摄入速率,确认日均落在 5k–15k 区间
- [ ] 验证 `iroh::*` / `noq_*` target 的 span 在 Sentry 上完全消失(target filter 是否生效)
- [ ] 触发一次真实错误(panic 或 ERROR 日志),确认 Issue / Log 上报链路不受 sampler 影响(只影响 transaction / span)