### PR TITLE
chore(coderabbit): flip code comments to English, keep docs Chinese

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,5 +1,11 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
 reviews:
+  path_filters:
+    # 开发自留地：调研笔记、agent skill、一次性诊断 crate 不进入 CodeRabbit 审查。
+    # 这些路径的语言/格式不要求与对外文档一致，bot 在这里发的几乎全是噪音。
+    - '!.planning/**'
+    - '!.claude/**'
+    - '!src-tauri/crates/p2p-bench/**'
   auto_review:
     enabled: true
     auto_incremental_review: true
@@ -14,9 +20,7 @@ reviews:
         Ignore all formatting-only problems.
     - path: '**/*.{rs,ts,tsx,js,jsx,vue,py,svelte,mjs,cjs}'
       instructions: |
-        Code comments in this repository MUST be written in Chinese (applies to `//`, `///`, `/* */`, and doc comments).
-        This rule is defined in AGENTS.md and CONTRIBUTING.md.
-        Do NOT suggest translating Chinese comments to English, and do NOT flag Chinese comments as issues.
+        Code comments (`//`, `///`, `/* */`, doc comments) for new or modified lines are written in English. Existing Chinese comments are preserved during gradual migration — do NOT flag, translate, or nitpick the language of any comment (added, modified, or context), in either direction. Project markdown documentation remains intentionally in Chinese per AGENTS.md; do not suggest translation there either.
         The following are intentionally kept in English and must not be flagged:
           - identifiers (function, type, variable, module names)
           - commit messages and PR titles/descriptions

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,9 +14,11 @@ Do not treat this file as a full memory dump. Read only the documents needed for
 - Use repo-relative paths in tracked docs.
 - Use language identifiers on fenced code blocks.
 - When conversation is in Chinese, respond in natural Chinese.
-- 本项目的代码注释与项目文档一律使用中文（包括 `docs/`、`.planning/`、crate 级 `AGENTS.md`、README、代码中的 `//` / `///` / `/* */` 注释、doc comments 等）。此约定覆盖全局 `CLAUDE.md` 中"写文档用英文"的默认规则。
-  - 例外：Git commit message / PR 标题与描述 / 代码标识符（函数、类型、变量名）保持英文，保证工具链与外部协作的兼容性。
-  - 引用外部规范（RFC、标准库 API 等）时，专有名词可保留英文原文。
+- **项目文档**（`docs/`、README、crate 级 `AGENTS.md`、`CONTRIBUTING*.md`）使用中文。此约定覆盖全局 `CLAUDE.md` 中"写文档用英文"的默认规则。
+  - 引用外部规范（RFC、标准库 API 等）时，专有名词保留英文原文。
+- **代码注释**（`//` / `///` / `/* */` / doc comments）使用英文。存量中文注释不强制迁移，新增或修改注释时按英文撰写；踏到旧中文注释可顺手改成英文。
+  - 代码标识符（函数、类型、变量名）、Git commit message、PR 标题与描述同样保持英文。
+  - **不强制语言审查的开发自留路径**：`.planning/`（调研/spike 笔记）、`.claude/`（本地 agent skill 与工具）、`publish = false` 的诊断 crate（例如 `src-tauri/crates/p2p-bench`）。这些目录按写作者方便即可，CodeRabbit 也已在 `.coderabbit.yaml` 中跳过。
 - `CLAUDE.md` is only a compatibility entrypoint. This file is the root instruction source.
 
 ## Read-on-Demand Map

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -267,7 +267,8 @@ Pre-commit hooks (via Husky and lint-staged) automatically run `eslint`, `pretti
 
 ### Style Guidelines
 
-- **Comments and project documentation are written in Chinese**, per `AGENTS.md`. Identifiers, commit messages, and PR titles/descriptions remain English so tooling and external collaborators stay aligned.
+- **Project documentation is written in Chinese** (`docs/`, `README`, crate-level `AGENTS.md`, `CONTRIBUTING*.md`), per `AGENTS.md`.
+- **Code comments are written in English** (`//`, `///`, `/* */`, doc comments) for new or modified code. Existing Chinese comments stay until naturally touched — no bulk translation. Identifiers, commit messages, and PR titles/descriptions also remain English. Developer scratch paths — `.planning/`, `.claude/`, and `publish = false` diagnostic crates — are excluded from CodeRabbit review via `.coderabbit.yaml`.
 - **No machine-specific absolute paths** in tracked files. Use repo-relative paths in docs and configuration.
 - **Markdown fenced code blocks must include a language identifier** (`bash`, `rust`, `ts`, `text`, etc.).
 - **Frontend code** follows the rules in [`docs/agent/frontend-ui-rules.md`](./docs/agent/frontend-ui-rules.md).

--- a/CONTRIBUTING_ZH.md
+++ b/CONTRIBUTING_ZH.md
@@ -230,7 +230,7 @@ fix(devices): show real online state and cut offline detection latency
 chore(observability): silence swarm_discovery::socket EHOSTUNREACH spam
 ```
 
-> commit 信息、PR 标题与描述使用英文，确保工具链与外部协作者通用。代码注释和项目内文档使用中文。
+> commit 信息、PR 标题与描述使用英文，确保工具链与外部协作者通用。项目文档使用中文，代码注释使用英文（详细范围与豁免目录见下方"代码风格与质量"小节）。
 
 ### 应避免的写法
 
@@ -264,7 +264,8 @@ cargo clippy --workspace --all-targets -- -D warnings
 
 ### 风格约定
 
-- **代码注释和项目文档使用中文**（依据 `AGENTS.md`）。代码标识符、commit message、PR 标题与描述保持英文，便于工具链与外部协作。
+- **项目文档使用中文**（`docs/`、README、crate 级 `AGENTS.md`、`CONTRIBUTING*.md`，依据 `AGENTS.md`）。
+- **代码注释使用英文**（`//`、`///`、`/* */`、doc comments）：新增或修改代码时按英文撰写，存量中文注释顺手改即可、不要求批量翻译。代码标识符、commit message、PR 标题与描述同样保持英文。开发自留路径 —— `.planning/`、`.claude/`、`publish = false` 的诊断 crate —— 在 `.coderabbit.yaml` 中排除 CodeRabbit 审查。
 - 仓库内文件 **不得包含机器特定的绝对路径**，统一使用相对仓库根的路径。
 - Markdown 代码围栏 **必须带语言标识**（`bash`、`rust`、`ts`、`text` 等）。
 - **前端代码** 遵循 [`docs/agent/frontend-ui-rules.md`](./docs/agent/frontend-ui-rules.md)。


### PR DESCRIPTION
## Summary

- **Code comments switch to English.** New or modified `//`, `///`, `/* */`, and doc comments are written in English. Existing Chinese comments stay until they're naturally touched — no bulk translation, no automated rewrite. CodeRabbit is configured to NOT flag, translate, or nitpick the language of any comment in either direction.
- **Project documentation stays Chinese.** `docs/`, `README`, crate-level `AGENTS.md`, and `CONTRIBUTING*.md` continue to be Chinese — this is for repo readability and isn't moving.
- **`.coderabbit.yaml` gets `reviews.path_filters`** to exclude `.planning/**`, `.claude/**`, and `src-tauri/crates/p2p-bench/**` from review. These are developer scratch paths (investigation notes, agent skill docs, throwaway diagnostic crates) where language/format conventions deliberately don't apply.

## Why

On #852 CodeRabbit emitted ~8 noise comments asking to translate English content into Chinese in scratch paths. The bot was faithfully enforcing what `.coderabbit.yaml` + `AGENTS.md` told it to. This PR fixes the rule (not the bot) and rebalances it to match how the codebase is actually written: docs are Chinese, code is increasingly English, scratch paths are whatever the author finds convenient.

Supersedes #859 (which proposed only narrowing the scope without flipping the comment language).

## Files

- `.coderabbit.yaml` — adds `path_filters`; rewrites the code-files `path_instructions` block to permit English comments and explicitly tell the bot not to nitpick comment language in either direction.
- `AGENTS.md` — splits the language rule into two bullets: docs Chinese / code comments English, plus the exempt-scratch-paths bullet.
- `CONTRIBUTING.md` / `CONTRIBUTING_ZH.md` — same split, both languages synced.

## Test plan

- [x] `git diff --stat`: 4 files changed, 17 insertions(+), 9 deletions(-)
- [x] pre-commit hooks (lint-staged + autocorrect + prettier + fix-md-cjk-emphasis) all pass
- [x] Branched from latest `origin/main` (`60296afb`), no drift
- [ ] Reviewer: confirm `reviews.path_filters` syntax with leading `!` matches CodeRabbit v2 schema
- [ ] After merge: next PR touching `.planning/`, `.claude/`, or `p2p-bench` should NOT receive CodeRabbit comments on those paths
- [ ] After merge: next PR adding English `//` comments to a `.rs` file should NOT receive a "请改为中文" comment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refined language guidelines for project documentation (Chinese) and code comments (English for new/modified code).
  * Clarified contribution standards across English and Chinese documentation files.

* **Chores**
  * Updated code review configuration with path exclusions for internal development directories.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/UniClipboard/UniClipboard/pull/860?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->