### PR TITLE
feat(network): pin iroh UDP port and advertise public address

### DIFF
--- a/docs/development/config.md
+++ b/docs/development/config.md
@@ -99,6 +99,33 @@ The application has two separate configuration systems:
 }
 ```
 
+## Environment Variables (advanced)
+
+A few runtime knobs are read from environment variables at daemon/CLI startup
+rather than from `settings.json`. They default to today's behavior when unset.
+
+### iroh direct reachability (server / VPS nodes)
+
+For a node behind NAT or a Docker bridge that should be dialable by remote
+peers at a known public address — without depending on a relay for
+reflexive-address discovery — set both of these (see
+[`ADR-007`](../architecture/adr-007-headless-server-node-deployment.md) §2.4):
+
+| Variable | Value | Effect |
+| --- | --- | --- |
+| `UC_IROH_BIND_PORT` | UDP port `1`–`65535` | Pins the iroh IPv4 UDP socket to `0.0.0.0:<port>` (stable across restarts) instead of a random ephemeral port, so the port can be port-forwarded / firewall-allowed. |
+| `UC_IROH_PUBLIC_ADDR` | `ip:port`, e.g. `203.0.113.7:51820` | Advertises this socket address as one of the node's own direct-connection candidates, injected before the first address exchange so paired peers store a reachable public address. |
+
+Notes:
+
+- Typically used together (the advertised port should match the forwarded
+  pinned port), with the relay disabled (LAN-only Mode on, i.e.
+  `allow_relay_fallback = false`) for pure direct connectivity.
+- Only the IPv4 socket is pinned; the IPv6 default bind is unaffected.
+- Invalid or empty values are logged at `WARN` and ignored (the node falls
+  back to the default ephemeral port / no advertised address); they never
+  abort startup. `UC_IROH_BIND_PORT=0` is treated as "ephemeral" and ignored.
+
 ## Migrating from Development to Production
 
 When you're ready to test production behavior:

--- a/src-tauri/crates/uc-bootstrap/src/builders.rs
+++ b/src-tauri/crates/uc-bootstrap/src/builders.rs
@@ -218,12 +218,15 @@ pub async fn build_daemon_lifecycle(
     // 【checker BLOCKER 4 — 单一取反点铁律】
     // `disable_relays` 的值**只能**通过 `relay_policy_to_iroh_config` 取得,
     // **不**在此处内联写 `let disable_relays = !allow_relay_fallback;`。
-    let iroh_config = crate::network_policy::relay_policy_to_iroh_config(
+    let mut iroh_config = crate::network_policy::relay_policy_to_iroh_config(
         allow_relay_fallback,
         allow_overlay_network_addrs,
         custom_relay_urls,
         None, // production 不 override rendezvous,使用默认 RENDEZVOUS_BASE_URL
     );
+    // #900：从 env 读取直连可达性（固定 UDP 端口 + 广播公网地址）并写入。
+    // 必须在 `build_space_setup_assembly`（首次 endpoint 快照/配对交换）之前。
+    crate::network_policy::apply_iroh_direct_reachability_from_env(&mut iroh_config);
 
     tracing::info!(
         target: "settings.network",

--- a/src-tauri/crates/uc-bootstrap/src/network_policy.rs
+++ b/src-tauri/crates/uc-bootstrap/src/network_policy.rs
@@ -20,6 +20,8 @@
 //!
 //! 见 `.planning/phases/094-backend-network-allow-relay-fallback/094-CONTEXT.md`。
 
+use std::net::SocketAddr;
+
 use crate::space_setup::IrohNodeConfig;
 
 /// 把业务侧 `Settings.network` 翻译为 infra 侧 `IrohNodeConfig`。
@@ -55,7 +57,97 @@ pub(crate) fn relay_policy_to_iroh_config(
         allow_overlay_network_addrs,
         custom_relay_urls,
         rendezvous_base_url,
+        // 直连可达性（#900）来源于 env，不在本设置翻译点决定；由
+        // `apply_iroh_direct_reachability_from_env` 在 daemon / CLI 入口处填充。
+        bind_port: None,
+        public_addr: None,
     }
+}
+
+/// iroh 直连可达性输入（UniClipboard#900），来源于环境变量。两者默认
+/// `None`（沿用现状：随机 UDP 端口、不广播任何公网地址）。
+///
+/// 这是给 NAT / Docker bridge / VPS 后的无头节点用的：固定 UDP 端口让运维
+/// 能端口转发 / 防火墙放行一个已知端口；广播公网地址让远端桌面在 relay 关闭
+/// 时仍能凭存下来的地址直连。见 `docs/architecture/adr-007-...md` §2.4。
+#[derive(Debug, Default, PartialEq, Eq)]
+pub(crate) struct IrohDirectReachability {
+    pub bind_port: Option<u16>,
+    pub public_addr: Option<SocketAddr>,
+}
+
+/// 纯解析两个直连可达性 env 值（保持纯函数便于单测——只吃 `Option<&str>`，
+/// 不碰进程环境）。非法值**记 WARN 并回退 `None`**，不让 daemon 启动失败 ——
+/// 与 `parse_clipboard_integration_mode` 同样的防御姿态。
+///
+/// `UC_IROH_BIND_PORT=0` 视为"随机端口"哨兵 → 忽略（要固定就给非零端口）。
+pub(crate) fn parse_iroh_direct_reachability(
+    bind_port_raw: Option<&str>,
+    public_addr_raw: Option<&str>,
+) -> IrohDirectReachability {
+    let bind_port = bind_port_raw
+        .map(str::trim)
+        .filter(|raw| !raw.is_empty())
+        .and_then(|raw| match raw.parse::<u16>() {
+            Ok(0) => {
+                tracing::warn!(
+                    uc_iroh_bind_port = %raw,
+                    "UC_IROH_BIND_PORT=0 is the ephemeral-port sentinel; ignoring (use a non-zero fixed port)",
+                );
+                None
+            }
+            Ok(port) => Some(port),
+            Err(err) => {
+                tracing::warn!(
+                    uc_iroh_bind_port = %raw,
+                    error = %err,
+                    "invalid UC_IROH_BIND_PORT; ignoring (expected an integer 1..=65535)",
+                );
+                None
+            }
+        });
+
+    let public_addr = public_addr_raw
+        .map(str::trim)
+        .filter(|raw| !raw.is_empty())
+        .and_then(|raw| match raw.parse::<SocketAddr>() {
+            Ok(addr) => Some(addr),
+            Err(err) => {
+                tracing::warn!(
+                    uc_iroh_public_addr = %raw,
+                    error = %err,
+                    "invalid UC_IROH_PUBLIC_ADDR; ignoring (expected ip:port, e.g. 203.0.113.7:51820)",
+                );
+                None
+            }
+        });
+
+    IrohDirectReachability {
+        bind_port,
+        public_addr,
+    }
+}
+
+/// 读取直连可达性 env 并写入 `cfg`。在每个 production daemon / CLI 入口
+/// （`build_daemon_lifecycle` / `build_cli_app_runtime`）紧跟
+/// `relay_policy_to_iroh_config` 之后调用——daemon 与 CLI 配对路径都要广播
+/// 同一个公网地址。让 `relay_policy_to_iroh_config` 保持纯（只吃 settings、
+/// 不碰 env）。
+pub(crate) fn apply_iroh_direct_reachability_from_env(cfg: &mut IrohNodeConfig) {
+    let reach = parse_iroh_direct_reachability(
+        std::env::var("UC_IROH_BIND_PORT").ok().as_deref(),
+        std::env::var("UC_IROH_PUBLIC_ADDR").ok().as_deref(),
+    );
+    if reach.bind_port.is_some() || reach.public_addr.is_some() {
+        tracing::info!(
+            target: "settings.network",
+            bind_port = ?reach.bind_port,
+            public_addr = ?reach.public_addr,
+            "iroh direct-reachability configured from env (UC_IROH_BIND_PORT / UC_IROH_PUBLIC_ADDR)",
+        );
+    }
+    cfg.bind_port = reach.bind_port;
+    cfg.public_addr = reach.public_addr;
 }
 
 #[cfg(test)]
@@ -123,5 +215,73 @@ mod tests {
             cfg.custom_relay_urls,
             vec!["https://relay.example.com.".to_string()]
         );
+    }
+
+    /// settings 翻译点不负责直连可达性——两个字段恒为 None，由 env applier 填充。
+    #[test]
+    fn relay_policy_leaves_direct_reachability_unset() {
+        let cfg = relay_policy_to_iroh_config(true, false, Vec::new(), None);
+        assert_eq!(cfg.bind_port, None);
+        assert_eq!(cfg.public_addr, None);
+    }
+
+    /// #900：两个 env 都未设置 → 沿用现状（None/None）。
+    #[test]
+    fn direct_reachability_unset_is_none() {
+        let reach = parse_iroh_direct_reachability(None, None);
+        assert_eq!(reach, IrohDirectReachability::default());
+    }
+
+    /// #900：合法端口 + 合法地址 → Some/Some。
+    #[test]
+    fn direct_reachability_valid_values_parse() {
+        let reach = parse_iroh_direct_reachability(Some("51820"), Some("203.0.113.7:51820"));
+        assert_eq!(reach.bind_port, Some(51820));
+        assert_eq!(
+            reach.public_addr,
+            Some("203.0.113.7:51820".parse::<SocketAddr>().unwrap())
+        );
+    }
+
+    /// #900：前后空白被裁剪，仍能解析。
+    #[test]
+    fn direct_reachability_trims_whitespace() {
+        let reach = parse_iroh_direct_reachability(Some("  51820 "), Some(" 203.0.113.7:51820 "));
+        assert_eq!(reach.bind_port, Some(51820));
+        assert_eq!(
+            reach.public_addr,
+            Some("203.0.113.7:51820".parse::<SocketAddr>().unwrap())
+        );
+    }
+
+    /// #900：空字符串等价于未设置。
+    #[test]
+    fn direct_reachability_empty_is_none() {
+        let reach = parse_iroh_direct_reachability(Some("   "), Some(""));
+        assert_eq!(reach.bind_port, None);
+        assert_eq!(reach.public_addr, None);
+    }
+
+    /// #900：端口 0 是随机端口哨兵 → 忽略（回退 None）。
+    #[test]
+    fn direct_reachability_port_zero_ignored() {
+        let reach = parse_iroh_direct_reachability(Some("0"), None);
+        assert_eq!(reach.bind_port, None);
+    }
+
+    /// #900：非法值 WARN 后回退 None，不让 daemon 启动失败。
+    #[test]
+    fn direct_reachability_invalid_values_fall_back_to_none() {
+        let reach = parse_iroh_direct_reachability(Some("abc"), Some("not-an-addr"));
+        assert_eq!(reach.bind_port, None);
+        assert_eq!(reach.public_addr, None);
+
+        // 端口超出 u16 范围同样回退。
+        let overflow = parse_iroh_direct_reachability(Some("70000"), None);
+        assert_eq!(overflow.bind_port, None);
+
+        // 缺少端口的裸 IP 不是合法 SocketAddr → 回退。
+        let no_port = parse_iroh_direct_reachability(None, Some("203.0.113.7"));
+        assert_eq!(no_port.public_addr, None);
     }
 }

--- a/src-tauri/crates/uc-bootstrap/src/non_gui_runtime.rs
+++ b/src-tauri/crates/uc-bootstrap/src/non_gui_runtime.rs
@@ -571,12 +571,15 @@ pub async fn build_cli_app_runtime(
 
     // 【checker BLOCKER 4 — 单一取反点铁律】见 builders.rs 同处注释。
     // 不在此处内联 `let disable_relays = !allow_relay_fallback;`。
-    let iroh_config = crate::network_policy::relay_policy_to_iroh_config(
+    let mut iroh_config = crate::network_policy::relay_policy_to_iroh_config(
         allow_relay_fallback,
         allow_overlay_network_addrs,
         custom_relay_urls,
         None,
     );
+    // #900：从 env 读取直连可达性（固定 UDP 端口 + 广播公网地址）并写入。
+    // 必须在 `build_space_setup_assembly`（首次 endpoint 快照/配对交换）之前。
+    crate::network_policy::apply_iroh_direct_reachability_from_env(&mut iroh_config);
 
     tracing::info!(
         target: "settings.network",

--- a/src-tauri/crates/uc-bootstrap/tests/slice1_handshake_e2e.rs
+++ b/src-tauri/crates/uc-bootstrap/tests/slice1_handshake_e2e.rs
@@ -346,6 +346,7 @@ async fn build_side(name: &'static str, rendezvous_base_url: String) -> Side {
             disable_relays: true,
             allow_overlay_network_addrs: false,
             custom_relay_urls: Vec::new(),
+            ..Default::default()
         },
     )
     .await

--- a/src-tauri/crates/uc-bootstrap/tests/slice2_phase1_presence_e2e.rs
+++ b/src-tauri/crates/uc-bootstrap/tests/slice2_phase1_presence_e2e.rs
@@ -356,6 +356,7 @@ async fn build_side(name: &'static str, rendezvous_base_url: String) -> Side {
             disable_relays: true,
             allow_overlay_network_addrs: false,
             custom_relay_urls: Vec::new(),
+            ..Default::default()
         },
     )
     .await

--- a/src-tauri/crates/uc-bootstrap/tests/slice2_phase2_clipboard_e2e.rs
+++ b/src-tauri/crates/uc-bootstrap/tests/slice2_phase2_clipboard_e2e.rs
@@ -460,6 +460,7 @@ async fn build_side(name: &'static str, rendezvous_base_url: String) -> Side {
             disable_relays: true,
             allow_overlay_network_addrs: false,
             custom_relay_urls: Vec::new(),
+            ..Default::default()
         },
     )
     .await

--- a/src-tauri/crates/uc-infra/src/network/iroh/node.rs
+++ b/src-tauri/crates/uc-infra/src/network/iroh/node.rs
@@ -17,6 +17,7 @@
 //! [`install_presence`]: IrohNodeBuilder::install_presence
 //! [`install_clipboard`]: IrohNodeBuilder::install_clipboard
 
+use std::net::{Ipv4Addr, SocketAddr};
 #[cfg(not(any(test, feature = "test-util")))]
 use std::sync::OnceLock;
 use std::{path::PathBuf, sync::Arc, time::Duration};
@@ -199,6 +200,29 @@ pub struct IrohNodeConfig {
     /// are unconditionally filtered regardless of this flag — they have no
     /// legitimate cross-host use case.
     pub allow_overlay_network_addrs: bool,
+    /// Pin the iroh UDP socket to a fixed IPv4 port instead of an
+    /// OS-assigned ephemeral one (UniClipboard#900). `None` → bind
+    /// `0.0.0.0:0` (today's behavior). `Some(port)` → bind `0.0.0.0:port`
+    /// so the port is stable across restarts, letting an operator
+    /// port-forward / firewall-allow a known UDP port to a NAT'd or
+    /// containerized node. Only the IPv4 socket is pinned; the IPv6 default
+    /// bind is left untouched (matches the VPS / Docker-bridge scenario and
+    /// avoids a hard-fail on v4-only hosts).
+    ///
+    /// Sourced from `UC_IROH_BIND_PORT` (parsed in `uc-bootstrap`); infra
+    /// only consumes the typed value.
+    pub bind_port: Option<u16>,
+    /// Advertise a configured public socket address as one of this node's
+    /// own direct-connection candidates (UniClipboard#900). `None` → only
+    /// discovered/reflexive addresses are advertised (today's behavior).
+    /// `Some(addr)` → inject `addr` into the advertised endpoint address at
+    /// **bind time** (iroh `Builder::external_addr`), so it is present in the
+    /// very first `endpoint.addr()` snapshot — i.e. before pairing/dispatch
+    /// exchange the address blob with peers. With the relay disabled, a
+    /// remote desktop that knows only this address can dial the node directly.
+    ///
+    /// Sourced from `UC_IROH_PUBLIC_ADDR` (parsed in `uc-bootstrap`).
+    pub public_addr: Option<SocketAddr>,
 }
 
 /// Snapshot the candidate set this endpoint is currently advertising and
@@ -518,6 +542,43 @@ impl IrohNodeBuilder {
             info!(
                 target: "iroh.address_lookup",
                 "LAN-only mode: cleared n0 pkarr/DNS lookup services; only mDNS will publish/resolve",
+            );
+        }
+
+        // UniClipboard#900 (a): pin the UDP socket to a fixed IPv4 port so a
+        // NAT'd / containerized node is reachable at a stable port across
+        // restarts. `bind_addr("0.0.0.0:port")` replaces iroh's default
+        // ephemeral IPv4 socket (still listens on all interfaces); the IPv6
+        // default bind is left untouched. The port is pre-parsed from
+        // `UC_IROH_BIND_PORT` in `uc-bootstrap`, so the only realistic failure
+        // here is the port already being in use — surfaced as `Bind`.
+        if let Some(port) = config.bind_port {
+            endpoint_builder = endpoint_builder
+                .bind_addr((Ipv4Addr::UNSPECIFIED, port))
+                .map_err(|err| {
+                    IrohNodeError::Bind(format!(
+                        "pin iroh UDP port {port} (UC_IROH_BIND_PORT): {err}"
+                    ))
+                })?;
+            info!(
+                target: "iroh.bind",
+                bind_port = port,
+                "pinned iroh UDP socket to fixed IPv4 port 0.0.0.0:{port} (UC_IROH_BIND_PORT)",
+            );
+        }
+
+        // UniClipboard#900 (b): advertise a configured public address as a
+        // direct-connection candidate. `external_addr` is applied at build
+        // time, so the address is present in the very first `endpoint.addr()`
+        // snapshot — before pairing/dispatch exchange the address blob with
+        // peers (acceptance criterion). With the relay disabled, a remote
+        // desktop that knows only this address can dial the node directly.
+        if let Some(public_addr) = config.public_addr {
+            endpoint_builder = endpoint_builder.external_addr(public_addr);
+            info!(
+                target: "iroh.bind",
+                %public_addr,
+                "advertising configured public address as a direct candidate (UC_IROH_PUBLIC_ADDR)",
             );
         }
 
@@ -950,6 +1011,53 @@ mod tests {
             Arc::new(InMemorySecureStorage::default()),
             Arc::new(Sha256IdentityFingerprintFactory),
         ))
+    }
+
+    /// UniClipboard#900: `bind_port` pins the iroh UDP socket to a fixed
+    /// IPv4 port. We grab a currently-free port from the OS, release it, then
+    /// assert the endpoint binds exactly that number (stable across restarts).
+    #[tokio::test]
+    async fn bind_pins_fixed_udp_port() {
+        // Ask the OS for a free UDP port, then drop the probe so iroh can
+        // claim the same number. Small TOCTOU window, acceptable for a test.
+        let probe = std::net::UdpSocket::bind((Ipv4Addr::LOCALHOST, 0)).expect("probe socket");
+        let port = probe.local_addr().expect("probe addr").port();
+        drop(probe);
+
+        let store = identity_store();
+        let cfg = IrohNodeConfig {
+            bind_port: Some(port),
+            ..Default::default()
+        };
+        let builder = IrohNodeBuilder::bind(&store, cfg).await.expect("bind");
+        let bound = builder.endpoint.bound_sockets();
+        assert!(
+            bound.iter().any(|s| s.is_ipv4() && s.port() == port),
+            "expected pinned IPv4 port {port} in bound sockets {bound:?}"
+        );
+    }
+
+    /// UniClipboard#900: `public_addr` injects a configured public address
+    /// into the advertised endpoint address at bind time, so it is present in
+    /// the very first `endpoint.addr()` snapshot — before any pairing exchange.
+    #[tokio::test]
+    async fn bind_advertises_configured_public_addr() {
+        // A public, non-virtual IPv4 — never dropped by the address filter.
+        let public_addr = SocketAddr::V4(std::net::SocketAddrV4::new(
+            Ipv4Addr::new(1, 2, 3, 4),
+            12345,
+        ));
+        let store = identity_store();
+        let cfg = IrohNodeConfig {
+            public_addr: Some(public_addr),
+            ..Default::default()
+        };
+        let builder = IrohNodeBuilder::bind(&store, cfg).await.expect("bind");
+        let addr = builder.endpoint.addr();
+        assert!(
+            addr.ip_addrs().any(|a| *a == public_addr),
+            "configured public addr {public_addr} not advertised in {addr:?}"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Make a node behind NAT / a Docker bridge (the headless server node from ADR-007) directly dialable by remote peers at a known public address, without relying on a relay for reflexive-address discovery. Two env-sourced iroh host config inputs, both defaulting to today's behavior when unset (063eeadf):

- **`UC_IROH_BIND_PORT`** — pins the iroh IPv4 UDP socket to a fixed port (`Builder::bind_addr("0.0.0.0:<port>")`) instead of a random ephemeral one, so the port is stable across restarts and can be port-forwarded / firewall-allowed. Only the IPv4 socket is pinned; the IPv6 default bind is untouched (avoids a hard-fail regression on v4-only hosts).
- **`UC_IROH_PUBLIC_ADDR`** — advertises a configured public socket address as a direct-connection candidate via **build-time** `Builder::external_addr`, so it is present in the very first `endpoint.addr()` snapshot — before pairing/dispatch exchange the address blob with peers. With the relay disabled, a remote desktop that knows only this address can dial the node directly.
- `IrohNodeConfig` gains `bind_port` / `public_addr` (`Option`, default `None`). Env parsing is a pure, unit-tested helper in `uc-bootstrap` (`network_policy`) applied at **both** the daemon (`build_daemon_lifecycle`) and CLI (`build_cli_app_runtime`) config-build paths; `relay_policy_to_iroh_config` stays pure (single-inversion-point contract untouched). Invalid/empty values are logged at WARN and ignored rather than aborting startup (`UC_IROH_BIND_PORT=0` treated as the ephemeral sentinel).

Design pre-approved by `docs/architecture/adr-007-headless-server-node-deployment.md` §2.4. Refs #900.

## Test plan

- [x] `cargo test -p uc-infra --lib network::iroh::node` — incl. new `bind_pins_fixed_udp_port` (asserts `bound_sockets()` uses the pinned port) and `bind_advertises_configured_public_addr` (asserts `endpoint.addr().ip_addrs()` includes the configured addr). 26 passed.
- [x] `cargo test -p uc-bootstrap --lib network_policy` — 7 new parser tests (valid / empty / whitespace / port-0 sentinel / invalid → None). 14 passed.
- [x] `cargo check -p uc-infra -p uc-bootstrap -p uc-desktop -p uc-cli` — clean; no new clippy warnings from changed code.
- [ ] **Manual deployment-slice validation (out of scope here, per #900):** real cross-WAN — a desktop peer that knows only the public address (relay disabled) establishes a direct iroh connection to a VPS/container node.

## Notes

- `docs/development/config.md` gains an env-var reference for the two variables. `docs-site/` left as-is — nothing there describes these vars yet; the user-facing VPS deployment guide belongs to the separate deployment slice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added environment variable documentation for advanced network configuration enabling direct reachability settings at daemon/CLI startup.

* **New Features**
  * Introduced support for configurable direct reachability via environment variables: `UC_IROH_BIND_PORT` to pin UDP port bindings and `UC_IROH_PUBLIC_ADDR` to advertise public addresses to peers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/UniClipboard/UniClipboard/pull/905?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->