### PR TITLE
fix(ci): use bun install in release + recover workflows

### DIFF
--- a/.github/workflows/recover-release-archive.yml
+++ b/.github/workflows/recover-release-archive.yml
@@ -49,10 +49,14 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: lts/*
-          cache: 'npm'
 
-      - name: Install npm dependencies
-        run: npm ci
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install frontend dependencies
+        run: bun install --frozen-lockfile
 
       - name: Install wrangler
         run: npm install -g wrangler

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,12 +185,16 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: lts/*
-          cache: 'npm'
 
-      - name: Install npm dependencies
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install frontend dependencies
         # archive-release-notes.js imports `semver`; without node_modules
         # the Archive step fails with ERR_MODULE_NOT_FOUND.
-        run: npm ci
+        run: bun install --frozen-lockfile
 
       - name: Download all artifacts
         uses: actions/download-artifact@v6


### PR DESCRIPTION
## Summary

Follow-up to #843, which incorrectly used `npm ci` to install deps in the release and recover workflows. The project uses **Bun** (`bun.lock` is tracked, `package-lock.json` is not), so:

- The recover-release-archive run for v0.11.1 failed at *Setup Node.js* — [run 26359266251](https://github.com/UniClipboard/UniClipboard/actions/runs/26359266251) — with `Dependencies lock file is not found ... Supported file patterns: package-lock.json, npm-shrinkwrap.json, yarn.lock`.
- The same misconfiguration would have broken the next real release (`release.yml`).

Replaces `setup-node` cache + `npm ci` with `oven-sh/setup-bun@v2` + `bun install --frozen-lockfile`, matching the canonical pattern already used by `build.yml`, `format.yml`, `cache-warmup.yml`, `frontend-coverage.yml`, `pr-check.yml`. `setup-node` itself is kept so explicit `node scripts/*.js` invocations still resolve a Node runtime; `npm install -g wrangler` stays as-is (global CLI install, unrelated to local deps).

This is my mistake — sorry for the extra round. I should have grepped existing workflows for the install pattern before writing the first fix.

## Test plan

- [ ] Merge PR
- [ ] `gh workflow run recover-release-archive.yml -f version=0.11.1 -f channel=stable --ref main`
- [ ] Verify the recover run is green (Setup Node.js → Install Bun → Install frontend dependencies → wrangler → download .sig → archive → assemble → gh-pages deploy)
- [ ] Verify R2 has `release-notes/v0.11.1.json` and `release-notes/index/stable.json` lists 0.11.1 at the top
- [ ] Verify `https://uniclipboard.github.io/UniClipboard/stable.json` reports version 0.11.1 (and other channel files preserved by `keep_files: true`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow dependency installation configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/UniClipboard/UniClipboard/pull/844?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->