### PR TITLE
feat(clipboard-write): structured Windows clipboard holder diagnostics

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -9922,6 +9922,7 @@ dependencies = [
  "wayland-client",
  "wayland-protocols",
  "wayland-protocols-wlr",
+ "windows-sys 0.61.2",
  "x11rb",
 ]
 

--- a/src-tauri/crates/uc-application/Cargo.toml
+++ b/src-tauri/crates/uc-application/Cargo.toml
@@ -10,6 +10,15 @@ uc-core = { path = "../uc-core" }
 # Infrastructure (pragmatic exception: SearchPipeline is a concrete infra helper
 # grouped in AppDeps.search for single-ownership, per Phase 92 plan decision)
 uc-infra = { path = "../uc-infra" }
+# Platform layer — needed at runtime by `ClipboardWriteCoordinator` to recover
+# `ClipboardHolderInfo` diagnostics from the anyhow error chain returned by
+# `SystemClipboardPort::write_snapshot` failures. The trait itself stays in
+# uc-core; the diagnostic record is platform-produced metadata and belongs in
+# uc-platform (see `uc-platform::clipboard::holder` doc). uc-app/AGENTS §3
+# permits depending on uc-platform (uc-platform is the platform-difference
+# layer, not infra); the inverse is also explicitly allowed by
+# uc-platform/AGENTS §3 ("uc-platform 可以被 uc-app 使用").
+uc-platform = { path = "../uc-platform" }
 
 # Observability (flow correlation, stage constants)
 uc-observability = { path = "../uc-observability" }
@@ -66,7 +75,6 @@ features = ["v4"]
 
 [dev-dependencies]
 uc-infra = { path = "../uc-infra" }
-uc-platform = { path = "../uc-platform" }
 mockall = "0.13"
 tempfile = "3"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/src-tauri/crates/uc-application/src/clipboard_write/coordinator.rs
+++ b/src-tauri/crates/uc-application/src/clipboard_write/coordinator.rs
@@ -24,6 +24,7 @@ use tracing::{error, info, info_span, warn};
 use uc_core::clipboard::ClipboardChangeOrigin;
 use uc_core::clipboard::SystemClipboardSnapshot;
 use uc_core::ports::clipboard::{ClipboardChangeOriginPort, SystemClipboardPort};
+use uc_platform::clipboard::ClipboardHolderInfo;
 
 /// Number of consecutive OS-write failures that trip the circuit.
 ///
@@ -157,18 +158,38 @@ impl ClipboardWriteCoordinator {
     /// re-reading the atomic. Note: on a trip the atomic is reset to 0,
     /// but the returned value still reflects the pre-reset count — i.e.
     /// "this was failure number N which tripped the circuit".
-    fn record_failure(&self) -> u32 {
+    fn record_failure(&self, holder: Option<&ClipboardHolderInfo>) -> u32 {
         let new_count = self.consecutive_failures.fetch_add(1, Ordering::AcqRel) + 1;
         if new_count >= CIRCUIT_FAILURE_THRESHOLD {
             let until = Instant::now() + self.cooldown;
             *self.circuit_open_until.lock().expect("poisoned") = Some(until);
             self.consecutive_failures.store(0, Ordering::Release);
-            warn!(
+            // `error!` (not `warn!`) — circuit_tripped is the single actionable
+            // signal for "OS clipboard genuinely unavailable for this user".
+            // Per sentry-tracing EventFilter config in `uc-bootstrap::tracing`,
+            // ERROR maps to `Event | Log` (creates a Sentry issue); WARN maps
+            // to `Log` only. Per-failure events (os_write_failed, R/Q upstream)
+            // are warn; this trip event is the one that should page.
+            //
+            // `holder_*` reflect the foreign process recorded by the most
+            // recent failure on the streak (i.e. the failure that tripped
+            // the breaker). For sustained contention this is typically the
+            // same process across all five failures; if it isn't, this
+            // value at least points at *one* concrete contender rather
+            // than nothing. Recovered via `anyhow::Error::chain()` downcast
+            // from the platform-layer error per `ClipboardHolderInfo` contract.
+            let (holder_pid, holder_exe) = match holder {
+                Some(h) => (Some(h.holder_pid), Some(h.holder_exe.as_str())),
+                None => (None, None),
+            };
+            error!(
                 event = "circuit_tripped",
                 error_kind = "circuit_tripped",
                 consecutive_failures = new_count,
                 threshold = CIRCUIT_FAILURE_THRESHOLD,
                 cooldown_ms = self.cooldown.as_millis() as u64,
+                holder_pid = ?holder_pid,
+                holder_exe = ?holder_exe,
                 "clipboard_write_coordinator: circuit breaker tripped — pausing OS writes"
             );
         }
@@ -286,20 +307,40 @@ impl ClipboardWriteCoordinator {
             // writes start from a clean slate (and so outages surface in Seq/stdout
             // instead of being hidden in the `Err` bubbling back up the call chain).
             if let Err(err) = self.system_clipboard.write_snapshot(snapshot) {
+                // Recover platform-layer holder diagnostic from the anyhow
+                // chain (see `ClipboardHolderInfo` doc for the contract).
+                // Cloned so we can drop the borrow on `err` before logging
+                // `error = %err` later in this block.
+                let holder: Option<ClipboardHolderInfo> = err
+                    .chain()
+                    .find_map(|e| e.downcast_ref::<ClipboardHolderInfo>())
+                    .cloned();
                 self.clipboard_change_origin
                     .consume_origin_for_snapshot_or_default(
                         &origin_guard_key,
                         ClipboardChangeOrigin::LocalCapture,
                     )
                     .await;
-                // Record failure first so the error event below can include
+                // Record failure first so the warn event below can include
                 // the post-increment count and `circuit_tripped` derived state.
                 // Whoever reads Sentry can pair `error_kind=os_write_failed`
                 // with `consecutive_failures` and `circuit_tripped` to see
                 // immediately whether this is the Nth failure in a row.
-                let consecutive_failures = self.record_failure();
+                let consecutive_failures = self.record_failure(holder.as_ref());
                 let circuit_tripped = consecutive_failures >= CIRCUIT_FAILURE_THRESHOLD;
-                error!(
+                let (holder_pid, holder_exe) = match holder.as_ref() {
+                    Some(h) => (Some(h.holder_pid), Some(h.holder_exe.as_str())),
+                    None => (None, None),
+                };
+                // A single OS-write failure is `warn!` — transient OS clipboard
+                // contention (AV scan, IME hook, RDP clip proxy) is expected and
+                // not actionable on its own. The `circuit_tripped` event emitted
+                // by `record_failure` above promotes the signal to `error!` when
+                // the failure is sustained (≥ THRESHOLD in a row), which is the
+                // condition that should create a Sentry issue. See sentry-tracing
+                // EventFilter config in `uc-bootstrap::tracing` for the
+                // WARN→Log / ERROR→Event mapping that makes this work.
+                warn!(
                     event = "os_write_failed",
                     error_kind = "os_write_failed",
                     error = %err,
@@ -308,6 +349,8 @@ impl ClipboardWriteCoordinator {
                     consecutive_failures,
                     threshold = CIRCUIT_FAILURE_THRESHOLD,
                     circuit_tripped,
+                    holder_pid = ?holder_pid,
+                    holder_exe = ?holder_exe,
                     "clipboard_write_coordinator: OS clipboard write failed"
                 );
                 return Err(err);
@@ -433,6 +476,63 @@ mod tests {
             .returning(|_, default| default);
         origin.expect_set_next_origin().returning(|_, _| ());
         origin
+    }
+
+    /// `ClipboardHolderInfo` attached by a platform backend rides the
+    /// anyhow chain through the coordinator without disrupting circuit
+    /// behaviour, and the outer message (the human OS-error text) is
+    /// preserved as `err.to_string()` — i.e. the same downcast path the
+    /// non-test `record_failure` uses to populate `holder_*` on the
+    /// `circuit_tripped` event keeps working end-to-end. The uc-core
+    /// `local_clipboard::tests` already pin the raw transport contract;
+    /// this verifies that contract survives the mock → trait → coordinator
+    /// hop.
+    #[tokio::test]
+    async fn holder_bearing_error_propagates_and_trips_breaker() {
+        let mut clipboard = MockSystemClipboard::new();
+        clipboard.expect_write_snapshot().times(5).returning(|_| {
+            Err(anyhow::Error::new(ClipboardHolderInfo {
+                holder_pid: 9999,
+                holder_exe: "Ditto.exe".to_string(),
+            })
+            .context("OS clipboard write failed: ERROR_ACCESS_DENIED"))
+        });
+
+        let coord =
+            ClipboardWriteCoordinator::new(Arc::new(clipboard), Arc::new(permissive_origin_mock()));
+
+        for i in 0..5 {
+            let r = coord
+                .write(make_snapshot(), ClipboardWriteIntent::RemotePush)
+                .await;
+            let err = r.expect_err("expected OS error to propagate");
+            // Outer Display must remain the human OS-error message — the
+            // `error = %err` log field would otherwise be shadowed by the
+            // holder record.
+            assert_eq!(
+                err.to_string(),
+                "OS clipboard write failed: ERROR_ACCESS_DENIED",
+                "iteration {i}: outer Display must be the OS message, not the holder",
+            );
+            // Holder must remain reachable for the coordinator's downcast
+            // path (the same path `record_failure` uses).
+            let holder = err
+                .chain()
+                .find_map(|e| e.downcast_ref::<ClipboardHolderInfo>())
+                .expect("holder must survive the trait-object round-trip");
+            assert_eq!(holder.holder_pid, 9999);
+            assert_eq!(holder.holder_exe, "Ditto.exe");
+        }
+
+        // Sixth call must NOT reach the mock — breaker tripped.
+        let err = coord
+            .write(make_snapshot(), ClipboardWriteIntent::RemotePush)
+            .await
+            .expect_err("breaker should reject 6th call");
+        assert!(
+            err.to_string().contains("circuit breaker open"),
+            "expected circuit-open error, got: {err}"
+        );
     }
 
     /// 5 consecutive OS failures must trip the breaker, after which the

--- a/src-tauri/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/usecase.rs
+++ b/src-tauri/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/usecase.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use moka::sync::Cache;
-use tracing::{debug, error, info, instrument, warn, Instrument};
+use tracing::{debug, info, instrument, warn, Instrument};
 use uc_observability::FlowId;
 
 use uc_core::ids::EntryId;
@@ -320,7 +320,18 @@ impl ApplyInboundClipboardUseCase {
             tokio::spawn(
                 async move {
                     if let Err(e) = write_port.write(snapshot_for_write).await {
-                        error!(
+                        // `warn!` (not `error!`): the underlying OS write
+                        // failure already goes through `ClipboardWriteCoordinator`,
+                        // which emits a single `error!(event=circuit_tripped)`
+                        // when the breaker trips (≥ N consecutive failures).
+                        // Logging this as `error!` here would create a duplicate
+                        // Sentry issue for every individual failed inbound
+                        // write — previously the root cause of Q's volume
+                        // (UNICLIPBOARD-RUST-Q). Per sentry-tracing
+                        // EventFilter (see `uc-bootstrap::tracing`),
+                        // WARN→Log keeps this searchable without raising an
+                        // issue.
+                        warn!(
                             event = "inbound_os_write_failed",
                             error_kind = "inbound_os_write_failed",
                             error = %e,

--- a/src-tauri/crates/uc-core/src/ports/clipboard/local_clipboard.rs
+++ b/src-tauri/crates/uc-core/src/ports/clipboard/local_clipboard.rs
@@ -20,5 +20,12 @@ pub trait SystemClipboardPort: Send + Sync {
     /// text, images, files, or other supported content types.
     fn read_snapshot(&self) -> Result<SystemClipboardSnapshot>;
 
+    /// Write a snapshot to the system clipboard.
+    ///
+    /// On failure, the returned `anyhow::Error`'s causal chain may carry
+    /// backend-specific diagnostic records; consumers that care about such
+    /// diagnostics walk the chain via `anyhow::Error::chain()` and
+    /// downcast, but the trait contract does not require any specific
+    /// diagnostic type to be present — its absence is a valid outcome.
     fn write_snapshot(&self, snapshot: SystemClipboardSnapshot) -> Result<()>;
 }

--- a/src-tauri/crates/uc-platform/Cargo.toml
+++ b/src-tauri/crates/uc-platform/Cargo.toml
@@ -163,6 +163,17 @@ clipboard-rs = { version = "0.3.3", features = ["default"] }
 
 [target.'cfg(windows)'.dependencies]
 clipboard-win = { version = "5.4" }
+# Used only by `clipboard::platform::windows::clipboard_holder_diagnostics`
+# to identify which process currently holds the Windows clipboard when a
+# write retry burst exhausts (Sentry UNICLIPBOARD-RUST-R triage). Version
+# tracks the one clipboard-win 5.x already pulls in transitively, so this
+# does not add a second windows-sys to the dep graph.
+windows-sys = { version = "0.61", features = [
+    "Win32_Foundation",
+    "Win32_System_DataExchange",
+    "Win32_System_Threading",
+    "Win32_UI_WindowsAndMessaging",
+] }
 
 # macOS 平台原子多 rep 写入（见 `clipboard/platform/macos.rs::write_snapshot_multi_macos`）。
 # 显式启用 NSPasteboard + NSPasteboardItem feature，以拿到 NSPasteboardTypeString /

--- a/src-tauri/crates/uc-platform/src/clipboard/holder.rs
+++ b/src-tauri/crates/uc-platform/src/clipboard/holder.rs
@@ -1,0 +1,141 @@
+//! Diagnostic data attached by clipboard backends to write-failure errors
+//! when contention can be attributed to a specific foreign process.
+//!
+//! This is **observability metadata**, not a domain concept — pids and
+//! executable names exist only inside a running OS process and have no
+//! meaning to the business layer. It lives in `uc-platform` (the layer
+//! that can probe OS-level clipboard ownership) and rides up to consumers
+//! via `anyhow::Error`'s causal chain. Consumers that care about
+//! contention diagnostics walk the chain and downcast; consumers that
+//! don't see it ignore it.
+
+/// Diagnostic record describing a foreign process that holds the system
+/// clipboard at the moment a write attempt fails because of ownership
+/// contention.
+///
+/// ## Contract
+///
+/// Backends that can identify the contending peer attach this value to the
+/// error chain of [`uc_core::ports::SystemClipboardPort::write_snapshot`];
+/// consumers recover it via
+/// `anyhow::Error::chain().find_map(|e| e.downcast_ref::<ClipboardHolderInfo>())`.
+/// Backends that cannot identify the peer simply omit the attachment — the
+/// absence of the diagnostic is itself information (probe race lost,
+/// ownership not introspectable on this platform, etc.).
+///
+/// ## Layering
+///
+/// To preserve the original error message as the outer `Display` (so log
+/// fields like `error = %err` keep showing the OS-error text), attach via
+/// `anyhow::Error::new(ClipboardHolderInfo { … }).context(human_message)`.
+/// `.context(...)` puts the new layer on top of `Display`, so the holder
+/// must be at the bottom of the chain (the source) and the human message
+/// on top (the context). Reversing this layering shadows the message with
+/// "clipboard held by pid=… exe=…" and silently regresses logs.
+///
+/// ## Semantics
+///
+/// The record reflects ownership *at the moment of probing*, which by
+/// contract should be as close as the backend can practically get to the
+/// original conflict. It is **not** guaranteed to be the same process by
+/// the time the error surfaces upstream; treat it as a strong hint, not a
+/// proof.
+///
+/// Implements [`std::error::Error`] so it can ride along in
+/// `anyhow::Error`'s causal chain via `.context(...)`. The error chain is
+/// the canonical transport — do not add bespoke fields to the
+/// `SystemClipboardPort` trait surface for this.
+#[derive(Debug, Clone)]
+pub struct ClipboardHolderInfo {
+    /// OS-level identifier of the contending process.
+    pub holder_pid: u32,
+    /// Executable name of the contending process (e.g. its file-name
+    /// component). When the backend obtains a pid but cannot resolve the
+    /// executable, it records a sentinel value (such as `"<access denied>"`)
+    /// so a partial result remains observable instead of being silently lost.
+    pub holder_exe: String,
+}
+
+impl std::fmt::Display for ClipboardHolderInfo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "clipboard held by pid={} exe={}",
+            self.holder_pid, self.holder_exe
+        )
+    }
+}
+
+impl std::error::Error for ClipboardHolderInfo {}
+
+#[cfg(test)]
+mod tests {
+    //! Contract tests for [`ClipboardHolderInfo`]'s anyhow transport.
+    //!
+    //! These pin the two invariants consumers depend on:
+    //!
+    //! 1. A backend can attach `ClipboardHolderInfo` to an error such that
+    //!    the human-facing message is preserved as the outer `Display`
+    //!    (so `error = %err` log fields don't get shadowed by the holder
+    //!    record).
+    //! 2. The holder can be recovered by walking `anyhow::Error::chain()`
+    //!    and `downcast_ref`, regardless of how deeply nested it is.
+    //!
+    //! Without these tests the contract is purely a doc-comment claim —
+    //! and the layering is subtle enough that "context puts the new layer
+    //! on top of Display" is easy to flip by accident.
+    use super::*;
+
+    /// The recipe documented above: holder at the bottom
+    /// (`anyhow::Error::new`), human message on top (`.context(...)`). The
+    /// outer `Display` must be the message — not "clipboard held by pid=…".
+    #[test]
+    fn holder_via_context_preserves_outer_display_and_remains_downcastable() {
+        let err = anyhow::Error::new(ClipboardHolderInfo {
+            holder_pid: 4242,
+            holder_exe: "Ditto.exe".to_string(),
+        })
+        .context("OS clipboard write failed: ERROR_ACCESS_DENIED");
+
+        // Outer Display = the human message (not the holder record).
+        assert_eq!(
+            err.to_string(),
+            "OS clipboard write failed: ERROR_ACCESS_DENIED",
+        );
+
+        // Downcast still finds the holder somewhere in the chain.
+        let holder = err
+            .chain()
+            .find_map(|e| e.downcast_ref::<ClipboardHolderInfo>())
+            .expect("holder must be reachable via chain downcast");
+        assert_eq!(holder.holder_pid, 4242);
+        assert_eq!(holder.holder_exe, "Ditto.exe");
+    }
+
+    /// Errors without a holder must still be ergonomic for the consumer —
+    /// the downcast simply returns `None`, no panic, no surprise.
+    #[test]
+    fn chain_without_holder_returns_none_on_downcast() {
+        let err = anyhow::anyhow!("OS clipboard write failed");
+        assert!(err
+            .chain()
+            .find_map(|e| e.downcast_ref::<ClipboardHolderInfo>())
+            .is_none());
+    }
+
+    /// Alternate `{:#}` formatting includes both the message and the
+    /// holder — useful for full-context dumps without losing structured
+    /// downcast access.
+    #[test]
+    fn alternate_display_includes_holder_message() {
+        let err = anyhow::Error::new(ClipboardHolderInfo {
+            holder_pid: 7,
+            holder_exe: "X.exe".to_string(),
+        })
+        .context("top message");
+        let combined = format!("{:#}", err);
+        assert!(combined.contains("top message"), "got: {combined}");
+        assert!(combined.contains("pid=7"), "got: {combined}");
+        assert!(combined.contains("X.exe"), "got: {combined}");
+    }
+}

--- a/src-tauri/crates/uc-platform/src/clipboard/mod.rs
+++ b/src-tauri/crates/uc-platform/src/clipboard/mod.rs
@@ -4,6 +4,7 @@
 #[cfg(any(target_os = "macos", target_os = "windows"))]
 pub mod common;
 pub mod event_loop;
+pub mod holder;
 #[cfg(target_os = "windows")]
 pub mod image_convert;
 pub mod noop;
@@ -17,6 +18,7 @@ pub mod watcher;
 pub use event_loop::{
     build_event_loop, shutdown_channel, PlatformClipboardEventLoop, ShutdownRx, ShutdownTx,
 };
+pub use holder::ClipboardHolderInfo;
 pub use noop::NoopSystemClipboard;
 pub use platform::LocalClipboard;
 pub use watcher::{PlatformEvent, PlatformEventSender};

--- a/src-tauri/crates/uc-platform/src/clipboard/platform/windows.rs
+++ b/src-tauri/crates/uc-platform/src/clipboard/platform/windows.rs
@@ -1,5 +1,6 @@
 use super::super::common::CommonClipboardImpl;
 use super::super::payload::rep_bytes;
+use crate::clipboard::ClipboardHolderInfo;
 use anyhow::Result;
 use async_trait::async_trait;
 use clipboard_rs::{Clipboard, ClipboardContext};
@@ -250,6 +251,108 @@ fn classify_windows_write_error(err: &anyhow::Error) -> &'static str {
     }
 }
 
+/// Probe the process currently holding the Windows clipboard.
+///
+/// Returns `Some((pid, exe_name))` when the clipboard is open by another
+/// process and we can identify it. Any failure along the chain — clipboard
+/// not open, target process gone, OpenProcess access denied, image-name
+/// query failed — collapses to `None` (or a sentinel exe name when we got
+/// the pid but couldn't resolve the path). The probe must never fail loud:
+/// it is best-effort diagnostic data attached to a *different* failure, and
+/// any panic / unwrap here would mask the real write error.
+///
+/// ## When to call
+///
+/// Call immediately after the *first* failed write attempt, before any
+/// backoff sleep. `GetOpenClipboardWindow` only returns a valid HWND while
+/// some process has the clipboard open — by the time the outer retry loop
+/// has slept 100ms+500ms+2000ms and given up, the original contender has
+/// almost certainly closed it (and a different, innocent process may have
+/// opened it in the meantime, which would give us a misleading holder tag).
+/// The first failure is the closest we can get to the actual conflict.
+///
+/// ## Why pid alone isn't enough
+///
+/// pid → exe name resolution requires `OpenProcess` + `QueryFullProcessImageNameW`.
+/// We deliberately use `PROCESS_QUERY_LIMITED_INFORMATION` (not
+/// `QUERY_INFORMATION`) so antivirus / protected processes don't trip on
+/// the probe — they're exactly the processes most likely to be holding the
+/// clipboard. Even so, some protected processes will deny even the limited
+/// query; the sentinel exe name lets the operator see "pid known, exe
+/// blocked" rather than silently dropping the pid.
+#[cfg(windows)]
+fn clipboard_holder_diagnostics() -> Option<(u32, String)> {
+    use std::ffi::OsString;
+    use std::os::windows::ffi::OsStringExt;
+    use windows_sys::Win32::Foundation::CloseHandle;
+    use windows_sys::Win32::System::DataExchange::GetOpenClipboardWindow;
+    use windows_sys::Win32::System::Threading::{
+        OpenProcess, QueryFullProcessImageNameW, PROCESS_QUERY_LIMITED_INFORMATION,
+    };
+    use windows_sys::Win32::UI::WindowsAndMessaging::GetWindowThreadProcessId;
+
+    // SAFETY: `GetOpenClipboardWindow` is a pure read with no preconditions
+    // and is safe to call from any thread. Returns NULL HWND when no
+    // process has the clipboard open.
+    let hwnd = unsafe { GetOpenClipboardWindow() };
+    if hwnd.is_null() {
+        return None;
+    }
+
+    let mut pid: u32 = 0;
+    // SAFETY: `hwnd` is a valid non-null HWND just returned by the OS;
+    // `&mut pid` is a valid mutable u32 pointer. The function writes pid
+    // through the out param and returns the tid (we don't need it).
+    unsafe { GetWindowThreadProcessId(hwnd, &mut pid) };
+    if pid == 0 {
+        // hwnd became invalid between the two calls (holder process
+        // exited). Nothing actionable; drop the probe silently.
+        return None;
+    }
+
+    // SAFETY: `PROCESS_QUERY_LIMITED_INFORMATION` is sufficient for
+    // `QueryFullProcessImageNameW` and is the least-privileged access
+    // mask that works against AV / protected processes. Returns NULL on
+    // access-denied or process-gone.
+    let handle = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid) };
+    if handle.is_null() {
+        // We have the pid but can't open the process — surface the pid
+        // alone with a sentinel name so operators can see the partial
+        // result instead of losing the whole probe.
+        return Some((pid, String::from("<access denied>")));
+    }
+
+    let mut buf: [u16; 1024] = [0; 1024];
+    let mut len: u32 = buf.len() as u32;
+    // SAFETY: `handle` is a valid process handle from OpenProcess above;
+    // `buf.as_mut_ptr()` is a valid u16 buffer of declared `len`; `&mut len`
+    // is a valid in/out u32 pointer. Returns 0 on failure.
+    let ok = unsafe { QueryFullProcessImageNameW(handle, 0, buf.as_mut_ptr(), &mut len) };
+    // SAFETY: `handle` was obtained via OpenProcess above and is non-null
+    // here; CloseHandle takes ownership. Closing once unconditionally
+    // before we leave the function avoids the leak that an early-return
+    // ladder would have introduced.
+    unsafe { CloseHandle(handle) };
+
+    if ok == 0 {
+        return Some((pid, String::from("<query failed>")));
+    }
+
+    let exe_path = OsString::from_wide(&buf[..len as usize])
+        .to_string_lossy()
+        .into_owned();
+    // Strip the directory — full Win32 paths often contain user-specific
+    // tokens (`C:\Users\<name>\…`) that add noise without aiding triage.
+    // The exe name is what tells us "Ditto.exe" vs "MsMpEng.exe" vs
+    // "TextInputHost.exe".
+    let exe_name = std::path::Path::new(&exe_path)
+        .file_name()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or(exe_path);
+
+    Some((pid, exe_name))
+}
+
 /// Windows 原子多 representation 写入。
 ///
 /// 在**单次** `OpenClipboard` 会话内写入多个剪贴板格式（CF_UNICODETEXT + CF_HTML +
@@ -401,6 +504,12 @@ pub(crate) fn write_snapshot_multi_windows(snapshot: SystemClipboardSnapshot) ->
     // 要么含极少量已写入格式（尚未让用户感知），重新 empty 不会进一步损失用户
     // 可见的内容。
     let mut last_err: Option<anyhow::Error> = None;
+    // Holder probe captured at the *first* failed attempt — see
+    // `clipboard_holder_diagnostics` doc for why probing later (after
+    // backoff sleeps) tends to point at innocent bystanders rather than
+    // the actual contender. `None` if every attempt succeeded or the
+    // probe itself couldn't identify a holder.
+    let mut first_failure_holder: Option<(u32, String)> = None;
     for attempt in 0..MAX_WRITE_ATTEMPTS {
         if attempt > 0 {
             std::thread::sleep(std::time::Duration::from_millis(
@@ -427,6 +536,11 @@ pub(crate) fn write_snapshot_multi_windows(snapshot: SystemClipboardSnapshot) ->
             }
             Err(e) => {
                 let error_kind = classify_windows_write_error(&e);
+                if attempt == 0 {
+                    // Probe BEFORE the backoff sleep below — the holder is
+                    // most likely still there in this microsecond window.
+                    first_failure_holder = clipboard_holder_diagnostics();
+                }
                 warn!(
                     event = "windows_multi_write_attempt_failed",
                     error_kind,
@@ -449,23 +563,65 @@ pub(crate) fn write_snapshot_multi_windows(snapshot: SystemClipboardSnapshot) ->
         .as_ref()
         .map(classify_windows_write_error)
         .unwrap_or("unknown");
-    error!(
+    // `holder_at_first_failure_*` names emphasise the probe timing — these
+    // are NOT necessarily the holder at the moment the exhausted event was
+    // logged ~2.6s later. `?` debug repr keeps `None` visible literally so
+    // operators can distinguish "probe couldn't identify" from a missing
+    // field.
+    let (holder_pid, holder_exe) = match &first_failure_holder {
+        Some((pid, exe)) => (Some(*pid), Some(exe.as_str())),
+        None => (None, None),
+    };
+    // `warn!` (not `error!`): a single exhausted retry burst is transient
+    // OS contention; `ClipboardWriteCoordinator` upstream tracks the
+    // consecutive-failure count and promotes to `error!` (which sentry-tracing
+    // maps to a Sentry Event) once the breaker trips. See
+    // `uc-bootstrap::tracing` for the WARN→Log / ERROR→Event mapping that
+    // avoids creating duplicate Sentry issues for the same underlying
+    // failure (previously R + Q + F were three separate issues for one
+    // failure). The holder fields stay on this `warn!` so platform-layer
+    // logs remain self-contained for grep / dashboard queries; the holder
+    // also rides up the error chain (below) so the eventual
+    // `circuit_tripped` event can include it as structured fields without
+    // depending on log-side correlation.
+    warn!(
         event = "windows_multi_write_exhausted",
         error_kind = "windows_multi_write_exhausted",
         final_attempt_error_kind = final_error_kind,
         max_attempts = MAX_WRITE_ATTEMPTS,
         cumulative_backoff_ms,
+        holder_at_first_failure_pid = ?holder_pid,
+        holder_at_first_failure_exe = ?holder_exe,
         error = ?last_err.as_ref().map(|e| e.to_string()),
         "Windows 多 rep 写入：所有重试已耗尽"
     );
 
-    anyhow::bail!(
+    // Build the surface error. When we identified a holder, put
+    // `ClipboardHolderInfo` at the BOTTOM of the chain and the human
+    // message on top via `.context(...)` — `anyhow`'s Display shows the
+    // outermost layer, so this preserves the original message as the
+    // `error = %err` log field while still letting consumers recover the
+    // holder via `err.chain().find_map(|e| e.downcast_ref::<ClipboardHolderInfo>())`
+    // (the canonical transport per `uc-core::ports::clipboard`). Reversing
+    // the layering (holder on top) would shadow the message with
+    // "clipboard held by pid=… exe=…" — Display defaults to the outermost
+    // node, not the chain.
+    let context_msg = format!(
         "Windows 多 rep 写入：{} 次尝试均失败；最后一次错误：{}",
         MAX_WRITE_ATTEMPTS,
         last_err
             .map(|e| e.to_string())
             .unwrap_or_else(|| "<unknown>".to_string())
-    )
+    );
+    let surface_err = match first_failure_holder {
+        Some((pid, exe)) => anyhow::Error::new(ClipboardHolderInfo {
+            holder_pid: pid,
+            holder_exe: exe,
+        })
+        .context(context_msg),
+        None => anyhow::Error::msg(context_msg),
+    };
+    Err(surface_err)
 }
 
 /// 单次写入尝试：打开 → empty → 逐 rep 写入 → guard drop 时关闭。


### PR DESCRIPTION
## Summary

- When a Windows clipboard write retry burst fails (typically `ERROR_ACCESS_DENIED` from AV / IME / RDP clip proxy / a clipboard manager like Ditto), probe the foreign process that's currently holding the clipboard on the **first** failed attempt and carry the `holder_pid` / `holder_exe` through the `anyhow` error chain. `ClipboardWriteCoordinator` then attaches them to the `circuit_tripped` Sentry event — so "5 access-denied retries" becomes "Ditto.exe is holding the clipboard" without any log-time correlation step. (b2720550)
- Collapses three duplicate Sentry issues (UNICLIPBOARD-RUST-R / -Q / -F) into a single actionable signal: per-failure events drop from `error!` → `warn!` (sentry-tracing maps WARN to a Log only, not an Issue), and `circuit_tripped` stays `error!` as the one on-call page. (b2720550)

Implementation notes:

- `uc-platform::clipboard::ClipboardHolderInfo` lives in the platform layer (pid/exe are OS-level, not domain concepts) and rides upstream via `anyhow::Error::new(holder).context(message)` so the outer `Display` is preserved.
- Holder is probed **before** any backoff sleep, so the recorded process is the actual contender rather than an innocent bystander that grabbed the clipboard during the ~2.6 s retry burst.
- `SystemClipboardPort` trait surface is unchanged; the coordinator downcasts via `err.chain().find_map(downcast_ref)` on the failure path. macOS / Linux / Noop backends require no changes.

## Test plan

- [x] `cargo check --target x86_64-pc-windows-gnu --tests` across `uc-core` / `uc-platform` / `uc-application` / `uc-bootstrap`.
- [x] `holder.rs` unit tests pin the contract: chain transport, `Display` preservation, alternate-formatting fallback.
- [x] `coordinator::tests` end-to-end test covers the trait-object round-trip through the mock port.
- [ ] On a real Windows host, reproduce a clipboard contention scenario (e.g. Ditto running) and confirm the next `circuit_tripped` Sentry event carries `holder_pid` and `holder_exe` tags.
- [ ] Confirm in Sentry that per-attempt failures show up as Logs only (no new Issues created), while the `circuit_tripped` event still creates a single Issue with the structured tags attached.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced clipboard write failure diagnostics to identify which process is holding the clipboard when write attempts fail.
  * Improved error tracking and circuit breaker behavior for clipboard synchronization failures.

* **Documentation**
  * Added documentation clarifying error diagnostics for clipboard operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/UniClipboard/UniClipboard/pull/856?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->