### PR TITLE
docs(mobile-sync): add Tailscale cross-network section

### DIFF
--- a/docs-site/content/docs/en/guides/mobile-sync.mdx
+++ b/docs-site/content/docs/en/guides/mobile-sync.mdx
@@ -309,6 +309,132 @@ Either way, the connection settings are the same:
   gate writes when the app is not in the foreground.
 </Callout>
 
+## Cross-network sync via Tailscale
+
+By default, **mobile sync is same-Wi-Fi only** — once the phone moves
+to cellular (4G/5G) or to a different Wi-Fi, it can't reach the
+desktop's listener. Since **0.12**, the **Bind IP** dropdown also
+lists addresses in `100.64.0.0/10` (the CGNAT block Tailscale assigns
+to its virtual interfaces). If both the desktop and the phone are
+signed in to the same Tailscale network (tailnet), you can pair them
+exactly like on a LAN, with the **whole path carried over the
+Tailscale / WireGuard tunnel**.
+
+Typical setup:
+
+- Desktop sits at home on Ethernet / Wi-Fi;
+- Phone is out on 4G/5G cellular, or on someone else's Wi-Fi;
+- Both signed in to the same Tailscale account → reachable over the
+  tailnet directly.
+
+<Callout type="info">
+  **This only changes _reachability_, not the v1 HTTP wire format.** The
+  listener still speaks plain HTTP + Basic Auth; confidentiality is
+  provided by the Tailscale / WireGuard tunnel you trust. If you don't
+  trust Tailscale as a network layer, keep using the LAN-only setup.
+</Callout>
+
+<Steps>
+
+<Step>
+
+### Install Tailscale on the desktop and phone, sign in to the same account
+
+- **Desktop** — install the official client
+  ([tailscale.com/download](https://tailscale.com/download)) and stay
+  **Connected**. On Linux run `tailscale up` after the daemon is up;
+  on macOS / Windows, hit **Connect** from the menu bar / system tray.
+- **Phone** — install **Tailscale** from the App Store / Google Play,
+  sign in to the **same account**, and flip the VPN toggle on. iOS
+  will ask permission to add a VPN configuration — accept it.
+
+Once both ends are **Connected**, you'll see each other in the
+Tailscale client's **Machines** list, each with a `100.x.x.x` tailnet
+IPv4.
+
+</Step>
+
+<Step>
+
+### Pick the Tailscale interface in the desktop **Configure** dialog
+
+Go back to **Devices → Mobile sync → Configure**. In the **Bind IP**
+dropdown, pick the `100.x.x.x` entry (the Tailscale CGNAT one). The
+**current listening address** row immediately switches to
+`http://100.x.x.x:42720`, and any credentials minted from now on will
+embed that address.
+
+No daemon restart is needed — the listener hot-swaps. The actual
+socket still binds on `0.0.0.0`; **the "Bind IP" picker only controls
+which address is advertised to the phone.**
+
+<Callout type="info">
+  This is **independent** of the **Settings → Network → Allow overlay
+  network addrs** toggle. That toggle gates desktop-↔-desktop P2P path
+  candidates; mobile sync is a manual pick of an address that gets
+  handed to the phone, so the Tailscale CGNAT range is always listed
+  here.
+</Callout>
+
+</Step>
+
+<Step>
+
+### Click **Add device** and scan from the phone
+
+Run the normal **Add device** flow from
+[Enable mobile sync](#enable-mobile-sync-one-shot). The connect-URI
+QR at the top of the credentials modal now encodes the tailnet
+`http://100.x.x.x:42720` address.
+
+If you've already paired a device on a LAN interface, you don't have
+to re-add it: open the device card's dialog (or the credentials
+modal) and switch the **baseUrl dropdown** to the Tailscale entry —
+the QR refreshes in place with a new connect URI. No trip back to
+Configure required.
+
+</Step>
+
+<Step>
+
+### Scan from the phone and keep Tailscale connected
+
+Scan the top QR from the UniClipboard iOS / Android app; all fields
+auto-fill. **As long as the phone's Tailscale VPN stays Connected**,
+sync works the same way it would on the home LAN, whether the phone
+is on cellular or some unrelated Wi-Fi.
+
+</Step>
+
+</Steps>
+
+### Caveats and limits
+
+- **Both ends must stay Connected on Tailscale.** If the phone's
+  Tailscale drops (manual disconnect, OS background-killed, or
+  carrier idle-timeout), you're back to "unreachable from off-LAN"
+  and requests will hang / fail.
+- **MagicDNS hostnames aren't used.** The credentials URL embeds the
+  raw `100.x.x.x` IP; even if you've given the desktop a Tailscale
+  alias (e.g. `desktop.tail-XXXX.ts.net`), we **don't** write that
+  name into the connect URI. Stick with the numeric IP.
+- **Mobile background restrictions still apply.** iOS clipboard reads
+  are gated on lock / background, and Android 10+ has similar limits.
+  Tailscale doesn't change OS behaviour here. For predictable
+  "background sync," keep the app foregrounded or whitelisted.
+- **This is not v2 TLS.** Tailscale gives you _network-layer_
+  confidentiality. If your threat model needs end-to-end semantics
+  (e.g. you can't trust the desktop machine itself), this path
+  doesn't fix that — wait for v2 TLS.
+
+Troubleshooting: if the phone can ping `100.x.x.x` but the app times
+out, the desktop's Tailscale is usually the problem — either it
+isn't Connected, or you're going through a DERP relay with throttled
+throughput (Tailscale free plan caps relays around ~50 KB/s, which
+makes large images / files crawl). Check both ends are **Online** in
+the Tailscale "Machines" list and confirm a **direct** connection
+(rather than a DERP relay) between them.
+
 ## Manage paired devices
 
 | Action               | GUI                                              | CLI                                                    |
@@ -340,7 +466,7 @@ records, use `devices revoke` (or the GUI revoke button) explicitly.
 | On-disk password storage      | **Yes** — only an Argon2id hash is persisted server-side.                 |
 | Credential rotation           | **Yes** — `Rotate password` mints a new one and invalidates the old hash. |
 | LAN-side wire confidentiality | **No (v1)** — plain HTTP. TLS comes in v2.                                |
-| Cross-network reachability    | **No** — LAN only. Phone off the LAN can't reach the desktop.             |
+| Cross-network reachability    | **No by default** — LAN only. Tailscale / VPN gives a workaround (below). |
 | Mobile-as-peer trust          | **No** — phone never participates in the iroh / space trust mesh.         |
 
 Practical implications:
@@ -349,10 +475,14 @@ Practical implications:
   selective about where you turn it on.
 - Public Wi-Fi: keep the listener disabled. Re-enable on a trusted
   network when you actually want the integration.
-- VPN: a VPN that gives both desktop and phone the same RFC1918
-  subnet works as a workaround for "I want LAN-style sync from
-  outside the home" — but it's still plain HTTP, so the VPN itself
-  must be trusted.
+- VPN / Tailscale: a VPN or Tailscale tailnet that puts both the
+  desktop and the phone on the same virtual subnet (RFC1918 or
+  Tailscale's `100.64.0.0/10`) is a reasonable "LAN-style sync from
+  outside the home" workaround — full steps in
+  [Cross-network sync via Tailscale](#cross-network-sync-via-tailscale).
+  It's still plain HTTP on the wire; the VPN / WireGuard tunnel
+  provides the confidentiality, so the overlay network itself must
+  be trusted.
 
 ## Troubleshooting
 

--- a/docs-site/content/docs/zh/guides/mobile-sync.mdx
+++ b/docs-site/content/docs/zh/guides/mobile-sync.mdx
@@ -277,6 +277,116 @@ SyncClipboard 协议兼容客户端也能接入。推荐顺序：
   空间的信任网格，并且 Android 10+ 的后台剪贴板限制会让 App 不在前台时收发被延迟或拦截。
 </Callout>
 
+## 跨网络同步：搭配 Tailscale
+
+默认场景里，**移动端同步** 只覆盖同一个 Wi-Fi —— 手机走 4G/5G、或人在
+外面接别人的 Wi-Fi 时，是 **拨不通** 桌面那个监听器的。从
+**0.12** 起，「监听 IP」下拉额外把 `100.64.0.0/10` 这一段 CGNAT
+地址（Tailscale 默认给虚拟网卡用的 IPv4 区段）也列了出来，所以只要
+桌面与手机都接入同一个 Tailscale 网络（tailnet），就能像在同一个
+LAN 里一样直接配对，**整条通道由 Tailscale / WireGuard 加密承载**。
+
+典型使用场景：
+
+- 电脑在家走有线 / 公司 Wi-Fi；
+- 手机在外走 4G / 5G 蜂窝网络，或者接的是另一个咖啡馆 Wi-Fi；
+- 两端都登录同一个 Tailscale 账号 → 走 tailnet 直接互通。
+
+<Callout type="info">
+  **这条路径只换了「可达性」，没换 v1 的 HTTP 协议本身。** 监听器对外
+  依然是明文 HTTP + Basic Auth；机密性由你信任的 Tailscale / WireGuard
+  隧道托底。如果你只把 Tailscale 当工具，不把它视作可信网络，请
+  暂时保持原本的「仅限同 LAN」做法。
+</Callout>
+
+<Steps>
+
+<Step>
+
+### 在桌面与手机上分别安装 Tailscale 并登录同一账号
+
+- **桌面端** —— 装官方客户端（[tailscale.com/download](https://tailscale.com/download)），
+  登录后保持「连接」状态。Linux 上启动 `tailscaled` 后执行
+  `tailscale up`；macOS / Windows 直接在状态栏 / 系统托盘里点
+  **Connect**。
+- **手机端** —— 在 App Store / Google Play 安装 **Tailscale** App，
+  登录 **同一个账号**，把 VPN 开关打开。iOS 上系统会要求授权
+  添加 VPN 配置，确认即可。
+
+两端都 **Connect** 之后，可以在桌面 / 手机的 Tailscale 客户端里看到
+对方设备出现在「Machines」列表中，每台机器都拿到一个 `100.x.x.x`
+的 tailnet IPv4。
+
+</Step>
+
+<Step>
+
+### 在桌面 **配置** modal 选 Tailscale 网卡
+
+回到 **设备 → 移动端同步 → 配置**。在 **监听 IP** 下拉里，找到形如
+`100.x.x.x`（Tailscale 段）的那一项选中。**当前监听地址** 行立即切到
+对应的 `http://100.x.x.x:42720`，所有后续签发的设备凭据 URL 都会
+带上这个地址。
+
+不需要重启 daemon —— 监听器是热切换的，实际 socket 还是 bind 在
+`0.0.0.0`，**「监听 IP」这个选项只决定对外宣告哪一个地址**。
+
+<Callout type="info">
+  这与 **设置 → 网络 → 允许覆盖网络地址** 开关 **无关**。后者控制的是
+  桌面 ↔ 桌面 P2P 的路径候选，移动端同步是手动挑一个地址给手机扫码，
+  所以 Tailscale CGNAT 在这里始终可见。
+</Callout>
+
+</Step>
+
+<Step>
+
+### 点 **添加设备**，让手机扫码
+
+照常走 [一键启用](#一键启用) 里的 **添加设备** 流程。凭据弹窗顶部
+那张 connect URI 二维码现在编码的就是 `http://100.x.x.x:42720` 的
+tailnet 地址。
+
+如果已经把设备加好，但当时选的是 LAN 网卡，可以直接在凭据弹窗 / 设备卡片 dialog 的
+**baseUrl 下拉** 里切到 Tailscale 网卡，二维码会原地刷新成新的 connect URI，
+不需要回到「配置」modal、也不用重新添加设备。
+
+</Step>
+
+<Step>
+
+### 手机端扫码并保持 Tailscale 在线
+
+用 UniClipboard iOS / Android App 扫顶部那张大码，所有字段自动填好。
+**之后只要手机端的 Tailscale VPN 处于「Connected」状态**，无论手机
+走 4G/5G 还是任意一个外部 Wi-Fi，都能像在家里同 LAN 一样跟桌面双向
+同步。
+
+</Step>
+
+</Steps>
+
+### 注意事项与限制
+
+- **两端都要保持 Tailscale 在线。** 手机端 Tailscale 一旦断开（手动
+  Disconnect、被系统杀后台、或长时间没流量被运营商挂起），就回到「LAN
+  外不可达」的状态，请求会超时或拨号失败。
+- **不支持 MagicDNS 主机名。** 凭据 URL 用的是 `100.x.x.x` 形式的
+  数字 IP；如果你给桌面在 Tailscale 上配了别名（如 `desktop.tail-XXXX.ts.net`），
+  我们 **不会** 把这个名字写进 connect URI。固定走 `100.x.x.x` 即可。
+- **跨网络场景手机后台限制更明显。** iOS 在锁屏 / 切后台后会限制
+  剪贴板读写，Android 10+ 也有类似限制；这与 Tailscale 无关，是
+  系统行为。需要稳定的"后台同步"请把 App 留在前台或加进系统的
+  "始终允许"白名单。
+- **它不是 v2 TLS。** Tailscale 给的是 **网络层** 的机密性。如果
+  你的威胁模型要求"端到端"语义（例如担心桌面机器本身被攻破），这条
+  路径不解决该问题，等 v2 的 TLS 即可。
+
+故障排查：手机端能 ping 通 `100.x.x.x` 但 App 报连接超时，多半是
+桌面端那台 Tailscale 没接入 / 退到了 DERP 中继的限速档（个人版限速
+约 50KB/s，跑大图大文件会很慢）；先确认两端在 Tailscale 客户端的
+「Machines」列表里都显示在线，再确认两台机器的连接类型（直连 vs DERP）。
+
 ## 管理已配对设备
 
 | 操作           | GUI                                       | CLI                                              |
@@ -305,16 +415,18 @@ App、快捷指令或其他客户端）。
 | 桌面侧密码存储             | **是** —— 只持久化 Argon2id 哈希。                 |
 | 凭据轮换                   | **是** —— `Rotate password` 签发新值并失效旧哈希。 |
 | LAN 上的传输机密性         | **否（v1）** —— 明文 HTTP。TLS 在 v2 才会有。      |
-| 跨网络可达性               | **否** —— 仅限 LAN。手机离开局域网就连不上桌面。   |
+| 跨网络可达性               | **默认否** —— 仅限 LAN。可通过 Tailscale / VPN 折中（见下方）。 |
 | 把手机当作 peer 加入信任网 | **否** —— 手机不会进入 iroh / 空间的信任网络。     |
 
 实操含义：
 
 - 把 LAN 监听器当作私网里的 SSH 服务来对待 —— 选择性地开启。
 - 公共 Wi-Fi：保持监听器关闭。回到可信网络再启用。
-- VPN：让桌面与手机进入同一个 RFC1918 子网的 VPN 可以当成
-  「我想在家里之外用 LAN 风格同步」的折中，但仍然是明文 HTTP，
-  必须信任这条 VPN。
+- VPN / Tailscale：让桌面与手机进入同一个虚拟子网（RFC1918 VPN 或
+  Tailscale 的 `100.64.0.0/10` tailnet）可以当成「我想在家里之外用
+  LAN 风格同步」的折中。具体步骤见
+  [跨网络同步：搭配 Tailscale](#跨网络同步搭配-tailscale)。仍然是明文
+  HTTP，机密性由 VPN / WireGuard 隧道托底，必须信任这条覆盖网络。
 
 ## 故障排查
 


### PR DESCRIPTION
## Summary

- Document the cross-network mobile-sync workflow that 0.12 unlocked when the Bind IP dropdown started listing Tailscale's `100.64.0.0/10` CGNAT range alongside RFC1918 candidates (follow-up to #883). Adds a new **"Cross-network sync via Tailscale / 跨网络同步：搭配 Tailscale"** section to `mobile-sync.mdx` walking through: install Tailscale on both ends → sign in to the same tailnet → pick the `100.x.x.x` interface in the Configure dialog → run the normal Add device flow. Already-paired devices can switch via the baseUrl dropdown on the device card without re-pairing. (d70d9525)
- Caveat list: Tailscale must stay Connected on both ends, the connect URI embeds the raw `100.x.x.x` IP (no MagicDNS hostname), iOS / Android background clipboard restrictions are unchanged, and DERP-relay throughput is capped (~50 KB/s on free plan) — useful when the phone can ping the desktop but transfers are slow. (d70d9525)
- Security-model table updated: **Cross-network reachability** flipped from a flat "No" to "No by default — Tailscale / VPN gives a workaround", and the VPN bullet under *Practical implications* now links into the new section and notes confidentiality is provided by the overlay tunnel (network-layer, not v2 TLS). (d70d9525)
- `en/` and `zh/` updated in lockstep. `docs-site/scripts/check-docs.mjs` passes (anchors resolve).

## Test plan

- [x] `node docs-site/scripts/check-docs.mjs` → `OK — 18 en pages, 18 zh pages, anchors check passed.`
- [ ] Reviewer: visually check the new section renders in both `en` and `zh` (fumadocs `Steps`, `Callout`, anchor link to `#cross-network-sync-via-tailscale` / `#跨网络同步搭配-tailscale` from the security-model section).
- [ ] Reviewer: sanity-check the Tailscale claims — CGNAT range `100.64.0.0/10`, DERP free-plan throttle (~50 KB/s), iOS VPN-config prompt behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guide for cross-network mobile sync via Tailscale with pairing and setup instructions
  * Updated security model documentation to clarify cross-network reachability is disabled by default
  * Added caveats and limitations for cross-network synchronization
  * Updates available in English and Chinese

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/UniClipboard/UniClipboard/pull/885?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->