### PR TITLE
fix: recover phase-3 migration from every unlock path

### DIFF
--- a/src-tauri/crates/uc-application/src/facade/space_setup/facade.rs
+++ b/src-tauri/crates/uc-application/src/facade/space_setup/facade.rs
@@ -502,6 +502,20 @@ impl SpaceSetupFacade {
     ) -> Result<UnlockSpaceResult, UnlockSpaceError> {
         let cmd: UnlockSpaceCommand = input.into();
         let out = self.unlock_space.execute(cmd).await?;
+
+        // Switch-space migration recovery hook — 镜像 try_resume_session:412-419。
+        // 手动 unlock 也必须推进 migration replay：startup_recovery 在 auto-unlock
+        // 关闭时会跳过 try_resume_session（避免无 KEK 弹钥匙串），那 hook 就不会
+        // 接管 pending HandshakeDone migration。没有这一行, 用户在 auto-unlock=off
+        // 的设备上一旦 phase 3 中断, 主表 inline 永远停在旧 master_key 加密、
+        // session 持新 master_key 的 wedged 态 —— UI 看不到任何历史。
+        if let Err(err) = self.switch_space.resume_pending().await {
+            warn!(error = %err, "switch-space resume_pending failed during unlock_space");
+            return Err(UnlockSpaceError::Internal(format!(
+                "migration resume failed: {err}"
+            )));
+        }
+
         self.auto_prime_presence().await;
         Ok(out)
     }
@@ -1227,7 +1241,28 @@ mod tests {
     // 验证留给 `usecases::setup::switch_space::tests` 与下面的
     // `switch_space::*` smoke。
 
-    struct FakeMigrationState;
+    /// 内存版 `MigrationStatePort`，默认行为与之前一致（`None` + 任意写都成功）。
+    /// 新增能力：通过 `with_phase` / `with_get_failure` 让单测注入 pending 阶段
+    /// 或读失败，覆盖 unlock_space → resume_pending hook 的两条关键分支。
+    #[derive(Default)]
+    struct FakeMigrationState {
+        current: StdMutex<Option<uc_core::setup::MigrationPhase>>,
+        fail_get: std::sync::atomic::AtomicBool,
+    }
+    impl FakeMigrationState {
+        fn with_phase(phase: uc_core::setup::MigrationPhase) -> Self {
+            Self {
+                current: StdMutex::new(Some(phase)),
+                fail_get: std::sync::atomic::AtomicBool::new(false),
+            }
+        }
+        fn with_get_failure() -> Self {
+            Self {
+                current: StdMutex::new(None),
+                fail_get: std::sync::atomic::AtomicBool::new(true),
+            }
+        }
+    }
     #[async_trait]
     impl uc_core::ports::setup::MigrationStatePort for FakeMigrationState {
         async fn get_current(
@@ -1236,12 +1271,18 @@ mod tests {
             Option<uc_core::setup::MigrationPhase>,
             uc_core::ports::setup::MigrationStateError,
         > {
-            Ok(None)
+            if self.fail_get.load(std::sync::atomic::Ordering::SeqCst) {
+                return Err(uc_core::ports::setup::MigrationStateError::Storage(
+                    "injected migration_state get failure".into(),
+                ));
+            }
+            Ok(self.current.lock().unwrap().clone())
         }
         async fn set_current(
             &self,
-            _phase: Option<uc_core::setup::MigrationPhase>,
+            phase: Option<uc_core::setup::MigrationPhase>,
         ) -> Result<(), uc_core::ports::setup::MigrationStateError> {
+            *self.current.lock().unwrap() = phase;
             Ok(())
         }
     }
@@ -1377,6 +1418,24 @@ mod tests {
         Arc<FakeInvitationPort>,
         Arc<FakePeerAddrRepo>,
     ) {
+        make_facade_with_migration_state(
+            space_access,
+            setup_status,
+            settings,
+            Arc::new(FakeMigrationState::default()),
+        )
+    }
+
+    fn make_facade_with_migration_state(
+        space_access: Arc<dyn SpaceAccessPort>,
+        setup_status: Arc<dyn SetupStatusPort>,
+        settings: Arc<dyn SettingsPort>,
+        migration_state: Arc<FakeMigrationState>,
+    ) -> (
+        SpaceSetupFacade,
+        Arc<FakeInvitationPort>,
+        Arc<FakePeerAddrRepo>,
+    ) {
         let pairing_invitation = Arc::new(FakeInvitationPort::default());
         let peer_addr_repo = Arc::new(FakePeerAddrRepo::default());
         let facade = SpaceSetupFacade::new(SpaceSetupDeps {
@@ -1401,7 +1460,7 @@ mod tests {
             peer_addr_repo: Arc::clone(&peer_addr_repo)
                 as Arc<dyn uc_core::ports::PeerAddressRepositoryPort>,
             presence: Arc::new(FakePresence),
-            migration_state: Arc::new(FakeMigrationState),
+            migration_state,
             key_migration: Arc::new(FakeKeyMigration),
             blob_migration_repo: Arc::new(FakeBlobMigrationRepo),
             blob_cipher: Arc::new(FakeBlobCipher),
@@ -1504,6 +1563,77 @@ mod tests {
         };
         let err = facade.unlock_space(cmd).await.unwrap_err();
         assert!(matches!(err, UnlockSpaceError::WrongPassphrase));
+    }
+
+    #[tokio::test]
+    async fn unlock_space_drives_resume_pending_when_migration_pending() {
+        // 回归 phase 3 中断后没人推进的 wedged 态：startup_recovery 在
+        // auto-unlock 关闭时会跳过 try_resume_session，那时 unlock_space
+        // 是唯一能在解锁后接管 migration replay 的入口。
+        //
+        // Prepared 分支走 cleanup_after_phase2_failure：跑完后
+        // migration_state 应被推回 None（验证 hook 真的被触发了，而不是
+        // 拿了个空 phase 跑回 noop）。
+        let setup_status = InMemorySetupStatus::default();
+        *setup_status.status.lock().unwrap() = SetupStatus {
+            has_completed: true,
+            space_id: None,
+        };
+        let migration_state = Arc::new(FakeMigrationState::with_phase(
+            uc_core::setup::MigrationPhase::Prepared {
+                run_id: uc_core::setup::MigrationRunId::new("test-pending-run"),
+            },
+        ));
+        let (facade, _inv, _peer) = make_facade_with_migration_state(
+            Arc::new(FakeSpaceAccess::default()),
+            Arc::new(setup_status),
+            Arc::new(InMemorySettings::default()),
+            Arc::clone(&migration_state),
+        );
+        let cmd = UnlockSpaceInput {
+            passphrase: "hunter22hunter22".to_string(),
+        };
+        facade
+            .unlock_space(cmd)
+            .await
+            .expect("unlock_space succeeds with Prepared phase recovery");
+        let after = uc_core::ports::setup::MigrationStatePort::get_current(&*migration_state)
+            .await
+            .expect("get_current ok");
+        assert!(
+            after.is_none(),
+            "resume_pending Prepared 分支应清掉 migration_state，实际仍为 {after:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn unlock_space_returns_internal_when_resume_pending_fails() {
+        // resume_pending 任何失败都要冒到 unlock_space 调用方，不能 silent
+        // 吞掉——否则又会复刻 fedora 事故：session 拿到新 master_key，但
+        // 主表仍用旧 key，UI 看不到任何数据，daemon 还报 "解锁成功"。
+        let setup_status = InMemorySetupStatus::default();
+        *setup_status.status.lock().unwrap() = SetupStatus {
+            has_completed: true,
+            space_id: None,
+        };
+        let migration_state = Arc::new(FakeMigrationState::with_get_failure());
+        let (facade, _inv, _peer) = make_facade_with_migration_state(
+            Arc::new(FakeSpaceAccess::default()),
+            Arc::new(setup_status),
+            Arc::new(InMemorySettings::default()),
+            migration_state,
+        );
+        let cmd = UnlockSpaceInput {
+            passphrase: "hunter22hunter22".to_string(),
+        };
+        let err = facade.unlock_space(cmd).await.unwrap_err();
+        match err {
+            UnlockSpaceError::Internal(msg) => assert!(
+                msg.contains("migration resume failed"),
+                "expected prefix in internal message, got {msg}"
+            ),
+            other => panic!("expected Internal, got {other:?}"),
+        }
     }
 
     // ── F2 shutdown ──────────────────────────────────────────────────────

--- a/src-tauri/crates/uc-infra/src/security/key_migration_adapter.rs
+++ b/src-tauri/crates/uc-infra/src/security/key_migration_adapter.rs
@@ -9,7 +9,8 @@
 //! 命名规则平行；`v1:` 前缀做版本化预留，未来切算法时新版本走 `v2:`，
 //! 旧 entry 可以共存。
 
-use std::sync::Arc;
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
 
 use async_trait::async_trait;
 use rand::RngCore;
@@ -26,29 +27,47 @@ const KEYRING_PREFIX: &str = "migration_key:v1:";
 
 pub struct DefaultKeyMigrationAdapter {
     secure_storage: Arc<dyn SecureStoragePort>,
+    // 进程内缓存：phase 3 swap 循环会按条目反复调 decrypt_with_migration_key，
+    // 在 Linux 上每次穿透到 secret-service 都是一次 D-Bus 往返。Linux gnome-keyring
+    // 在数百次连续 get_secret 后会主动断开客户端连接，导致 phase 3 中途
+    // permission denied、配对回滚。缓存让一次 switch_space 内多条 record 只
+    // 触发一次 SecureStoragePort::get；discard_migration_key 时连带清掉缓存
+    // 项，确保 phase 4 后的"已 discard 但仍能命中缓存"不会发生。
+    key_cache: RwLock<HashMap<MigrationRunId, Arc<MasterKey>>>,
 }
 
 impl DefaultKeyMigrationAdapter {
     pub fn new(secure_storage: Arc<dyn SecureStoragePort>) -> Self {
-        Self { secure_storage }
+        Self {
+            secure_storage,
+            key_cache: RwLock::new(HashMap::new()),
+        }
     }
 
     fn keyring_name(run_id: &MigrationRunId) -> String {
         format!("{KEYRING_PREFIX}{}", run_id.as_str())
     }
 
-    fn load_key(&self, run_id: &MigrationRunId) -> Result<MasterKey, KeyMigrationError> {
+    fn load_key(&self, run_id: &MigrationRunId) -> Result<Arc<MasterKey>, KeyMigrationError> {
+        if let Some(cached) = self.key_cache.read().unwrap().get(run_id) {
+            return Ok(Arc::clone(cached));
+        }
+
         let name = Self::keyring_name(run_id);
         let raw = self
             .secure_storage
             .get(&name)
             .map_err(|e| KeyMigrationError::Internal(format!("secure_storage.get: {e}")))?;
-        match raw {
-            None => Err(KeyMigrationError::NotFound(run_id.clone())),
-            Some(bytes) => MasterKey::from_bytes(&bytes).map_err(|e| {
-                KeyMigrationError::Internal(format!("invalid migration key bytes: {e}"))
-            }),
-        }
+        let bytes = match raw {
+            None => return Err(KeyMigrationError::NotFound(run_id.clone())),
+            Some(b) => b,
+        };
+        let key = MasterKey::from_bytes(&bytes).map_err(|e| {
+            KeyMigrationError::Internal(format!("invalid migration key bytes: {e}"))
+        })?;
+        let mut cache = self.key_cache.write().unwrap();
+        let entry = cache.entry(run_id.clone()).or_insert_with(|| Arc::new(key));
+        Ok(Arc::clone(entry))
     }
 }
 
@@ -137,31 +156,42 @@ impl KeyMigrationPort for DefaultKeyMigrationAdapter {
         // 文档约定本方法幂等，所以 happy path 上重复调用应当无副作用。
         self.secure_storage
             .delete(&name)
-            .map_err(|e| KeyMigrationError::Internal(format!("secure_storage.delete: {e}")))
+            .map_err(|e| KeyMigrationError::Internal(format!("secure_storage.delete: {e}")))?;
+        // 缓存与 keyring 保持一致：discard 之后再 encrypt/decrypt 必须按
+        // NotFound 处理，否则会出现"keyring 已清但内存仍能解密"的幽灵态。
+        self.key_cache.write().unwrap().remove(run_id);
+        Ok(())
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::HashMap;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Mutex;
 
     use uc_core::ports::SecureStorageError;
 
     /// 内存版 `SecureStoragePort` fake：足够覆盖本 adapter 的契约测试。
+    /// `get_calls` 记录穿透到底层的 get 次数，缓存命中测试用它断言旁路效果。
     struct InMemorySecureStorage {
         entries: Mutex<HashMap<String, Vec<u8>>>,
+        get_calls: AtomicUsize,
     }
     impl InMemorySecureStorage {
         fn new() -> Self {
             Self {
                 entries: Mutex::new(HashMap::new()),
+                get_calls: AtomicUsize::new(0),
             }
+        }
+        fn get_call_count(&self) -> usize {
+            self.get_calls.load(Ordering::SeqCst)
         }
     }
     impl SecureStoragePort for InMemorySecureStorage {
         fn get(&self, key: &str) -> Result<Option<Vec<u8>>, SecureStorageError> {
+            self.get_calls.fetch_add(1, Ordering::SeqCst);
             Ok(self.entries.lock().unwrap().get(key).cloned())
         }
         fn set(&self, key: &str, value: &[u8]) -> Result<(), SecureStorageError> {
@@ -281,5 +311,57 @@ mod tests {
     async fn fresh_run_id_starts_with_mig_prefix() {
         let id = fresh_run_id();
         assert!(id.as_str().starts_with("mig-"), "got {id}");
+    }
+
+    #[tokio::test]
+    async fn repeated_decrypt_hits_secure_storage_at_most_once() {
+        // 回归 Linux gnome-keyring 在 phase 3 swap 中被密集打挂的问题：一次
+        // switch_space 里上百条 record 都用同一把 migration_key 解密，必须命
+        // 中 adapter 内的缓存、只穿透 secure_storage.get 一次。
+        let (adapter, storage) = build_adapter();
+        let run_id = adapter.prepare_migration_key().await.unwrap();
+        let baseline = storage.get_call_count();
+
+        let aad = Aad::new(b"aad".to_vec());
+        let ct = adapter
+            .encrypt_with_migration_key(&run_id, &Plaintext::new(b"x".to_vec()), &aad)
+            .await
+            .unwrap();
+        for _ in 0..200 {
+            adapter
+                .decrypt_with_migration_key(&run_id, &ct, &aad)
+                .await
+                .unwrap();
+        }
+
+        // encrypt 触发首次 load_key（cache miss → 1 次 get），之后 200 次
+        // decrypt 全部命中缓存。所以净增量恰好是 1。
+        assert_eq!(storage.get_call_count() - baseline, 1);
+    }
+
+    #[tokio::test]
+    async fn discard_clears_key_cache() {
+        // 防止"已 discard 但缓存仍能解密"的幽灵态：discard 之后必须重新走
+        // secure_storage，且因为 keyring 已经清空，结果是 NotFound。
+        let (adapter, _) = build_adapter();
+        let run_id = adapter.prepare_migration_key().await.unwrap();
+        let aad = Aad::new(b"aad".to_vec());
+        let ct = adapter
+            .encrypt_with_migration_key(&run_id, &Plaintext::new(b"x".to_vec()), &aad)
+            .await
+            .unwrap();
+        // 先让缓存填上。
+        adapter
+            .decrypt_with_migration_key(&run_id, &ct, &aad)
+            .await
+            .unwrap();
+
+        adapter.discard_migration_key(&run_id).await.unwrap();
+
+        let err = adapter
+            .decrypt_with_migration_key(&run_id, &ct, &aad)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, KeyMigrationError::NotFound(_)));
     }
 }

--- a/src-tauri/crates/uc-tauri/src/commands/space_setup.rs
+++ b/src-tauri/crates/uc-tauri/src/commands/space_setup.rs
@@ -206,10 +206,19 @@ pub async fn try_silent_unlock(
     record_trace_fields(&span, &_trace);
 
     async move {
+        // Route to `AppFacade.try_resume_session` rather than the bare
+        // `encryption.unlock`. The thin variant only resumes the
+        // session; the wrapped variant also fires the switch-space
+        // migration recovery hook (`resume_pending`). Without that hook,
+        // a device that crashed mid-`switch_space` silently lands here
+        // on next launch, gets a new master_key, leaves the main table
+        // inline_data encrypted under the prior key, and surfaces as
+        // "no history" in the UI — exactly the wedged state we just
+        // dug out of on fedora dev. Mirrors the webserver handler fix
+        // since GUI in-process traffic doesn't go through HTTP.
         let resumed = runtime
             .app_facade()
-            .encryption
-            .unlock()
+            .try_resume_session()
             .await
             .map_err(|err| TrySilentUnlockError::Internal {
                 message: err.to_string(),

--- a/src-tauri/crates/uc-webserver/src/api/encryption.rs
+++ b/src-tauri/crates/uc-webserver/src/api/encryption.rs
@@ -88,7 +88,16 @@ async fn unlock_handler(
 ) -> Result<Json<serde_json::Value>, ApiError> {
     let app = state.app_facade_or_error()?;
 
-    match app.encryption.unlock().await {
+    // Route to `space_setup.try_resume_session()` rather than the bare
+    // `encryption.unlock()`. The thin variant only resumes the session;
+    // the SpaceSetupFacade variant also runs the switch-space migration
+    // recovery hook (`resume_pending`) so a pending HandshakeDone replay
+    // gets advanced the moment the session unlocks. Without that, a
+    // device that crashed mid-`switch_space` would silently land here,
+    // get a new master_key, leave the main table inline_data encrypted
+    // with the previous key, and surface as "no history" in the UI —
+    // exactly the wedged state we just dug out of on fedora dev.
+    match app.try_resume_session().await {
         Ok(true) => {
             info!("encryption session auto-unlocked via keyring");
 


### PR DESCRIPTION
## Summary

- 加 KEK 进程内缓存让 phase 3 swap 循环不再每条记录都穿透 secret-service。Linux gnome-keyring 在数百次连续 `get_secret` 后会主动断开客户端连接，导致 phase 3 中途 permission denied、配对回滚 (`2b9530c9`)。
- 把 switch-space migration recovery hook 从 `startup_recovery` 复制到 `SpaceSetupFacade.unlock_space`：auto-unlock 关闭时 `startup_recovery` 会跳过 `try_resume_session`（避免无 KEK 弹钥匙串），那时手动 unlock 就是唯一能续上 pending HandshakeDone 的入口 (`e6a90616`)。
- `/encryption/unlock` HTTP handler 改走 `try_resume_session()` 而非裸 `encryption.unlock()`，让 web API 解锁路径也驱动 migration replay (`1da88dd4`)。
- Tauri `try_silent_unlock` 命令同样改走 `try_resume_session()`，GUI in-process silent unlock 不再绕过 hook (`7380df8b`)。

修复的 wedged 态：phase 3 中断后 session 拿到新 master_key，但主表 `inline_data` 仍用旧 key 加密，UI 表现为"无历史"，daemon 还报"解锁成功"——已经在 fedora dev 上挖出过。

## Test plan

- [x] `cargo test -p uc-application` —— 新增 `unlock_space_drives_resume_pending_when_migration_pending` / `unlock_space_returns_internal_when_resume_pending_fails` 覆盖 hook 触发与错误冒泡两条分支。
- [x] `cargo test -p uc-infra security::key_migration_adapter::tests` —— `get_call_count` 断言 KEK 缓存命中、`discard_migration_key` 后缓存清除。
- [x] 手动回归：auto-unlock=off 的 Linux 设备 phase 3 中断后，下次启动 + 手动 unlock 应能恢复历史，而非停在 wedged 态。
- [x] 手动回归：web API `POST /encryption/unlock` 在 phase 3 中断后驱动 migration replay。
- [x] 手动回归：GUI silent unlock（Tauri 启动路径）在 phase 3 中断后驱动 migration replay。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Migration recovery mechanism now executes during unlock to resolve pending states and prevent locked states.
  * Added error handling for failed migration recovery during unlock.

* **Performance**
  * Optimized key retrieval with in-process caching to reduce repeated secure storage access during encryption operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/UniClipboard/UniClipboard/pull/857?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->