### PR TITLE
fix(clipboard-sync): stop re-dialing offline peers on every copy

### DIFF
--- a/src-tauri/crates/uc-application/src/usecases/clipboard_sync/dispatch_entry.rs
+++ b/src-tauri/crates/uc-application/src/usecases/clipboard_sync/dispatch_entry.rs
@@ -41,10 +41,12 @@
 //! genuinely need them (broadcast `subscribe + emit`; see
 //! `ingest_inbound.rs::tests` and Phase 1 `roster/facade.rs::FakePresence`).
 
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use bytes::Bytes;
+use tokio::sync::Mutex;
 use tokio::task::{JoinError, JoinSet};
 use tracing::{debug, info, info_span, instrument, warn, Instrument};
 use uc_observability::FlowId;
@@ -65,6 +67,34 @@ use uc_observability::FlowId;
 /// (实测 ~3s 内完成),既能让主流程在常见场景下等到所有 peer 的真实结果,
 /// 又避免被离线 peer 的 staggered retry 长尾拖死。详见 #785。
 const FAN_OUT_DEADLINE: Duration = Duration::from_secs(5);
+
+/// In-process negative cache TTL for "most recent dial failure".
+///
+/// On the dial-failure path inside `clipboard_dispatch_adapter`,
+/// `mark_offline` writes presence `last_state = Offline`, which lets the
+/// next dispatch's spawn-time preflight short-circuit immediately. But that
+/// signal only arrives after `connect_with_staggered_retry` has exhausted
+/// all three attempts (~27s worst case) — and `FAN_OUT_DEADLINE = 5s` has
+/// already cut the main flow short, so the staggered retry continues in a
+/// background task.
+///
+/// When the user copies repeatedly (interval < 27s), the new dispatch's
+/// preflight still observes `Unknown` for the peer (the first dispatch
+/// hasn't reached `mark_offline` yet) and kicks off another full 27s dial
+/// loop. Background tasks accumulate like a snowball; the logs get flooded
+/// with `iroh connect` and `staggered retry failed` lines.
+///
+/// This TTL gives the use case its own "I just tried, it didn't get
+/// through" evidence, so subsequent dispatches can short-circuit *before*
+/// presence has officially flipped to Offline. `mark_offline` remains
+/// presence's authoritative update; the local stamp is just a "fires 25s
+/// earlier" suppression layer that gets out of the way (after TTL) and
+/// lets the normal presence + keepalive recovery path resume.
+///
+/// 30s is picked to slightly exceed the staggered retry's worst-case
+/// lifetime (~27s) without interfering with the keepalive worker's 25s
+/// cadence for state corrections.
+const RECENT_DIAL_FAILURE_TTL: Duration = Duration::from_secs(30);
 
 use crate::facade::blob_transfer::SharedHostEventEmitter;
 use crate::facade::host_event::{DeliveryHostEvent, HostEvent};
@@ -305,6 +335,17 @@ pub(crate) struct DispatchClipboardEntryUseCase {
     /// dispatch 主路径;事件丢失 / 乱序由前端 refetch 幂等吸收。CLI / 单元
     /// 测试装配传一根空 bus 即可(无下游 = noop)。
     host_event_bus: SharedHostEventEmitter,
+    /// In-process negative cache for "most recent dial failure". The
+    /// spawn-time preflight checks this map in addition to
+    /// `presence.current_state`: a stamp within TTL is treated as
+    /// known-offline and short-circuits the dial. Written on dispatch
+    /// failures classified as `Offline` / `Io`. See
+    /// [`RECENT_DIAL_FAILURE_TTL`] for the rationale.
+    ///
+    /// Not exposed via `new()` — this is purely internal state the use
+    /// case maintains for itself; callers stay unaware and tests +
+    /// wiring keep the original constructor signature.
+    recent_dial_failures: Arc<Mutex<HashMap<DeviceId, Instant>>>,
 }
 
 impl DispatchClipboardEntryUseCase {
@@ -338,6 +379,7 @@ impl DispatchClipboardEntryUseCase {
             first_sync_state,
             entry_delivery_repo,
             host_event_bus,
+            recent_dial_failures: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 
@@ -471,6 +513,7 @@ impl DispatchClipboardEntryUseCase {
             let presence = Arc::clone(&self.presence);
             let analytics = Arc::clone(&self.analytics);
             let first_sync_state = Arc::clone(&self.first_sync_state);
+            let recent_dial_failures = Arc::clone(&self.recent_dial_failures);
             let header = header.clone();
             let device_id = device_id.clone();
             let payload = SyncPayload {
@@ -489,7 +532,24 @@ impl DispatchClipboardEntryUseCase {
                     //   用户感知尝试 = attempted - deferred
                     // 详见 docs/architecture/telemetry-events.md §7.3b。
                     let preflight_state = presence.current_state(&device_id).await;
-                    let known_offline = matches!(preflight_state, ReachabilityState::Offline);
+                    // Local negative cache — covers the window before
+                    // presence has had a chance to flip to Offline. See
+                    // `RECENT_DIAL_FAILURE_TTL` for rationale. The lock
+                    // is held across no awaits, and we opportunistically
+                    // evict expired stamps so the map can't grow unbounded.
+                    let recently_failed = {
+                        let mut map = recent_dial_failures.lock().await;
+                        match map.get(&device_id) {
+                            Some(t) if t.elapsed() < RECENT_DIAL_FAILURE_TTL => true,
+                            Some(_) => {
+                                map.remove(&device_id);
+                                false
+                            }
+                            None => false,
+                        }
+                    };
+                    let known_offline = matches!(preflight_state, ReachabilityState::Offline)
+                        || recently_failed;
                     capture_sync_attempted(
                         &analytics,
                         &first_sync_state,
@@ -534,6 +594,28 @@ impl DispatchClipboardEntryUseCase {
                     let result = dispatch.dispatch(&device_id, &header, payload).await;
                     let duration_ms =
                         started_at.elapsed().as_millis().min(u32::MAX as u128) as u32;
+
+                    // Stamp the local negative cache — but only for "dial-class"
+                    // failures. `Offline` is what the dispatch adapter
+                    // produces after its dial path fully fails; `Io` covers
+                    // wire-stage failures (open_bi / write / read errors)
+                    // which are typically network problems too.
+                    // `PeerRejected` means the peer is reachable but
+                    // refused (e.g. wire-version mismatch) — must not
+                    // suppress retries. `LocalPolicyExceeded` is a local
+                    // refusal (e.g. payload too big) unrelated to
+                    // reachability. `Internal` is a bug on our side;
+                    // stamping would mask it.
+                    if let Err(err) = &result {
+                        if matches!(
+                            err,
+                            ClipboardDispatchError::Offline | ClipboardDispatchError::Io(_)
+                        ) {
+                            let mut map = recent_dial_failures.lock().await;
+                            map.insert(device_id, Instant::now());
+                        }
+                    }
+
                     let event = match &result {
                         Ok(_) => Event::SyncSucceeded(SyncEventProps {
                             direction: Direction::Outbound,
@@ -2979,5 +3061,163 @@ mod tests {
             2,
             "background should have emitted slow peer's delivery event"
         );
+    }
+
+    // ── recent-dial-failure local negative cache ────────────────────────
+    //
+    // These verdicts guard the use case's own short-term "most recent dial
+    // failure" negative cache: the dispatch adapter's `mark_offline` only
+    // takes effect after the staggered retry finishes (~27s), and the
+    // user's next copy spawns a new dispatch well before that — without
+    // this local layer, every copy would repeat the 27s dial tail and
+    // flood the logs.
+    //
+    // Three invariants:
+    //   1. Offline failure → same peer is not re-dialed within 30s (local
+    //      short-circuit fires).
+    //   2. Io failure → also stamps, next dispatch is short-circuited.
+    //   3. PeerRejected does NOT stamp — peer is online but refused
+    //      (e.g. wire-version mismatch); retries must not be suppressed.
+
+    /// 1. Offline failure → local stamp takes effect → second dispatch
+    /// does not hit the port. The mockall `.times(1)` is the contract:
+    /// if the negative cache fails to kick in, the second execution
+    /// triggers a second dispatch call and exceeds the expectation,
+    /// causing mockall to panic.
+    #[tokio::test]
+    async fn recent_offline_failure_short_circuits_next_dispatch() {
+        let mut repo = MockPeerAddrRepo::new();
+        repo.expect_list()
+            .times(2)
+            .returning(|| Ok(vec![record("peer-flaky")]));
+
+        let mut cipher = MockCipher::new();
+        cipher
+            .expect_encrypt()
+            .times(2)
+            .returning(|p| Ok(p.to_vec()));
+
+        let mut dispatch = MockDispatch::new();
+        dispatch
+            .expect_dispatch()
+            .with(eq(DeviceId::new("peer-flaky")), always(), always())
+            .times(1)
+            .returning(|_, _, _| Err(ClipboardDispatchError::Offline));
+
+        let uc = build_uc(
+            repo,
+            make_member_repo_all_enabled(),
+            cipher,
+            dispatch,
+            make_device_identity("self-device"),
+            make_local_identity_stub(),
+            make_settings_stub(),
+        );
+
+        let first = uc.execute(input()).await.expect("first dispatch ok");
+        assert_eq!(first.total_offline, 1);
+        assert_eq!(first.total_accepted, 0);
+
+        let second = uc.execute(input()).await.expect("second dispatch ok");
+        assert_eq!(
+            second.total_offline, 1,
+            "second pass must short-circuit via local stamp",
+        );
+        assert_eq!(second.total_accepted, 0);
+    }
+
+    /// 2. Io failures also stamp — treated the same as Offline because
+    /// wire-layer errors are usually network problems too.
+    #[tokio::test]
+    async fn recent_io_failure_short_circuits_next_dispatch() {
+        let mut repo = MockPeerAddrRepo::new();
+        repo.expect_list()
+            .times(2)
+            .returning(|| Ok(vec![record("peer-iowedged")]));
+
+        let mut cipher = MockCipher::new();
+        cipher
+            .expect_encrypt()
+            .times(2)
+            .returning(|p| Ok(p.to_vec()));
+
+        let mut dispatch = MockDispatch::new();
+        dispatch
+            .expect_dispatch()
+            .with(eq(DeviceId::new("peer-iowedged")), always(), always())
+            .times(1)
+            .returning(|_, _, _| Err(ClipboardDispatchError::Io("open_bi: reset".into())));
+
+        let uc = build_uc(
+            repo,
+            make_member_repo_all_enabled(),
+            cipher,
+            dispatch,
+            make_device_identity("self-device"),
+            make_local_identity_stub(),
+            make_settings_stub(),
+        );
+
+        let first = uc.execute(input()).await.expect("first dispatch ok");
+        assert_eq!(first.total_errored, 1);
+
+        // Second preflight observes the local stamp → treats as
+        // known-offline → counted as offline.
+        let second = uc.execute(input()).await.expect("second dispatch ok");
+        assert_eq!(
+            second.total_offline, 1,
+            "Io failure must also stamp the local cache",
+        );
+    }
+
+    /// 3. PeerRejected does NOT stamp — the peer is online but refused
+    /// (wire-version mismatch, space locked, etc.), which is unrelated
+    /// to reachability. The next dispatch must try again and must not be
+    /// incorrectly short-circuited.
+    #[tokio::test]
+    async fn peer_rejected_does_not_stamp_local_cache() {
+        let mut repo = MockPeerAddrRepo::new();
+        repo.expect_list()
+            .times(2)
+            .returning(|| Ok(vec![record("peer-rejecty")]));
+
+        let mut cipher = MockCipher::new();
+        cipher
+            .expect_encrypt()
+            .times(2)
+            .returning(|p| Ok(p.to_vec()));
+
+        let mut dispatch = MockDispatch::new();
+        // Expect 2 calls: first rejection does not stamp the cache, so
+        // the second dispatch must hit the port again.
+        dispatch
+            .expect_dispatch()
+            .with(eq(DeviceId::new("peer-rejecty")), always(), always())
+            .times(2)
+            .returning(|_, _, _| {
+                Err(ClipboardDispatchError::PeerRejected(
+                    "wire version mismatch".into(),
+                ))
+            });
+
+        let uc = build_uc(
+            repo,
+            make_member_repo_all_enabled(),
+            cipher,
+            dispatch,
+            make_device_identity("self-device"),
+            make_local_identity_stub(),
+            make_settings_stub(),
+        );
+
+        let first = uc.execute(input()).await.expect("first dispatch ok");
+        assert_eq!(first.total_errored, 1);
+
+        let second = uc.execute(input()).await.expect("second dispatch ok");
+        assert_eq!(
+            second.total_errored, 1,
+            "PeerRejected must not suppress retries; dispatch port should be called again",
+        );
+        assert_eq!(second.total_offline, 0);
     }
 }

--- a/src-tauri/crates/uc-infra/src/network/iroh/presence_adapter.rs
+++ b/src-tauri/crates/uc-infra/src/network/iroh/presence_adapter.rs
@@ -123,7 +123,7 @@ const FAST_PATH_TTL: Duration = Duration::from_secs(30);
 struct HandlerState {
     member_repo: Arc<dyn MemberRepositoryPort>,
     fingerprint_factory: Arc<dyn IdentityFingerprintFactoryPort>,
-    last_state: Arc<Mutex<HashMap<String, ReachabilityState>>>,
+    last_state: Arc<Mutex<HashMap<DeviceId, ReachabilityState>>>,
     event_tx: broadcast::Sender<PresenceEvent>,
     clock: Arc<dyn ClockPort>,
 }
@@ -209,7 +209,6 @@ impl ProtocolHandler for IrohPresenceHandler {
 
         let remote_bytes: [u8; 32] = *remote.as_bytes();
         if let Some(device_id) = self.state.resolve_device(&remote_bytes).await {
-            let key = device_id.as_str().to_string();
             let now_at = self.state.now();
 
             // Acquire `last_state` only long enough to insert and observe
@@ -217,12 +216,12 @@ impl ProtocolHandler for IrohPresenceHandler {
             // lock drops to avoid holding it across `.send`.
             let prev = {
                 let mut last = self.state.last_state.lock().await;
-                last.insert(key, ReachabilityState::Online)
+                last.insert(device_id, ReachabilityState::Online)
             };
 
             if prev != Some(ReachabilityState::Online) {
                 let _ = self.state.event_tx.send(PresenceEvent {
-                    device_id: device_id.clone(),
+                    device_id,
                     state: ReachabilityState::Online,
                     at: now_at,
                 });
@@ -271,19 +270,17 @@ pub struct IrohPresenceAdapter {
     endpoint: Arc<Endpoint>,
     peer_addr_repo: Arc<dyn PeerAddressRepositoryPort>,
     clock: Arc<dyn ClockPort>,
-    /// Live iroh connections keyed by `DeviceId` serialised as `String` —
-    /// `uc_core::ids::DeviceId` deliberately does not derive `Hash`, so
-    /// the adapter projects it down to its stringified form for map keys.
-    /// `DeviceId` is reconstructed via `DeviceId::new` at the event
-    /// broadcast boundary so the port contract stays strongly typed.
-    peers: Arc<Mutex<HashMap<String, TrackedPeer>>>,
+    /// Live iroh connections keyed by `DeviceId`. `DeviceId` is `Copy +
+    /// Hash` (a 64-byte inline `ArrayString`), so it can be used directly
+    /// as a map key without a stringified projection.
+    peers: Arc<Mutex<HashMap<DeviceId, TrackedPeer>>>,
     /// Remember the last observed outcome for every device the adapter has
     /// ever probed. Distinct from `peers` because a failed dial should
     /// surface as `Offline` on `current_state` without leaving a live
     /// connection entry behind. Shared with [`HandlerState`] so inbound
     /// connections can flip a peer to Online under the same lock the
     /// outbound watchdog uses to flip to Offline.
-    last_state: Arc<Mutex<HashMap<String, ReachabilityState>>>,
+    last_state: Arc<Mutex<HashMap<DeviceId, ReachabilityState>>>,
     event_tx: broadcast::Sender<PresenceEvent>,
     /// Cheap-clone state for [`IrohPresenceHandler`]. Constructed once in
     /// [`IrohPresenceAdapter::new`] and handed out via
@@ -408,8 +405,6 @@ impl IrohPresenceAdapter {
     ///    抖动失败，旧连接其实还可用；`verify_reachable` 在外层补偿
     ///    "把假装活着的旧连接 close 掉"的清理动作）
     async fn dial_and_track(&self, device: &DeviceId) -> Result<ReachabilityState, PresenceError> {
-        let key = device.as_str().to_string();
-
         // Look up the stored transport address.
         let record = self
             .peer_addr_repo
@@ -475,7 +470,7 @@ impl IrohPresenceAdapter {
                     // that the peer is reachable *right now*, so the
                     // fast-path TTL clock should reset even though we're
                     // discarding the new connection in favour of the old.
-                    if let Some(existing) = peers.get_mut(&key) {
+                    if let Some(existing) = peers.get_mut(device) {
                         if existing.connection.close_reason().is_none() {
                             existing.last_verified_at = Instant::now();
                             debug!(
@@ -488,14 +483,14 @@ impl IrohPresenceAdapter {
                             // 仍旧 broadcast Online — verify_reachable 调用方
                             // 期望"拨号成功 ⇒ Online 信号回传"。
                             let mut last = self.last_state.lock().await;
-                            last.insert(key.clone(), ReachabilityState::Online);
+                            last.insert(*device, ReachabilityState::Online);
                             drop(last);
-                            self.broadcast(device.clone(), ReachabilityState::Online, now);
+                            self.broadcast(*device, ReachabilityState::Online, now);
                             return Ok(ReachabilityState::Online);
                         }
                     }
                     peers.insert(
-                        key.clone(),
+                        *device,
                         TrackedPeer {
                             connection,
                             watchdog,
@@ -506,10 +501,10 @@ impl IrohPresenceAdapter {
 
                 {
                     let mut last = self.last_state.lock().await;
-                    last.insert(key.clone(), ReachabilityState::Online);
+                    last.insert(*device, ReachabilityState::Online);
                 }
                 info!("dial_and_track: dial succeeded, peer marked Online");
-                self.broadcast(device.clone(), ReachabilityState::Online, now);
+                self.broadcast(*device, ReachabilityState::Online, now);
                 Ok(ReachabilityState::Online)
             }
             Err(err) => {
@@ -521,9 +516,9 @@ impl IrohPresenceAdapter {
                 let now = self.now();
                 {
                     let mut last = self.last_state.lock().await;
-                    last.insert(key, ReachabilityState::Offline);
+                    last.insert(*device, ReachabilityState::Offline);
                 }
-                self.broadcast(device.clone(), ReachabilityState::Offline, now);
+                self.broadcast(*device, ReachabilityState::Offline, now);
                 Ok(ReachabilityState::Offline)
             }
         }
@@ -537,8 +532,6 @@ impl PresencePort for IrohPresenceAdapter {
         &self,
         device: &DeviceId,
     ) -> Result<ReachabilityState, PresenceError> {
-        let key = device.as_str().to_string();
-
         // Step 1: fast-path on an already-tracked live connection.
         //
         // Both predicates must hold to return Online without a fresh dial:
@@ -559,7 +552,7 @@ impl PresencePort for IrohPresenceAdapter {
         // distinguishable from a closed-conn eviction in production.
         {
             let mut peers = self.peers.lock().await;
-            if let Some(entry) = peers.get(&key) {
+            if let Some(entry) = peers.get(device) {
                 let still_alive = entry.connection.close_reason().is_none();
                 let recently_verified = entry.last_verified_at.elapsed() < FAST_PATH_TTL;
                 if still_alive && recently_verified {
@@ -571,7 +564,7 @@ impl PresencePort for IrohPresenceAdapter {
                 // Evict so the re-dial path below starts from a clean
                 // slate (and so `dial_and_track`'s "alive entry already
                 // exists" branch doesn't accidentally preserve a corpse).
-                if let Some(stale) = peers.remove(&key) {
+                if let Some(stale) = peers.remove(device) {
                     stale.watchdog.abort();
                     debug!(
                         still_alive,
@@ -607,7 +600,7 @@ impl PresencePort for IrohPresenceAdapter {
         if matches!(result, ReachabilityState::Offline) {
             let stale = {
                 let mut peers = self.peers.lock().await;
-                peers.remove(device.as_str())
+                peers.remove(device)
             };
             if let Some(stale) = stale {
                 stale.connection.close(0u32.into(), b"verify_failed");
@@ -620,8 +613,6 @@ impl PresencePort for IrohPresenceAdapter {
 
     #[instrument(skip_all, fields(device = %device.as_str()))]
     async fn mark_offline(&self, device: &DeviceId) {
-        let key = device.as_str().to_string();
-
         // 1) Evict the live-connection slot. The peer is held to be dead by
         //    an external observer — anything we cached as alive is now a lie
         //    that the fast-path in `ensure_reachable` would happily serve.
@@ -636,7 +627,7 @@ impl PresencePort for IrohPresenceAdapter {
         //    fired yet, and that's fine; we don't depend on it running).
         let stale = {
             let mut peers = self.peers.lock().await;
-            peers.remove(&key)
+            peers.remove(device)
         };
         if let Some(stale) = stale {
             stale.connection.close(0u32.into(), b"mark_offline");
@@ -649,14 +640,14 @@ impl PresencePort for IrohPresenceAdapter {
         //    doesn't slip a duplicate Offline through.
         let should_broadcast = {
             let mut last = self.last_state.lock().await;
-            let prev = last.insert(key, ReachabilityState::Offline);
+            let prev = last.insert(*device, ReachabilityState::Offline);
             prev != Some(ReachabilityState::Offline)
         };
 
         if should_broadcast {
             let now = self.now();
             debug!("mark_offline: peer marked Offline");
-            self.broadcast(device.clone(), ReachabilityState::Offline, now);
+            self.broadcast(*device, ReachabilityState::Offline, now);
         }
     }
 
@@ -667,19 +658,18 @@ impl PresencePort for IrohPresenceAdapter {
     // `verify_reachable` 真做拨号,继续保留 instrument(uc-infra §10.1
     // 强制要求关键 adapter 有 tracing)。
     async fn current_state(&self, device: &DeviceId) -> ReachabilityState {
-        let key = device.as_str();
         // Prefer the last-observed snapshot — it's authoritative for
         // `Offline` (which is not represented in `peers`) and strictly
         // consistent with the live-connection map for `Online` because
         // `ensure_reachable` and the watchdog update both under lock.
-        if let Some(state) = self.last_state.lock().await.get(key).copied() {
+        if let Some(state) = self.last_state.lock().await.get(device).copied() {
             return state;
         }
         // Fall back to the tracked-connection map in case something
         // bypassed `last_state` bookkeeping. Under the current API surface
         // this branch is unreachable, but the check is cheap.
         let peers = self.peers.lock().await;
-        match peers.get(key) {
+        match peers.get(device) {
             Some(entry) if entry.connection.close_reason().is_none() => ReachabilityState::Online,
             Some(_) => ReachabilityState::Offline,
             None => ReachabilityState::Unknown,
@@ -709,8 +699,8 @@ impl PresencePort for IrohPresenceAdapter {
 /// Errors on the broadcast send are ignored (no subscriber is a valid
 /// state; consumers recover via `current_state`).
 fn spawn_watchdog(
-    peers: Arc<Mutex<HashMap<String, TrackedPeer>>>,
-    last_state: Arc<Mutex<HashMap<String, ReachabilityState>>>,
+    peers: Arc<Mutex<HashMap<DeviceId, TrackedPeer>>>,
+    last_state: Arc<Mutex<HashMap<DeviceId, ReachabilityState>>>,
     event_tx: broadcast::Sender<PresenceEvent>,
     clock: Arc<dyn ClockPort>,
     device_id: DeviceId,
@@ -724,15 +714,13 @@ fn spawn_watchdog(
             "presence watchdog fired; peer marked Offline",
         );
 
-        let key = device_id.as_str().to_string();
-
         // Remove the map entry first so concurrent `ensure_reachable`
         // readers observe "not tracked" + "last_state == Offline". The
         // `TrackedPeer::drop` impl will attempt to abort this very task,
         // which is harmless — we're already past the `.await` point.
         {
             let mut map = peers.lock().await;
-            map.remove(&key);
+            map.remove(&device_id);
         }
 
         let ms = clock.now_ms();
@@ -743,7 +731,7 @@ fn spawn_watchdog(
 
         {
             let mut last = last_state.lock().await;
-            last.insert(key, ReachabilityState::Offline);
+            last.insert(device_id, ReachabilityState::Offline);
         }
 
         let _ = event_tx.send(PresenceEvent {


### PR DESCRIPTION
## Summary

- **Dispatch keeps re-dialing already-offline peers.** Each clipboard copy spawned a fresh ~27s staggered retry against unreachable peers — `presence.mark_offline` only fires after all three attempts time out, but `FAN_OUT_DEADLINE = 5s` returns the main flow before that, leaving the retry running in the background. New copies arriving inside the window see `presence.current_state == Unknown` and start another full loop; tasks pile up and `iroh connect` floods the logs. Add a 30s in-process negative cache on the dispatch use case so subsequent copies short-circuit the dial. Stamps fire on `Offline` / `Io`; `PeerRejected` / `LocalPolicyExceeded` / `Internal` deliberately do not. (`df6b9d71`)
- **`presence_adapter` HashMap keys: `String` → `DeviceId`.** The "DeviceId deliberately does not derive Hash" comment is stale — DeviceId was reworked into `ArrayString<64>` (Copy + Hash + Eq) and the stringified projection is no longer needed. Drop the temporaries and use DeviceId directly. (`5e749dcb`)

`mark_offline` remains the authoritative state update; the local stamp is a "fires ~25s earlier" suppression layer that defers to presence + keepalive once it expires. No user-visible contract changes — `FAN_OUT_DEADLINE`, settings, CLI flags, error messages, and the device page's "detected in ~25–60s" offline semantics are all unchanged. **docs-site left as-is.**

## Test plan

- [x] 3 new verdicts covering the negative cache: Offline / Io stamp and short-circuit the next dispatch; PeerRejected does NOT (`cargo test -p uc-application --lib usecases::clipboard_sync::dispatch_entry::tests::recent` + `peer_rejected_does_not_stamp_local_cache`).
- [x] Full `dispatch_entry` suite green: 26/26.
- [x] `presence_adapter` suite green after refactor: 8/8 (`cargo test -p uc-infra --lib network::iroh::presence_adapter`).
- [x] `cargo check -p uc-application` / `cargo check -p uc-infra` clean.
- [ ] Manual repro: pair with a peer, take it offline, copy ~5 items in a row — expect `iroh connect` logs to stop after the first failed dispatch (not every copy), and `dispatch_capture completed` to surface `offline=N` instead of `offline=0 pending=N`.
- [ ] Verify recovery: bring the peer back online, confirm `keepalive` flips presence back inside one tick (≤ 25s) and the next copy lands without delay.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced clipboard synchronization with intelligent retry suppression that tracks recent connection failures and temporarily pauses retries to unavailable peers, improving responsiveness.

* **Refactor**
  * Optimized internal peer tracking data structures to reduce memory overhead and improve performance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/UniClipboard/UniClipboard/pull/863?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->