### PR TITLE
refactor(uc-platform): introduce desktop / portable feature flags

### DIFF
--- a/src-tauri/crates/uc-application/AGENTS.md
+++ b/src-tauri/crates/uc-application/AGENTS.md
@@ -52,7 +52,7 @@
 
 ### 2.2 非职责
 
-以下内容**不属于** `uc-app`：
+以下内容 **不属于** `uc-app`：
 
 | 类别      | 示例                                          |
 | ------- | ------------------------------------------- |
@@ -81,7 +81,7 @@ UI / CLI / Daemon API
 
 * `uc-app` **可以依赖** `uc-core`
 * `uc-app` **可以依赖** `uc-core` 中定义的 ports
-* `uc-app` **不可以依赖**具体 infra 实现类型
+* `uc-app` **不可以依赖** 具体 infra 实现类型
 * `uc-app` **不可以自己重新定义领域真相**
 * `uc-app` **不可以承担表示层职责**
 * 对外只暴露 `src/facade/` 目录下的 **Facade**（以及经 Facade 转发的 UseCase / Command / Query / Result / Error / 状态枚举）作为应用层入口；业务子模块（`pairing/`、`setup/`、`clipboard_capture/`、`usecases/*` 等）与 Orchestrator / StateMachine / SessionManager 等实现细节一律 `pub(crate)`，外部 crate 不得直接访问 —— 详见 §11.4
@@ -227,7 +227,7 @@ UI / CLI / daemon API 不应直接理解：
 
 面向上层应用调用的输入输出模型。
 
-注意：这里是**应用层模型**，不是 HTTP DTO，也不是数据库 model。
+注意：这里是 **应用层模型**，不是 HTTP DTO，也不是数据库 model。
 
 ---
 
@@ -239,7 +239,7 @@ UI / CLI / daemon API 不应直接理解：
 * `ClipboardCaptureError`
 * `SearchError`
 
-这些错误应表达**应用动作失败**，而不是底层库错误。
+这些错误应表达 **应用动作失败**，而不是底层库错误。
 
 ---
 
@@ -308,6 +308,35 @@ UI / CLI / daemon API 不应直接理解：
 * app 适配 core
 * 上层也适配 app
 * 不让 core 为某一层临时需求变形
+
+---
+
+## 6.5 禁止在应用层埋平台原生 MIME / 格式字面量
+
+引擎边界（`ObservedClipboardRepresentation::mime`、`MimeType`、`MimeClass`）
+在 **`uc-core` 内部统一为 RFC 形态**（`type/subtype` 或带参数的合法 RFC MIME，
+通过 `MimeType::is_rfc_shape()` 校验）。平台原生标识（macOS UTI 如 `public.utf8-plain-text`、
+Windows `CF_UNICODETEXT`、X11 selection target atom 等）只允许出现在
+`ObservedClipboardRepresentation.format_id` 字段——那是该字段的语义本意，
+也是上下行翻译表（`uc-platform/clipboard/format_id_mime.rs`）的输入。
+
+应用层在编排、materialize、ingest、wire encode/decode 任意路径上，禁止：
+
+* 写形如 `"public.utf8-plain-text"` / `"NSStringPboardType"` / `"CF_UNICODETEXT"` /
+  `"public.png"` 的 UTI / Windows 格式字面量并把它当作 `mime` 字段值塞回 rep
+* 给 mime 字段做"如果是 UTI 就拍脑袋猜一个 RFC mime"的兜底分支
+  （wire decoder 和 DB 读路径已经在边界用 `normalize_wire_mime` 统一兜过了，
+  应用层重复 normalize 等于把不变量分散到多处）
+* 在 application 里复刻 `format_id → mime` 的翻译表
+  （历史上 `image_file_mime_from_path` 出现过两份，已统一到
+  `uc_core::clipboard::image_mime_from_extension`）
+
+正确做法：
+
+* 需要把 platform-native 标识翻译成 RFC mime，统一调 `uc-platform::clipboard::format_id_mime::format_id_default_mime`
+* 需要把可疑 wire mime 收口成 RFC 形态，调 `uc_core::clipboard::normalize_wire_mime`
+* 文件后缀 → 图片 mime 走 `uc_core::clipboard::image_mime_from_extension`
+* 任何在 application 内部生成 / 改写 rep 的代码，必须保证最终写入 `mime: Option<MimeType>` 的值满足 RFC 形态——`ObservedClipboardRepresentation::new` 的 `debug_assert` 会兜底验证
 
 ---
 
@@ -638,26 +667,26 @@ External (daemon / tauri / CLI / bootstrap)
 
 * 所有 Facade 类型必须定义在 `src/facade/` 目录下
 * 顶层 `AppFacade` 聚合各域 Facade；每个域 Facade（`SpaceSetupFacade`、`ClipboardSyncFacade`、`PairingFacade` 等）暴露该域的应用动作
-* `src/facade/mod.rs` 的 `pub use` 是 crate 对外的**白名单**。只允许导出：
+* `src/facade/mod.rs` 的 `pub use` 是 crate 对外的 **白名单**。只允许导出：
   * Facade 类型本身（`AppFacade`、`<Domain>Facade`）
   * Facade 方法的输入输出类型：Command / Query / Result / Error / 显式状态枚举
   * Facade 构造所需的 Deps 结构（供 bootstrap 组装）
   * 外部需订阅的事件类型 / event port trait
-* **禁止**在 `src/facade/mod.rs` 里 `pub use` 任何 `*Orchestrator` / `*SessionManager` / `*StateMachine` / `*Handler` / 业务子模块内部类型
+* **禁止** 在 `src/facade/mod.rs` 里 `pub use` 任何 `*Orchestrator` / `*SessionManager` / `*StateMachine` / `*Handler` / 业务子模块内部类型
 * UseCase 类型若需要被外部以"无状态动作"形式直接调用，也必须通过 Facade 目录下某个 Facade 的方法转发；不鼓励把裸 UseCase 当作对外 API 暴露
 
 ### 11.4.3 Crate 根 `lib.rs` 的纪律
 
-* `lib.rs` 的顶层 `pub mod` / `pub use` **只允许**暴露 `facade` 模块（或从 `facade` 再导出的符号）
+* `lib.rs` 的顶层 `pub mod` / `pub use` **只允许** 暴露 `facade` 模块（或从 `facade` 再导出的符号）
 * 业务子模块在 `lib.rs` 中必须是 `pub(crate) mod <domain>;` 或完全不 `pub`
-* 如需为测试开放内部可见性，使用 `pub(crate)` + `#[cfg(test)]` 或独立的 `mod tests`，**绝不**为了测试把业务子模块整体升级为 `pub`
+* 如需为测试开放内部可见性，使用 `pub(crate)` + `#[cfg(test)]` 或独立的 `mod tests`，**绝不** 为了测试把业务子模块整体升级为 `pub`
 
 ### 11.4.4 构造与持有
 
 * Facade 内部持有 `Arc<Orchestrator>` / `Arc<UseCase>` / Ports 的方式由 Facade 自行决定
-* bootstrap 层只允许持有 `Arc<AppFacade>` 或 `Arc<<Domain>Facade>`；**不得**持有 `Arc<*Orchestrator>` / `Arc<*SessionManager>` 等内部类型
+* bootstrap 层只允许持有 `Arc<AppFacade>` 或 `Arc<<Domain>Facade>`；**不得** 持有 `Arc<*Orchestrator>` / `Arc<*SessionManager>` 等内部类型
 * 同一业务模块内部允许 UseCase 与 Orchestrator 以 `pub(crate)` 互相持有引用，这类依赖不穿越 crate 边界
-* 若某方法语义上只是"读一下 orchestrator 状态"，也必须在 Facade 上加一个 thin method 转发；**不得**通过 `pub(crate)` 或任何 trick 把 Orchestrator 引用泄露给外部
+* 若某方法语义上只是"读一下 orchestrator 状态"，也必须在 Facade 上加一个 thin method 转发；**不得** 通过 `pub(crate)` 或任何 trick 把 Orchestrator 引用泄露给外部
 
 ### 11.4.5 反模式
 
@@ -679,7 +708,7 @@ External (daemon / tauri / CLI / bootstrap)
 
 ### 11.4.7 迁移现状与新实现要求
 
-当前代码库**尚未完全符合本节规则**：部分外部消费者仍然直接从 `uc_application::<业务子模块>::...` 导入类型。这是历史欠账，会逐步迁移到 `src/facade/` 下。
+当前代码库 **尚未完全符合本节规则**：部分外部消费者仍然直接从 `uc_application::<业务子模块>::...` 导入类型。这是历史欠账，会逐步迁移到 `src/facade/` 下。
 
 但从本条规则写入本文件起：
 

--- a/src-tauri/crates/uc-application/AGENTS.md
+++ b/src-tauri/crates/uc-application/AGENTS.md
@@ -333,10 +333,18 @@ Windows `CF_UNICODETEXT`、X11 selection target atom 等）只允许出现在
 
 正确做法：
 
-* 需要把 platform-native 标识翻译成 RFC mime，统一调 `uc-platform::clipboard::format_id_mime::format_id_default_mime`
-* 需要把可疑 wire mime 收口成 RFC 形态，调 `uc_core::clipboard::normalize_wire_mime`
-* 文件后缀 → 图片 mime 走 `uc_core::clipboard::image_mime_from_extension`
-* 任何在 application 内部生成 / 改写 rep 的代码，必须保证最终写入 `mime: Option<MimeType>` 的值满足 RFC 形态——`ObservedClipboardRepresentation::new` 的 `debug_assert` 会兜底验证
+* application 层可用的入口（uc-core，三 host 共享）：
+  * 收口可疑 wire mime → `uc_core::clipboard::normalize_wire_mime`
+  * 文件后缀 → 图片 mime → `uc_core::clipboard::image_mime_from_extension`
+* platform-native 标识（UTI / CF_* / X11 atom）→ RFC mime 的翻译表
+  住在 `uc-platform::clipboard::format_id_mime::format_id_default_mime`，**只在
+  桌面适配器内部使用**（属于 `desktop` feature）。application 不直接调用——
+  capture 路径在 platform 层就该把 mime 标好交给 application，wire/DB 边界又
+  各自有 `normalize_wire_mime` 兜底。若 application 真的需要这层翻译，说明
+  rep 的责任划分错位，应该回头把翻译挪回 platform / wire decoder。
+* 任何在 application 内部生成 / 改写 rep 的代码，必须保证最终写入
+  `mime: Option<MimeType>` 的值满足 RFC 形态——`ObservedClipboardRepresentation::new`
+  的 `debug_assert` 会兜底验证
 
 ---
 

--- a/src-tauri/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/materializer.rs
+++ b/src-tauri/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/materializer.rs
@@ -18,6 +18,7 @@ use async_trait::async_trait;
 use tracing::{debug, info, warn};
 use url::Url;
 
+use uc_core::clipboard::image_mime_from_extension;
 use uc_core::ids::{DeviceId, EntryId, FormatId, RepresentationId};
 use uc_core::{MimeType, ObservedClipboardRepresentation, SystemClipboardSnapshot};
 
@@ -501,7 +502,7 @@ impl InboundBlobMaterializer for FileCacheBlobMaterializer {
         });
         if !already_has_image_rep {
             for path in &local_paths {
-                let Some(image_mime) = image_file_mime_from_path(path) else {
+                let Some(image_mime) = image_mime_from_extension(path) else {
                     continue;
                 };
                 let Ok(meta) = std::fs::metadata(path) else {
@@ -694,25 +695,6 @@ fn supported_for_capture(rep: &ObservedClipboardRepresentation) -> bool {
         || rep.format_id.eq_ignore_ascii_case("public.utf8-plain-text")
         || rep.format_id.eq_ignore_ascii_case("public.text")
         || rep.format_id.eq_ignore_ascii_case("NSStringPboardType")
-}
-
-/// 基于文件后缀推断常见图片 MIME。与 `uc-platform/clipboard/common.rs` 的同名 helper
-/// 表项保持一致(打开扩展时两边一起改);该函数刻意复制一份在 application 层,避免把
-/// 接收端的 image rep 合成逻辑硬连到 platform crate。
-fn image_file_mime_from_path(path: &std::path::Path) -> Option<&'static str> {
-    let ext = path
-        .extension()
-        .and_then(|e| e.to_str())?
-        .to_ascii_lowercase();
-    Some(match ext.as_str() {
-        "png" => "image/png",
-        "jpg" | "jpeg" => "image/jpeg",
-        "gif" => "image/gif",
-        "webp" => "image/webp",
-        "bmp" => "image/bmp",
-        "tif" | "tiff" => "image/tiff",
-        _ => return None,
-    })
 }
 
 fn is_file_list_representation(rep: &ObservedClipboardRepresentation) -> bool {

--- a/src-tauri/crates/uc-core/src/clipboard/mime.rs
+++ b/src-tauri/crates/uc-core/src/clipboard/mime.rs
@@ -143,6 +143,33 @@ impl MimeType {
 /// `mime` be a free-form string: any peer or historical record that
 /// shipped UTI in `mime` is normalized at the boundary, so the engine
 /// layer can rely on `mime: Option<MimeType>` always being RFC-shaped.
+/// Resolve a portable image RFC MIME from a file path's extension.
+///
+/// Returns the canonical `image/*` MIME for common raster formats, or `None`
+/// when the extension is missing / unknown. Pure extension lookup — does not
+/// open the file, allocate, or depend on any platform clipboard knowledge.
+///
+/// Used by capture paths that synthesize a `LocalFile`-source representation
+/// for an image rep (no byte sniffing available at attach time) and by the
+/// receive-side materializer when re-attaching downloaded blobs as rep files.
+/// Centralizing the table here keeps both ends agreeing on the extension set
+/// without duplication.
+pub fn image_mime_from_extension(path: &std::path::Path) -> Option<&'static str> {
+    let ext = path
+        .extension()
+        .and_then(|e| e.to_str())?
+        .to_ascii_lowercase();
+    Some(match ext.as_str() {
+        "png" => "image/png",
+        "jpg" | "jpeg" => "image/jpeg",
+        "gif" => "image/gif",
+        "webp" => "image/webp",
+        "bmp" => "image/bmp",
+        "tif" | "tiff" => "image/tiff",
+        _ => return None,
+    })
+}
+
 pub fn normalize_wire_mime(raw: Option<String>) -> Option<MimeType> {
     let raw = raw?;
     let candidate = MimeType(raw);

--- a/src-tauri/crates/uc-core/src/clipboard/mod.rs
+++ b/src-tauri/crates/uc-core/src/clipboard/mod.rs
@@ -37,7 +37,7 @@ pub use system::{
 pub use decision::{ClipboardContentActionDecision, DuplicationHint, RejectReason};
 pub use hash::{ContentHash, HashAlgorithm};
 pub use integration_mode::ClipboardIntegrationMode;
-pub use mime::{normalize_wire_mime, ImageKind, MimeClass, MimeType};
+pub use mime::{image_mime_from_extension, normalize_wire_mime, ImageKind, MimeClass, MimeType};
 pub use origin::ClipboardOrigin;
 pub use payload_availability::PayloadAvailability;
 pub use thumbnail::ThumbnailMetadata;

--- a/src-tauri/crates/uc-platform/Cargo.toml
+++ b/src-tauri/crates/uc-platform/Cargo.toml
@@ -6,6 +6,36 @@ edition = "2021"
 description = "Platform-specific implementations for UniClipboard (clipboard, security, storage)"
 
 [features]
+# `desktop`（默认）启用桌面 host 所需的全部 OS 适配器：keyring、应用目录解析、
+# clipboard-rs / wayland / x11rb / Win32 / NSPasteboard 绑定、eventfd-shutdown。
+# 所有现存 host（uc-tauri / uc-desktop / uc-daemon-local / uc-cli / uc-bootstrap）
+# 走这条路径，保持向后兼容。
+#
+# `portable` 是空 feature（不引入任何 OS 适配器），只暴露 ports 抽象 + 纯 Rust 件
+# （`file_secure_storage`、`migrating_secure_storage`、`clipboard::payload`、
+# `clipboard::noop`、`clipboard::format_id_mime`、`clipboard::watcher` 抽象、
+# `clipboard::event_loop` 的 Condvar fallback 段）。它供未来 mobile (UniFFI) host
+# 与"engine 可移植性回归测试"使用：
+#   cargo check -p uc-platform --no-default-features --features portable
+# 该命令必须在任何 host 上都成功且不在 dep graph 里出现 keyring / dirs /
+# clipboard-rs / clipboard-win / rustix / wayland-* / x11rb / objc2-*。
+default = ["desktop"]
+desktop = [
+    "dep:keyring",
+    "dep:dirs",
+    "dep:clipboard-rs",
+    "dep:clipboard-win",
+    "dep:rustix",
+    "dep:wayland-client",
+    "dep:wayland-protocols",
+    "dep:wayland-protocols-wlr",
+    "dep:x11rb",
+    "dep:objc2",
+    "dep:objc2-app-kit",
+    "dep:objc2-foundation",
+]
+portable = []
+
 test-helpers = []
 # 启用后，未设置 `UC_PROFILE` 时默认使用 "dev" profile：
 # - app_dirs 数据目录后缀变为 `-dev`
@@ -51,8 +81,10 @@ subtle = "2.5"
 # Image handling
 image = "0.25"
 
-# File system
-dirs = "6.0"
+# File system — desktop-only（XDG / Known Folders / Application Support 路径解析）。
+# Mobile host 走 `AppDirsPort` trait + 平台原生 API（iOS `NSFileManager`,
+# Android `Context.filesDir`），不需要 `dirs` crate。
+dirs = { version = "6.0", optional = true }
 
 # UUID
 uuid = { version = "1", features = ["v4", "fast-rng"] }
@@ -82,7 +114,7 @@ keyring = { version = "3.6.3", features = [
   # 而非 plain。Fedora 44 gnome-keyring 50.0-1 在 plain_negotiate 路径有崩溃 bug
   # (service_method_open_session 构造 GVariant 时遇 NULL → glib abort),DH 路径绕开。
   "crypto-rust",
-] }
+], optional = true }
 thiserror = "2.0.17"
 
 # Cross-language schema codegen — 仅供 `uc-tauri` 启用 `specta` feature 时使用，
@@ -152,21 +184,21 @@ libdbus-sys = { version = "0.2", features = ["vendored"] }
 #     * x11rb 0.13.x is the current stable line; the `xfixes` feature is
 #       what the watcher needs for selection-change notifications.
 [target.'cfg(target_os = "linux")'.dependencies]
-rustix = { version = "0.38", features = ["event", "fs", "pipe"] }
-wayland-client = "0.31"
-wayland-protocols = { version = "0.32", features = ["client", "staging"] }
-wayland-protocols-wlr = { version = "0.3", features = ["client"] }
-x11rb = { version = "0.13", features = ["xfixes"] }
+rustix = { version = "0.38", features = ["event", "fs", "pipe"], optional = true }
+wayland-client = { version = "0.31", optional = true }
+wayland-protocols = { version = "0.32", features = ["client", "staging"], optional = true }
+wayland-protocols-wlr = { version = "0.3", features = ["client"], optional = true }
+x11rb = { version = "0.13", features = ["xfixes"], optional = true }
 
 # `clipboard-rs` is now Linux-free (Phase 4): native Wayland + native x11rb
 # cover every Linux session we support. Keep it on macOS/Windows where the
 # native backends still wrap it. The `LinuxClipboard` / `X11Clipboard` /
 # `WaylandClipboard` impls in `clipboard/platform/linux/` do not pull this in.
 [target.'cfg(any(target_os = "macos", target_os = "windows"))'.dependencies]
-clipboard-rs = { version = "0.3.3", features = ["default"] }
+clipboard-rs = { version = "0.3.3", features = ["default"], optional = true }
 
 [target.'cfg(windows)'.dependencies]
-clipboard-win = { version = "5.4" }
+clipboard-win = { version = "5.4", optional = true }
 
 # macOS 平台原子多 rep 写入（见 `clipboard/platform/macos.rs::write_snapshot_multi_macos`）。
 # 显式启用 NSPasteboard + NSPasteboardItem feature，以拿到 NSPasteboardTypeString /
@@ -174,6 +206,6 @@ clipboard-win = { version = "5.4" }
 # objc2-foundation 的 features 虽然被 NSPasteboard feature transitively 启用，
 # 但这里显式列出以便阅读；避免未来 objc2-app-kit 的 feature 传递规则变更后静默失效。
 [target.'cfg(target_os = "macos")'.dependencies]
-objc2 = "0.6"
-objc2-app-kit = { version = "0.3", features = ["NSPasteboard", "NSPasteboardItem"] }
-objc2-foundation = { version = "0.3", features = ["NSArray", "NSData", "NSString"] }
+objc2 = { version = "0.6", optional = true }
+objc2-app-kit = { version = "0.3", features = ["NSPasteboard", "NSPasteboardItem"], optional = true }
+objc2-foundation = { version = "0.3", features = ["NSArray", "NSData", "NSString"], optional = true }

--- a/src-tauri/crates/uc-platform/src/clipboard/common.rs
+++ b/src-tauri/crates/uc-platform/src/clipboard/common.rs
@@ -5,7 +5,8 @@ use tracing::{debug, info, warn};
 #[cfg(target_os = "macos")]
 use uc_core::clipboard::ImageKind;
 use uc_core::clipboard::{
-    MimeClass, MimeType, ObservedClipboardRepresentation, SystemClipboardSnapshot,
+    image_mime_from_extension, MimeClass, MimeType, ObservedClipboardRepresentation,
+    SystemClipboardSnapshot,
 };
 use uc_core::ids::RepresentationId;
 
@@ -78,24 +79,6 @@ pub(crate) fn compute_effective_mime(rep: &ObservedClipboardRepresentation) -> O
         (Some(m), _) => Some(m.clone()),
         (None, _) => format_default,
     }
-}
-
-/// 基于文件后缀推断常见图片 MIME。仅用于 `image-from-file` LocalFile rep 的 mime 标注;
-/// 与 `sniff_image_magic` 字节嗅探互补 —— 这里在抓取阶段不读字节,所以只能凭扩展名。
-fn image_file_mime_from_path(path: &std::path::Path) -> Option<&'static str> {
-    let ext = path
-        .extension()
-        .and_then(|e| e.to_str())?
-        .to_ascii_lowercase();
-    Some(match ext.as_str() {
-        "png" => "image/png",
-        "jpg" | "jpeg" => "image/jpeg",
-        "gif" => "image/gif",
-        "webp" => "image/webp",
-        "bmp" => "image/bmp",
-        "tif" | "tiff" => "image/tiff",
-        _ => return None,
-    })
 }
 
 /// Known TIFF UTI aliases on macOS pasteboard.
@@ -461,7 +444,7 @@ impl CommonClipboardImpl {
         #[cfg(target_os = "macos")]
         let suppress_image_due_to_file_thumbnail = captured_file_paths
             .iter()
-            .any(|p| image_file_mime_from_path(p).is_some());
+            .any(|p| image_mime_from_extension(p).is_some());
         #[cfg(not(target_os = "macos"))]
         let suppress_image_due_to_file_thumbnail = false;
 
@@ -637,7 +620,7 @@ impl CommonClipboardImpl {
             const MAX_IMAGE_FILE_BYTES: u64 = 100 * 1024 * 1024;
 
             for path in &captured_file_paths {
-                let Some(mime) = image_file_mime_from_path(path) else {
+                let Some(mime) = image_mime_from_extension(path) else {
                     continue;
                 };
                 let meta = match std::fs::metadata(path) {

--- a/src-tauri/crates/uc-platform/src/clipboard/event_loop.rs
+++ b/src-tauri/crates/uc-platform/src/clipboard/event_loop.rs
@@ -25,10 +25,10 @@
 use anyhow::Result;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Condvar, Mutex};
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", feature = "desktop"))]
 use tracing::warn;
 
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", feature = "desktop"))]
 use std::os::fd::{AsRawFd, OwnedFd, RawFd};
 
 use super::watcher::ClipboardWatcher;
@@ -37,7 +37,7 @@ struct ShutdownInner {
     signaled: AtomicBool,
     cv_lock: Mutex<()>,
     cv: Condvar,
-    #[cfg(target_os = "linux")]
+    #[cfg(all(target_os = "linux", feature = "desktop"))]
     eventfd: Option<OwnedFd>,
 }
 
@@ -60,7 +60,7 @@ pub struct ShutdownRx {
 /// Condvar path; only [`ShutdownRx::raw_fd`] returns `None`. macOS / Windows /
 /// other Unix have no eventfd and use the Condvar path exclusively.
 pub fn shutdown_channel() -> (ShutdownTx, ShutdownRx) {
-    #[cfg(target_os = "linux")]
+    #[cfg(all(target_os = "linux", feature = "desktop"))]
     let eventfd = match rustix::event::eventfd(
         0,
         rustix::event::EventfdFlags::CLOEXEC | rustix::event::EventfdFlags::NONBLOCK,
@@ -79,7 +79,7 @@ pub fn shutdown_channel() -> (ShutdownTx, ShutdownRx) {
         signaled: AtomicBool::new(false),
         cv_lock: Mutex::new(()),
         cv: Condvar::new(),
-        #[cfg(target_os = "linux")]
+        #[cfg(all(target_os = "linux", feature = "desktop"))]
         eventfd,
     });
 
@@ -105,7 +105,7 @@ impl ShutdownTx {
             self.inner.cv.notify_all();
         }
         // Wake fd pollers.
-        #[cfg(target_os = "linux")]
+        #[cfg(all(target_os = "linux", feature = "desktop"))]
         {
             if let Some(fd) = self.inner.eventfd.as_ref() {
                 let buf = 1u64.to_ne_bytes();
@@ -141,7 +141,7 @@ impl ShutdownRx {
     /// their poll loop in case the fd is unavailable. Only exposed on Linux:
     /// macOS / Windows / other Unix have no eventfd, so pollable adapters must
     /// be Linux-gated as well.
-    #[cfg(target_os = "linux")]
+    #[cfg(all(target_os = "linux", feature = "desktop"))]
     pub fn raw_fd(&self) -> Option<RawFd> {
         self.inner.eventfd.as_ref().map(|fd| fd.as_raw_fd())
     }
@@ -172,7 +172,10 @@ pub trait PlatformClipboardEventLoop: Send + 'static {
 ///
 /// Linux selects between Wayland and X11 at runtime (`WAYLAND_DISPLAY`
 /// presence + protocol probe); other platforms wrap their existing
-/// `clipboard_rs` listener.
+/// `clipboard_rs` listener. Only available with the `desktop` feature —
+/// mobile / portable hosts implement [`PlatformClipboardEventLoop`] themselves
+/// (e.g. driven by host lifecycle callbacks).
+#[cfg(feature = "desktop")]
 pub fn build_event_loop() -> Result<Box<dyn PlatformClipboardEventLoop>> {
     crate::clipboard::platform::build_event_loop()
 }

--- a/src-tauri/crates/uc-platform/src/clipboard/mod.rs
+++ b/src-tauri/crates/uc-platform/src/clipboard/mod.rs
@@ -6,25 +6,43 @@
 // so non-Windows release builds don't trip `-D dead-code` (CI runs that on
 // Linux), while `cargo test` on every host still compiles and runs the unit
 // tests (cfg(test) is enabled during the test build).
-#[cfg(any(test, target_os = "windows"))]
+#[cfg(any(test, all(target_os = "windows", feature = "desktop")))]
 pub(crate) mod cf_html;
-#[cfg(any(target_os = "macos", target_os = "windows"))]
+// `common` wraps `clipboard_rs::ClipboardContext`; only macOS/Windows still
+// use it (Linux switched to native wayland/x11rb in Phase 4) and only the
+// `desktop` feature pulls `clipboard-rs` in. Mobile / portable hosts implement
+// their own adapter against `SystemClipboardPort` and do not need this.
+#[cfg(all(any(target_os = "macos", target_os = "windows"), feature = "desktop"))]
 pub mod common;
 pub mod event_loop;
 pub mod format_id_mime;
-#[cfg(target_os = "windows")]
+// `image_convert::dib_to_png` is pure `image`-crate logic but is only invoked
+// by the Windows desktop adapter. Compile it together with the Windows
+// adapter to avoid `-D dead-code` warnings under `desktop`.
+#[cfg(all(target_os = "windows", feature = "desktop"))]
 pub mod image_convert;
 pub mod noop;
-// `payload.rs` 是跨平台 rep payload helper（按 source 分流读字节），三平台写入
-// 路径都依赖它来消化入站的 `LocalFile` source rep。它独立于 `clipboard-rs`，
-// 因此不与 `common` 共享 cfg gate（Linux Wayland / X11 写入器也调用它）。
+// `payload.rs` 是跨平台 rep payload helper（按 source 分流读字节），桌面三平台
+// 写入路径都依赖它来消化入站的 `LocalFile` source rep。逻辑纯 std + uc-core，
+// 形态上是 portable 的，但目前唯一的消费者都在 desktop 适配器内（macOS/Windows
+// `common.rs` + Linux `platform/linux/*` 的 wayland/x11rb 写入器）；portable 构建
+// 里没有人调用它，全部会触发 `dead_code` 警告，因此随 `desktop` feature 一并编入。
+// 未来 mobile 写入路径若需要按 source 分流读盘，再把这层 gate 撤掉。
+#[cfg(feature = "desktop")]
 pub(crate) mod payload;
+#[cfg(feature = "desktop")]
 pub mod platform;
 pub mod watcher;
 
-pub use event_loop::{
-    build_event_loop, shutdown_channel, PlatformClipboardEventLoop, ShutdownRx, ShutdownTx,
-};
+pub use event_loop::{shutdown_channel, PlatformClipboardEventLoop, ShutdownRx, ShutdownTx};
 pub use noop::NoopSystemClipboard;
-pub use platform::LocalClipboard;
 pub use watcher::{PlatformEvent, PlatformEventSender};
+
+// Concrete OS-bound adapter + factory only exist when the `desktop` feature
+// is on. Portable / mobile hosts wire their own `SystemClipboardPort`
+// implementation and their own event loop (e.g. driven by host lifecycle
+// callbacks on iOS / Android), so these re-exports stay desktop-only.
+#[cfg(feature = "desktop")]
+pub use event_loop::build_event_loop;
+#[cfg(feature = "desktop")]
+pub use platform::LocalClipboard;

--- a/src-tauri/crates/uc-platform/src/clipboard/watcher.rs
+++ b/src-tauri/crates/uc-platform/src/clipboard/watcher.rs
@@ -6,7 +6,7 @@ use tracing::{debug, warn};
 // adapter that wraps `ClipboardWatcherContext`. The native Wayland and X11
 // (x11rb) adapters drive `notify_change` directly, so as of Phase 4 the
 // trait impl is gated to the platforms that still need `clipboard_rs`.
-#[cfg(any(target_os = "macos", target_os = "windows"))]
+#[cfg(all(any(target_os = "macos", target_os = "windows"), feature = "desktop"))]
 use clipboard_rs::ClipboardHandler;
 
 use uc_core::clipboard::SystemClipboardSnapshot;
@@ -151,7 +151,7 @@ impl ClipboardWatcher {
 // Wayland and X11 (x11rb) implementations call
 // [`ClipboardWatcher::notify_change`] directly and do not go through this
 // trait.
-#[cfg(any(target_os = "macos", target_os = "windows"))]
+#[cfg(all(any(target_os = "macos", target_os = "windows"), feature = "desktop"))]
 impl ClipboardHandler for ClipboardWatcher {
     fn on_clipboard_change(&mut self) {
         self.notify_change();

--- a/src-tauri/crates/uc-platform/src/lib.rs
+++ b/src-tauri/crates/uc-platform/src/lib.rs
@@ -44,7 +44,9 @@ pub const fn default_profile() -> Option<&'static str> {
 /// Resolve the active profile name (single source of truth for `app_dirs` + `system_secure_storage`).
 ///
 /// Runtime `UC_PROFILE` takes precedence over the compile-time `default_profile()` fallback.
-/// Returns `None` when neither is set.
+/// Returns `None` when neither is set. Only the desktop adapters consume this
+/// — portable builds drop it together with `app_dirs` / `system_secure_storage`.
+#[cfg(feature = "desktop")]
 pub(crate) fn resolve_profile() -> Option<String> {
     if let Ok(profile) = std::env::var("UC_PROFILE") {
         if !profile.is_empty() {
@@ -54,6 +56,12 @@ pub(crate) fn resolve_profile() -> Option<String> {
     default_profile().map(str::to_string)
 }
 
+// Desktop-only modules. They pull in `dirs` / `keyring` (and on Linux,
+// `secret-service` via libdbus), so they only exist when the `desktop` feature
+// is enabled. Mobile / portable hosts get the trait surface from `ports`
+// and provide their own adapters (iOS `NSFileManager`, Android `Context`,
+// platform secret APIs, …).
+#[cfg(feature = "desktop")]
 pub mod app_dirs;
 pub mod bootstrap;
 pub mod capability;
@@ -61,5 +69,7 @@ pub mod clipboard;
 pub mod file_secure_storage;
 pub mod migrating_secure_storage;
 pub mod ports;
+#[cfg(feature = "desktop")]
 pub mod secure_storage;
+#[cfg(feature = "desktop")]
 pub mod system_secure_storage;


### PR DESCRIPTION
## Summary

引擎可移植性 phase P1 — 给 `uc-platform` 引入 `desktop` (默认) / `portable` 两组 cargo features，让 engine 可移植性有了**第一个客观自动化回归测试**：

```bash
cargo check -p uc-platform --no-default-features --features portable
```

该命令在任何 host 上都应成功且不在 dep graph 里出现 keyring / dirs / clipboard-rs / clipboard-win / rustix / wayland-* / x11rb / objc2-*。这是后续 P2（移动 target 编译 spike）和 P3（物理拆 crate）的前提。

- **`377287f9` feat(uc-platform): introduce desktop / portable feature flags** — 把全部桌面 deps 标 `optional = true`（包括 target-cfg Linux 的 `rustix` / `wayland-*` / `x11rb`），desktop-only 模块加 `#[cfg(feature = "desktop")]`，`event_loop.rs` 的 Linux eventfd 段收紧为 `#[cfg(all(target_os = "linux", feature = "desktop"))]`，Condvar fallback + `PlatformClipboardEventLoop` trait 保持 portable
- **`7dde5260` refactor(mime): dedupe image_mime_from_extension into uc-core** — `image_file_mime_from_path` 在 `uc-platform::clipboard::common` 和 `uc-application::apply_inbound::materializer` 是完全重复的实现（连 cross-reference 注释都互相提醒"两边一起改"），提到 `uc-core::clipboard::image_mime_from_extension`。不放 uc-platform 的原因：那会迫使 uc-application 从 dev-dep 升 runtime-dep，破坏 application 不依赖 platform 的边界
- **`57558679` docs(uc-application): clarify §6.5 mime entry points by layer** — 顺手补 `uc-application/AGENTS.md §6.5` 把 P0 已确立的「application 层禁止埋 UTI / CF_* 字面量」契约写进 AGENTS.md，按 application 可用 vs platform 内部使用分两栏列入口
- **`0ff998d4` docs(planning): commit engine-portability planning files** — 把 `task_plan.md` / `findings.md` / `progress.md` 入库，记录 P0 + P1 完整决策、commit 坐标、测试矩阵，方便后续 session / archive

下游 feature 透传未做（advisor 提醒后 dep audit 确认）：`uc-application` 只把 `uc-platform` 列 dev-dep，`uc-infra` 完全不依赖 `uc-platform`，transitive default activation 不存在。

## Test plan

- [x] `cargo check -p uc-platform` (default desktop) ✅
- [x] `cargo check -p uc-platform --no-default-features --features portable` ✅
- [x] `cargo check -p uc-application --no-default-features` ✅
- [x] `cargo check -p uc-infra --no-default-features` ✅
- [x] `cargo check --workspace` ✅
- [x] `cargo check -p uc-tauri --features dev-profile` ✅（feature 透传未受影响）
- [x] `cargo tree -p uc-platform --no-default-features --features portable` 不含任何桌面适配器 crate ✅
- [x] 测试基线 1050 全绿（uc-core 118 + uc-platform 39 + uc-application 568 + uc-infra 325），与 P0 末持平
- [ ] CI 在 macOS / Windows runner 上验证 `desktop` feature 的 `dep:objc2-*` / `dep:clipboard-win` 等 target-conditional 引用工作正常（本地只在 Linux 上验证；Cargo 文档说应该 silently no-op 在不匹配 target 上，但只有跨 OS CI 能锤实）
- [ ] 评审：`uc-application/AGENTS.md §6.5` 文案是否准确表达「application 层 mime RFC-only 契约」

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for portable build mode with reduced platform-specific dependencies.

* **Refactor**
  * Centralized image MIME type resolution across platform adapters.
  * Gated platform-specific clipboard and storage modules behind feature flags for more granular build configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/UniClipboard/UniClipboard/pull/881?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->