### PR TITLE
fix(secure-storage): use DH OpenSession on Linux, classify D-Bus errors

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -995,6 +995,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1217,6 +1226,15 @@ checksum = "374b7c592d9c00c1f4972ea58390ac6b18cbb6ab79011f3bdc90a0b82ca06b77"
 dependencies = [
  "serde",
  "toml 0.9.12+spec-1.1.0",
+]
+
+[[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -1977,7 +1995,15 @@ version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "708b509edf7889e53d7efb0ffadd994cc6c2345ccb62f55cfd6b0682165e4fa6"
 dependencies = [
+ "aes",
+ "block-padding",
+ "cbc",
  "dbus",
+ "fastrand",
+ "hkdf",
+ "num",
+ "once_cell",
+ "sha2 0.10.9",
  "zeroize",
 ]
 
@@ -4053,6 +4079,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
+ "block-padding",
  "generic-array",
 ]
 
@@ -4598,6 +4625,7 @@ dependencies = [
  "dbus-secret-service",
  "linux-keyutils",
  "log",
+ "secret-service",
  "security-framework 2.11.1",
  "security-framework 3.7.0",
  "windows-sys 0.60.2",
@@ -5296,6 +5324,19 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
+name = "nix"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
@@ -5414,7 +5455,7 @@ dependencies = [
  "mac-notification-sys",
  "serde",
  "tauri-winrt-notification",
- "zbus",
+ "zbus 5.15.0",
 ]
 
 [[package]]
@@ -5424,6 +5465,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
 ]
 
 [[package]]
@@ -5450,6 +5505,15 @@ dependencies = [
  "rand 0.8.6",
  "smallvec",
  "zeroize",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -5922,7 +5986,7 @@ checksum = "e4022a17595a00d6a369236fdae483f0de7f0a339960a53118b818238e132224"
 dependencies = [
  "android_system_properties",
  "log",
- "nix",
+ "nix 0.30.1",
  "objc2",
  "objc2-foundation",
  "objc2-ui-kit",
@@ -7626,6 +7690,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "secret-service"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4d35ad99a181be0a60ffcbe85d680d98f87bdc4d7644ade319b87076b9dbfd4"
+dependencies = [
+ "aes",
+ "cbc",
+ "futures-util",
+ "generic-array",
+ "hkdf",
+ "num",
+ "once_cell",
+ "rand 0.8.6",
+ "serde",
+ "sha2 0.10.9",
+ "zbus 4.4.0",
+]
+
+[[package]]
 name = "security-framework"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8380,6 +8463,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "string_cache"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8854,7 +8943,7 @@ dependencies = [
  "thiserror 2.0.18",
  "url",
  "windows 0.61.3",
- "zbus",
+ "zbus 5.15.0",
 ]
 
 [[package]]
@@ -8869,7 +8958,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tracing",
  "windows-sys 0.60.2",
- "zbus",
+ "zbus 5.15.0",
 ]
 
 [[package]]
@@ -11646,6 +11735,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "xdg-home"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec1cdab258fb55c0da61328dc52c8764709b249011b2cad0454c72f0bf10a1f6"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "xkeysym"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11718,6 +11817,38 @@ dependencies = [
 
 [[package]]
 name = "zbus"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb97012beadd29e654708a0fdb4c84bc046f537aecfde2c3ee0a9e4b4d48c725"
+dependencies = [
+ "async-broadcast",
+ "async-process",
+ "async-recursion",
+ "async-trait",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "hex",
+ "nix 0.29.0",
+ "ordered-stream",
+ "rand 0.8.6",
+ "serde",
+ "serde_repr",
+ "sha1",
+ "static_assertions",
+ "tracing",
+ "uds_windows",
+ "windows-sys 0.52.0",
+ "xdg-home",
+ "zbus_macros 4.4.0",
+ "zbus_names 3.0.0",
+ "zvariant 4.2.0",
+]
+
+[[package]]
+name = "zbus"
 version = "5.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3bcbf15c8708d7fc1be0c993622e0a5cbd5e8b52bfa40afa4c3e0cd8d724ac1"
@@ -11746,9 +11877,22 @@ dependencies = [
  "uuid",
  "windows-sys 0.61.2",
  "winnow 1.0.3",
- "zbus_macros",
- "zbus_names",
- "zvariant",
+ "zbus_macros 5.15.0",
+ "zbus_names 4.3.2",
+ "zvariant 5.11.0",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "267db9407081e90bbfa46d841d3cbc60f59c0351838c4bc65199ecd79ab1983e"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zvariant_utils 2.1.0",
 ]
 
 [[package]]
@@ -11761,9 +11905,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
- "zbus_names",
- "zvariant",
- "zvariant_utils",
+ "zbus_names 4.3.2",
+ "zvariant 5.11.0",
+ "zvariant_utils 3.3.1",
+]
+
+[[package]]
+name = "zbus_names"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b9b1fef7d021261cc16cba64c351d291b715febe0fa10dc3a443ac5a5022e6c"
+dependencies = [
+ "serde",
+ "static_assertions",
+ "zvariant 4.2.0",
 ]
 
 [[package]]
@@ -11774,7 +11929,7 @@ checksum = "7074f3e50b894eac91750142016d30d0a89be8e67dbfd9704fb875825760e52d"
 dependencies = [
  "serde",
  "winnow 1.0.3",
- "zvariant",
+ "zvariant 5.11.0",
 ]
 
 [[package]]
@@ -11959,6 +12114,19 @@ dependencies = [
 
 [[package]]
 name = "zvariant"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2084290ab9a1c471c38fc524945837734fbf124487e105daec2bb57fd48c81fe"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "static_assertions",
+ "zvariant_derive 4.2.0",
+]
+
+[[package]]
+name = "zvariant"
 version = "5.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c1567a6ec68df868cbbfde844cfc6d81649fe5109a62b116b19fabd53e618ee"
@@ -11967,8 +12135,21 @@ dependencies = [
  "enumflags2",
  "serde",
  "winnow 1.0.3",
- "zvariant_derive",
- "zvariant_utils",
+ "zvariant_derive 5.11.0",
+ "zvariant_utils 3.3.1",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73e2ba546bda683a90652bac4a279bc146adad1386f25379cf73200d2002c449"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zvariant_utils 2.1.0",
 ]
 
 [[package]]
@@ -11981,7 +12162,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
- "zvariant_utils",
+ "zvariant_utils 3.3.1",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/src-tauri/crates/uc-platform/Cargo.toml
+++ b/src-tauri/crates/uc-platform/Cargo.toml
@@ -78,6 +78,10 @@ keyring = { version = "3.6.3", features = [
   "apple-native",
   "windows-native",
   "linux-native-sync-persistent",
+  # crypto-rust: secret-service OpenSession 走 DH (algorithm=dh-ietf1024-sha256-aes128-cbc-pkcs7)
+  # 而非 plain。Fedora 44 gnome-keyring 50.0-1 在 plain_negotiate 路径有崩溃 bug
+  # (service_method_open_session 构造 GVariant 时遇 NULL → glib abort),DH 路径绕开。
+  "crypto-rust",
 ] }
 thiserror = "2.0.17"
 

--- a/src-tauri/crates/uc-platform/src/system_secure_storage.rs
+++ b/src-tauri/crates/uc-platform/src/system_secure_storage.rs
@@ -3,6 +3,54 @@ use uc_core::ports::{SecureStorageError, SecureStoragePort};
 
 const SERVICE_NAME: &str = "UniClipboard";
 
+/// Classify a `keyring::Error::PlatformFailure` into a domain `SecureStorageError`.
+///
+/// Linux backends surface D-Bus / Secret Service transport faults as `PlatformFailure(msg)`
+/// with the underlying error text. These should map to `Unavailable` (service crashed, no
+/// owner, activation failed, connection lost) rather than `PermissionDenied`, which is
+/// reserved for genuine ACL / prompt-dismissed outcomes.
+fn classify_platform_failure(msg: &str) -> SecureStorageError {
+    let lower = msg.to_ascii_lowercase();
+    let unavailable_markers = [
+        "remote peer disconnected",
+        "connection reset",
+        "broken pipe",
+        "no such file or directory",
+        "no such interface",
+        "no such object",
+        "serviceunknown",
+        "service_unknown",
+        "namehasnoowner",
+        "name_has_no_owner",
+        "activationfailed",
+        "activation_failed",
+        "nameowner",
+        "disconnected",
+        "no reply",
+        "noreply",
+        "timed out",
+        "timeout",
+    ];
+    let denied_markers = [
+        "prompt dismissed",
+        "promptdismissed",
+        "access denied",
+        "accessdenied",
+        "access_denied",
+        "permission denied",
+        "permissiondenied",
+        "not authorized",
+        "notauthorized",
+    ];
+    if unavailable_markers.iter().any(|m| lower.contains(m)) {
+        SecureStorageError::Unavailable(msg.to_string())
+    } else if denied_markers.iter().any(|m| lower.contains(m)) {
+        SecureStorageError::PermissionDenied(msg.to_string())
+    } else {
+        SecureStorageError::Other(format!("platform failure: {msg}"))
+    }
+}
+
 /// Builds the keychain service name used to namespace secure storage entries.
 ///
 /// The returned name is `SERVICE_NAME` when no environment-derived suffixes are present;
@@ -79,7 +127,7 @@ impl SecureStoragePort for SystemSecureStorage {
             Ok(secret) => Ok(Some(secret)),
             Err(keyring::Error::NoEntry) => Ok(None),
             Err(keyring::Error::PlatformFailure(msg)) => {
-                Err(SecureStorageError::PermissionDenied(msg.to_string()))
+                Err(classify_platform_failure(&msg.to_string()))
             }
             Err(err) => Err(SecureStorageError::Other(format!(
                 "failed to read secure storage: {err}"
@@ -90,9 +138,7 @@ impl SecureStoragePort for SystemSecureStorage {
     fn set(&self, key: &str, value: &[u8]) -> Result<(), SecureStorageError> {
         let entry = self.entry_for_key(key)?;
         entry.set_secret(value).map_err(|err| match err {
-            keyring::Error::PlatformFailure(msg) => {
-                SecureStorageError::PermissionDenied(msg.to_string())
-            }
+            keyring::Error::PlatformFailure(msg) => classify_platform_failure(&msg.to_string()),
             _ => SecureStorageError::Other(format!("failed to write secure storage: {err}")),
         })
     }
@@ -102,11 +148,52 @@ impl SecureStoragePort for SystemSecureStorage {
         match entry.delete_credential() {
             Ok(()) | Err(keyring::Error::NoEntry) => Ok(()),
             Err(keyring::Error::PlatformFailure(msg)) => {
-                Err(SecureStorageError::PermissionDenied(msg.to_string()))
+                Err(classify_platform_failure(&msg.to_string()))
             }
             Err(err) => Err(SecureStorageError::Other(format!(
                 "failed to delete secure storage: {err}"
             ))),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unavailable_classification() {
+        assert!(matches!(
+            classify_platform_failure("DBus error: Remote peer disconnected"),
+            SecureStorageError::Unavailable(_)
+        ));
+        assert!(matches!(
+            classify_platform_failure("org.freedesktop.DBus.Error.ServiceUnknown: ..."),
+            SecureStorageError::Unavailable(_)
+        ));
+        assert!(matches!(
+            classify_platform_failure("org.freedesktop.DBus.Error.NameHasNoOwner"),
+            SecureStorageError::Unavailable(_)
+        ));
+    }
+
+    #[test]
+    fn denied_classification() {
+        assert!(matches!(
+            classify_platform_failure("Prompt dismissed by user"),
+            SecureStorageError::PermissionDenied(_)
+        ));
+        assert!(matches!(
+            classify_platform_failure("AccessDenied"),
+            SecureStorageError::PermissionDenied(_)
+        ));
+    }
+
+    #[test]
+    fn unknown_classification_falls_through_to_other() {
+        match classify_platform_failure("something totally weird") {
+            SecureStorageError::Other(msg) => assert!(msg.contains("platform failure")),
+            _ => panic!("expected Other"),
         }
     }
 }


### PR DESCRIPTION
## Summary

- **Switch the Linux secret-service path from plain to DH OpenSession** (`a22b5e66`). Enable the `crypto-rust` feature on the `keyring` crate so `dbus-secret-service` negotiates a `dh-ietf1024-sha256-aes128-cbc-pkcs7` session instead of `plain`. Fedora 44 ships gnome-keyring `50.0-1` which crashes inside `service_method_open_session` → `g_variant_new` on a NULL field when handling `plain_negotiate` — the daemon `SIGABRT`s mid-call and the client sees `secure_storage.set: DBus error: Remote peer disconnected`. The DH path forces the daemon to build a full session/client context before replying, sidestepping the buggy branch. Side benefit: secrets no longer cross the bus in cleartext.
- **Stop reporting D-Bus transport faults as `PermissionDenied`** (`a22b5e66`). `SystemSecureStorage::{get,set,delete}` now routes `keyring::Error::PlatformFailure` through `classify_platform_failure()`, which maps peer-disconnected / ServiceUnknown / NameHasNoOwner / ActivationFailed / timeout / no-reply to `Unavailable`, and only routes `Prompt dismissed` / `AccessDenied` / `Permission denied` / `Not authorized` to `PermissionDenied`. Anything unrecognized falls through to `Other("platform failure: …")` instead of being mislabeled. Unit tests cover the three buckets.

Verified end-to-end on Fedora 44 aarch64 (gnome-keyring 50.0-1, niri Wayland session): a fresh profile reached `switch-space phase 1 (prepare) complete` with the new binary on the same host that previously took down the keyring daemon with a coredump on the very first `secure_storage.set`. No new `coredumpctl` entries for gnome-keyring after the run.

No user-visible surface changed (no CLI flag, setting, or error string is rewired), so `docs-site/` is left untouched — the Snap-AppArmor troubleshooting entry covers a different failure mode and remains accurate.

## Test plan

- [x] `cargo check -p uc-platform` on macOS host (DH feature enabled, no breakage in dependent crates).
- [x] `cargo build --release --bin uniclipboard --features custom-protocol` on Fedora 44 aarch64.
- [x] Manual run on Fedora 44: launched daemon with an isolated `UC_PROFILE=keyring-fix`, started setup flow, watched `~/.local/share/app.uniclipboard.desktop-keyring-fix/logs/uniclipboard.json.*` — `secure_storage.set` succeeded, `switch-space phase 1 (prepare) complete` reached, zero `Remote peer disconnected` / `DBus error` lines, zero gnome-keyring coredumps in `coredumpctl list`.
- [x] New unit tests in `system_secure_storage.rs` cover the three error-classification buckets.
- [ ] CI: linux-gnu / linux-musl builds pull in the new `aes` / `cbc` / `num` / `fastrand` crates via `keyring`'s `crypto-rust` feature — confirm musl static link still completes (`libdbus-sys` vendored path unchanged).
- [ ] Smoke check on a working desktop Linux (Ubuntu / Arch with gnome-keyring or KWallet): confirm the DH session still negotiates and existing entries written under plain remain readable. Stored entries are values, not session-keyed — the algorithm choice only governs transport over D-Bus, so historical entries should round-trip without migration.
- [ ] Windows + macOS: no code path change, but worth a quick sanity check that `cargo build` on those targets still passes (keyring crate's apple-native / windows-native features are unchanged).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a crash on Fedora systems during secure storage initialization.
  * Improved error classification for secure storage operations to better distinguish between unavailable services and permission errors.

* **Tests**
  * Added unit tests for secure storage error handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/UniClipboard/UniClipboard/pull/882?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->