### PR TITLE
chore(coderabbit): scope chinese-doc rule to user-facing docs

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,5 +1,11 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
 reviews:
+  path_filters:
+    # 开发自留地：调研笔记、agent skill、一次性诊断 crate 不进入 CodeRabbit 审查。
+    # 这些路径的语言/格式不要求与对外文档一致，bot 在这里发的几乎全是噪音。
+    - '!.planning/**'
+    - '!.claude/**'
+    - '!src-tauri/crates/p2p-bench/**'
   auto_review:
     enabled: true
     auto_incremental_review: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,9 +14,10 @@ Do not treat this file as a full memory dump. Read only the documents needed for
 - Use repo-relative paths in tracked docs.
 - Use language identifiers on fenced code blocks.
 - When conversation is in Chinese, respond in natural Chinese.
-- 本项目的代码注释与项目文档一律使用中文（包括 `docs/`、`.planning/`、crate 级 `AGENTS.md`、README、代码中的 `//` / `///` / `/* */` 注释、doc comments 等）。此约定覆盖全局 `CLAUDE.md` 中"写文档用英文"的默认规则。
+- 本项目的 **代码注释与对外项目文档** 使用中文，覆盖范围：`docs/`、README、crate 级 `AGENTS.md`、`CONTRIBUTING*.md`、以及代码中的 `//` / `///` / `/* */` / doc comments。此约定覆盖全局 `CLAUDE.md` 中"写文档用英文"的默认规则。
   - 例外：Git commit message / PR 标题与描述 / 代码标识符（函数、类型、变量名）保持英文，保证工具链与外部协作的兼容性。
   - 引用外部规范（RFC、标准库 API 等）时，专有名词可保留英文原文。
+  - **不强制中文的开发自留路径**：`.planning/`（调研/spike 笔记）、`.claude/`（本地 agent skill 与工具）、`publish = false` 的诊断 crate（例如 `src-tauri/crates/p2p-bench`）。这些目录按写作者方便即可，CodeRabbit 也已在 `.coderabbit.yaml` 中跳过。
 - `CLAUDE.md` is only a compatibility entrypoint. This file is the root instruction source.
 
 ## Read-on-Demand Map

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -267,7 +267,7 @@ Pre-commit hooks (via Husky and lint-staged) automatically run `eslint`, `pretti
 
 ### Style Guidelines
 
-- **Comments and project documentation are written in Chinese**, per `AGENTS.md`. Identifiers, commit messages, and PR titles/descriptions remain English so tooling and external collaborators stay aligned.
+- **Code comments and user-facing project documentation are written in Chinese**, per `AGENTS.md` — covers `docs/`, `README`, crate-level `AGENTS.md`, `CONTRIBUTING*.md`, and code comments. Identifiers, commit messages, and PR titles/descriptions remain English so tooling and external collaborators stay aligned. Developer scratch paths — `.planning/`, `.claude/`, and `publish = false` diagnostic crates — are exempt and are also excluded from CodeRabbit review via `.coderabbit.yaml`.
 - **No machine-specific absolute paths** in tracked files. Use repo-relative paths in docs and configuration.
 - **Markdown fenced code blocks must include a language identifier** (`bash`, `rust`, `ts`, `text`, etc.).
 - **Frontend code** follows the rules in [`docs/agent/frontend-ui-rules.md`](./docs/agent/frontend-ui-rules.md).

--- a/CONTRIBUTING_ZH.md
+++ b/CONTRIBUTING_ZH.md
@@ -230,7 +230,7 @@ fix(devices): show real online state and cut offline detection latency
 chore(observability): silence swarm_discovery::socket EHOSTUNREACH spam
 ```
 
-> commit 信息、PR 标题与描述使用英文，确保工具链与外部协作者通用。代码注释和项目内文档使用中文。
+> commit 信息、PR 标题与描述使用英文，确保工具链与外部协作者通用。代码注释和对外项目文档使用中文（详细范围与豁免目录见下方"代码风格与质量"小节）。
 
 ### 应避免的写法
 
@@ -264,7 +264,7 @@ cargo clippy --workspace --all-targets -- -D warnings
 
 ### 风格约定
 
-- **代码注释和项目文档使用中文**（依据 `AGENTS.md`）。代码标识符、commit message、PR 标题与描述保持英文，便于工具链与外部协作。
+- **代码注释与对外项目文档使用中文**（依据 `AGENTS.md`，覆盖 `docs/`、README、crate 级 `AGENTS.md`、`CONTRIBUTING*.md`、代码注释）。代码标识符、commit message、PR 标题与描述保持英文，便于工具链与外部协作。开发自留路径 —— `.planning/`、`.claude/`、`publish = false` 的诊断 crate —— 不强制中文，且已在 `.coderabbit.yaml` 中排除 CodeRabbit 审查。
 - 仓库内文件 **不得包含机器特定的绝对路径**，统一使用相对仓库根的路径。
 - Markdown 代码围栏 **必须带语言标识**（`bash`、`rust`、`ts`、`text` 等）。
 - **前端代码** 遵循 [`docs/agent/frontend-ui-rules.md`](./docs/agent/frontend-ui-rules.md)。


### PR DESCRIPTION
## Summary

- **Add `reviews.path_filters` in `.coderabbit.yaml`** to exclude `.planning/**`, `.claude/**`, and `src-tauri/crates/p2p-bench/**` from CodeRabbit review. These are developer scratch paths (investigation notes, agent skill docs, throwaway diagnostic crates) — the bot's repeated "请改为中文" nits on PRs like #852 were noise, not signal.
- **Narrow the rule in `AGENTS.md` and `CONTRIBUTING(_ZH).md`** from "all code comments and project documentation" to "code comments and **user-facing** project documentation": `docs/`, `README`, crate-level `AGENTS.md`, `CONTRIBUTING*.md`, and code comments. Scratch paths are explicitly listed as exempt so the written rule matches what the bot is configured to enforce — single source of truth preserved.
- No code or runtime behavior changes.

## Why this matters

On #852, CodeRabbit emitted ~8 same-shape comments asking to translate English content in `.planning/debug/iroh-throughput-bbr-cubic/*`, `.claude/skills/dual-side-debug/*`, and `p2p-bench/`. The bot was faithfully executing the rule the repo gave it; the rule itself was too broad. This PR fixes the rule, not the bot.

## Test plan

- [x] `git apply --check` clean on a branch off latest `main`
- [x] Local diff stat matches expectation: 4 files changed, 11 insertions(+), 4 deletions(-)
- [x] pre-commit hooks (lint-staged, autocorrect, prettier) pass — only whitespace-around-emphasis tweaks, no semantic drift
- [ ] Reviewer: confirm `path_filters` syntax with leading `!` matches CodeRabbit v2 schema (per https://coderabbit.ai/integrations/schema.v2.json)
- [ ] After merge: next PR touching `.planning/` or `.claude/skills/` should NOT receive language-related CodeRabbit comments on those files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal documentation and code review configuration to clarify language conventions and exclude certain development paths from automated reviews. No changes to product functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/UniClipboard/UniClipboard/pull/859?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->