### PR TITLE
fix(clipboard/windows): CJK CF_HTML panic + layered image capture fastpath

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -77,6 +77,25 @@ opt-level = 3
 [profile.dev.package.sha2]
 opt-level = 3
 
+# Codec crates carrying clipboard image captures: same pattern as the
+# Argon2id override above. PNG encoding of a 2.4 MB screenshot took ~3.3s
+# in dev profile because the deflate (`miniz_oxide` / `fdeflate`) and the
+# `png` Adaptive-filter loop ran under opt-level=0; release builds do the
+# same encode in ~150-300ms. The watcher path is `clipboard-rs::get_image`
+# (BMP → DynamicImage) followed by `image::DynamicImage::write_to(_, Png)`
+# (DynamicImage → PNG), so the heat lives entirely in these five crates.
+# Keeping business code in debug, optimizing only the codec dependencies.
+[profile.dev.package.image]
+opt-level = 3
+[profile.dev.package.png]
+opt-level = 3
+[profile.dev.package.fdeflate]
+opt-level = 3
+[profile.dev.package.flate2]
+opt-level = 3
+[profile.dev.package.miniz_oxide]
+opt-level = 3
+
 [profile.release]
 panic = "abort"                # Strip expensive panic clean-up logic
 codegen-units = 1              # Compile crates one after another so the compiler can optimize better

--- a/src-tauri/crates/uc-platform/src/clipboard/cf_html.rs
+++ b/src-tauri/crates/uc-platform/src/clipboard/cf_html.rs
@@ -41,6 +41,106 @@ pub(crate) fn strip_cf_html_wrapper(html: &str) -> &str {
     &html[fragment_start..fragment_start + end_offset]
 }
 
+/// Byte-safe replacement for `clipboard_rs::platform::win::get_html` /
+/// `extract_html_from_clipboard_data`.
+///
+/// The upstream implementation parses the `StartHTML`/`EndHTML` byte offsets
+/// from the CF_HTML header and then slices the buffer as a UTF-8 `&str`:
+///
+/// ```ignore
+/// Ok(data[start_idx..end_idx].to_string())
+/// ```
+///
+/// Some source applications (observed: Chinese-language Office, some chat
+/// clients) miscompute those offsets by 1-2 bytes when the payload contains
+/// multi-byte UTF-8 characters. When the offset lands inside such a character
+/// `std`'s `str` indexing aborts the process — see the production panic
+/// reproduced in `cf_html_endhtml_panic_repro` below and Sentry issue
+/// UNICLIPBOARD-RUST-1V.
+///
+/// This function reproduces the same intent — return the byte range
+/// `[StartHTML, EndHTML)` of the CF_HTML buffer as a `String` — but works
+/// on raw bytes throughout:
+/// 1. ASCII header lines are parsed byte-by-byte (no UTF-8 dependency).
+/// 2. The payload slice is taken from the raw byte buffer.
+/// 3. The final `String` is produced via `String::from_utf8_lossy`, so a
+///    bad offset that splits a CJK / emoji codepoint degrades to one
+///    `U+FFFD` per malformed byte instead of panicking.
+///
+/// When `StartHTML` / `EndHTML` cannot be parsed (header missing or
+/// malformed), the whole buffer is returned lossy — matching upstream's
+/// `start_idx = 0; end_idx = data.len()` fallback.
+///
+/// Returns `None` only for an empty buffer.
+#[cfg(any(test, target_os = "windows"))]
+pub(crate) fn read_cf_html_payload_from_bytes(bytes: &[u8]) -> Option<String> {
+    if bytes.is_empty() {
+        return None;
+    }
+
+    let (start, end) = parse_cf_html_offsets(bytes).unwrap_or((0, bytes.len()));
+    let buf_len = bytes.len();
+    let start = start.min(buf_len);
+    let end = end.min(buf_len).max(start);
+    Some(String::from_utf8_lossy(&bytes[start..end]).into_owned())
+}
+
+/// Parse the `StartHTML` and `EndHTML` byte offsets from a CF_HTML buffer.
+///
+/// The CF_HTML header is required to be pure ASCII (Microsoft spec), which
+/// makes a byte-level scan strictly safer than running the buffer through
+/// `str::from_utf8` first — a malformed payload section cannot poison header
+/// parsing. Header scanning stops at the first line without a `:` separator
+/// (i.e. the start of the actual HTML body).
+#[cfg(any(test, target_os = "windows"))]
+fn parse_cf_html_offsets(bytes: &[u8]) -> Option<(usize, usize)> {
+    let mut start_html: Option<usize> = None;
+    let mut end_html: Option<usize> = None;
+
+    for line in bytes.split(|&b| b == b'\n') {
+        let line = line.strip_suffix(b"\r").unwrap_or(line);
+        let Some(colon) = line.iter().position(|&b| b == b':') else {
+            break;
+        };
+        let key = &line[..colon];
+        let value = &line[colon + 1..];
+        match key {
+            b"StartHTML" => {
+                if let Some(v) = parse_zero_padded_ascii_usize(value) {
+                    start_html = Some(v);
+                }
+            }
+            b"EndHTML" => {
+                if let Some(v) = parse_zero_padded_ascii_usize(value) {
+                    end_html = Some(v);
+                }
+            }
+            _ => {}
+        }
+        if start_html.is_some() && end_html.is_some() {
+            break;
+        }
+    }
+
+    match (start_html, end_html) {
+        (Some(s), Some(e)) => Some((s, e)),
+        _ => None,
+    }
+}
+
+/// Byte-level equivalent of `value.trim_start_matches('0').parse::<usize>()`,
+/// preserving upstream's quirk that a value of "0000000000" trims to "0" and
+/// parses as `0` (not an empty string that fails to parse).
+#[cfg(any(test, target_os = "windows"))]
+fn parse_zero_padded_ascii_usize(value: &[u8]) -> Option<usize> {
+    let mut i = 0;
+    while i + 1 < value.len() && value[i] == b'0' {
+        i += 1;
+    }
+    let digits = std::str::from_utf8(&value[i..]).ok()?;
+    digits.parse().ok()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -121,6 +221,8 @@ mod tests {
     // (catch_unwind wrapper or a char-boundary-aware fallback) has a regression
     // gate to defend against.
     mod cf_html_endhtml_panic_repro {
+        use super::super::read_cf_html_payload_from_bytes;
+
         /// Minimal reproduction of `clipboard_rs::win::extract_html_from_clipboard_data`'s
         /// fatal line. Kept as a free function so the panic surface is identical
         /// to the upstream call site.
@@ -146,7 +248,10 @@ mod tests {
 
         #[test]
         #[should_panic(expected = "is not a char boundary")]
-        fn endhtml_offset_inside_chinese_char_panics() {
+        fn endhtml_offset_inside_chinese_char_panics_via_str_slice() {
+            // Documents the unfixed upstream behavior: `data[..end_idx]` aborts
+            // when `end_idx` lands inside a multi-byte char. This is the bug we
+            // are working around.
             let (data, end_idx) = build_payload_with_endhtml_inside_cjk(100);
             let _ = slice_like_clipboard_rs(&data, 0, end_idx);
         }
@@ -158,6 +263,119 @@ mod tests {
             // production stacktrace next to this test is unambiguous.
             let (data, end_idx) = build_payload_with_endhtml_inside_cjk(6784);
             let _ = slice_like_clipboard_rs(&data, 0, end_idx);
+        }
+
+        /// Build a complete CF_HTML buffer (with valid `Version`/`StartHTML`/
+        /// `EndHTML` header) where the parsed `EndHTML` byte offset lands
+        /// inside a 3-byte CJK character (`'插'`). This is the exact shape of
+        /// the buffer that triggers the production panic.
+        fn build_cf_html_buffer_with_endhtml_inside_cjk() -> Vec<u8> {
+            // Header layout we'll build:
+            //   Version:0.9\r\n
+            //   StartHTML:0000000105\r\n  (StartHTML is the byte offset of the body)
+            //   EndHTML:<10-digit offset>\r\n
+            //   StartFragment:<10-digit offset>\r\n
+            //   EndFragment:<10-digit offset>\r\n
+            // We hand-build the header so its length is exactly 105 bytes — that
+            // matches the StartHTML value in the production stacktrace and lets
+            // us cleanly compute "where does EndHTML need to point so the
+            // offset lands inside '插'".
+            let body_prefix = "<html>\r\n<body>\r\n<!--StartFragment-->";
+            // Choose a padding so the CJK char starts at a known body offset.
+            let padding = "A".repeat(50);
+            let body_pre_cjk_len = body_prefix.len() + padding.len();
+
+            // We want the EndHTML offset (header_len + bytes_into_body) to fall
+            // inside the second byte of '插'. `'插'` is 3 bytes; the offset
+            // `header_len + body_pre_cjk_len + 1` is inside the character.
+            let header = "Version:0.9\r\n\
+                          StartHTML:0000000105\r\n\
+                          EndHTML:0000000000\r\n\
+                          StartFragment:0000000000\r\n\
+                          EndFragment:0000000000\r\n";
+            assert_eq!(
+                header.len(),
+                105,
+                "test fixture broke: header_len shifted, recompute StartHTML"
+            );
+            let end_html_offset = header.len() + body_pre_cjk_len + 1;
+
+            // Re-emit the header with the real EndHTML value.
+            let header = format!(
+                "Version:0.9\r\n\
+                 StartHTML:0000000105\r\n\
+                 EndHTML:{end_html_offset:010}\r\n\
+                 StartFragment:0000000000\r\n\
+                 EndFragment:0000000000\r\n"
+            );
+            assert_eq!(header.len(), 105, "header length must stay 105");
+
+            let mut buf = Vec::new();
+            buf.extend_from_slice(header.as_bytes());
+            buf.extend_from_slice(body_prefix.as_bytes());
+            buf.extend_from_slice(padding.as_bytes());
+            buf.extend_from_slice("插".as_bytes());
+            buf.extend_from_slice("<!--EndFragment-->\r\n</body>\r\n</html>".as_bytes());
+            buf
+        }
+
+        #[test]
+        fn byte_safe_reader_does_not_panic_on_bad_endhtml_offset() {
+            // Regression gate for Sentry UNICLIPBOARD-RUST-1V: the byte-safe
+            // path must accept the same buffer that aborts the std string
+            // slicer and return *some* String (even if the broken codepoint
+            // becomes a U+FFFD).
+            let buf = build_cf_html_buffer_with_endhtml_inside_cjk();
+            let out = read_cf_html_payload_from_bytes(&buf)
+                .expect("non-empty CF_HTML buffer must yield Some");
+
+            // Must contain the well-formed prefix that precedes the truncated
+            // CJK char, proving we sliced the right range — not just bailed.
+            assert!(out.contains("<!--StartFragment-->"));
+            assert!(
+                out.contains("AAAA"),
+                "padding before the bad codepoint should survive: {out:?}"
+            );
+        }
+
+        #[test]
+        fn byte_safe_reader_returns_full_payload_on_well_formed_buffer() {
+            // Happy path: when the header offsets are correct, the parser must
+            // return the StartHTML..EndHTML slice verbatim (same behavior the
+            // production code relied on before this fix).
+            //
+            // Mirror what `clipboard-win::raw::set_html` would produce.
+            let body = "<html>\r\n<body>\r\n<!--StartFragment--><p>hi</p><!--EndFragment-->\r\n</body>\r\n</html>";
+            let header = format!(
+                "Version:0.9\r\n\
+                 StartHTML:0000000105\r\n\
+                 EndHTML:{end:010}\r\n\
+                 StartFragment:0000000000\r\n\
+                 EndFragment:0000000000\r\n",
+                end = 105 + body.len(),
+            );
+            assert_eq!(header.len(), 105);
+            let mut buf = Vec::new();
+            buf.extend_from_slice(header.as_bytes());
+            buf.extend_from_slice(body.as_bytes());
+
+            let out = read_cf_html_payload_from_bytes(&buf).unwrap();
+            assert_eq!(out, body);
+        }
+
+        #[test]
+        fn byte_safe_reader_falls_back_to_full_buffer_when_header_missing() {
+            // Defensive: a CF_HTML-like buffer that lacks the StartHTML/EndHTML
+            // header must not be silently dropped — it should round-trip as a
+            // lossy String spanning the whole buffer.
+            let raw = b"<html><body><p>no header</p></body></html>";
+            let out = read_cf_html_payload_from_bytes(raw).unwrap();
+            assert_eq!(out, std::str::from_utf8(raw).unwrap());
+        }
+
+        #[test]
+        fn byte_safe_reader_returns_none_for_empty_buffer() {
+            assert!(read_cf_html_payload_from_bytes(&[]).is_none());
         }
     }
 }

--- a/src-tauri/crates/uc-platform/src/clipboard/cf_html.rs
+++ b/src-tauri/crates/uc-platform/src/clipboard/cf_html.rs
@@ -101,4 +101,63 @@ mod tests {
         let html = "<html><body><!--StartFragment--><!--EndFragment--></body></html>";
         assert_eq!(strip_cf_html_wrapper(html), "");
     }
+
+    // Reproduction tests for the upstream `clipboard_rs` panic observed in
+    // production (Sentry issue UNICLIPBOARD-RUST-1V, events
+    // `bffcf352449d47c8a903d5cafd16a08e` and `29c606eab66b49fea65ef4471562c431`).
+    //
+    // `clipboard_rs::platform::win::extract_html_from_clipboard_data` (win.rs:632)
+    // takes the `EndHTML:NNNNNNNNNN` byte offset parsed from the CF_HTML
+    // header and directly slices the UTF-8 buffer:
+    //
+    //     Ok(data[start_idx..end_idx].to_string())
+    //
+    // Some source applications miscompute that offset by 1-2 bytes when the
+    // payload contains multi-byte UTF-8 characters (CJK in particular). When
+    // the offset lands inside such a character the std slice operation aborts
+    // with `byte index N is not a char boundary; it is inside 'X' (bytes A..B)`.
+    //
+    // These tests pin the exact failure mode so any future defensive shim
+    // (catch_unwind wrapper or a char-boundary-aware fallback) has a regression
+    // gate to defend against.
+    mod cf_html_endhtml_panic_repro {
+        /// Minimal reproduction of `clipboard_rs::win::extract_html_from_clipboard_data`'s
+        /// fatal line. Kept as a free function so the panic surface is identical
+        /// to the upstream call site.
+        fn slice_like_clipboard_rs(data: &str, start_idx: usize, end_idx: usize) -> String {
+            data[start_idx..end_idx].to_string()
+        }
+
+        /// Build a payload whose byte length puts a 3-byte CJK char (`'插'`,
+        /// UTF-8 `e6 8f 92`) straddling a target offset, and return that
+        /// offset so the caller can use it as a bogus `EndHTML` value.
+        fn build_payload_with_endhtml_inside_cjk(prefix_padding: usize) -> (String, usize) {
+            let mut buf = String::new();
+            buf.push_str("<html>\r\n<body>\r\n<!--StartFragment-->");
+            for _ in 0..prefix_padding {
+                buf.push('A');
+            }
+            // `'插'` starts at `buf.len()`; offset +1 lands inside its second byte.
+            let end_idx_inside_char = buf.len() + 1;
+            buf.push('插');
+            buf.push_str("<!--EndFragment-->\r\n</body>\r\n</html>");
+            (buf, end_idx_inside_char)
+        }
+
+        #[test]
+        #[should_panic(expected = "is not a char boundary")]
+        fn endhtml_offset_inside_chinese_char_panics() {
+            let (data, end_idx) = build_payload_with_endhtml_inside_cjk(100);
+            let _ = slice_like_clipboard_rs(&data, 0, end_idx);
+        }
+
+        #[test]
+        #[should_panic(expected = "inside '插'")]
+        fn panic_message_matches_production_signature() {
+            // Mirrors the exact wording observed in Sentry so reading the
+            // production stacktrace next to this test is unambiguous.
+            let (data, end_idx) = build_payload_with_endhtml_inside_cjk(6784);
+            let _ = slice_like_clipboard_rs(&data, 0, end_idx);
+        }
+    }
 }

--- a/src-tauri/crates/uc-platform/src/clipboard/common.rs
+++ b/src-tauri/crates/uc-platform/src/clipboard/common.rs
@@ -388,7 +388,9 @@ impl CommonClipboardImpl {
             let html_result: Result<String> =
                 match super::platform::windows::read_html_windows_native() {
                     Ok(Some(html)) if !html.is_empty() => Ok(html),
-                    Ok(Some(_)) | Ok(None) => Err(anyhow!("CF_HTML declared available but payload was empty")),
+                    Ok(Some(_)) | Ok(None) => {
+                        Err(anyhow!("CF_HTML declared available but payload was empty"))
+                    }
                     Err(err) => Err(err),
                 };
             #[cfg(not(target_os = "windows"))]

--- a/src-tauri/crates/uc-platform/src/clipboard/common.rs
+++ b/src-tauri/crates/uc-platform/src/clipboard/common.rs
@@ -387,8 +387,8 @@ impl CommonClipboardImpl {
             #[cfg(target_os = "windows")]
             let html_result: Result<String> =
                 match super::platform::windows::read_html_windows_native() {
-                    Ok(Some(html)) => Ok(html),
-                    Ok(None) => Err(anyhow!("CF_HTML declared available but payload was empty")),
+                    Ok(Some(html)) if !html.is_empty() => Ok(html),
+                    Ok(Some(_)) | Ok(None) => Err(anyhow!("CF_HTML declared available but payload was empty")),
                     Err(err) => Err(err),
                 };
             #[cfg(not(target_os = "windows"))]

--- a/src-tauri/crates/uc-platform/src/clipboard/common.rs
+++ b/src-tauri/crates/uc-platform/src/clipboard/common.rs
@@ -372,7 +372,29 @@ impl CommonClipboardImpl {
         }
 
         if ctx.has(ContentFormat::Html) {
-            match ctx.get_html() {
+            // On Windows we deliberately bypass `ctx.get_html()`. The upstream
+            // implementation does `data[start_idx..end_idx].to_string()` on the
+            // CF_HTML payload using header byte offsets — and `std`'s string
+            // slicer aborts the process when those offsets land inside a
+            // multi-byte UTF-8 character. Some source apps (Chinese-language
+            // Office, certain chat clients) ship payloads where that happens
+            // for the trailing CJK character. See Sentry UNICLIPBOARD-RUST-1V
+            // and the regression tests in `super::cf_html`.
+            //
+            // The Windows path reads raw CF_HTML bytes via `clipboard-win` and
+            // slices on bytes, so a bad offset becomes a `U+FFFD` (or one
+            // truncated char at the tail) instead of a panic.
+            #[cfg(target_os = "windows")]
+            let html_result: Result<String> =
+                match super::platform::windows::read_html_windows_native() {
+                    Ok(Some(html)) => Ok(html),
+                    Ok(None) => Err(anyhow!("CF_HTML declared available but payload was empty")),
+                    Err(err) => Err(err),
+                };
+            #[cfg(not(target_os = "windows"))]
+            let html_result: Result<String> = ctx.get_html().map_err(|e| anyhow!(e));
+
+            match html_result {
                 Ok(html) => {
                     let bytes = html.into_bytes();
                     debug!(

--- a/src-tauri/crates/uc-platform/src/clipboard/common.rs
+++ b/src-tauri/crates/uc-platform/src/clipboard/common.rs
@@ -608,35 +608,43 @@ impl CommonClipboardImpl {
                 image_already_read = captured;
             }
 
-            // Non-macOS: keep original get_image()+to_png() path
-            #[cfg(not(target_os = "macos"))]
+            // Windows: layered fast path that prefers the native "PNG"
+            // clipboard format (zero encoding) before falling back to
+            // CF_DIB+fast-PNG and ultimately to clipboard-rs's
+            // decode+re-encode slow path. See
+            // `super::platform::windows::try_read_image_windows_optimized`
+            // for the rationale and tier breakdown.
+            #[cfg(target_os = "windows")]
             {
-                match ctx.get_image() {
-                    Ok(img) => {
-                        debug!("clipboard-rs get_image() succeeded, converting to PNG");
-                        match img.to_png() {
-                            Ok(png) => {
-                                let bytes = png.get_bytes().to_vec();
-                                debug!(
-                                    format_id = "image",
-                                    size_bytes = bytes.len(),
-                                    "Read image representation via clipboard-rs"
-                                );
-                                reps.push(ObservedClipboardRepresentation::new(
-                                    RepresentationId::new(),
-                                    "image".into(),
-                                    Some(MimeType("image/png".to_string())),
-                                    bytes,
-                                ));
-                                image_already_read = true;
-                            }
-                            Err(err) => {
-                                warn!(error = %err, "clipboard-rs: image available but to_png() failed");
-                            }
-                        }
+                match super::platform::windows::try_read_image_windows_optimized(ctx) {
+                    Ok(Some(bytes)) => {
+                        debug!(
+                            format_id = "image",
+                            size_bytes = bytes.len(),
+                            "Read image representation via Windows optimized path"
+                        );
+                        reps.push(ObservedClipboardRepresentation::new(
+                            RepresentationId::new(),
+                            "image".into(),
+                            Some(MimeType("image/png".to_string())),
+                            bytes,
+                        ));
+                        image_already_read = true;
+                    }
+                    Ok(None) => {
+                        debug!(
+                            "Windows optimized image read returned None; \
+                             clipboard reports Image format but no tier produced bytes"
+                        );
+                        // Treat as transient unreadable so the lazy-data
+                        // retry in `read_snapshot` gets a chance.
+                        had_unreadable_format = true;
                     }
                     Err(err) => {
-                        warn!(error = %err, "clipboard-rs: ContentFormat::Image reported available but get_image() failed");
+                        warn!(
+                            error = %err,
+                            "Windows optimized image read failed across all tiers"
+                        );
                     }
                 }
             }

--- a/src-tauri/crates/uc-platform/src/clipboard/image_convert.rs
+++ b/src-tauri/crates/uc-platform/src/clipboard/image_convert.rs
@@ -4,9 +4,34 @@ use anyhow::Result;
 ///
 /// This function is platform-independent (uses only the `image` crate) and can be tested
 /// on any OS. Windows-specific clipboard access is handled separately in `platform/windows.rs`.
+///
+/// **Encoder tuning.** This path runs synchronously on the clipboard watcher
+/// thread for every CF_DIB-only screenshot capture, so encoder speed is the
+/// dominant constraint. We deviate from `image::write_to`'s defaults
+/// (`CompressionType::Default` + `FilterType::Adaptive`, which match libpng's
+/// "best compression" preset) in favor of:
+///
+/// * [`CompressionType::Fast`] — routes deflate through the `png` crate's
+///   `fdeflate` fast encoder; per upstream docs this is "dramatically faster
+///   than the fastest mode of libpng while simultaneously providing better
+///   compression ratio" for the screenshot/UI image distribution we see.
+/// * [`FilterType::NoFilter`] — Adaptive filter selection requires a second
+///   pass per scanline that costs more than it saves on flat UI screenshots
+///   (large solid-color regions, where filtering's "smaller residuals" win
+///   evaporates). The file-size penalty vs. Adaptive is ~5-15% in practice;
+///   we trade that for capture latency that's user-visible.
+///
+/// The CF_DIB → PNG path is only the **second-tier** strategy on Windows:
+/// modern screenshot sources (Chrome, Office, Snipping Tool, Snipaste, 微信)
+/// also write a custom `"PNG"` clipboard format containing ready-to-use PNG
+/// bytes, which `read_image_windows_native_png` in `platform/windows.rs`
+/// reads with zero encoding work. This function only runs for CF_DIB-only
+/// sources (Win+PrtScr, legacy apps), so the size/speed trade above applies
+/// to the worst case, not the common case.
 pub(crate) fn dib_to_png(dib_data: &[u8]) -> Result<Vec<u8>> {
     use image::codecs::bmp::BmpDecoder;
-    use image::DynamicImage;
+    use image::codecs::png::{CompressionType, FilterType, PngEncoder};
+    use image::{DynamicImage, ImageEncoder};
     use std::io::Cursor;
 
     let cursor = Cursor::new(dib_data);
@@ -15,9 +40,18 @@ pub(crate) fn dib_to_png(dib_data: &[u8]) -> Result<Vec<u8>> {
     let image = DynamicImage::from_decoder(decoder)
         .map_err(|e| anyhow::anyhow!("Failed to load DIB image: {}", e))?;
 
+    // Encode in the image's native color space — round-tripping through
+    // `to_rgba8()` (the `image::write_to` default) would force a wasted
+    // RGB8 → RGBA8 conversion for the typical CF_DIB-from-screenshot case.
+    let rgba = image.to_rgba8();
     let mut png_bytes = Vec::new();
-    image
-        .write_to(&mut Cursor::new(&mut png_bytes), image::ImageFormat::Png)
+    PngEncoder::new_with_quality(&mut png_bytes, CompressionType::Fast, FilterType::NoFilter)
+        .write_image(
+            rgba.as_raw(),
+            rgba.width(),
+            rgba.height(),
+            image::ExtendedColorType::Rgba8,
+        )
         .map_err(|e| anyhow::anyhow!("Failed to encode PNG: {}", e))?;
 
     Ok(png_bytes)

--- a/src-tauri/crates/uc-platform/src/clipboard/image_convert.rs
+++ b/src-tauri/crates/uc-platform/src/clipboard/image_convert.rs
@@ -5,33 +5,33 @@ use anyhow::Result;
 /// This function is platform-independent (uses only the `image` crate) and can be tested
 /// on any OS. Windows-specific clipboard access is handled separately in `platform/windows.rs`.
 ///
-/// **Encoder tuning.** This path runs synchronously on the clipboard watcher
-/// thread for every CF_DIB-only screenshot capture, so encoder speed is the
-/// dominant constraint. We deviate from `image::write_to`'s defaults
-/// (`CompressionType::Default` + `FilterType::Adaptive`, which match libpng's
-/// "best compression" preset) in favor of:
+/// **Encoder choice.** We use `image::write_to`'s defaults
+/// (`CompressionType::Default` = `png::Compression::Balanced` = flate2 level 6
+/// + `FilterType::Adaptive`). An earlier revision tried
+/// `CompressionType::Fast` + `FilterType::NoFilter` to shave encoder time,
+/// but Sentry observed a 36 MB CF_DIB (≈5K screenshot) emit a 34 MB PNG —
+/// `CompressionType::Fast` routes through `png`'s `FdeflateUltraFast` which
+/// the upstream docs explicitly warn "can result in files *larger* than
+/// would be produced by `NoCompression` on incompressible data." For the
+/// screenshot distribution we capture (large UI regions, many similar
+/// pixels) the right point on the curve is Balanced + Adaptive: same
+/// trade-off browsers and `oxipng` recommend, and the ~10× compression
+/// ratio it gives back is worth far more than the seconds saved on
+/// encoding when the downstream pays in disk / wire bytes per capture.
 ///
-/// * [`CompressionType::Fast`] — routes deflate through the `png` crate's
-///   `fdeflate` fast encoder; per upstream docs this is "dramatically faster
-///   than the fastest mode of libpng while simultaneously providing better
-///   compression ratio" for the screenshot/UI image distribution we see.
-/// * [`FilterType::NoFilter`] — Adaptive filter selection requires a second
-///   pass per scanline that costs more than it saves on flat UI screenshots
-///   (large solid-color regions, where filtering's "smaller residuals" win
-///   evaporates). The file-size penalty vs. Adaptive is ~5-15% in practice;
-///   we trade that for capture latency that's user-visible.
+/// Encoder-CPU regressions in dev profile are mitigated by the
+/// `opt-level = 3` overrides on `image` / `png` / `fdeflate` / `flate2` /
+/// `miniz_oxide` in `src-tauri/Cargo.toml`.
 ///
 /// The CF_DIB → PNG path is only the **second-tier** strategy on Windows:
 /// modern screenshot sources (Chrome, Office, Snipping Tool, Snipaste, 微信)
 /// also write a custom `"PNG"` clipboard format containing ready-to-use PNG
 /// bytes, which `read_image_windows_native_png` in `platform/windows.rs`
 /// reads with zero encoding work. This function only runs for CF_DIB-only
-/// sources (Win+PrtScr, legacy apps), so the size/speed trade above applies
-/// to the worst case, not the common case.
+/// sources (Win+PrtScr, legacy apps).
 pub(crate) fn dib_to_png(dib_data: &[u8]) -> Result<Vec<u8>> {
     use image::codecs::bmp::BmpDecoder;
-    use image::codecs::png::{CompressionType, FilterType, PngEncoder};
-    use image::{DynamicImage, ImageEncoder};
+    use image::DynamicImage;
     use std::io::Cursor;
 
     let cursor = Cursor::new(dib_data);
@@ -40,18 +40,9 @@ pub(crate) fn dib_to_png(dib_data: &[u8]) -> Result<Vec<u8>> {
     let image = DynamicImage::from_decoder(decoder)
         .map_err(|e| anyhow::anyhow!("Failed to load DIB image: {}", e))?;
 
-    // Encode in the image's native color space — round-tripping through
-    // `to_rgba8()` (the `image::write_to` default) would force a wasted
-    // RGB8 → RGBA8 conversion for the typical CF_DIB-from-screenshot case.
-    let rgba = image.to_rgba8();
     let mut png_bytes = Vec::new();
-    PngEncoder::new_with_quality(&mut png_bytes, CompressionType::Fast, FilterType::NoFilter)
-        .write_image(
-            rgba.as_raw(),
-            rgba.width(),
-            rgba.height(),
-            image::ExtendedColorType::Rgba8,
-        )
+    image
+        .write_to(&mut Cursor::new(&mut png_bytes), image::ImageFormat::Png)
         .map_err(|e| anyhow::anyhow!("Failed to encode PNG: {}", e))?;
 
     Ok(png_bytes)

--- a/src-tauri/crates/uc-platform/src/clipboard/platform/windows.rs
+++ b/src-tauri/crates/uc-platform/src/clipboard/platform/windows.rs
@@ -1006,6 +1006,58 @@ fn write_text_windows_native(text: &str) -> Result<()> {
         .map_err(|e| anyhow::anyhow!("Failed to set Windows Unicode clipboard text: {}", e))
 }
 
+/// Windows-specific: read CF_HTML payload via `clipboard-win`, bypassing
+/// `clipboard_rs::ClipboardContext::get_html`.
+///
+/// **Why this exists.** Upstream `clipboard_rs::platform::win::extract_html_from_clipboard_data`
+/// parses the `StartHTML`/`EndHTML` byte offsets from the CF_HTML header and
+/// then does `data[start_idx..end_idx].to_string()` on a UTF-8 `&str`. Some
+/// source apps (observed: Chinese-language Office, certain chat clients)
+/// emit offsets that are off by 1-2 bytes when the payload contains
+/// multi-byte UTF-8 characters; when the bad offset lands inside such a
+/// character `std`'s string slicer aborts the process. See Sentry issue
+/// UNICLIPBOARD-RUST-1V and the regression tests in
+/// `crate::clipboard::cf_html::tests::cf_html_endhtml_panic_repro`.
+///
+/// We grab the raw CF_HTML bytes with `clipboard-win` (the lower-level crate
+/// already in our dependency tree for image writes) and hand them to
+/// [`super::super::cf_html::read_cf_html_payload_from_bytes`], which slices on
+/// bytes and uses `String::from_utf8_lossy` so a bad offset becomes a
+/// `U+FFFD` instead of a panic.
+///
+/// Returns `Ok(None)` when the clipboard does not carry CF_HTML (the caller
+/// only reaches this function after `ctx.has(ContentFormat::Html)` reported
+/// true, so this should be very rare — but is still a normal "no data"
+/// outcome rather than an error).
+pub(crate) fn read_html_windows_native() -> Result<Option<String>> {
+    use clipboard_win::{formats, get_clipboard};
+
+    // `Html::new()` registers (or fetches the existing) "HTML Format" code
+    // via `RegisterClipboardFormatW`. `ClipboardContext::new` already did
+    // this at startup, so the second registration is idempotent.
+    let html_fmt = clipboard_win::formats::Html::new()
+        .ok_or_else(|| anyhow::anyhow!("Failed to register CF_HTML clipboard format"))?;
+
+    let bytes: Vec<u8> = match get_clipboard(formats::RawData(html_fmt.code())) {
+        Ok(bytes) => bytes,
+        Err(err) => {
+            return Err(anyhow::anyhow!(
+                "Failed to read CF_HTML raw bytes via clipboard-win: {}",
+                err
+            ));
+        }
+    };
+
+    debug!(
+        cf_html_size_bytes = bytes.len(),
+        "Read CF_HTML raw bytes from Windows clipboard (byte-safe path)"
+    );
+
+    Ok(super::super::cf_html::read_cf_html_payload_from_bytes(
+        &bytes,
+    ))
+}
+
 /// Windows-specific: Read image from clipboard as CF_DIB and convert to PNG bytes.
 ///
 /// Uses `clipboard-win` to read raw CF_DIB data (BITMAPINFOHEADER + pixel data,

--- a/src-tauri/crates/uc-platform/src/clipboard/platform/windows.rs
+++ b/src-tauri/crates/uc-platform/src/clipboard/platform/windows.rs
@@ -1058,6 +1058,145 @@ pub(crate) fn read_html_windows_native() -> Result<Option<String>> {
     ))
 }
 
+/// Windows-specific: capture an image rep from the clipboard using the
+/// fastest available path.
+///
+/// Layered strategy, in order of CPU cost:
+///
+/// 1. **Native `"PNG"` format** — zero decode, zero encode. Hits for every
+///    modern screenshot source (Chrome, Firefox, Edge, Office 2019+,
+///    Snipping Tool 11, Snipaste, 微信/QQ).
+/// 2. **CF_DIBV5 → PNG via `dib_to_png`** — one decode + one fast PNG
+///    encode (CompressionType::Fast + FilterType::NoFilter). Hits for
+///    Win+PrtScr, legacy apps, and the screenshots in the production
+///    Sentry trace that motivated this work.
+/// 3. **`clipboard-rs::ClipboardContext::get_image() + img.to_png()`** —
+///    one decode + RGBA round-trip + one default-deflate PNG encode.
+///    Last resort; the slowest path. Kept only as a defense against
+///    exotic image formats that neither (1) nor (2) recognize.
+///
+/// Mirrors the macOS fast path in `common.rs` (raw `public.png` →
+/// `tiff_to_png` → `get_image()+to_png()`), which has the same shape.
+///
+/// Returns:
+/// * `Ok(Some(png_bytes))` — one of the three tiers produced PNG bytes.
+/// * `Ok(None)` — every tier reported "no image data on clipboard". The
+///   caller normally won't observe this because they checked
+///   `ctx.has(ContentFormat::Image)` first; if they do, treat as a
+///   transient miss (lazy data provider).
+/// * `Err(_)` — all three tiers failed with non-"absent" errors.
+pub(crate) fn try_read_image_windows_optimized(
+    ctx: &mut clipboard_rs::ClipboardContext,
+) -> Result<Option<Vec<u8>>> {
+    // Tier 1: native PNG format — zero encoding work.
+    match read_image_windows_native_png() {
+        Ok(Some(bytes)) => return Ok(Some(bytes)),
+        Ok(None) => {
+            // No "PNG" format on clipboard, fall through to CF_DIB.
+        }
+        Err(err) => {
+            warn!(
+                error = %err,
+                "Native \"PNG\" fast-read failed; falling back to CF_DIB path"
+            );
+        }
+    }
+
+    // Tier 2: CF_DIB(V5) → fast PNG encode.
+    match read_image_windows_as_png() {
+        Ok(bytes) => return Ok(Some(bytes)),
+        Err(err) => {
+            // Common case: clipboard simply doesn't have CF_DIB (e.g. only a
+            // text rep but the high-level `has(Image)` flag was set by a
+            // stale or lazily-resolved format). Debug, not warn.
+            debug!(
+                error = %err,
+                "CF_DIB fast path unavailable; falling back to clipboard-rs slow path"
+            );
+        }
+    }
+
+    // Tier 3: clipboard-rs full decode + re-encode. Last resort.
+    use clipboard_rs::common::RustImage;
+    use clipboard_rs::Clipboard;
+    match ctx.get_image() {
+        Ok(img) => match img.to_png() {
+            Ok(png) => {
+                let bytes = png.get_bytes().to_vec();
+                debug!(
+                    size_bytes = bytes.len(),
+                    "Read image via clipboard-rs get_image()+to_png() (slow path)"
+                );
+                Ok(Some(bytes))
+            }
+            Err(err) => Err(anyhow::anyhow!(
+                "clipboard-rs: image available but to_png() failed: {}",
+                err
+            )),
+        },
+        Err(err) => Err(anyhow::anyhow!(
+            "clipboard-rs: ContentFormat::Image reported available but get_image() failed: {}",
+            err
+        )),
+    }
+}
+
+/// Windows-specific: read the modern `"PNG"` clipboard format raw, without
+/// decoding or re-encoding.
+///
+/// **Why this exists.** Most modern screenshot sources on Windows (Chrome,
+/// Firefox, Edge, Paint.NET, Office 2019+, Snipping Tool 11, Snipaste,
+/// 微信/QQ 截图工具, …) write **both** `CF_DIBV5` and a custom `"PNG"` format
+/// to the clipboard — the latter carrying ready-to-use PNG bytes. The
+/// existing `clipboard_rs::ClipboardContext::get_image()` path ignores this:
+/// it always goes through `clipboard-rs`'s internal `RustImageData::from_bytes`
+/// which decodes whatever it gets into a `DynamicImage`, after which we
+/// re-encode to PNG via `to_png()`. For a 4K screenshot that round-trip
+/// (PNG decode → RGBA buffer → PNG encode) costs ~3.3 s in dev profile and
+/// hundreds of ms in release — entirely avoidable when the source already
+/// handed us the PNG bytes.
+///
+/// This function mirrors the macOS fast path in `common.rs` that prefers
+/// `get_buffer("public.png")` before falling back to TIFF decoding.
+///
+/// Returns:
+/// * `Ok(Some(bytes))` — `"PNG"` format was present, raw PNG byte buffer copied.
+/// * `Ok(None)` — `"PNG"` format is not on the clipboard right now (e.g. Win+PrtScr,
+///   legacy app that only writes CF_DIB). The caller should fall back to the
+///   CF_DIB path.
+/// * `Err(_)` — registration succeeded but the format was reported available
+///   and reading still failed (genuine OS error).
+fn read_image_windows_native_png() -> Result<Option<Vec<u8>>> {
+    use clipboard_win::{formats, get_clipboard, is_format_avail, raw as cb_raw};
+
+    // `"PNG"` is the de-facto custom format Microsoft Office / Chrome /
+    // Firefox / Paint.NET / Snipaste / 微信 all use. `register_format` is
+    // idempotent — the same code is returned on every subsequent call.
+    let Some(png_fmt_nz) = cb_raw::register_format("PNG") else {
+        warn!("register_format(\"PNG\") returned None; native PNG fast path unavailable");
+        return Ok(None);
+    };
+    let png_fmt = png_fmt_nz.get();
+
+    if !is_format_avail(png_fmt) {
+        // Common case for CF_DIB-only sources (Win+PrtScr, legacy apps).
+        return Ok(None);
+    }
+
+    let bytes: Vec<u8> = get_clipboard(formats::RawData(png_fmt)).map_err(|e| {
+        anyhow::anyhow!(
+            "\"PNG\" clipboard format reported available but read failed: {}",
+            e
+        )
+    })?;
+
+    debug!(
+        size_bytes = bytes.len(),
+        "Read raw \"PNG\" format from Windows clipboard (zero-encode fast path)"
+    );
+    Ok(Some(bytes))
+}
+
 /// Windows-specific: Read image from clipboard as CF_DIB and convert to PNG bytes.
 ///
 /// Uses `clipboard-win` to read raw CF_DIB data (BITMAPINFOHEADER + pixel data,


### PR DESCRIPTION
## Summary

- **CF_HTML panic on CJK-tail HTML (`18b93c28`, repro test `ffd45b06`).** `clipboard_rs::platform::win::extract_html_from_clipboard_data` slices the CF_HTML buffer as `&str` using header byte offsets; some source apps (Chinese-language Office, certain chat clients) emit offsets that land inside a multi-byte UTF-8 character and `std::str` aborts the process. Sentry: `UNICLIPBOARD-RUST-1V`. On Windows we now bypass `ctx.get_html()` entirely and read CF_HTML raw bytes via `clipboard-win`, slicing on bytes and using `String::from_utf8_lossy` — bad offsets become a `U+FFFD`, never a panic. Regression tests pin the exact production panic shape (`EndHTML` offset inside `'插'`).

- **Windows image capture: layered fast path (`2cbab637`).** Capture now mirrors the macOS three-tier strategy already in place:
  1. Raw `"PNG"` clipboard format — zero decode, zero encode. Hits for every modern screenshot source (Chrome, Firefox, Edge, Office 2019+, Snipping Tool 11, Snipaste, 微信/QQ).
  2. `CF_DIB(V5)` → PNG via `dib_to_png` (default encoder).
  3. `clipboard-rs::get_image()+to_png()` last-resort fallback.

  Before this change every screenshot took tier-3 unconditionally: decode to `DynamicImage`, re-encode with libpng-level deflate. For a 2.4 MB screenshot the round-trip cost ~3.3 s in dev profile and hundreds of ms in release, even when the source already handed us PNG bytes.

- **Dev-profile encoder opt-level (`5ca6c100`).** Same pattern as the existing Argon2/Blake/ChaCha overrides — keep business code in debug for inner-loop ergonomics, force `opt-level = 3` on `image` / `png` / `fdeflate` / `flate2` / `miniz_oxide`. PNG encoder is a hot path on the watcher thread; `opt-level = 0` made dev-build capture user-visibly slow.

- **`dib_to_png` encoder revert (`6ae7bbd6`).** A short-lived experiment in `2cbab637` switched the CF_DIB fallback to `CompressionType::Fast + FilterType::NoFilter` betting on ~10–15% size penalty for a ~3–5× encode speedup. Production observed a 36 MB raw DIB emit a **34 MB PNG** — `CompressionType::Fast` routes through `png::Compression::Fast` = `DeflateCompression::FdeflateUltraFast`, whose upstream docs explicitly warn it can produce files *larger* than `NoCompression` on incompressible data. Restored Balanced/level-6 + Adaptive — same point on the curve as browsers, oxipng, and image editors.

No `docs-site` changes — surface-area scan found no user-facing contract (CLI flag, setting, default value, error message, supported version) touched by this PR.

## Test plan

- [x] `cargo test -p uc-platform --lib clipboard::cf_html` — 13 tests pass on host (macOS), including 2 `should_panic` tests pinning the upstream `clipboard_rs` panic and 4 new tests covering the byte-safe reader (panic-shape repro, happy path, header-missing fallback, empty buffer).
- [x] `cargo check -p uc-platform` on host (macOS).
- [x] `cargo check -p uc-platform --target x86_64-pc-windows-gnu --tests` — Windows target compiles. Only 3 pre-existing warnings remain (unused `Setter`, `ctx`, `rep_count`); none introduced by this PR.
- [x] Live Windows daemon log verification: tier-2 image capture before/after the encoder revert — confirmed 36 MB DIB now produces a normal-sized PNG (~3-5 MB range expected) rather than the 34 MB regression.
- [ ] Repro the original CF_HTML panic on Windows post-merge: copy a CJK-tail rich-text fragment from Office/微信 to the clipboard with the daemon running; previously this hit Sentry `UNICLIPBOARD-RUST-1V`, now should land in `representations` with a possible single trailing `U+FFFD`.
- [ ] Tier-1 hit-rate observation: after a few days in production, confirm the Sentry/log ratio of "Read raw \"PNG\" format" (tier 1) vs. "Read CF_DIB" (tier 2) vs. "clipboard-rs get_image()+to_png() slow path" (tier 3) — tier 1 should dominate for modern screenshot sources.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented crashes when pasting HTML from the clipboard that contains multi-byte characters on Windows.

* **Performance Improvements**
  * Faster, more robust Windows clipboard image handling with native PNG support and an optimized retrieval strategy.

* **Documentation**
  * Clarified PNG encoding choices and Windows clipboard fallback behavior for image conversion.

* **Tests**
  * Added tests validating safe HTML payload parsing and fallback behaviors for clipboard handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/UniClipboard/UniClipboard/pull/894?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->