### PR TITLE
feat(tray): add Check for Updates and Restart items to the tray menu

### DIFF
--- a/src-tauri/crates/uc-tauri/src/commands/restart.rs
+++ b/src-tauri/crates/uc-tauri/src/commands/restart.rs
@@ -55,42 +55,52 @@ pub async fn restart_app(
     record_trace_fields(&span, &_trace);
 
     async move {
-        info!("restarting app for settings change");
-
-        // graceful shutdown daemon 前先通知前端断 WS,让 axum
-        // `with_graceful_shutdown` 立即返回不等 30s heartbeat。
-        if let Err(error) = app.emit(FRONTEND_SHUTDOWN_EVENT, ()) {
-            warn!(
-                error = %error,
-                event = FRONTEND_SHUTDOWN_EVENT,
-                "failed to emit shutdown hint to frontend before restart; daemon \
-                 graceful shutdown will fall back to heartbeat-driven WS disconnect"
-            );
-        }
-
-        // 给前端 close frame 飞过 loopback 的时间。
-        tokio::time::sleep(Duration::from_millis(SHUTDOWN_FRONTEND_GRACE_MS)).await;
-
-        // 主动 graceful shutdown owned daemon,等到 HTTP / LAN 端口完全
-        // 释放再 spawn 新进程 —— 否则新进程 daemon bind 撞 WSAEADDRINUSE,
-        // 即便 Phase 1 已修了连带 panic,daemon 仍然起不来。
-        let ownership = app.state::<DaemonOwnership>().inner().clone();
-        if let Some(handle) = ownership.take_owned() {
-            match handle.shutdown(DAEMON_SHUTDOWN_TIMEOUT).await {
-                Ok(()) => info!("daemon stopped before restart"),
-                Err(err) => error!(
-                    error = %err,
-                    "daemon shutdown failed before restart; new process may fail to bind"
-                ),
-            }
-        }
-
-        // 新进程 spawn + 当前进程 exit。app.restart() 内部调用
-        // std::process::exit,以下代码不可达。
-        app.restart();
+        perform_restart(&app).await;
         #[allow(unreachable_code)]
         Ok(())
     }
     .instrument(span)
     .await
+}
+
+/// Graceful shutdown + `app.restart()`.
+///
+/// Shared entry for the `restart_app` Tauri command and the tray "Restart"
+/// menu item. Does not return — `app.restart()` internally calls
+/// `std::process::exit`. Callers must therefore expect this future to never
+/// complete on the happy path.
+pub(crate) async fn perform_restart(app: &tauri::AppHandle) {
+    info!("restarting app for settings change");
+
+    // graceful shutdown daemon 前先通知前端断 WS,让 axum
+    // `with_graceful_shutdown` 立即返回不等 30s heartbeat。
+    if let Err(error) = app.emit(FRONTEND_SHUTDOWN_EVENT, ()) {
+        warn!(
+            error = %error,
+            event = FRONTEND_SHUTDOWN_EVENT,
+            "failed to emit shutdown hint to frontend before restart; daemon \
+             graceful shutdown will fall back to heartbeat-driven WS disconnect"
+        );
+    }
+
+    // 给前端 close frame 飞过 loopback 的时间。
+    tokio::time::sleep(Duration::from_millis(SHUTDOWN_FRONTEND_GRACE_MS)).await;
+
+    // 主动 graceful shutdown owned daemon,等到 HTTP / LAN 端口完全
+    // 释放再 spawn 新进程 —— 否则新进程 daemon bind 撞 WSAEADDRINUSE,
+    // 即便 Phase 1 已修了连带 panic,daemon 仍然起不来。
+    let ownership = app.state::<DaemonOwnership>().inner().clone();
+    if let Some(handle) = ownership.take_owned() {
+        match handle.shutdown(DAEMON_SHUTDOWN_TIMEOUT).await {
+            Ok(()) => info!("daemon stopped before restart"),
+            Err(err) => error!(
+                error = %err,
+                "daemon shutdown failed before restart; new process may fail to bind"
+            ),
+        }
+    }
+
+    // 新进程 spawn + 当前进程 exit。app.restart() 内部调用
+    // std::process::exit,后续代码不可达。
+    app.restart();
 }

--- a/src-tauri/crates/uc-tauri/src/commands/updater.rs
+++ b/src-tauri/crates/uc-tauri/src/commands/updater.rs
@@ -430,6 +430,95 @@ pub async fn check_for_update(
     .await
 }
 
+/// Manual update check triggered from the system tray menu item.
+///
+/// Behaves like the `check_for_update` Tauri command (same `Manual` telemetry
+/// source, same `LastCheckAt` refresh) and additionally routes
+/// "found a new version" through [`NotifyContext::notify_if_new_version`] so
+/// the user sees the Sparkle-style update window without having to open the
+/// main window first.
+///
+/// Fire-and-forget; errors are logged but not propagated — the tray click
+/// handler is synchronous and has no UI to report errors to. The
+/// `UPDATE_AVAILABLE_EVENT` emitted by [`do_check_for_update`] still feeds
+/// the main window's `UpdateContext` if it happens to be open.
+pub(crate) async fn perform_manual_check_from_tray(app: &AppHandle) {
+    let runtime = match app.try_state::<Arc<TauriAppRuntime>>() {
+        Some(r) => r,
+        None => {
+            warn!(
+                target: "updater",
+                "TauriAppRuntime not mounted; aborting tray-initiated update check"
+            );
+            return;
+        }
+    };
+    let pending = match app.try_state::<PendingUpdate>() {
+        Some(p) => p,
+        None => {
+            warn!(
+                target: "updater",
+                "PendingUpdate not mounted; aborting tray-initiated update check"
+            );
+            return;
+        }
+    };
+
+    // Channel resolution mirrors the scheduler / window_show_check path:
+    // settings-pinned channel wins, otherwise detect from app version.
+    let app_version = app.package_info().version.to_string();
+    let resolved_channel = match runtime.settings_port().load().await {
+        Ok(settings) => crate::update_scheduler::scheduler::resolve_channel(
+            settings.general.update_channel.clone(),
+            &app_version,
+        ),
+        Err(err) => {
+            warn!(
+                target: "updater",
+                error = %err,
+                "failed to load settings; falling back to version-detected channel"
+            );
+            detect_channel(&app_version)
+        }
+    };
+
+    info!(target: "updater", "running tray-initiated update check");
+    let result = do_check_for_update(app, Some(resolved_channel.clone()), pending.inner()).await;
+
+    app.state::<crate::update_scheduler::LastCheckAt>()
+        .record_now();
+
+    let install_kind = install_kind_for_telemetry(detect_install_kind());
+
+    if let Ok(Some(metadata)) = &result {
+        match app.try_state::<Arc<crate::update_scheduler::NotifyContext>>() {
+            Some(ctx) => {
+                ctx.notify_if_new_version(&resolved_channel, &metadata.version, install_kind)
+                    .await;
+            }
+            None => warn!(
+                target: "updater",
+                "NotifyContext not mounted; tray check found update but cannot dedup/notify"
+            ),
+        }
+    }
+
+    let (outcome, failure_kind) = match &result {
+        Ok(Some(_)) => (UpdateCheckOutcome::Available, None),
+        Ok(None) => (UpdateCheckOutcome::UpToDate, None),
+        Err(err) => (
+            UpdateCheckOutcome::Failed,
+            Some(classify_check_failure(err)),
+        ),
+    };
+    runtime.analytics().capture(Event::UpdateCheckPerformed {
+        source: UpdateCheckSource::Manual,
+        outcome,
+        failure_kind,
+        install_kind,
+    });
+}
+
 /// Download the pending update in the background.
 ///
 /// Crate-internal entry shared by the `download_update` Tauri command and

--- a/src-tauri/crates/uc-tauri/src/tray.rs
+++ b/src-tauri/crates/uc-tauri/src/tray.rs
@@ -29,6 +29,8 @@ struct TrayHandles {
     status: MenuItem<tauri::Wry>,
     open: MenuItem<tauri::Wry>,
     settings: MenuItem<tauri::Wry>,
+    check_update: MenuItem<tauri::Wry>,
+    restart: MenuItem<tauri::Wry>,
     quit: MenuItem<tauri::Wry>,
     language: String,
     lan_only_active: bool,
@@ -61,7 +63,7 @@ impl TrayState {
         }
 
         let language = normalize_language(initial_language);
-        let (open_label, settings_label, quit_label) = labels_for_language(language);
+        let labels = MenuLabels::for_language(language);
         let status_label = lan_only_status_label(language, lan_only_active);
         let tooltip = lan_only_tooltip(language, lan_only_active);
 
@@ -69,17 +71,32 @@ impl TrayState {
         // `tray.status` 是不可交互的状态展示行(`enabled = false`),
         // 用户右键 tray 时一眼可见 LAN-only Mode 是否已生效。
         let status = MenuItem::with_id(app, "tray.status", status_label, false, None::<&str>)?;
-        let open = MenuItem::with_id(app, "tray.open", open_label, true, None::<&str>)?;
-        let settings = MenuItem::with_id(app, "tray.settings", settings_label, true, None::<&str>)?;
-        let quit = MenuItem::with_id(app, "tray.quit", quit_label, true, None::<&str>)?;
+        let open = MenuItem::with_id(app, "tray.open", labels.open, true, None::<&str>)?;
+        let settings =
+            MenuItem::with_id(app, "tray.settings", labels.settings, true, None::<&str>)?;
+        let check_update = MenuItem::with_id(
+            app,
+            "tray.check_update",
+            labels.check_update,
+            true,
+            None::<&str>,
+        )?;
+        let restart = MenuItem::with_id(app, "tray.restart", labels.restart, true, None::<&str>)?;
+        let quit = MenuItem::with_id(app, "tray.quit", labels.quit, true, None::<&str>)?;
 
-        // Build the context menu
+        // Build the context menu.
+        // 布局意图:
+        //   - "检查更新" 紧贴 "设置",语义上属于"应用维护"组
+        //   - "重启" 与 "退出" 同组(都是进程级动作),但用分隔符与上方拉开
+        //     一些距离,降低"想点退出却点到重启"的误触
         let menu = MenuBuilder::new(app)
             .item(&status)
             .separator()
             .item(&open)
             .item(&settings)
+            .item(&check_update)
             .separator()
+            .item(&restart)
             .item(&quit)
             .build()?;
 
@@ -97,6 +114,26 @@ impl TrayState {
                     if let Err(e) = app.emit("ui://navigate", "/settings") {
                         warn!("Failed to emit ui://navigate event: {}", e);
                     }
+                }
+                "tray.check_update" => {
+                    // Fire-and-forget:菜单 handler 是 sync,真正的检查必须
+                    // 放到 tokio runtime 上。helper 自带 telemetry + 找到
+                    // 新版本时弹更新窗口,所以这里不需要再打开主窗口
+                    // —— 没有新版本时用户得到"什么也没发生"的体感,等同于
+                    // AboutSection 里点击检查更新但结果为 UpToDate 的情况。
+                    let app = app.clone();
+                    tauri::async_runtime::spawn(async move {
+                        crate::commands::updater::perform_manual_check_from_tray(&app).await;
+                    });
+                }
+                "tray.restart" => {
+                    // Fire-and-forget。`perform_restart` 内部走 graceful
+                    // shutdown → `app.restart()`,后者调用 `process::exit`,
+                    // 该 future 在 happy path 永不返回。
+                    let app = app.clone();
+                    tauri::async_runtime::spawn(async move {
+                        crate::commands::restart::perform_restart(&app).await;
+                    });
                 }
                 "tray.quit" => {
                     app.exit(0);
@@ -181,6 +218,8 @@ impl TrayState {
             status,
             open,
             settings,
+            check_update,
+            restart,
             quit,
             language: language.to_string(),
             lan_only_active,
@@ -219,13 +258,15 @@ impl TrayState {
         };
 
         let language = normalize_language(language);
-        let (open_label, settings_label, quit_label) = labels_for_language(language);
+        let labels = MenuLabels::for_language(language);
         let status_label = lan_only_status_label(language, handles.lan_only_active);
         let tooltip = lan_only_tooltip(language, handles.lan_only_active);
 
-        handles.open.set_text(open_label)?;
-        handles.settings.set_text(settings_label)?;
-        handles.quit.set_text(quit_label)?;
+        handles.open.set_text(labels.open)?;
+        handles.settings.set_text(labels.settings)?;
+        handles.check_update.set_text(labels.check_update)?;
+        handles.restart.set_text(labels.restart)?;
+        handles.quit.set_text(labels.quit)?;
         handles.status.set_text(status_label)?;
         // Tray icon tooltip 也要随语言切换刷新。
         let _ = handles.tray.set_tooltip(Some(&tooltip));
@@ -294,11 +335,38 @@ pub(crate) fn normalize_language(language: &str) -> &'static str {
     }
 }
 
-/// Return `(open, settings, quit)` labels for the given normalized language.
-fn labels_for_language(language: &str) -> (&'static str, &'static str, &'static str) {
-    match language {
-        "zh-CN" => ("打开 UniClipboard", "设置", "退出"),
-        _ => ("Open UniClipboard", "Settings", "Quit"),
+/// Localized labels for the tray menu's interactive items.
+///
+/// Held as `&'static str` because every supported locale's strings are
+/// compile-time literals — `MenuItem::set_text` only requires
+/// `impl Into<String>`, but keeping these as static slices avoids per-call
+/// allocations and makes the table grep-friendly.
+struct MenuLabels {
+    open: &'static str,
+    settings: &'static str,
+    check_update: &'static str,
+    restart: &'static str,
+    quit: &'static str,
+}
+
+impl MenuLabels {
+    fn for_language(language: &str) -> Self {
+        match language {
+            "zh-CN" => Self {
+                open: "打开",
+                settings: "设置",
+                check_update: "检查更新…",
+                restart: "重启",
+                quit: "退出",
+            },
+            _ => Self {
+                open: "Open",
+                settings: "Settings",
+                check_update: "Check for Updates…",
+                restart: "Restart",
+                quit: "Quit",
+            },
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- Adds two new entries to the system tray right-click menu: **Check for Updates…** (grouped with Settings under "app maintenance") and **Restart** (grouped with Quit as process-level actions, but separated by a divider to reduce mis-clicks). (`d7c5d8c1`)
- Extracts the core flow of `restart_app` and `check_for_update` into crate-internal `perform_restart` / `perform_manual_check_from_tray` helpers so the tray click handler and the existing Tauri commands share one path — same `Manual` telemetry source, same `LastCheckAt` refresh, same `NotifyContext` dedup + update-window popup, same graceful daemon shutdown before `app.restart()`. (`d7c5d8c1`)
- Refactors `labels_for_language` into a `MenuLabels` struct (zh-CN + en) so adding more localized items doesn't keep growing a tuple signature. Also shortens "Open UniClipboard" / "打开 UniClipboard" → "Open" / "打开" for tray menu density.

## Test plan

- [x] `cargo fmt` (run automatically by pre-commit hook)
- [ ] Build the app and right-click the tray icon; verify both new items show with the correct localized label after a language switch.
- [ ] Click **Check for Updates…** with auto-check disabled — confirm the update window pops up when a newer release exists, and that the click is silent when up-to-date (matching AboutSection's "manual check, no result" behavior).
- [ ] Click **Restart** — confirm graceful daemon shutdown happens (no `WSAEADDRINUSE` on Windows on next start), the WS close hint fires to the frontend, and the app comes back up.
- [ ] Verify `update_check_performed` telemetry is emitted with `source = Manual` when the tray check runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * System tray menu now includes "Check for Updates" and "Restart" options for quick access to these actions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/UniClipboard/UniClipboard/pull/893?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->