### PR TITLE
fix(scripts): recognize 'does not exist' as missing R2 object

### DIFF
--- a/scripts/archive-release-notes.js
+++ b/scripts/archive-release-notes.js
@@ -140,8 +140,15 @@ function r2GetText(bucket, key) {
     return fs.readFileSync(outPath, 'utf8')
   } catch (err) {
     // 对象不存在时 wrangler 退出码非零；这里识别 404 并返回 null。
+    // 实测 wrangler 对缺失对象输出 "The specified key does not exist."，
+    // 加上 "not found" / "NoSuchKey" / "404" 一起兜底。
     const stderr = String(err?.stderr ?? '')
-    if (stderr.includes('not found') || stderr.includes('NoSuchKey') || stderr.includes('404')) {
+    if (
+      stderr.includes('not found') ||
+      stderr.includes('NoSuchKey') ||
+      stderr.includes('404') ||
+      stderr.includes('does not exist')
+    ) {
       return null
     }
     throw err


### PR DESCRIPTION
## Summary

`r2GetText()` in `scripts/archive-release-notes.js` maps a missing R2 object to `null` so that the first-ever write to a channel index is treated as *create empty index, then insert this version*. The matcher covered `not found` / `NoSuchKey` / `404` but missed wrangler's actual stderr — `The specified key does not exist.` — so the first archive attempt for v0.11.1 (the inaugural write to `release-notes/index/stable.json`) threw with a non-matching message instead of seeding a new index.

Adds `does not exist` to the substrings.

Reproduced live in [run 26359399546](https://github.com/UniClipboard/UniClipboard/actions/runs/26359399546):

```
Uploading release-notes/v0.11.1.json → uniclipboard-releases    ← OK
Fetching release-notes/index/stable.json…
Command failed: wrangler r2 object get …/release-notes/index/stable.json
✘ [ERROR] The specified key does not exist.
```

Once the index exists, subsequent versions hit the read-modify-write path and never trigger this branch — so this latent bug only surfaces on the first release of each channel.

## Test plan

- [ ] Merge PR
- [ ] `gh workflow run recover-release-archive.yml -f version=0.11.1 -f channel=stable --ref main`
- [ ] Verify the Archive step now completes (creates the index with `0.11.1` as the sole entry)
- [ ] Verify R2 `release-notes/index/stable.json` and `release-notes/v0.11.1.json`
- [ ] Verify gh-pages `stable.json` updated to v0.11.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for archived release notes retrieval, now more reliably identifies and handles missing files from storage, returning gracefully instead of throwing errors in additional scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/UniClipboard/UniClipboard/pull/845?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->