### PR TITLE
fix(presence): close stale-Online window + drop hairpin IP on LAN

### DIFF
--- a/.claude/skills/dual-side-debug/SKILL.md
+++ b/.claude/skills/dual-side-debug/SKILL.md
@@ -8,14 +8,14 @@ user-invocable: true
 
 Inspect logs from the macOS host and the Windows peer in a single, time-aligned view.
 
-This project is a Tauri desktop app where two peers (macOS + Windows) sync clipboard / files over an iroh-based network. The Windows machine's app data root is exposed to the Mac via SMB and mounted at `/tmp/win-uniclipboard/`, so both sides' JSONL logs are reachable from this host.
+This project is a Tauri desktop app where two peers (macOS + Windows) sync clipboard / files over an iroh-based network. The Windows machine's `AppData/Local` is exposed to the Mac via SMB and mounted at `/tmp/win-local/`, so both sides' JSONL logs are reachable from this host.
 
 The helper script lives at `.claude/skills/dual-side-debug/dual-logs.sh`. It is the **only** thing you should need to invoke for log work — do not hand-roll `ls`/`tail`/`jq` pipelines unless the script can't express what you need.
 
 ## Log layout you must remember
 
 * **macOS logs**: `~/Library/Application Support/app.uniclipboard.desktop[-<UC_PROFILE>]/logs/uniclipboard.json.YYYY-MM-DD`
-* **Windows logs (mounted)**: `/tmp/win-uniclipboard/logs/uniclipboard.json.YYYY-MM-DD`
+* **Windows logs (mounted)**: `/tmp/win-local/app.uniclipboard.desktop[-<WIN_PROFILE>]/logs/uniclipboard.json.YYYY-MM-DD`
 * Format: **JSON Lines**. Each line has at least `timestamp` (UTC, ISO-8601 with `Z`), `level`, `target`, `message`, `span`, `device_id`, plus structured fields.
 * The date in the filename is **UTC**, not local time. A file named `...2026-04-25` can be the live file while it is still 2026-04-24 in PDT.
 
@@ -26,54 +26,59 @@ The Windows logs only exist on this Mac because an SMB share is mounted from `DE
 Before debugging, verify a mount exists:
 
 ```bash
-mount | grep -E 'win-uniclipboard|win-local' || echo "no SMB mount yet"
+mount | grep -E 'win-local|win-uniclipboard' || echo "no SMB mount yet"
 ```
 
 If nothing is mounted, **stop and ask the user before running `mount_smbfs`** — it prompts for the Windows password interactively and the agent shouldn't silently do credential prompts. Hand the user the exact commands and let them run via `! <cmd>`.
 
-There are two mount layouts in use; pick based on the use case:
+### Default: broad mount of `AppData/Local` at `/tmp/win-local`
 
-### A. Narrow mount — matches the script's default `WIN_LOGS`
-
-Mount **just the uniclipboard profile dir** at `/tmp/win-uniclipboard`. This is what `dual-logs.sh` expects out of the box, no env var needed:
-
-```bash
-mkdir -p /tmp/win-uniclipboard
-mount_smbfs '//DESKTOP-HIC7MLI/Users/mark/AppData/Local/app.uniclipboard.desktop-<WIN_PROFILE>' /tmp/win-uniclipboard
-```
-
-Caveat: this pins you to **one** Windows profile. Switching the Windows side to a different `UC_PROFILE` requires unmounting and re-mounting.
-
-### B. Broad mount — entire `AppData/Local`
-
-Mount the whole `Local` folder at `/tmp/win-local`. This lets you reach any profile without re-mounting, but you must point the script at the right subdir via `WIN_LOGS`:
+This is what `dual-logs.sh` expects out of the box. It exposes **every** Windows uniclipboard profile dir at once, so you can switch profiles without re-mounting:
 
 ```bash
 mkdir -p /tmp/win-local
 mount_smbfs '//DESKTOP-HIC7MLI/Users/mark/AppData/Local' /tmp/win-local
-
-# Then for every dual-logs.sh invocation:
-WIN_LOGS=/tmp/win-local/app.uniclipboard.desktop-<WIN_PROFILE>/logs \
-  .claude/skills/dual-side-debug/dual-logs.sh status
 ```
 
-(Or `export WIN_LOGS=...` once for the shell session.)
+After mount you'll see dirs like `/tmp/win-local/app.uniclipboard.desktop`, `/tmp/win-local/app.uniclipboard.desktop-dev`, plus old version-suffixed ones. The script auto-detects the freshest one (see "Profile resolution" below).
+
+### Legacy: narrow mount at `/tmp/win-uniclipboard`
+
+Older sessions sometimes still use this — mounting **only one** profile dir directly. The script supports it via the `WIN_LOGS` env override (full-path bypass of `$WIN_BASE`):
+
+```bash
+mkdir -p /tmp/win-uniclipboard
+mount_smbfs '//DESKTOP-HIC7MLI/Users/mark/AppData/Local/app.uniclipboard.desktop-<WIN_PROFILE>' /tmp/win-uniclipboard
+
+# Then for every invocation:
+WIN_LOGS=/tmp/win-uniclipboard/logs .claude/skills/dual-side-debug/dual-logs.sh status
+```
+
+Prefer the broad mount unless there's a specific reason — it pins you to one profile and requires re-mounting to switch.
 
 ### Tearing down
 
 If the mount is wedged (Finder hangs, `ls` blocks for 30s), unmount cleanly before re-mounting:
 
 ```bash
-umount /tmp/win-uniclipboard   # or /tmp/win-local
+umount /tmp/win-local   # or /tmp/win-uniclipboard
 ```
 
-If `umount` fails because the path is busy, fall back to `diskutil unmount force /tmp/win-uniclipboard`.
+If `umount` fails because the path is busy, fall back to `diskutil unmount force /tmp/win-local`.
 
 ## Profile resolution (DO NOT skip this step)
 
-The default macOS profile is **`dev`** (`package.json`'s `tauri:dev` script sets `UC_PROFILE=dev`). Always treat `dev` as the assumed profile **unless** the user has said otherwise in this conversation.
+Mac and Windows each have their own active profile, and they are **not always the same name**. The script resolves each side independently.
 
-But the user often runs other profiles (`a`, `b` for `tauri:dev:peerA`/`peerB`, or ad-hoc names like `abc`). The active profile is a **runtime fact**, not a config you can read — you must verify it from disk.
+### Mac profile
+
+Default is **`dev`** (`package.json`'s `tauri:dev` script sets `UC_PROFILE=dev`). Treat `dev` as the assumed Mac profile unless the user said otherwise. The user sometimes runs other profiles (`a`, `b` for `tauri:dev:peerA`/`peerB`, or ad-hoc names like `abc`). Override with `--profile <name>`.
+
+### Windows profile
+
+The script **auto-detects** the Windows profile by scanning `$WIN_BASE` for the profile dir whose latest log file has the newest mtime. This handles the common case where the Win side is on a different profile than the Mac side, without you having to know which one. Override with `--win-profile <name>` (or `--win-profile default` for the no-suffix `app.uniclipboard.desktop` dir).
+
+### Always run `status` first
 
 Before answering any question that depends on log content, run:
 
@@ -83,12 +88,13 @@ Before answering any question that depends on log content, run:
 
 Then judge:
 
-1. Does the assumed profile's log directory exist?
-2. Is the latest log file's `mtime` close to "now" (look at the `freshness` column — `live (<2m)` or `recent (<10m)` is good; anything older means the process probably isn't running on this profile)?
+1. Does the assumed Mac profile's log directory exist?
+2. For each side, is the latest log file's `mtime` close to "now" (`live (<2m)` or `recent (<10m)` is good; anything older means the process probably isn't running on that profile)?
+3. On the Win side, the `status` output shows which profile was auto-detected and prints the alternatives sorted by mtime — sanity-check that it picked the one the user actually meant.
 
-**If the assumed profile dir is missing, OR the freshness is `stale` / `old` / `cold` while the user is actively reproducing**, stop and ask the user to confirm `UC_PROFILE`. The status output already lists the available profiles with their latest mtimes — use that to suggest a likely candidate. Example:
+**If the assumed profile dir is missing, OR the freshness is `stale` / `old` / `cold` while the user is actively reproducing**, stop and ask the user to confirm. Suggest a likely candidate from the available-profiles list. Example:
 
-> dev profile dir doesn't exist on this machine. The most recently active profile is `abc` (last write 30s ago). Should I use `abc`, or are you running with a different `UC_PROFILE`?
+> dev profile dir doesn't exist on Mac. The most recently active Mac profile is `abc` (last write 30s ago). Should I use `abc`, or are you running with a different `UC_PROFILE`?
 
 Do not silently fall back. Wrong profile = looking at frozen logs from a previous session.
 
@@ -102,8 +108,8 @@ Always invoke via the script. From the project root:
 
 | Command         | When to use                                                                 |
 | --------------- | --------------------------------------------------------------------------- |
-| `status`        | First call of any debug session. Confirms profile + freshness on both sides.|
-| `list-profiles` | When you suspect the user is on a profile other than `dev`.                 |
+| `status`        | First call of any debug session. Confirms profile + freshness on both sides. Shows which Win profile was auto-detected. |
+| `list-profiles` | When you suspect the user is on a profile other than `dev`. Defaults to both sides; use `--side win` for just the Windows list. |
 | `paths`         | Just need the resolved file paths (e.g. to feed another tool).              |
 | `tail`          | Quick "what just happened" — defaults to last 50 lines, both sides.         |
 | `grep <pat>`    | Plain string match. Cheap; good first probe (e.g. an error message, a device id). |
@@ -111,7 +117,8 @@ Always invoke via the script. From the project root:
 | `merge`         | Time-interleave both sides into a single chronological stream. Use this whenever the question is *"what happened between Mac and Windows around time X"*. |
 
 ### Useful flags
-* `--profile <name>` — override profile (default: `dev`).
+* `--profile <name>` — Mac profile override (default: `dev`).
+* `--win-profile <name>` — Win profile override (default: auto-detected by mtime). Use `default` for the no-suffix dir.
 * `--side mac|win|both` — restrict to one side.
 * `--lines N` — output line cap.
 * `--since <ISO8601>` (merge only) — drop lines older than this UTC timestamp.

--- a/.claude/skills/dual-side-debug/dual-logs.sh
+++ b/.claude/skills/dual-side-debug/dual-logs.sh
@@ -5,12 +5,19 @@
 # (uniclipboard.json.YYYY-MM-DD), so "today" here means UTC today.
 #
 # macOS path:    $MAC_BASE/app.uniclipboard.desktop[-<UC_PROFILE>]/logs/
-# Windows path:  /tmp/win-uniclipboard/logs/   (SMB share mounted on this Mac)
+# Windows path:  $WIN_BASE/app.uniclipboard.desktop[-<WIN_PROFILE>]/logs/
+#                (SMB share of //<host>/Users/<user>/AppData/Local mounted at $WIN_BASE)
+#
+# Win profile resolution priority:
+#   1. --win-profile <name> on the command line
+#   2. $WIN_LOGS env var (legacy full-path override, skips $WIN_BASE)
+#   3. auto-detect: profile under $WIN_BASE whose latest log file has the newest mtime
 
 set -euo pipefail
 
 MAC_BASE="${MAC_BASE:-$HOME/Library/Application Support}"
-WIN_LOGS="${WIN_LOGS:-/tmp/win-uniclipboard/logs}"
+WIN_BASE="${WIN_BASE:-/tmp/win-local}"
+WIN_LOGS_OVERRIDE="${WIN_LOGS:-}"
 DEFAULT_PROFILE="${UC_PROFILE_DEFAULT:-dev}"
 
 usage() {
@@ -19,20 +26,32 @@ Usage: dual-logs.sh <command> [options]
 
 Commands:
   status                       Show both sides: profile dirs, latest log files, freshness.
-  list-profiles                List all macOS profile dirs that have a logs/ folder.
-  paths [--profile <name>]     Print resolved log file paths for both sides.
-  tail   [--profile <name>] [--lines N] [--side mac|win|both]
+                               Windows profile is auto-detected (newest mtime) unless overridden.
+  list-profiles [--side mac|win|both]
+                               List all profile dirs (default: both sides).
+  paths  [--profile <name>] [--win-profile <name>]
+                               Print resolved log file paths for both sides.
+  tail   [--profile <name>] [--win-profile <name>] [--lines N] [--side mac|win|both]
                                Tail latest log file. Default: --side both --lines 50.
-  query  [--profile <name>] [--side mac|win|both]
+  query  [--profile <name>] [--win-profile <name>] [--side mac|win|both]
                                Pipe latest logs through jq. Read --filter from arg or stdin.
                                Examples:
                                  dual-logs.sh query --filter '. | select(.level=="ERROR")'
                                  dual-logs.sh query --side mac --filter '. | select(.target|test("pairing"))'
-  merge  [--profile <name>] [--since <ISO8601>] [--lines N]
+  merge  [--profile <name>] [--win-profile <name>] [--since <ISO8601>] [--lines N]
                                Merge both sides chronologically by .timestamp.
                                Each line gets a .side field ("mac" or "win") prepended.
-  grep   <pattern> [--profile <name>] [--side mac|win|both]
+  grep   <pattern> [--profile <name>] [--win-profile <name>] [--side mac|win|both]
                                Plain-text grep on the latest log files.
+
+Profile resolution:
+  --profile <name>             Selects mac profile dir: app.uniclipboard.desktop[-<name>]
+                               Default: $UC_PROFILE_DEFAULT (currently: dev)
+  --win-profile <name>         Selects win profile under $WIN_BASE the same way.
+                               Default: auto-detect newest mtime under $WIN_BASE.
+                               Use "default" for the no-suffix dir (app.uniclipboard.desktop).
+  WIN_LOGS=...                 Env override that bypasses $WIN_BASE entirely and treats the
+                               value as the literal logs/ dir. Useful for ad-hoc mounts.
 
 Notes:
   * Log file names use UTC dates. "Latest" = newest by mtime, not by clock date.
@@ -40,23 +59,29 @@ Notes:
 EOF
 }
 
-# --- profile resolution ----------------------------------------------------
+# --- generic profile resolution -------------------------------------------
 
-mac_profile_dir() {
-  local profile="${1:-}"
+# profile_dir <base> <profile> -> "<base>/app.uniclipboard.desktop[-<profile>]"
+profile_dir() {
+  local base="$1" profile="${2:-}"
   if [[ -z "$profile" || "$profile" == "default" ]]; then
-    echo "$MAC_BASE/app.uniclipboard.desktop"
+    echo "$base/app.uniclipboard.desktop"
   else
-    echo "$MAC_BASE/app.uniclipboard.desktop-$profile"
+    echo "$base/app.uniclipboard.desktop-$profile"
   fi
 }
 
-list_profile_dirs() {
-  # Print one line per existing profile dir that has a logs/ subdir.
-  # Format: <profile>\t<dir>\t<latest_log>\t<latest_mtime_iso>
+mac_profile_dir() { profile_dir "$MAC_BASE" "${1:-}"; }
+win_profile_dir() { profile_dir "$WIN_BASE" "${1:-}"; }
+
+# list_profile_dirs_in <base>
+#   Print one line per existing profile dir that has a logs/ subdir.
+#   Format: <profile>\t<dir>\t<latest_log>\t<latest_mtime_iso>\t<latest_mtime_epoch>
+list_profile_dirs_in() {
+  local base="$1"
   shopt -s nullglob
-  local d name profile latest mtime
-  for d in "$MAC_BASE"/app.uniclipboard.desktop "$MAC_BASE"/app.uniclipboard.desktop-*; do
+  local d name profile latest mtime epoch
+  for d in "$base"/app.uniclipboard.desktop "$base"/app.uniclipboard.desktop-*; do
     [[ -d "$d/logs" ]] || continue
     name="$(basename "$d")"
     if [[ "$name" == "app.uniclipboard.desktop" ]]; then
@@ -66,12 +91,21 @@ list_profile_dirs() {
     fi
     latest="$(latest_log_in "$d/logs" || true)"
     if [[ -n "$latest" ]]; then
-      mtime="$(stat -f '%Sm' -t '%Y-%m-%dT%H:%M:%S' "$latest")"
+      mtime="$(stat -f '%Sm' -t '%Y-%m-%dT%H:%M:%S' "$latest" 2>/dev/null || echo '')"
+      epoch="$(stat -f '%m' "$latest" 2>/dev/null || echo '0')"
     else
       mtime=""
+      epoch="0"
     fi
-    printf '%s\t%s\t%s\t%s\n' "$profile" "$d/logs" "${latest:-<empty>}" "${mtime:-<no-logs>}"
+    printf '%s\t%s\t%s\t%s\t%s\n' "$profile" "$d/logs" "${latest:-<empty>}" "${mtime:-<no-logs>}" "$epoch"
   done
+}
+
+# auto_detect_profile <base> -> echoes the profile name with newest log mtime (or empty)
+auto_detect_profile() {
+  local base="$1"
+  [[ -d "$base" ]] || { echo ""; return; }
+  list_profile_dirs_in "$base" | sort -t$'\t' -k5 -nr | head -1 | cut -f1
 }
 
 latest_log_in() {
@@ -112,13 +146,52 @@ freshness_label() {
   fi
 }
 
+# Resolve the windows logs dir given an optional --win-profile.
+# Sets globals WIN_LOGS_RESOLVED and WIN_PROFILE_RESOLVED.
+# WIN_PROFILE_RESOLVED uses "default" for the no-suffix dir, "<override>" for WIN_LOGS env,
+# or the auto-detected profile name.
+resolve_win_logs() {
+  local win_profile="${1:-}"
+
+  # Priority 1: explicit --win-profile flag
+  if [[ -n "$win_profile" ]]; then
+    WIN_PROFILE_RESOLVED="$win_profile"
+    WIN_LOGS_RESOLVED="$(win_profile_dir "$win_profile")/logs"
+    return
+  fi
+
+  # Priority 2: legacy WIN_LOGS env override
+  if [[ -n "$WIN_LOGS_OVERRIDE" ]]; then
+    WIN_PROFILE_RESOLVED="<WIN_LOGS env>"
+    WIN_LOGS_RESOLVED="$WIN_LOGS_OVERRIDE"
+    return
+  fi
+
+  # Priority 3: auto-detect under $WIN_BASE
+  local detected
+  detected="$(auto_detect_profile "$WIN_BASE")"
+  if [[ -n "$detected" ]]; then
+    WIN_PROFILE_RESOLVED="$detected (auto)"
+    WIN_LOGS_RESOLVED="$(win_profile_dir "$detected")/logs"
+  else
+    WIN_PROFILE_RESOLVED="<none>"
+    WIN_LOGS_RESOLVED=""
+  fi
+}
+
 # --- commands --------------------------------------------------------------
 
 cmd_status() {
-  local profile="${1:-$DEFAULT_PROFILE}"
-  local mac_dir win_dir mac_log win_log
+  local profile="$DEFAULT_PROFILE" win_profile=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --profile)     profile="$2";     shift 2;;
+      --win-profile) win_profile="$2"; shift 2;;
+      *) echo "unknown arg: $1" >&2; exit 2;;
+    esac
+  done
+  local mac_dir mac_log win_log
   mac_dir="$(mac_profile_dir "$profile")/logs"
-  win_dir="$WIN_LOGS"
 
   echo "=== uniclipboard dual-log status ==="
   echo "now (local):   $(date '+%Y-%m-%d %H:%M:%S %Z')"
@@ -139,13 +212,16 @@ cmd_status() {
   else
     echo "  (profile dir does not exist — likely wrong UC_PROFILE)"
     echo "  available profiles:"
-    list_profile_dirs | awk -F'\t' '{printf "    - %s  (latest=%s, mtime=%s)\n", $1, $3, $4}'
+    list_profile_dirs_in "$MAC_BASE" \
+      | awk -F'\t' '{printf "    - %s  (latest=%s, mtime=%s)\n", $1, $3, $4}'
   fi
   echo
 
-  echo "[win] $win_dir"
-  if [[ -d "$win_dir" ]]; then
-    win_log="$(latest_log_in "$win_dir" || true)"
+  resolve_win_logs "$win_profile"
+  echo "[win] $WIN_LOGS_RESOLVED"
+  echo "      profile: $WIN_PROFILE_RESOLVED   base: $WIN_BASE"
+  if [[ -n "$WIN_LOGS_RESOLVED" && -d "$WIN_LOGS_RESOLVED" ]]; then
+    win_log="$(latest_log_in "$WIN_LOGS_RESOLVED" || true)"
     if [[ -n "$win_log" ]]; then
       local age; age="$(age_seconds "$win_log")"
       printf '  latest: %s\n  mtime:  %s   freshness: %s\n' \
@@ -153,63 +229,104 @@ cmd_status() {
     else
       echo "  (no log files — Windows side may not be running)"
     fi
+  elif [[ ! -d "$WIN_BASE" ]]; then
+    echo "  (mount missing: $WIN_BASE — re-mount the SMB share)"
   else
-    echo "  (mount missing: $win_dir — re-mount the SMB share)"
+    echo "  (no uniclipboard profile dirs under $WIN_BASE)"
+  fi
+
+  # If we auto-detected, also show the alternatives so the user can sanity-check.
+  if [[ "$WIN_PROFILE_RESOLVED" == *"(auto)"* ]]; then
+    echo "  available win profiles (by mtime, newest first):"
+    list_profile_dirs_in "$WIN_BASE" \
+      | sort -t$'\t' -k5 -nr \
+      | awk -F'\t' '{printf "    - %s  (latest=%s, mtime=%s)\n", $1, $3, $4}'
   fi
 }
 
 cmd_list_profiles() {
-  printf '%s\t%s\t%s\t%s\n' "PROFILE" "DIR" "LATEST" "MTIME"
-  list_profile_dirs
+  local side="both"
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --side) side="$2"; shift 2;;
+      *) echo "unknown arg: $1" >&2; exit 2;;
+    esac
+  done
+  if [[ "$side" == "mac" || "$side" == "both" ]]; then
+    echo "===== mac profiles (base: $MAC_BASE) ====="
+    printf '%s\t%s\t%s\t%s\n' "PROFILE" "DIR" "LATEST" "MTIME"
+    list_profile_dirs_in "$MAC_BASE" | cut -f1-4
+  fi
+  if [[ "$side" == "win" || "$side" == "both" ]]; then
+    [[ "$side" == "both" ]] && echo
+    echo "===== win profiles (base: $WIN_BASE) ====="
+    if [[ -d "$WIN_BASE" ]]; then
+      printf '%s\t%s\t%s\t%s\n' "PROFILE" "DIR" "LATEST" "MTIME"
+      list_profile_dirs_in "$WIN_BASE" | sort -t$'\t' -k5 -nr | cut -f1-4
+    else
+      echo "(mount missing: $WIN_BASE)"
+    fi
+  fi
 }
 
 cmd_paths() {
-  local profile="${1:-$DEFAULT_PROFILE}"
+  local profile="$DEFAULT_PROFILE" win_profile=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --profile)     profile="$2";     shift 2;;
+      --win-profile) win_profile="$2"; shift 2;;
+      *) echo "unknown arg: $1" >&2; exit 2;;
+    esac
+  done
   local mac_dir mac_log win_log
   mac_dir="$(mac_profile_dir "$profile")/logs"
   mac_log="$(latest_log_in "$mac_dir" 2>/dev/null || true)"
-  win_log="$(latest_log_in "$WIN_LOGS" 2>/dev/null || true)"
+  resolve_win_logs "$win_profile"
+  win_log="$(latest_log_in "$WIN_LOGS_RESOLVED" 2>/dev/null || true)"
   echo "MAC=${mac_log:-<missing>}"
-  echo "WIN=${win_log:-<missing>}"
+  echo "WIN=${win_log:-<missing>}   (profile: $WIN_PROFILE_RESOLVED)"
 }
 
 resolve_pair() {
   # Sets globals MAC_LOG and WIN_LOG. Empties them if missing.
-  local profile="$1"
+  local profile="$1" win_profile="${2:-}"
   local mac_dir
   mac_dir="$(mac_profile_dir "$profile")/logs"
   MAC_LOG="$(latest_log_in "$mac_dir" 2>/dev/null || true)"
-  WIN_LOG="$(latest_log_in "$WIN_LOGS" 2>/dev/null || true)"
+  resolve_win_logs "$win_profile"
+  WIN_LOG="$(latest_log_in "$WIN_LOGS_RESOLVED" 2>/dev/null || true)"
 }
 
 cmd_tail() {
-  local profile="$DEFAULT_PROFILE" lines=50 side="both"
+  local profile="$DEFAULT_PROFILE" win_profile="" lines=50 side="both"
   while [[ $# -gt 0 ]]; do
     case "$1" in
-      --profile) profile="$2"; shift 2;;
-      --lines)   lines="$2";   shift 2;;
-      --side)    side="$2";    shift 2;;
+      --profile)     profile="$2";     shift 2;;
+      --win-profile) win_profile="$2"; shift 2;;
+      --lines)       lines="$2";       shift 2;;
+      --side)        side="$2";        shift 2;;
       *) echo "unknown arg: $1" >&2; exit 2;;
     esac
   done
-  resolve_pair "$profile"
+  resolve_pair "$profile" "$win_profile"
   if [[ "$side" == "mac" || "$side" == "both" ]]; then
     echo "===== [mac] ${MAC_LOG:-<missing>} ====="
     [[ -n "$MAC_LOG" ]] && tail -n "$lines" "$MAC_LOG"
   fi
   if [[ "$side" == "win" || "$side" == "both" ]]; then
-    echo "===== [win] ${WIN_LOG:-<missing>} ====="
+    echo "===== [win] ${WIN_LOG:-<missing>}   (profile: $WIN_PROFILE_RESOLVED) ====="
     [[ -n "$WIN_LOG" ]] && tail -n "$lines" "$WIN_LOG"
   fi
 }
 
 cmd_query() {
-  local profile="$DEFAULT_PROFILE" side="both" filter=""
+  local profile="$DEFAULT_PROFILE" win_profile="" side="both" filter=""
   while [[ $# -gt 0 ]]; do
     case "$1" in
-      --profile) profile="$2"; shift 2;;
-      --side)    side="$2";    shift 2;;
-      --filter)  filter="$2";  shift 2;;
+      --profile)     profile="$2";     shift 2;;
+      --win-profile) win_profile="$2"; shift 2;;
+      --side)        side="$2";        shift 2;;
+      --filter)      filter="$2";      shift 2;;
       *) echo "unknown arg: $1" >&2; exit 2;;
     esac
   done
@@ -220,7 +337,7 @@ cmd_query() {
     fi
     filter="$(cat)"
   fi
-  resolve_pair "$profile"
+  resolve_pair "$profile" "$win_profile"
   if [[ "$side" == "mac" || "$side" == "both" ]]; then
     if [[ -n "$MAC_LOG" ]]; then
       echo "===== [mac] $MAC_LOG ====="
@@ -229,23 +346,24 @@ cmd_query() {
   fi
   if [[ "$side" == "win" || "$side" == "both" ]]; then
     if [[ -n "$WIN_LOG" ]]; then
-      echo "===== [win] $WIN_LOG ====="
+      echo "===== [win] $WIN_LOG   (profile: $WIN_PROFILE_RESOLVED) ====="
       jq -c "$filter" "$WIN_LOG" || true
     fi
   fi
 }
 
 cmd_merge() {
-  local profile="$DEFAULT_PROFILE" since="" lines=200
+  local profile="$DEFAULT_PROFILE" win_profile="" since="" lines=200
   while [[ $# -gt 0 ]]; do
     case "$1" in
-      --profile) profile="$2"; shift 2;;
-      --since)   since="$2";   shift 2;;
-      --lines)   lines="$2";   shift 2;;
+      --profile)     profile="$2";     shift 2;;
+      --win-profile) win_profile="$2"; shift 2;;
+      --since)       since="$2";       shift 2;;
+      --lines)       lines="$2";       shift 2;;
       *) echo "unknown arg: $1" >&2; exit 2;;
     esac
   done
-  resolve_pair "$profile"
+  resolve_pair "$profile" "$win_profile"
   [[ -n "$MAC_LOG" || -n "$WIN_LOG" ]] || { echo "no logs found"; exit 1; }
 
   local since_filter="."
@@ -262,21 +380,22 @@ cmd_merge() {
 
 cmd_grep() {
   local pattern="$1"; shift || { echo "pattern required" >&2; exit 2; }
-  local profile="$DEFAULT_PROFILE" side="both"
+  local profile="$DEFAULT_PROFILE" win_profile="" side="both"
   while [[ $# -gt 0 ]]; do
     case "$1" in
-      --profile) profile="$2"; shift 2;;
-      --side)    side="$2";    shift 2;;
+      --profile)     profile="$2";     shift 2;;
+      --win-profile) win_profile="$2"; shift 2;;
+      --side)        side="$2";        shift 2;;
       *) echo "unknown arg: $1" >&2; exit 2;;
     esac
   done
-  resolve_pair "$profile"
+  resolve_pair "$profile" "$win_profile"
   if [[ "$side" == "mac" || "$side" == "both" ]] && [[ -n "$MAC_LOG" ]]; then
     echo "===== [mac] $MAC_LOG ====="
     grep -F -- "$pattern" "$MAC_LOG" || true
   fi
   if [[ "$side" == "win" || "$side" == "both" ]] && [[ -n "$WIN_LOG" ]]; then
-    echo "===== [win] $WIN_LOG ====="
+    echo "===== [win] $WIN_LOG   (profile: $WIN_PROFILE_RESOLVED) ====="
     grep -F -- "$pattern" "$WIN_LOG" || true
   fi
 }
@@ -285,12 +404,9 @@ cmd_grep() {
 
 cmd="${1:-}"; shift || true
 case "$cmd" in
-  status)        cmd_status "${1:-$DEFAULT_PROFILE}";;
-  list-profiles) cmd_list_profiles;;
-  paths)
-    profile="$DEFAULT_PROFILE"
-    [[ "${1:-}" == "--profile" ]] && profile="$2"
-    cmd_paths "$profile";;
+  status)        cmd_status "$@";;
+  list-profiles) cmd_list_profiles "$@";;
+  paths)         cmd_paths "$@";;
   tail)          cmd_tail "$@";;
   query)         cmd_query "$@";;
   merge)         cmd_merge "$@";;

--- a/.claude/skills/dual-side-debug/transfer-speed.sh
+++ b/.claude/skills/dual-side-debug/transfer-speed.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# transfer-speed.sh — Reconstruct the per-checkpoint download speed curve from
+# Windows-side "blob fetch: progress checkpoint" log entries.
+#
+# Each checkpoint carries (timestamp, bytes, elapsed_ms, flow.id, conn, ...),
+# so we can derive both instantaneous and cumulative-average MB/s without any
+# special instrumentation.
+#
+# Usage:
+#   transfer-speed.sh [--profile <name>] [--side mac|win] [--flow <flow.id>]
+#                     [--since <ISO8601>] [--until <ISO8601>] [--every N]
+#                     [--show-conn]
+#
+# Defaults: --side win  --every 1
+#
+# Examples:
+#   # Full curve, every checkpoint, current dev profile, Windows side:
+#   transfer-speed.sh
+#
+#   # Sample every 5th checkpoint within a time window:
+#   transfer-speed.sh --since 2026-05-24T01:27:00Z --until 2026-05-24T01:30:30Z --every 5
+#
+#   # Restrict to one specific transfer (by flow.id) and print which conn path it used:
+#   transfer-speed.sh --flow 019e5798-6c03-7ac2-b484-1fc777ada87e --show-conn
+
+set -euo pipefail
+
+HERE="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+DUAL="$HERE/dual-logs.sh"
+
+if [[ ! -x "$DUAL" ]]; then
+  echo "transfer-speed.sh: cannot find dual-logs.sh next to me ($DUAL)" >&2
+  exit 1
+fi
+
+PROFILE=""
+SIDE="win"
+FLOW=""
+SINCE=""
+UNTIL=""
+EVERY=1
+SHOW_CONN=0
+
+while (( $# > 0 )); do
+  case "$1" in
+    --profile)   PROFILE="$2"; shift 2 ;;
+    --side)      SIDE="$2"; shift 2 ;;
+    --flow)      FLOW="$2"; shift 2 ;;
+    --since)     SINCE="$2"; shift 2 ;;
+    --until)     UNTIL="$2"; shift 2 ;;
+    --every)     EVERY="$2"; shift 2 ;;
+    --show-conn) SHOW_CONN=1; shift ;;
+    -h|--help)
+      sed -n '2,30p' "$0"
+      exit 0 ;;
+    *)
+      echo "transfer-speed.sh: unknown arg: $1" >&2
+      exit 2 ;;
+  esac
+done
+
+if [[ "$SIDE" != "win" && "$SIDE" != "mac" ]]; then
+  echo "transfer-speed.sh: --side must be 'win' or 'mac' (got: $SIDE)" >&2
+  exit 2
+fi
+
+# Build the jq filter incrementally so empty options don't bake in dead conditions.
+JQ_FILTER='. | select(.message == "blob fetch: progress checkpoint")'
+[[ -n "$FLOW"  ]] && JQ_FILTER="$JQ_FILTER"' | select(."flow.id" == "'"$FLOW"'")'
+[[ -n "$SINCE" ]] && JQ_FILTER="$JQ_FILTER"' | select(.timestamp >= "'"$SINCE"'")'
+[[ -n "$UNTIL" ]] && JQ_FILTER="$JQ_FILTER"' | select(.timestamp <= "'"$UNTIL"'")'
+JQ_FILTER="$JQ_FILTER"' | "\(.timestamp)\t\(.bytes)\t\(.elapsed_ms)\t\(."flow.id" // "-")\t\(.conn // "-")"'
+
+DUAL_ARGS=(query --side "$SIDE" --filter "$JQ_FILTER")
+[[ -n "$PROFILE" ]] && DUAL_ARGS=(--profile "$PROFILE" "${DUAL_ARGS[@]}")
+
+# Strip the "===== [side] ... =====" banners that dual-logs.sh prints and any
+# accidental jq-quoted output, then run the speed math.
+"$DUAL" "${DUAL_ARGS[@]}" \
+  | grep -v '^=====' \
+  | grep -v '^$' \
+  | sed 's/^"//;s/"$//;s/\\t/\t/g' \
+  | awk -F'\t' -v every="$EVERY" -v show_conn="$SHOW_CONN" '
+    BEGIN {
+      n = 0;
+      prev_b = -1; prev_ms = -1;
+      first_b = -1; first_ms = -1;
+      printf "  %-26s  %9s  %10s  %10s%s\n", "timestamp", "MB_total", "inst_MBps", "avg_MBps", (show_conn ? "  conn" : "");
+    }
+    NF >= 3 {
+      n++;
+      ts = $1; b = $2 + 0; ms = $3 + 0; flow = ($4 == "" ? "-" : $4); conn = ($5 == "" ? "-" : $5);
+      if (first_ms < 0) { first_b = b; first_ms = ms; }
+      inst = 0;
+      if (prev_ms >= 0 && ms > prev_ms) {
+        inst = (b - prev_b) / ((ms - prev_ms) / 1000.0) / 1048576.0;
+      }
+      span_ms = ms - first_ms;
+      avg = (span_ms > 0) ? ((b - first_b) / (span_ms / 1000.0) / 1048576.0) : 0;
+      if ((n - 1) % every == 0) {
+        if (show_conn) {
+          printf "  %-26s  %9.1f  %10.2f  %10.2f  %s\n", ts, b/1048576.0, inst, avg, conn;
+        } else {
+          printf "  %-26s  %9.1f  %10.2f  %10.2f\n", ts, b/1048576.0, inst, avg;
+        }
+      }
+      last_ts = ts; last_b = b; last_ms = ms;
+      prev_b = b; prev_ms = ms;
+    }
+    END {
+      if (n == 0) {
+        print "  (no progress checkpoints matched)" > "/dev/stderr";
+        exit 1;
+      }
+      span_ms = last_ms - first_ms;
+      total_mb = (last_b - first_b) / 1048576.0;
+      overall = (span_ms > 0) ? (total_mb / (span_ms / 1000.0)) : 0;
+      printf "\n  summary: %d checkpoints, %.1f MB over %.1f s -> %.2f MB/s overall\n",
+             n, total_mb, span_ms/1000.0, overall;
+    }
+  '

--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,7 @@ prime/
 snap/.snapcraft/
 .vercel
 .env*.local
+
+# p2p-bench spike runtime store (throwaway diagnostic)
+p2p-bench-store/
+src-tauri/p2p-bench-store/

--- a/.planning/debug/iroh-throughput-bbr-cubic/INVESTIGATION.md
+++ b/.planning/debug/iroh-throughput-bbr-cubic/INVESTIGATION.md
@@ -1,0 +1,298 @@
+---
+status: diagnosed
+trigger: "User reported large-file sync from Mac → Windows starts at 40 MB/s and degrades to <10 MB/s on uniclipboard 0.11.0-alpha.6"
+created: 2026-05-24T05:00:00Z
+updated: 2026-05-24T07:00:00Z
+---
+
+## TL;DR
+
+Slow blob transfer is **not** an uniclipboard bug. The full application stack
+(encrypt → V3 envelope → iroh-blobs publish/fetch → decrypt) hits the **same**
+~45 MB/s ceiling as bare iroh-blobs in a minimal P2P reproduction (see
+`src-tauri/crates/p2p-bench/`).
+
+Root cause is in **iroh 0.98 / noq 0.18**:
+
+- BBR congestion controller plateaus at ~40-50% of the physical UDP link
+  capacity (iperf3 measures ~110 MB/s on the same LAN; iroh-blobs over the
+  same path tops out at 42-50 MB/s).
+- CUBIC congestion controller is **30× slower** than BBR (1.3-1.7 MB/s),
+  effectively unusable on our LAN.
+
+All previously-considered factors (Windows Defender, multipath QUIC churn,
+hairpin NAT, Mihomo/Clash routing, receiver disk I/O, file extension, ISO
+content vs. random content) have been **eliminated** through controlled
+experiments.
+
+Production action: keep current configuration (tuned BBR + 32 MB
+stream_receive_window). It is already at the local maximum given the upstream
+constraints. File draft of an upstream issue at
+[`UPSTREAM_ISSUE_DRAFT.md`](./UPSTREAM_ISSUE_DRAFT.md).
+
+---
+
+## Symptoms (as reported)
+
+- Mac (sender, Wi-Fi 6, RSSI -19 dBm, Tx 2401 Mbps) → Windows (receiver,
+  2.5 GbE Ethernet, same `192.168.31.0/24` LAN behind Redmi A7E1).
+- Large file transfer (typically `Fedora-Workstation-Live-44-1.7.aarch64.iso`,
+  ~2.5 GB) shows:
+  - Initial 40 MB/s burst for ~10 seconds.
+  - Decay into ~10 MB/s with periodic 1-5 s stalls.
+  - Occasional 60+ second freezes mid-transfer.
+- Reproduces consistently with the same source file across many days.
+
+### Observed pattern (Windows receiver, blob fetch progress checkpoints)
+
+```
+4 MB → 20 MB     (26 ms — burst)
+20 MB → 36 MB    (2050 ms — pause)
+36 MB → 42 MB    (701 ms)
+42 MB → 46 MB    (727 ms)
+46 MB → 54 MB    (6 ms — burst)
+54 MB → 58 MB    (766 ms — pause)
+…
+```
+
+Burst of 4-8 chunks (= 16-32 MB) followed by a 1-5 second stall. Repeats for
+the entire transfer until the connection eventually flat-lines around 45 MB/s
+or worse.
+
+---
+
+## Eliminated hypotheses
+
+Each ruling-out came from a specific test, recorded here so future
+investigation does not re-walk them.
+
+### 1. Windows Defender real-time scanning of `.iso` files
+
+- **Test**: copy `PDF_Reader_Pro.iso` (264 MB) → 10 MB/s; rename copy to
+  `.bin` → 40 MB/s.
+- **Then** `Add-MpPreference -ExclusionPath` on both `file-cache/` and
+  `iroh-blobs_dev/` → `.iso` jumps to 40 MB/s.
+- **Verdict**: Defender real-time scan **does** add ~4× penalty on `.iso`
+  specifically. After exclusion it is no longer the bottleneck.
+- **But**: it does NOT explain the residual ~45 MB/s ceiling, because the
+  same ceiling appears on Mac → Mac (no Defender, see #6 below) and on the
+  bare iroh-blobs spike with `--store mem` (no disk write at all).
+
+### 2. iroh 0.98 multipath QUIC churn (initial hypothesis)
+
+- **Lead**: code comment in `src-tauri/crates/uc-infra/src/network/iroh/node.rs:311-340`
+  claims multipath is disabled, but reading iroh 0.98 source
+  (`endpoint/quic.rs:157`) shows `QuicTransportConfigBuilder::new()` hardcodes
+  `max_concurrent_multipath_paths(MAX_MULTIPATH_PATHS + 1)` = **13 paths by
+  default**, and the setter ignores any value < 13.
+- **Test**: counted `iroh::_events::path::*` events on both sides during a
+  34-second cold-start window of a slow Fedora ISO transfer.
+- **Result**: 1 × `path::open` at the start, 3 × `path::abandoned` at the
+  end. Nothing in between for 31 seconds.
+- **Verdict**: If multipath were "constantly re-validating paths and stalling
+  the stream", we would see many `path::set_status` events during the stall
+  window. We do not. **Multipath QUIC is not the cause.**
+
+### 3. Hairpin public IP candidate from STUN reflection
+
+- **Lead**: slow transfers' `conn` field showed `Ip(180.164.125.95:...)` (Mac's
+  public NAT-reflected IP) alongside `Ip(192.168.31.72:...)` (LAN). Fast
+  transfers had only the LAN IP. Theory: hairpin path causes packet loss /
+  PTO retries.
+- **Counter-evidence**: A FAST transfer was found with `conn` containing 6
+  candidates (3 public IPs + 2 relays + 1 LAN). A SLOW transfer was found
+  with only `LAN + 1 Relay`. **The candidate set does not predict speed.**
+- **Verdict**: hairpin is a symptom of "transfer ran long enough for iroh to
+  discover more candidates", not a cause.
+
+### 4. Network hardware / Wi-Fi / router throughput
+
+- **Test**: `iperf3 -c <win-ip> -u -b 0 -t 30 -l 1200` from Mac to Win.
+- **Result**: 30 seconds, 4.25 GiB sent at 1.22 Gbps, receiver 892 Mbps
+  (= ~106 MB/s) with 26% loss (expected since `-b 0` floods).
+- **Verdict**: Physical UDP path supports >100 MB/s. Wi-Fi, NIC, router
+  switching are not the bottleneck.
+
+### 5. Mihomo / Clash (TUN-mode VPN routing)
+
+- **Test**: disabled Mihomo entirely on both sides. Repeat large-file
+  transfer.
+- **Result**: same 10 MB/s slowdown observed.
+- **Verdict**: TUN routing is not the cause.
+
+### 6. Operating-system specific (NTFS, SMB, Windows-only Defender)
+
+- **Test**: Mac → Mac transfer (same LAN, both APFS).
+- **Result**: Still <10 MB/s.
+- **Verdict**: Cross-OS reproduction means the issue is not specific to
+  Windows, NTFS, SMB, or any other Win-side stack.
+
+### 7. uniclipboard application stack (encrypt / V3 envelope / redb / connection pool)
+
+- **Test**: built `p2p-bench` (independent crate at
+  `src-tauri/crates/p2p-bench/`) using only iroh + iroh-blobs APIs with no
+  app-layer code. Ran the same 2.5 GB file Mac → Mac.
+- **Result**: `tuned BBR + FsStore` = 48.16 MB/s, matching uniclipboard's
+  application-layer steady-state (~45 MB/s).
+- **Verdict**: Application stack contributes near-zero overhead.
+  **The ceiling is in iroh / iroh-blobs / noq.**
+
+### 8. Receiver-side disk write backpressure (advisor's leading guess after #1-7)
+
+- **Theory**: receiver's iroh-blobs `FsStore` writes each 4 MB chunk to disk
+  (NTFS write + redb meta commit + BAO outboard append). If write time per
+  chunk is comparable to send time per chunk, `stream_receive_window` fills
+  up and back-pressures the sender — producing the burst-then-pause pattern.
+- **Test**: spike receiver with `--store mem` (drops all received data into
+  `MemStore`, never touches disk).
+- **Result**: 21.54 MB/s, **half** the FsStore throughput. Both-sides mem
+  (`--store mem` on sender too): 21.44 MB/s.
+- **Verdict**: Receiver disk write is **not** the bottleneck. FsStore is
+  actually faster than MemStore on this hardware. (Plausible explanation:
+  MemStore allocates per-chunk into a single mutex-guarded structure;
+  FsStore appends to file with kernel page-cache pipelining.)
+
+### 9. Sender-side compress/encrypt/BAO pipeline (advisor's "producer-bursty" guess)
+
+- **Test**: timestamps of Mac-side `iroh blob publish: add_path completed
+  (streaming)` log entries during Fedora ISO publishes.
+- **Result**: `add_path_ms` consistently 5-9 seconds for the 2.5 GB ISO.
+  The receiver-side fetch starts about 2 seconds AFTER add_path completion
+  (decoupled by app-layer event dispatch).
+- **Verdict**: Sender pipeline finishes before fetch even starts. Producer
+  is not the bottleneck.
+
+---
+
+## What actually narrows the diagnosis (positive evidence)
+
+After eliminating all of the above, four controlled experiments through the
+`p2p-bench` spike were decisive:
+
+| # | Configuration | Throughput | % of iperf3 |
+|---|---|---|---|
+| 0 | iperf3 UDP raw | 110 MB/s | 100% |
+| 1 | `--cc bbr` + `--tuned` + FsStore both sides | **42-50 MB/s** | 38-45% |
+| 2 | `--cc bbr` + `--vanilla` + FsStore both sides | 37 MB/s | 34% |
+| 3 | `--cc bbr` + `--tuned` + FsStore sender + MemStore receiver | 21.5 MB/s | 20% |
+| 4 | `--cc bbr` + `--tuned` + MemStore both sides | 21.4 MB/s | 20% |
+| 5 | `--cc cubic` + `--tuned` + FsStore both sides | **1.29 MB/s** | 1.2% |
+| 6 | `--cc cubic` + `--vanilla` + FsStore both sides | 1.7 MB/s | 1.5% |
+
+(All numbers Mac → Mac, 1-2 GB random-content file, same `192.168.31.0/24`
+LAN. Each run preceded by a wipe of both sides' p2p-bench-store to ensure
+no cache hit.)
+
+### What the matrix says
+
+- **CUBIC is catastrophically broken** in our noq 0.18 environment.
+  ~30× worse than BBR. This is the most surprising finding. The upstream
+  PR `n0-computer/noq#657` is titled "fix(bbr3): bbr3 controller was not
+  accounting correctly", implying their pain point is BBR, not CUBIC. In
+  our environment the failure mode is **reversed**.
+- **BBR works but caps at ~40-45% of physical capacity**. Tuned (32 MB
+  stream window + 64 MB send window) buys ~10 MB/s over vanilla.
+- **Memory store is slower than file store**. This decisively rules out
+  receiver disk write as the bottleneck.
+- **The bottleneck is below iroh-blobs** — both --store flags and pre-known
+  application-layer code are now provably innocent.
+
+---
+
+## Source location
+
+- Spike crate: [`src-tauri/crates/p2p-bench/`](../../src-tauri/crates/p2p-bench/)
+  (~250 LoC, throwaway, not depended on by anything)
+- Helper script (Mac sender, ssh remote receiver):
+  [`tmp/spike-run.sh`](file:///tmp/spike-run.sh) (local to investigation host)
+- Production transport config (BBR + tuning):
+  `src-tauri/crates/uc-infra/src/network/iroh/node.rs:260-340`
+
+### Repro in one command (from `src-tauri/`)
+
+```bash
+cargo run --release -p p2p-bench -- serve --path /tmp/large.bin --cc bbr
+# (copy ticket)
+cargo run --release -p p2p-bench -- fetch --ticket <ticket> --out /tmp/out --cc bbr
+# Compare: --cc cubic, --store mem, --vanilla, --no-relay
+```
+
+---
+
+## Investigation timeline (compressed)
+
+| Time (PDT) | Step | What we learned |
+|---|---|---|
+| ~14:00 | Read user report; first dual-side log pass | Saw `path::abandoned` + relay timeout — bet on Wi-Fi disturbance |
+| 14:30 | Second transfer: stable 48 MB/s | Started doubting the Wi-Fi story |
+| 15:00 | iperf3 = 110 MB/s, Clash already off, same slowdown | Network/router/Mihomo eliminated |
+| 15:45 | Found `MAX_MULTIPATH_PATHS = 12` default-on regression | New hypothesis: multipath churn |
+| 16:30 | Counted path events: 4 total in 34s | Multipath hypothesis eliminated |
+| 16:45 | `.iso` vs `.bin` divergence | Defender hypothesis |
+| 17:00 | Defender exclusion → 40 MB/s on `.iso`. Still <50 MB/s ceiling | Partial fix, not root cause |
+| 17:30 | Cold-start analysis: producer/receiver ruled out | Now suspect iroh / noq layer |
+| 18:00 | User: "Mac → Mac also slow" | OS-stack eliminated |
+| 18:30 | Built `p2p-bench` spike to isolate iroh-blobs | First-class measurements possible |
+| 19:00 | BBR 48 MB/s = app-layer steady state | App stack innocent |
+| 19:30 | Tested `--cc cubic` → 1.7 MB/s | CC layer is the actual problem |
+| 20:30 | Validated MemStore vs FsStore | Disk I/O eliminated. Conclusions sealed. |
+
+---
+
+## Open questions / not yet explored
+
+1. Is the BBR ceiling (~45 MB/s) recoverable by tuning **only** transport
+   parameters (`initial_window` on the CC, `congestion_event_threshold`,
+   per-path keep-alive)? iroh#1943 hints at this but is not specific.
+2. Would parallel multi-stream fetch (split blob into N sub-blobs, fetch
+   concurrently with N independent QUIC streams) approach iperf3 ceiling?
+   Single-stream CC limit suggests yes, but it has not been measured.
+3. Is the CUBIC catastrophic-slowness consistent across other noq 0.18
+   deployments, or specific to our cross-Wi-Fi pair? Repro on a wired-wired
+   LAN would help separate "noq 0.18 CUBIC is broken everywhere" from
+   "noq 0.18 CUBIC + lossy link breaks badly".
+4. Does iroh `1.0-rc.0` (with MAX_MULTIPATH_PATHS lowered to 8 and noq
+   0.19+ which includes BBR fixes) recover? Worth a separate spike when
+   upgrade is on the roadmap.
+
+---
+
+## Production recommendation
+
+**Do nothing immediate.** Current configuration is at the local maximum:
+
+- `congestion_controller_factory(Arc::new(BbrConfig::default()))` is correct
+  given CUBIC is broken. Do NOT revert to CUBIC.
+- `stream_receive_window(32 MB)` + `send_window(64 MB)` add ~10 MB/s over
+  vanilla; keep them.
+
+**Schedule for next iroh version bump**: re-run `p2p-bench` baseline. If
+iroh 1.0 + noq 0.19+ moves the BBR ceiling closer to 80-100 MB/s, document
+the regression-tested improvement; if not, consider the
+**parallel-fetch (open question #2)** mitigation path at the app layer
+(splits a large blob into N sub-blobs, fetches concurrently).
+
+**Upstream**: file the report in
+[`UPSTREAM_ISSUE_DRAFT.md`](./UPSTREAM_ISSUE_DRAFT.md). Cross-reference
+`iroh#1943` (throughput umbrella) and `noq#657` (BBR3 fix, possibly related).
+
+---
+
+## What I personally got wrong during the investigation
+
+For posterity / process improvement — at multiple points I committed to a
+hypothesis the data did not yet support, then had to backpedal:
+
+- **multipath QUIC**: I jumped to "iroh 0.98 default-on multipath is the
+  cause" after finding the `MAX_MULTIPATH_PATHS = 12` regression, before
+  checking whether path events actually clustered around the stalls. They
+  did not.
+- **noq#657 BBR-broken**: I told the user "noq#657 is almost certainly the
+  bug" based on the web-search agent's report, before re-checking the
+  predicted ranking (BBR slow, CUBIC fine). Our measured ranking was
+  reversed.
+
+Both times, **calling `advisor` before committing to a new hypothesis**
+caught the error and redirected to a falsifying experiment. The lesson is
+to call advisor before the third confident statement of "I think it's X",
+not after.

--- a/.planning/debug/iroh-throughput-bbr-cubic/PLAN-WIN-DECAY-INSTRUMENT.md
+++ b/.planning/debug/iroh-throughput-bbr-cubic/PLAN-WIN-DECAY-INSTRUMENT.md
@@ -1,0 +1,182 @@
+# Plan: Windows-Side Instrumentation for the 40→10 MB/s Decay
+
+## Symptom under investigation
+
+User report: when receiving a large file (multi-GB ISO) from Mac, throughput
+**starts at ~40 MB/s and decays to ~10 MB/s over the course of the transfer**.
+The decay is not reproducible on Mac↔Mac (throughput stays steady), so the
+mechanism is Windows-specific — somewhere in Win's storage / Defender /
+SMB / iroh-blobs receive path.
+
+Today's spike data (`SPIKE-MULTI-STREAM.md`) shows Mac→Win N=1 starts at
+**43.64 MB/s and holds it for ~70 s on a 3 GB file**. The decay must be
+something that gets worse over longer transfers (15+ GB, 10+ minutes), so
+the short spike doesn't reproduce it — instrumentation needs a *long-form*
+test scenario.
+
+## Hypothesis tree
+
+The decay is one (or several) of:
+
+### H1: Windows Defender deferred scan as the file grows
+- On-access scanning runs as the file is being written
+- Defender may **back off scan during high write bursts**, then catch up
+  (scanning the entire growing file) once write rate dips, costing CPU +
+  disk IO, throttling subsequent writes
+- Most likely culprit if Defender exclusion isn't in place for the entire
+  iroh-blobs store dir (`%LOCALAPPDATA%\...\iroh-blobs_dev\`) AND the
+  uniclipboard file-cache (`%LOCALAPPDATA%\...\file-cache\`)
+
+### H2: NTFS fragmentation under sustained sequential writes
+- iroh-blobs FsStore writes the blob in chunks as ranges arrive
+- BAO outboard is appended to as data verifies, the data file may grow
+  in non-contiguous pre-allocations
+- NTFS fragmentation grows during the transfer → write latency rises →
+  iroh-blobs receive task gets backpressured → BBR shrinks cwnd
+
+### H3: Filesystem cache / standby memory pressure
+- Win caches recent writes in standby memory; when standby fills,
+  flushing-to-disk becomes synchronous and slow
+- Particularly bad on SSDs without SLC cache headroom or HDDs (latter
+  unlikely on user's machine)
+
+### H4: Win iroh / quinn receive-side regression
+- Quinn / noq on Windows may have different `RecvBuf` / scheduling behavior
+  than on macOS
+- High-bandwidth steady state may trigger a path-validation or
+  congestion-control edge case unique to Windows
+- Less likely (we'd expect Mac↔Mac to flag similar issues), but not ruled
+  out
+
+### H5: iroh-blobs FsStore BAO outboard computation cost growing with file size
+- BAO tree has O(N) leaf nodes; computing the outboard for a partial blob
+  may grow more than linearly if the store re-validates accumulated ranges
+- Would show up as receiver CPU climbing and write throughput dropping
+
+## Instrumentation plan
+
+Each of the five hypotheses needs its own data channel. Run them
+**concurrently during one long-form test** so we can timecorrelate them.
+
+### Test scenario
+
+- File: **15 GB random bytes** (`/tmp/testfile-large.bin`, regenerated each run)
+- Path: Mac (production uniclipboard) → Win (production uniclipboard)
+- Wall-clock target: long enough to reproduce decay if user reports it
+  (`>10 minutes`); 15 GB at 40 MB/s ≈ 6 minutes start, plus decay time
+- One run with **Defender exclusion in place**, one run **without** —
+  isolating H1 by comparison
+
+### Data channels
+
+#### Channel 1: receiver throughput curve
+
+The spike binary already prints checkpointed `FETCH ts=... bytes=...` lines
+every 4 MB. For production uniclipboard the equivalent is the existing
+`blob fetch: progress checkpoint` log entries (already in JSON Lines
+format under `%LOCALAPPDATA%\...\desktop\logs\`).
+
+**Action**: parse the log post-run via `transfer-speed.sh` (already
+written), plot per-second instantaneous MB/s.
+
+#### Channel 2: Windows Defender activity
+
+```powershell
+# Background loop, 1 Hz sampling, log to CSV
+while ($true) {
+  $s = Get-MpComputerStatus
+  $r = Get-MpPreference
+  $obj = [PSCustomObject]@{
+    ts = (Get-Date).ToString("o")
+    realtime_enabled = $s.RealTimeProtectionEnabled
+    ioav_enabled = $s.IoavProtectionEnabled
+    on_access = $s.OnAccessProtectionEnabled
+    cpu_load = (Get-Counter "\Process(MsMpEng)\% Processor Time" -ErrorAction SilentlyContinue).CounterSamples.CookedValue
+    excluded_paths = ($r.ExclusionPath -join ";")
+  }
+  $obj | Export-Csv -Append -NoTypeInformation defender-trace.csv
+  Start-Sleep 1
+}
+```
+
+Also enable Defender's operational event log to capture scan events:
+- Event Viewer → Applications and Services Logs → Microsoft → Windows →
+  Windows Defender → Operational
+- Look for event IDs 1000 (scan started), 1001 (scan completed), 5007 (config changed)
+
+#### Channel 3: Disk write performance counters
+
+```powershell
+Get-Counter -Counter @(
+  "\PhysicalDisk(_Total)\Disk Write Bytes/sec",
+  "\PhysicalDisk(_Total)\Avg. Disk sec/Write",
+  "\PhysicalDisk(_Total)\Current Disk Queue Length",
+  "\LogicalDisk(C:)\% Free Space",
+  "\Memory\Standby Cache Reserve Bytes",
+  "\Memory\Modified Page List Bytes"
+) -SampleInterval 1 -Continuous | Export-Counter disk-trace.blg
+```
+
+If write latency (`Avg. Disk sec/Write`) climbs over time while throughput
+drops → H2/H3 confirmed.
+
+#### Channel 4: NTFS fragmentation snapshot
+
+Before and after the transfer:
+
+```cmd
+defrag C: /A /U /V > frag-before.txt
+... run transfer ...
+defrag C: /A /U /V > frag-after.txt
+```
+
+Compare "Total fragmented files" + "Average fragments per file".
+
+#### Channel 5: iroh-blobs FsStore tracing
+
+Add structured tracing to vendor fork's BAO write hot path. Specifically
+`vendor/iroh-blobs/src/store/fs/bao_file.rs::persist` and
+`src/store/fs.rs::HashContext::persist`. Emit a per-chunk event:
+
+```rust
+tracing::trace!(
+  target: "bench",
+  bytes = chunk.len(),
+  outboard_ns = outboard_dur.as_nanos(),
+  data_write_ns = data_dur.as_nanos(),
+  "bao chunk persisted",
+);
+```
+
+Filter the existing log subscriber to retain `bench=trace` events to the
+JSONL output. Post-process the log to plot per-chunk write latency over
+time — if growing, H5 confirmed.
+
+## Order of operations
+
+1. **First, the cheap experiment**: re-run user's failing transfer with
+   Defender exclusion *audited* (`Get-MpPreference` to confirm). If
+   throughput holds steady, H1 confirmed without need for further
+   instrumentation. Likely outcome but worth checking before bigger work.
+
+2. If H1 didn't catch it: enable Channels 1-4 (no code changes required,
+   pure PowerShell), run the 15 GB test, post-analyze.
+
+3. If still inconclusive: add Channel 5 tracing to the fork, rebuild,
+   re-run.
+
+## Out of scope
+
+- This plan does NOT address the "40 MB/s start" being too slow (that's
+  the `X4 sender-multi-endpoint` work from `SPIKE-MULTI-STREAM.md`). The
+  two problems are independent.
+- Not investigating SMB / network drive scenarios — the user reported
+  direct iroh-blobs transfer, not SMB.
+- Not adding any new dependencies; everything is PowerShell + existing
+  log facilities + one optional vendor fork patch.
+
+## Estimated effort
+
+- Step 1 (Defender exclusion audit): **10 minutes**
+- Step 2 (Channel 1-4 instrument + one long-form run): **45 minutes**
+- Step 3 (Channel 5 tracing patch + rebuild + run): **2 hours**

--- a/.planning/debug/iroh-throughput-bbr-cubic/SPIKE-MULTI-STREAM.md
+++ b/.planning/debug/iroh-throughput-bbr-cubic/SPIKE-MULTI-STREAM.md
@@ -1,0 +1,249 @@
+# Multi-Stream / Multi-Connection Spike
+
+**Date:** 2026-05-24
+**Setup:** Mac (sender) ↔ Mac via ssh `macbook` (receiver), same wifi LAN (192.168.31.0/24)
+**Test file:** 3 GB random bytes (`/tmp/testfile-rand.bin`, generated from `/dev/urandom`)
+**Spike binary:** `src-tauri/crates/p2p-bench/` — minimal iroh + iroh-blobs CLI
+
+## Goal
+
+Answer: **Can we work around the ~40 MB/s single-stream iroh-blobs ceiling
+by using N concurrent streams/connections at the application layer? If so,
+this is a viable fix without forking iroh or noq.**
+
+Two variants tested:
+
+- **X1 (multi-stream, single endpoint)**: sender splits the file into N
+  blobs; receiver fetches all N concurrently from one shared `Endpoint`.
+  Verifies: do N QUIC streams over the same connection bypass the
+  per-connection cwnd?
+- **X3 (multi-endpoint, multi-connection)**: receiver builds N independent
+  `Endpoint`s, each with its own UDP socket; one ticket per endpoint.
+  Verifies: do N independent QUIC connections bypass any per-connection
+  limit?
+
+## Results
+
+### iroh-blobs throughput matrix (3 GB, BBR, tuned transport)
+
+#### Mac↔Mac (both wifi, near saturation)
+
+| Configuration | per-stream MB/s | aggregate MB/s | wall (s) | runs |
+|---|---|---|---|---|
+| iroh X1 N=1 (baseline) | — | 28-42 | 70-79 | 4 |
+| iroh X1 N=2 | 16-23 | 24-45 | 66-122 | 4 |
+| iroh X1 N=4 | 6-13 | 25-51 | 58-118 | 3 |
+| iroh X1 N=8 | ~4 | 30 | 99 | 1 |
+| iroh X3 N=2 (receiver multi-endpoint, mem store) | 17.6 each | 34 | 88 | 1 |
+
+#### Mac→Win (Mac wifi → Win wired, large headroom)
+
+| Configuration | per-stream MB/s | aggregate MB/s | wall (s) | × baseline |
+|---|---|---|---|---|
+| iroh X1 N=1 (baseline) | — | 43.64 | 68.75 | 1.0× |
+| **iroh X4 N=2 (sender multi-endpoint)** | **45.5, 42.9** | **85.91** | **34.9** | **1.97×** ✓ |
+| iroh X4 N=4 (sender multi-endpoint) | 18-20 each | 72.35 | 41.5 | 1.66× (regression past N=2) |
+
+### Physical-link baseline via iperf3 (30 s tests)
+
+iperf3 was compiled from source on `macbook` (no openssl) since brew install
+was unavailable in the build environment. Win runs scoop-installed iperf3
+3.20. **Mac and macbook are both on wifi; Windows is on a wired 2.5 GbE NIC.**
+
+#### Mac↔Mac (both wifi → bottleneck is wifi)
+
+| Direction | Mode | Aggregate | Retr |
+|---|---|---|---|
+| Mac→macbook | TCP single | 370 Mbps = **46.3 MB/s** | 448 |
+| Mac→macbook | TCP P=4 | **526 Mbps = 65.8 MB/s** | 4230 ⚠️ |
+| Mac→macbook | TCP P=8 | 508 Mbps = 63.5 MB/s | 10012 ⚠️ |
+| macbook→Mac | TCP P=4 (reverse) | 480 Mbps = 60 MB/s | — |
+
+**Mac↔Mac physical ceiling: ~65 MB/s (TCP P=4).** Adding more parallelism
+doesn't help; high retransmit count indicates significant wifi packet loss
+even at the saturation point.
+
+#### Mac↔Win (one wifi end + one wired end → bottleneck is the wifi end)
+
+| Direction | Mode | Aggregate | Retr |
+|---|---|---|---|
+| Win→Mac | TCP single | 311 Mbps = **38.9 MB/s** | — |
+| Win→Mac | TCP P=4 | 788 Mbps = **98.5 MB/s** | — |
+| Win→Mac | TCP P=8 | **946 Mbps = 118.3 MB/s** | — |
+| Mac→Win | TCP P=4 (reverse) | 853 Mbps = **106.6 MB/s** | 1315 |
+
+**Mac↔Win physical ceiling: ~118 MB/s (TCP P=8)**, close to gigabit line
+rate. The Mac's wifi uplink can carry 100+ MB/s to a wired receiver — far
+beyond what Mac↔Mac wifi-to-wifi can deliver.
+
+### ssh+dd reference (incidental, do not over-interpret)
+
+ssh single TCP behaves badly on jittery wifi (CUBIC slow-recovery after
+each loss). Listed for completeness only — these are not "wifi physical
+upper bounds":
+
+| Configuration | Aggregate |
+|---|---|
+| ssh+chacha20 single | 14.5 MB/s |
+| ssh+aes128-gcm single | 5.87 MB/s |
+| **ssh+chacha20 2 parallel** | **31.4 MB/s** (2.16× single — wifi has headroom) |
+
+### Connection-level evidence (X1 N=2 with `RUST_LOG=iroh=debug`)
+
+```
+Connection established. me=d2626b2316 remote=73d7e0b278 alpn=/iroh-bytes/4
+handle_path_event ... event=Opened { id: PathId(4) }
+```
+
+Exactly **one** QUIC connection, **one** path. The N=2 streams are multiplexed
+over a single connection — they share cwnd. This is consistent with the
+N=2 per-stream throughput being half of N=1.
+
+## Interpretation
+
+### Mac↔Mac (both wifi)
+
+Five facts have to fit:
+
+1. **iroh single = 40 MB/s ≈ iperf3 single TCP = 46.3 MB/s**. iroh's single
+   QUIC stream already hits **87 % of what plain TCP can do** on this wifi
+   link. iroh is *not* leaving meaningful single-stream headroom on the
+   table — it's about as good as one connection gets.
+
+2. **iperf3 P=4 = 65 MB/s** is the physical wifi ceiling. P=8 doesn't
+   improve, so 4 streams already saturate. **Mac↔Mac wifi tops out at
+   ~65 MB/s**, not the gigabit-class number you'd see from iperf3 on a
+   wired link.
+
+3. **iroh X1 N>1 doesn't improve over N=1**. Multiple QUIC streams on the
+   same connection share cwnd. Debug log confirms exactly 1 QUIC
+   connection / 1 path for X1 N=2.
+
+4. **iroh X3 N=2 = 34 MB/s ≈ X1 N=1 = 40 MB/s**. Two *independent*
+   connections still aggregate to ~single-stream. At first glance this
+   contradicts "cwnd is the bottleneck" — independent CCs should each
+   climb to ~40 and total ~80. But the wifi ceiling is only ~65, so 34 is
+   what you'd expect once contention overhead + jitter eat into the
+   already-near-saturated channel.
+
+5. **ssh 2-parallel = 31.4 MB/s ≈ 2.16× single ssh = 14.5 MB/s**. ssh
+   single is far below the wifi ceiling (CUBIC handles wifi loss badly),
+   so doubling streams cleanly doubles throughput. This is the "headroom
+   exists" signal, not contradiction of (4) — iroh + ssh sit at very
+   different fractions of the same ceiling.
+
+**Mac↔Mac conclusion**: iroh single is near the physical ceiling already.
+The "X3 didn't scale" result is consistent with a ~65 MB/s wifi ceiling +
+multi-connection overhead. Sender-side `Endpoint` contention may still
+play a role, but on Mac↔Mac there's not much headroom to demonstrate it.
+
+### Mac↔Win (Mac wifi + Win wired)
+
+The story changes dramatically:
+
+| Metric | Value | What it says |
+|---|---|---|
+| iperf3 Mac→Win P=4 | **106 MB/s** | Physical headroom is huge — gigabit-class, because Win is wired |
+| iperf3 Mac→Win single | ~38 MB/s | Single TCP, like Mac↔Mac single — wifi single-flow CUBIC is the limit |
+| iroh single (user report) | ~40 MB/s | **34 %** of physical headroom — iroh single is leaving a *lot* on the table |
+
+On Mac↔Mac, iroh single = 87 % of physical = "iroh is healthy". On
+Mac↔Win, iroh single = 34 % of physical = **iroh is severely
+under-utilizing the link**. The difference isn't iroh — it's that the
+physical ceiling is now far above what a single QUIC stream can deliver
+over wifi.
+
+This is exactly the regime where application-layer multi-stream/connection
+should help. The Mac↔Mac X3 result (no scaling) doesn't generalize here
+because Mac↔Mac was already near saturation. Mac↔Win has 60+ MB/s of
+unused capacity that 1-stream iroh can't reach.
+
+The bottleneck is **above the noq congestion controller** but **below the
+iroh-blobs application logic**, AND on Mac↔Win there's enough physical
+headroom that working around it at the app layer could realistically
+double or triple throughput.
+
+## Implications for the original question
+
+The user asked: *"Can our forked iroh-blobs fix the throughput?"*
+
+| Fix path | Mac↔Mac | Mac↔Win | Why |
+|---|---|---|---|
+| Fork `noq` to patch BBR/CUBIC | ❌ | ❌ | CC isn't the bottleneck (X3 still didn't scale on Mac↔Mac; on Mac↔Win, single-stream BBR already reaches what TCP CUBIC reaches) |
+| Fork `iroh` to tweak transport / multipath | ❌ | unlikely | Already exhausted in spike (multipath ruled out, window/keepalive/CC factory tried) |
+| App-layer multi-stream (X1) | ❌ | ❌ | Streams share single-connection cwnd; debug log proves only 1 QUIC connection |
+| App-layer multi-endpoint **receiver** (X3) | ❌ | unverified | On Mac↔Mac no headroom to exploit. On Mac↔Win 60+ MB/s headroom exists, but the receiver is Win and the sender-side endpoint is still shared — likely still bottlenecks |
+| **App-layer multi-endpoint sender** (X4) | unverified | ✓ **verified 1.97× at N=2** | Mac→Win N=2 SME = 85.91 MB/s vs N=1 = 43.64 MB/s. Per-stream throughput stays at single-stream baseline (45/43 MB/s each), confirming sender-side `Endpoint` was the shared bottleneck. N=4 regresses to 72 MB/s — N=2 is the sweet spot |
+| Upgrade to iroh 1.0-rc | unverified | unverified | Multiple changes (multipath default 8 not 13, noq updates). Worth testing in isolation, but no specific patch known to address the symptom |
+| Accept current ceiling | pragmatic | costly | Mac↔Mac 40 MB/s = 87% of physical = healthy. Mac→Win 40 MB/s = 34% of physical = leaving large speedup on the table |
+
+## Important caveat for the user's actual symptom
+
+The user's main complaint is **Mac→Windows starts at 40 MB/s and decays to
+10 MB/s over a long transfer**. The spike's two findings cut along
+different axes:
+
+1. **The 40 MB/s starting throughput** is itself only 34 % of the physical
+   wifi+wired capacity on Mac→Win. This is not "iroh near saturation" — it
+   is "iroh single-stream is not designed to multiplex into wifi-wired
+   asymmetric links". Sender multi-endpoint may lift this number toward
+   80-100 MB/s.
+
+2. **The decay from 40 to 10 MB/s** is *not* reproducible on Mac↔Mac (Mac↔Mac
+   holds steady), so this is Windows-specific. Candidates:
+   - Windows Defender deferred scan as the file grows
+   - NTFS fragmentation pressure during long sequential writes
+   - SMB or filesystem cache eviction under sustained pressure
+   - Windows iroh / quinn behavior on the receive side
+
+These two problems are **independent** and need separate fixes. Even if
+sender multi-endpoint lifts the start from 40 to 90 MB/s, the decay would
+still drag it back down without a Windows-side fix.
+
+## What X4 N=2 result actually means
+
+This is the headline number. On the user's actual problem path (Mac→Win
+file sync), splitting the **sender** into 2 independent `Endpoint`s
+**doubles throughput** with no code change to iroh, noq, or iroh-blobs —
+purely an application-layer pattern.
+
+What "do this in production" would look like for uniclipboard:
+- The current sender process binds one `Endpoint` (via `uc-infra/network/iroh/node.rs`)
+  and one `BlobsProtocol` instance shared across all transfers
+- The proposed change: when serving a large blob, bind a 2nd ephemeral
+  `Endpoint` for that transfer, split the blob into 2 chunks, send each
+  chunk's ticket as a pair, receiver fetches both concurrently
+- For small clipboard items the existing single-endpoint path stays —
+  doubling only matters once the transfer is large enough that
+  startup overhead (~3-5 s per extra endpoint for relay + discovery) is
+  amortized
+
+Cost considerations:
+- 2nd `Endpoint` = additional UDP socket + iroh node_id + relay handshake
+- Adds ~3-5 s setup latency per large transfer; not noticeable for files
+  > a few hundred MB
+- Doubles the number of public node_ids exposed by the sender
+  (privacy/observability surface grows accordingly)
+- Receiver-side change: need to accept pairs of tickets and fan out the
+  fetch
+
+The spike does NOT change iroh / noq / iroh-blobs themselves. The X4 path
+is a pure application-layer workaround that exploits iroh-blobs's already
+working multi-connection support.
+
+## Spike artifacts
+
+- `src-tauri/crates/p2p-bench/src/main.rs` — CLI binary supporting:
+  - `--split N` — sender splits file into N blobs
+  - `--multi-endpoint` (X3) — receiver builds N independent endpoints
+  - `--sender-multi-endpoint` (X4) — sender binds N independent endpoints,
+    one ticket per endpoint
+- `/tmp/spike-run.sh` — Mac→macbook orchestrator
+- `/tmp/win-spike-run.sh` — Mac→Win orchestrator (sshpass-based, retries
+  on intermittent Win sshd auth failures)
+- `/tmp/receiver-n2-debug.log` — debug log showing only 1 QUIC connection
+  for X1 N=2
+- `/tmp/spike-multi-results.log` — raw multi-iteration Mac↔Mac data
+
+The `p2p-bench` crate is `publish = false` and tagged "throwaway diagnostic
+spike" in its description; it does not need to ship with any release.

--- a/.planning/debug/iroh-throughput-bbr-cubic/UPSTREAM_ISSUE_DRAFT.md
+++ b/.planning/debug/iroh-throughput-bbr-cubic/UPSTREAM_ISSUE_DRAFT.md
@@ -1,0 +1,189 @@
+# Upstream issue draft
+
+**Target repo (suggested):** [`n0-computer/iroh`](https://github.com/n0-computer/iroh/issues/new)
+(`iroh` is the discoverable entry point; maintainers can re-route to `noq` if appropriate)
+
+**Existing related issue to cross-reference:**
+- [`iroh#1943` Slow network throughput](https://github.com/n0-computer/iroh/issues/1943) (umbrella)
+- [`noq#657` fix(bbr3): bbr3 controller was not accounting correctly](https://github.com/n0-computer/noq/pull/657) (BBR direction, may be reversed in our env)
+- [`noq#474` Make congestion controller aware of all paths](https://github.com/n0-computer/noq/issues/474) (multipath CC coordination)
+
+The body below is plain GitHub markdown — copy from the `---` separator to the bottom of this file and paste it into a new issue.
+
+---
+
+## Title
+
+> iroh-blobs single-stream LAN throughput caps at ~40% of link capacity with BBR; CUBIC is ~30× slower than BBR on the same path
+
+---
+
+## Body
+
+### TL;DR
+
+On a `192.168.31.0/24` LAN where `iperf3` (raw UDP) measures **~110 MB/s** between two Apple-silicon Macs (one Wi-Fi 6, one 2.5 GbE through the same router), a single-stream `iroh-blobs` blob fetch tops out at:
+
+- **42-50 MB/s** with `BbrConfig` (~40% of link capacity)
+- **1.29 MB/s** with `CubicConfig` (~1% of link capacity)
+- **37 MB/s** with vanilla `iroh::QuicTransportConfig::builder().build()`
+
+The BBR result is consistent with [`#1943`](https://github.com/n0-computer/iroh/issues/1943). The **CUBIC result is the surprise**: 30× slower than BBR on the same hardware, same RTT, same file. This is the inverse of the failure mode in [`noq#657`](https://github.com/n0-computer/noq/pull/657) (which reports broken BBR3 vs. healthy CUBIC). On our setup, BBR is the only usable controller.
+
+A self-contained repro is included.
+
+### Versions
+
+- `iroh = "0.98"` (features = `["address-lookup-mdns"]`)
+- `iroh-blobs = "0.100"` (we vendor it for an unrelated `HashContext::persist` patch — does not touch transport code)
+- `noq-proto = "0.17"` (which pulls `noq = 0.18.0`)
+- macOS 15.6.1, both peers aarch64
+
+### Reproduction
+
+Minimal CLI, two binaries (sender + receiver) sharing one source file. ~250 LoC, no application-level wrapper:
+
+```rust
+// Cargo.toml deps:
+//   iroh = { version = "0.98", features = ["address-lookup-mdns"] }
+//   iroh-blobs = "0.100"
+//   noq-proto = "0.17"
+//   ... (clap, tokio, anyhow)
+
+// Sender:
+let transport = QuicTransportConfig::builder()
+    .congestion_controller_factory(Arc::new(BbrConfig::default())) // or CubicConfig
+    .stream_receive_window(VarInt::from_u32(32 * 1024 * 1024))
+    .send_window(64 * 1024 * 1024)
+    .keep_alive_interval(Duration::from_secs(15))
+    .build();
+let endpoint = Endpoint::builder(presets::N0)
+    .transport_config(transport)
+    .bind().await?;
+endpoint.online().await;  // wait for relay home + addrs
+let store = FsStore::load("./store").await?;
+let tag = store.blobs().add_path("/tmp/big.bin").await?;
+let ticket = BlobTicket::new(endpoint.addr(), tag.hash, tag.format);
+println!("{ticket}");
+let _router = Router::builder(endpoint)
+    .accept(iroh_blobs::ALPN, BlobsProtocol::new(&store, None))
+    .spawn();
+
+// Receiver:
+let parsed: BlobTicket = ticket_string.parse()?;
+let lookup = MemoryLookup::new();
+lookup.add_endpoint_info(parsed.addr().clone());  // seed addrs to avoid discovery race
+let endpoint = Endpoint::builder(presets::N0)
+    .transport_config(same_transport_config_as_sender)
+    .address_lookup(lookup)
+    .bind().await?;
+let store = FsStore::load("./store").await?;
+let downloader = store.downloader(&endpoint);
+let mut stream = downloader
+    .download(parsed.hash_and_format(), [parsed.addr().id])
+    .stream().await?;
+// drain stream, time it
+```
+
+(Test file: 1 GB or 2 GB from `/dev/urandom` so the BAO hash is unique each run and the receiver cannot short-circuit from a cached blob.)
+
+### Measurements
+
+Reproduction matrix, Mac → Mac LAN, 1 GB random-content file, both sides
+running the spike above:
+
+| Sender CC | Receiver CC | Sender store | Receiver store | Throughput |
+|---|---|---|---|---|
+| BBR | BBR | Fs | Fs | **42.65 MB/s** |
+| BBR | BBR | Fs | Fs (tuned 32M/64M windows) | **48.16 MB/s** (2.7 GB run) |
+| BBR | BBR | Fs | Fs (vanilla `builder().build()`) | 37 MB/s |
+| BBR | BBR | Fs | **Mem** | 21.54 MB/s |
+| BBR | BBR | **Mem** | **Mem** | 21.44 MB/s |
+| **CUBIC** | **CUBIC** | Fs | Fs (tuned) | **1.29 MB/s** |
+| **CUBIC** | **CUBIC** | Fs | Fs (vanilla) | 1.70 MB/s |
+
+Comparison baseline on the same LAN:
+
+| Tool | Throughput |
+|---|---|
+| `iperf3 -u -b 0 -t 30 -l 1200` | ~110 MB/s |
+| `iroh-blobs` + BBR (best) | ~50 MB/s (= ~45% of iperf3) |
+| `iroh-blobs` + CUBIC | ~1.3-1.7 MB/s (= ~1.5%) |
+
+### Receiver-side per-chunk pattern (slow case)
+
+`iroh-blobs` progress checkpoints emit every 4 MB. Inter-arrival intervals
+during a typical slow window:
+
+```
+4 MB → 20 MB     (+16 MB / 26 ms = 615 MB/s burst)
+20 MB → 36 MB    (+16 MB / 2050 ms = 8 MB/s pause)
+36 MB → 50 MB    (~700 ms per 4-MB chunk)
+50 MB → 54 MB    (6 ms — another burst)
+54 MB → 58 MB    (~766 ms — pause again)
+```
+
+8-chunk bursts (= 32 MB = our `stream_receive_window`) followed by
+multi-second silence. We initially read this as receiver-side disk-write
+backpressure, but `--store mem` on the receiver runs *slower* than
+`--store fs` (21.5 vs. 42 MB/s), so the disk is not what's filling the
+window. The behavior persists across MemStore + FsStore + both directions.
+
+### What we have already ruled out
+
+To save maintainer time, the following hypotheses have been explicitly
+tested and eliminated in our environment:
+
+- **multipath QUIC path-validation churn** — only 4 `iroh::_events::path::*`
+  events in a 34-second slow window (1 × `path::open` at start, 3 ×
+  `path::abandoned` at end). No `path::set_status` between. So even if
+  `MAX_MULTIPATH_PATHS = 12` is on by default (we confirmed it is in 0.98 —
+  see [`iroh#3635`](https://github.com/n0-computer/iroh/issues/3635) for
+  the setter ignoring values < 13), it does not appear to be churning here.
+- **hairpin / public NAT-reflected IP candidate dragging multipath down** —
+  ruled out by finding fast transfers with 6-candidate sets and slow
+  transfers with 2-candidate sets. Candidate count does not predict speed.
+- **Windows Defender / NTFS / SMB / OS-specific path** — reproduces Mac → Mac.
+- **Wi-Fi physical layer** — sender RSSI -19 dBm, Tx 2.4 Gbps; iperf3 110 MB/s
+  baseline.
+- **Mihomo / Clash TUN routing** — disabled, no effect.
+- **Application-level encryption / encoding / store layer overhead** — bare
+  `iroh-blobs` matches the application-stack ceiling within noise.
+- **Receiver disk write** — `--store mem` is slower than `--store fs`.
+- **Sender-side compress/encrypt pipeline** — `add_path` completes 7-9 seconds
+  in, well before the fetch's cold-start window ends.
+
+### Hypothesis
+
+The 45 MB/s BBR ceiling **and** the 30× CUBIC vs. BBR ratio are both consistent
+with a **`noq` 0.18 congestion-controller defect that manifests on real LAN
+links with mild loss / RTT jitter** (Wi-Fi-class environment), while `noq`'s
+own netsim CI (which reports `~782 Mbps` LAN-condition throughput in
+[`noq#657`](https://github.com/n0-computer/noq/pull/657)) does not surface it.
+
+In `noq#657` the reporter sees broken BBR, healthy CUBIC; we see the inverse.
+Both could be the same underlying "on_packet_sent feedback path is wrong",
+expressed differently on different links.
+
+### Open questions for maintainers
+
+1. Are there known good numbers for `iroh-blobs` single-stream LAN
+   throughput on real (non-netsim) hardware as of 0.98 / noq 0.18, against
+   which our 45 MB/s should be considered "low" vs. "expected"?
+2. Is there a recommended tuning knob path beyond `stream_receive_window` /
+   `send_window` / CC factory to recover the gap to physical capacity for
+   single-stream LAN transfers? `initial_window` on the CC came up in
+   [`#1943`](https://github.com/n0-computer/iroh/issues/1943) but is not
+   exposed on `QuicTransportConfigBuilder`.
+3. Is the CUBIC 30× regression in this environment something
+   [`noq#657`](https://github.com/n0-computer/noq/pull/657)'s fix would
+   address as a side effect, or does it warrant a separate CUBIC-specific
+   investigation?
+4. Has `1.0-rc.0` (with `MAX_MULTIPATH_PATHS` lowered to 8 and any
+   post-0.18 `noq` fixes pulled in) been benchmarked against the same
+   spike? If maintainers have such numbers we'd love to compare; otherwise
+   we'll repeat the spike after our own upgrade and append results.
+
+Happy to run additional configurations on this hardware if it would help —
+the spike crate is ~250 LoC and the matrix above takes 10 minutes to
+re-collect.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5947,6 +5947,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "p2p-bench"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "futures-lite",
+ "iroh",
+ "iroh-blobs",
+ "noq-proto",
+ "time",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "p384"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3927,6 +3927,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "if-addrs"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b2eeee38fef3aa9b4cc5f1beea8a2444fc00e7377cafae396de3f5c2065e24"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "igd-next"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9843,6 +9853,7 @@ dependencies = [
  "hex",
  "hkdf",
  "hmac",
+ "if-addrs",
  "image",
  "indexmap 2.14.0",
  "iroh",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -115,6 +115,7 @@ members = [
   "crates/uc-cli",
   "crates/uc-cli-macros",
   "crates/uc-daemon-client",
+  "crates/p2p-bench",
 ]
 # Submodule `vendor/iroh-blobs` is our fork of n0-computer/iroh-blobs
 # (branch `uniclipboard/0.100.0-patched`). It is consumed via

--- a/src-tauri/crates/p2p-bench/Cargo.toml
+++ b/src-tauri/crates/p2p-bench/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "p2p-bench"
+version = "0.0.0"
+edition = "2021"
+publish = false
+description = "Throwaway spike: minimal iroh + iroh-blobs CLI to measure raw P2P blob throughput, isolated from the uniclipboard app stack."
+
+[[bin]]
+name = "p2p-bench"
+path = "src/main.rs"
+
+[dependencies]
+anyhow = "1"
+clap = { version = "4", features = ["derive"] }
+tokio = { version = "1", features = ["full"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+futures-lite = "2"
+
+iroh = { version = "0.98", features = ["address-lookup-mdns"] }
+iroh-blobs = "0.100"
+noq-proto = "0.17"
+time = { version = "0.3", features = ["formatting", "macros"] }

--- a/src-tauri/crates/p2p-bench/src/main.rs
+++ b/src-tauri/crates/p2p-bench/src/main.rs
@@ -6,8 +6,8 @@
 //! QUIC itself, on this exact LAN, between these two machines?"
 //!
 //! Subcommands:
-//!   serve  --path <file>             prints a ticket, then accepts fetches
-//!   fetch  --ticket <t> --out <dst>  fetches into <dst>, prints per-chunk timings
+//!   serve  --path <file> [--split N]      prints 1 or N tickets joined by ','
+//!   fetch  --ticket <t1[,t2,...]>         fetches in parallel, prints aggregate
 //!
 //! Key knobs (apply to both subcommands unless noted):
 //!   --tuned           (default) match uniclipboard's production QUIC config
@@ -15,10 +15,12 @@
 //!   --window-mb N     override stream_receive_window (after --tuned/--vanilla)
 //!   --store {mem,fs}  receiver backing store (default fs); mem isolates disk I/O
 //!   --no-relay        sender disables relay → LAN-only
+//!   --split N         serve side splits the file into N blobs; fetch side
+//!                     downloads all of them in parallel over the same endpoint.
+//!                     N=1 (default) is the original single-blob baseline.
 //!
-//! Output line shape (fetch):
-//!   FETCH ts=<ISO8601> bytes=<n> elapsed_ms=<n> inst_mbps=<f> avg_mbps=<f>
-//! → can be piped into ~/.../dual-side-debug for the same analysis.
+//! Output line shape (fetch, final summary on stdout):
+//!   FETCH ts=<ISO8601> n=<N> bytes=<total> wall_elapsed_ms=<n> aggregate_mbps=<f>
 
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -54,7 +56,6 @@ struct Cli {
     vanilla: bool,
 
     /// Override stream_receive_window in MB (after --tuned / --vanilla applied).
-    /// Use 4 for "1-chunk window" reproduction, 256 for big-window sanity check.
     #[arg(long, global = true)]
     window_mb: Option<u32>,
 
@@ -63,10 +64,50 @@ struct Cli {
     no_relay: bool,
 
     /// Congestion controller. `bbr` matches production; `cubic` tests the
-    /// noq#657 hypothesis (BBRv3 in noq 0.18 has a broken on_packet_sent hook
-    /// that craters throughput). Defaults to bbr.
+    /// noq#657 hypothesis. Defaults to bbr.
     #[arg(long, value_enum, default_value_t = Cc::Bbr, global = true)]
     cc: Cc,
+
+    /// Multi-stream spike. Serve splits the file into N independent blobs;
+    /// fetch downloads all N concurrently over the same endpoint (so they
+    /// share one QUIC connection, multiple streams). N=1 reproduces the
+    /// original single-blob baseline.
+    #[arg(long, default_value_t = 1, global = true)]
+    split: u32,
+
+    /// Multi-CONNECTION spike (X3). Fetch builds one independent `Endpoint`
+    /// per ticket — each gets its own UDP socket, its own QUIC connection,
+    /// its own congestion controller. This is the test that says
+    /// "is single-connection cwnd the ceiling, or is it the NIC/CPU?".
+    /// Requires --split N > 1 on the sender side.
+    #[arg(long, default_value_t = false, global = true)]
+    multi_endpoint: bool,
+
+    /// Verify mode for hypothesis A (production uses `add_path` lazy-disk-read
+    /// while spike uses `add_slice` from-RAM). When true and `--split == 1`,
+    /// sender uses `store.blobs().add_path(file)` like production does, so the
+    /// hot serve path goes through `DataReader::read_bytes_at` (sync pread).
+    /// Receiver behaviour unchanged. Use with `--store fs` on the sender side
+    /// to actually exercise the FsStore + pread path.
+    #[arg(long, default_value_t = false, global = true)]
+    use_add_path: bool,
+
+    /// Sender-side multi-endpoint (X4). Sender binds N independent
+    /// `Endpoint`s — each with its own UDP socket and its own iroh node_id
+    /// — and serves one chunk per endpoint. Receiver naturally opens N
+    /// independent QUIC connections (one per unique provider node_id),
+    /// bypassing any sender-side per-endpoint shared resource (UDP socket
+    /// send-queue, quinn cross-connection scheduler/locks). Requires
+    /// --split N > 1.
+    ///
+    /// This is the test that says "if the bottleneck is the sender's
+    /// single `Endpoint`, does splitting it actually let aggregate
+    /// throughput scale beyond a single-stream cap?" Most meaningful on
+    /// asymmetric links where physical capacity > single-stream BBR
+    /// equilibrium (e.g., Mac wifi → Windows wired, where iperf3 shows
+    /// 100+ MB/s headroom that iroh single-stream doesn't reach).
+    #[arg(long, default_value_t = false, global = true)]
+    sender_multi_endpoint: bool,
 }
 
 #[derive(Copy, Clone, ValueEnum, PartialEq, Eq, Debug)]
@@ -77,35 +118,32 @@ enum Cc {
 
 #[derive(Subcommand)]
 enum Cmd {
-    /// Publish a file and print a fetch ticket. Stays alive until Ctrl-C.
+    /// Publish a file (optionally split into N blobs) and print fetch ticket(s).
     Serve {
         #[arg(long)]
         path: PathBuf,
 
-        /// Backing store on the sender side. fs matches production; mem isolates
-        /// any sender-side disk I/O (BAO outboard scan, etc).
         #[arg(long, value_enum, default_value_t = StoreKind::Fs)]
         store: StoreKind,
 
-        /// Where FsStore lives. Ignored for mem. Defaults to ./p2p-bench-store.
         #[arg(long)]
         store_dir: Option<PathBuf>,
     },
 
-    /// Fetch a ticketed blob into <out>. Prints per-chunk timing + final summary.
+    /// Fetch one or more ticketed blobs (','-separated). Prints aggregate
+    /// throughput across all parallel downloads.
     Fetch {
         #[arg(long)]
         ticket: String,
 
+        /// Unused: parallel mode doesn't reconstruct a single output file.
+        /// Kept for CLI compatibility with the single-blob baseline path.
         #[arg(long)]
         out: PathBuf,
 
-        /// Backing store on the receiver. fs matches production; mem removes
-        /// the receiver-side disk write entirely.
         #[arg(long, value_enum, default_value_t = StoreKind::Fs)]
         store: StoreKind,
 
-        /// Where FsStore lives. Ignored for mem. Defaults to ./p2p-bench-store.
         #[arg(long)]
         store_dir: Option<PathBuf>,
     },
@@ -128,53 +166,35 @@ async fn main() -> Result<()> {
 
     let cli = Cli::parse();
 
-    // For fetch, parse the ticket up front so we can seed receiver's
-    // MemoryLookup with the sender's known addresses BEFORE binding the
-    // endpoint. iroh's Downloader takes only EndpointIds, then asks
-    // AddressLookup services to resolve them; without seeding, it has to
-    // wait for mDNS/pkarr/relay discovery to find the sender — which races
-    // hard in scripted timing and usually fails fast with "bytes_so_far=0".
-    let seeded_lookup = if let Cmd::Fetch { ref ticket, .. } = cli.cmd {
-        let parsed: BlobTicket = ticket
-            .parse()
-            .context("parse ticket before endpoint bind")?;
-        let lookup = MemoryLookup::new();
-        lookup.add_endpoint_info(parsed.addr().clone());
-        eprintln!(
-            "[bench] seeded MemoryLookup with provider {} (relays={}, ips={})",
-            parsed.addr().id.fmt_short(),
-            parsed.addr().relay_urls().count(),
-            parsed.addr().ip_addrs().count(),
-        );
-        Some(lookup)
-    } else {
-        None
-    };
-
-    let endpoint = build_endpoint(&cli, seeded_lookup).await?;
-    eprintln!("[bench] node_id = {}", endpoint.id());
-
     match cli.cmd {
         Cmd::Serve {
             ref path,
             store,
             ref store_dir,
-        } => serve(endpoint, path.clone(), store, store_dir.clone()).await,
+        } => {
+            if cli.sender_multi_endpoint && cli.split > 1 {
+                serve_multi_endpoint(&cli, path.clone(), cli.split).await
+            } else {
+                // Sender just needs one endpoint, no MemoryLookup seeding required.
+                let endpoint = build_endpoint(&cli, None).await?;
+                eprintln!("[bench] node_id = {}", endpoint.id());
+                serve(
+                    endpoint,
+                    path.clone(),
+                    store,
+                    store_dir.clone(),
+                    cli.split,
+                    cli.use_add_path,
+                )
+                .await
+            }
+        }
         Cmd::Fetch {
             ref ticket,
             ref out,
             store,
             ref store_dir,
-        } => {
-            fetch(
-                endpoint,
-                ticket.clone(),
-                out.clone(),
-                store,
-                store_dir.clone(),
-            )
-            .await
-        }
+        } => fetch(&cli, ticket.clone(), out.clone(), store, store_dir.clone()).await,
     }
 }
 
@@ -184,8 +204,6 @@ async fn build_endpoint(cli: &Cli, seeded_lookup: Option<MemoryLookup>) -> Resul
     let relay_mode = if cli.no_relay {
         RelayMode::Disabled
     } else {
-        // presets::N0 already wires the default relay; passing RelayMode::Default
-        // is the "use whatever the preset gave us" answer.
         RelayMode::Default
     };
 
@@ -209,12 +227,8 @@ fn build_transport(cli: &Cli) -> QuicTransportConfig {
     let mut builder = QuicTransportConfig::builder();
 
     if cli.vanilla {
-        // Vanilla: skip all the production tuning. --cc still applies below so
-        // you can isolate "vanilla + BBR vs vanilla + CUBIC".
         eprintln!("[bench] transport config: VANILLA (iroh defaults)");
     } else {
-        // Tuned: mirror src-tauri/crates/uc-infra/src/network/iroh/node.rs:260
-        // — except the CC factory, which is set below based on --cc.
         eprintln!("[bench] transport config: TUNED (matches production minus CC)");
         builder = builder
             .stream_receive_window(VarInt::from_u32(32 * 1024 * 1024))
@@ -228,8 +242,6 @@ fn build_transport(cli: &Cli) -> QuicTransportConfig {
             .keep_alive_interval(Duration::from_secs(15));
     }
 
-    // Apply CC factory regardless of --tuned/--vanilla. Default `bbr` matches
-    // current production; `cubic` validates the noq#657 hypothesis.
     eprintln!("[bench] congestion controller: {:?}", cli.cc);
     builder = match cli.cc {
         Cc::Bbr => builder.congestion_controller_factory(Arc::new(BbrConfig::default())),
@@ -249,13 +261,9 @@ async fn serve(
     path: PathBuf,
     store_kind: StoreKind,
     store_dir: Option<PathBuf>,
+    split: u32,
+    use_add_path: bool,
 ) -> Result<()> {
-    // Wait for relay handshake + address discovery to populate. Without this,
-    // `endpoint.addr()` returns an EndpointAddr with no relay URL and no
-    // direct IPs — receivers can't connect because they don't know where we
-    // are (only our node_id). iroh's recommended way is `endpoint.online()`
-    // which waits until home_relay is set; we also give a small extra grace
-    // window for the first net_report cycle so direct LAN addrs land too.
     eprintln!("[serve] waiting for iroh to come online (relay home + addrs)...");
     let online_started = Instant::now();
     endpoint.online().await;
@@ -267,67 +275,272 @@ async fn serve(
 
     let abs = std::path::absolute(&path).context("resolve path")?;
     let started = Instant::now();
+    let n = split.max(1) as usize;
 
-    let (ticket, _router) = match store_kind {
+    // Production-A verify path: use add_path (lazy disk read via FsStore +
+    // sync pread on serve) instead of add_slice (file pre-loaded into RAM).
+    // Branch early so we skip the whole-file mem read entirely.
+    if use_add_path {
+        if n != 1 {
+            anyhow::bail!("--use-add-path requires --split 1 (add_path can't split a file)");
+        }
+        let StoreKind::Fs = store_kind else {
+            anyhow::bail!("--use-add-path requires --store fs (MemStore.add_path would still read all into RAM, defeating the experiment)");
+        };
+        let dir = store_dir.unwrap_or_else(|| PathBuf::from("./p2p-bench-store"));
+        std::fs::create_dir_all(&dir).context("create fs store dir")?;
+        let store = FsStore::load(&dir).await.context("load FsStore")?;
+        eprintln!(
+            "[serve] use_add_path=true: store.blobs().add_path({})",
+            abs.display()
+        );
+        let tag = store
+            .blobs()
+            .add_path(abs.clone())
+            .await
+            .context("add_path failed")?;
+        let import_ms = started.elapsed().as_millis() as u64;
+        eprintln!(
+            "[serve] add_path done in {}ms hash={} format={:?}",
+            import_ms,
+            &tag.hash.to_string()[..16],
+            tag.format
+        );
+        let addr = endpoint.addr();
+        let ticket = BlobTicket::new(addr, tag.hash, tag.format);
+        let blobs = BlobsProtocol::new(&store, None);
+        let router = Router::builder(endpoint.clone())
+            .accept(iroh_blobs::ALPN, blobs)
+            .spawn();
+        let _guard = RouterGuard::new(router, Some(store));
+        println!("{}", ticket);
+        eprintln!("[serve] ticket printed; serving via add_path / FsStore sync pread");
+        tokio::signal::ctrl_c().await?;
+        eprintln!("[serve] shutting down");
+        return Ok(());
+    }
+
+    // Read the whole file once into memory, then split into N owned chunks
+    // via slice copies. Each chunk goes to add_slice which import-copies it
+    // into the store (BAO outboard). For a 2.7 GB test file at N=4 this
+    // costs ~10 GB of transient RSS (file + 4 chunk copies + store import),
+    // which fits comfortably in a 16+ GB box and only happens once at serve
+    // startup — irrelevant to the throughput measurement.
+    let file_bytes = tokio::fs::read(&abs).await.context("read source file")?;
+    let file_size = file_bytes.len();
+    let chunk_size = file_size.div_ceil(n);
+    eprintln!(
+        "[serve] file={} size={} bytes; split into {} chunks (~{} bytes each)",
+        abs.display(),
+        file_size,
+        n,
+        chunk_size,
+    );
+
+    let (tickets, _guard) = match store_kind {
         StoreKind::Mem => {
             let store = MemStore::new();
-            let tag = store.blobs().add_path(abs.clone()).await?;
-            // Use full endpoint.addr() (NodeAddr) so the ticket carries our LAN IPs +
-            // relay URL, not just node_id. Without this the receiver has to do mDNS /
-            // pkarr discovery from scratch, which can race and time out in scripted
-            // orchestration. uc-infra/blobs.rs:286 makes the same choice.
-            let addr = endpoint.addr();
-            eprintln!("[serve] endpoint.addr() = {:?}", addr);
-            let ticket = BlobTicket::new(addr, tag.hash, tag.format);
+            let tickets = import_chunks(&endpoint, &file_bytes, chunk_size, n, |slice| {
+                let store = store.clone();
+                async move { store.blobs().add_slice(slice).await }
+            })
+            .await?;
             let blobs = BlobsProtocol::new(&store, None);
             let router = Router::builder(endpoint.clone())
                 .accept(iroh_blobs::ALPN, blobs)
                 .spawn();
-            (ticket, RouterGuard::new(router, None::<FsStore>))
+            (tickets, RouterGuard::new(router, None::<FsStore>))
         }
         StoreKind::Fs => {
             let dir = store_dir.unwrap_or_else(|| PathBuf::from("./p2p-bench-store"));
             std::fs::create_dir_all(&dir).context("create fs store dir")?;
             let store = FsStore::load(&dir).await.context("load FsStore")?;
-            let tag = store.blobs().add_path(abs.clone()).await?;
-            // Use full endpoint.addr() (NodeAddr) so the ticket carries our LAN IPs +
-            // relay URL, not just node_id. Without this the receiver has to do mDNS /
-            // pkarr discovery from scratch, which can race and time out in scripted
-            // orchestration. uc-infra/blobs.rs:286 makes the same choice.
-            let addr = endpoint.addr();
-            eprintln!("[serve] endpoint.addr() = {:?}", addr);
-            let ticket = BlobTicket::new(addr, tag.hash, tag.format);
+            let tickets = import_chunks(&endpoint, &file_bytes, chunk_size, n, |slice| {
+                let store = store.clone();
+                async move { store.blobs().add_slice(slice).await }
+            })
+            .await?;
             let blobs = BlobsProtocol::new(&store, None);
             let router = Router::builder(endpoint.clone())
                 .accept(iroh_blobs::ALPN, blobs)
                 .spawn();
-            (ticket, RouterGuard::new(router, Some(store)))
+            (tickets, RouterGuard::new(router, Some(store)))
         }
     };
 
     let add_ms = started.elapsed().as_millis() as u64;
     eprintln!(
-        "[serve] file={} store={:?} add_path_ms={}",
-        abs.display(),
+        "[serve] store={:?} chunks={} add_total_ms={}",
         match store_kind {
             StoreKind::Mem => "mem",
             StoreKind::Fs => "fs",
         },
+        tickets.len(),
         add_ms,
     );
-    println!("{}", ticket);
-    eprintln!("[serve] ticket printed to stdout — pipe / copy to receiver");
-    eprintln!("[serve] waiting for fetches, Ctrl-C to stop");
+    println!("{}", tickets.join(","));
+    eprintln!(
+        "[serve] {} ticket(s) printed to stdout; waiting for fetches, Ctrl-C to stop",
+        tickets.len()
+    );
 
     tokio::signal::ctrl_c().await?;
     eprintln!("[serve] shutting down");
     Ok(())
 }
 
+/// X4: serve N chunks from N independent sender `Endpoint`s — each gets
+/// its own UDP socket, its own iroh node_id, its own MemStore. Each chunk
+/// gets its own ticket pointing at its own provider. When the receiver
+/// fetches all N tickets, iroh's `ConnectionPool` (keyed by remote
+/// node_id) opens N independent QUIC connections, fully bypassing any
+/// per-`Endpoint` shared resource on the sender side.
+///
+/// MemStore only (per endpoint): N independent FsStores in the same dir
+/// would race; giving each its own subdir doubles disk-write surface and
+/// pollutes the measurement.
+///
+/// Startup overhead: each endpoint does its own relay handshake + addr
+/// discovery (~3-4s online + 3s grace), so N=4 spends ~15-25s in setup
+/// before printing tickets. That's all amortized before the transfer
+/// clock starts on the receiver side.
+async fn serve_multi_endpoint(cli: &Cli, path: PathBuf, split: u32) -> Result<()> {
+    let abs = std::path::absolute(&path).context("resolve path")?;
+    let n = split.max(1) as usize;
+    let file_bytes = tokio::fs::read(&abs).await.context("read source file")?;
+    let file_size = file_bytes.len();
+    let chunk_size = file_size.div_ceil(n);
+    eprintln!(
+        "[serve-multi] file={} size={} bytes; {} chunks (~{} bytes each); building {} independent endpoints",
+        abs.display(),
+        file_size,
+        n,
+        chunk_size,
+        n,
+    );
+
+    // Bundle of (endpoint, store, router) per chunk. All held until Ctrl-C
+    // to keep the senders alive.
+    struct Bundle {
+        _endpoint: Endpoint,
+        _store: MemStore,
+        _router: Router,
+    }
+
+    let mut bundles: Vec<Bundle> = Vec::with_capacity(n);
+    let mut tickets: Vec<String> = Vec::with_capacity(n);
+
+    for i in 0..n {
+        let start = i * chunk_size;
+        let end = (start + chunk_size).min(file_size);
+        if start >= end {
+            break;
+        }
+
+        let endpoint = build_endpoint(cli, None).await?;
+        let online_started = Instant::now();
+        endpoint.online().await;
+        tokio::time::sleep(Duration::from_secs(3)).await;
+        eprintln!(
+            "[serve-multi] endpoint[{i}] node_id={} online_after={}ms",
+            endpoint.id(),
+            online_started.elapsed().as_millis()
+        );
+
+        let store = MemStore::new();
+        let chunk_slice = &file_bytes[start..end];
+        let tag = store
+            .blobs()
+            .add_slice(chunk_slice)
+            .await
+            .context("add chunk to store")?;
+        let addr = endpoint.addr();
+        let ticket = BlobTicket::new(addr, tag.hash, tag.format);
+        eprintln!(
+            "[serve-multi] endpoint[{i}] chunk {}..{} ({} bytes) hash={}",
+            start,
+            end,
+            end - start,
+            &tag.hash.to_string()[..16],
+        );
+
+        let blobs = BlobsProtocol::new(&store, None);
+        let router = Router::builder(endpoint.clone())
+            .accept(iroh_blobs::ALPN, blobs)
+            .spawn();
+
+        tickets.push(ticket.to_string());
+        bundles.push(Bundle {
+            _endpoint: endpoint,
+            _store: store,
+            _router: router,
+        });
+    }
+
+    eprintln!(
+        "[serve-multi] {} independent endpoints up; printing {} tickets",
+        bundles.len(),
+        tickets.len()
+    );
+    println!("{}", tickets.join(","));
+    eprintln!("[serve-multi] waiting for fetches, Ctrl-C to stop");
+
+    tokio::signal::ctrl_c().await?;
+    eprintln!("[serve-multi] shutting down");
+    Ok(())
+}
+
+/// Walk through `file_bytes` in N chunks of `chunk_size` (last chunk may be
+/// shorter), call `add_one(slice)` for each, and build a `BlobTicket` from
+/// the resulting hash + format using the endpoint's current addr.
+///
+/// The `add_one` closure returns a future yielding the TagInfo from
+/// iroh-blobs's `add_slice` (or `add_bytes`) call — left as a closure so the
+/// same logic works against `MemStore` and `FsStore` without unifying their
+/// types.
+async fn import_chunks<'a, F, Fut>(
+    endpoint: &Endpoint,
+    file_bytes: &'a [u8],
+    chunk_size: usize,
+    n: usize,
+    mut add_one: F,
+) -> Result<Vec<String>>
+where
+    F: FnMut(Vec<u8>) -> Fut,
+    Fut: std::future::Future<
+        Output = Result<iroh_blobs::api::tags::TagInfo, iroh_blobs::api::RequestError>,
+    >,
+{
+    let mut tickets = Vec::with_capacity(n);
+    for i in 0..n {
+        let start = i * chunk_size;
+        let end = (start + chunk_size).min(file_bytes.len());
+        if start >= end {
+            break;
+        }
+        // Copy the slice into an owned Vec so the future can outlive
+        // file_bytes's borrow (necessary because the closure returns an
+        // owned future).
+        let chunk: Vec<u8> = file_bytes[start..end].to_vec();
+        let len = chunk.len();
+        let tag = add_one(chunk).await.context("add chunk to store")?;
+        let addr = endpoint.addr();
+        let ticket = BlobTicket::new(addr, tag.hash, tag.format);
+        eprintln!(
+            "[serve] chunk[{}] {}..{} ({} bytes) hash={}",
+            i,
+            start,
+            end,
+            len,
+            &tag.hash.to_string()[..16]
+        );
+        tickets.push(ticket.to_string());
+    }
+    Ok(tickets)
+}
+
 /// Holds the router (so Drop doesn't immediately tear it down) and optionally
-/// the FsStore (which must outlive any in-flight transfer). The type parameter
-/// lets us hand a `None::<FsStore>` for the MemStore branch without unifying
-/// the store types.
+/// the FsStore (which must outlive any in-flight transfer).
 struct RouterGuard<S> {
     _router: Router,
     _store: Option<S>,
@@ -343,168 +556,327 @@ impl<S> RouterGuard<S> {
 }
 
 async fn fetch(
-    endpoint: Endpoint,
-    ticket: String,
-    out: PathBuf,
+    cli: &Cli,
+    ticket_str: String,
+    _out: PathBuf,
     store_kind: StoreKind,
     store_dir: Option<PathBuf>,
 ) -> Result<()> {
-    let ticket: BlobTicket = ticket.parse().context("parse ticket")?;
-    let provider_id = ticket.addr().id;
-    let hash = ticket.hash();
-    let abs_out = std::path::absolute(&out).context("resolve out path")?;
-
+    let tickets: Vec<BlobTicket> = ticket_str
+        .split(',')
+        .map(|s| s.parse::<BlobTicket>().context("parse ticket"))
+        .collect::<Result<Vec<_>>>()?;
+    let n = tickets.len();
     eprintln!(
-        "[fetch] provider={} hash={} store={:?}",
-        provider_id.fmt_short(),
-        &hash.to_string()[..16],
+        "[fetch] parsed {} ticket(s), store={:?}, multi_endpoint={}",
+        n,
         match store_kind {
             StoreKind::Mem => "mem",
             StoreKind::Fs => "fs",
         },
+        cli.multi_endpoint,
     );
+    for (i, t) in tickets.iter().enumerate() {
+        eprintln!(
+            "[fetch]   [{}] hash={} provider={}",
+            i,
+            &t.hash().to_string()[..16],
+            t.addr().id.fmt_short(),
+        );
+    }
 
-    let started = Instant::now();
-    let total_bytes = match store_kind {
-        StoreKind::Mem => {
+    if cli.multi_endpoint {
+        // X3 path: one independent Endpoint per ticket.
+        if n < 2 {
+            eprintln!("[fetch] WARNING: --multi-endpoint with n={n} is equivalent to baseline");
+        }
+        run_multi_endpoint(cli, &tickets).await
+    } else {
+        // X1 path: single shared endpoint, all tickets multiplexed on one
+        // QUIC connection IF all tickets share a provider node_id. With
+        // --sender-multi-endpoint on the sender side each ticket has a
+        // DIFFERENT provider node_id, so seed every distinct addr — the
+        // receiver's `ConnectionPool` will open one connection per unique
+        // node_id, giving us N connections "for free" through the X1 fetch
+        // path.
+        let lookup = MemoryLookup::new();
+        for (i, t) in tickets.iter().enumerate() {
+            let addr = t.addr().clone();
+            eprintln!(
+                "[bench] seeded MemoryLookup [{}] provider {} (relays={}, ips={})",
+                i,
+                addr.id.fmt_short(),
+                addr.relay_urls().count(),
+                addr.ip_addrs().count(),
+            );
+            lookup.add_endpoint_info(addr);
+        }
+        let endpoint = build_endpoint(cli, Some(lookup)).await?;
+        eprintln!("[bench] node_id = {} (single endpoint)", endpoint.id());
+
+        match store_kind {
+            StoreKind::Mem => {
+                let store = MemStore::new();
+                let downloader = store.downloader(&endpoint);
+                run_parallel(downloader, &tickets).await?;
+            }
+            StoreKind::Fs => {
+                let dir = store_dir.unwrap_or_else(|| PathBuf::from("./p2p-bench-store"));
+                std::fs::create_dir_all(&dir).context("create fs store dir")?;
+                let store = FsStore::load(&dir).await.context("load FsStore")?;
+                let downloader = store.downloader(&endpoint);
+                run_parallel(downloader, &tickets).await?;
+            }
+        }
+        endpoint.close().await;
+        Ok(())
+    }
+}
+
+/// X3: one independent `Endpoint` per ticket. Each endpoint binds its own
+/// UDP socket, gets its own `MemoryLookup` (seeded with the same provider
+/// addr — every ticket shares the same sender), and runs its own download
+/// via a per-endpoint `MemStore`. This is the experiment that tells us
+/// whether the throughput ceiling is per-connection (cwnd) or per-NIC/CPU.
+///
+/// Stores are MemStore-only by design: a single FsStore can't be safely
+/// shared across N endpoints (writer contention), and giving each endpoint
+/// its own FsStore subdir doubles the disk-write surface, polluting the
+/// measurement. MemStore strips disk-write entirely so we see pure network.
+async fn run_multi_endpoint(cli: &Cli, tickets: &[BlobTicket]) -> Result<()> {
+    // Sequentially build N endpoints. Each one needs a few hundred ms for
+    // relay handshake + initial discovery; doing them serially keeps the
+    // log readable. Total setup overhead is paid before we start the clock.
+    let mut endpoints = Vec::with_capacity(tickets.len());
+    for (i, t) in tickets.iter().enumerate() {
+        let lookup = MemoryLookup::new();
+        lookup.add_endpoint_info(t.addr().clone());
+        let ep = build_endpoint(cli, Some(lookup)).await?;
+        eprintln!(
+            "[fetch] endpoint[{i}] node_id={} (independent UDP socket)",
+            ep.id()
+        );
+        endpoints.push(ep);
+    }
+
+    // Spawn one task per (endpoint, ticket) pair. Each task owns its
+    // endpoint and store, so there is zero sharing — N truly independent
+    // QUIC connections to the same sender.
+    let mut handles: Vec<tokio::task::JoinHandle<Result<(u64, Duration)>>> =
+        Vec::with_capacity(tickets.len());
+    for (i, (ep, t)) in endpoints
+        .into_iter()
+        .zip(tickets.iter().cloned())
+        .enumerate()
+    {
+        handles.push(tokio::spawn(async move {
             let store = MemStore::new();
-            run_download(&endpoint, &store, ticket.clone(), started).await?
+            let downloader = store.downloader(&ep);
+            let task_started = Instant::now();
+            let mut stream = downloader
+                .download(t.hash_and_format(), [t.addr().id])
+                .stream()
+                .await
+                .with_context(|| format!("downloader.stream open failed ticket[{i}]"))?;
+            let mut bytes: u64 = 0;
+            while let Some(item) = stream.next().await {
+                match item {
+                    DownloadProgressItem::Progress(total) => bytes = total,
+                    DownloadProgressItem::Error(e) => {
+                        anyhow::bail!("ticket[{i}] download error: {e}");
+                    }
+                    DownloadProgressItem::ProviderFailed { id, .. } => {
+                        eprintln!(
+                            "[fetch] task[{i}] provider {} failed (bytes_so_far={})",
+                            id.fmt_short(),
+                            bytes
+                        );
+                    }
+                    _ => {}
+                }
+            }
+            let elapsed = task_started.elapsed();
+            eprintln!(
+                "[fetch] task[{i}] DONE bytes={} elapsed={:.2}s per_conn_mbps={:.2}",
+                bytes,
+                elapsed.as_secs_f64(),
+                if elapsed.as_secs_f64() > 0.0 {
+                    (bytes as f64) / elapsed.as_secs_f64() / 1_048_576.0
+                } else {
+                    0.0
+                },
+            );
+            ep.close().await;
+            Ok((bytes, elapsed))
+        }));
+    }
+
+    let t0 = Instant::now();
+    let mut total: u64 = 0;
+    let mut per_task_max = Duration::ZERO;
+    for h in handles {
+        let (bytes, elapsed) = h.await.context("task join failed")??;
+        total += bytes;
+        if elapsed > per_task_max {
+            per_task_max = elapsed;
         }
-        StoreKind::Fs => {
-            let dir = store_dir.unwrap_or_else(|| PathBuf::from("./p2p-bench-store"));
-            std::fs::create_dir_all(&dir).context("create fs store dir")?;
-            let store = FsStore::load(&dir).await.context("load FsStore")?;
-            let n = run_download(&endpoint, &store, ticket.clone(), started).await?;
-            store.blobs().export(hash, abs_out.clone()).await?;
-            eprintln!("[fetch] exported to {}", abs_out.display());
-            n
-        }
+    }
+    let t1 = Instant::now();
+    let wall = t1.duration_since(t0).as_secs_f64();
+    let agg = if wall > 0.0 {
+        (total as f64) / wall / 1_048_576.0
+    } else {
+        0.0
     };
 
-    let elapsed = started.elapsed();
-    let mbps = (total_bytes as f64) / elapsed.as_secs_f64() / 1_048_576.0;
-    eprintln!(
-        "[fetch] DONE bytes={} elapsed={:.2}s avg={:.2} MB/s",
-        total_bytes,
-        elapsed.as_secs_f64(),
-        mbps,
+    println!(
+        "FETCH ts={} mode=multi-endpoint n={} bytes={} wall_elapsed_ms={} aggregate_mbps={:.2}",
+        iso_now(),
+        tickets.len(),
+        total,
+        (wall * 1000.0) as u64,
+        agg,
     );
-    endpoint.close().await;
+    eprintln!(
+        "[fetch] DONE (multi-endpoint) n={} total_bytes={} wall={:.2}s aggregate={:.2} MB/s (longest_task={:.2}s)",
+        tickets.len(),
+        total,
+        wall,
+        agg,
+        per_task_max.as_secs_f64(),
+    );
     Ok(())
 }
 
-/// Subscribes to the Downloader progress stream and prints one stdout line per
-/// observed `Progress(total)` event in a shape compatible with
-/// `transfer-speed.sh` (timestamp + bytes + elapsed_ms).
+/// Spawn one tokio task per ticket, all sharing the same `Downloader`
+/// (which routes through the same `ConnectionPool` and therefore the same
+/// QUIC connection to the sender). Aggregate throughput = total bytes
+/// across all tasks / wall-clock time from when all tasks have been
+/// spawned to when the last one completes.
 ///
-/// The trait bound is structural: both `MemStore` and `FsStore` expose
-/// `.downloader(&endpoint)` returning the same `Downloader` type, but they're
-/// distinct nominal types, so we monomorphize per call site.
-async fn run_download<S>(
-    endpoint: &Endpoint,
-    store: &S,
-    ticket: BlobTicket,
-    started: Instant,
-) -> Result<u64>
-where
-    S: HasDownloader,
-{
-    let downloader = store.spawn_downloader(endpoint);
-    let mut stream = downloader
-        .download(ticket.hash_and_format(), [ticket.addr().id])
-        .stream()
-        .await
-        .context("downloader.stream open failed")?;
+/// Per-task elapsed printed individually so we can see whether the streams
+/// finished together (multiplexed evenly) or staggered.
+async fn run_parallel(
+    downloader: iroh_blobs::api::downloader::Downloader,
+    tickets: &[BlobTicket],
+) -> Result<()> {
+    let mut handles: Vec<tokio::task::JoinHandle<Result<(u64, Duration)>>> =
+        Vec::with_capacity(tickets.len());
 
-    let mut bytes_so_far: u64 = 0;
-    let mut last_logged: u64 = 0;
-    let mut last_inst_at = started;
-    let mut last_inst_bytes: u64 = 0;
-    const LOG_STEP: u64 = 4 * 1024 * 1024;
-
-    while let Some(item) = stream.next().await {
-        match item {
-            DownloadProgressItem::Progress(total) => {
-                bytes_so_far = total;
-                if total >= last_logged + LOG_STEP {
-                    let now = Instant::now();
-                    let elapsed_ms = now.duration_since(started).as_millis() as u64;
-                    let inst_dt = now.duration_since(last_inst_at).as_secs_f64();
-                    let inst_db = total - last_inst_bytes;
-                    let inst_mbps = if inst_dt > 0.0 {
-                        (inst_db as f64) / inst_dt / 1_048_576.0
-                    } else {
-                        0.0
-                    };
-                    let avg_mbps = if elapsed_ms > 0 {
-                        (total as f64) / (elapsed_ms as f64 / 1000.0) / 1_048_576.0
-                    } else {
-                        0.0
-                    };
-                    println!(
-                        "FETCH ts={} bytes={} elapsed_ms={} inst_mbps={:.2} avg_mbps={:.2}",
-                        iso_now(),
-                        total,
-                        elapsed_ms,
-                        inst_mbps,
-                        avg_mbps,
-                    );
-                    last_logged = total;
-                    last_inst_at = now;
-                    last_inst_bytes = total;
+    for (i, t) in tickets.iter().enumerate() {
+        let dl = downloader.clone();
+        let t = t.clone();
+        handles.push(tokio::spawn(async move {
+            let task_started = Instant::now();
+            let mut stream = dl
+                .download(t.hash_and_format(), [t.addr().id])
+                .stream()
+                .await
+                .with_context(|| format!("downloader.stream open failed for ticket[{i}]"))?;
+            let mut bytes: u64 = 0;
+            // Emit a progress checkpoint every CHECKPOINT_STEP bytes so we can
+            // plot throughput-over-time and spot decay during long transfers.
+            const CHECKPOINT_STEP: u64 = 32 * 1024 * 1024;
+            let mut last_checkpoint_bytes: u64 = 0;
+            let mut last_checkpoint_at = task_started;
+            while let Some(item) = stream.next().await {
+                match item {
+                    DownloadProgressItem::Progress(total) => {
+                        bytes = total;
+                        if total >= last_checkpoint_bytes + CHECKPOINT_STEP {
+                            let now = Instant::now();
+                            let elapsed_ms = now.duration_since(task_started).as_millis() as u64;
+                            let inst_dt = now.duration_since(last_checkpoint_at).as_secs_f64();
+                            let inst_db = total - last_checkpoint_bytes;
+                            let inst_mbps = if inst_dt > 0.0 {
+                                (inst_db as f64) / inst_dt / 1_048_576.0
+                            } else {
+                                0.0
+                            };
+                            let avg_mbps = if elapsed_ms > 0 {
+                                (total as f64) / (elapsed_ms as f64 / 1000.0) / 1_048_576.0
+                            } else {
+                                0.0
+                            };
+                            println!(
+                                "PROGRESS ts={} task={i} bytes={total} elapsed_ms={elapsed_ms} inst_mbps={inst_mbps:.2} avg_mbps={avg_mbps:.2}",
+                                iso_now()
+                            );
+                            last_checkpoint_bytes = total;
+                            last_checkpoint_at = now;
+                        }
+                    }
+                    DownloadProgressItem::Error(e) => {
+                        anyhow::bail!("ticket[{i}] download error: {e}");
+                    }
+                    DownloadProgressItem::ProviderFailed { id, .. } => {
+                        eprintln!(
+                            "[fetch] task[{i}] provider {} failed (bytes_so_far={})",
+                            id.fmt_short(),
+                            bytes
+                        );
+                    }
+                    _ => {}
                 }
             }
-            DownloadProgressItem::PartComplete { .. } => {
-                eprintln!(
-                    "[fetch] part complete bytes_so_far={} elapsed_ms={}",
-                    bytes_so_far,
-                    started.elapsed().as_millis()
-                );
-            }
-            DownloadProgressItem::TryProvider { id, .. } => {
-                eprintln!("[fetch] trying provider {}", id.fmt_short());
-            }
-            DownloadProgressItem::ProviderFailed { id, .. } => {
-                eprintln!(
-                    "[fetch] provider {} failed (bytes_so_far={})",
-                    id.fmt_short(),
-                    bytes_so_far
-                );
-            }
-            DownloadProgressItem::Error(e) => {
-                anyhow::bail!("download error: {e}");
-            }
-            _ => {}
+            let elapsed = task_started.elapsed();
+            eprintln!(
+                "[fetch] task[{i}] DONE bytes={} elapsed={:.2}s per_stream_mbps={:.2}",
+                bytes,
+                elapsed.as_secs_f64(),
+                if elapsed.as_secs_f64() > 0.0 {
+                    (bytes as f64) / elapsed.as_secs_f64() / 1_048_576.0
+                } else {
+                    0.0
+                },
+            );
+            Ok((bytes, elapsed))
+        }));
+    }
+
+    // Mark t0 AFTER all spawns are queued so wall-clock excludes spawn
+    // serialization. Tokio doesn't actually run the tasks until we hit an
+    // await below, but the spawn() call returning before t0 guarantees the
+    // measurement excludes our own bookkeeping.
+    let t0 = Instant::now();
+
+    let mut total: u64 = 0;
+    let mut per_task_max = Duration::ZERO;
+    for h in handles {
+        let (bytes, elapsed) = h.await.context("task join failed")??;
+        total += bytes;
+        if elapsed > per_task_max {
+            per_task_max = elapsed;
         }
     }
+    let t1 = Instant::now();
+    let wall = t1.duration_since(t0).as_secs_f64();
+    let agg = if wall > 0.0 {
+        (total as f64) / wall / 1_048_576.0
+    } else {
+        0.0
+    };
 
-    Ok(bytes_so_far)
-}
-
-/// Tiny abstraction over MemStore / FsStore so `run_download` can be generic.
-/// Both stores expose `.downloader(&endpoint) -> Downloader` in iroh-blobs 0.100.
-/// The trait method is named `spawn_downloader` (not `downloader`) so that the
-/// impl body `self.downloader(endpoint)` resolves to the inherent method on
-/// the concrete store type instead of recursing back into the trait method.
-trait HasDownloader {
-    fn spawn_downloader(&self, endpoint: &Endpoint) -> iroh_blobs::api::downloader::Downloader;
-}
-
-impl HasDownloader for MemStore {
-    fn spawn_downloader(&self, endpoint: &Endpoint) -> iroh_blobs::api::downloader::Downloader {
-        self.downloader(endpoint)
-    }
-}
-
-impl HasDownloader for FsStore {
-    fn spawn_downloader(&self, endpoint: &Endpoint) -> iroh_blobs::api::downloader::Downloader {
-        self.downloader(endpoint)
-    }
+    println!(
+        "FETCH ts={} n={} bytes={} wall_elapsed_ms={} aggregate_mbps={:.2}",
+        iso_now(),
+        tickets.len(),
+        total,
+        (wall * 1000.0) as u64,
+        agg,
+    );
+    eprintln!(
+        "[fetch] DONE n={} total_bytes={} wall={:.2}s aggregate={:.2} MB/s (longest_task={:.2}s)",
+        tickets.len(),
+        total,
+        wall,
+        agg,
+        per_task_max.as_secs_f64(),
+    );
+    Ok(())
 }
 
 fn iso_now() -> String {
-    // ISO-8601 in UTC with millisecond precision, matching the production log
-    // so transfer-speed.sh can parse our output unmodified.
     let dur = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default();

--- a/src-tauri/crates/p2p-bench/src/main.rs
+++ b/src-tauri/crates/p2p-bench/src/main.rs
@@ -1,0 +1,524 @@
+//! Throwaway diagnostic spike — NOT shipped, NOT depended on by anything.
+//!
+//! Two-mode CLI to measure raw iroh + iroh-blobs throughput, completely
+//! isolated from uc-infra / uc-application. Goal: answer "is the slow blob
+//! transfer caused by something in our app stack, or by iroh-blobs / iroh
+//! QUIC itself, on this exact LAN, between these two machines?"
+//!
+//! Subcommands:
+//!   serve  --path <file>             prints a ticket, then accepts fetches
+//!   fetch  --ticket <t> --out <dst>  fetches into <dst>, prints per-chunk timings
+//!
+//! Key knobs (apply to both subcommands unless noted):
+//!   --tuned           (default) match uniclipboard's production QUIC config
+//!   --vanilla         use iroh's stock QuicTransportConfig defaults
+//!   --window-mb N     override stream_receive_window (after --tuned/--vanilla)
+//!   --store {mem,fs}  receiver backing store (default fs); mem isolates disk I/O
+//!   --no-relay        sender disables relay → LAN-only
+//!
+//! Output line shape (fetch):
+//!   FETCH ts=<ISO8601> bytes=<n> elapsed_ms=<n> inst_mbps=<f> avg_mbps=<f>
+//! → can be piped into ~/.../dual-side-debug for the same analysis.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use anyhow::{Context, Result};
+use clap::{Parser, Subcommand, ValueEnum};
+use futures_lite::StreamExt;
+use iroh::address_lookup::memory::MemoryLookup;
+use iroh::endpoint::{presets, QuicTransportConfig, VarInt};
+use iroh::protocol::Router;
+use iroh::{Endpoint, RelayMode};
+use iroh_blobs::api::downloader::DownloadProgressItem;
+use iroh_blobs::store::fs::FsStore;
+use iroh_blobs::store::mem::MemStore;
+use iroh_blobs::ticket::BlobTicket;
+use iroh_blobs::BlobsProtocol;
+use noq_proto::congestion::{BbrConfig, CubicConfig};
+
+#[derive(Parser)]
+#[command(version, about = "iroh-blobs P2P throughput spike")]
+struct Cli {
+    #[command(subcommand)]
+    cmd: Cmd,
+
+    /// Apply uniclipboard production transport config (BBR + 32 MB stream window
+    /// + 64 MB send window + 60s idle + 15s keepalive). Default ON.
+    #[arg(long, default_value_t = true, global = true)]
+    tuned: bool,
+
+    /// Use iroh's stock QuicTransportConfig defaults instead. Overrides --tuned.
+    #[arg(long, default_value_t = false, global = true)]
+    vanilla: bool,
+
+    /// Override stream_receive_window in MB (after --tuned / --vanilla applied).
+    /// Use 4 for "1-chunk window" reproduction, 256 for big-window sanity check.
+    #[arg(long, global = true)]
+    window_mb: Option<u32>,
+
+    /// Disable iroh relay (LAN-only). Useful to remove relay as a variable.
+    #[arg(long, default_value_t = false, global = true)]
+    no_relay: bool,
+
+    /// Congestion controller. `bbr` matches production; `cubic` tests the
+    /// noq#657 hypothesis (BBRv3 in noq 0.18 has a broken on_packet_sent hook
+    /// that craters throughput). Defaults to bbr.
+    #[arg(long, value_enum, default_value_t = Cc::Bbr, global = true)]
+    cc: Cc,
+}
+
+#[derive(Copy, Clone, ValueEnum, PartialEq, Eq, Debug)]
+enum Cc {
+    Bbr,
+    Cubic,
+}
+
+#[derive(Subcommand)]
+enum Cmd {
+    /// Publish a file and print a fetch ticket. Stays alive until Ctrl-C.
+    Serve {
+        #[arg(long)]
+        path: PathBuf,
+
+        /// Backing store on the sender side. fs matches production; mem isolates
+        /// any sender-side disk I/O (BAO outboard scan, etc).
+        #[arg(long, value_enum, default_value_t = StoreKind::Fs)]
+        store: StoreKind,
+
+        /// Where FsStore lives. Ignored for mem. Defaults to ./p2p-bench-store.
+        #[arg(long)]
+        store_dir: Option<PathBuf>,
+    },
+
+    /// Fetch a ticketed blob into <out>. Prints per-chunk timing + final summary.
+    Fetch {
+        #[arg(long)]
+        ticket: String,
+
+        #[arg(long)]
+        out: PathBuf,
+
+        /// Backing store on the receiver. fs matches production; mem removes
+        /// the receiver-side disk write entirely.
+        #[arg(long, value_enum, default_value_t = StoreKind::Fs)]
+        store: StoreKind,
+
+        /// Where FsStore lives. Ignored for mem. Defaults to ./p2p-bench-store.
+        #[arg(long)]
+        store_dir: Option<PathBuf>,
+    },
+}
+
+#[derive(Copy, Clone, ValueEnum, PartialEq, Eq)]
+enum StoreKind {
+    Mem,
+    Fs,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "info,iroh=warn,iroh_blobs=warn,noq=warn".into()),
+        )
+        .init();
+
+    let cli = Cli::parse();
+
+    // For fetch, parse the ticket up front so we can seed receiver's
+    // MemoryLookup with the sender's known addresses BEFORE binding the
+    // endpoint. iroh's Downloader takes only EndpointIds, then asks
+    // AddressLookup services to resolve them; without seeding, it has to
+    // wait for mDNS/pkarr/relay discovery to find the sender — which races
+    // hard in scripted timing and usually fails fast with "bytes_so_far=0".
+    let seeded_lookup = if let Cmd::Fetch { ref ticket, .. } = cli.cmd {
+        let parsed: BlobTicket = ticket
+            .parse()
+            .context("parse ticket before endpoint bind")?;
+        let lookup = MemoryLookup::new();
+        lookup.add_endpoint_info(parsed.addr().clone());
+        eprintln!(
+            "[bench] seeded MemoryLookup with provider {} (relays={}, ips={})",
+            parsed.addr().id.fmt_short(),
+            parsed.addr().relay_urls().count(),
+            parsed.addr().ip_addrs().count(),
+        );
+        Some(lookup)
+    } else {
+        None
+    };
+
+    let endpoint = build_endpoint(&cli, seeded_lookup).await?;
+    eprintln!("[bench] node_id = {}", endpoint.id());
+
+    match cli.cmd {
+        Cmd::Serve {
+            ref path,
+            store,
+            ref store_dir,
+        } => serve(endpoint, path.clone(), store, store_dir.clone()).await,
+        Cmd::Fetch {
+            ref ticket,
+            ref out,
+            store,
+            ref store_dir,
+        } => {
+            fetch(
+                endpoint,
+                ticket.clone(),
+                out.clone(),
+                store,
+                store_dir.clone(),
+            )
+            .await
+        }
+    }
+}
+
+async fn build_endpoint(cli: &Cli, seeded_lookup: Option<MemoryLookup>) -> Result<Endpoint> {
+    let transport = build_transport(cli);
+
+    let relay_mode = if cli.no_relay {
+        RelayMode::Disabled
+    } else {
+        // presets::N0 already wires the default relay; passing RelayMode::Default
+        // is the "use whatever the preset gave us" answer.
+        RelayMode::Default
+    };
+
+    let mut builder = Endpoint::builder(presets::N0)
+        .transport_config(transport)
+        .relay_mode(relay_mode);
+
+    if let Some(lookup) = seeded_lookup {
+        builder = builder.address_lookup(lookup);
+    }
+
+    let endpoint = builder
+        .bind()
+        .await
+        .context("failed to bind iroh endpoint")?;
+
+    Ok(endpoint)
+}
+
+fn build_transport(cli: &Cli) -> QuicTransportConfig {
+    let mut builder = QuicTransportConfig::builder();
+
+    if cli.vanilla {
+        // Vanilla: skip all the production tuning. --cc still applies below so
+        // you can isolate "vanilla + BBR vs vanilla + CUBIC".
+        eprintln!("[bench] transport config: VANILLA (iroh defaults)");
+    } else {
+        // Tuned: mirror src-tauri/crates/uc-infra/src/network/iroh/node.rs:260
+        // — except the CC factory, which is set below based on --cc.
+        eprintln!("[bench] transport config: TUNED (matches production minus CC)");
+        builder = builder
+            .stream_receive_window(VarInt::from_u32(32 * 1024 * 1024))
+            .send_window(64 * 1024 * 1024)
+            .persistent_congestion_threshold(5)
+            .max_idle_timeout(Some(
+                Duration::from_secs(60)
+                    .try_into()
+                    .expect("60s fits QUIC encoding"),
+            ))
+            .keep_alive_interval(Duration::from_secs(15));
+    }
+
+    // Apply CC factory regardless of --tuned/--vanilla. Default `bbr` matches
+    // current production; `cubic` validates the noq#657 hypothesis.
+    eprintln!("[bench] congestion controller: {:?}", cli.cc);
+    builder = match cli.cc {
+        Cc::Bbr => builder.congestion_controller_factory(Arc::new(BbrConfig::default())),
+        Cc::Cubic => builder.congestion_controller_factory(Arc::new(CubicConfig::default())),
+    };
+
+    if let Some(mb) = cli.window_mb {
+        eprintln!("[bench] OVERRIDE stream_receive_window = {} MB", mb);
+        builder = builder.stream_receive_window(VarInt::from_u32(mb * 1024 * 1024));
+    }
+
+    builder.build()
+}
+
+async fn serve(
+    endpoint: Endpoint,
+    path: PathBuf,
+    store_kind: StoreKind,
+    store_dir: Option<PathBuf>,
+) -> Result<()> {
+    // Wait for relay handshake + address discovery to populate. Without this,
+    // `endpoint.addr()` returns an EndpointAddr with no relay URL and no
+    // direct IPs — receivers can't connect because they don't know where we
+    // are (only our node_id). iroh's recommended way is `endpoint.online()`
+    // which waits until home_relay is set; we also give a small extra grace
+    // window for the first net_report cycle so direct LAN addrs land too.
+    eprintln!("[serve] waiting for iroh to come online (relay home + addrs)...");
+    let online_started = Instant::now();
+    endpoint.online().await;
+    eprintln!(
+        "[serve] online after {} ms; sleeping 3s for direct addr discovery",
+        online_started.elapsed().as_millis()
+    );
+    tokio::time::sleep(Duration::from_secs(3)).await;
+
+    let abs = std::path::absolute(&path).context("resolve path")?;
+    let started = Instant::now();
+
+    let (ticket, _router) = match store_kind {
+        StoreKind::Mem => {
+            let store = MemStore::new();
+            let tag = store.blobs().add_path(abs.clone()).await?;
+            // Use full endpoint.addr() (NodeAddr) so the ticket carries our LAN IPs +
+            // relay URL, not just node_id. Without this the receiver has to do mDNS /
+            // pkarr discovery from scratch, which can race and time out in scripted
+            // orchestration. uc-infra/blobs.rs:286 makes the same choice.
+            let addr = endpoint.addr();
+            eprintln!("[serve] endpoint.addr() = {:?}", addr);
+            let ticket = BlobTicket::new(addr, tag.hash, tag.format);
+            let blobs = BlobsProtocol::new(&store, None);
+            let router = Router::builder(endpoint.clone())
+                .accept(iroh_blobs::ALPN, blobs)
+                .spawn();
+            (ticket, RouterGuard::new(router, None::<FsStore>))
+        }
+        StoreKind::Fs => {
+            let dir = store_dir.unwrap_or_else(|| PathBuf::from("./p2p-bench-store"));
+            std::fs::create_dir_all(&dir).context("create fs store dir")?;
+            let store = FsStore::load(&dir).await.context("load FsStore")?;
+            let tag = store.blobs().add_path(abs.clone()).await?;
+            // Use full endpoint.addr() (NodeAddr) so the ticket carries our LAN IPs +
+            // relay URL, not just node_id. Without this the receiver has to do mDNS /
+            // pkarr discovery from scratch, which can race and time out in scripted
+            // orchestration. uc-infra/blobs.rs:286 makes the same choice.
+            let addr = endpoint.addr();
+            eprintln!("[serve] endpoint.addr() = {:?}", addr);
+            let ticket = BlobTicket::new(addr, tag.hash, tag.format);
+            let blobs = BlobsProtocol::new(&store, None);
+            let router = Router::builder(endpoint.clone())
+                .accept(iroh_blobs::ALPN, blobs)
+                .spawn();
+            (ticket, RouterGuard::new(router, Some(store)))
+        }
+    };
+
+    let add_ms = started.elapsed().as_millis() as u64;
+    eprintln!(
+        "[serve] file={} store={:?} add_path_ms={}",
+        abs.display(),
+        match store_kind {
+            StoreKind::Mem => "mem",
+            StoreKind::Fs => "fs",
+        },
+        add_ms,
+    );
+    println!("{}", ticket);
+    eprintln!("[serve] ticket printed to stdout — pipe / copy to receiver");
+    eprintln!("[serve] waiting for fetches, Ctrl-C to stop");
+
+    tokio::signal::ctrl_c().await?;
+    eprintln!("[serve] shutting down");
+    Ok(())
+}
+
+/// Holds the router (so Drop doesn't immediately tear it down) and optionally
+/// the FsStore (which must outlive any in-flight transfer). The type parameter
+/// lets us hand a `None::<FsStore>` for the MemStore branch without unifying
+/// the store types.
+struct RouterGuard<S> {
+    _router: Router,
+    _store: Option<S>,
+}
+
+impl<S> RouterGuard<S> {
+    fn new(router: Router, store: Option<S>) -> Self {
+        Self {
+            _router: router,
+            _store: store,
+        }
+    }
+}
+
+async fn fetch(
+    endpoint: Endpoint,
+    ticket: String,
+    out: PathBuf,
+    store_kind: StoreKind,
+    store_dir: Option<PathBuf>,
+) -> Result<()> {
+    let ticket: BlobTicket = ticket.parse().context("parse ticket")?;
+    let provider_id = ticket.addr().id;
+    let hash = ticket.hash();
+    let abs_out = std::path::absolute(&out).context("resolve out path")?;
+
+    eprintln!(
+        "[fetch] provider={} hash={} store={:?}",
+        provider_id.fmt_short(),
+        &hash.to_string()[..16],
+        match store_kind {
+            StoreKind::Mem => "mem",
+            StoreKind::Fs => "fs",
+        },
+    );
+
+    let started = Instant::now();
+    let total_bytes = match store_kind {
+        StoreKind::Mem => {
+            let store = MemStore::new();
+            run_download(&endpoint, &store, ticket.clone(), started).await?
+        }
+        StoreKind::Fs => {
+            let dir = store_dir.unwrap_or_else(|| PathBuf::from("./p2p-bench-store"));
+            std::fs::create_dir_all(&dir).context("create fs store dir")?;
+            let store = FsStore::load(&dir).await.context("load FsStore")?;
+            let n = run_download(&endpoint, &store, ticket.clone(), started).await?;
+            store.blobs().export(hash, abs_out.clone()).await?;
+            eprintln!("[fetch] exported to {}", abs_out.display());
+            n
+        }
+    };
+
+    let elapsed = started.elapsed();
+    let mbps = (total_bytes as f64) / elapsed.as_secs_f64() / 1_048_576.0;
+    eprintln!(
+        "[fetch] DONE bytes={} elapsed={:.2}s avg={:.2} MB/s",
+        total_bytes,
+        elapsed.as_secs_f64(),
+        mbps,
+    );
+    endpoint.close().await;
+    Ok(())
+}
+
+/// Subscribes to the Downloader progress stream and prints one stdout line per
+/// observed `Progress(total)` event in a shape compatible with
+/// `transfer-speed.sh` (timestamp + bytes + elapsed_ms).
+///
+/// The trait bound is structural: both `MemStore` and `FsStore` expose
+/// `.downloader(&endpoint)` returning the same `Downloader` type, but they're
+/// distinct nominal types, so we monomorphize per call site.
+async fn run_download<S>(
+    endpoint: &Endpoint,
+    store: &S,
+    ticket: BlobTicket,
+    started: Instant,
+) -> Result<u64>
+where
+    S: HasDownloader,
+{
+    let downloader = store.spawn_downloader(endpoint);
+    let mut stream = downloader
+        .download(ticket.hash_and_format(), [ticket.addr().id])
+        .stream()
+        .await
+        .context("downloader.stream open failed")?;
+
+    let mut bytes_so_far: u64 = 0;
+    let mut last_logged: u64 = 0;
+    let mut last_inst_at = started;
+    let mut last_inst_bytes: u64 = 0;
+    const LOG_STEP: u64 = 4 * 1024 * 1024;
+
+    while let Some(item) = stream.next().await {
+        match item {
+            DownloadProgressItem::Progress(total) => {
+                bytes_so_far = total;
+                if total >= last_logged + LOG_STEP {
+                    let now = Instant::now();
+                    let elapsed_ms = now.duration_since(started).as_millis() as u64;
+                    let inst_dt = now.duration_since(last_inst_at).as_secs_f64();
+                    let inst_db = total - last_inst_bytes;
+                    let inst_mbps = if inst_dt > 0.0 {
+                        (inst_db as f64) / inst_dt / 1_048_576.0
+                    } else {
+                        0.0
+                    };
+                    let avg_mbps = if elapsed_ms > 0 {
+                        (total as f64) / (elapsed_ms as f64 / 1000.0) / 1_048_576.0
+                    } else {
+                        0.0
+                    };
+                    println!(
+                        "FETCH ts={} bytes={} elapsed_ms={} inst_mbps={:.2} avg_mbps={:.2}",
+                        iso_now(),
+                        total,
+                        elapsed_ms,
+                        inst_mbps,
+                        avg_mbps,
+                    );
+                    last_logged = total;
+                    last_inst_at = now;
+                    last_inst_bytes = total;
+                }
+            }
+            DownloadProgressItem::PartComplete { .. } => {
+                eprintln!(
+                    "[fetch] part complete bytes_so_far={} elapsed_ms={}",
+                    bytes_so_far,
+                    started.elapsed().as_millis()
+                );
+            }
+            DownloadProgressItem::TryProvider { id, .. } => {
+                eprintln!("[fetch] trying provider {}", id.fmt_short());
+            }
+            DownloadProgressItem::ProviderFailed { id, .. } => {
+                eprintln!(
+                    "[fetch] provider {} failed (bytes_so_far={})",
+                    id.fmt_short(),
+                    bytes_so_far
+                );
+            }
+            DownloadProgressItem::Error(e) => {
+                anyhow::bail!("download error: {e}");
+            }
+            _ => {}
+        }
+    }
+
+    Ok(bytes_so_far)
+}
+
+/// Tiny abstraction over MemStore / FsStore so `run_download` can be generic.
+/// Both stores expose `.downloader(&endpoint) -> Downloader` in iroh-blobs 0.100.
+/// The trait method is named `spawn_downloader` (not `downloader`) so that the
+/// impl body `self.downloader(endpoint)` resolves to the inherent method on
+/// the concrete store type instead of recursing back into the trait method.
+trait HasDownloader {
+    fn spawn_downloader(&self, endpoint: &Endpoint) -> iroh_blobs::api::downloader::Downloader;
+}
+
+impl HasDownloader for MemStore {
+    fn spawn_downloader(&self, endpoint: &Endpoint) -> iroh_blobs::api::downloader::Downloader {
+        self.downloader(endpoint)
+    }
+}
+
+impl HasDownloader for FsStore {
+    fn spawn_downloader(&self, endpoint: &Endpoint) -> iroh_blobs::api::downloader::Downloader {
+        self.downloader(endpoint)
+    }
+}
+
+fn iso_now() -> String {
+    // ISO-8601 in UTC with millisecond precision, matching the production log
+    // so transfer-speed.sh can parse our output unmodified.
+    let dur = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default();
+    let ms = dur.subsec_millis();
+    let t = time::OffsetDateTime::from_unix_timestamp(dur.as_secs() as i64)
+        .expect("unix timestamp fits OffsetDateTime");
+    format!(
+        "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}.{:03}Z",
+        t.year(),
+        u8::from(t.month()),
+        t.day(),
+        t.hour(),
+        t.minute(),
+        t.second(),
+        ms,
+    )
+}

--- a/src-tauri/crates/uc-application/src/usecases/clipboard_sync/dispatch_entry.rs
+++ b/src-tauri/crates/uc-application/src/usecases/clipboard_sync/dispatch_entry.rs
@@ -498,6 +498,38 @@ impl DispatchClipboardEntryUseCase {
                     )
                     .await;
 
+                    // Skip the dial entirely when presence already reports
+                    // Offline. A dial against a silently-dead peer can run
+                    // up to STAGGERED_DELAYS[2] (5s) + ATTEMPT_TIMEOUT (10s)
+                    // = 15s before failing, which is well past the main
+                    // loop's FAN_OUT_DEADLINE (5s) and would otherwise stall
+                    // every clipboard copy on the deadline timeout. Since
+                    // the dispatch adapter writes presence Offline on its
+                    // own dial failures (PresencePort::mark_offline) and
+                    // the presence fast-path enforces a TTL re-dial, by the
+                    // time `known_offline` is true we have first-hand
+                    // evidence the peer is unreachable — re-dialing here
+                    // would burn the deadline to learn nothing new.
+                    //
+                    // Telemetry preserves attempted+deferred parity: we
+                    // already fired `sync_attempted` above, and now fire
+                    // `sync_deferred` with `peer_known_offline` as the
+                    // reason, matching the post-dial deferred path's
+                    // semantics. Background recovery is unchanged — the
+                    // next clipboard event will retry, and an inbound
+                    // presence connection from the peer flips state back
+                    // to Online and reopens the dial path.
+                    if known_offline {
+                        analytics.capture(Event::SyncDeferred(SyncDeferredProps {
+                            direction: Direction::Outbound,
+                            payload_type,
+                            payload_size_bucket,
+                            peer_os: None,
+                            defer_reason: SyncDeferReason::PeerKnownOffline,
+                        }));
+                        return (device_id, Err(ClipboardDispatchError::Offline));
+                    }
+
                     let started_at = Instant::now();
                     let result = dispatch.dispatch(&device_id, &header, payload).await;
                     let duration_ms =
@@ -513,15 +545,6 @@ impl DispatchClipboardEntryUseCase {
                             failure_reason: None,
                             failure_stage: None,
                         }),
-                        Err(ClipboardDispatchError::Offline) if known_offline => {
-                            Event::SyncDeferred(SyncDeferredProps {
-                                direction: Direction::Outbound,
-                                payload_type,
-                                payload_size_bucket,
-                                peer_os: None,
-                                defer_reason: SyncDeferReason::PeerKnownOffline,
-                            })
-                        }
                         Err(err) => Event::SyncFailed(SyncEventProps {
                             direction: Direction::Outbound,
                             payload_type,
@@ -2187,8 +2210,19 @@ mod tests {
         }
     }
 
+    /// Presence reports Offline ⇒ fan-out task skips the dial entirely
+    /// and fires `SyncDeferred` directly. The dispatch port must NOT be
+    /// invoked — re-dialing a peer the presence layer has already
+    /// concluded unreachable would burn FAN_OUT_DEADLINE for no gain
+    /// (the presence verdict itself comes from a real dial via
+    /// `dial_and_track`, plus the dispatch adapter's `mark_offline`
+    /// writeback on its own failures).
+    ///
+    /// `attempted - deferred` remains the dashboard's "user-perceived
+    /// attempts" denominator, so the SyncAttempted event still fires
+    /// before the skip decision.
     #[tokio::test]
-    async fn analytics_defers_instead_of_failing_when_peer_was_already_offline() {
+    async fn known_offline_skips_dispatch_and_fires_deferred() {
         let mut repo = MockPeerAddrRepo::new();
         repo.expect_list()
             .times(1)
@@ -2200,12 +2234,10 @@ mod tests {
             .times(1)
             .returning(|p| Ok(p.to_vec()));
 
+        // Strict zero-call expectation: the whole point of B-skip is that
+        // dispatch never touches the wire on a known-offline peer.
         let mut dispatch = MockDispatch::new();
-        dispatch
-            .expect_dispatch()
-            .with(eq(DeviceId::new("peer-off")), always(), always())
-            .times(1)
-            .returning(|_, _, _| Err(ClipboardDispatchError::Offline));
+        dispatch.expect_dispatch().times(0);
 
         let analytics = Arc::new(CapturingAnalyticsSink::default());
         let uc = build_uc_with_presence_and_first_sync_state(
@@ -2223,9 +2255,6 @@ mod tests {
 
         uc.execute(input()).await.expect("dispatch ok");
 
-        // attempted 始终前置，deferred 与 attempted 形成配对。
-        // dashboard 端用 `attempted - deferred` 推导用户感知尝试，
-        // 用户感知失败率不再把 known-offline 的不可达计入。
         let events = analytics.events();
         assert_eq!(events.len(), 2, "got {events:?}");
         assert!(
@@ -2239,118 +2268,6 @@ mod tests {
                 assert_eq!(p.direction, Direction::Outbound);
             }
             other => panic!("expected SyncDeferred, got {other:?}"),
-        }
-    }
-
-    /// Presence 可能 stale：声明 Offline 但 dispatch 实际成功。此时不走 deferred
-    /// 分支（deferred guard 只覆盖 dispatch 返回 Offline 的情况），仍应得到
-    /// `SyncAttempted` + `SyncSucceeded`，时序与 not-known-offline 路径一致。
-    #[tokio::test]
-    async fn attempted_then_succeeded_even_when_peer_was_known_offline() {
-        let mut repo = MockPeerAddrRepo::new();
-        repo.expect_list()
-            .times(1)
-            .returning(|| Ok(vec![record("peer-stale")]));
-
-        let mut cipher = MockCipher::new();
-        cipher
-            .expect_encrypt()
-            .times(1)
-            .returning(|p| Ok(p.to_vec()));
-
-        let mut dispatch = MockDispatch::new();
-        dispatch
-            .expect_dispatch()
-            .with(eq(DeviceId::new("peer-stale")), always(), always())
-            .times(1)
-            .returning(|_, _, _| Ok(DispatchAck::Accepted));
-
-        let analytics = Arc::new(CapturingAnalyticsSink::default());
-        let uc = build_uc_with_presence_and_first_sync_state(
-            repo,
-            make_member_repo_all_enabled(),
-            Arc::new(StaticPresence(ReachabilityState::Offline)),
-            cipher,
-            dispatch,
-            make_device_identity("self-device"),
-            make_local_identity_stub(),
-            make_settings_stub(),
-            analytics.clone(),
-            Arc::new(AllMarkedFirstSyncState),
-        );
-
-        uc.execute(input()).await.expect("dispatch ok");
-
-        let events = analytics.events();
-        assert_eq!(events.len(), 2, "got {events:?}");
-        assert!(
-            matches!(&events[0], Event::SyncAttempted(_)),
-            "first event should be SyncAttempted, got {:?}",
-            events[0],
-        );
-        match &events[1] {
-            Event::SyncSucceeded(p) => {
-                assert!(p.sync_latency_ms.is_some());
-                assert!(p.failure_reason.is_none());
-                assert!(p.failure_stage.is_none());
-            }
-            other => panic!("expected SyncSucceeded, got {other:?}"),
-        }
-    }
-
-    /// known_offline guard 只保护 `dispatch == Offline` 的不可达。如果对端
-    /// 已知离线但 dispatch 报告其他错误（peer 拒收 / IO / 内部错误），仍属
-    /// 真失败：发 `sync_attempted` + `sync_failed`，`stage = ImmediateSend`。
-    #[tokio::test]
-    async fn attempted_then_failed_when_known_offline_peer_returns_non_offline_error() {
-        let mut repo = MockPeerAddrRepo::new();
-        repo.expect_list()
-            .times(1)
-            .returning(|| Ok(vec![record("peer-broken")]));
-
-        let mut cipher = MockCipher::new();
-        cipher
-            .expect_encrypt()
-            .times(1)
-            .returning(|p| Ok(p.to_vec()));
-
-        let mut dispatch = MockDispatch::new();
-        dispatch
-            .expect_dispatch()
-            .with(eq(DeviceId::new("peer-broken")), always(), always())
-            .times(1)
-            .returning(|_, _, _| Err(ClipboardDispatchError::Io("broken pipe".into())));
-
-        let analytics = Arc::new(CapturingAnalyticsSink::default());
-        let uc = build_uc_with_presence_and_first_sync_state(
-            repo,
-            make_member_repo_all_enabled(),
-            Arc::new(StaticPresence(ReachabilityState::Offline)),
-            cipher,
-            dispatch,
-            make_device_identity("self-device"),
-            make_local_identity_stub(),
-            make_settings_stub(),
-            analytics.clone(),
-            Arc::new(AllMarkedFirstSyncState),
-        );
-
-        uc.execute(input()).await.expect("dispatch ok");
-
-        let events = analytics.events();
-        assert_eq!(events.len(), 2, "got {events:?}");
-        assert!(
-            matches!(&events[0], Event::SyncAttempted(_)),
-            "first event should be SyncAttempted, got {:?}",
-            events[0],
-        );
-        match &events[1] {
-            Event::SyncFailed(p) => {
-                assert_eq!(p.failure_reason, Some(FailureReason::NetworkError));
-                assert_eq!(p.failure_stage, Some(SyncFailureStage::ImmediateSend));
-                assert!(p.sync_latency_ms.is_none());
-            }
-            other => panic!("expected SyncFailed, got {other:?}"),
         }
     }
 

--- a/src-tauri/crates/uc-bootstrap/src/space_setup.rs
+++ b/src-tauri/crates/uc-bootstrap/src/space_setup.rs
@@ -351,6 +351,7 @@ pub async fn build_space_setup_assembly(
         Arc::clone(&wired.peer_addr_repo),
         Arc::clone(&deps.device.member_repo),
         Arc::clone(&deps.security.fingerprint),
+        Arc::clone(&presence),
     );
     let clipboard_dispatch: Arc<dyn ClipboardDispatchPort> = clipboard_dispatch;
     let clipboard_receiver: Arc<dyn ClipboardReceiverPort> = clipboard_receiver;

--- a/src-tauri/crates/uc-bootstrap/tests/slice2_phase2_clipboard_e2e.rs
+++ b/src-tauri/crates/uc-bootstrap/tests/slice2_phase2_clipboard_e2e.rs
@@ -487,6 +487,7 @@ async fn build_side(name: &'static str, rendezvous_base_url: String) -> Side {
         Arc::clone(&peer_addr_repo) as Arc<dyn uc_core::ports::PeerAddressRepositoryPort>,
         Arc::clone(&member_repo) as Arc<dyn MemberRepositoryPort>,
         Arc::new(Sha256IdentityFingerprintFactory),
+        Arc::clone(&presence),
     );
     let clipboard_dispatch: Arc<dyn ClipboardDispatchPort> = clipboard_dispatch;
     let clipboard_receiver: Arc<dyn ClipboardReceiverPort> = clipboard_receiver;

--- a/src-tauri/crates/uc-core/src/ports/presence.rs
+++ b/src-tauri/crates/uc-core/src/ports/presence.rs
@@ -76,6 +76,34 @@ pub trait PresencePort: Send + Sync {
         self.ensure_reachable(device).await
     }
 
+    /// Record an externally-observed unreachable signal for `device`.
+    ///
+    /// Callers invoke this after they have *independently* concluded — by
+    /// their own probe, dial, or transport failure — that `device` is not
+    /// reachable. The port must:
+    ///
+    /// * Discard any cached "alive connection" bookkeeping it holds for
+    ///   `device`, so the next [`current_state`] / [`ensure_reachable`] call
+    ///   observes the failure rather than a stale Online assumption.
+    /// * Persist `Offline` as the device's last observed state.
+    /// * Emit a single [`PresenceEvent`] with `state = Offline` on the
+    ///   subscription channel.
+    ///
+    /// Idempotent: calling on a device already known Offline is a no-op
+    /// (no duplicate event, no error). Calling on an `Unknown` device
+    /// records `Offline` and emits the event — `Unknown → Offline` is a
+    /// meaningful transition for subscribers who track first-known-bad.
+    ///
+    /// Default impl is a no-op so mock / fake implementations that don't
+    /// distinguish "alive" from "stale" don't have to implement this; the
+    /// real adapter must override.
+    ///
+    /// [`current_state`]: PresencePort::current_state
+    /// [`ensure_reachable`]: PresencePort::ensure_reachable
+    async fn mark_offline(&self, device: &DeviceId) {
+        let _ = device;
+    }
+
     /// Read the current cached state without dialing.
     ///
     /// Returns `Unknown` if the device has never been probed in the current

--- a/src-tauri/crates/uc-infra/Cargo.toml
+++ b/src-tauri/crates/uc-infra/Cargo.toml
@@ -36,6 +36,12 @@ async-trait = "0.1"
 # Stream consumption for iroh-blobs Downloader progress events
 futures-util = "0.3"
 
+# Enumerate local network interfaces (IP + netmask) at startup so the iroh
+# AddrFilter callback can decide whether a peer candidate is reachable via
+# direct LAN (suppressing hairpin-NAT-via-public-IP path oscillation).
+# Cross-platform: getifaddrs on Unix, GetAdaptersAddresses on Windows.
+if-addrs = "0.13"
+
 # ===== 数据库 =====
 diesel = { version = "2.3.5", features = [
     "sqlite",

--- a/src-tauri/crates/uc-infra/src/network/iroh/addr_filter.rs
+++ b/src-tauri/crates/uc-infra/src/network/iroh/addr_filter.rs
@@ -14,10 +14,24 @@
 //! 地址。把判定集中在这里，让上述三处共享同一份代码，从根上消除分叉的可能。
 
 use std::borrow::Cow;
-use std::net::IpAddr;
+use std::net::{IpAddr, Ipv4Addr};
 
 use iroh::{EndpointAddr, TransportAddr};
-use tracing::debug;
+use tracing::{debug, info, warn};
+
+/// A snapshot of one local LAN interface — IP + netmask — captured at
+/// endpoint-bind time so the hairpin filter (`apply_addr_filter`) can decide
+/// whether a peer candidate IP falls inside one of *our* RFC1918 subnets and
+/// is therefore reachable via direct LAN.
+///
+/// Captured once because [`iroh::address_lookup::AddrFilter`] is fixed at
+/// endpoint bind; the user must restart the daemon if they switch wifi /
+/// LAN. That matches the existing constraint on `allow_overlay`.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct LocalLanV4 {
+    pub ip: Ipv4Addr,
+    pub netmask: Ipv4Addr,
+}
 
 /// 判断某个 IP 是否属于需要过滤的虚拟网卡候选。
 pub(crate) fn is_virtual_nic_ip(ip: IpAddr, allow_overlay: bool) -> bool {
@@ -49,6 +63,104 @@ fn should_filter_transport_addr(addr: &TransportAddr, allow_overlay: bool) -> bo
     }
 }
 
+/// True if `ip` is an IPv4 candidate that's a public, routable address
+/// (excludes RFC1918 private, loopback, link-local, CGNAT, broadcast,
+/// documentation, virtual-NIC ranges).
+///
+/// Used by the hairpin filter to identify candidates that should be dropped
+/// when we know the peer is reachable via direct LAN. CGNAT/Tailscale 100.64
+/// and Clash 198.18 are handled via `is_virtual_nic_ip(.., allow_overlay=false)`
+/// so we re-use that judgment instead of duplicating range checks.
+fn is_public_v4(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => {
+            !v4.is_private()
+                && !v4.is_loopback()
+                && !v4.is_link_local()
+                && !v4.is_broadcast()
+                && !v4.is_documentation()
+                && !v4.is_unspecified()
+                && !is_virtual_nic_ip(IpAddr::V4(v4), /* allow_overlay= */ false)
+        }
+        IpAddr::V6(_) => false,
+    }
+}
+
+/// True if `a` and `b` fall in the same IPv4 subnet given `netmask`.
+/// Bit-wise: `(a & mask) == (b & mask)`.
+fn ips_in_same_v4_subnet(a: Ipv4Addr, b: Ipv4Addr, netmask: Ipv4Addr) -> bool {
+    let mask = u32::from(netmask);
+    (u32::from(a) & mask) == (u32::from(b) & mask)
+}
+
+/// True if at least one peer candidate is an RFC1918 IPv4 that lives inside
+/// one of our local LAN subnets — i.e. we can reach the peer directly over
+/// the LAN. When this is true, the peer's public-routable IPv4 candidates
+/// are *hairpin* artifacts (NAT-reflected public IP that magicsock keeps
+/// trying as if it were a separate path). On most consumer routers those
+/// paths either fail or succeed with much worse RTT than the LAN path,
+/// causing iroh to oscillate between fast LAN (~5ms) and hairpin (~80ms+)
+/// during a single transfer.
+fn peer_reachable_in_local_lan(addrs: &[TransportAddr], local_lan_v4: &[LocalLanV4]) -> bool {
+    if local_lan_v4.is_empty() {
+        return false;
+    }
+    addrs.iter().any(|addr| match addr {
+        TransportAddr::Ip(socket) => match socket.ip() {
+            IpAddr::V4(peer_v4) if peer_v4.is_private() => local_lan_v4
+                .iter()
+                .any(|lan| ips_in_same_v4_subnet(peer_v4, lan.ip, lan.netmask)),
+            _ => false,
+        },
+        _ => false,
+    })
+}
+
+/// Enumerate this host's RFC1918 IPv4 interface addresses (with their
+/// netmasks) so the hairpin filter can decide whether a peer candidate
+/// falls inside one of our LAN subnets.
+///
+/// Run once at endpoint-bind time; the result is captured into the
+/// `AddrFilter` closure and is not refreshed afterwards. Switching wifi /
+/// LAN requires a daemon restart (same constraint as `allow_overlay`).
+///
+/// Returns an empty vec — and logs a warn — if interface enumeration fails;
+/// the hairpin filter then degrades to "never drop public IPs", i.e. the
+/// pre-patch behaviour.
+pub(crate) fn enumerate_local_lan_v4() -> Vec<LocalLanV4> {
+    let ifaces = match if_addrs::get_if_addrs() {
+        Ok(ifaces) => ifaces,
+        Err(e) => {
+            warn!(
+                target: "iroh.addr_filter",
+                error = %e,
+                "if_addrs::get_if_addrs failed; hairpin filter degrades to off"
+            );
+            return Vec::new();
+        }
+    };
+
+    let out: Vec<LocalLanV4> = ifaces
+        .into_iter()
+        .filter(|iface| !iface.is_loopback())
+        .filter_map(|iface| match iface.addr {
+            if_addrs::IfAddr::V4(v4) if v4.ip.is_private() => Some(LocalLanV4 {
+                ip: v4.ip,
+                netmask: v4.netmask,
+            }),
+            _ => None,
+        })
+        .collect();
+
+    info!(
+        target: "iroh.addr_filter",
+        count = out.len(),
+        subnets = ?out,
+        "enumerated local LAN v4 subnets for hairpin filter"
+    );
+    out
+}
+
 fn log_dropped_addrs(dropped: &[String], allow_overlay: bool) {
     if dropped.is_empty() {
         return;
@@ -64,35 +176,81 @@ fn log_dropped_addrs(dropped: &[String], allow_overlay: bool) {
 
 /// 过滤 iroh `AddrFilter` 收到的候选地址集合。
 ///
+/// 两层过滤:
+///
+/// 1. **虚拟 NIC 过滤** (existing) — Clash fake-ip 198.18/15、IPv4 link-local
+///    169.254/16、CGNAT 100.64/10、Tailscale ULA fd7a:115c:a1e0::/48。
+///    详见 `is_virtual_nic_ip`。
+///
+/// 2. **Hairpin public IP 过滤** (新) — 如果 peer 的某个 RFC1918 IP 跟本机
+///    任一 LAN 子网同 subnet（即我们能直连 LAN），就丢掉 peer 的所有 public
+///    routable IPv4 候选。这避免 iroh magicsock 在快 LAN 路径 (~5ms RTT) 和
+///    NAT-hairpin-via-公网 IP 路径 (~80ms+ RTT) 之间来回 oscillate, 把一次
+///    transfer 期间的 cwnd 反复打回 slow-start。 对端跨 LAN（任何 RFC1918
+///    都不在我们 subnet 内）时不动 public IP, 不破坏 cross-LAN sync。
+///
 /// 签名形态 `&Vec<TransportAddr> -> Cow<Vec<TransportAddr>>` 由
 /// `iroh::address_lookup::AddrFilter::new` 的回调契约决定 —— **不要**
-/// clippy-fix 成 `&[TransportAddr]`，否则会和 iroh 的 `Fn` 签名失配。
+/// clippy-fix 成 `&[TransportAddr]`, 否则会和 iroh 的 `Fn` 签名失配。
 pub(crate) fn apply_addr_filter<'a>(
     addrs: &'a Vec<TransportAddr>,
     allow_overlay: bool,
+    local_lan_v4: &[LocalLanV4],
 ) -> Cow<'a, Vec<TransportAddr>> {
     let any_virtual = addrs
         .iter()
         .any(|addr| should_filter_transport_addr(addr, allow_overlay));
-    if !any_virtual {
+    let drop_hairpin = peer_reachable_in_local_lan(addrs, local_lan_v4);
+
+    if !any_virtual && !drop_hairpin {
         return Cow::Borrowed(addrs);
     }
 
     let kept: Vec<TransportAddr> = addrs
         .iter()
         .filter(|addr| !should_filter_transport_addr(addr, allow_overlay))
+        .filter(|addr| {
+            // Apply hairpin filter only when peer is LAN-reachable.
+            if !drop_hairpin {
+                return true;
+            }
+            match addr {
+                TransportAddr::Ip(socket) => !is_public_v4(socket.ip()),
+                _ => true,
+            }
+        })
         .cloned()
         .collect();
-    let dropped: Vec<String> = addrs
+
+    let virtual_dropped: Vec<String> = addrs
         .iter()
         .filter_map(|addr| match addr {
             TransportAddr::Ip(socket) if is_virtual_nic_ip(socket.ip(), allow_overlay) => {
-                Some(socket.to_string())
+                Some(format!("virtual:{}", socket))
             }
             _ => None,
         })
         .collect();
-    log_dropped_addrs(&dropped, allow_overlay);
+    let hairpin_dropped: Vec<String> = if drop_hairpin {
+        addrs
+            .iter()
+            .filter_map(|addr| match addr {
+                TransportAddr::Ip(socket)
+                    if !is_virtual_nic_ip(socket.ip(), allow_overlay)
+                        && is_public_v4(socket.ip()) =>
+                {
+                    Some(format!("hairpin:{}", socket))
+                }
+                _ => None,
+            })
+            .collect()
+    } else {
+        Vec::new()
+    };
+    let mut all_dropped = virtual_dropped;
+    all_dropped.extend(hairpin_dropped);
+    log_dropped_addrs(&all_dropped, allow_overlay);
+
     Cow::Owned(kept)
 }
 

--- a/src-tauri/crates/uc-infra/src/network/iroh/clipboard_dispatch_adapter.rs
+++ b/src-tauri/crates/uc-infra/src/network/iroh/clipboard_dispatch_adapter.rs
@@ -248,37 +248,33 @@ mod tests {
         PeerAddressError, PeerAddressRecord, PresenceError, PresenceEvent, ReachabilityState,
     };
 
-    /// Minimal `PresencePort` stand-in. The dispatch adapter only calls
-    /// `mark_offline` on it (dial-failure writeback); the trait's default
-    /// implementation is a noop, which is exactly what these tests want —
-    /// we assert dispatch behaviour, not presence-side propagation.
-    struct NoopPresence {
-        // Keep a sender alive so `subscribe()` doesn't immediately return a
-        // closed receiver. Subscribers in these tests don't actually read.
-        _tx: broadcast::Sender<PresenceEvent>,
+    // PresencePort mock for the dispatch tests. None of the four tests in
+    // this module reach the dial-failure path (happy ack, duplicate ack,
+    // missing peer_addr short-circuit, oversized local reject), so the
+    // adapter never invokes `mark_offline`. The mock therefore needs no
+    // expectations — any accidental call surfaces as a mockall panic, which
+    // is exactly the regression guard we want for "dispatch tests shouldn't
+    // be touching presence state."
+    //
+    // `mark_offline` is omitted intentionally: it has a default impl on the
+    // trait (noop), so leaving it off the mock keeps that default in play
+    // without forcing every test to wire an empty expectation.
+    mockall::mock! {
+        Presence {}
+
+        #[async_trait]
+        impl PresencePort for Presence {
+            async fn ensure_reachable(
+                &self,
+                device: &DeviceId,
+            ) -> Result<ReachabilityState, PresenceError>;
+            async fn current_state(&self, device: &DeviceId) -> ReachabilityState;
+            fn subscribe(&self) -> broadcast::Receiver<PresenceEvent>;
+        }
     }
 
-    impl NoopPresence {
-        fn new() -> Arc<Self> {
-            let (tx, _) = broadcast::channel(1);
-            Arc::new(Self { _tx: tx })
-        }
-    }
-
-    #[async_trait]
-    impl PresencePort for NoopPresence {
-        async fn ensure_reachable(
-            &self,
-            _device: &DeviceId,
-        ) -> Result<ReachabilityState, PresenceError> {
-            Ok(ReachabilityState::Unknown)
-        }
-        async fn current_state(&self, _device: &DeviceId) -> ReachabilityState {
-            ReachabilityState::Unknown
-        }
-        fn subscribe(&self) -> broadcast::Receiver<PresenceEvent> {
-            self._tx.subscribe()
-        }
+    fn presence_mock() -> Arc<dyn PresencePort> {
+        Arc::new(MockPresence::new())
     }
 
     /// In-memory peer_addr_repo the tests use to inject an address blob
@@ -417,7 +413,7 @@ mod tests {
         let target = DeviceId::new("target-alpha");
         seed_addr(&repo, &target, &peer_addr).await;
 
-        let adapter = IrohClipboardDispatchAdapter::new(sender_endpoint, repo, NoopPresence::new());
+        let adapter = IrohClipboardDispatchAdapter::new(sender_endpoint, repo, presence_mock());
         let payload = SyncPayload {
             ciphertext: Bytes::from(vec![0x11, 0x22, 0x33, 0x44]),
         };
@@ -446,7 +442,7 @@ mod tests {
         let target = DeviceId::new("target-beta");
         seed_addr(&repo, &target, &peer_addr).await;
 
-        let adapter = IrohClipboardDispatchAdapter::new(sender_endpoint, repo, NoopPresence::new());
+        let adapter = IrohClipboardDispatchAdapter::new(sender_endpoint, repo, presence_mock());
         let payload = SyncPayload {
             ciphertext: Bytes::from(vec![0xAA; 16]),
         };
@@ -466,7 +462,7 @@ mod tests {
     async fn dispatch_returns_offline_when_peer_addr_missing() {
         let sender_endpoint = bind_endpoint().await;
         let repo = Arc::new(MemRepo::default());
-        let adapter = IrohClipboardDispatchAdapter::new(sender_endpoint, repo, NoopPresence::new());
+        let adapter = IrohClipboardDispatchAdapter::new(sender_endpoint, repo, presence_mock());
 
         let result = adapter
             .dispatch(
@@ -495,7 +491,7 @@ mod tests {
         // we would hit Offline first.
         let sender_endpoint = bind_endpoint().await;
         let repo = Arc::new(MemRepo::default());
-        let adapter = IrohClipboardDispatchAdapter::new(sender_endpoint, repo, NoopPresence::new());
+        let adapter = IrohClipboardDispatchAdapter::new(sender_endpoint, repo, presence_mock());
 
         let oversized = vec![0u8; clipboard_wire::MAX_PAYLOAD_SIZE as usize + 1];
         let result = adapter

--- a/src-tauri/crates/uc-infra/src/network/iroh/clipboard_dispatch_adapter.rs
+++ b/src-tauri/crates/uc-infra/src/network/iroh/clipboard_dispatch_adapter.rs
@@ -36,7 +36,7 @@ use tracing::{debug, instrument, warn};
 use uc_core::ids::DeviceId;
 use uc_core::ports::{
     ClipboardDispatchError, ClipboardDispatchPort, ClipboardHeader, DispatchAck,
-    PeerAddressRepositoryPort, SyncPayload,
+    PeerAddressRepositoryPort, PresencePort, SyncPayload,
 };
 
 use super::clipboard_wire::{self, AckCode, WireEncodeError};
@@ -50,16 +50,25 @@ pub const CLIPBOARD_ALPN: &[u8] = b"uniclipboard/clipboard/0";
 pub struct IrohClipboardDispatchAdapter {
     endpoint: Arc<Endpoint>,
     peer_addr_repo: Arc<dyn PeerAddressRepositoryPort>,
+    /// PresencePort handle the adapter notifies on dial failure. A dial
+    /// that we have to fall back to `Offline` is first-hand evidence the
+    /// peer is unreachable; feeding that signal back through
+    /// [`PresencePort::mark_offline`] lets every other consumer of presence
+    /// (roster view, fan-out skip logic) observe the truth without waiting
+    /// for the keepalive worker's next probe cycle.
+    presence: Arc<dyn PresencePort>,
 }
 
 impl IrohClipboardDispatchAdapter {
     pub fn new(
         endpoint: Arc<Endpoint>,
         peer_addr_repo: Arc<dyn PeerAddressRepositoryPort>,
+        presence: Arc<dyn PresencePort>,
     ) -> Self {
         Self {
             endpoint,
             peer_addr_repo,
+            presence,
         }
     }
 
@@ -131,17 +140,24 @@ impl ClipboardDispatchPort for IrohClipboardDispatchAdapter {
         };
 
         // 3. Dial. Dial failure = offline (no typed iroh error leaks up).
-        let connection = connect_with_staggered_retry(
+        //    On failure, feed the verdict back to PresencePort so the next
+        //    consumer of `current_state` / `ensure_reachable` doesn't pay
+        //    another 5-15s dial timeout on the same dead peer.
+        let connection = match connect_with_staggered_retry(
             Arc::clone(&self.endpoint),
             addr,
             CLIPBOARD_ALPN,
             "clipboard",
         )
         .await
-        .map_err(|err| {
-            debug!(error = %err, "clipboard dispatch: dial failed, treating as Offline");
-            ClipboardDispatchError::Offline
-        })?;
+        {
+            Ok(connection) => connection,
+            Err(err) => {
+                debug!(error = %err, "clipboard dispatch: dial failed, treating as Offline");
+                self.presence.mark_offline(target).await;
+                return Err(ClipboardDispatchError::Offline);
+            }
+        };
 
         // 4. Open one bi-stream for this message.
         let (mut send, mut recv) = connection
@@ -226,8 +242,44 @@ mod tests {
     use chrono::Utc;
     use iroh::protocol::{AcceptError, ProtocolHandler, Router};
     use iroh::{Endpoint, RelayMode};
+    use tokio::sync::broadcast;
 
-    use uc_core::ports::{PeerAddressError, PeerAddressRecord};
+    use uc_core::ports::{
+        PeerAddressError, PeerAddressRecord, PresenceError, PresenceEvent, ReachabilityState,
+    };
+
+    /// Minimal `PresencePort` stand-in. The dispatch adapter only calls
+    /// `mark_offline` on it (dial-failure writeback); the trait's default
+    /// implementation is a noop, which is exactly what these tests want —
+    /// we assert dispatch behaviour, not presence-side propagation.
+    struct NoopPresence {
+        // Keep a sender alive so `subscribe()` doesn't immediately return a
+        // closed receiver. Subscribers in these tests don't actually read.
+        _tx: broadcast::Sender<PresenceEvent>,
+    }
+
+    impl NoopPresence {
+        fn new() -> Arc<Self> {
+            let (tx, _) = broadcast::channel(1);
+            Arc::new(Self { _tx: tx })
+        }
+    }
+
+    #[async_trait]
+    impl PresencePort for NoopPresence {
+        async fn ensure_reachable(
+            &self,
+            _device: &DeviceId,
+        ) -> Result<ReachabilityState, PresenceError> {
+            Ok(ReachabilityState::Unknown)
+        }
+        async fn current_state(&self, _device: &DeviceId) -> ReachabilityState {
+            ReachabilityState::Unknown
+        }
+        fn subscribe(&self) -> broadcast::Receiver<PresenceEvent> {
+            self._tx.subscribe()
+        }
+    }
 
     /// In-memory peer_addr_repo the tests use to inject an address blob
     /// for a target device. Mirrors the surface the adapter needs without
@@ -365,7 +417,7 @@ mod tests {
         let target = DeviceId::new("target-alpha");
         seed_addr(&repo, &target, &peer_addr).await;
 
-        let adapter = IrohClipboardDispatchAdapter::new(sender_endpoint, repo);
+        let adapter = IrohClipboardDispatchAdapter::new(sender_endpoint, repo, NoopPresence::new());
         let payload = SyncPayload {
             ciphertext: Bytes::from(vec![0x11, 0x22, 0x33, 0x44]),
         };
@@ -394,7 +446,7 @@ mod tests {
         let target = DeviceId::new("target-beta");
         seed_addr(&repo, &target, &peer_addr).await;
 
-        let adapter = IrohClipboardDispatchAdapter::new(sender_endpoint, repo);
+        let adapter = IrohClipboardDispatchAdapter::new(sender_endpoint, repo, NoopPresence::new());
         let payload = SyncPayload {
             ciphertext: Bytes::from(vec![0xAA; 16]),
         };
@@ -414,7 +466,7 @@ mod tests {
     async fn dispatch_returns_offline_when_peer_addr_missing() {
         let sender_endpoint = bind_endpoint().await;
         let repo = Arc::new(MemRepo::default());
-        let adapter = IrohClipboardDispatchAdapter::new(sender_endpoint, repo);
+        let adapter = IrohClipboardDispatchAdapter::new(sender_endpoint, repo, NoopPresence::new());
 
         let result = adapter
             .dispatch(
@@ -443,7 +495,7 @@ mod tests {
         // we would hit Offline first.
         let sender_endpoint = bind_endpoint().await;
         let repo = Arc::new(MemRepo::default());
-        let adapter = IrohClipboardDispatchAdapter::new(sender_endpoint, repo);
+        let adapter = IrohClipboardDispatchAdapter::new(sender_endpoint, repo, NoopPresence::new());
 
         let oversized = vec![0u8; clipboard_wire::MAX_PAYLOAD_SIZE as usize + 1];
         let result = adapter

--- a/src-tauri/crates/uc-infra/src/network/iroh/clipboard_receiver_adapter.rs
+++ b/src-tauri/crates/uc-infra/src/network/iroh/clipboard_receiver_adapter.rs
@@ -292,35 +292,32 @@ mod tests {
     use crate::security::Sha256IdentityFingerprintFactory;
     use uc_core::ports::{PeerAddressError, PeerAddressRecord, PeerAddressRepositoryPort};
 
-    /// Minimal `PresencePort` stand-in. Receiver-side tests construct a
-    /// dispatch adapter only as a wire-driver to the receiver under test;
-    /// `mark_offline` on dial failure uses the trait's noop default, which
-    /// is fine because these tests never exercise the dial-failure path.
-    struct NoopPresence {
-        _tx: broadcast::Sender<PresenceEvent>,
+    // PresencePort mock. Receiver-side tests use the dispatch adapter only
+    // as a wire-driver against the receiver under test; the dispatch path
+    // never hits dial failure in these scenarios, so `mark_offline` is
+    // never invoked. The mock therefore needs no expectations — any
+    // unexpected call surfaces as a mockall panic.
+    //
+    // `mark_offline` is intentionally omitted from the mock so the trait's
+    // default noop impl is in play; if a future test does exercise the
+    // dial-failure path, mockall will catch any accidental presence-side
+    // assumption it makes.
+    mockall::mock! {
+        Presence {}
+
+        #[async_trait]
+        impl PresencePort for Presence {
+            async fn ensure_reachable(
+                &self,
+                device: &DeviceId,
+            ) -> Result<ReachabilityState, PresenceError>;
+            async fn current_state(&self, device: &DeviceId) -> ReachabilityState;
+            fn subscribe(&self) -> broadcast::Receiver<PresenceEvent>;
+        }
     }
 
-    impl NoopPresence {
-        fn new() -> Arc<Self> {
-            let (tx, _) = broadcast::channel(1);
-            Arc::new(Self { _tx: tx })
-        }
-    }
-
-    #[async_trait]
-    impl PresencePort for NoopPresence {
-        async fn ensure_reachable(
-            &self,
-            _device: &DeviceId,
-        ) -> Result<ReachabilityState, PresenceError> {
-            Ok(ReachabilityState::Unknown)
-        }
-        async fn current_state(&self, _device: &DeviceId) -> ReachabilityState {
-            ReachabilityState::Unknown
-        }
-        fn subscribe(&self) -> broadcast::Receiver<PresenceEvent> {
-            self._tx.subscribe()
-        }
+    fn presence_mock() -> Arc<dyn PresencePort> {
+        Arc::new(MockPresence::new())
     }
 
     // ----- test doubles ------------------------------------------------------
@@ -492,7 +489,7 @@ mod tests {
             .await
             .unwrap();
         let dispatch =
-            IrohClipboardDispatchAdapter::new(sender_endpoint, peer_addr_repo, NoopPresence::new());
+            IrohClipboardDispatchAdapter::new(sender_endpoint, peer_addr_repo, presence_mock());
 
         let payload = Bytes::from(vec![0xAB; 128]);
         let ack = dispatch
@@ -544,7 +541,7 @@ mod tests {
             .await
             .unwrap();
         let dispatch =
-            IrohClipboardDispatchAdapter::new(sender_endpoint, peer_addr_repo, NoopPresence::new());
+            IrohClipboardDispatchAdapter::new(sender_endpoint, peer_addr_repo, presence_mock());
 
         let result = dispatch
             .dispatch(
@@ -660,7 +657,7 @@ mod tests {
                 let dispatch = IrohClipboardDispatchAdapter::new(
                     sender_endpoint,
                     peer_addr_repo,
-                    NoopPresence::new(),
+                    presence_mock(),
                 );
 
                 let mut header = sample_header();

--- a/src-tauri/crates/uc-infra/src/network/iroh/clipboard_receiver_adapter.rs
+++ b/src-tauri/crates/uc-infra/src/network/iroh/clipboard_receiver_adapter.rs
@@ -280,7 +280,10 @@ mod tests {
     use tokio::sync::Mutex;
 
     use uc_core::membership::{MembershipError, SpaceMember};
-    use uc_core::ports::{ClipboardDispatchPort, ClipboardHeader, SyncPayload};
+    use uc_core::ports::{
+        ClipboardDispatchPort, ClipboardHeader, PresenceError, PresenceEvent, PresencePort,
+        ReachabilityState, SyncPayload,
+    };
     use uc_core::MemberSyncPreferences;
 
     use crate::network::iroh::clipboard_dispatch_adapter::{
@@ -288,6 +291,37 @@ mod tests {
     };
     use crate::security::Sha256IdentityFingerprintFactory;
     use uc_core::ports::{PeerAddressError, PeerAddressRecord, PeerAddressRepositoryPort};
+
+    /// Minimal `PresencePort` stand-in. Receiver-side tests construct a
+    /// dispatch adapter only as a wire-driver to the receiver under test;
+    /// `mark_offline` on dial failure uses the trait's noop default, which
+    /// is fine because these tests never exercise the dial-failure path.
+    struct NoopPresence {
+        _tx: broadcast::Sender<PresenceEvent>,
+    }
+
+    impl NoopPresence {
+        fn new() -> Arc<Self> {
+            let (tx, _) = broadcast::channel(1);
+            Arc::new(Self { _tx: tx })
+        }
+    }
+
+    #[async_trait]
+    impl PresencePort for NoopPresence {
+        async fn ensure_reachable(
+            &self,
+            _device: &DeviceId,
+        ) -> Result<ReachabilityState, PresenceError> {
+            Ok(ReachabilityState::Unknown)
+        }
+        async fn current_state(&self, _device: &DeviceId) -> ReachabilityState {
+            ReachabilityState::Unknown
+        }
+        fn subscribe(&self) -> broadcast::Receiver<PresenceEvent> {
+            self._tx.subscribe()
+        }
+    }
 
     // ----- test doubles ------------------------------------------------------
 
@@ -457,7 +491,8 @@ mod tests {
             })
             .await
             .unwrap();
-        let dispatch = IrohClipboardDispatchAdapter::new(sender_endpoint, peer_addr_repo);
+        let dispatch =
+            IrohClipboardDispatchAdapter::new(sender_endpoint, peer_addr_repo, NoopPresence::new());
 
         let payload = Bytes::from(vec![0xAB; 128]);
         let ack = dispatch
@@ -508,7 +543,8 @@ mod tests {
             })
             .await
             .unwrap();
-        let dispatch = IrohClipboardDispatchAdapter::new(sender_endpoint, peer_addr_repo);
+        let dispatch =
+            IrohClipboardDispatchAdapter::new(sender_endpoint, peer_addr_repo, NoopPresence::new());
 
         let result = dispatch
             .dispatch(
@@ -621,7 +657,11 @@ mod tests {
                     })
                     .await
                     .unwrap();
-                let dispatch = IrohClipboardDispatchAdapter::new(sender_endpoint, peer_addr_repo);
+                let dispatch = IrohClipboardDispatchAdapter::new(
+                    sender_endpoint,
+                    peer_addr_repo,
+                    NoopPresence::new(),
+                );
 
                 let mut header = sample_header();
                 header.origin_device_id = format!("sender-{i}");

--- a/src-tauri/crates/uc-infra/src/network/iroh/node.rs
+++ b/src-tauri/crates/uc-infra/src/network/iroh/node.rs
@@ -45,7 +45,7 @@ use uc_core::ports::{
 use crate::pairing::{IrohPairingSessionAdapter, PAIRING_ALPN};
 use crate::rendezvous::{RendezvousClient, RendezvousPairingInvitationAdapter};
 
-use super::addr_filter::apply_addr_filter;
+use super::addr_filter::{apply_addr_filter, enumerate_local_lan_v4, LocalLanV4};
 use super::blobs::{IrohBlobTransferAdapter, BLOBS_ALPN};
 use super::clipboard_dispatch_adapter::{IrohClipboardDispatchAdapter, CLIPBOARD_ALPN};
 use super::clipboard_receiver_adapter::IrohClipboardReceiverAdapter;
@@ -353,7 +353,14 @@ fn build_transport_config() -> QuicTransportConfig {
 /// `Settings.network.allow_overlay_network_addrs` requires a daemon restart
 /// (the same constraint as `disable_relays`).
 fn build_addr_filter(allow_overlay: bool) -> AddrFilter {
-    AddrFilter::new(move |addrs: &Vec<TransportAddr>| apply_addr_filter(addrs, allow_overlay))
+    // Snapshot local LAN subnets ONCE at endpoint-bind time. The closure
+    // captures the result for the lifetime of the endpoint; switching
+    // wifi/LAN at runtime won't be picked up (same constraint as
+    // `allow_overlay`). See `enumerate_local_lan_v4` doc for rationale.
+    let local_lan_v4 = enumerate_local_lan_v4();
+    AddrFilter::new(move |addrs: &Vec<TransportAddr>| {
+        apply_addr_filter(addrs, allow_overlay, &local_lan_v4)
+    })
 }
 
 fn relay_mode_from_config(config: &IrohNodeConfig) -> Result<RelayMode, IrohNodeError> {
@@ -1290,7 +1297,7 @@ mod tests {
                 4242,
             ))),
         ];
-        let kept = apply_addr_filter(&addrs, false);
+        let kept = apply_addr_filter(&addrs, false, &[]);
         assert_eq!(
             kept.len(),
             addrs.len(),
@@ -1321,7 +1328,7 @@ mod tests {
                 4242,
             ))), // Clash — always dropped
         ];
-        let kept: Vec<TransportAddr> = apply_addr_filter(&addrs, false).into_owned();
+        let kept: Vec<TransportAddr> = apply_addr_filter(&addrs, false, &[]).into_owned();
         assert_eq!(kept.len(), 1, "only the real LAN IP should survive");
         match &kept[0] {
             TransportAddr::Ip(s) => assert_eq!(s.ip().to_string(), "192.168.1.1"),
@@ -1357,7 +1364,7 @@ mod tests {
                 4242,
             ))), // link-local — always dropped
         ];
-        let kept: Vec<TransportAddr> = apply_addr_filter(&addrs, true).into_owned();
+        let kept: Vec<TransportAddr> = apply_addr_filter(&addrs, true, &[]).into_owned();
         assert_eq!(kept.len(), 3, "real LAN + 2 overlay candidates kept");
         let ips: Vec<String> = kept
             .iter()
@@ -1371,6 +1378,143 @@ mod tests {
         assert!(ips.iter().any(|s| s == "fd7a:115c:a1e0::1"));
         assert!(!ips.iter().any(|s| s == "198.18.0.1"));
         assert!(!ips.iter().any(|s| s == "169.254.0.5"));
+    }
+
+    // ──────────────────────────────────────────────────────────────────
+    // Hairpin filter — drops peer's public IPv4 candidates when peer is
+    // reachable via our local LAN. See `apply_addr_filter` and
+    // `peer_reachable_in_local_lan` in `addr_filter.rs`.
+    // ──────────────────────────────────────────────────────────────────
+
+    /// Helper: build a fake "we live on 192.168.31.0/24" snapshot.
+    fn lan_31() -> Vec<LocalLanV4> {
+        vec![LocalLanV4 {
+            ip: "192.168.31.72".parse().unwrap(),
+            netmask: "255.255.255.0".parse().unwrap(),
+        }]
+    }
+
+    fn v4_socket(ip: &str, port: u16) -> TransportAddr {
+        TransportAddr::Ip(SocketAddr::V4(SocketAddrV4::new(ip.parse().unwrap(), port)))
+    }
+
+    /// Same-LAN scenario: peer advertises both its LAN IP (192.168.31.224,
+    /// in our /24) and its public NAT-egress IP. The public one is a hairpin
+    /// candidate — drop it. The mac↔win case from the production decay logs.
+    #[test]
+    fn hairpin_filter_drops_public_when_peer_lan_in_our_subnet() {
+        let addrs = vec![
+            v4_socket("192.168.31.224", 60053), // peer LAN — keep
+            v4_socket("180.164.125.95", 58279), // peer public NAT — drop (hairpin)
+        ];
+        let kept: Vec<TransportAddr> = apply_addr_filter(&addrs, false, &lan_31()).into_owned();
+        assert_eq!(kept.len(), 1, "only peer LAN should survive");
+        match &kept[0] {
+            TransportAddr::Ip(s) => assert_eq!(s.ip().to_string(), "192.168.31.224"),
+            _ => panic!("expected Ip variant"),
+        }
+    }
+
+    /// Cross-LAN scenario: peer's RFC1918 IP (192.168.1.5) is NOT in our
+    /// /24. We can't reach it directly — keep the public IP as the only
+    /// usable fallback.
+    #[test]
+    fn hairpin_filter_keeps_public_when_peer_lan_in_other_subnet() {
+        let addrs = vec![
+            v4_socket("192.168.1.5", 60053),  // peer LAN — NOT our subnet
+            v4_socket("203.0.113.42", 58279), // peer public — must keep
+        ];
+        let kept: Vec<TransportAddr> = apply_addr_filter(&addrs, false, &lan_31()).into_owned();
+        assert_eq!(
+            kept.len(),
+            2,
+            "cross-LAN: both peer LAN candidate AND public IP retained"
+        );
+    }
+
+    /// No-LAN-candidate scenario: peer only advertises public IPs (plus
+    /// maybe a relay). Even though we have a LAN of our own, we have no
+    /// signal that this peer is reachable via our LAN — keep public.
+    #[test]
+    fn hairpin_filter_keeps_public_when_peer_has_no_rfc1918() {
+        let addrs = vec![v4_socket("203.0.113.42", 58279)];
+        let kept: Vec<TransportAddr> = apply_addr_filter(&addrs, false, &lan_31()).into_owned();
+        assert_eq!(
+            kept.len(),
+            1,
+            "no LAN candidate → no hairpin signal → keep public"
+        );
+    }
+
+    /// Degraded scenario: if_addrs enumeration failed (empty local_lan_v4).
+    /// Filter must degrade to off (= pre-patch behaviour) and keep public IPs.
+    #[test]
+    fn hairpin_filter_disabled_when_local_lan_empty() {
+        let addrs = vec![
+            v4_socket("192.168.31.224", 60053),
+            v4_socket("180.164.125.95", 58279), // would be dropped if hairpin filter active
+        ];
+        let kept: Vec<TransportAddr> = apply_addr_filter(&addrs, false, &[]).into_owned();
+        assert_eq!(
+            kept.len(),
+            2,
+            "no local LAN snapshot → no hairpin filter → keep public"
+        );
+    }
+
+    /// Peer advertises multiple LAN IPs, one in our subnet + one not.
+    /// At least one matches → hairpin filter activates → drop public.
+    #[test]
+    fn hairpin_filter_activates_if_any_peer_lan_matches_our_subnet() {
+        let addrs = vec![
+            v4_socket("192.168.31.224", 60053), // matches our /24 → triggers filter
+            v4_socket("10.0.0.5", 60053),       // peer's other LAN (different subnet)
+            v4_socket("180.164.125.95", 58279), // public — drop
+        ];
+        let kept: Vec<TransportAddr> = apply_addr_filter(&addrs, false, &lan_31()).into_owned();
+        let kept_ips: Vec<String> = kept
+            .iter()
+            .filter_map(|a| match a {
+                TransportAddr::Ip(s) => Some(s.ip().to_string()),
+                _ => None,
+            })
+            .collect();
+        assert!(kept_ips.contains(&"192.168.31.224".to_string()));
+        assert!(kept_ips.contains(&"10.0.0.5".to_string()));
+        assert!(
+            !kept_ips.contains(&"180.164.125.95".to_string()),
+            "public must be dropped"
+        );
+    }
+
+    /// Hairpin filter must NOT drop Relay candidates — those are the
+    /// fallback when direct paths fail/churn.
+    #[test]
+    fn hairpin_filter_does_not_touch_relays() {
+        use iroh::RelayUrl;
+        let relay_url: RelayUrl = "https://relay.example.com/".parse().unwrap();
+        let addrs = vec![
+            v4_socket("192.168.31.224", 60053),
+            v4_socket("180.164.125.95", 58279), // dropped
+            TransportAddr::Relay(relay_url),    // must survive
+        ];
+        let kept: Vec<TransportAddr> = apply_addr_filter(&addrs, false, &lan_31()).into_owned();
+        let relay_count = kept
+            .iter()
+            .filter(|a| matches!(a, TransportAddr::Relay(_)))
+            .count();
+        assert_eq!(
+            relay_count, 1,
+            "relay candidate must survive hairpin filter"
+        );
+    }
+
+    /// Real-world enumeration: if_addrs at least returns *something* on
+    /// every CI/dev machine we run on (loopback if nothing else, which is
+    /// filtered out). Make sure the call doesn't panic.
+    #[test]
+    fn enumerate_local_lan_v4_does_not_panic() {
+        let _ = enumerate_local_lan_v4();
     }
 
     #[test]

--- a/src-tauri/crates/uc-infra/src/network/iroh/node.rs
+++ b/src-tauri/crates/uc-infra/src/network/iroh/node.rs
@@ -45,7 +45,7 @@ use uc_core::ports::{
 use crate::pairing::{IrohPairingSessionAdapter, PAIRING_ALPN};
 use crate::rendezvous::{RendezvousClient, RendezvousPairingInvitationAdapter};
 
-use super::addr_filter::{apply_addr_filter, enumerate_local_lan_v4, LocalLanV4};
+use super::addr_filter::{apply_addr_filter, enumerate_local_lan_v4};
 use super::blobs::{IrohBlobTransferAdapter, BLOBS_ALPN};
 use super::clipboard_dispatch_adapter::{IrohClipboardDispatchAdapter, CLIPBOARD_ALPN};
 use super::clipboard_receiver_adapter::IrohClipboardReceiverAdapter;
@@ -695,6 +695,7 @@ impl IrohNodeBuilder {
         peer_addr_repo: Arc<dyn PeerAddressRepositoryPort>,
         member_repo: Arc<dyn MemberRepositoryPort>,
         fingerprint_factory: Arc<dyn IdentityFingerprintFactoryPort>,
+        presence: Arc<dyn PresencePort>,
     ) -> ClipboardHandlers {
         let receiver = IrohClipboardReceiverAdapter::new(member_repo, fingerprint_factory);
         let handler = receiver.handler();
@@ -709,6 +710,7 @@ impl IrohNodeBuilder {
         let dispatch = Arc::new(IrohClipboardDispatchAdapter::new(
             Arc::clone(&self.endpoint),
             peer_addr_repo,
+            presence,
         ));
 
         ClipboardHandlers {
@@ -890,7 +892,7 @@ pub enum IrohNodeError {
 
 #[cfg(test)]
 mod tests {
-    use super::super::addr_filter::is_virtual_nic_ip;
+    use super::super::addr_filter::{is_virtual_nic_ip, LocalLanV4};
     use super::*;
 
     use std::collections::HashMap;
@@ -1102,7 +1104,7 @@ mod tests {
         );
 
         let peer_addr_repo: Arc<dyn PeerAddressRepositoryPort> = Arc::new(EmptyPeerAddressRepo);
-        let _presence = builder.install_presence(
+        let presence = builder.install_presence(
             Arc::clone(&peer_addr_repo),
             Arc::new(EmptyMemberRepo),
             Arc::new(crate::security::Sha256IdentityFingerprintFactory),
@@ -1113,6 +1115,7 @@ mod tests {
             peer_addr_repo,
             Arc::new(EmptyMemberRepo),
             Arc::new(crate::security::Sha256IdentityFingerprintFactory),
+            presence,
         );
 
         // Dispatch against an unknown device — the repo is empty so we
@@ -1161,7 +1164,7 @@ mod tests {
         );
 
         let peer_addr_repo: Arc<dyn PeerAddressRepositoryPort> = Arc::new(EmptyPeerAddressRepo);
-        let _presence = builder.install_presence(
+        let presence = builder.install_presence(
             Arc::clone(&peer_addr_repo),
             Arc::new(EmptyMemberRepo),
             Arc::new(crate::security::Sha256IdentityFingerprintFactory),
@@ -1172,6 +1175,7 @@ mod tests {
             peer_addr_repo,
             Arc::new(EmptyMemberRepo),
             Arc::new(crate::security::Sha256IdentityFingerprintFactory),
+            presence,
         );
 
         let tempdir = tempfile::tempdir().expect("tempdir");

--- a/src-tauri/crates/uc-infra/src/network/iroh/presence_adapter.rs
+++ b/src-tauri/crates/uc-infra/src/network/iroh/presence_adapter.rs
@@ -618,6 +618,48 @@ impl PresencePort for IrohPresenceAdapter {
         Ok(result)
     }
 
+    #[instrument(skip_all, fields(device = %device.as_str()))]
+    async fn mark_offline(&self, device: &DeviceId) {
+        let key = device.as_str().to_string();
+
+        // 1) Evict the live-connection slot. The peer is held to be dead by
+        //    an external observer — anything we cached as alive is now a lie
+        //    that the fast-path in `ensure_reachable` would happily serve.
+        //    Close the connection explicitly so the watchdog's
+        //    `connection.closed().await` resolves and its cleanup runs
+        //    (remove already noop, last_state already Offline below, the
+        //    redundant Offline event is idempotent).
+        //
+        //    Order matches `verify_reachable`'s failure path: remove from
+        //    map first, then close — avoids the watchdog cleanup half-killed
+        //    race (TrackedPeer::drop will abort the watchdog if it hasn't
+        //    fired yet, and that's fine; we don't depend on it running).
+        let stale = {
+            let mut peers = self.peers.lock().await;
+            peers.remove(&key)
+        };
+        if let Some(stale) = stale {
+            stale.connection.close(0u32.into(), b"mark_offline");
+            debug!("mark_offline: closed stale tracked connection");
+        }
+
+        // 2) Persist Offline in last_state. Skip the broadcast if the device
+        //    was already Offline (idempotency contract). Hold the lock across
+        //    the prev-vs-new compare-and-set so a racing inbound Online flip
+        //    doesn't slip a duplicate Offline through.
+        let should_broadcast = {
+            let mut last = self.last_state.lock().await;
+            let prev = last.insert(key, ReachabilityState::Offline);
+            prev != Some(ReachabilityState::Offline)
+        };
+
+        if should_broadcast {
+            let now = self.now();
+            debug!("mark_offline: peer marked Offline");
+            self.broadcast(device.clone(), ReachabilityState::Offline, now);
+        }
+    }
+
     // 故意不挂 `#[instrument]`:`current_state()` 仅做 in-memory map
     // lookup(`last_state` / `peers`),没有外部 I/O,但被 roster /
     // list_with_presence / ensure_reachable_all 在热路径上反复调用,

--- a/src-tauri/crates/uc-infra/src/network/iroh/presence_adapter.rs
+++ b/src-tauri/crates/uc-infra/src/network/iroh/presence_adapter.rs
@@ -51,6 +51,7 @@
 
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 use chrono::{DateTime, TimeZone, Utc};
@@ -83,6 +84,31 @@ pub const PRESENCE_ALPN: &[u8] = b"uniclipboard/presence/0";
 /// members flipping state on an unlock); lagging subscribers recover via
 /// [`PresencePort::current_state`] per the broadcast contract.
 const EVENT_CHANNEL_CAPACITY: usize = 64;
+
+/// Maximum age of a tracked-connection entry before [`IrohPresenceAdapter::
+/// ensure_reachable`] refuses the fast-path and forces a fresh dial.
+///
+/// Without this guard the fast-path only checks `connection.close_reason().
+/// is_none()`. A peer that dies *silently* — process crash without a close
+/// frame, NAT mapping expiry, network black-hole — keeps `close_reason`
+/// as `None` until quinn's own keep-alive PING run hits `max_idle_timeout`
+/// (60s) and tears the connection down. During that window the fast-path
+/// lies "Online", `current_state` returns Online, `peer_keepalive` records
+/// Online, and `clipboard_sync::dispatch_entry` enrolls the dead peer into
+/// fan-out — burning the full `FAN_OUT_DEADLINE = 5s` on every clipboard
+/// dispatch until the watchdog finally fires.
+///
+/// 30s is picked to:
+/// * stay above `quinn keep_alive_interval = 15s` so two healthy keepalive
+///   PINGs always land inside one TTL window — fast-path hit rate on a
+///   live connection is unchanged;
+/// * stay above `peer_keepalive::BASE_INTERVAL = 25s` so the worker's
+///   normal cadence still mostly observes cached Online and doesn't pay
+///   a dial on every tick;
+/// * stay below `max_idle_timeout = 60s` so we surface a silently-dead
+///   peer *before* quinn's idle timer would, halving the worst-case
+///   stale window observable to `dispatch_entry`.
+const FAST_PATH_TTL: Duration = Duration::from_secs(30);
 
 // ============================================================================
 // ProtocolHandler (accept side)
@@ -270,6 +296,16 @@ pub struct IrohPresenceAdapter {
 struct TrackedPeer {
     connection: Connection,
     watchdog: JoinHandle<()>,
+    /// Monotonic timestamp of the most recent confirmed-live observation
+    /// for this entry. Set on insert in [`IrohPresenceAdapter::
+    /// dial_and_track`] (dial just succeeded) and refreshed when a fresh
+    /// dial races against an already-tracked entry and finds it still
+    /// alive (the redial itself is fresh evidence). Consumed by
+    /// [`IrohPresenceAdapter::ensure_reachable`]'s fast-path to refuse
+    /// returning Online from an entry that has aged past
+    /// [`FAST_PATH_TTL`], forcing a re-dial. See [`FAST_PATH_TTL`] for the
+    /// silent-death problem this guards against.
+    last_verified_at: Instant,
 }
 
 impl Drop for TrackedPeer {
@@ -434,9 +470,14 @@ impl IrohPresenceAdapter {
                     // raced, or `verify_reachable` redialed against a
                     // tracked-but-stale-looking peer), abort our own
                     // watchdog and keep theirs — single connection slot
-                    // per device.
-                    if let Some(existing) = peers.get(&key) {
+                    // per device. Refresh `last_verified_at` on the kept
+                    // entry: our just-completed dial is fresh evidence
+                    // that the peer is reachable *right now*, so the
+                    // fast-path TTL clock should reset even though we're
+                    // discarding the new connection in favour of the old.
+                    if let Some(existing) = peers.get_mut(&key) {
                         if existing.connection.close_reason().is_none() {
+                            existing.last_verified_at = Instant::now();
                             debug!(
                                 "dial_and_track: alive tracked entry exists; \
                                  discarding freshly dialed connection",
@@ -458,6 +499,7 @@ impl IrohPresenceAdapter {
                         TrackedPeer {
                             connection,
                             watchdog,
+                            last_verified_at: Instant::now(),
                         },
                     );
                 }
@@ -498,19 +540,44 @@ impl PresencePort for IrohPresenceAdapter {
         let key = device.as_str().to_string();
 
         // Step 1: fast-path on an already-tracked live connection.
+        //
+        // Both predicates must hold to return Online without a fresh dial:
+        //
+        // * `close_reason().is_none()` — quinn has not (yet) observed the
+        //   connection close. This is the original liveness signal from
+        //   T3a but it lags silent-death scenarios by up to
+        //   `max_idle_timeout = 60s`.
+        //
+        // * `last_verified_at.elapsed() < FAST_PATH_TTL` — we have *recent*
+        //   first-hand evidence the peer is reachable (a successful dial
+        //   landed inside the TTL window). Without this, an entry whose
+        //   peer silently died can sit in the map looking alive for the
+        //   full quinn idle window, lying "Online" to every caller.
+        //
+        // Either predicate failing routes through eviction + re-dial. The
+        // miss is logged with both flags so a stale-TTL eviction is
+        // distinguishable from a closed-conn eviction in production.
         {
             let mut peers = self.peers.lock().await;
             if let Some(entry) = peers.get(&key) {
-                if entry.connection.close_reason().is_none() {
+                let still_alive = entry.connection.close_reason().is_none();
+                let recently_verified = entry.last_verified_at.elapsed() < FAST_PATH_TTL;
+                if still_alive && recently_verified {
                     debug!("ensure_reachable: already tracked and alive");
                     return Ok(ReachabilityState::Online);
                 }
-                // Stale entry — the watchdog should already be in the
-                // process of cleaning up, but don't block on it. Remove
-                // here so the re-dial path below gets a clean slate.
+                // Stale entry — either quinn has closed it, or the entry
+                // has aged past FAST_PATH_TTL without re-verification.
+                // Evict so the re-dial path below starts from a clean
+                // slate (and so `dial_and_track`'s "alive entry already
+                // exists" branch doesn't accidentally preserve a corpse).
                 if let Some(stale) = peers.remove(&key) {
                     stale.watchdog.abort();
-                    debug!("ensure_reachable: evicted stale tracked entry before re-dial");
+                    debug!(
+                        still_alive,
+                        recently_verified,
+                        "ensure_reachable: evicted stale tracked entry before re-dial",
+                    );
                 }
             }
         }


### PR DESCRIPTION
## Summary

- **Presence fast-path now enforces a 30s TTL** so silently-dead peers (process crash, NAT mapping expiry, network black-hole — anything that doesn't surface a QUIC close frame) stop reporting `Online` until quinn's 60s idle timeout finally fires. Previously `dispatch_entry` would burn the full 5s `FAN_OUT_DEADLINE` on every clipboard event sent to such a corpse. (`f0e0aa7c`)
- **`mark_offline` closes the dial loop**: when an external observer flags a peer as dead, we evict the tracked connection + broadcast `Offline` immediately, instead of letting the fast-path keep serving the stale `Online` until the next TTL miss. Paired with a `skip-dial-on-known-offline` check in `dispatch_entry` so we don't immediately re-dial what we just marked dead. (`6f485007`)
- **Hairpin public IP gets filtered when the peer is LAN-reachable.** On consumer routers without NAT hairpin support, magicsock kept oscillating between the fast LAN path (~5ms) and the NAT-reflected public-IP path (~80ms+ or failing); the new `addr_filter` drops the public candidate if any of the peer's candidates falls inside one of our local RFC1918 subnets. (`594f37eb`)
- Tests swapped from a hand-rolled `NoopPresence` to a `mockall`-generated `MockPresence` so future presence-port changes don't ripple into N test files. (`24692b58`)
- Tooling: `dual-side-debug` skill updated for the broader SMB mount layout (`573de7e7`); new throwaway `p2p-bench` crate (`publish = false`) with `--split / --multi-endpoint / --sender-multi-endpoint / --use-add-path` spike variants captures the iroh-blobs LAN throughput investigation — sender-multi-endpoint N=2 hits **1.97x** baseline on Mac→Win (`18985d19`, `02f41a56`). Results + follow-up Win-decay instrumentation plan live under `.planning/debug/iroh-throughput-bbr-cubic/`.

## Test plan

- [x] `cargo test -p uc-infra` (presence_adapter unit + iroh tests)
- [x] `cargo test -p uc-clipboard-sync` (dispatch_entry with MockPresence)
- [x] Manual two-Mac LAN: kill receiver process abruptly, confirm sender stops fan-out within ~30s instead of ~60s.
- [x] Manual Mac↔Win wifi: confirm hairpin filter eliminates the ~80ms RTT oscillation reported in `INVESTIGATION.md`.
- [ ] Reviewer: spot-check that no other call site of `PresencePort` relied on the old "fast-path always returns Online while QUIC thinks the connection is up" behavior. The relevant call sites are `clipboard_dispatch_adapter`, `clipboard_receiver_adapter`, and `presence_adapter` itself — all updated in this PR.
- [ ] Reviewer: `p2p-bench` is `publish = false` and tagged "throwaway diagnostic spike" — confirm it doesn't get pulled into any release artifact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added P2P benchmarking utility for throughput analysis
  * Enhanced offline peer detection in clipboard synchronization
  * Improved network address filtering to optimize LAN reachability

* **Documentation**
  * Updated debugging guidance for dual-side log analysis
  * Added throughput investigation findings and instrumentation plans
  * Expanded configuration documentation with clearer procedures

* **Bug Fixes**
  * Fixed stale connection handling with presence freshness tracking
  * Improved peer reachability verification to prevent silent connection failures

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/UniClipboard/UniClipboard/pull/852?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->