### PR TITLE
fix(ci): recover v0.11.1 archive + prevent regression

### DIFF
--- a/.github/workflows/recover-release-archive.yml
+++ b/.github/workflows/recover-release-archive.yml
@@ -1,0 +1,120 @@
+name: Recover Release Archive
+
+# One-shot recovery for the "Archive release notes" / "Assemble update manifest" /
+# "Deploy update manifests to GitHub Pages" tail of release.yml.
+#
+# Use this when those steps failed for a release whose primary outputs
+# (GitHub Release + R2 manifest) already succeeded. It re-runs only the
+# archive / GH Pages portion against an existing tag, fetching .sig files
+# from the GitHub Release so it does not depend on the build artifacts of
+# the original workflow run.
+#
+# Typical invocation:
+#   gh workflow run recover-release-archive.yml \
+#     -f version=0.11.1 \
+#     -f channel=stable
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to recover (no v prefix), e.g. 0.11.1'
+        required: true
+        type: string
+      channel:
+        description: 'Release channel'
+        required: true
+        default: 'stable'
+        type: choice
+        options:
+          - stable
+          - rc
+          - beta
+          - alpha
+
+jobs:
+  recover:
+    name: Recover archive for v${{ inputs.version }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pages: write
+    steps:
+      - name: Checkout repository at tag
+        uses: actions/checkout@v6
+        with:
+          ref: v${{ inputs.version }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: lts/*
+          cache: 'npm'
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Install wrangler
+        run: npm install -g wrangler
+
+      - name: Download .sig files from GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p release-assets
+          gh release download "v${{ inputs.version }}" \
+            --repo "${{ github.repository }}" \
+            --pattern '*.sig' \
+            --dir release-assets
+          echo "Downloaded .sig files:"
+          ls -la release-assets
+
+      - name: Archive release notes and update channel index
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          VERSION="${{ inputs.version }}"
+          CHANNEL="${{ inputs.channel }}"
+
+          node scripts/archive-release-notes.js \
+            --version "$VERSION" \
+            --channel "$CHANNEL" \
+            --notes-file "docs/changelog/${VERSION}.md" \
+            --zh-notes-file "docs/changelog/${VERSION}.zh.md"
+
+      - name: Assemble update manifest
+        run: |
+          VERSION="${{ inputs.version }}"
+          CHANNEL="${{ inputs.channel }}"
+          BASE_URL="https://github.com/${{ github.repository }}/releases/download/v${VERSION}"
+
+          node scripts/assemble-update-manifest.js \
+            --version "$VERSION" \
+            --artifacts-dir release-assets \
+            --output "updates/${CHANNEL}.json" \
+            --base-url "$BASE_URL" \
+            --notes-file "docs/changelog/${VERSION}.md" \
+            --zh-notes-file "docs/changelog/${VERSION}.zh.md"
+
+          echo "Manifest assembled for channel: ${CHANNEL}"
+          cat "updates/${CHANNEL}.json"
+
+      - name: Deploy update manifests to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./updates
+          destination_dir: .
+          keep_files: true
+          commit_message: 'deploy(recover): update ${{ inputs.channel }} manifest for v${{ inputs.version }}'
+
+      - name: Summary
+        run: |
+          {
+            echo "## Recovered archive for v${{ inputs.version }} (${{ inputs.channel }})"
+            echo ""
+            echo "- R2 archive: \`release-notes/v${{ inputs.version }}.json\`"
+            echo "- R2 channel index: \`release-notes/index/${{ inputs.channel }}.json\`"
+            echo "- GitHub Pages: \`${{ inputs.channel }}.json\` updated"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,6 +185,12 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: lts/*
+          cache: 'npm'
+
+      - name: Install npm dependencies
+        # archive-release-notes.js imports `semver`; without node_modules
+        # the Archive step fails with ERR_MODULE_NOT_FOUND.
+        run: npm ci
 
       - name: Download all artifacts
         uses: actions/download-artifact@v6


### PR DESCRIPTION
## Summary

- **fix(ci): install npm deps in release job before archive script** — `scripts/archive-release-notes.js` imports `semver`, which was declared in `package.json` but not installed in the release job. The v0.11.1 release failed at *Archive release notes and update channel index* with `ERR_MODULE_NOT_FOUND`. Adds `npm ci` (and setup-node's npm cache) so the archive and assemble scripts always have their deps.
- **feat(ci): add recover-release-archive workflow** — a `workflow_dispatch` entry point that re-runs only the archive / assemble / GH Pages tail of `release.yml` against an existing tag, fetching `.sig` files from the GitHub Release itself. Useful when the tail steps fail but the GitHub Release + R2 manifest already published — re-running the full release pipeline would recreate the release and duplicate uploads.

## Context

v0.11.1 release workflow ([run #26357584938](https://github.com/UniClipboard/UniClipboard/actions/runs/26357584938)) succeeded in publishing the GitHub Release and R2 `manifests/stable.json`, but failed before it could:

- archive `release-notes/v0.11.1.json` and update `release-notes/index/stable.json` on R2 (used by the `/<channel>.json?from=<version>` cross-version notes endpoint introduced in #836)
- deploy the legacy GitHub Pages `stable.json`

Users on the updater were not impacted (R2 primary manifest is up to date and the cross-version endpoint degrades to latest-only when the index is missing).

## Test plan

- [ ] Merge PR
- [ ] `gh workflow run recover-release-archive.yml -f version=0.11.1 -f channel=stable` (or trigger from the Actions UI)
- [ ] Verify the recover run is green
- [ ] Verify `release-notes/v0.11.1.json` exists in the `uniclipboard-releases` R2 bucket and `release-notes/index/stable.json` has `0.11.1` at the top
- [ ] Verify `https://uniclipboard.github.io/UniClipboard/stable.json` shows version `0.11.1` and the other channel files were preserved (`keep_files: true`)
- [ ] On the next real release, confirm the `Archive release notes and update channel index` step succeeds with `npm ci` in place

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added a new workflow to enable manual recovery and restoration of release archives, supporting flexible configuration of versions and distribution channels for improved release management
  * Improved the automated release workflow with enhanced Node.js environment setup, including optimized caching and explicit dependency installation to strengthen build reliability and prevent generation failures

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/UniClipboard/UniClipboard/pull/843?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->