### PR TITLE
fix(ci): recover workflow checks out main, not the release tag

### DIFF
--- a/.github/workflows/recover-release-archive.yml
+++ b/.github/workflows/recover-release-archive.yml
@@ -40,10 +40,18 @@ jobs:
       contents: write
       pages: write
     steps:
-      - name: Checkout repository at tag
+      - name: Checkout repository (default branch)
+        # Intentionally NOT pinned to the v<version> tag: the recover
+        # workflow is meant to apply *post-release* script fixes against
+        # an older release. The tagged commit contains the scripts as
+        # they existed at release time, which may carry the very bug we
+        # are recovering from (e.g. v0.11.1 shipped without the
+        # "does not exist" R2 404 recognition added in #845).
+        # docs/changelog/<version>.{md,zh.md} are added by prepare-release
+        # before the tag is cut and remain on main afterwards, so the
+        # default branch always has both the latest scripts and the
+        # changelog files this workflow needs.
         uses: actions/checkout@v6
-        with:
-          ref: v${{ inputs.version }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v6


### PR DESCRIPTION
## Summary

Follow-up to #845. The recover workflow re-ran for v0.11.1 ([run 26359485742](https://github.com/UniClipboard/UniClipboard/actions/runs/26359485742)) and still failed on the same `does not exist` line — because *Checkout repository at tag* pinned `ref: v0.11.1`, and the v0.11.1 tag still contains the pre-fix `archive-release-notes.js`. The script fix only landed on main.

The recover workflow's whole purpose is to apply *post-release* fixes against an already-tagged release, so pinning to the tag works against itself. Drop the `ref:` pin so checkout uses the triggering ref (main when invoked with `--ref main`).

`docs/changelog/<version>.{md,zh.md}` are committed by `prepare-release` before the tag is cut and remain on main afterwards, so the default branch always has both the latest scripts and the changelog files this workflow needs.

## Test plan

- [ ] Merge PR
- [ ] `gh workflow run recover-release-archive.yml -f version=0.11.1 -f channel=stable --ref main`
- [ ] Archive step completes (creates new `release-notes/index/stable.json` with v0.11.1)
- [ ] R2 has `release-notes/v0.11.1.json` (already uploaded on previous run) and `release-notes/index/stable.json`
- [ ] gh-pages `stable.json` shows v0.11.1, other channel files preserved