### PR TITLE
fix(pairing): handle consumed invitation codes

### DIFF
--- a/src-tauri/crates/uc-infra/src/pairing/session.rs
+++ b/src-tauri/crates/uc-infra/src/pairing/session.rs
@@ -677,11 +677,14 @@ fn map_resolve_err(err: RendezvousHttpError) -> DialError {
         RendezvousHttpError::Transport(_) | RendezvousHttpError::ServiceUnavailable(_) => {
             DialError::ServiceUnavailable
         }
-        // 409 is not a documented outcome on /resolve; treat as internal
-        // so the server anomaly shows up in logs.
-        RendezvousHttpError::Conflict => {
-            DialError::Internal("rendezvous resolve: unexpected 409".to_string())
-        }
+        // 409 on /resolve means the rendezvous entry has reached a terminal
+        // state (sponsor side already called /consume; see `pairing_inbound`
+        // orchestrator: it consumes as soon as the joiner's `Request` is
+        // matched, which happens *before* the KeyslotOffer is sent). From
+        // the joiner's POV the code is no longer usable — collapse to
+        // `InvitationNotFound`, mirroring how `map_consume_err` already
+        // treats 404/410/409 as a single "lifecycle terminal" bucket.
+        RendezvousHttpError::Conflict => DialError::InvitationNotFound,
         RendezvousHttpError::Unexpected { status, slug } => {
             DialError::Internal(format!("rendezvous resolve: status {status} slug={slug}"))
         }
@@ -905,6 +908,34 @@ mod tests {
         {
             Err(DialError::InvitationExpired) => {}
             other => panic!("expected InvitationExpired, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn dial_maps_409_to_invitation_not_found() {
+        // Sponsor consumes the rendezvous entry as soon as it matches the
+        // joiner's first Request (see `pairing_inbound::orchestrator`).
+        // A subsequent /resolve on the same code therefore returns 409
+        // `pairing_already_consumed`. From the joiner's POV the code is
+        // dead — surface it as `InvitationNotFound` so the daemon returns
+        // HTTP 404 with a meaningful message ("invitation not found")
+        // instead of a 500 internal error.
+        let rendezvous = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/pairings/resolve"))
+            .respond_with(ResponseTemplate::new(409))
+            .mount(&rendezvous)
+            .await;
+
+        let endpoint = bound_endpoint().await;
+        let adapter = adapter_with_rendezvous(endpoint, rendezvous.uri());
+
+        match adapter
+            .dial_by_invitation(&InvitationCode::new("CONSUMED"))
+            .await
+        {
+            Err(DialError::InvitationNotFound) => {}
+            other => panic!("expected InvitationNotFound, got {other:?}"),
         }
     }
 

--- a/src/components/device/SwitchSpaceDialog.tsx
+++ b/src/components/device/SwitchSpaceDialog.tsx
@@ -139,11 +139,26 @@ export default function SwitchSpaceDialog({ open, onOpenChange }: SwitchSpaceDia
     }
   }
 
+  // 邀请码已废类（被 sponsor consume、过期、或 sponsor 不认）—— 原 code 不可能再
+  // resolve 成功，"重试"按钮文案与回到 input 时的清空策略都按这个走。
+  const isCodeDead =
+    errorKind === 'invitation_not_found' ||
+    errorKind === 'invitation_expired' ||
+    errorKind === 'sponsor_rejected'
+
   const handleRetry = () => {
+    if (isCodeDead) {
+      setCode('')
+      setPass('')
+    } else if (errorKind === 'passphrase_mismatch') {
+      setPass('')
+    }
     setErrorKind(null)
     setErrorRaw(null)
     setStep('input')
   }
+
+  const retryLabel = isCodeDead ? t('actions.useNewCode') : t('actions.retry')
 
   const failureMessage = useMemo(() => {
     if (!errorKind) return null
@@ -297,7 +312,7 @@ export default function SwitchSpaceDialog({ open, onOpenChange }: SwitchSpaceDia
         <Button variant="outline" onClick={() => onOpenChange(false)}>
           {t('actions.close')}
         </Button>
-        <Button onClick={handleRetry}>{t('actions.retry')}</Button>
+        <Button onClick={handleRetry}>{retryLabel}</Button>
       </>
     )
   }

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -1125,7 +1125,8 @@
         "switching": "Switching…",
         "cancel": "Cancel",
         "close": "Close",
-        "retry": "Retry"
+        "retry": "Retry",
+        "useNewCode": "Enter a new code"
       },
       "migrating": {
         "title": "Migrating clipboard history",
@@ -1150,9 +1151,9 @@
           "not_setup": "This device hasn't completed first-time setup. Use \"Initialize\" or \"Join\" first.",
           "pending_migration": "A previous migration is still in flight. Restart the app to auto-resume.",
           "not_unlocked": "Space session is locked. Restart the app so the keychain re-unlocks it.",
-          "sponsor_rejected": "Sponsor did not recognise the invitation code.",
+          "sponsor_rejected": "Sponsor did not recognise the invitation code. Ask them to issue a fresh one.",
           "sponsor_declined": "Sponsor declined the pairing.",
-          "invitation_not_found": "Invitation code is invalid. Ask the sponsor to issue a fresh one.",
+          "invitation_not_found": "Invitation code has already been used or is no longer valid. Ask the sponsor to issue a fresh one.",
           "invitation_expired": "Invitation expired. Ask the sponsor to issue a fresh one.",
           "passphrase_mismatch": "Wrong passphrase — please retry.",
           "device_name_required": "Device name is required.",
@@ -1487,11 +1488,11 @@
         "passphrase": "Enter the passphrase from the host device"
       },
       "errors": {
-        "invitationNotFound": "This invitation code is not recognised. Double-check what was shown on the other device.",
+        "invitationNotFound": "This invitation code has already been used or is no longer valid. Ask the host to issue a new one.",
         "invitationExpired": "This invitation has expired. Ask the host to issue a new one.",
         "passphraseMismatch": "The passphrase doesn't match. Try again.",
         "sponsorUnreachable": "The host device is not reachable right now. Make sure both devices are online.",
-        "sponsorRejected": "The host did not recognise this code.",
+        "sponsorRejected": "The host did not recognise this code. Ask them to issue a new one.",
         "sponsorDeclined": "The host declined the pairing request.",
         "timeout": "The pairing handshake timed out. Please try again.",
         "connectionLost": "The connection dropped mid-handshake. Please try again.",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -1116,7 +1116,8 @@
         "switching": "切换中…",
         "cancel": "取消",
         "close": "关闭",
-        "retry": "重试"
+        "retry": "重试",
+        "useNewCode": "重新输入邀请码"
       },
       "migrating": {
         "title": "迁移剪贴板历史",
@@ -1141,10 +1142,10 @@
           "not_setup": "本设备尚未完成首次 setup，请先“初始化”或“加入”。",
           "pending_migration": "上次迁移未完成，请重启应用让其自动续跑。",
           "not_unlocked": "空间会话未解锁，请重启应用让 keychain 重新解锁。",
-          "sponsor_rejected": "对方没有识别这个邀请码。",
+          "sponsor_rejected": "对方未识别这个邀请码，请让对方重新生成。",
           "sponsor_declined": "对方拒绝了配对请求。",
-          "invitation_not_found": "邀请码无效，请让对方重新签发。",
-          "invitation_expired": "邀请码已过期，请让对方重新签发。",
+          "invitation_not_found": "邀请码已被使用或失效，请让对方重新生成一个。",
+          "invitation_expired": "邀请码已过期，请让对方重新生成一个。",
           "passphrase_mismatch": "口令错误，请重试。",
           "device_name_required": "缺少设备名。",
           "sponsor_unreachable": "无法连接到对方，请检查 NAT / relay。",
@@ -1571,11 +1572,11 @@
         "passphrase": "输入对方在创建空间时使用的口令"
       },
       "errors": {
-        "invitationNotFound": "邀请码无效，请仔细核对对方设备上显示的字符。",
-        "invitationExpired": "邀请码已过期，请请求对方重新生成一个。",
+        "invitationNotFound": "邀请码已被使用或失效，请让对方重新生成一个。",
+        "invitationExpired": "邀请码已过期，请让对方重新生成一个。",
         "passphraseMismatch": "口令错误，请重试。",
         "sponsorUnreachable": "暂时无法连接对方设备，请确认两台设备都在线。",
-        "sponsorRejected": "对方未识别该邀请码。",
+        "sponsorRejected": "对方未识别该邀请码，请让对方重新生成。",
         "sponsorDeclined": "对方拒绝了本次配对请求。",
         "timeout": "配对握手超时，请重试。",
         "connectionLost": "配对过程中连接中断，请重试。",

--- a/src/pages/setup/screens.tsx
+++ b/src/pages/setup/screens.tsx
@@ -485,7 +485,22 @@ export function RedeemInvitationScreen({
     setErrorKind(null)
     if (!canSubmit) return
     const res = await onSubmit({ code, passphrase: pass })
-    if (!res.ok) setErrorKind(res.kind)
+    if (!res.ok) {
+      setErrorKind(res.kind)
+      // 邀请码已废类——原 code 必然 404,清掉让用户必须输入新邀请码。
+      // 口令错——保留 code,清 pass,焦点跳回口令框。
+      if (
+        res.kind === 'invitation_not_found' ||
+        res.kind === 'invitation_expired' ||
+        res.kind === 'sponsor_rejected'
+      ) {
+        setCode('')
+        setPass('')
+      } else if (res.kind === 'passphrase_mismatch') {
+        setPass('')
+        passInputRef.current?.focus()
+      }
+    }
   }
 
   return (


### PR DESCRIPTION
## Summary

- **Backend (`src-tauri/.../pairing/session.rs`)**: the joiner's `/resolve` receives 409 from rendezvous when the sponsor has already consumed the entry — this happens as soon as the joiner's `Request` is matched, *before* the `KeyslotOffer` is sent (see `pairing_inbound` orchestrator). Previously mapped to `DialError::Internal` (HTTP 500); now maps to `DialError::InvitationNotFound` (HTTP 404), mirroring how `map_consume_err` already buckets 404/410/409 as a single "lifecycle terminal" outcome. New unit test covers the 409 → `InvitationNotFound` path.
- **Frontend join UX (`screens.tsx` first-run flow + `SwitchSpaceDialog.tsx` space switcher)**: `invitation_not_found` / `invitation_expired` / `sponsor_rejected` are now treated as "code is dead" — both fields are cleared and the action button label switches to "Enter a new code". Passphrase mismatches preserve the code and refocus the passphrase field.
- **i18n copy (en/zh)**: messages now say "already been used or no longer valid, ask the host to issue a new one" — the previous "double-check what was shown" wording was misleading once the code was consumed. Added `actions.useNewCode` key. This brings the UI in line with what `docs-site/.../troubleshooting.mdx` already states ("short-lived and single-use. Once consumed or expired, regenerate one on the sponsor").

## Test plan

- [x] `cargo test -p uc-infra pairing::session::tests::dial_maps_409_to_invitation_not_found` passes.
- [x] Existing `dial_maps_5xx_to_service_unavailable` and friends still pass (no regression on other status code mappings).
- [ ] Manual: trigger the race by having the sponsor accept on device A, then have device B attempt to join with the same (now-consumed) code — verify the join dialog shows "already been used" copy and the action button reads "Enter a new code"; clicking it clears both fields.
- [ ] Manual: enter a wrong passphrase with a valid code — verify only the passphrase field is cleared and refocused, the code is preserved, and the button still reads "Retry".
- [ ] Manual: repeat both scenarios on the first-run `RedeemInvitationScreen` (not just the in-app `SwitchSpaceDialog`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved detection of invalid or expired invitation codes during pairing setup
  * Enhanced error handling to distinguish between dead codes and passphrase mismatches
  * Tailored retry actions based on specific error type

* **Tests**
  * Added test coverage for invitation code validation

* **Documentation**
  * Updated English and Chinese UI messages to provide clearer error guidance for invitation-related failures

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/UniClipboard/UniClipboard/pull/837?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->