### PR TITLE
fix(updater): pop update window on window_show check too

### DIFF
--- a/src-tauri/crates/uc-tauri/src/run.rs
+++ b/src-tauri/crates/uc-tauri/src/run.rs
@@ -606,13 +606,20 @@ pub fn run(tauri_ctx: tauri::Context<tauri::Wry>) -> anyhow::Result<()> {
                     &last_notified_path,
                 )
                 .await;
-                let scheduler_deps = crate::update_scheduler::SchedulerDeps {
+                // 同一个 Arc<NotifyContext> 同时给 scheduler 和
+                // window_show_check 用：app.manage 一份，SchedulerDeps 收一份。
+                // 共享意味着去重 mutex / 落盘路径 / analytics 出口完全一致。
+                let notify_ctx = Arc::new(crate::update_scheduler::NotifyContext {
                     app_handle: app_handle_for_startup.clone(),
-                    settings_port: runtime.settings_port(),
-                    setup_status_port: runtime.setup_status_port(),
                     analytics: runtime.analytics(),
                     last_notified: Arc::new(tokio::sync::Mutex::new(store)),
                     last_notified_path,
+                });
+                app_handle_for_startup.manage(notify_ctx.clone());
+                let scheduler_deps = crate::update_scheduler::SchedulerDeps {
+                    settings_port: runtime.settings_port(),
+                    setup_status_port: runtime.setup_status_port(),
+                    notify: notify_ctx,
                 };
                 runtime
                     .task_registry()

--- a/src-tauri/crates/uc-tauri/src/update_scheduler/mod.rs
+++ b/src-tauri/crates/uc-tauri/src/update_scheduler/mod.rs
@@ -8,12 +8,14 @@
 
 pub mod last_check_at;
 pub mod last_notified;
+pub mod notify_context;
 pub mod scheduler;
 pub mod window;
 pub mod window_show_check;
 
 pub use last_check_at::LastCheckAt;
 pub use last_notified::LastNotifiedUpdateStore;
+pub use notify_context::NotifyContext;
 pub use scheduler::{run, SchedulerDeps};
 pub use window::{open_or_focus_updater_window, UPDATER_WINDOW_LABEL};
 pub use window_show_check::maybe_trigger_window_show_check;

--- a/src-tauri/crates/uc-tauri/src/update_scheduler/notify_context.rs
+++ b/src-tauri/crates/uc-tauri/src/update_scheduler/notify_context.rs
@@ -1,0 +1,100 @@
+//! 共享的"找到新版本 → 去重 → 弹更新窗口 → 持久化已通知版本"上下文。
+//!
+//! Scheduler 主循环和 `window_show_check` 都会走这条路径，所以把所需
+//! 依赖打包成一个 struct 挂到 Tauri app state；两条路径都通过
+//! `app.state::<Arc<NotifyContext>>()` 拿同一份，确保去重 store 的
+//! `Mutex` 是同一把、落盘路径是同一个、analytics 出口也一致。
+
+use std::{path::PathBuf, sync::Arc};
+
+use tauri::AppHandle;
+use tokio::sync::Mutex;
+use tracing::{debug, warn};
+use uc_core::settings::model::UpdateChannel;
+use uc_observability::analytics::{
+    AnalyticsPort, Event, InstallKind as AnalyticsInstallKind, NotificationDeliveryStatus,
+};
+
+use super::last_notified::LastNotifiedUpdateStore;
+use super::window::open_or_focus_updater_window;
+
+/// 所有走"通知 + 弹窗 + 持久化"路径的调用方共享的依赖集合。
+pub struct NotifyContext {
+    pub app_handle: AppHandle,
+    pub analytics: Arc<dyn AnalyticsPort>,
+    /// 已通知版本 store。两个调用方共享同一个 `Arc<Mutex<_>>`，避免
+    /// 双源去重相互覆盖。
+    pub last_notified: Arc<Mutex<LastNotifiedUpdateStore>>,
+    /// `last_notified` 持久化目标路径。
+    pub last_notified_path: PathBuf,
+}
+
+impl NotifyContext {
+    /// Available 分支：若 (channel, version) 未通知过，弹出 Sparkle 风格更新
+    /// 窗口，emit `update_notification_shown`，仅在窗口成功创建后 `record`
+    /// 持久化。
+    ///
+    /// 返回 `true` 表示这次确实打开（或聚焦了）窗口，`false` 表示被去重
+    /// store short-circuit 或 builder 失败。Scheduler 用这个布尔值判断
+    /// 是否需要在 auto-download Ready 阶段兜底再开一次窗口。
+    ///
+    /// `delivery_status` 字段语义：`Sent` 表示窗口已打开，`SendFailed`
+    /// 表示 `WebviewWindowBuilder::build` 失败（OS 资源耗尽 / 平台异常）。
+    pub async fn notify_if_new_version(
+        &self,
+        channel: &UpdateChannel,
+        version: &str,
+        install_kind: AnalyticsInstallKind,
+    ) -> bool {
+        let already_notified = {
+            let store = self.last_notified.lock().await;
+            store.contains(channel, version)
+        };
+        if already_notified {
+            debug!(
+                target: "update_scheduler",
+                channel = ?channel,
+                version,
+                "version already notified; skipping updater window open"
+            );
+            return false;
+        }
+
+        let delivery = match open_or_focus_updater_window(&self.app_handle, false) {
+            Ok(()) => NotificationDeliveryStatus::Sent,
+            Err(err) => {
+                warn!(
+                    target: "update_scheduler",
+                    error = %err,
+                    "failed to open updater window"
+                );
+                NotificationDeliveryStatus::SendFailed
+            }
+        };
+        self.analytics.capture(Event::UpdateNotificationShown {
+            version: version.to_string(),
+            delivery_status: delivery,
+            install_kind,
+        });
+
+        let opened = matches!(delivery, NotificationDeliveryStatus::Sent);
+        if opened {
+            let mut store = self.last_notified.lock().await;
+            if let Err(err) = store
+                .record(
+                    channel.clone(),
+                    version.to_string(),
+                    &self.last_notified_path,
+                )
+                .await
+            {
+                warn!(
+                    target: "update_scheduler",
+                    error = %err,
+                    "failed to persist last_notified_update.json"
+                );
+            }
+        }
+        opened
+    }
+}

--- a/src-tauri/crates/uc-tauri/src/update_scheduler/scheduler.rs
+++ b/src-tauri/crates/uc-tauri/src/update_scheduler/scheduler.rs
@@ -18,25 +18,22 @@
 //!   4. 成功 6h ± 15min jitter；失败 30min（Q9：固定，不是指数 backoff）
 //! - 任一 sleep 内被 cancellation token 打断 → 立即退出
 
-use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
 use rand::Rng;
 use tauri::{AppHandle, Manager};
-use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 use uc_core::ports::{SettingsPort, SetupStatusPort};
 use uc_core::settings::channel::detect_channel;
 use uc_core::settings::model::UpdateChannel;
 use uc_observability::analytics::{
-    AnalyticsPort, Event, InstallKind as AnalyticsInstallKind, NotificationDeliveryStatus,
-    UpdateAction, UpdateActionOutcome, UpdateCheckOutcome, UpdateCheckSource,
+    Event, UpdateAction, UpdateActionOutcome, UpdateCheckOutcome, UpdateCheckSource,
 };
 
 use super::last_check_at::LastCheckAt;
-use super::last_notified::LastNotifiedUpdateStore;
+use super::notify_context::NotifyContext;
 use super::window::open_or_focus_updater_window;
 use crate::commands::updater::{
     classify_check_failure, detect_install_kind, do_check_for_update, do_download_update,
@@ -57,17 +54,13 @@ pub(crate) const FAILURE_RETRY_INTERVAL: Duration = Duration::from_secs(30 * 60)
 /// 持有 strong refs；scheduler task 生命周期由 `CancellationToken` 与
 /// `task_registry.shutdown()` 联合管理（见 `run.rs:589` ExitRequested
 /// 路径，Phase 3C 接入）。
+///
+/// 与"通知/弹窗/去重"相关的依赖打包在 [`NotifyContext`] 里，scheduler
+/// 主循环和 `window_show_check` 通过 `Arc<NotifyContext>` 共享同一份。
 pub struct SchedulerDeps {
-    pub app_handle: AppHandle,
     pub settings_port: Arc<dyn SettingsPort>,
     pub setup_status_port: Arc<dyn SetupStatusPort>,
-    pub analytics: Arc<dyn AnalyticsPort>,
-    /// 已通知版本去重存储——`Available` 分支查 / 写。
-    pub last_notified: Arc<Mutex<LastNotifiedUpdateStore>>,
-    /// `last_notified.record(...)` 落盘所需的文件路径，由 `run.rs` 从
-    /// `AppPaths::last_notified_update_path()` 解析一次后传入，避免每次
-    /// 落盘都重新拼路径。
-    pub last_notified_path: PathBuf,
+    pub notify: Arc<NotifyContext>,
 }
 
 /// 启动 scheduler 主循环。调用方 `run.rs:480` 内 `tauri::async_runtime::spawn`
@@ -181,9 +174,9 @@ async fn run_one_iteration(
         return IterationOutcome::Success;
     }
 
-    let app_version = deps.app_handle.package_info().version.to_string();
+    let app_version = deps.notify.app_handle.package_info().version.to_string();
     let resolved_channel = resolve_channel(settings.general.update_channel.clone(), &app_version);
-    let app = deps.app_handle.clone();
+    let app = deps.notify.app_handle.clone();
     let pending = app.state::<PendingUpdate>();
     let result = do_check_for_update(&app, Some(resolved_channel.clone()), pending.inner()).await;
     // Phase 5B: 任何 source 的 check 完成（成功或失败）都标记时间戳，让
@@ -202,21 +195,17 @@ async fn run_one_iteration(
     // 是 (notification_shown?, action_invoked Started?, check_performed,
     // action_invoked Terminal?)——与 manual 路径相符。
     if let Ok(Some(metadata)) = &result {
-        let window_opened = notify_if_new_version(
-            deps,
-            &resolved_channel,
-            &metadata.version,
-            settings.general.language.as_deref(),
-            install_kind,
-        )
-        .await;
+        let window_opened = deps
+            .notify
+            .notify_if_new_version(&resolved_channel, &metadata.version, install_kind)
+            .await;
         if settings.general.auto_download_update && should_auto_download(install_kind_raw) {
             let downloaded_to_ready = auto_download(deps, &app, pending.inner()).await;
             // 兜底：去重让窗口没弹（之前的进程通知过这版本），但本进程
             // 又新下到了 Ready。用户从未在本次会话里见过更新提示——
             // 此时再开一次窗口，UI 会显示 "已下载，立即安装"。
             if downloaded_to_ready && !window_opened {
-                if let Err(err) = open_or_focus_updater_window(&deps.app_handle, false) {
+                if let Err(err) = open_or_focus_updater_window(&deps.notify.app_handle, false) {
                     warn!(
                         target: "update_scheduler",
                         error = %err,
@@ -245,7 +234,7 @@ async fn run_one_iteration(
         ),
     };
 
-    deps.analytics.capture(Event::UpdateCheckPerformed {
+    deps.notify.analytics.capture(Event::UpdateCheckPerformed {
         source: UpdateCheckSource::Scheduled,
         outcome,
         failure_kind,
@@ -280,76 +269,6 @@ pub(crate) fn should_auto_download(install_kind: InstallKind) -> bool {
     )
 }
 
-/// Available 分支：若 (channel, version) 未通知过，弹出 Sparkle 风格更新
-/// 窗口，emit `update_notification_shown`，仅在窗口成功创建后 `record` 持久化。
-///
-/// 返回 `true` 表示这次确实打开（或聚焦了）窗口，`false` 表示被去重 store
-/// short-circuit 或 builder 失败。调用方用这个布尔值判断是否需要 Ready
-/// 阶段兜底再开一次（见 scheduler iteration）。
-///
-/// `delivery_status` 字段语义被复用：`Sent` 表示窗口已打开，`SendFailed`
-/// 表示 `WebviewWindowBuilder::build` 失败（OS 资源耗尽 / 平台异常）。
-/// `language` 参数当前未使用——窗口内文案由前端 i18n 决定，保留参数避免
-/// 修改调用点签名，等通知 schema 整体迁移时再清理。
-async fn notify_if_new_version(
-    deps: &SchedulerDeps,
-    channel: &UpdateChannel,
-    version: &str,
-    _language: Option<&str>,
-    install_kind: AnalyticsInstallKind,
-) -> bool {
-    let already_notified = {
-        let store = deps.last_notified.lock().await;
-        store.contains(channel, version)
-    };
-    if already_notified {
-        debug!(
-            target: "update_scheduler",
-            channel = ?channel,
-            version,
-            "version already notified; skipping updater window open"
-        );
-        return false;
-    }
-
-    let delivery = match open_or_focus_updater_window(&deps.app_handle, false) {
-        Ok(()) => NotificationDeliveryStatus::Sent,
-        Err(err) => {
-            warn!(
-                target: "update_scheduler",
-                error = %err,
-                "failed to open updater window"
-            );
-            NotificationDeliveryStatus::SendFailed
-        }
-    };
-    deps.analytics.capture(Event::UpdateNotificationShown {
-        version: version.to_string(),
-        delivery_status: delivery,
-        install_kind,
-    });
-
-    let opened = matches!(delivery, NotificationDeliveryStatus::Sent);
-    if opened {
-        let mut store = deps.last_notified.lock().await;
-        if let Err(err) = store
-            .record(
-                channel.clone(),
-                version.to_string(),
-                &deps.last_notified_path,
-            )
-            .await
-        {
-            warn!(
-                target: "update_scheduler",
-                error = %err,
-                "failed to persist last_notified_update.json"
-            );
-        }
-    }
-    opened
-}
-
 /// 触发 in-place 自动下载，emit `update_action_invoked` Started + terminal 配对。
 ///
 /// 与 `commands/updater.rs::download_update` Tauri command body 完全同
@@ -364,7 +283,7 @@ async fn auto_download(deps: &SchedulerDeps, app: &AppHandle, pending: &PendingU
 
     let did_start = !matches!(result, Err(DownloadError::Precondition(_)));
     if did_start {
-        deps.analytics.capture(Event::UpdateActionInvoked {
+        deps.notify.analytics.capture(Event::UpdateActionInvoked {
             action: UpdateAction::DownloadBg,
             outcome: UpdateActionOutcome::Started,
             error_kind: None,
@@ -378,7 +297,7 @@ async fn auto_download(deps: &SchedulerDeps, app: &AppHandle, pending: &PendingU
         Err(DownloadError::Precondition(_)) => None,
     };
     if let Some(outcome) = terminal {
-        deps.analytics.capture(Event::UpdateActionInvoked {
+        deps.notify.analytics.capture(Event::UpdateActionInvoked {
             action: UpdateAction::DownloadBg,
             outcome,
             error_kind: result

--- a/src-tauri/crates/uc-tauri/src/update_scheduler/window.rs
+++ b/src-tauri/crates/uc-tauri/src/update_scheduler/window.rs
@@ -45,6 +45,11 @@ pub fn open_or_focus_updater_window(app: &AppHandle, dev: bool) -> Result<(), ta
         .resizable(false)
         .decorations(false)
         .transparent(true)
+        // OS shadow draws a rectangle outside the webview; combined with
+        // transparent + CSS border-radius it bleeds past the rounded corners
+        // (tauri-apps/tauri#9287 macOS, #11321 Win10). CSS shadow-2xl on the
+        // root div already paints a corner-aware shadow.
+        .shadow(false)
         .center()
         .focused(true)
         .visible(true);

--- a/src-tauri/crates/uc-tauri/src/update_scheduler/window_show_check.rs
+++ b/src-tauri/crates/uc-tauri/src/update_scheduler/window_show_check.rs
@@ -10,10 +10,11 @@
 //!
 //! ## 范围
 //!
-//! 本 helper 只做 **检查 + telemetry**——不发系统通知、不自动下载：
-//! - 用户已经打开主窗口，sidebar 更新指示器会因为 `PendingUpdate` state 变化
-//!   而自动刷新；OS 通知反而成了 UX 噪音
-//! - 自动下载是 scheduler 的职责，下一次 scheduler tick（≤ 6h）会接管
+//! 本 helper 做 **检查 + 弹窗 + telemetry**，但不自动下载：
+//! - 检测到新版本会调 [`notify_if_new_version`] 走 Sparkle 风格更新窗口
+//!   （与 scheduler 主循环共用同一段去重逻辑，`last_notified_update.json`
+//!   保证同一 (channel, version) 只弹一次）
+//! - 自动下载仍是 scheduler 的职责，下一次 scheduler tick（≤ 6h）会接管
 //!
 //! ## 调用约束
 //!
@@ -28,11 +29,15 @@
 //! （tray menu open/settings、tray icon click、startup silent_start=false、
 //! startup barrier、macOS dock reopen）。
 
+use std::sync::Arc;
+
 use tauri::{AppHandle, Manager};
 use tracing::{debug, info, warn};
 use uc_observability::analytics::{Event, UpdateCheckOutcome, UpdateCheckSource};
 
 use super::last_check_at::LastCheckAt;
+use super::notify_context::NotifyContext;
+use super::scheduler::resolve_channel;
 use crate::bootstrap::TauriAppRuntime;
 use crate::commands::updater::{
     classify_check_failure, detect_install_kind, do_check_for_update, install_kind_for_telemetry,
@@ -127,12 +132,35 @@ async fn run_window_show_check(app: AppHandle) {
 
     let analytics = runtime.analytics();
     let pending = app.state::<PendingUpdate>();
+    // 与 scheduler 主循环一致：用户在 settings 里指定的 channel 优先，
+    // 否则按 app_version 走 detect_channel 兜底。两条路径共用同一份
+    // resolve_channel 实现，避免去重 key 不一致导致弹窗去重失效。
+    let app_version = app.package_info().version.to_string();
+    let resolved_channel = resolve_channel(settings.general.update_channel.clone(), &app_version);
     info!(target: "update_scheduler", "running window_show check");
-    let result = do_check_for_update(&app, None, pending.inner()).await;
+    let result = do_check_for_update(&app, Some(resolved_channel.clone()), pending.inner()).await;
 
     app.state::<LastCheckAt>().record_now();
 
     let install_kind = install_kind_for_telemetry(detect_install_kind());
+
+    // 找到新版本时也弹更新窗口；走与 scheduler 共享的 NotifyContext，
+    // 同一个 (channel, version) 只弹一次，用户每 30min 重开主窗口
+    // 不会被骚扰。NotifyContext 由 run.rs setup 阶段 mount 到 app state；
+    // 未挂载视为前置 wiring 缺失，warn 后回退到"只发 telemetry"老行为。
+    if let Ok(Some(metadata)) = &result {
+        match app.try_state::<Arc<NotifyContext>>() {
+            Some(ctx) => {
+                ctx.notify_if_new_version(&resolved_channel, &metadata.version, install_kind)
+                    .await;
+            }
+            None => warn!(
+                target: "update_scheduler",
+                "NotifyContext not mounted; window_show check found update but cannot dedup/notify"
+            ),
+        }
+    }
+
     let (outcome, failure_kind) = match &result {
         Ok(Some(_)) => (UpdateCheckOutcome::Available, None),
         Ok(None) => (UpdateCheckOutcome::UpToDate, None),

--- a/src/updater/UpdaterWindow.tsx
+++ b/src/updater/UpdaterWindow.tsx
@@ -14,6 +14,7 @@ import {
 } from '@/api/updater'
 import { Progress } from '@/components/ui/progress'
 import { ReleaseNotes } from '@/components/update/ReleaseNotes'
+import { useThemeSync } from '@/hooks/useThemeSync'
 import { createLogger } from '@/lib/logger'
 import { cn } from '@/lib/utils'
 
@@ -63,6 +64,12 @@ const isDevPreview = (): boolean => {
 }
 
 const UpdaterWindow: React.FC = () => {
+  // Independent webview — no SettingContext here, so pull theme straight from
+  // the daemon (same approach as the quick panel). Falls back to system
+  // prefers-color-scheme if settings load fails (e.g. dev preview without
+  // daemon).
+  useThemeSync()
+
   const { t } = useTranslation()
   const [state, setState] = useState<UpdateState>(initialState)
   const [cancelling, setCancelling] = useState(false)


### PR DESCRIPTION
## Summary

- Window_show check (the 30min "user just opened main window" top-up check) used to only refresh `PendingUpdate` state without opening the updater window. Repro: local prod log on 2026-05-26 showed `running window_show check` → `update available, new_version=0.12.0-alpha.3` at 11:31:55, then the app exited at 11:32:19 — no popup, because only the next 6h scheduler tick would have triggered `notify_if_new_version` and the tick never fired. This PR routes window_show_check through the same notify path as the scheduler tick, so the popup fires immediately on the top-up check (87d8ccf8).
- Dedup is preserved via the existing `last_notified_update.json` so reopening the main window every 30min doesn't re-pop the same version (87d8ccf8).
- Wires a shared `Arc<NotifyContext>` (app_handle + analytics + last_notified store + path) through `app.manage`, so scheduler and window_show_check share the same mutex / file / analytics sink instead of two parallel copies. Collapses `SchedulerDeps` from 6 fields to 3 (`notify` + `settings_port` + `setup_status_port`) and turns `notify_if_new_version` into a `&self` method on `NotifyContext` (87d8ccf8).

## Test plan

- [x] \`cargo check -p uc-tauri\` clean
- [x] \`cargo test -p uc-tauri --lib update_scheduler\` — 32 passed
- [x] Docs cross-check: \`docs-site/.../guides/settings.mdx\` (en + zh) already documents "open updater window on window_show check, dedup per version" — code now matches existing docs, no doc edits needed
- [ ] Manual: with \`last_notified_update.json\` pointing at an older alpha, open main window after 30min and confirm the update window pops on the new alpha
- [ ] Manual: dismiss the popup, reopen main window after 30min, confirm it does NOT re-pop the same version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated update notification, deduplication, and analytics into a shared notification context for more consistent update handling.

* **New Features**
  * Updater window now synchronizes theme with the host environment for consistent appearance.

* **Behavior Changes**
  * Updater window shadow rendering disabled for a cleaner visual.
  * Scheduler and one-shot window checks now share de-dup logic; if notification handling isn’t available they fall back to telemetry-only reporting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/UniClipboard/UniClipboard/pull/865?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->