### PR TITLE
fix(clipboard): CF_HTML nesting, Linux URL percent-encoding, macOS UTF-8 mime regression

### DIFF
--- a/src-tauri/crates/uc-core/src/clipboard/mime.rs
+++ b/src-tauri/crates/uc-core/src/clipboard/mime.rs
@@ -26,6 +26,84 @@ impl MimeType {
     pub fn as_str(&self) -> &str {
         &self.0
     }
+
+    /// The `type/subtype` part of the MIME, lowercased with surrounding
+    /// whitespace stripped. Parameters (`;charset=...`) are discarded.
+    ///
+    /// Comparing essences — rather than full MIME strings — is the only
+    /// reliable way to classify a MIME, because real-world sources advertise
+    /// the same type with arbitrary parameters and casing
+    /// (`text/plain`, `text/plain;charset=utf-8`, `Text/Plain; charset="UTF-8"`).
+    pub fn essence(&self) -> String {
+        self.0
+            .split(';')
+            .next()
+            .unwrap_or("")
+            .trim()
+            .to_ascii_lowercase()
+    }
+
+    /// Lookup a parameter value (case-insensitive name match). Returns the
+    /// raw value with surrounding whitespace and a single pair of double
+    /// quotes stripped (no full RFC 2045 quoted-string parser; covers the
+    /// 99% case of `charset="utf-8"`).
+    pub fn parameter(&self, name: &str) -> Option<String> {
+        let mut parts = self.0.split(';');
+        let _ = parts.next();
+        for raw in parts {
+            let (k, v) = match raw.split_once('=') {
+                Some(kv) => kv,
+                None => continue,
+            };
+            if k.trim().eq_ignore_ascii_case(name) {
+                let v = v.trim();
+                let unquoted = v
+                    .strip_prefix('"')
+                    .and_then(|s| s.strip_suffix('"'))
+                    .unwrap_or(v);
+                return Some(unquoted.to_string());
+            }
+        }
+        None
+    }
+
+    /// Classify into a semantic bucket usable for all platform write
+    /// decisions and application-layer rep filtering.
+    ///
+    /// Callers that care about specific subtypes (e.g. `image/png` vs
+    /// `image/tiff`) should match on the returned [`MimeClass`] variants
+    /// rather than reading the underlying string.
+    pub fn classify(&self) -> MimeClass {
+        MimeClass::from_essence(&self.essence())
+    }
+
+    pub fn is_text_plain(&self) -> bool {
+        matches!(self.classify(), MimeClass::TextPlain)
+    }
+    pub fn is_text_html(&self) -> bool {
+        matches!(self.classify(), MimeClass::TextHtml)
+    }
+    pub fn is_text_rtf(&self) -> bool {
+        matches!(self.classify(), MimeClass::TextRtf)
+    }
+    pub fn is_uri_list(&self) -> bool {
+        matches!(self.classify(), MimeClass::UriList)
+    }
+    pub fn is_image(&self) -> bool {
+        matches!(self.classify(), MimeClass::Image(_))
+    }
+    pub fn is_text_like(&self) -> bool {
+        matches!(
+            self.classify(),
+            MimeClass::TextPlain
+                | MimeClass::TextHtml
+                | MimeClass::TextRtf
+                | MimeClass::TextMarkdown
+                | MimeClass::UriList
+                | MimeClass::TextLink
+                | MimeClass::TextOther
+        )
+    }
 }
 
 impl fmt::Display for MimeType {
@@ -65,5 +143,318 @@ impl std::ops::Deref for MimeType {
 
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+
+/// Semantic classification of a MIME type.
+///
+/// Use this — never the raw string — when making clipboard-routing
+/// decisions. The set of variants is intentionally narrow: every variant
+/// corresponds to a clipboard behavior the platform layer must support;
+/// anything not listed is [`MimeClass::Unrecognized`] and must be handled
+/// by callers (typically by refusing to write, per §11.2 of
+/// `uc-platform/AGENTS.md`).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum MimeClass {
+    /// `text/plain` (any charset variant) and the `public.utf8-plain-text`
+    /// UTI (treated as plain text for clipboard purposes).
+    TextPlain,
+    TextHtml,
+    TextRtf,
+    TextMarkdown,
+    /// `text/uri-list` (RFC 2483) and the historical `file/uri-list`
+    /// variant — both carry newline-separated `file://` or `http(s)://`
+    /// URIs and must be treated as a file list for clipboard purposes.
+    UriList,
+    /// `text/x-uri`, `text/x-url`, `text/uri` — link-bearing text MIMEs
+    /// distinct from `text/uri-list`'s file-list semantics.
+    TextLink,
+    /// Any `text/*` subtype that doesn't match a more specific variant
+    /// above (e.g. `text/csv`, `text/yaml`, `text/javascript`).
+    TextOther,
+    Image(ImageKind),
+    /// `application/octet-stream` — present here so callers can match it
+    /// explicitly and apply byte-sniffing recovery instead of refusing.
+    OctetStream,
+    /// MIME doesn't match any clipboard-relevant category. Platform write
+    /// paths must refuse this rather than guess.
+    Unrecognized,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum ImageKind {
+    Png,
+    Jpeg,
+    Tiff,
+    Gif,
+    Webp,
+    Bmp,
+    /// `image/*` of an unknown subtype.
+    Other,
+}
+
+impl MimeClass {
+    /// Classify an already-lowercased essence string (no parameters).
+    fn from_essence(essence: &str) -> Self {
+        // Plain text covers both the standard MIME and the macOS UTI that
+        // sometimes shows up in `mime` fields (notably when an upstream
+        // adapter passes the UTI through verbatim).
+        match essence {
+            "text/plain" | "public.utf8-plain-text" | "public.text" => return Self::TextPlain,
+            "text/html" => return Self::TextHtml,
+            "text/rtf" | "application/rtf" => return Self::TextRtf,
+            "text/markdown" => return Self::TextMarkdown,
+            "text/uri-list" | "file/uri-list" => return Self::UriList,
+            "text/x-uri" | "text/x-url" | "text/uri" => return Self::TextLink,
+            "application/octet-stream" => return Self::OctetStream,
+            "image/png" => return Self::Image(ImageKind::Png),
+            "image/jpeg" | "image/jpg" => return Self::Image(ImageKind::Jpeg),
+            "image/tiff" | "image/tif" => return Self::Image(ImageKind::Tiff),
+            "image/gif" => return Self::Image(ImageKind::Gif),
+            "image/webp" => return Self::Image(ImageKind::Webp),
+            "image/bmp" | "image/x-bmp" => return Self::Image(ImageKind::Bmp),
+            _ => {}
+        }
+
+        if let Some(rest) = essence.strip_prefix("image/") {
+            // Defensive: covers any `image/*` subtype we didn't enumerate
+            // above. Real-world image payloads should still be carried as
+            // PNG by the time they reach the platform layer (image
+            // normalization happens upstream), but a non-PNG `image/*`
+            // arriving here is still recognizable as an image.
+            let _ = rest;
+            return Self::Image(ImageKind::Other);
+        }
+        if essence.starts_with("text/") {
+            return Self::TextOther;
+        }
+        Self::Unrecognized
+    }
+}
+
+/// Single source of truth: platform format identifiers (NSPasteboard UTIs,
+/// X11/Wayland MIME atoms, internal short tags like `"text"` / `"image"`)
+/// to their default MIME type.
+///
+/// Used by all platform write paths to decide a `rep`'s effective MIME
+/// when its `mime` field is absent. Returning [`None`] means the
+/// format identifier is not recognized as carrying a clipboard-relevant
+/// payload — callers must treat this as "refuse to write" rather than
+/// guessing.
+pub fn format_id_default_mime(format_id: &str) -> Option<MimeType> {
+    let normalized = format_id.trim().to_ascii_lowercase();
+    let s: &str = match normalized.as_str() {
+        // Text plain (UTIs, Windows clipboard short tag, generic "text")
+        "public.utf8-plain-text" | "public.text" | "nsstringpboardtype" | "text" => "text/plain",
+        // HTML
+        "public.html" | "apple html pasteboard type" | "html" => "text/html",
+        // RTF
+        "public.rtf" | "rtf" => "text/rtf",
+        // Image: format_id "image" is the project-internal canonical
+        // identifier for image reps; both `image` and `public.png`
+        // default to PNG because image normalization upstream re-encodes
+        // everything to PNG (see uc-infra/src/clipboard/background_blob_worker.rs).
+        "public.png" | "image" => "image/png",
+        "public.tiff" => "image/tiff",
+        "public.jpeg" | "public.jpg" => "image/jpeg",
+        // File URI list
+        "public.file-url" | "nsfilenamespboardtype" | "files" => "text/uri-list",
+        _ => return None,
+    };
+    Some(MimeType(s.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn essence_strips_parameters_and_normalizes_case() {
+        assert_eq!(MimeType("text/plain".into()).essence(), "text/plain");
+        assert_eq!(
+            MimeType("text/plain;charset=utf-8".into()).essence(),
+            "text/plain"
+        );
+        assert_eq!(
+            MimeType("Text/Plain; Charset=UTF-8".into()).essence(),
+            "text/plain"
+        );
+        assert_eq!(
+            MimeType("  text/plain  ;  charset = utf-8  ".into()).essence(),
+            "text/plain"
+        );
+        assert_eq!(
+            MimeType("text/plain;charset=\"utf-8\"".into()).essence(),
+            "text/plain"
+        );
+    }
+
+    #[test]
+    fn parameter_lookup_is_case_insensitive_and_unquotes() {
+        let m = MimeType("text/plain;charset=utf-8".into());
+        assert_eq!(m.parameter("charset"), Some("utf-8".into()));
+        assert_eq!(m.parameter("CHARSET"), Some("utf-8".into()));
+        assert_eq!(m.parameter("boundary"), None);
+
+        let m = MimeType("text/plain; charset=\"UTF-8\"".into());
+        assert_eq!(m.parameter("charset"), Some("UTF-8".into()));
+    }
+
+    #[test]
+    fn classify_text_plain_variants() {
+        // The exact regression that motivated this work: Linux upstream
+        // changed text mime to `text/plain;charset=utf-8`, and the macOS
+        // write path's `Some("text/plain") =>` arm missed it, dropping
+        // the rep into the `set_buffer` fallback and breaking paste.
+        for s in [
+            "text/plain",
+            "text/plain;charset=utf-8",
+            "Text/Plain; Charset=UTF-8",
+            "  text/plain ; charset = \"utf-8\" ",
+            "TEXT/PLAIN",
+            "public.utf8-plain-text",
+        ] {
+            assert_eq!(
+                MimeType(s.into()).classify(),
+                MimeClass::TextPlain,
+                "expected TextPlain for {s:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn classify_html_rtf_uri_link() {
+        assert_eq!(MimeType("text/html".into()).classify(), MimeClass::TextHtml);
+        assert_eq!(
+            MimeType("text/html;charset=utf-8".into()).classify(),
+            MimeClass::TextHtml
+        );
+        assert_eq!(MimeType("text/rtf".into()).classify(), MimeClass::TextRtf);
+        assert_eq!(
+            MimeType("application/rtf".into()).classify(),
+            MimeClass::TextRtf
+        );
+        assert_eq!(
+            MimeType("text/uri-list".into()).classify(),
+            MimeClass::UriList
+        );
+        assert_eq!(
+            MimeType("file/uri-list".into()).classify(),
+            MimeClass::UriList
+        );
+        assert_eq!(
+            MimeType("text/x-url".into()).classify(),
+            MimeClass::TextLink
+        );
+    }
+
+    #[test]
+    fn classify_image_subtypes() {
+        assert_eq!(
+            MimeType("image/png".into()).classify(),
+            MimeClass::Image(ImageKind::Png)
+        );
+        assert_eq!(
+            MimeType("Image/PNG".into()).classify(),
+            MimeClass::Image(ImageKind::Png)
+        );
+        assert_eq!(
+            MimeType("image/jpeg".into()).classify(),
+            MimeClass::Image(ImageKind::Jpeg)
+        );
+        assert_eq!(
+            MimeType("image/jpg".into()).classify(),
+            MimeClass::Image(ImageKind::Jpeg)
+        );
+        assert_eq!(
+            MimeType("image/tiff".into()).classify(),
+            MimeClass::Image(ImageKind::Tiff)
+        );
+        assert_eq!(
+            MimeType("image/heic".into()).classify(),
+            MimeClass::Image(ImageKind::Other)
+        );
+    }
+
+    #[test]
+    fn classify_text_other_and_unrecognized() {
+        assert_eq!(MimeType("text/csv".into()).classify(), MimeClass::TextOther);
+        assert_eq!(
+            MimeType("text/yaml".into()).classify(),
+            MimeClass::TextOther
+        );
+        assert_eq!(
+            MimeType("application/octet-stream".into()).classify(),
+            MimeClass::OctetStream
+        );
+        assert_eq!(
+            MimeType("application/json".into()).classify(),
+            MimeClass::Unrecognized
+        );
+        assert_eq!(MimeType("".into()).classify(), MimeClass::Unrecognized);
+    }
+
+    #[test]
+    fn format_id_default_mime_handles_known_ids() {
+        assert_eq!(
+            format_id_default_mime("text"),
+            Some(MimeType("text/plain".into()))
+        );
+        assert_eq!(
+            format_id_default_mime("public.utf8-plain-text"),
+            Some(MimeType("text/plain".into()))
+        );
+        assert_eq!(
+            format_id_default_mime("NSStringPboardType"),
+            Some(MimeType("text/plain".into()))
+        );
+        assert_eq!(
+            format_id_default_mime("html"),
+            Some(MimeType("text/html".into()))
+        );
+        assert_eq!(
+            format_id_default_mime("Apple HTML pasteboard type"),
+            Some(MimeType("text/html".into()))
+        );
+        assert_eq!(
+            format_id_default_mime("image"),
+            Some(MimeType("image/png".into()))
+        );
+        assert_eq!(
+            format_id_default_mime("public.png"),
+            Some(MimeType("image/png".into()))
+        );
+        assert_eq!(
+            format_id_default_mime("public.tiff"),
+            Some(MimeType("image/tiff".into()))
+        );
+        assert_eq!(
+            format_id_default_mime("files"),
+            Some(MimeType("text/uri-list".into()))
+        );
+        assert_eq!(
+            format_id_default_mime("public.file-url"),
+            Some(MimeType("text/uri-list".into()))
+        );
+        // Trim + case fold so callers don't need to pre-normalize.
+        assert_eq!(
+            format_id_default_mime("  HTML  "),
+            Some(MimeType("text/html".into()))
+        );
+        // Unknown identifier returns None — callers must refuse to write.
+        assert_eq!(format_id_default_mime("application/foo"), None);
+        assert_eq!(format_id_default_mime("unknown-format"), None);
+    }
+
+    #[test]
+    fn convenience_predicates_agree_with_classify() {
+        let m = MimeType("text/plain;charset=utf-8".into());
+        assert!(m.is_text_plain());
+        assert!(m.is_text_like());
+        assert!(!m.is_image());
+
+        let m = MimeType("image/png".into());
+        assert!(m.is_image());
+        assert!(!m.is_text_plain());
     }
 }

--- a/src-tauri/crates/uc-core/src/clipboard/mod.rs
+++ b/src-tauri/crates/uc-core/src/clipboard/mod.rs
@@ -37,7 +37,7 @@ pub use system::{
 pub use decision::{ClipboardContentActionDecision, DuplicationHint, RejectReason};
 pub use hash::{ContentHash, HashAlgorithm};
 pub use integration_mode::ClipboardIntegrationMode;
-pub use mime::MimeType;
+pub use mime::{format_id_default_mime, ImageKind, MimeClass, MimeType};
 pub use origin::ClipboardOrigin;
 pub use payload_availability::PayloadAvailability;
 pub use thumbnail::ThumbnailMetadata;

--- a/src-tauri/crates/uc-core/src/clipboard/system.rs
+++ b/src-tauri/crates/uc-core/src/clipboard/system.rs
@@ -4,7 +4,7 @@ use std::sync::OnceLock;
 
 use crate::{
     ids::{FormatId, RepresentationId},
-    ContentHash, MimeType,
+    ContentHash, MimeClass, MimeType,
 };
 use serde::{Deserialize, Serialize};
 
@@ -259,11 +259,7 @@ impl<'de> serde::Deserialize<'de> for ObservedClipboardRepresentation {
 /// 不包含 `text/html` / `text/rtf` / `text/markdown` 等富文本子类型。
 pub fn is_plain_text_mime_or_format(mime: Option<&MimeType>, format_id: &FormatId) -> bool {
     if let Some(mime) = mime {
-        let mime_str = mime.as_str();
-        if mime_str.eq_ignore_ascii_case("text/plain")
-            || mime_str.to_ascii_lowercase().starts_with("text/plain;")
-            || mime_str.eq_ignore_ascii_case("public.utf8-plain-text")
-        {
+        if mime.is_text_plain() {
             return true;
         }
     }
@@ -274,11 +270,12 @@ pub(crate) fn is_plain_text_representation(rep: &ObservedClipboardRepresentation
     is_plain_text_mime_or_format(rep.mime.as_ref(), &rep.format_id)
 }
 
+/// Any text-bearing rep (plain or rich). Used by snapshot identity
+/// derivation when a plain-text rep is absent but a text-shaped rep
+/// (HTML, RTF, markdown, …) is present.
 fn is_text_representation(rep: &ObservedClipboardRepresentation) -> bool {
-    if let Some(mime) = rep.mime.as_ref() {
-        let mime_str = mime.as_str();
-        if mime_str.starts_with("text/") || mime_str.eq_ignore_ascii_case("public.utf8-plain-text")
-        {
+    if let Some(m) = rep.mime.as_ref() {
+        if m.is_text_like() {
             return true;
         }
     }
@@ -288,10 +285,7 @@ fn is_text_representation(rep: &ObservedClipboardRepresentation) -> bool {
 }
 
 pub(crate) fn is_image_representation(rep: &ObservedClipboardRepresentation) -> bool {
-    rep.mime
-        .as_ref()
-        .is_some_and(|mime| mime.as_str().starts_with("image/"))
-        || rep.format_id.eq_ignore_ascii_case("image")
+    rep.mime.as_ref().is_some_and(|m| m.is_image()) || rep.format_id.eq_ignore_ascii_case("image")
 }
 
 /// Check if a mime type and format ID combination represents a file clipboard entry.
@@ -301,8 +295,7 @@ pub(crate) fn is_image_representation(rep: &ObservedClipboardRepresentation) -> 
 /// should delegate to this function.
 pub fn is_file_mime_or_format(mime: Option<&MimeType>, format_id: &FormatId) -> bool {
     if let Some(mime) = mime {
-        let s = mime.as_str();
-        if s.eq_ignore_ascii_case("text/uri-list") || s.eq_ignore_ascii_case("file/uri-list") {
+        if mime.is_uri_list() {
             return true;
         }
     }
@@ -320,8 +313,7 @@ pub(crate) fn is_file_representation(rep: &ObservedClipboardRepresentation) -> b
 /// fall through here.
 pub(crate) fn is_rich_text_representation(rep: &ObservedClipboardRepresentation) -> bool {
     if let Some(m) = rep.mime.as_ref() {
-        let s = m.as_str();
-        if s.eq_ignore_ascii_case("text/html") || s.eq_ignore_ascii_case("text/rtf") {
+        if m.is_text_html() || m.is_text_rtf() {
             return true;
         }
     }
@@ -337,8 +329,15 @@ pub(crate) fn is_rich_text_representation(rep: &ObservedClipboardRepresentation)
 /// (file's territory) doesn't get reclassified here.
 pub(crate) fn is_link_representation(rep: &ObservedClipboardRepresentation) -> bool {
     if let Some(m) = rep.mime.as_ref() {
-        let s = m.as_str().to_ascii_lowercase();
-        if s == "text/x-uri" || s == "text/x-url" || s == "text/uri" || s.contains("url") {
+        if matches!(m.classify(), MimeClass::TextLink) {
+            return true;
+        }
+        // Wider net for vendor-specific link mimes that don't fit the
+        // canonical `text/x-uri` shape (e.g. `application/x-moz-url`).
+        // Kept as a substring check to preserve historical behavior; new
+        // canonical link mimes should be added to `MimeClass::TextLink`
+        // in `mime.rs` instead of relying on this fallback.
+        if m.essence().contains("url") {
             return true;
         }
     }
@@ -353,7 +352,7 @@ pub(crate) fn is_link_representation(rep: &ObservedClipboardRepresentation) -> b
 pub(crate) fn is_any_text_representation(rep: &ObservedClipboardRepresentation) -> bool {
     rep.mime
         .as_ref()
-        .is_some_and(|m| m.as_str().to_ascii_lowercase().starts_with("text/"))
+        .is_some_and(|m| m.essence().starts_with("text/"))
 }
 
 /// Heuristic: a text-bearing rep whose entire payload (after `trim`) is

--- a/src-tauri/crates/uc-platform/src/clipboard/cf_html.rs
+++ b/src-tauri/crates/uc-platform/src/clipboard/cf_html.rs
@@ -1,0 +1,104 @@
+//! Helpers for normalizing Windows CF_HTML payloads.
+//!
+//! `clipboard_win::raw::set_html` unconditionally prepends a
+//! `<html>\r\n<body>\r\n<!--StartFragment-->` header and appends a
+//! `<!--EndFragment-->\r\n</body>\r\n</html>` footer around whatever it is
+//! handed. On the read side, `clipboard-rs::get_html` returns the full
+//! document delimited by `StartHTML..EndHTML`, i.e. **including** those
+//! wrappers. Without normalization, every Win → peer → Win round-trip nests
+//! one extra wrapper layer; the user's `content_hash`-based dedup cannot
+//! collapse them because each layer changes the hash.
+//!
+//! Lives outside the `windows.rs` `cfg` gate so unit tests run on every host.
+
+/// Strip every outer CF_HTML wrapper introduced by `clipboard-win::raw::set_html`,
+/// returning the inner fragment payload.
+///
+/// Detection is anchored on the literal `<!--StartFragment-->` /
+/// `<!--EndFragment-->` markers, which are unique to CF_HTML and never appear
+/// in HTML that a normal source application emits. The function picks the
+/// **innermost** `StartFragment` (`rfind`, i.e. rightmost) and then the
+/// nearest following `EndFragment`, so a payload that has already accumulated
+/// N nested layers is collapsed back to the original fragment in a single
+/// call.
+///
+/// Why `rfind` for `StartFragment`: in an N-layer nesting all N `StartFragment`
+/// markers appear before all N `EndFragment` markers in source order, so a
+/// naive `find`/`find` pair would span the outermost-Start to the innermost-End
+/// and leave N-1 layers of opening wrappers inside the result. The
+/// innermost-Start to its first-following-End is the only balanced pair.
+pub(crate) fn strip_cf_html_wrapper(html: &str) -> &str {
+    const START_MARKER: &str = "<!--StartFragment-->";
+    const END_MARKER: &str = "<!--EndFragment-->";
+
+    let Some(start_idx) = html.rfind(START_MARKER) else {
+        return html;
+    };
+    let fragment_start = start_idx + START_MARKER.len();
+    let Some(end_offset) = html[fragment_start..].find(END_MARKER) else {
+        return html;
+    };
+    &html[fragment_start..fragment_start + end_offset]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn passthrough_when_no_markers() {
+        let html = "<p>plain web html with no CF_HTML markers</p>";
+        assert_eq!(strip_cf_html_wrapper(html), html);
+    }
+
+    #[test]
+    fn extracts_fragment_from_one_wrapper() {
+        let html = "<html>\r\n<body>\r\n<!--StartFragment--><p>hello</p><!--EndFragment-->\r\n</body>\r\n</html>";
+        assert_eq!(strip_cf_html_wrapper(html), "<p>hello</p>");
+    }
+
+    #[test]
+    fn collapses_nested_wrappers_in_one_call() {
+        // Reproduces the user's observed pathological state: 4 nested layers
+        // around a single fragment. A single normalize call must collapse
+        // back to the innermost payload.
+        let mut current = String::from("<p>inner payload</p>");
+        for _ in 0..4 {
+            current = format!(
+                "<html>\r\n<body>\r\n<!--StartFragment-->{current}<!--EndFragment-->\r\n</body>\r\n</html>"
+            );
+        }
+        assert_eq!(strip_cf_html_wrapper(&current), "<p>inner payload</p>");
+    }
+
+    #[test]
+    fn returns_input_when_only_start_marker_present() {
+        // Defensive: a malformed CF_HTML buffer with only StartFragment must
+        // not panic and must not silently truncate.
+        let html = "<html><body><!--StartFragment--><p>broken</p></body></html>";
+        assert_eq!(strip_cf_html_wrapper(html), html);
+    }
+
+    #[test]
+    fn returns_input_when_only_end_marker_present() {
+        let html = "<html><body><p>broken</p><!--EndFragment--></body></html>";
+        assert_eq!(strip_cf_html_wrapper(html), html);
+    }
+
+    #[test]
+    fn preserves_meta_and_attributes_inside_fragment() {
+        // Matches the user's reproduction: a meta tag with attributes lives
+        // inside the innermost fragment and must survive normalization.
+        let html = "<html>\r\n<body>\r\n<!--StartFragment--><meta http-equiv=\"content-type\" content=\"text/html; charset=utf-8\">UniClipboard is the open-source clipboard.<!--EndFragment-->\r\n</body>\r\n</html>";
+        assert_eq!(
+            strip_cf_html_wrapper(html),
+            "<meta http-equiv=\"content-type\" content=\"text/html; charset=utf-8\">UniClipboard is the open-source clipboard."
+        );
+    }
+
+    #[test]
+    fn handles_empty_fragment() {
+        let html = "<html><body><!--StartFragment--><!--EndFragment--></body></html>";
+        assert_eq!(strip_cf_html_wrapper(html), "");
+    }
+}

--- a/src-tauri/crates/uc-platform/src/clipboard/common.rs
+++ b/src-tauri/crates/uc-platform/src/clipboard/common.rs
@@ -2,7 +2,12 @@ use super::payload::rep_bytes;
 use anyhow::{anyhow, Result};
 use clipboard_rs::{common::RustImage, Clipboard, ContentFormat};
 use tracing::{debug, info, warn};
-use uc_core::clipboard::{MimeType, ObservedClipboardRepresentation, SystemClipboardSnapshot};
+#[cfg(target_os = "macos")]
+use uc_core::clipboard::ImageKind;
+use uc_core::clipboard::{
+    format_id_default_mime, MimeClass, MimeType, ObservedClipboardRepresentation,
+    SystemClipboardSnapshot,
+};
 use uc_core::ids::RepresentationId;
 
 /// 文件头魔数嗅探,返回桌面剪贴板能消费的 `image/*` mime 字符串。
@@ -27,6 +32,51 @@ pub(crate) fn sniff_image_magic(body: &[u8]) -> Option<&'static str> {
         return Some("image/tiff");
     }
     None
+}
+
+/// Decide the "effective MIME" used by the single-rep write fast path.
+///
+/// This is the only function that needs to know how `format_id` and the
+/// rep's declared `mime` field combine into a single canonical MIME for
+/// the OS clipboard. Keeping it as a free function (no `&mut ClipboardContext`
+/// dependency) means we can exhaustively unit-test every variant — the
+/// regression that motivated this work (`text/plain;charset=utf-8` silently
+/// missing the `text/plain` arm) belongs to this function's contract.
+///
+/// Three cases:
+/// * `mime` present, `format_id` implies `image/*`, but `mime` is *not*
+///   `image/*`: byte-sniff the payload (recovers iOS / SyncClipboard
+///   uploads that omit Content-Type and get tagged `application/octet-stream`),
+///   otherwise fall back to the format_id's default mime. **Never** let an
+///   image rep flow through with a non-image mime — the 2026-05-08
+///   IMG_20260508_200644.jpg incident took that path.
+/// * `mime` present, anything else: use it as-is.
+/// * `mime` absent: fall back to `format_id_default_mime`.
+///
+/// Returns `None` only when the rep has neither a mime nor a recognized
+/// `format_id` — in that case the caller must refuse to write (§11.2,
+/// no silent fallback to a non-UTI pasteboard type).
+pub(crate) fn compute_effective_mime(rep: &ObservedClipboardRepresentation) -> Option<MimeType> {
+    let format_default: Option<MimeType> = format_id_default_mime(rep.format_id.as_str());
+
+    match (rep.mime.as_ref(), format_default.as_ref()) {
+        (Some(m), Some(default)) if default.is_image() && !m.is_image() => {
+            let recovered = rep_bytes(rep)
+                .ok()
+                .and_then(|b| sniff_image_magic(&b))
+                .map(|s| MimeType(s.to_string()))
+                .unwrap_or_else(|| default.clone());
+            warn!(
+                format_id = %rep.format_id,
+                wire_mime = m.as_str(),
+                recovered_mime = recovered.as_str(),
+                "compute_effective_mime: image rep declared non-image mime; recovered via byte sniff/format_id default"
+            );
+            Some(recovered)
+        }
+        (Some(m), _) => Some(m.clone()),
+        (None, _) => format_default,
+    }
 }
 
 /// 基于文件后缀推断常见图片 MIME。仅用于 `image-from-file` LocalFile rep 的 mime 标注;
@@ -708,53 +758,10 @@ impl CommonClipboardImpl {
             return Self::write_snapshot_multi(ctx, snapshot);
         }
 
-        // 单 rep 快路径：走既有 clipboard-rs 高层 API（行为与改动前完全一致）。
+        // 单 rep 快路径：走既有 clipboard-rs 高层 API。
         let rep = &snapshot.representations[0];
 
-        // 先按 format_id 推断默认 mime。
-        let format_default = match rep.format_id.as_str() {
-            "public.utf8-plain-text" | "public.text" | "NSStringPboardType" | "text" => {
-                Some("text/plain")
-            }
-            "public.html" | "Apple HTML pasteboard type" | "html" => Some("text/html"),
-            "public.rtf" | "rtf" => Some("text/rtf"),
-            "public.png" | "image" => Some("image/png"),
-            "public.tiff" => Some("image/tiff"),
-            "public.jpeg" => Some("image/jpeg"),
-            "public.file-url" | "NSFilenamesPboardType" => Some("text/uri-list"),
-            _ => None,
-        };
-
-        // 决定 effective_mime:
-        //   情况 A —— image-like format_id 但显式 mime 不是 image/*:几乎一定是客户端
-        //     误标(典型:iOS / SyncClipboard 兼容客户端 PUT /file 时不设 Content-Type
-        //     → 服务端默认 application/octet-stream → 这里 mime=Some("application/octet-stream"))。
-        //     先字节嗅探拿真实图片 mime,失败再回退到 format_id 默认。**绝不**让 image rep
-        //     携带 application/octet-stream 流到下游 set_image / set_buffer:
-        //     2026-05-08 真机回归(IMG_20260508_200644.jpg)就是这条路径把 JPEG 字节
-        //     用非法 NSPasteboard type 写进了系统剪贴板。
-        //   情况 B —— 显式 mime 存在 → 沿用。
-        //   情况 C —— 没有显式 mime → 回退 format_id 默认。
-        let effective_mime: Option<&str> = match (rep.mime.as_deref(), format_default) {
-            (Some(m), Some(default))
-                if default.starts_with("image/") && !m.starts_with("image/") =>
-            {
-                // sniff 路径罕见；rep 是 LocalFile source 读盘失败时退回 format_id 默认 mime。
-                let recovered = rep_bytes(rep)
-                    .ok()
-                    .and_then(|b| sniff_image_magic(&b))
-                    .unwrap_or(default);
-                warn!(
-                    format_id = %rep.format_id,
-                    wire_mime = m,
-                    recovered_mime = recovered,
-                    "write_snapshot: image rep declared non-image mime; recovered via byte sniff/format_id default"
-                );
-                Some(recovered)
-            }
-            (Some(m), _) => Some(m),
-            (None, default) => default,
-        };
+        let effective_mime = compute_effective_mime(rep);
 
         // 把单 rep 的字节预读到 owned `Vec<u8>`（Inline 转 owned, LocalFile 同步读盘）。
         // 后续各分支再从这份 owned 字节构造 String / RustImageData / set_buffer 输入,
@@ -762,17 +769,39 @@ impl CommonClipboardImpl {
         // 见 `common::rep_bytes` 注释）。
         let single_rep_bytes = rep_bytes(rep)?.into_owned();
 
-        match effective_mime {
-            Some("text/plain") => {
+        // Refuse to write when we couldn't derive an effective mime — neither
+        // the rep's declared mime nor its format_id maps to a known clipboard
+        // category. Per `uc-platform/AGENTS.md` §11.2, raw set_buffer with a
+        // non-UTI pasteboard type is a silent failure on macOS (the system
+        // accepts the write but no application can Cmd+V it) and must be
+        // surfaced rather than papered over.
+        let Some(effective_mime) = effective_mime else {
+            anyhow::bail!(
+                "write_snapshot: no effective mime — rep has no declared mime and \
+                 format_id {:?} is not in the platform mapping",
+                rep.format_id
+            );
+        };
+
+        match effective_mime.classify() {
+            // All `text/*` reps that we can carry on the system clipboard
+            // ultimately land on the OS string buffer. Markdown / csv /
+            // x-url / etc are written as plain text — system pasteboards
+            // don't have a richer slot for them, and pasting as plain text
+            // is what every consumer expects.
+            MimeClass::TextPlain
+            | MimeClass::TextMarkdown
+            | MimeClass::TextLink
+            | MimeClass::TextOther => {
                 map_clipboard_err(ctx.set_text(String::from_utf8(single_rep_bytes)?))?;
             }
-            Some("text/rtf") => {
+            MimeClass::TextRtf => {
                 map_clipboard_err(ctx.set_rich_text(String::from_utf8(single_rep_bytes)?))?;
             }
-            Some("text/html") => {
+            MimeClass::TextHtml => {
                 map_clipboard_err(ctx.set_html(String::from_utf8(single_rep_bytes)?))?;
             }
-            Some("text/uri-list") | Some("file/uri-list") => {
+            MimeClass::UriList => {
                 // Convert file:// URIs back to raw OS paths for set_files(),
                 // which expects native paths. Also handle raw paths for compatibility
                 // with inbound cache paths that aren't URI-encoded.
@@ -783,7 +812,6 @@ impl CommonClipboardImpl {
                         if line.is_empty() {
                             return None;
                         }
-                        // Try as file:// URI first
                         if let Ok(url) = url::Url::parse(line) {
                             if url.scheme() == "file" {
                                 if let Ok(path) = url.to_file_path() {
@@ -791,15 +819,14 @@ impl CommonClipboardImpl {
                                 }
                             }
                         }
-                        // Fallback: treat as raw path
                         Some(line.to_string())
                     })
                     .collect();
                 map_clipboard_err(ctx.set_files(files))?;
             }
-            Some(mime) if mime.starts_with("image/") => {
+            MimeClass::Image(kind) => {
                 debug!(
-                    mime = mime,
+                    mime = effective_mime.as_str(),
                     data_size = rep.size_bytes(),
                     format_id = %rep.format_id,
                     "write_snapshot: writing image to clipboard"
@@ -811,14 +838,13 @@ impl CommonClipboardImpl {
                 // with the "public.png" UTI (equivalent to NSPasteboardTypePNG).
                 #[cfg(target_os = "macos")]
                 {
-                    if mime == "image/png" {
+                    if matches!(kind, ImageKind::Png) {
                         map_clipboard_err(ctx.set_buffer("public.png", single_rep_bytes))?;
                     } else {
-                        // Non-PNG images still need format conversion via set_image
                         let img = clipboard_rs::RustImageData::from_bytes(&single_rep_bytes)
                             .map_err(|e| {
                                 warn!(
-                                    mime = mime,
+                                    mime = effective_mime.as_str(),
                                     data_size = rep.size_bytes(),
                                     error = %e,
                                     "write_snapshot: failed to decode image bytes"
@@ -830,10 +856,11 @@ impl CommonClipboardImpl {
                 }
                 #[cfg(not(target_os = "macos"))]
                 {
+                    let _ = kind;
                     let img = clipboard_rs::RustImageData::from_bytes(&single_rep_bytes).map_err(
                         |e| {
                             warn!(
-                                mime = mime,
+                                mime = effective_mime.as_str(),
                                 data_size = rep.size_bytes(),
                                 error = %e,
                                 "write_snapshot: failed to decode image bytes"
@@ -844,44 +871,31 @@ impl CommonClipboardImpl {
                     map_clipboard_err(ctx.set_image(img))?;
                 }
                 debug!(
-                    mime = mime,
+                    mime = effective_mime.as_str(),
                     "write_snapshot: image set on system clipboard successfully"
                 );
             }
-            _ => {
-                // 兜底分支:effective_mime 没命中任何已支持类型。这条路径之前会
-                // 静默 set_buffer(format_id, bytes) —— 历史教训(2026-05-08
-                // IMG_20260508_200644.jpg 真机回归):image rep + mime
-                // application/octet-stream 落到这里,把 JPEG 字节用非法
-                // pasteboard type "image" 写进了系统剪贴板,既无法以图像形式
-                // 粘贴,又把原始 EXIF 字节当文本暴露给用户。违反
-                // `uc-platform/AGENTS.md` §11.2「不允许静默降级」。
+            MimeClass::OctetStream | MimeClass::Unrecognized => {
+                // §11.2: any rep that survives this far without a recognized
+                // mime would previously be written via `set_buffer(format_id, …)`,
+                // which on macOS attaches the bytes to a non-UTI pasteboard
+                // type that no consumer (including the OS clipboard manager)
+                // recognizes — Cmd+V silently produces nothing. Refusing the
+                // write surfaces the upstream mis-classification instead.
                 //
-                // 现在:
-                //   * image-like format_id 在 effective_mime 决策阶段已被字节
-                //     嗅探纠正,不会再到达这里;若到达说明前置守卫失效 —— bail。
-                //   * 其它未识别 mime 的 rep 仍走 set_buffer,但必须先 WARN,让
-                //     "OS 剪贴板里写了非标准 type"这件事可观测。
-                let format_default_image_like = matches!(
-                    rep.format_id.as_str(),
-                    "image" | "public.png" | "public.tiff" | "public.jpeg" | "public.gif"
+                // The 2026-05-08 IMG_20260508_200644.jpg regression took
+                // this exact path: image rep + application/octet-stream
+                // landed here and corrupted the clipboard. Image bytes are
+                // now caught earlier by the byte-sniff guard above; this
+                // branch remains as a hard floor against future regressions.
+                anyhow::bail!(
+                    "write_snapshot: refusing to write rep with unrecognized mime \
+                     (mime={:?}, format_id={:?}, bytes={}); rep would land on a \
+                     non-standard pasteboard type that no consumer can read",
+                    effective_mime.as_str(),
+                    rep.format_id,
+                    rep.size_bytes()
                 );
-                if format_default_image_like {
-                    anyhow::bail!(
-                        "write_snapshot: image-like format_id {:?} reached fallback branch \
-                         with mime {:?} — image-mime recovery should have run upstream; \
-                         refusing to set_buffer with a non-UTI pasteboard type",
-                        rep.format_id,
-                        rep.mime
-                    );
-                }
-                warn!(
-                    format_id = %rep.format_id,
-                    mime = ?rep.mime,
-                    bytes = rep.size_bytes(),
-                    "write_snapshot: writing rep via raw set_buffer fallback (no recognized mime mapping)"
-                );
-                map_clipboard_err(ctx.set_buffer(&rep.format_id, single_rep_bytes))?;
             }
         }
 
@@ -1212,5 +1226,107 @@ mod tests {
         riff_wav.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]);
         riff_wav.extend_from_slice(b"WAVE");
         assert_eq!(sniff_image_magic(&riff_wav), None);
+    }
+
+    mod effective_mime {
+        use super::*;
+        use uc_core::clipboard::MimeClass;
+        use uc_core::ids::{FormatId, RepresentationId};
+
+        fn rep(
+            format: &str,
+            mime: Option<&str>,
+            bytes: Vec<u8>,
+        ) -> ObservedClipboardRepresentation {
+            ObservedClipboardRepresentation::new(
+                RepresentationId::new(),
+                FormatId::from_str(format),
+                mime.map(|m| MimeType(m.to_string())),
+                bytes,
+            )
+        }
+
+        /// 直接复现今天用户报的 fedora → mac 同步问题：
+        /// `text/plain;charset=utf-8` 必须命中 `MimeClass::TextPlain`,
+        /// 而不是掉进 OctetStream/Unrecognized 让 write_snapshot bail.
+        #[test]
+        fn parameterized_text_plain_classifies_as_text_plain() {
+            let cases = [
+                "text/plain",
+                "text/plain;charset=utf-8",
+                "text/plain; charset=utf-8",
+                "Text/Plain; Charset=UTF-8",
+                "  text/plain ; charset = \"utf-8\" ",
+                "TEXT/PLAIN",
+                "public.utf8-plain-text",
+            ];
+            for raw in cases {
+                let r = rep("text", Some(raw), b"hello".to_vec());
+                let effective = compute_effective_mime(&r).expect("effective mime");
+                assert_eq!(
+                    effective.classify(),
+                    MimeClass::TextPlain,
+                    "expected TextPlain for mime={raw:?}"
+                );
+            }
+        }
+
+        #[test]
+        fn parameterized_text_html_classifies_as_text_html() {
+            let r = rep("html", Some("text/html;charset=utf-8"), b"<p>hi".to_vec());
+            assert_eq!(
+                compute_effective_mime(&r).unwrap().classify(),
+                MimeClass::TextHtml
+            );
+        }
+
+        #[test]
+        fn format_id_falls_back_when_mime_missing() {
+            // 现代 capture 路径会给 rep 打 mime,但旧 envelope / legacy 客户端
+            // 可能省略 mime —— 单源映射表必须能从 format_id 兜底。
+            let r = rep("text", None, b"hello".to_vec());
+            assert_eq!(
+                compute_effective_mime(&r).unwrap().classify(),
+                MimeClass::TextPlain
+            );
+
+            let r = rep("public.png", None, vec![0x89, b'P', b'N', b'G']);
+            assert!(matches!(
+                compute_effective_mime(&r).unwrap().classify(),
+                MimeClass::Image(_)
+            ));
+        }
+
+        #[test]
+        fn image_format_id_with_octet_stream_mime_is_sniffed_back_to_image() {
+            // 历史回归 (2026-05-08 IMG_20260508_200644.jpg)：iOS 客户端 PUT /file
+            // 不带 Content-Type → 服务端默认 application/octet-stream,但
+            // format_id 仍是 image-like。必须字节嗅探 recover,不能让 octet-stream
+            // 落到下游写入分支。
+            let png_magic = vec![
+                0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, // PNG signature
+                0x00, 0x00, 0x00, 0x0D, // IHDR length
+            ];
+            let r = rep("public.png", Some("application/octet-stream"), png_magic);
+            let effective = compute_effective_mime(&r).expect("effective mime");
+            assert_eq!(effective.essence(), "image/png");
+        }
+
+        #[test]
+        fn no_mime_and_unknown_format_id_returns_none() {
+            // 此时 write_snapshot 会 bail —— §11.2 不允许静默用 format_id 当
+            // pasteboard type 写非 UTI 内容。
+            let r = rep("vendor-private-format", None, b"opaque".to_vec());
+            assert!(compute_effective_mime(&r).is_none());
+        }
+
+        #[test]
+        fn application_json_classifies_as_unrecognized() {
+            // unrecognized application/* mime 必须分类为 Unrecognized,
+            // 让 write_snapshot bail 而不是走 fallback set_buffer。
+            let r = rep("unknown", Some("application/json"), b"{}".to_vec());
+            let effective = compute_effective_mime(&r).expect("effective mime");
+            assert_eq!(effective.classify(), MimeClass::Unrecognized);
+        }
     }
 }

--- a/src-tauri/crates/uc-platform/src/clipboard/mod.rs
+++ b/src-tauri/crates/uc-platform/src/clipboard/mod.rs
@@ -1,6 +1,9 @@
 // `common.rs` wraps `clipboard_rs::ClipboardContext`. Phase 4 narrowed
 // `clipboard-rs` to macOS/Windows targets, so `common` follows; Linux's
 // native Wayland + x11rb backends don't need it.
+// CF_HTML wrapper normalization. Lives outside any cfg gate because it is
+// pure string logic and we want its unit tests to run on every host.
+pub(crate) mod cf_html;
 #[cfg(any(target_os = "macos", target_os = "windows"))]
 pub mod common;
 pub mod event_loop;

--- a/src-tauri/crates/uc-platform/src/clipboard/mod.rs
+++ b/src-tauri/crates/uc-platform/src/clipboard/mod.rs
@@ -1,8 +1,12 @@
 // `common.rs` wraps `clipboard_rs::ClipboardContext`. Phase 4 narrowed
 // `clipboard-rs` to macOS/Windows targets, so `common` follows; Linux's
 // native Wayland + x11rb backends don't need it.
-// CF_HTML wrapper normalization. Lives outside any cfg gate because it is
-// pure string logic and we want its unit tests to run on every host.
+// CF_HTML wrapper normalization. Pure string logic, but only called from the
+// Windows write path — gate the module with `any(test, target_os = "windows")`
+// so non-Windows release builds don't trip `-D dead-code` (CI runs that on
+// Linux), while `cargo test` on every host still compiles and runs the unit
+// tests (cfg(test) is enabled during the test build).
+#[cfg(any(test, target_os = "windows"))]
 pub(crate) mod cf_html;
 #[cfg(any(target_os = "macos", target_os = "windows"))]
 pub mod common;

--- a/src-tauri/crates/uc-platform/src/clipboard/platform/linux/wayland/snapshot.rs
+++ b/src-tauri/crates/uc-platform/src/clipboard/platform/linux/wayland/snapshot.rs
@@ -59,6 +59,26 @@ fn format_id_for(mime: &str) -> &'static str {
     }
 }
 
+/// Lower number = read first when the source advertises multiple aliased
+/// text targets. Mirrors `x11::atoms::text_mime_priority`; the two are kept
+/// in sync deliberately rather than shared because the X11 and Wayland
+/// modules don't otherwise have a common helper module and the function
+/// is short. Rationale: real-world sources (Chromium, file managers)
+/// often advertise `STRING` (a 7-bit-safe, often percent-encoded copy of
+/// non-ASCII URLs) before `UTF8_STRING` (the original UTF-8). Reading in
+/// advertise order captures the percent-encoded variant and propagates
+/// `%XX` sequences to every paste / sync target.
+fn text_mime_priority(mime: &str) -> u32 {
+    match mime {
+        "text/plain;charset=utf-8" | "text/plain;charset=UTF-8" => 0,
+        "UTF8_STRING" => 1,
+        "text/plain" => 2,
+        "STRING" => 3,
+        "TEXT" => 4,
+        _ => u32::MAX,
+    }
+}
+
 pub(super) fn build_from_offer<O: OfferLike>(
     conn: &Connection,
     offer: &O,
@@ -72,10 +92,15 @@ pub(super) fn build_from_offer<O: OfferLike>(
     let mut text_captured = false;
     let mut image_captured = false;
 
-    for mime in mimes {
-        if !is_interesting_mime(mime) {
-            continue;
-        }
+    // Stable-sort the interesting mimes so UTF-8 text variants come before
+    // Latin-1 fallbacks. See `text_mime_priority` for the why. Non-text
+    // mimes share `u32::MAX` and keep their relative advertise-order
+    // position via stable sort.
+    let mut interesting_mimes: Vec<&String> =
+        mimes.iter().filter(|m| is_interesting_mime(m)).collect();
+    interesting_mimes.sort_by_key(|m| text_mime_priority(m.as_str()));
+
+    for mime in interesting_mimes {
         // Skip secondary text mimes once we've captured a primary one — the
         // compositor often advertises STRING + UTF8_STRING + text/plain;charset=utf-8
         // as aliases of the same data, and reading all three would inflate
@@ -146,6 +171,37 @@ mod tests {
         assert!(!is_interesting_mime("application/octet-stream"));
         assert!(!is_interesting_mime("x-special/gnome-copied-files"));
         assert!(!is_interesting_mime("application/x-kde4-urilist"));
+    }
+
+    #[test]
+    fn text_mime_priority_prefers_utf8_variants() {
+        assert!(text_mime_priority("text/plain;charset=utf-8") < text_mime_priority("UTF8_STRING"));
+        assert!(text_mime_priority("UTF8_STRING") < text_mime_priority("text/plain"));
+        assert!(text_mime_priority("text/plain") < text_mime_priority("STRING"));
+        assert!(text_mime_priority("STRING") < text_mime_priority("TEXT"));
+    }
+
+    #[test]
+    fn text_mime_priority_demotes_non_text_to_back() {
+        let last_text = text_mime_priority("TEXT");
+        for non_text in ["text/html", "text/uri-list", "image/png"] {
+            assert!(text_mime_priority(non_text) > last_text);
+        }
+    }
+
+    #[test]
+    fn sort_pulls_utf8_text_mime_in_front_of_string() {
+        // Simulates a source that advertises STRING (percent-encoded URL)
+        // before UTF8_STRING (UTF-8 original) — a documented Chromium
+        // pattern. After sorting, UTF8_STRING must come first so we read
+        // the UTF-8 variant and never touch the percent-encoded copy.
+        let mut mimes: Vec<&str> = vec!["STRING", "UTF8_STRING", "text/html", "image/png"];
+        mimes.sort_by_key(|m| text_mime_priority(m));
+        assert_eq!(mimes[0], "UTF8_STRING");
+        assert_eq!(mimes[1], "STRING");
+        // Non-text mimes retained but pushed behind every text variant.
+        assert!(mimes.contains(&"text/html"));
+        assert!(mimes.contains(&"image/png"));
     }
 
     #[test]

--- a/src-tauri/crates/uc-platform/src/clipboard/platform/linux/x11/atoms.rs
+++ b/src-tauri/crates/uc-platform/src/clipboard/platform/linux/x11/atoms.rs
@@ -103,6 +103,37 @@ pub(super) fn is_text_mime(mime: &str) -> bool {
     )
 }
 
+/// Lower number = read first when the source advertises multiple aliased
+/// text targets. ICCCM recommends `UTF8_STRING` / `text/plain;charset=utf-8`
+/// over the Latin-1-bounded `STRING` and `TEXT`, but real-world sources
+/// (Chromium, file managers, some IDE widgets) often list `STRING` *before*
+/// `UTF8_STRING` in their `TARGETS` reply. If we honored that order we'd
+/// read the `STRING` copy first — which for URLs containing non-ASCII
+/// characters (e.g. `http://host/job/玉兔Pro/`) is the percent-encoded
+/// `http://host/job/%E7%8E%89%E5%85%94Pro/` fallback the source emits as
+/// the 7-bit-safe variant, leaving the user's paste / sync target with the
+/// `%XX` form. By sorting text candidates with this key before reading, we
+/// always reach for the UTF-8 native variant first regardless of source
+/// ordering.
+pub(super) fn text_mime_priority(mime: &str) -> u32 {
+    match mime {
+        // Explicit UTF-8 plain-text MIMEs — always preferred when present.
+        "text/plain;charset=utf-8" | "text/plain;charset=UTF-8" => 0,
+        // ICCCM's UTF-8 atom — second-best (some legacy sources reorder it).
+        "UTF8_STRING" => 1,
+        // Charset-less `text/plain`; modern sources treat it as UTF-8, but
+        // it's allowed to be Latin-1, so prefer the explicit variants above.
+        "text/plain" => 2,
+        // ICCCM defines `STRING` as Latin-1 only — sources commonly use it
+        // for a 7-bit-safe (often percent-encoded) fallback. Read last.
+        "STRING" => 3,
+        // ICCCM `TEXT` is locale-encoded. Same story as `STRING`.
+        "TEXT" => 4,
+        // Non-text mimes — keep them after all text mimes.
+        _ => u32::MAX,
+    }
+}
+
 /// Map a snapshot `format_id` → the canonical X11 mime atom name we advertise.
 /// Mirrors `wayland::protocol::default_mime_for_format`.
 pub(super) fn default_mime_for_format(format_id: &str) -> Option<&'static str> {
@@ -145,6 +176,29 @@ mod tests {
         assert_eq!(format_id_for("text/uri-list"), "files");
         assert_eq!(format_id_for("image/png"), "image");
         assert_eq!(format_id_for("image/jpeg"), "image");
+    }
+
+    #[test]
+    fn text_mime_priority_prefers_utf8_variants() {
+        // Strict ordering: explicit UTF-8 < UTF8_STRING < text/plain < STRING < TEXT.
+        assert!(text_mime_priority("text/plain;charset=utf-8") < text_mime_priority("UTF8_STRING"));
+        assert!(text_mime_priority("text/plain;charset=UTF-8") < text_mime_priority("UTF8_STRING"));
+        assert!(text_mime_priority("UTF8_STRING") < text_mime_priority("text/plain"));
+        assert!(text_mime_priority("text/plain") < text_mime_priority("STRING"));
+        assert!(text_mime_priority("STRING") < text_mime_priority("TEXT"));
+    }
+
+    #[test]
+    fn text_mime_priority_demotes_non_text_to_back() {
+        // Non-text MIMEs must sort after every text MIME so that the
+        // reorder pass never moves them in front of a text variant.
+        let last_text = text_mime_priority("TEXT");
+        for non_text in ["text/html", "text/uri-list", "image/png", "x-special/foo"] {
+            assert!(
+                text_mime_priority(non_text) > last_text,
+                "non-text mime {non_text} ranked above text"
+            );
+        }
     }
 
     #[test]

--- a/src-tauri/crates/uc-platform/src/clipboard/platform/linux/x11/reader.rs
+++ b/src-tauri/crates/uc-platform/src/clipboard/platform/linux/x11/reader.rs
@@ -31,7 +31,7 @@ use x11rb::protocol::xproto::{Atom, AtomEnum, ConnectionExt as _, Property, Prop
 use x11rb::protocol::Event;
 use x11rb::CURRENT_TIME;
 
-use super::atoms::{format_id_for, is_interesting_mime, is_text_mime};
+use super::atoms::{format_id_for, is_interesting_mime, is_text_mime, text_mime_priority};
 use super::connection::X11Server;
 use super::writer::WriterState;
 
@@ -85,6 +85,16 @@ pub(super) fn read_snapshot(
             candidates.push((a, name));
         }
     }
+    // Reorder so we read UTF-8-friendly text mimes (e.g. `UTF8_STRING`,
+    // `text/plain;charset=utf-8`) before the Latin-1-bounded fallbacks
+    // (`STRING`, `TEXT`). Sources like Chromium often advertise `STRING`
+    // first with a percent-encoded copy of a non-ASCII URL, then
+    // `UTF8_STRING` with the original UTF-8 — reading in advertise order
+    // captures the percent-encoded variant, which the user then sees
+    // wherever the entry is pasted or synced. `sort_by_key` is stable, so
+    // non-text mimes (priority `u32::MAX`) keep their advertise-order
+    // relative position — only the text mimes shuffle among themselves.
+    candidates.sort_by_key(|(_, mime)| text_mime_priority(mime));
 
     let mut reps = Vec::new();
     let mut text_captured = false;

--- a/src-tauri/crates/uc-platform/src/clipboard/platform/macos.rs
+++ b/src-tauri/crates/uc-platform/src/clipboard/platform/macos.rs
@@ -13,7 +13,10 @@ use objc2_app_kit::{
 use objc2_foundation::{NSArray, NSData};
 use std::sync::{Arc, Mutex};
 use tracing::{debug, debug_span, info, warn};
-use uc_core::clipboard::{ObservedClipboardRepresentation, SystemClipboardSnapshot};
+use uc_core::clipboard::{
+    format_id_default_mime, ImageKind, MimeClass, MimeType, ObservedClipboardRepresentation,
+    SystemClipboardSnapshot,
+};
 use uc_core::ports::SystemClipboardPort;
 
 /// macOS clipboard implementation using clipboard-rs
@@ -64,54 +67,57 @@ impl SystemClipboardPort for MacOSClipboard {
     }
 }
 
-/// 推断 rep 在 macOS 多 rep 写入路径下的"有效 MIME"。
+/// Classify a rep for the macOS multi-rep write path.
 ///
-/// 与 `common.rs` 单 rep 快路径、`windows.rs::resolve_multi_rep_mime` 保持一致的
-/// 推断表：显式 mime → 使用；否则 format_id 映射。
-///
-/// 例外:image-like format_id 但显式 mime 不是 `image/*` 时,先做字节魔数嗅探,
-/// 失败回退到 format_id 默认。原因见 `common.rs::write_snapshot` 同位置注释。
-fn resolve_multi_rep_mime(rep: &ObservedClipboardRepresentation) -> Option<&str> {
-    let format_default = match rep.format_id.as_str() {
-        "public.utf8-plain-text" | "public.text" | "NSStringPboardType" | "text" => {
-            Some("text/plain")
-        }
-        "public.html" | "Apple HTML pasteboard type" | "html" => Some("text/html"),
-        // RTF：从 Word / Pages 等富文本源复制时常与 plain text + html 同时出现；
-        // common.rs::read_snapshot 把它存为 format_id="rtf"，mime="text/rtf"。
-        "public.rtf" | "rtf" => Some("text/rtf"),
-        // PixPin 截图 / Windows 端复制图片等场景 format_id 为 "image"，mime 通常为
-        // "image/png"。`common.rs::read_snapshot` 已把图像统一标准化为 PNG，因此 jpeg /
-        // webp / gif 不会出现在 envelope 中（与 windows.rs 保持同样取舍）。
-        "public.png" | "image" => Some("image/png"),
-        "public.tiff" => Some("image/tiff"),
-        // file-list 表示：接收端 materializer 会把 rep.bytes 改写为本机 file:// URI
-        // 列表（每行一条），写入时为每个 URI 生成一个独立 NSPasteboardItem 承载
-        // NSPasteboardTypeFileURL —— Finder / NSDocumentController 识别的规范形式。
-        "public.file-url" | "NSFilenamesPboardType" | "files" => Some("text/uri-list"),
-        _ => None,
-    };
+/// Single source of mapping (shared with `common.rs` single-rep path and
+/// `windows.rs::resolve_multi_rep_mime`):
+/// 1. If the rep has an explicit mime, use it.
+/// 2. Otherwise fall back to `format_id_default_mime` (the project-wide
+///    single source for `format_id → MIME`).
+/// 3. Special case: when the format_id implies `image/*` but the explicit
+///    mime contradicts it (e.g. `application/octet-stream` from an iOS /
+///    SyncClipboard upload that omits Content-Type), recover via byte
+///    magic-number sniff. See `common.rs::write_snapshot` for the historic
+///    incident (IMG_20260508_200644.jpg).
+fn resolve_multi_rep_mime(rep: &ObservedClipboardRepresentation) -> Option<MimeClass> {
+    let format_default = format_id_default_mime(rep.format_id.as_str());
 
-    match (rep.mime.as_deref(), format_default) {
-        (Some(m), Some(default)) if default.starts_with("image/") && !m.starts_with("image/") => {
-            // sniff 路径罕见（要求 image-like format_id + 显式 mime 不是 image/*）；
-            // 即便 rep 是 LocalFile source 读盘失败，也只是退回 format_id 默认 mime,
-            // 不影响后续 setData 分支的实际写入决策。
+    let effective: Option<MimeType> = match (rep.mime.as_ref(), format_default.as_ref()) {
+        (Some(m), Some(default)) if default.is_image() && !m.is_image() => {
             let recovered = rep_bytes(rep)
                 .ok()
                 .and_then(|b| crate::clipboard::common::sniff_image_magic(&b))
-                .unwrap_or(default);
+                .map(|s| MimeType(s.to_string()))
+                .unwrap_or_else(|| default.clone());
             tracing::warn!(
                 format_id = %rep.format_id,
-                wire_mime = m,
-                recovered_mime = recovered,
+                wire_mime = m.as_str(),
+                recovered_mime = recovered.as_str(),
                 "macOS multi-rep: image rep declared non-image mime; recovered via byte sniff/format_id default"
             );
             Some(recovered)
         }
-        (Some(m), _) => Some(m),
-        (None, default) => default,
-    }
+        (Some(m), _) => Some(m.clone()),
+        (None, _) => format_default.clone(),
+    };
+
+    effective.map(|m| m.classify())
+}
+
+/// Whether a [`MimeClass`] can be written through the macOS multi-rep path.
+/// Multi-rep only supports the small set of MIME types that map to a
+/// dedicated `NSPasteboardType*` — anything else is skipped (and logged)
+/// rather than dropped on a non-UTI pasteboard type.
+fn is_multi_rep_writable(class: &MimeClass) -> bool {
+    matches!(
+        class,
+        MimeClass::TextPlain
+            | MimeClass::TextHtml
+            | MimeClass::TextRtf
+            | MimeClass::UriList
+            | MimeClass::Image(ImageKind::Png)
+            | MimeClass::Image(ImageKind::Tiff)
+    )
 }
 
 /// 把 text/uri-list rep 的字节解析为每行一条 URI 字符串。
@@ -203,17 +209,10 @@ fn make_nsdata(bytes: &[u8]) -> Retained<NSData> {
 pub(crate) fn write_snapshot_multi_macos(snapshot: SystemClipboardSnapshot) -> Result<()> {
     // 预扫描：snapshot 中至少要有一条可写 rep（text/plain、text/html、text/uri-list、
     // image/png 或 image/tiff）。否则直接 bail，不打开 / 不 clear pasteboard。
-    let has_writable = snapshot.representations.iter().any(|rep| {
-        matches!(
-            resolve_multi_rep_mime(rep),
-            Some("text/plain")
-                | Some("text/html")
-                | Some("text/rtf")
-                | Some("text/uri-list")
-                | Some("image/png")
-                | Some("image/tiff")
-        )
-    });
+    let has_writable = snapshot
+        .representations
+        .iter()
+        .any(|rep| resolve_multi_rep_mime(rep).is_some_and(|c| is_multi_rep_writable(&c)));
 
     if !has_writable {
         let skipped: Vec<String> = snapshot
@@ -261,7 +260,7 @@ pub(crate) fn write_snapshot_multi_macos(snapshot: SystemClipboardSnapshot) -> R
 
     for rep in &snapshot.representations {
         match resolve_multi_rep_mime(rep) {
-            Some("text/plain") => {
+            Some(MimeClass::TextPlain) => {
                 // text/plain 的字节是 UTF-8，NSPasteboardTypeString 期望 UTF-8 字节，
                 // 直接写原始字节，不经 NSString 转换（避免对非法 UTF-8 误报）。
                 let bytes = match rep_bytes(rep) {
@@ -292,7 +291,7 @@ pub(crate) fn write_snapshot_multi_macos(snapshot: SystemClipboardSnapshot) -> R
                     skipped.push(rep.format_id.as_str().to_string());
                 }
             }
-            Some("text/html") => {
+            Some(MimeClass::TextHtml) => {
                 let bytes = match rep_bytes(rep) {
                     Ok(b) => b,
                     Err(err) => {
@@ -320,7 +319,7 @@ pub(crate) fn write_snapshot_multi_macos(snapshot: SystemClipboardSnapshot) -> R
                     skipped.push(rep.format_id.as_str().to_string());
                 }
             }
-            Some("text/rtf") => {
+            Some(MimeClass::TextRtf) => {
                 // RTF 与 plain/html 同属"同一份内容的多种文本表示"，合并到 text_item。
                 // Word / Pages / 写字板等富文本目的地优先读 RTF；纯文本目的地（终端 /
                 // TextEdit 纯文本模式）继续用 NSPasteboardTypeString。原始 RTF 字节是
@@ -352,7 +351,7 @@ pub(crate) fn write_snapshot_multi_macos(snapshot: SystemClipboardSnapshot) -> R
                     skipped.push(rep.format_id.as_str().to_string());
                 }
             }
-            Some("image/png") => {
+            Some(MimeClass::Image(ImageKind::Png)) => {
                 // image rep 独立成一个 NSPasteboardItem，不合并进 text_item。
                 // 同一 item 的多个 type 在 NSPasteboard 语义里表达"同一份内容的多种表示"，
                 // 把 PNG bytes 与 plain text 混在一个 item 会让 reader 误判一致性。
@@ -388,7 +387,7 @@ pub(crate) fn write_snapshot_multi_macos(snapshot: SystemClipboardSnapshot) -> R
                     skipped.push(rep.format_id.as_str().to_string());
                 }
             }
-            Some("image/tiff") => {
+            Some(MimeClass::Image(ImageKind::Tiff)) => {
                 let item: Retained<NSPasteboardItem> = NSPasteboardItem::new();
                 let bytes = match rep_bytes(rep) {
                     Ok(b) => b,
@@ -419,7 +418,7 @@ pub(crate) fn write_snapshot_multi_macos(snapshot: SystemClipboardSnapshot) -> R
                     skipped.push(rep.format_id.as_str().to_string());
                 }
             }
-            Some("text/uri-list") => {
+            Some(MimeClass::UriList) => {
                 let bytes = match rep_bytes(rep) {
                     Ok(b) => b,
                     Err(err) => {
@@ -475,7 +474,8 @@ pub(crate) fn write_snapshot_multi_macos(snapshot: SystemClipboardSnapshot) -> R
             other => {
                 info!(
                     format_id = %rep.format_id,
-                    mime = ?other,
+                    rep_mime = ?rep.mime.as_ref().map(|m| m.as_str()),
+                    classified = ?other,
                     bytes = rep.size_bytes(),
                     "macOS 多 rep 写入：跳过不支持的 rep（当前支持 text/plain, text/html, text/rtf, text/uri-list, image/png, image/tiff）"
                 );
@@ -572,11 +572,11 @@ mod tests {
         // PixPin 截图 / common.rs 标准化后的 format_id 路径。
         assert_eq!(
             resolve_multi_rep_mime(&rep("public.png", None)),
-            Some("image/png")
+            Some(MimeClass::Image(ImageKind::Png))
         );
         assert_eq!(
             resolve_multi_rep_mime(&rep("image", None)),
-            Some("image/png")
+            Some(MimeClass::Image(ImageKind::Png))
         );
     }
 
@@ -584,7 +584,7 @@ mod tests {
     fn resolves_image_tiff_from_format_id() {
         assert_eq!(
             resolve_multi_rep_mime(&rep("public.tiff", None)),
-            Some("image/tiff")
+            Some(MimeClass::Image(ImageKind::Tiff))
         );
     }
 
@@ -592,16 +592,22 @@ mod tests {
     fn explicit_image_mime_takes_priority_over_format_id() {
         // 显式 mime 优先于 format_id 推断（与 windows.rs 对称）。
         let r = rep("unknown-format-id", Some("image/png"));
-        assert_eq!(resolve_multi_rep_mime(&r), Some("image/png"));
+        assert_eq!(
+            resolve_multi_rep_mime(&r),
+            Some(MimeClass::Image(ImageKind::Png))
+        );
     }
 
     #[test]
     fn resolves_text_rtf_from_format_id() {
         // 与 common.rs::read_snapshot 写库时使用的 format_id="rtf" 对齐。
-        assert_eq!(resolve_multi_rep_mime(&rep("rtf", None)), Some("text/rtf"));
+        assert_eq!(
+            resolve_multi_rep_mime(&rep("rtf", None)),
+            Some(MimeClass::TextRtf)
+        );
         assert_eq!(
             resolve_multi_rep_mime(&rep("public.rtf", None)),
-            Some("text/rtf")
+            Some(MimeClass::TextRtf)
         );
     }
 
@@ -610,7 +616,7 @@ mod tests {
         // 上游（common.rs）总会给 RTF rep 显式打 mime="text/rtf"；显式 mime 必须优先
         // 于 format_id 推断，避免被未来的 format_id 重命名意外打回 None。
         let r = rep("unknown-format-id", Some("text/rtf"));
-        assert_eq!(resolve_multi_rep_mime(&r), Some("text/rtf"));
+        assert_eq!(resolve_multi_rep_mime(&r), Some(MimeClass::TextRtf));
     }
 
     #[test]
@@ -620,6 +626,21 @@ mod tests {
         assert_eq!(resolve_multi_rep_mime(&rep("DataObject", None)), None);
         assert_eq!(resolve_multi_rep_mime(&rep("PixPinData", None)), None);
         assert_eq!(resolve_multi_rep_mime(&rep("Ole Private Data", None)), None);
+    }
+
+    #[test]
+    fn classify_handles_parameterized_text_mime() {
+        // Regression: Linux upstream advertises `text/plain;charset=utf-8`
+        // (commit 388e65bf). Before this refactor the macOS multi-rep
+        // path matched on the bare literal `"text/plain"` and missed the
+        // parameterized form, dropping the rep into the skip-and-log
+        // branch. The classifier must normalize this so Cmd+V keeps
+        // working for cross-platform synced text.
+        let r = rep("text", Some("text/plain;charset=utf-8"));
+        assert_eq!(resolve_multi_rep_mime(&r), Some(MimeClass::TextPlain));
+
+        let r = rep("text", Some("Text/Plain; Charset=UTF-8"));
+        assert_eq!(resolve_multi_rep_mime(&r), Some(MimeClass::TextPlain));
     }
 
     // `rep_bytes` 自身的回归测试在 `crate::clipboard::payload::tests` 里（与 helper

--- a/src-tauri/crates/uc-platform/src/clipboard/platform/windows.rs
+++ b/src-tauri/crates/uc-platform/src/clipboard/platform/windows.rs
@@ -7,57 +7,63 @@ use clipboard_rs::{Clipboard, ClipboardContext};
 use std::ops::Range;
 use std::sync::{Arc, Mutex};
 use tracing::{debug, debug_span, error, info, warn};
-use uc_core::clipboard::{MimeType, ObservedClipboardRepresentation, SystemClipboardSnapshot};
+use uc_core::clipboard::{
+    format_id_default_mime, ImageKind, MimeClass, MimeType, ObservedClipboardRepresentation,
+    SystemClipboardSnapshot,
+};
 use uc_core::ids::RepresentationId;
 use uc_core::ports::SystemClipboardPort;
 
-/// 推断 rep 在 Windows 多 rep 写入路径下的"有效 MIME"。
+/// Classify a rep for the Windows multi-rep write path.
 ///
-/// 与 `write_snapshot_multi_windows` 主循环使用的推断逻辑保持一致 ——
-/// 既用于前置 "有无可写 rep" 扫描，也用于主循环分派，避免两处逻辑漂移。
-/// 与 `common.rs` 单 rep 快路径的 format_id → mime 推断表对齐。
-fn resolve_multi_rep_mime(rep: &ObservedClipboardRepresentation) -> Option<&str> {
-    let format_default = match rep.format_id.as_str() {
-        "public.utf8-plain-text" | "public.text" | "NSStringPboardType" | "text" => {
-            Some("text/plain")
-        }
-        "public.html" | "Apple HTML pasteboard type" | "html" => Some("text/html"),
-        // RTF：从 Word / Pages / 写字板等富文本源复制时常与 plain + html 一起出现；
-        // common.rs::read_snapshot 写库时使用 format_id="rtf", mime="text/rtf"。
-        // Windows 上对应 RegisterClipboardFormat("Rich Text Format") 注册的自定义
-        // format（CF_RTF 不是 Win32 预定义常量）。
-        "public.rtf" | "rtf" => Some("text/rtf"),
-        // PixPin 截图等场景 format_id 为 "image"，mime 通常为 "image/png"。
-        // `common.rs::read_snapshot` 把 macOS `public.png` / `public.tiff` 都转成 PNG。
-        "public.png" | "image" => Some("image/png"),
-        // file-list 表示：接收端 materializer 会把 rep.bytes 改写为本机 file:// URI
-        // 列表（每行一条），写入时解析为原生路径后通过 CF_HDROP 提交，Explorer /
-        // 资源管理器识别的规范形式。
-        "public.file-url" | "NSFilenamesPboardType" | "files" => Some("text/uri-list"),
-        _ => None,
-    };
+/// Single source of mapping (shared with `common.rs` single-rep path and
+/// `macos.rs::resolve_multi_rep_mime`):
+/// 1. Use the rep's declared mime when present.
+/// 2. Otherwise fall back to `format_id_default_mime` (the project-wide
+///    `format_id → MIME` table).
+/// 3. Recover image bytes mis-labeled as non-image (typically
+///    `application/octet-stream` from clients that omit Content-Type) by
+///    sniffing the magic-number. See `common.rs::write_snapshot` for the
+///    incident history.
+fn resolve_multi_rep_mime(rep: &ObservedClipboardRepresentation) -> Option<MimeClass> {
+    let format_default = format_id_default_mime(rep.format_id.as_str());
 
-    // image-like format_id 但显式 mime 非 image/*:见 `common.rs::write_snapshot` 同位置注释。
-    match (rep.mime.as_deref(), format_default) {
-        (Some(m), Some(default)) if default.starts_with("image/") && !m.starts_with("image/") => {
-            // sniff 路径罕见（要求 image-like format_id + 显式 mime 不是 image/*）；
-            // 即便 rep 是 LocalFile source 读盘失败，也只是退回 format_id 默认 mime,
-            // 不影响后续 setData 分支的实际写入决策。
+    let effective: Option<MimeType> = match (rep.mime.as_ref(), format_default.as_ref()) {
+        (Some(m), Some(default)) if default.is_image() && !m.is_image() => {
             let recovered = rep_bytes(rep)
                 .ok()
                 .and_then(|b| crate::clipboard::common::sniff_image_magic(&b))
-                .unwrap_or(default);
+                .map(|s| MimeType(s.to_string()))
+                .unwrap_or_else(|| default.clone());
             tracing::warn!(
                 format_id = %rep.format_id,
-                wire_mime = m,
-                recovered_mime = recovered,
+                wire_mime = m.as_str(),
+                recovered_mime = recovered.as_str(),
                 "Windows multi-rep: image rep declared non-image mime; recovered via byte sniff/format_id default"
             );
             Some(recovered)
         }
-        (Some(m), _) => Some(m),
-        (None, default) => default,
-    }
+        (Some(m), _) => Some(m.clone()),
+        (None, _) => format_default.clone(),
+    };
+
+    effective.map(|m| m.classify())
+}
+
+/// Whether a [`MimeClass`] is writable through the Windows multi-rep path.
+/// Multi-rep only supports MIMEs that map to a known clipboard format
+/// (CF_UNICODETEXT / CF_HTML / "Rich Text Format" / CF_DIBV5 + "PNG" /
+/// CF_HDROP); anything else is skipped rather than dropped on a custom
+/// format that no consumer can read.
+fn is_multi_rep_writable(class: &MimeClass) -> bool {
+    matches!(
+        class,
+        MimeClass::TextPlain
+            | MimeClass::TextHtml
+            | MimeClass::TextRtf
+            | MimeClass::UriList
+            | MimeClass::Image(ImageKind::Png)
+    )
 }
 
 /// 把 text/uri-list rep 的字节解析为本机路径列表（`Vec<PathBuf>`）。
@@ -322,16 +328,10 @@ pub(crate) fn write_snapshot_multi_windows(snapshot: SystemClipboardSnapshot) ->
     // 前置扫描：如果没有任何 rep 是我们能写的（text/plain、text/html 或 image/png），
     // 直接 bail；**不**打开 Windows 剪贴板、**不**调 empty()。
     // 避免把用户原本的 OS 剪贴板清掉却什么都写不进去（见上方 doc comment "empty() 副作用的防御"）。
-    let has_writable = snapshot.representations.iter().any(|rep| {
-        matches!(
-            resolve_multi_rep_mime(rep),
-            Some("text/plain")
-                | Some("text/html")
-                | Some("text/rtf")
-                | Some("image/png")
-                | Some("text/uri-list")
-        )
-    });
+    let has_writable = snapshot
+        .representations
+        .iter()
+        .any(|rep| resolve_multi_rep_mime(rep).is_some_and(|c| is_multi_rep_writable(&c)));
 
     if !has_writable {
         let skipped: Vec<String> = snapshot
@@ -363,7 +363,10 @@ pub(crate) fn write_snapshot_multi_windows(snapshot: SystemClipboardSnapshot) ->
         .representations
         .iter()
         .map(|rep| {
-            if resolve_multi_rep_mime(rep) != Some("image/png") {
+            if !matches!(
+                resolve_multi_rep_mime(rep),
+                Some(MimeClass::Image(ImageKind::Png))
+            ) {
                 return None;
             }
             let bytes = match rep_bytes(rep) {
@@ -514,7 +517,7 @@ fn attempt_multi_write_inner(
         let effective_mime = resolve_multi_rep_mime(rep);
 
         match effective_mime {
-            Some("text/plain") => {
+            Some(MimeClass::TextPlain) => {
                 // 必须使用 set_string_with::<NoClear>：
                 // set_string 内部调用 DoClear（EmptyClipboard），会把已写的其他 format 抹掉。
                 let bytes = match rep_bytes(rep) {
@@ -537,7 +540,7 @@ fn attempt_multi_write_inner(
                 debug!(bytes = text.len(), "写入 CF_UNICODETEXT 成功");
                 wrote_any = true;
             }
-            Some("text/html") => {
+            Some(MimeClass::TextHtml) => {
                 let Some(html_fmt) = html_fmt_opt else {
                     warn!("注册 HTML Format 失败，跳过 text/html rep");
                     skipped.push(rep.format_id.as_str().to_string());
@@ -578,7 +581,7 @@ fn attempt_multi_write_inner(
                 );
                 wrote_any = true;
             }
-            Some("text/rtf") => {
+            Some(MimeClass::TextRtf) => {
                 // RTF 走 RegisterClipboardFormat("Rich Text Format")。RTF 1.x 规范要求
                 // 字节流是 ASCII 安全（非 ASCII 字符均通过 \uN 转义），因此可以直接以
                 // 原始字节写入 raw set_without_clear，不需要 UTF-8 / UTF-16 转换。
@@ -606,7 +609,7 @@ fn attempt_multi_write_inner(
                 debug!(bytes = bytes.len(), "写入 Rich Text Format 成功");
                 wrote_any = true;
             }
-            Some("image/png") => {
+            Some(MimeClass::Image(ImageKind::Png)) => {
                 // 双写策略：CF_DIBV5（标准格式，Windows 自动合成 CF_BITMAP/CF_DIB 给老应用）
                 // + 自定义 "PNG" format（现代应用直读 PNG 字节，保留 PNG 压缩率与 alpha 元数据）。
                 //
@@ -661,7 +664,7 @@ fn attempt_multi_write_inner(
                     skipped.push(rep.format_id.as_str().to_string());
                 }
             }
-            Some("text/uri-list") => {
+            Some(MimeClass::UriList) => {
                 // CF_HDROP 写入路径：把 rep 里的 file:// URI 列表（接收端 materializer
                 // 已把 blob 落地到本机 iroh-blobs 缓存目录并改写为本机 URI）解析回本机
                 // 路径，打包成 DROPFILES + UTF-16 名字串，`SetClipboardData(CF_HDROP)`。
@@ -721,7 +724,8 @@ fn attempt_multi_write_inner(
                 // 返回构造时记录的 meta.len()），避免触发 expect_inline_bytes panic。
                 info!(
                     format_id = %rep.format_id,
-                    mime = ?other,
+                    rep_mime = ?rep.mime.as_ref().map(|m| m.as_str()),
+                    classified = ?other,
                     bytes = rep.size_bytes(),
                     "Windows 多 rep 写入：跳过不支持的 rep（当前支持 text/plain, text/html, text/rtf, image/png, text/uri-list）"
                 );
@@ -775,11 +779,10 @@ impl SystemClipboardPort for WindowsClipboard {
             let mut snapshot = CommonClipboardImpl::read_snapshot(&mut ctx)?;
 
             // Check if clipboard-rs already captured an image
-            let has_image = snapshot.representations.iter().any(|rep| {
-                rep.mime
-                    .as_ref()
-                    .is_some_and(|m| m.as_str().starts_with("image/"))
-            });
+            let has_image = snapshot
+                .representations
+                .iter()
+                .any(|rep| rep.mime.as_ref().is_some_and(|m| m.is_image()));
 
             if has_image {
                 debug!(
@@ -956,11 +959,10 @@ impl SystemClipboardPort for WindowsClipboard {
 }
 
 fn extract_text_plain_utf8(snapshot: &SystemClipboardSnapshot) -> Result<Option<String>> {
-    let maybe_text_rep = snapshot.representations.iter().find(|rep| {
-        rep.mime
-            .as_ref()
-            .is_some_and(|mime| mime.as_str().eq_ignore_ascii_case("text/plain"))
-    });
+    let maybe_text_rep = snapshot
+        .representations
+        .iter()
+        .find(|rep| rep.mime.as_ref().is_some_and(|m| m.is_text_plain()));
 
     let Some(text_rep) = maybe_text_rep else {
         return Ok(None);
@@ -984,7 +986,7 @@ fn is_single_text_plain_snapshot(snapshot: &SystemClipboardSnapshot) -> bool {
     snapshot.representations[0]
         .mime
         .as_ref()
-        .is_some_and(|mime| mime.as_str().eq_ignore_ascii_case("text/plain"))
+        .is_some_and(|m| m.is_text_plain())
 }
 
 fn is_single_image_snapshot(snapshot: &SystemClipboardSnapshot) -> bool {
@@ -995,7 +997,7 @@ fn is_single_image_snapshot(snapshot: &SystemClipboardSnapshot) -> bool {
     snapshot.representations[0]
         .mime
         .as_ref()
-        .is_some_and(|mime| mime.as_str().starts_with("image/"))
+        .is_some_and(|m| m.is_image())
 }
 
 fn write_text_windows_native(text: &str) -> Result<()> {
@@ -1160,10 +1162,13 @@ mod tests {
     fn resolves_text_rtf_from_format_id() {
         // 与 common.rs::read_snapshot 写库时使用的 format_id="rtf" 对齐；
         // 与 macos.rs 同名测试镜像，保证两个平台的 multi-rep 派发结果一致。
-        assert_eq!(resolve_multi_rep_mime(&rep("rtf", None)), Some("text/rtf"));
+        assert_eq!(
+            resolve_multi_rep_mime(&rep("rtf", None)),
+            Some(MimeClass::TextRtf)
+        );
         assert_eq!(
             resolve_multi_rep_mime(&rep("public.rtf", None)),
-            Some("text/rtf")
+            Some(MimeClass::TextRtf)
         );
     }
 
@@ -1172,6 +1177,21 @@ mod tests {
         // 显式 mime 必须优先于 format_id 推断（与 macos.rs 对称），
         // 避免被未来的 format_id 重命名意外打回 None。
         let r = rep("unknown-format-id", Some("text/rtf"));
-        assert_eq!(resolve_multi_rep_mime(&r), Some("text/rtf"));
+        assert_eq!(resolve_multi_rep_mime(&r), Some(MimeClass::TextRtf));
+    }
+
+    #[test]
+    fn classify_handles_parameterized_text_mime() {
+        // Regression: Linux upstream advertises `text/plain;charset=utf-8`
+        // (commit 388e65bf). The Windows multi-rep path previously matched
+        // on the bare literal `"text/plain"` and missed the parameterized
+        // form, dropping the rep into the skip-and-log branch — paste
+        // would silently produce nothing on Windows when the synced rep
+        // carried an explicit charset.
+        let r = rep("text", Some("text/plain;charset=utf-8"));
+        assert_eq!(resolve_multi_rep_mime(&r), Some(MimeClass::TextPlain));
+
+        let r = rep("text", Some("Text/Plain; Charset=UTF-8"));
+        assert_eq!(resolve_multi_rep_mime(&r), Some(MimeClass::TextPlain));
     }
 }

--- a/src-tauri/crates/uc-platform/src/clipboard/platform/windows.rs
+++ b/src-tauri/crates/uc-platform/src/clipboard/platform/windows.rs
@@ -1,3 +1,4 @@
+use super::super::cf_html::strip_cf_html_wrapper;
 use super::super::common::CommonClipboardImpl;
 use super::super::payload::rep_bytes;
 use anyhow::Result;
@@ -557,11 +558,24 @@ fn attempt_multi_write_inner(
                 };
                 let html = String::from_utf8(bytes.into_owned())
                     .map_err(|e| anyhow::anyhow!("text/html rep is not valid UTF-8: {}", e))?;
+                // Strip any CF_HTML outer wrapper before handing the payload
+                // to `set_html`. `clipboard-win::raw::set_html` always re-wraps
+                // its input with `<html><body><!--StartFragment-->...<!--EndFragment-->`
+                // headers, while `clipboard-rs::get_html` returns the full
+                // document (StartHTML..EndHTML, wrappers included). Without
+                // this normalization each Win → peer → Win round-trip nests
+                // another wrapper layer; `content_hash`-based dedup cannot
+                // collapse them because each layer changes the hash.
+                let html_payload = strip_cf_html_wrapper(&html);
                 // set_html 默认走 NoClear 分支，内部构造 "Version:0.9 / StartHTML / EndHTML /
                 // StartFragment / EndFragment" 头并包裹 BODY_HEADER/BODY_FOOTER，适合累加。
-                cb_raw::set_html(html_fmt, &html)
+                cb_raw::set_html(html_fmt, html_payload)
                     .map_err(|e| anyhow::anyhow!("set CF_HTML failed: {}", e))?;
-                debug!(bytes = html.len(), "写入 CF_HTML 成功");
+                debug!(
+                    bytes = html_payload.len(),
+                    stripped_bytes = html.len() - html_payload.len(),
+                    "写入 CF_HTML 成功"
+                );
                 wrote_any = true;
             }
             Some("text/rtf") => {


### PR DESCRIPTION
This PR fixes three distinct symptoms reported against #850 — all manifested as "cross-platform sync fidelity broken" on dual-sync setups, plus a follow-up regression introduced by the first two fixes.

## Fix 1 — CF_HTML round-trip nesting on Windows (commit `abd42a7d`)

- Windows CF_HTML 写入路径 (`clipboard-win::raw::set_html`) 无条件给 payload 外层再包一对 `<html>\r\n<body>\r\n<!--StartFragment-->...<!--EndFragment-->\r\n</body>\r\n</html>`，而读取路径 (`clipboard-rs::get_html`) 按 `StartHTML..EndHTML` 切片返回整段（含 wrapper）。两者不对称导致 Win ↔ peer 每轮 round-trip 都嵌套一层；payload 字节每轮都变，连带 `content_hash` 变化，击穿 `apply_inbound` 的 `find_recent_duplicate` 窗口 —— dual-sync 用户在 dashboard 看到指数级累积的嵌套 HTML（这正是 #850 OP 截图里的现象）。
- 新增 `clipboard::cf_html::strip_cf_html_wrapper`：用 `rfind` 锁定最内层 `<!--StartFragment-->`，一次调用收敛任意层数嵌套。
- 在 `windows.rs` 的 `attempt_multi_write_inner` 里给 `cb_raw::set_html` 之前先剥 wrapper，从写入侧切断累积。读取端存储格式不动；已被污染的旧 entry 在下一次 round-trip 自动清洗回 1 层。

## Fix 2 — Linux text-mime ordering leaks percent-encoded URLs (commit `388e65bf`)

- #850 最新评论描述的第二个症状：在 Linux 复制 `http://10.156.57.80:8080/job/玉兔Pro/`，被 UniClipboard 同步或本机粘贴后变成 `http://10.156.57.80:8080/job/%E7%8E%89%E5%85%94Pro/` —— `%E7%8E%89%E5%85%94` 正是 `玉兔` 的 UTF-8 字节 `E7 8E 89 / E5 85 94` 各自 percent-encoded 的结果。
- 根因：Chromium / 不少 GTK 文件管理器同时在 `STRING`（ICCCM Latin-1，URL 用 7-bit-safe 的 percent-encoded fallback 装）和 `UTF8_STRING`（UTF-8 原文）上 advertise 同一份逻辑文本，但常常把 `STRING` 排在 `UTF8_STRING` 之前。我们的 X11 reader / Wayland snapshot builder 按 advertise 顺序遍历，命中第一个 text mime 就停 —— 落到 percent-encoded 的 `STRING` 上，原文 `UTF8_STRING` 被丢弃。
- 新增 `text_mime_priority` 排序键：`text/plain;charset=utf-8` < `UTF8_STRING` < `text/plain` < `STRING` < `TEXT`。在 X11 reader 和 Wayland snapshot builder 读取前 stable-sort 一次；非 text mime 共享 `u32::MAX` 保持 advertise 顺序，只对 text mime 内部重排，让 UTF-8 变体永远先被读到。
- Caveat：若 source 只 advertise `STRING`（没有 UTF-8 变体）或者把 percent-encoded 内容直接装进 `UTF8_STRING`，此修复无能为力 —— 那种 case 需要 heuristic decode，超出本 PR 范围。

## Fix 3 — macOS write paths drop `text/plain;charset=utf-8` after Fix 2 (commit `e3ca7223`)

- Fix 2 让 Linux capture 端开始使用 `text/plain;charset=utf-8` 作为 text rep 的 mime。同步到 macOS 后，`uc-platform::common::write_snapshot` 的 `match effective_mime { Some("text/plain") => ... }` arm 是裸字符串字面量，**不命中** `text/plain;charset=utf-8`，rep 落到 `_ =>` 的 `set_buffer(format_id, bytes)` fallback。在 macOS 上这等于把字节挂到一个非 UTI 的 pasteboard type（如 `"text"`），系统接受写入但任何应用 Cmd+V 都拿不到内容 —— 用户看历史能看到这条 entry、点 restore 也"成功"，但实际粘不出来。`macos.rs::resolve_multi_rep_mime` / `windows.rs::resolve_multi_rep_mime` 也是同样的字符串字面量结构，对 `;charset=utf-8` 一样脆。
- 根因不是少写了一行字符串，而是**用 `String == "literal"` 表达 MIME 语义** —— 任何下游 match 漏一处就静默坏一次，而 fallback 还吞掉错误。
- 根本性修复：
  - `uc-core::MimeType` 新增 `essence()` / `parameter()` / `classify()` / `is_text_plain()` / `is_image()` 等语义方法，外加 `MimeClass` / `ImageKind` enum。所有平台写入决策从字符串 match 改为 `MimeClass` enum match，参数 / 大小写 / 空白等变体在 `classify()` 内规范化一次。
  - `format_id_default_mime()` 是 `format_id → MIME` 的单源，替换原本散落在 `common.rs`、`platform/macos.rs`、`platform/windows.rs` 等处的 6 张几乎一样的映射表。下次加 format_id 改一处。
  - `compute_effective_mime()` 抽成纯函数（不依赖 `&mut ClipboardContext`），mime 推断 + image-magic 字节嗅探（防御 mis-tagged `application/octet-stream`）可独立单测覆盖每种 mime 变体。
  - `write_snapshot` / `write_snapshot_multi_macos` / `write_snapshot_multi_windows` 三处写入路径全部走 `MimeClass`。单 rep 路径里原本 `warn! + set_buffer(format_id, bytes)` 的兜底改为 `bail!` —— 符合 `uc-platform/AGENTS.md` §11.2 "不允许静默降级"，未识别 MIME 必须 surface，不能落到非 UTI pasteboard type 上让用户撞墙。
  - `uc-core::system` 的 6 个 `is_*` 谓词（`is_plain_text_mime_or_format` / `is_image_representation` / `is_file_mime_or_format` / `is_rich_text_representation` / `is_link_representation` / `is_any_text_representation`）全部委托给 `MimeType::classify()` / `is_*()`。手写的 `eq_ignore_ascii_case + starts_with` 组合都带有同样的 charset-parameter 隐藏 bug，一并消除。
- 范围外（后续 PR）：Linux 读取侧 `platform/linux/{x11,wayland}/*.rs` 的 `format_id_for` / `default_mime_for_format`；capture 侧 `uc-application::clipboard_capture` 的字符串分支；`facade::search::projection` / `mobile_sync::sync_clipboard_mapping`。它们都是同一类问题但不在本次回归路径上。

## Test plan

- [x] `cargo test -p uc-core --lib` — 117/117 pass（mime.rs 新增 8 个 essence / classify / format_id_default_mime 单测覆盖参数 / 大小写 / 空白全矩阵）
- [x] `cargo test -p uc-platform --lib` — 53/53 pass（common.rs 新增 6 个 `compute_effective_mime` 单测，包含 `text/plain;charset=utf-8` 回归用例 / format_id-only 兜底 / octet-stream 字节嗅探 recover / 未知 mime refuse；macos.rs + windows.rs 各加 `classify_handles_parameterized_text_mime` round-trip 测试）
- [x] `cargo test -p uc-platform --lib clipboard::cf_html` — 7/7 pass
- [x] `cargo check -p uc-platform --target x86_64-pc-windows-gnu --tests` — clean
- [x] `cargo build --workspace`（macOS）— clean
- [x] `RUSTFLAGS="-D dead-code" cargo check -p uc-platform --lib`（macOS）— clean
- [ ] Linux CI 跑 `x11::atoms::tests::text_mime_priority_*` / `wayland::snapshot::tests::*priority*` / `sort_pulls_utf8_text_mime_in_front_of_string`（macOS 上 cross-compile 受 `libdbus` pkg-config 限制，本地无法验证 —— 依赖 CI）
- [ ] 真机验证（Windows + Linux 双机）：浏览器复制带中文路径的 URL，确认本机 / 跨机粘贴都拿到 UTF-8 原文（Fix 2）
- [ ] 真机验证：HTML 内容反复同步，dashboard 的 `text/html` rep 不再累积 wrapper 层；已污染的历史 entry 是否自动清洗（Fix 1）
- [ ] 真机验证（Linux → macOS）：从 Linux 浏览器复制带中文参数的 URL，Mac 端收到后 Cmd+V 能粘出原文；其余 mime 变体（`Text/Plain; Charset=UTF-8` / `text/plain;charset="utf-8"` / `text/html;charset=utf-8`）走相同路径不再触发 fallback bail（Fix 3）

Refs #850.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Windows clipboard: strip redundant CF_HTML wrappers to prevent nested or empty fragments when copying/pasting HTML.

* **New Features**
  * Improved MIME classification for clipboard content (better detection of text/html, text/plain, images, URI lists), yielding more accurate paste behavior and safer handling of unknown formats.
  * Refined image handling and explicit refusal of unconsumable binary-only clipboard writes.

* **Improvements**
  * Cross-platform: prefer UTF‑8-friendly text variants when multiple text formats are offered, improving fidelity on Linux and X11.
  * macOS/Windows: more consistent multi-format write behavior via unified MIME-based routing.

* **Tests**
  * Added unit tests covering CF_HTML stripping, MIME classification, priority ordering, and multi-format write cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/UniClipboard/UniClipboard/pull/862?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->