### PR TITLE
feat(mobile-sync): add download onboarding step to credential modal

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -48,6 +48,7 @@
         "lucide-react": "^1.16.0",
         "next-themes": "^0.4.6",
         "pino": "^10.3.1",
+        "qrcode.react": "^4.2.0",
         "radix-ui": "^1.4.3",
         "react": "^19.2.6",
         "react-colorful": "^5.7.0",
@@ -2134,6 +2135,8 @@
     "pump": ["pump@3.0.4", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA=="],
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
+    "qrcode.react": ["qrcode.react@4.2.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA=="],
 
     "qs": ["qs@6.14.0", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w=="],
 

--- a/docs-site/content/docs/en/guides/mobile-sync.mdx
+++ b/docs-site/content/docs/en/guides/mobile-sync.mdx
@@ -92,9 +92,13 @@ Pick a label (e.g. "My iPhone 15"). The desktop mints a one-time
 **username** and **password** and shows them inside a credentials
 modal split by onboarding method, not by platform:
 
-- **Scan to add** — a QR that encodes the base URL and credentials
-  as a single connect URI. Scan it from the **UniClipboard iOS
-  App** (TestFlight public beta — recommended; see
+- **Scan to add** — a two-step flow. Step ① **Download** shows a QR
+  pointing at the [download page](https://www.uniclipboard.app/download),
+  so first-time users can install the UniClipboard mobile app from
+  their phone; tap **"Installed — next"** to advance to step ②
+  **Pair**, which shows a QR that encodes the base URL and credentials
+  as a single connect URI. Scan it from the **UniClipboard iOS App**
+  (TestFlight public beta — recommended; see
   [Pair an iPhone](#pair-an-iphone) below) or any SyncClipboard-
   protocol client, including community Android apps. All fields
   auto-fill. No typing.
@@ -193,8 +197,13 @@ then **Install**, and UniClipboard will be added to the Home Screen.
 
 Back on the desktop, follow the flow above to click **Add device**
 under **Devices → Mobile sync**. The credentials modal opens on the
-**Scan to add** tab and shows a connect-URI QR that carries the
-base URL, username, and one-time password.
+**Scan to add** tab, sub-step **① Download** — it shows a QR
+pointing at the [download page](https://www.uniclipboard.app/download)
+so first-time users can install the mobile app from their phone. If
+you already installed it via the TestFlight steps above, click
+**"Installed — next"** to advance to **② Pair**, which shows the
+connect-URI QR that carries the base URL, username, and one-time
+password.
 
 </Step>
 
@@ -202,11 +211,11 @@ base URL, username, and one-time password.
 
 #### Enter the connection info in the App
 
-Open the UniClipboard iOS App, tap **Add server**, and scan the
-**Scan to add** QR from the desktop. The base URL, username, and
-password are filled in automatically; just confirm and save. Once
-connected, the iPhone syncs clipboard with the desktop in both
-directions.
+Open the UniClipboard iOS App, tap **Add server**, and scan the QR
+from the desktop's **Scan to add → ② Pair** sub-step. The base URL,
+username, and password are filled in automatically; just confirm
+and save. Once connected, the iPhone syncs clipboard with the
+desktop in both directions.
 
 </Step>
 

--- a/docs-site/content/docs/zh/guides/mobile-sync.mdx
+++ b/docs-site/content/docs/zh/guides/mobile-sync.mdx
@@ -81,11 +81,14 @@ modal 顶部会出现红色 Alert，列出具体原因；监听不起来时 tab 
 填一个标签（例如「My iPhone 15」）。桌面会签发一次性的 **用户名** 与
 **密码**，并在凭据弹窗中按 **接入方式**（而非平台）拆成两个 tab：
 
-- **扫码接入（Scan to add）** —— 一个把 base URL 与凭据编码进
-  connect URI 的二维码。用 **UniClipboard iOS App**（TestFlight beta
-  公测中，推荐路径，详见下文 [配对一台 iPhone](#配对一台-iphone)）的
-  "添加服务端"页扫一下；或任何兼容 SyncClipboard 协议的客户端（含
-  社区维护的安卓 App）也走同一条路径，所有字段自动填好，无需手输。
+- **扫码接入（Scan to add）** —— 分两步：① **下载** 展示一个指向
+  [下载页](https://www.uniclipboard.app/download) 的二维码，帮首次
+  接入的用户在手机上装 UniClipboard App；装好后点 **「已装好，下一
+  步」** 进入 ② **配对**，看到把 base URL 与凭据编码进 connect URI
+  的二维码。用 **UniClipboard iOS App**（TestFlight beta 公测中，
+  推荐路径，详见下文 [配对一台 iPhone](#配对一台-iphone)）的"添加
+  服务端"页扫一下；或任何兼容 SyncClipboard 协议的客户端（含社区
+  维护的安卓 App）也走同一条路径，所有字段自动填好，无需手输。
 - **安装快捷指令（Install Shortcut）** —— 一个指向 iCloud 上
   `UniClipboard.shortcut` 安装链接的二维码。扫码安装快捷指令后，
   **再从弹窗里手动复制** base URL / 用户名 / 密码填入快捷指令的对
@@ -174,8 +177,11 @@ https://testflight.apple.com/join/nyNQ8dQe
 #### 在桌面 **添加设备** 拿到凭据
 
 回到桌面端，按上文的流程在 **设备 → 移动端同步** 里点 **添加设备**。
-凭据弹窗会默认停在 **扫码接入** tab，展示一个把 base URL、用户名、
-一次性密码编码进 connect URI 的二维码。
+凭据弹窗会默认停在 **扫码接入** tab 的 **① 下载** 子步骤，展示一个
+指向 [下载页](https://www.uniclipboard.app/download) 的二维码，方便
+首次接入的用户在手机上装 App。已经按上文装好 TestFlight + UniClipboard
+App 的，直接点 **「已装好，下一步」** 进入 **② 配对** 子步骤，这一步
+才展示把 base URL、用户名、一次性密码编码进 connect URI 的二维码。
 
 </Step>
 
@@ -183,9 +189,9 @@ https://testflight.apple.com/join/nyNQ8dQe
 
 #### 在 App 里填入连接信息
 
-打开 UniClipboard iOS App，点 **「添加服务端」**，扫描桌面端的 **扫码
-接入** 二维码。base URL、用户名、密码会自动填好，确认保存即可。完成
-后即可与桌面双向同步剪贴板。
+打开 UniClipboard iOS App，点 **「添加服务端」**，扫描桌面端 **扫码
+接入 → ② 配对** 子步骤里的二维码。base URL、用户名、密码会自动填好，
+确认保存即可。完成后即可与桌面双向同步剪贴板。
 
 </Step>
 

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "lucide-react": "^1.16.0",
     "next-themes": "^0.4.6",
     "pino": "^10.3.1",
+    "qrcode.react": "^4.2.0",
     "radix-ui": "^1.4.3",
     "react": "^19.2.6",
     "react-colorful": "^5.7.0",

--- a/src/components/device/MobileSyncCredentialModal.tsx
+++ b/src/components/device/MobileSyncCredentialModal.tsx
@@ -35,7 +35,9 @@
  *    上层不应把这份对象长期持有)。
  */
 
-import { Check, Copy, Eye, EyeOff, XIcon } from 'lucide-react'
+import { openUrl } from '@tauri-apps/plugin-opener'
+import { AlertTriangle, Check, Copy, ExternalLink, Eye, EyeOff, XIcon } from 'lucide-react'
+import { QRCodeSVG } from 'qrcode.react'
 import React, { useCallback, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { type RegisterMobileDeviceResult } from '@/api/tauri-command/mobile_sync'
@@ -52,7 +54,14 @@ import {
 import { Label } from '@/components/ui/label'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { toast } from '@/components/ui/toast'
+import { createLogger } from '@/lib/logger'
 import { cn } from '@/lib/utils'
+
+const log = createLogger('mobile-sync-credential')
+
+// 官网下载页 — 该页根据 UA 提供 iOS / Android 两个平台的安装入口,
+// 桌面端用户直接扫即可在手机上打开。URL 是产品级常量,不本地化。
+const DOWNLOAD_PAGE_URL = 'https://www.uniclipboard.app/download'
 
 interface Props {
   /**
@@ -68,11 +77,17 @@ interface Props {
 
 type OnboardingTab = 'scan' | 'shortcut'
 
+// 扫码接入是两步流程: step 1 引导用户在手机上扫"下载页 QR"装 App,
+// step 2 才扫 connect URI 配对。第一次接入的用户根本没装 App,直接给
+// connect QR 是哑的 —— 必须先把"去哪下载"这件事讲清楚。
+type ScanStep = 'download' | 'pair'
+
 const MobileSyncCredentialModal: React.FC<Props> = ({ payload, onDiscard, onComplete }) => {
   const { t } = useTranslation()
   const [acknowledged, setAcknowledged] = useState(false)
   const [passwordVisible, setPasswordVisible] = useState(false)
   const [activeTab, setActiveTab] = useState<OnboardingTab>('scan')
+  const [scanStep, setScanStep] = useState<ScanStep>('download')
   // 用户尝试关闭但未勾选时的 inline 提示。toast 在 modal 遮罩下很容易被忽视,
   // 改成把红色高亮 + 错误文本直接挂在勾选框上,视线一定会被引到下一步操作。
   const [hintActive, setHintActive] = useState(false)
@@ -82,6 +97,7 @@ const MobileSyncCredentialModal: React.FC<Props> = ({ payload, onDiscard, onComp
     setAcknowledged(false)
     setPasswordVisible(false)
     setActiveTab('scan')
+    setScanStep('download')
     setHintActive(false)
   }, [])
 
@@ -158,18 +174,21 @@ const MobileSyncCredentialModal: React.FC<Props> = ({ payload, onDiscard, onComp
         </Button>
         <DialogHeader className="px-4 pt-4 pb-2">
           <DialogTitle>{t('devices.mobileSync.credential.title')}</DialogTitle>
-          <DialogDescription>{t('devices.mobileSync.credential.subtitle')}</DialogDescription>
+          {/* 视觉上不需要副标题 — 警告横幅 + tab + stepper 已经讲明白了。
+              但 Radix DialogContent 要求至少有 description (否则 a11y warn),
+              这里用 sr-only 给屏幕阅读器。 */}
+          <DialogDescription className="sr-only">
+            {t('devices.mobileSync.credential.subtitle')}
+          </DialogDescription>
         </DialogHeader>
 
-        <div className="flex-1 space-y-4 overflow-y-auto px-4 py-2">
-          {/* 警告横幅 */}
-          <div className="rounded-md border border-amber-500/30 bg-amber-500/10 p-3">
-            <p className="text-sm font-semibold text-amber-700 dark:text-amber-400">
-              {t('devices.mobileSync.credential.warning.title')}
-            </p>
-            <p className="mt-1 text-xs text-amber-700/90 dark:text-amber-400/90">
-              {t('devices.mobileSync.credential.warning.body')}
-            </p>
+        <div className="flex-1 space-y-3 overflow-y-auto px-4 py-2">
+          {/* 警告横幅 — 只留 title 一句。body ("关闭后无法再查看,如不慎遗失需
+              撤销并重新添加") 删了: title 已经传达核心,recovery 路径在 device
+              列表的撤销按钮上,信息不会失传。 */}
+          <div className="flex items-center gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-sm font-medium text-amber-700 dark:text-amber-400">
+            <AlertTriangle className="h-4 w-4 shrink-0" />
+            <span>{t('devices.mobileSync.credential.warning.title')}</span>
           </div>
 
           {/* 接入方式 tab —— 凭据 (URL/user/pwd) 共用,只切换"扫什么 QR" */}
@@ -183,21 +202,62 @@ const MobileSyncCredentialModal: React.FC<Props> = ({ payload, onDiscard, onComp
               </TabsTrigger>
             </TabsList>
 
-            {/* Tab A: 扫码接入 (默认主路径)
-                qrCodePngBase64 自后端阶段 2 起编码的是 connect URI
-                (uniclipboard://connect?v=1&svc=mobile-sync&p=...), 平台无关
-                —— iOS App、SyncClipboard 快捷指令、Android 第三方应用均可解。 */}
-            <TabsContent value="scan" className="mt-3 space-y-4">
-              <div className="flex flex-col items-center gap-2 rounded-md border border-border/60 bg-muted/30 p-4">
-                <Label className="text-xs uppercase tracking-wider text-muted-foreground">
-                  {t('devices.mobileSync.credential.scan.qr.label')}
-                </Label>
-                <img
-                  src={`data:image/png;base64,${payload.qrCodePngBase64}`}
-                  alt={t('devices.mobileSync.credential.scan.qr.alt')}
-                  className="h-48 w-48 rounded bg-white p-2"
-                />
-              </div>
+            {/* Tab A: 扫码接入 (默认主路径) — 两步 stepper
+                  step 1 = 下载 App (QR 指向官网下载页, 页面根据 UA 区分 iOS/Android)
+                  step 2 = 扫码配对 (QR = connect URI, qrCodePngBase64 由后端渲染)
+                connect URI 平台无关 —— iOS App、SyncClipboard 快捷指令、Android
+                客户端均可解; 但前置必须有 App, 所以 step 1 把"去哪下载"先讲清楚。
+                布局精简: 取消独立的提示卡, hint 内嵌到 QR 框顶端, "浏览器打开"
+                变成右上角小图标; pair step 不放"返回"按钮 — stepper 第 1 步可
+                点回退, 不需要重复入口。 */}
+            <TabsContent value="scan" className="mt-3 space-y-3">
+              <ScanStepper currentStep={scanStep} onSelect={setScanStep} />
+
+              {scanStep === 'download' ? (
+                <>
+                  <QrPanel
+                    hint={t('devices.mobileSync.credential.scan.download.hint')}
+                    topRight={
+                      <Button
+                        type="button"
+                        size="icon-sm"
+                        variant="ghost"
+                        aria-label={t(
+                          'devices.mobileSync.credential.scan.download.openInBrowserAria'
+                        )}
+                        title={t('devices.mobileSync.credential.scan.download.openInBrowserAria')}
+                        onClick={() =>
+                          openUrl(DOWNLOAD_PAGE_URL).catch(err =>
+                            log.error({ err }, 'Failed to open download page URL')
+                          )
+                        }
+                      >
+                        <ExternalLink className="h-3.5 w-3.5" />
+                      </Button>
+                    }
+                  >
+                    {/* 前端用 qrcode.react 现渲: download URL 是静态产品常量,
+                        每次都让后端编码一份 base64 PNG 是浪费。size 176 对应
+                        connect QR 显示 (h-48 w-48 减去 p-2)。 */}
+                    <QRCodeSVG
+                      value={DOWNLOAD_PAGE_URL}
+                      size={176}
+                      aria-label={t('devices.mobileSync.credential.scan.download.qrAlt')}
+                    />
+                  </QrPanel>
+                  <Button type="button" className="w-full" onClick={() => setScanStep('pair')}>
+                    {t('devices.mobileSync.credential.scan.download.next')}
+                  </Button>
+                </>
+              ) : (
+                <QrPanel hint={t('devices.mobileSync.credential.scan.pair.hint')}>
+                  <img
+                    src={`data:image/png;base64,${payload.qrCodePngBase64}`}
+                    alt={t('devices.mobileSync.credential.scan.pair.qrAlt')}
+                    className="h-44 w-44 rounded bg-white p-2"
+                  />
+                </QrPanel>
+              )}
             </TabsContent>
 
             {/* Tab B: 安装快捷指令 (一次性兜底)
@@ -352,12 +412,13 @@ const CredentialField: React.FC<CredentialFieldProps> = ({
   const display = secret ? value.replace(/./g, '•') : value
 
   return (
-    <div className="space-y-1">
-      <Label className="text-xs uppercase tracking-wider text-muted-foreground">{label}</Label>
-      <div className="flex items-center gap-1 rounded-md border border-border/60 bg-card px-3 py-2">
-        {/* min-w-0 is required: flex items default to min-width:auto which prevents
-            truncate from shrinking below the intrinsic content width. Without it
-            long URLs / passwords push the row past the modal edge. */}
+    // Inline layout: label 在左, value 框在右, 一行一个字段。比 stacked
+    // (label 在上, 框在下) 节省一半垂直空间, 跟整体精简方向一致。
+    // Label 用固定宽度 w-16 让三个字段对齐, value 框 min-w-0 + truncate 处理
+    // 长 URL 不溢出。
+    <div className="flex items-center gap-2">
+      <Label className="w-16 shrink-0 text-xs text-muted-foreground">{label}</Label>
+      <div className="flex min-w-0 flex-1 items-center gap-1 rounded-md border border-border/60 bg-card px-2 py-1">
         <span
           className={`min-w-0 flex-1 truncate text-sm ${mono ? 'font-mono' : ''} ${
             secret ? 'tracking-widest' : ''
@@ -392,5 +453,83 @@ const CredentialField: React.FC<CredentialFieldProps> = ({
     </div>
   )
 }
+
+interface ScanStepperProps {
+  currentStep: ScanStep
+  onSelect: (step: ScanStep) => void
+}
+
+/**
+ * 极简两步导航 —— "① 下载 · ② 配对",一行文字。
+ *
+ * 设计上故意没有圆 badge + 连接线: 只有两步, 视觉装饰反而抢 QR 的焦点;
+ * 编号 + 标签 + 中点分隔已经足够传达"我在第几步"。
+ * 完成步(currentStep 之前)是 muted + clickable(可点回退); 当前步是
+ * foreground 加粗。点击规则: 只能往回点, 不能往前点 — 强制走"下一步"
+ * 按钮, 让用户对"我装好了"做明确确认。
+ */
+const ScanStepper: React.FC<ScanStepperProps> = ({ currentStep, onSelect }) => {
+  const { t } = useTranslation()
+  const steps: { id: ScanStep; labelKey: string }[] = [
+    { id: 'download', labelKey: 'devices.mobileSync.credential.scan.stepper.download' },
+    { id: 'pair', labelKey: 'devices.mobileSync.credential.scan.stepper.pair' },
+  ]
+  const currentIndex = steps.findIndex(s => s.id === currentStep)
+
+  return (
+    <div className="flex items-center justify-center gap-1.5 text-xs">
+      {steps.map((step, index) => {
+        const isCurrent = index === currentIndex
+        const isPast = index < currentIndex
+        const clickable = isPast
+        return (
+          <React.Fragment key={step.id}>
+            <button
+              type="button"
+              disabled={!clickable}
+              onClick={clickable ? () => onSelect(step.id) : undefined}
+              className={cn(
+                'rounded-sm px-1 py-0.5 transition-colors',
+                isCurrent && 'font-medium text-foreground',
+                isPast &&
+                  'cursor-pointer text-muted-foreground underline-offset-2 hover:text-foreground hover:underline',
+                !isCurrent && !isPast && 'cursor-default text-muted-foreground/50'
+              )}
+              aria-current={isCurrent ? 'step' : undefined}
+            >
+              {index + 1}. {t(step.labelKey)}
+            </button>
+            {index < steps.length - 1 && <span className="text-muted-foreground/40">·</span>}
+          </React.Fragment>
+        )
+      })}
+    </div>
+  )
+}
+
+interface QrPanelProps {
+  /** QR 框顶端的一行内嵌说明。 */
+  hint: string
+  /** 右上角的额外操作(如"浏览器打开下载页"图标按钮)。 */
+  topRight?: React.ReactNode
+  children: React.ReactNode
+}
+
+/**
+ * QR 展示面板 —— hint + (可选) topRight icon + QR 主体。
+ *
+ * 把原来的"独立提示卡 + 独立 QR 卡 + 独立兜底链接"压成一个卡, hint 内嵌到
+ * 顶端, 兜底操作内嵌到右上角图标位。视觉重心全部落到 QR 上, 减少 7 段
+ * 独立文字到 1 段。
+ */
+const QrPanel: React.FC<QrPanelProps> = ({ hint, topRight, children }) => (
+  <div className="flex flex-col items-center gap-3 rounded-md border border-border/60 bg-muted/30 p-4">
+    <div className="flex w-full items-center justify-between gap-2">
+      <span className="text-xs text-muted-foreground">{hint}</span>
+      {topRight}
+    </div>
+    {children}
+  </div>
+)
 
 export default MobileSyncCredentialModal

--- a/src/components/device/__tests__/MobileSyncCredentialModal.test.tsx
+++ b/src/components/device/__tests__/MobileSyncCredentialModal.test.tsx
@@ -166,17 +166,18 @@ describe('MobileSyncCredentialModal close behavior', () => {
   // 父组件 DevicesPage 的 discardCredential 进入函数后立刻把 payload 清空
   // (乐观清空),避免连点 ✕ 触发第二次 revoke 拿到 DEVICE_NOT_FOUND。这里
   // 用一个 wrapper 复现该 contract,验证 modal 在 payload 清空后不再响应。
-  // 阶段 5: tab 按"接入方式"分,「扫码接入」(默认) 主 QR = connect URI,
-  // 「安装快捷指令」(次) 主 QR = install URL。这两个 QR 必须图源不串位,
-  // 文案也必须与新 i18n keys 对齐。后续误改文案 / 误删 tab / 把两个 QR
-  // 接反 (`installQrCodePngBase64` ↔ `qrCodePngBase64`) 都会立刻爆炸。
+  // 阶段 5: tab 按"接入方式"分,「扫码接入」(默认) / 「安装快捷指令」(次)。
+  // 阶段 6: scan tab 内部再分两步 — step 1 下载 App (前端用 qrcode.react 现渲
+  // download URL QR), step 2 才扫 connect URI 配对。两个步骤的 QR 必须图源
+  // 不串位 — pair step 必须用 payload.qrCodePngBase64, 不能误用 download URL
+  // 或 installQrCodePngBase64。
   //
   // 维护提醒: 这里断言的文案必须与 src/i18n/locales/en-US.json 里
   // devices.mobileSync.credential.* 的 key 一一对应。删/改 i18n key 时,
   // 同步删/改这里对应的 getByText/getByRole({ name }) 断言, 否则 CI 会以
   // "Unable to find an element with the text" 爆炸 (例: phase 5 polish
   // 删掉 scan.qr.help 时漏改测试导致 PR #813 CI 红)。
-  it('defaults to the Scan tab with the connect-URI QR', () => {
+  it('defaults to the Scan tab on the Download step with the download-page QR', () => {
     const { onDiscard, onComplete } = defaultHandlers()
     renderWithI18n(
       <MobileSyncCredentialModal
@@ -189,12 +190,48 @@ describe('MobileSyncCredentialModal close behavior', () => {
     // Tab triggers visible with new labels.
     expect(screen.getByRole('tab', { name: 'Scan to add' })).toBeInTheDocument()
     expect(screen.getByRole('tab', { name: 'Install Shortcut' })).toBeInTheDocument()
-    // Active tab is "Scan to add" — its panel renders the connect-URI QR.
-    const qr = screen.getByAltText('QR code that auto-fills the sync credentials')
-    expect(qr.getAttribute('src')).toBe('data:image/png;base64,iVBORw0KGgo=')
+    // Default sub-step is "Download" — its panel renders the download-page
+    // QR (rendered client-side via qrcode.react, not the backend's connect-URI
+    // PNG) and an "Installed — next" button to advance.
+    expect(screen.getByText('Scan with your phone to install the app')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Installed — next' })).toBeInTheDocument()
+    // qrcode.react renders an SVG with the URL embedded — assert by aria-label
+    // we set, not by attempting to decode the QR.
     expect(
-      screen.getByText('Scan with your phone to auto-fill the credentials')
+      screen.getByLabelText('QR code for the UniClipboard mobile download page')
     ).toBeInTheDocument()
+    // Pair-step QR must NOT be in the DOM yet — it's behind the stepper.
+    expect(
+      screen.queryByAltText('QR code that auto-fills the sync credentials')
+    ).not.toBeInTheDocument()
+  })
+
+  it('advances to the Pair step with the connect-URI QR after clicking next', async () => {
+    const user = userEvent.setup()
+    const { onDiscard, onComplete } = defaultHandlers()
+    renderWithI18n(
+      <MobileSyncCredentialModal
+        payload={mockPayload}
+        onDiscard={onDiscard}
+        onComplete={onComplete}
+      />
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Installed — next' }))
+
+    expect(screen.getByText('Scan inside the app to pair')).toBeInTheDocument()
+    const qr = screen.getByAltText('QR code that auto-fills the sync credentials')
+    // Pair QR must come from the backend-rendered connect URI PNG (not the
+    // download page QR). qrCodePngBase64 = 'iVBORw0KGgo=' per mockPayload.
+    expect(qr.getAttribute('src')).toBe('data:image/png;base64,iVBORw0KGgo=')
+    // No "Back" button in pair step — the stepper's "1. Download" entry is
+    // clickable and serves as the back path, avoiding a duplicate control.
+    // Verify the stepper Download entry is interactive (not disabled).
+    const downloadStepperBtn = screen.getByRole('button', { name: /1\. Download/i })
+    expect(downloadStepperBtn).not.toBeDisabled()
+    // Pair step is current, so the Download stepper entry must NOT be the
+    // current step (its aria-current="step" is only set on the active step).
+    expect(downloadStepperBtn).not.toHaveAttribute('aria-current', 'step')
   })
 
   it('switches to the Install Shortcut tab and shows the install-URL QR + link', async () => {

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -970,9 +970,19 @@
           "body": "After this dialog closes, the password cannot be recovered. If you lose it, you must revoke this device and add it again."
         },
         "scan": {
-          "qr": {
-            "label": "Scan with your phone to auto-fill the credentials",
-            "alt": "QR code that auto-fills the sync credentials"
+          "stepper": {
+            "download": "Download",
+            "pair": "Pair"
+          },
+          "download": {
+            "hint": "Scan with your phone to install the app",
+            "openInBrowserAria": "Open download page in browser",
+            "qrAlt": "QR code for the UniClipboard mobile download page",
+            "next": "Installed — next"
+          },
+          "pair": {
+            "hint": "Scan inside the app to pair",
+            "qrAlt": "QR code that auto-fills the sync credentials"
           }
         },
         "shortcut": {

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -961,9 +961,19 @@
           "body": "关闭此窗口后将无法再次查看密码。如不慎遗失，需要撤销此设备并重新添加。"
         },
         "scan": {
-          "qr": {
-            "label": "用手机扫一下，自动填入凭据",
-            "alt": "自动填入同步凭据的二维码"
+          "stepper": {
+            "download": "下载",
+            "pair": "配对"
+          },
+          "download": {
+            "hint": "在手机上扫码下载 App",
+            "openInBrowserAria": "在浏览器中打开下载页",
+            "qrAlt": "UniClipboard 移动端下载页的二维码",
+            "next": "已装好，下一步"
+          },
+          "pair": {
+            "hint": "在 App 内扫码完成配对",
+            "qrAlt": "自动填入同步凭据的二维码"
           }
         },
         "shortcut": {


### PR DESCRIPTION
## Summary

- **Add a Download sub-step to the Scan-to-add tab** (`c6cb549c`). The credentials modal now greets first-time users with a QR pointing at `https://www.uniclipboard.app/download` so they can install the mobile app from their phone before pairing. Tapping "Installed — next" advances to the existing connect-URI QR. The download-page QR is rendered client-side with `qrcode.react`; the connect-URI QR remains the backend-rendered PNG.
- **Collapse visual density in the same modal** (`c6cb549c`). The hint moves into the QR panel header, the "open in browser" link becomes a top-right icon, the stepper is a single line ("1. Download · 2. Pair"), credential rows go from stacked to inline, and the warning body drops to just the title. The Install Shortcut tab is unchanged; the user-visible password-recovery path (revoke + re-add from the device list) still applies.
- **Docs update** (`6f294b5e`). `docs-site` guide (en + zh) no longer claims the modal opens directly on a connect-URI QR — it now describes the two-step Download → Pair flow.

## Test plan

- [x] `bun run tsc --noEmit` — clean.
- [x] `bunx vitest run src/components/device/ src/pages/__tests__/DevicesPage.test.tsx` — 37/37 pass; one prior assertion split into two (default Download step + advance-to-Pair on click).
- [x] `bunx eslint` on touched files — clean.
- [x] JSON validity check on both i18n locales.
- [ ] Reviewer: open the credentials modal via **Devices → Mobile sync → Add device** and verify the Download step's QR resolves to `https://www.uniclipboard.app/download` on a phone, then "Installed — next" reveals the connect-URI QR.
- [ ] Reviewer: confirm the Install Shortcut tab is visually unchanged.
- [ ] Reviewer: skim the zh + en `mobile-sync.mdx` diffs and confirm the Download/Pair sub-step naming matches the UI labels they see in the running app.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Mobile device sync setup now uses a streamlined two-step QR onboarding flow: download the mobile app first, then pair your device using a connection QR code.

* **Documentation**
  * Updated mobile sync guides to reflect the new two-step onboarding process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/UniClipboard/UniClipboard/pull/855?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->