### PR TITLE
feat(mobile-sync): advertise full base URL for install URL/QR

### DIFF
--- a/docs-site/content/docs/en/guides/mobile-sync.mdx
+++ b/docs-site/content/docs/en/guides/mobile-sync.mdx
@@ -292,9 +292,30 @@ Either way, the connection settings are the same:
 
 - **Base URL / server address** — `http://<advertised-IP>:<port>`
   (e.g. `http://192.168.1.5:42720`). Note `http://`, not `https://`
-  — there's no TLS in v1.
+  — the listener itself has no TLS in v1.
 - **Username** — printed by the credentials modal / `setup`.
 - **Password** — printed by the credentials modal / `setup` (one-time).
+
+<Callout type="info">
+  **Public access via an HTTPS reverse proxy.** For deployments that
+  expose mobile sync over the public internet (e.g. a headless server
+  node), put a TLS reverse proxy such as Caddy or nginx in front of the
+  plain-HTTP listener and advertise its address instead of an internal
+  IP:
+
+  ```bash
+  uniclip mobile-sync lan enable \
+      --advertise-url https://clip.example.com \
+      --accept-network-risk
+  ```
+
+  The install URL / QR then encodes `https://clip.example.com` (no
+  internal port), while the listener stays plain HTTP on the internal
+  network. The proxy terminates TLS and forwards to the internal
+  `mobile_lan` port, which must **not** be published directly to the
+  public internet. The legacy `--advertise <IP>` form still produces
+  the LAN `http://<IP>:<port>` URL; the two are mutually exclusive.
+</Callout>
 
 <Callout type="info">
   `uc-android` is a fork of upstream `Jeric-X/SyncClipboard`. We carry our own patches and tag our

--- a/docs-site/content/docs/en/guides/mobile-sync.mdx
+++ b/docs-site/content/docs/en/guides/mobile-sync.mdx
@@ -303,18 +303,19 @@ Either way, the connection settings are the same:
   plain-HTTP listener and advertise its address instead of an internal
   IP:
 
-  ```bash
-  uniclip mobile-sync lan enable \
-      --advertise-url https://clip.example.com \
-      --accept-network-risk
-  ```
+```bash
+uniclip mobile-sync lan enable \
+    --advertise-url https://clip.example.com \
+    --accept-network-risk
+```
 
-  The install URL / QR then encodes `https://clip.example.com` (no
-  internal port), while the listener stays plain HTTP on the internal
-  network. The proxy terminates TLS and forwards to the internal
-  `mobile_lan` port, which must **not** be published directly to the
-  public internet. The legacy `--advertise <IP>` form still produces
-  the LAN `http://<IP>:<port>` URL; the two are mutually exclusive.
+The install URL / QR then encodes `https://clip.example.com` (no
+internal port), while the listener stays plain HTTP on the internal
+network. The proxy terminates TLS and forwards to the internal
+`mobile_lan` port, which must **not** be published directly to the
+public internet. The legacy `--advertise <IP>` form still produces
+the LAN `http://<IP>:<port>` URL; the two are mutually exclusive.
+
 </Callout>
 
 <Callout type="info">

--- a/docs-site/content/docs/en/reference/cli.mdx
+++ b/docs-site/content/docs/en/reference/cli.mdx
@@ -207,7 +207,11 @@ uniclip mobile-sync settings show     # advanced: settings dump
 
 # Listener configuration (write commands — daemon must be stopped)
 uniclip mobile-sync lan list-interfaces
+# LAN form: advertise an internal IPv4 → install URL is http://<IP>:<port>
 uniclip mobile-sync lan enable --advertise <LAN_IPV4> [--port 42720] --accept-network-risk
+# Reverse-proxy form: advertise a full base URL → install URL/QR points at
+# the HTTPS front-end (e.g. Caddy), while the listener stays plain HTTP.
+uniclip mobile-sync lan enable --advertise-url https://clip.example.com --accept-network-risk
 uniclip mobile-sync lan disable
 
 # Paired device management
@@ -237,6 +241,15 @@ Behavioural notes:
 - **Default port is `42720`** (SPEC §3.2). The daemon socket always
   binds to `0.0.0.0:<port>`; `--advertise` only chooses the IPv4 that
   is printed to the install URL.
+- **`lan enable` requires exactly one of `--advertise <IP>` or
+  `--advertise-url <URL>`.** `--advertise` produces the LAN form
+  `http://<IP>:<port>`. `--advertise-url` embeds a full base URL
+  (scheme + host + optional port) such as `https://clip.example.com`,
+  so the install URL / QR points at a TLS reverse proxy (Caddy, nginx,
+  …) while the listener itself stays plain HTTP on the internal
+  network. The two are mutually exclusive and setting one clears the
+  other; `mobile-sync status` / `settings show` reflect whichever is
+  active.
 - A **debug** subcommand group exists (`uniclip mobile-sync debug`)
   but is hidden from `--help` — it is reserved for development and
   E2E scripts (it bypasses HTTP and pokes the facade directly), and

--- a/docs-site/content/docs/zh/guides/mobile-sync.mdx
+++ b/docs-site/content/docs/zh/guides/mobile-sync.mdx
@@ -270,16 +270,17 @@ SyncClipboard 协议兼容客户端也能接入。推荐顺序：
   server 节点），在明文监听器前面放一层 TLS 反向代理（Caddy、nginx 等），
   并宣告它的地址而不是内网 IP：
 
-  ```bash
-  uniclip mobile-sync lan enable \
-      --advertise-url https://clip.example.com \
-      --accept-network-risk
-  ```
+```bash
+uniclip mobile-sync lan enable \
+    --advertise-url https://clip.example.com \
+    --accept-network-risk
+```
 
-  这样安装 URL / 二维码编码的是 `https://clip.example.com`（不带内网
-  端口），而监听器本身仍是内网明文 HTTP。反代终结 TLS 后转发到内网的
-  `mobile_lan` 端口 —— 该端口**绝不能**直接发布到公网。旧的
-  `--advertise <IP>` 形态仍然产出 LAN 的 `http://<IP>:<port>`，两者互斥。
+这样安装 URL / 二维码编码的是 `https://clip.example.com`（不带内网
+端口），而监听器本身仍是内网明文 HTTP。反代终结 TLS 后转发到内网的
+`mobile_lan` 端口 —— 该端口**绝不能**直接发布到公网。旧的
+`--advertise <IP>` 形态仍然产出 LAN 的 `http://<IP>:<port>`，两者互斥。
+
 </Callout>
 
 <Callout type="info">

--- a/docs-site/content/docs/zh/guides/mobile-sync.mdx
+++ b/docs-site/content/docs/zh/guides/mobile-sync.mdx
@@ -260,10 +260,27 @@ SyncClipboard 协议兼容客户端也能接入。推荐顺序：
 不论选哪一个，配置项都是同一组：
 
 - **Base URL / 服务端地址** —— `http://<对外宣告的 IP>:<port>`，例如
-  `http://192.168.1.5:42720`。注意是 `http://` 而非 `https://`，v1
-  没有 TLS。
+  `http://192.168.1.5:42720`。注意是 `http://` 而非 `https://`，监听器
+  本身在 v1 没有 TLS。
 - **Username** —— 凭据弹窗 / `setup` 输出。
 - **Password** —— 凭据弹窗 / `setup` 输出（一次性）。
+
+<Callout type="info">
+  **经 HTTPS 反向代理走公网。** 需要把移动同步暴露到公网时（例如无头
+  server 节点），在明文监听器前面放一层 TLS 反向代理（Caddy、nginx 等），
+  并宣告它的地址而不是内网 IP：
+
+  ```bash
+  uniclip mobile-sync lan enable \
+      --advertise-url https://clip.example.com \
+      --accept-network-risk
+  ```
+
+  这样安装 URL / 二维码编码的是 `https://clip.example.com`（不带内网
+  端口），而监听器本身仍是内网明文 HTTP。反代终结 TLS 后转发到内网的
+  `mobile_lan` 端口 —— 该端口**绝不能**直接发布到公网。旧的
+  `--advertise <IP>` 形态仍然产出 LAN 的 `http://<IP>:<port>`，两者互斥。
+</Callout>
 
 <Callout type="info">
   `uc-android` 是上游 `Jeric-X/SyncClipboard` 的 fork。我们带自己的补丁、打自己的 APK，但协议层

--- a/docs-site/content/docs/zh/reference/cli.mdx
+++ b/docs-site/content/docs/zh/reference/cli.mdx
@@ -186,7 +186,11 @@ uniclip mobile-sync settings show     # advanced：导出全部设置
 
 # 监听器配置（写命令 —— 必须先停 daemon）
 uniclip mobile-sync lan list-interfaces
+# LAN 形态：宣告内网 IPv4 → 安装 URL 为 http://<IP>:<port>
 uniclip mobile-sync lan enable --advertise <LAN_IPV4> [--port 42720] --accept-network-risk
+# 反代形态：宣告完整 base URL → 安装 URL/二维码指向 HTTPS 前端（如 Caddy），
+# 监听器本身仍是内网明文 HTTP
+uniclip mobile-sync lan enable --advertise-url https://clip.example.com --accept-network-risk
 uniclip mobile-sync lan disable
 
 # 已配对设备管理
@@ -213,6 +217,13 @@ uniclip mobile-sync disable
   或 CI 里管道喂密码，避免泄漏到 shell history。
 - **默认端口 `42720`**（SPEC §3.2）。daemon socket 永远 bind 在
   `0.0.0.0:<port>`，`--advertise` 只决定打印到安装 URL 的 IPv4。
+- **`lan enable` 必须二选一给出 `--advertise <IP>` 或
+  `--advertise-url <URL>`。** `--advertise` 得到 LAN 形态
+  `http://<IP>:<port>`；`--advertise-url` 写入完整 base URL（scheme +
+  host + 可选 port，如 `https://clip.example.com`），让安装 URL / 二维码
+  指向 TLS 反向代理（Caddy、nginx 等），而监听器本身仍是内网明文 HTTP。
+  两者互斥，设一个会清掉另一个；`mobile-sync status` / `settings show`
+  会反映当前生效的那个。
 - 还有一组 **debug** 子命令（`uniclip mobile-sync debug`），从 `--help`
   里隐藏 —— 仅供开发与 E2E 脚本使用（绕过 HTTP，直接打 facade），可能
   在不发版本说明的情况下变化。

--- a/src-tauri/crates/uc-application/src/facade/mobile_sync/facade.rs
+++ b/src-tauri/crates/uc-application/src/facade/mobile_sync/facade.rs
@@ -1000,6 +1000,7 @@ mod tests {
                 lan_listen_enabled: Some(true),
                 lan_advertise_ip: Some(Some("192.168.1.5".into())),
                 lan_port: Some(Some(42720)),
+                ..Default::default()
             })
             .await
             .expect("update_settings ok");
@@ -1342,6 +1343,7 @@ mod tests {
                 lan_listen_enabled: Some(true),
                 lan_advertise_ip: Some(Some("192.168.1.5".into())),
                 lan_port: Some(Some(43210)),
+                ..Default::default()
             })
             .await
             .unwrap();
@@ -1521,6 +1523,7 @@ mod tests {
             enabled: true,
             lan_listen_enabled: true,
             lan_advertise_ip: None,
+            lan_advertise_base_url: None,
             lan_port: Some(0),
             restart_required: false,
             lan_listener_bind_error: None,

--- a/src-tauri/crates/uc-application/src/usecases/mobile_sync/get_settings.rs
+++ b/src-tauri/crates/uc-application/src/usecases/mobile_sync/get_settings.rs
@@ -40,6 +40,10 @@ pub struct MobileSyncSettingsView {
     /// 持久化 `Settings.mobile_sync.lan_advertise_ip`。`None` 对应 UI 的
     /// "自动"选项,展示 / register_device base_url 都退回 `0.0.0.0`。
     pub lan_advertise_ip: Option<String>,
+    /// 持久化 `Settings.mobile_sync.lan_advertise_base_url`。`Some` 时优先于
+    /// `lan_advertise_ip` 决定对外公布的 base URL;`None` 时回退到由 advertise
+    /// IP + port 拼出的地址。
+    pub lan_advertise_base_url: Option<String>,
     /// 持久化 `Settings.mobile_sync.lan_port`。`None` 时 daemon 取默认 42720。
     pub lan_port: Option<u16>,
     /// daemon 端 LAN listener 的 bind 失败原因(端口占用 / IP 不存在 /
@@ -126,6 +130,7 @@ impl GetMobileSyncSettingsUseCase {
             enabled: mobile.enabled,
             lan_listen_enabled: mobile.lan_listen_enabled,
             lan_advertise_ip: mobile.lan_advertise_ip,
+            lan_advertise_base_url: mobile.lan_advertise_base_url,
             lan_port: mobile.lan_port,
             lan_listener_error,
             shortcut_install_methods: shortcut_install_methods_v1(),
@@ -258,6 +263,22 @@ mod tests {
         assert!(v.enabled);
         // bind 成功的 URL 不再透出到 view —— 上层从 lan_advertise_ip + lan_port 自行拼接。
         assert!(v.lan_listener_error.is_none());
+    }
+
+    #[tokio::test]
+    async fn surfaces_advertise_base_url_from_persisted_settings() {
+        let settings_port = Arc::new(InMemorySettings::default());
+        let mut s = Settings::default();
+        s.mobile_sync.enabled = true;
+        s.mobile_sync.lan_advertise_base_url = Some("https://clip.example.com".into());
+        settings_port.save(&s).await.unwrap();
+
+        let uc = build_uc(settings_port, None);
+        let v = uc.execute().await.expect("ok");
+        assert_eq!(
+            v.lan_advertise_base_url.as_deref(),
+            Some("https://clip.example.com")
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/crates/uc-application/src/usecases/mobile_sync/register_device.rs
+++ b/src-tauri/crates/uc-application/src/usecases/mobile_sync/register_device.rs
@@ -64,8 +64,9 @@ pub struct RegisterMobileShortcutDeviceOutput {
     /// 调用方若要把它原样转发给上层 view,应再过一次 summary 类型,避免
     /// password_hash 暴露给 UI(`list_devices::MobileDeviceSummary` 已实现)。
     pub device: MobileDevice,
-    /// daemon 当前对外暴露的 LAN URL,用户在 SyncClipboard shortcut 里
-    /// 填进 `url` 框,形如 `http://192.168.1.5:42720`。
+    /// daemon 当前对外公布的 base URL,用户在 SyncClipboard shortcut 里
+    /// 填进 `url` 框。LAN 形态形如 `http://192.168.1.5:42720`;若用户配置了
+    /// `lan_advertise_base_url`,则为该完整地址(可为 `https://域名`)。
     pub base_url: String,
     /// 一次性回显:用户在 SyncClipboard shortcut 里填进 `username` 框。
     /// 自定义模式下与 `input.username` 相同;自动模式下来自 minter。
@@ -264,6 +265,9 @@ impl RegisterMobileShortcutDeviceUseCase {
     ///
     /// base_url 由 settings 决定:
     /// `lan_listen_enabled=false` → `LanListenerDisabled`(用户没开 LAN);
+    /// `lan_advertise_base_url=Some(url)` → 直接用该完整地址(优先级最高,
+    ///   不需要本机有 LAN 网卡);
+    /// 否则回退 LAN 形态:
     /// `lan_advertise_ip=Some(ip)` → 用该 IP;
     /// `lan_advertise_ip=None` → 自动挑一个 RFC1918 LAN IPv4
     ///   ([`auto_pick_advertise_ip`]),没候选时 → `NoLanInterfaceAvailable`。
@@ -317,15 +321,28 @@ impl RegisterMobileShortcutDeviceUseCase {
         if !settings.mobile_sync.lan_listen_enabled {
             return Err(RegisterMobileShortcutDeviceError::LanListenerDisabled);
         }
-        // 用户选了"自动" → 让 daemon 替他挑一个 RFC1918 LAN IP。daemon 永远
-        // bind `0.0.0.0:lan_port`,但 iPhone 得到的 base_url 必须是真实可达
-        // 的 LAN 地址(0.0.0.0 / 127.0.0.1 在 iPhone 上都连不通)。
-        let advertise_ip: String = match settings.mobile_sync.lan_advertise_ip.clone() {
-            Some(ip) => ip,
-            None => self.auto_pick_advertise_ip().await?,
+        // base_url 的真相来源有两条,`lan_advertise_base_url` 优先:
+        //
+        // 1. `lan_advertise_base_url=Some(url)` —— 用户提供了完整广告地址
+        //    (scheme + host + 可选 port)。直接用它,不需要本机有 LAN 网卡 ——
+        //    典型场景:公网部署时 install URL / 二维码要指向前置的 TLS 反向
+        //    代理(如 Caddy 的 `https://域名`),内网仍是明文 mobile_lan
+        //    listener。该地址已在 update_settings 写入时校验 + 归一化。
+        // 2. `lan_advertise_base_url=None` —— 回退 LAN 形态。`lan_advertise_ip`
+        //    为 None("自动")时让 daemon 替他挑一个 RFC1918 LAN IP;daemon
+        //    永远 bind `0.0.0.0:lan_port`,但 iPhone 得到的 base_url 必须是
+        //    真实可达的 LAN 地址(0.0.0.0 / 127.0.0.1 在 iPhone 上都连不通)。
+        let base_url = match settings.mobile_sync.lan_advertise_base_url.clone() {
+            Some(url) => url,
+            None => {
+                let advertise_ip: String = match settings.mobile_sync.lan_advertise_ip.clone() {
+                    Some(ip) => ip,
+                    None => self.auto_pick_advertise_ip().await?,
+                };
+                let port = settings.mobile_sync.lan_port.unwrap_or(42720);
+                format!("http://{advertise_ip}:{port}")
+            }
         };
-        let port = settings.mobile_sync.lan_port.unwrap_or(42720);
-        let base_url = format!("http://{advertise_ip}:{port}");
 
         // 2. 颁发凭据 —— minter 一次性给 4 项 baseline;然后按 input
         //    选择性覆盖 username / (password + password_hash)。device_id
@@ -582,9 +599,11 @@ fn translate_device_error(err: MobileDeviceError) -> RegisterMobileShortcutDevic
 ///
 /// 设计上 build 路径仅可能撞到 [`ConnectUriError::UriTooLong`] —— label
 /// 过长导致 payload 超 800 字符。其余 6 个变体属于"上游契约保证不会发生":
-/// - `MissingField`: `base_url` 由 `format!("http://{ip}:{port}")` 拼出非空,
+/// - `MissingField`: `base_url` 要么由 `format!("http://{ip}:{port}")` 拼出,
+///   要么是 update_settings 已校验非空的 `lan_advertise_base_url`;
 ///   `username` / `password` 走 minter 或 0.1 步前置校验, 都非空。
-/// - `InvalidUrl`: base_url 永远以 `http://` 开头。
+/// - `InvalidUrl`: base_url 永远以 `http://` 或 `https://` 开头
+///   (LAN 形态硬编码 `http://`,override 形态已在 update_settings 校验)。
 /// - `InvalidScheme` / `UnsupportedVersion` / `UnsupportedService` /
 ///   `PayloadDecodeFailed`: 仅 parse 路径出现, build 不调 parse。
 ///
@@ -756,6 +775,22 @@ mod tests {
             settings.mobile_sync.enabled = true;
             settings.mobile_sync.lan_listen_enabled = true;
             settings.mobile_sync.lan_advertise_ip = None;
+            settings.mobile_sync.lan_port = Some(42720);
+            Ok(settings)
+        });
+        s
+    }
+
+    /// `lan_advertise_base_url = Some("https://clip.example.com")` 同时设了一个
+    /// `lan_advertise_ip` + `lan_port` —— 用来证明 base_url override 优先。
+    fn settings_port_base_url() -> MockSettingsPortImpl {
+        let mut s = MockSettingsPortImpl::new();
+        s.expect_load().returning(|| {
+            let mut settings = Settings::default();
+            settings.mobile_sync.enabled = true;
+            settings.mobile_sync.lan_listen_enabled = true;
+            settings.mobile_sync.lan_advertise_ip = Some("192.168.1.5".into());
+            settings.mobile_sync.lan_advertise_base_url = Some("https://clip.example.com".into());
             settings.mobile_sync.lan_port = Some(42720);
             Ok(settings)
         });
@@ -960,6 +995,32 @@ mod tests {
             out.install_qr_code_png_bytes, install_url_qr.0,
             "install QR PNG must encode install_url byte-for-byte"
         );
+    }
+
+    #[tokio::test]
+    async fn base_url_override_takes_precedence_over_advertise_ip() {
+        // settings 同时有 lan_advertise_ip 和 lan_advertise_base_url —— base_url
+        // 必须胜出, 出现在 out.base_url 与 connect_uri payload 里。
+        let uc = RegisterMobileShortcutDeviceUseCase::new(
+            Arc::new(deterministic_minter()),
+            Arc::new(recording_hasher()),
+            Arc::new(empty_device_repo()),
+            Arc::new(settings_port_base_url()),
+            Arc::new(clock_at(1_000)),
+            // probe 永远不该被调到(base_url 已定 → 不走 auto-pick)。给个空
+            // probe, 若实现误调它只会得到 NoLanInterfaceAvailable 而 panic 断言。
+            Arc::new(probe_returning(vec![])),
+            Arc::new(CapturingAnalyticsSink::default()),
+        );
+        let out = uc
+            .execute(label_only("我的 iPhone"))
+            .await
+            .expect("base_url override path must succeed");
+
+        assert_eq!(out.base_url, "https://clip.example.com");
+        let payload = parse_mobile_sync_connect_uri(&out.connect_uri)
+            .expect("connect URI must round-trip parse");
+        assert_eq!(payload.url, "https://clip.example.com");
     }
 
     // ── tests: custom username ─────────────────────────────────────────

--- a/src-tauri/crates/uc-application/src/usecases/mobile_sync/update_settings.rs
+++ b/src-tauri/crates/uc-application/src/usecases/mobile_sync/update_settings.rs
@@ -31,6 +31,7 @@
 use std::sync::Arc;
 
 use tracing::instrument;
+use url::Url;
 
 use uc_core::ports::SettingsPort;
 
@@ -45,11 +46,16 @@ use uc_core::ports::SettingsPort;
 /// 这样让 CLI / 前端都能以"只改自己关心的字段"的方式调用,无需先 read-
 /// modify-write。`lan_advertise_ip` 用嵌套 `Option<Option<String>>` 表达三态:
 /// `None` = 不动、`Some(None)` = 显式清空、`Some(Some(ip))` = 写入。
+/// `lan_advertise_base_url` 同款三态语义。
 #[derive(Debug, Clone, Default)]
 pub struct UpdateMobileSyncSettingsInput {
     pub enabled: Option<bool>,
     pub lan_listen_enabled: Option<bool>,
     pub lan_advertise_ip: Option<Option<String>>,
+    /// 完整广告地址(scheme + host + 可选 port)的三态 patch。`Some(Some(url))`
+    /// 时会校验它是合法的 `http://` / `https://` URL 并归一化(去掉尾部斜杠);
+    /// 校验失败翻 [`UpdateMobileSyncSettingsError::InvalidLanParameter`]。
+    pub lan_advertise_base_url: Option<Option<String>>,
     pub lan_port: Option<Option<u16>>,
 }
 
@@ -61,6 +67,8 @@ pub struct UpdateMobileSyncSettingsOutput {
     pub lan_listen_enabled: bool,
     /// 落盘后的 `lan_advertise_ip` 值。
     pub lan_advertise_ip: Option<String>,
+    /// 落盘后的 `lan_advertise_base_url` 值(已归一化)。
+    pub lan_advertise_base_url: Option<String>,
     /// 落盘后的 `lan_port` 值。
     pub lan_port: Option<u16>,
     /// Wire-兼容历史字段。在 lifecycle port 引入前,这个标志告诉调用方
@@ -127,6 +135,18 @@ impl UpdateMobileSyncSettingsUseCase {
                 "lan_port must be 1..=65535, got 0".into(),
             ));
         }
+        // Validate + normalize the advertise base URL patch up front, so a
+        // malformed override fails before any read-modify-write. The stored
+        // value is the normalized form (trailing slash stripped).
+        let lan_advertise_base_url_patch: Option<Option<String>> =
+            match input.lan_advertise_base_url {
+                Some(Some(raw)) => Some(Some(
+                    normalize_advertise_base_url(&raw)
+                        .map_err(UpdateMobileSyncSettingsError::InvalidLanParameter)?,
+                )),
+                Some(None) => Some(None),
+                None => None,
+            };
 
         let mut current =
             self.settings.load().await.map_err(|err| {
@@ -142,17 +162,22 @@ impl UpdateMobileSyncSettingsUseCase {
             .lan_advertise_ip
             .clone()
             .unwrap_or_else(|| prev.lan_advertise_ip.clone());
+        let target_lan_advertise_base_url = lan_advertise_base_url_patch
+            .clone()
+            .unwrap_or_else(|| prev.lan_advertise_base_url.clone());
         let target_lan_port = input.lan_port.unwrap_or(prev.lan_port);
 
         let restart_required = target_enabled != prev.enabled
             || target_lan_listen_enabled != prev.lan_listen_enabled
             || target_lan_advertise_ip != prev.lan_advertise_ip
+            || target_lan_advertise_base_url != prev.lan_advertise_base_url
             || target_lan_port != prev.lan_port;
 
         if restart_required {
             current.mobile_sync.enabled = target_enabled;
             current.mobile_sync.lan_listen_enabled = target_lan_listen_enabled;
             current.mobile_sync.lan_advertise_ip = target_lan_advertise_ip.clone();
+            current.mobile_sync.lan_advertise_base_url = target_lan_advertise_base_url.clone();
             current.mobile_sync.lan_port = target_lan_port;
             self.settings.save(&current).await.map_err(|err| {
                 UpdateMobileSyncSettingsError::SettingsSaveFailed(err.to_string())
@@ -165,6 +190,7 @@ impl UpdateMobileSyncSettingsUseCase {
             enabled: target_enabled,
             lan_listen_enabled: target_lan_listen_enabled,
             lan_advertise_ip: target_lan_advertise_ip,
+            lan_advertise_base_url: target_lan_advertise_base_url,
             lan_port: target_lan_port,
             restart_required,
             // use case 不知道 lifecycle 是否被装配,更不知道 apply 后的
@@ -173,6 +199,37 @@ impl UpdateMobileSyncSettingsUseCase {
             lan_listener_bind_error: None,
         })
     }
+}
+
+// ─── helpers ──────────────────────────────────────────────────────────────
+
+/// 校验并归一化用户给的完整广告地址。
+///
+/// 约束:
+/// - 能被解析为 URL;
+/// - scheme 必须是 `http` 或 `https`(install URL / 二维码消费方按这两种
+///   scheme 拼接子路径);
+/// - 必须带非空 host。
+///
+/// 归一化:去掉尾部斜杠,使其与 `http://<ip>:<port>` 形态一致(消费方自行
+/// 拼接 `/...` 子路径,不应出现 `//`)。返回归一化后的字符串;校验失败返回
+/// 面向用户的英文错误描述。
+fn normalize_advertise_base_url(raw: &str) -> Result<String, String> {
+    let parsed =
+        Url::parse(raw).map_err(|e| format!("lan_advertise_base_url is not a valid URL: {e}"))?;
+    match parsed.scheme() {
+        "http" | "https" => {}
+        other => {
+            return Err(format!(
+                "lan_advertise_base_url scheme must be http or https, got `{other}`"
+            ));
+        }
+    }
+    match parsed.host_str() {
+        Some(host) if !host.is_empty() => {}
+        _ => return Err("lan_advertise_base_url must include a host".into()),
+    }
+    Ok(raw.trim_end_matches('/').to_string())
 }
 
 // ─── tests ──────────────────────────────────────────────────────────────
@@ -358,6 +415,7 @@ mod tests {
                 lan_listen_enabled: Some(true),
                 lan_advertise_ip: Some(Some("192.168.1.5".into())),
                 lan_port: Some(Some(42721)),
+                ..Default::default()
             })
             .await
             .expect("ok");
@@ -385,6 +443,90 @@ mod tests {
         );
         assert_eq!(out2.lan_port, Some(42721), "lan_port must be retained");
         assert!(out2.restart_required);
+    }
+
+    #[tokio::test]
+    async fn base_url_round_trips_and_normalizes_trailing_slash() {
+        let settings = Arc::new(InMemorySettings::default());
+        let uc = build_uc(settings.clone());
+
+        // 写入带尾斜杠的 base URL → 落盘的是去掉尾斜杠的归一化形态。
+        let out = uc
+            .execute(UpdateMobileSyncSettingsInput {
+                enabled: Some(true),
+                lan_listen_enabled: Some(true),
+                lan_advertise_base_url: Some(Some("https://clip.example.com/".into())),
+                ..Default::default()
+            })
+            .await
+            .expect("ok");
+        assert_eq!(
+            out.lan_advertise_base_url.as_deref(),
+            Some("https://clip.example.com"),
+            "trailing slash must be normalized away"
+        );
+        assert!(out.restart_required);
+
+        // 同值再写(归一化后)→ 不触发 restart。
+        let out2 = uc
+            .execute(UpdateMobileSyncSettingsInput {
+                lan_advertise_base_url: Some(Some("https://clip.example.com".into())),
+                ..Default::default()
+            })
+            .await
+            .expect("ok");
+        assert!(
+            !out2.restart_required,
+            "same normalized value must not write"
+        );
+
+        // 显式清空。
+        let out3 = uc
+            .execute(UpdateMobileSyncSettingsInput {
+                lan_advertise_base_url: Some(None),
+                ..Default::default()
+            })
+            .await
+            .expect("ok");
+        assert_eq!(
+            out3.lan_advertise_base_url, None,
+            "base url must be cleared"
+        );
+        assert!(out3.restart_required);
+    }
+
+    #[tokio::test]
+    async fn rejects_non_http_base_url() {
+        let settings = Arc::new(InMemorySettings::default());
+        let uc = build_uc(settings);
+        let err = uc
+            .execute(UpdateMobileSyncSettingsInput {
+                lan_advertise_base_url: Some(Some("ftp://clip.example.com".into())),
+                ..Default::default()
+            })
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            UpdateMobileSyncSettingsError::InvalidLanParameter(ref s) if s.contains("http or https")
+        ));
+    }
+
+    #[tokio::test]
+    async fn rejects_malformed_base_url() {
+        let settings = Arc::new(InMemorySettings::default());
+        let uc = build_uc(settings);
+        let err = uc
+            .execute(UpdateMobileSyncSettingsInput {
+                lan_advertise_base_url: Some(Some("not a url".into())),
+                ..Default::default()
+            })
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            UpdateMobileSyncSettingsError::InvalidLanParameter(_)
+        ));
     }
 
     #[tokio::test]

--- a/src-tauri/crates/uc-cli/src/commands/mobile_sync/lan.rs
+++ b/src-tauri/crates/uc-cli/src/commands/mobile_sync/lan.rs
@@ -2,10 +2,14 @@
 //!
 //! 子命令:
 //! * `list-interfaces` —— 读命令,显示 RFC1918 LAN 候选(daemon 跑时也允许)。
-//! * `enable --advertise <IP> [--port <P>] [--accept-network-risk]` —— 写命令。
-//!   `--advertise` 决定写进 SyncClipboard install URL 给 iPhone 的 IP
-//!   (daemon socket 始终绑 0.0.0.0)。不带 `--accept-network-risk` 时打印
-//!   安全告警 + 交互确认(SPEC §3.4)。
+//! * `enable (--advertise <IP> | --advertise-url <URL>) [--port <P>]
+//!   [--accept-network-risk]` —— 写命令。二选一:
+//!   - `--advertise <IP>` 写进 install URL 的 LAN IP,得到
+//!     `http://<IP>:<port>`;
+//!   - `--advertise-url <URL>` 写进 install URL 的完整 base URL(如
+//!     `https://clip.example.com`),用于 TLS 反向代理前置的公网部署。
+//!   两者互斥且必须给其一。daemon socket 始终绑 `0.0.0.0:<port>`。不带
+//!   `--accept-network-risk` 时打印安全告警 + 交互确认(SPEC §3.4)。
 //! * `disable` —— 写命令。
 
 use clap::Subcommand;
@@ -21,13 +25,26 @@ use crate::ui;
 pub enum LanCommands {
     /// List eligible RFC1918 LAN IPv4 interfaces.
     ListInterfaces,
-    /// Enable the LAN listener (binds 0.0.0.0; --advertise decides the
-    /// IP printed in the install URL given to the iPhone).
+    /// Enable the LAN listener (binds 0.0.0.0). Exactly one of
+    /// --advertise / --advertise-url decides the address printed in the
+    /// install URL / QR given to the phone.
+    #[command(group(
+        clap::ArgGroup::new("advertise_target")
+            .required(true)
+            .args(["advertise", "advertise_url"])
+    ))]
     Enable {
         /// LAN IPv4 to embed in the SyncClipboard install URL
-        /// (e.g. `192.168.1.5`). Pick one from `list-interfaces`.
+        /// (e.g. `192.168.1.5`). Pick one from `list-interfaces`. Produces
+        /// `http://<IP>:<port>`. Mutually exclusive with --advertise-url.
         #[arg(long, value_name = "IP")]
-        advertise: String,
+        advertise: Option<String>,
+        /// Full base URL (scheme + host + optional port) to embed in the
+        /// install URL / QR, e.g. `https://clip.example.com`. Use when a
+        /// TLS reverse proxy (Caddy, nginx, …) fronts the plain-HTTP LAN
+        /// listener for public access. Mutually exclusive with --advertise.
+        #[arg(long, value_name = "URL")]
+        advertise_url: Option<String>,
         /// Custom port; default 42720.
         #[arg(long, value_name = "PORT")]
         port: Option<u16>,
@@ -45,9 +62,20 @@ pub async fn run(command: LanCommands, json: bool, verbose: bool) -> i32 {
         LanCommands::ListInterfaces => list_interfaces(json, verbose).await,
         LanCommands::Enable {
             advertise,
+            advertise_url,
             port,
             accept_network_risk,
-        } => enable(advertise, port, accept_network_risk, json, verbose).await,
+        } => {
+            enable(
+                advertise,
+                advertise_url,
+                port,
+                accept_network_risk,
+                json,
+                verbose,
+            )
+            .await
+        }
         LanCommands::Disable => disable(json, verbose).await,
     }
 }
@@ -102,23 +130,45 @@ struct EnableResult {
     enabled: bool,
     lan_listen_enabled: bool,
     lan_advertise_ip: Option<String>,
+    lan_advertise_base_url: Option<String>,
     lan_port: Option<u16>,
     restart_required: bool,
 }
 
 async fn enable(
-    advertise: String,
+    advertise: Option<String>,
+    advertise_url: Option<String>,
     port: Option<u16>,
     accept_network_risk: bool,
     json: bool,
     verbose: bool,
 ) -> i32 {
-    // Print header + run interactive risk confirmation BEFORE facade wiring,
-    // so we can short-circuit cheaply if the user aborts (or the JSON-mode
-    // missing-flag check fires).
     if !json {
         ui::header("Mobile-sync LAN enable");
     }
+
+    // Translate the advertise choice into the two persisted fields. The
+    // `advertise_target` ArgGroup (required, mutually exclusive) already
+    // guarantees exactly one of the flags at the clap level — the other two
+    // arms are defensive and only reachable if that contract regresses. The
+    // two fields are kept mutually exclusive in storage too: setting one
+    // clears the other, so base_url-vs-ip precedence is never ambiguous.
+    let (advertise_ip_patch, advertise_url_patch) = match (advertise, advertise_url) {
+        (Some(ip), None) => (Some(Some(ip)), Some(None)),
+        (None, Some(url)) => (Some(None), Some(Some(url))),
+        (None, None) => {
+            ui::error("One of --advertise <IP> or --advertise-url <URL> is required.");
+            return exit_codes::EXIT_ERROR;
+        }
+        (Some(_), Some(_)) => {
+            ui::error("--advertise and --advertise-url are mutually exclusive.");
+            return exit_codes::EXIT_ERROR;
+        }
+    };
+
+    // Run interactive risk confirmation BEFORE facade wiring, so we can
+    // short-circuit cheaply if the user aborts (or the JSON-mode missing-flag
+    // check fires).
     if !accept_network_risk {
         if json {
             ui::error("--accept-network-risk is required in JSON mode (no interactive prompt).");
@@ -146,7 +196,8 @@ async fn enable(
             // 否则 daemon 启动时仍因 enabled=false 跳过 listener。
             enabled: Some(true),
             lan_listen_enabled: Some(true),
-            lan_advertise_ip: Some(Some(advertise)),
+            lan_advertise_ip: advertise_ip_patch,
+            lan_advertise_base_url: advertise_url_patch,
             lan_port: Some(port),
         })
         .await;
@@ -158,6 +209,7 @@ async fn enable(
                     enabled: out.enabled,
                     lan_listen_enabled: out.lan_listen_enabled,
                     lan_advertise_ip: out.lan_advertise_ip.clone(),
+                    lan_advertise_base_url: out.lan_advertise_base_url.clone(),
                     lan_port: out.lan_port,
                     restart_required: out.restart_required,
                 };
@@ -167,6 +219,10 @@ async fn enable(
                 ui::info(
                     "advertise",
                     out.lan_advertise_ip.as_deref().unwrap_or("(unset)"),
+                );
+                ui::info(
+                    "advertiseUrl",
+                    out.lan_advertise_base_url.as_deref().unwrap_or("(unset)"),
                 );
                 ui::info(
                     "port",

--- a/src-tauri/crates/uc-cli/src/commands/mobile_sync/settings.rs
+++ b/src-tauri/crates/uc-cli/src/commands/mobile_sync/settings.rs
@@ -31,6 +31,7 @@ struct SettingsDto {
     enabled: bool,
     lan_listen_enabled: bool,
     lan_advertise_ip: Option<String>,
+    lan_advertise_base_url: Option<String>,
     lan_port: Option<u16>,
     /// daemon 端 LAN listener 的 bind 失败原因(`Some` 时表示真的尝试过 bind 但失败)。
     lan_listener_error: Option<String>,
@@ -52,6 +53,7 @@ impl From<&MobileSyncSettingsView> for SettingsDto {
             enabled: v.enabled,
             lan_listen_enabled: v.lan_listen_enabled,
             lan_advertise_ip: v.lan_advertise_ip.clone(),
+            lan_advertise_base_url: v.lan_advertise_base_url.clone(),
             lan_port: v.lan_port,
             lan_listener_error: v.lan_listener_error.clone(),
             listen_url: derive_listen_url(v),
@@ -87,6 +89,12 @@ async fn show(json: bool, verbose: bool) -> i32 {
                     view.lan_advertise_ip
                         .as_deref()
                         .unwrap_or("(none, fallback 0.0.0.0)"),
+                );
+                ui::info(
+                    "lanAdvertiseUrl",
+                    view.lan_advertise_base_url
+                        .as_deref()
+                        .unwrap_or("(none, using LAN ip:port)"),
                 );
                 ui::info(
                     "lanPort",

--- a/src-tauri/crates/uc-cli/src/commands/mobile_sync/setup.rs
+++ b/src-tauri/crates/uc-cli/src/commands/mobile_sync/setup.rs
@@ -231,6 +231,10 @@ pub async fn run(args: SetupArgs, json: bool, verbose: bool) -> i32 {
             enabled: Some(true),
             lan_listen_enabled: Some(true),
             lan_advertise_ip: Some(Some(advertise_ip.clone())),
+            // `setup` provisions the LAN ip:port form; clear any prior full
+            // base-URL override so the two never coexist (the reverse-proxy
+            // path is `lan enable --advertise-url`, see that command).
+            lan_advertise_base_url: Some(None),
             lan_port: Some(Some(port)),
         })
         .await

--- a/src-tauri/crates/uc-cli/src/commands/mobile_sync/status.rs
+++ b/src-tauri/crates/uc-cli/src/commands/mobile_sync/status.rs
@@ -21,6 +21,7 @@ struct StatusDto {
     enabled: bool,
     lan_listen_enabled: bool,
     lan_advertise_ip: Option<String>,
+    lan_advertise_base_url: Option<String>,
     lan_port: Option<u16>,
     /// daemon 端 LAN listener 的 bind 失败原因(`Some` 时表示真的尝试过 bind 但失败)。
     lan_listener_error: Option<String>,
@@ -55,10 +56,16 @@ struct InstallMethodDto {
     disabled_reason: Option<String>,
 }
 
-/// 用户视角的"监听 URL":daemon 永远 bind `0.0.0.0:<lan_port>`,
-/// 但 advertise IP 是写进 install URL / 二维码的对外地址,所以这里取
-/// `lan_advertise_ip ?? "0.0.0.0"` + `lan_port ?? 42720`。
+/// 用户视角的"监听 URL"(即写进 install URL / 二维码的对外地址):
+/// - `lan_advertise_base_url=Some(url)` → 直接用该完整地址(优先级最高);
+/// - 否则回退 LAN 形态 `lan_advertise_ip ?? "0.0.0.0"` + `lan_port ?? 42720`。
+///
+/// daemon 永远 bind `0.0.0.0:<lan_port>`,这里展示的是对外公布地址,不是
+/// 实际 bind 地址。
 pub(crate) fn derive_listen_url(v: &MobileSyncSettingsView) -> String {
+    if let Some(base) = v.lan_advertise_base_url.as_deref() {
+        return base.to_string();
+    }
     let host = v.lan_advertise_ip.as_deref().unwrap_or("0.0.0.0");
     let port = v.lan_port.unwrap_or(42720);
     format!("http://{host}:{port}")
@@ -70,6 +77,7 @@ impl From<&MobileSyncSettingsView> for StatusDto {
             enabled: v.enabled,
             lan_listen_enabled: v.lan_listen_enabled,
             lan_advertise_ip: v.lan_advertise_ip.clone(),
+            lan_advertise_base_url: v.lan_advertise_base_url.clone(),
             lan_port: v.lan_port,
             lan_listener_error: v.lan_listener_error.clone(),
             listen_url: derive_listen_url(v),
@@ -122,6 +130,12 @@ pub async fn run(json: bool, verbose: bool) -> i32 {
             view.lan_advertise_ip
                 .as_deref()
                 .unwrap_or("(none, fallback 0.0.0.0)"),
+        );
+        ui::info(
+            "lanAdvertiseUrl",
+            view.lan_advertise_base_url
+                .as_deref()
+                .unwrap_or("(none, using LAN ip:port)"),
         );
         ui::info(
             "lanPort",

--- a/src-tauri/crates/uc-cli/src/main.rs
+++ b/src-tauri/crates/uc-cli/src/main.rs
@@ -486,14 +486,52 @@ mod tests {
     }
 
     #[test]
-    fn mobile_sync_lan_enable_requires_advertise() {
-        // `lan enable` 必须强制 `--advertise <IP>` —— iPhone 客户端需要
-        // 一个具体可达的 IP 写进 install URL;daemon 自己始终绑 0.0.0.0,
-        // 与 advertise 无关。
+    fn mobile_sync_lan_enable_requires_an_advertise_target() {
+        // `lan enable` 必须强制给出一个广告目标 —— iPhone 客户端需要一个
+        // 具体可达的地址写进 install URL;daemon 自己始终绑 0.0.0.0,与
+        // advertise 无关。两种形态二选一(`advertise_target` ArgGroup)。
         let result = Cli::try_parse_from(["uniclip", "mobile-sync", "lan", "enable"]);
         assert!(
             result.is_err(),
-            "expected `lan enable` to require --advertise"
+            "expected `lan enable` to require --advertise or --advertise-url"
+        );
+    }
+
+    #[test]
+    fn mobile_sync_lan_enable_accepts_advertise_url() {
+        // 反代形态:`--advertise-url` 单独给出即可满足 advertise_target 组。
+        let result = Cli::try_parse_from([
+            "uniclip",
+            "mobile-sync",
+            "lan",
+            "enable",
+            "--advertise-url",
+            "https://clip.example.com",
+            "--accept-network-risk",
+        ]);
+        assert!(
+            result.is_ok(),
+            "expected `lan enable --advertise-url` to parse"
+        );
+    }
+
+    #[test]
+    fn mobile_sync_lan_enable_rejects_both_advertise_forms() {
+        // 互斥:同时给 --advertise 和 --advertise-url 必须被 ArgGroup 拒绝。
+        let result = Cli::try_parse_from([
+            "uniclip",
+            "mobile-sync",
+            "lan",
+            "enable",
+            "--advertise",
+            "192.168.1.5",
+            "--advertise-url",
+            "https://clip.example.com",
+            "--accept-network-risk",
+        ]);
+        assert!(
+            result.is_err(),
+            "expected `lan enable` to reject both advertise forms at once"
         );
     }
 

--- a/src-tauri/crates/uc-core/src/settings/defaults.rs
+++ b/src-tauri/crates/uc-core/src/settings/defaults.rs
@@ -269,6 +269,7 @@ impl Default for MobileSyncSettings {
             enabled: false,
             lan_listen_enabled: false,
             lan_advertise_ip: None,
+            lan_advertise_base_url: None,
             lan_port: None,
         }
     }
@@ -547,7 +548,8 @@ mod tests {
         assert_eq!(s.pairing.step_timeout, std::time::Duration::from_secs(30));
     }
 
-    /// `mobile_sync` 段缺 `lan_advertise_ip` / `lan_port` 时回退 None。
+    /// `mobile_sync` 段缺 `lan_advertise_ip` / `lan_advertise_base_url` /
+    /// `lan_port` 时回退 None。
     #[test]
     fn mobile_sync_missing_optional_fields_fall_back_to_none() {
         let json = r#"{ "mobile_sync": { "enabled": true } }"#;
@@ -555,6 +557,7 @@ mod tests {
         assert!(s.mobile_sync.enabled);
         assert!(!s.mobile_sync.lan_listen_enabled);
         assert!(s.mobile_sync.lan_advertise_ip.is_none());
+        assert!(s.mobile_sync.lan_advertise_base_url.is_none());
         assert!(s.mobile_sync.lan_port.is_none());
     }
 

--- a/src-tauri/crates/uc-core/src/settings/model.rs
+++ b/src-tauri/crates/uc-core/src/settings/model.rs
@@ -318,6 +318,9 @@ pub struct NetworkSettings {
 ///   从 list-interfaces 候选里挑一个 RFC1918 私有地址。`None` 对应 UI 的
 ///   "自动"选项,展示 / register_device base_url 都退回 `0.0.0.0`(iPhone
 ///   连不上,需用户挑一个具体 IP 后再添加设备)。
+/// * `lan_advertise_base_url` —— 用户指定的完整广告地址(scheme + host +
+///   可选 port)。`Some` 时优先于 `lan_advertise_ip` 决定对外公布的连接
+///   地址;`None` 时回退到由 advertise IP 与端口拼出的地址形态。
 /// * `lan_port` —— 自定义端口。`None` 时取默认 `42720`(SPEC §3.2)。
 ///
 /// 任意字段变更后都需要重启 daemon 才能生效(v1 不做配置热重载,详见
@@ -353,6 +356,12 @@ pub struct MobileSyncSettings {
     /// (daemon 永远绑 `0.0.0.0`)。`None` 对应 UI 的"自动"选项,退回
     /// `0.0.0.0`(iPhone 连不上,需挑具体 IP)。
     pub lan_advertise_ip: Option<String>,
+
+    /// 用户指定的完整广告地址(scheme + host + 可选 port)。作为对移动
+    /// 客户端公布的连接地址,`Some` 时优先于 [`Self::lan_advertise_ip`];
+    /// `None` 时回退到由 advertise IP 与端口拼出的地址形态。仅影响对外
+    /// 公布的地址本身,不改变本机实际监听的地址。
+    pub lan_advertise_base_url: Option<String>,
 
     /// 用户自定义的 LAN 监听端口。`None` 时取默认 `42720`(SPEC §3.2)。
     pub lan_port: Option<u16>,

--- a/src-tauri/crates/uc-desktop/src/daemon/mobile_lan_lifecycle.rs
+++ b/src-tauri/crates/uc-desktop/src/daemon/mobile_lan_lifecycle.rs
@@ -465,6 +465,7 @@ mod tests {
             enabled,
             lan_listen_enabled,
             lan_advertise_ip: None,
+            lan_advertise_base_url: None,
             lan_port,
             lan_listener_error: None,
             shortcut_install_methods: Vec::new(),

--- a/src-tauri/crates/uc-tauri/src/commands/mobile_sync.rs
+++ b/src-tauri/crates/uc-tauri/src/commands/mobile_sync.rs
@@ -748,6 +748,12 @@ pub async fn update_mobile_sync_settings(
             enabled: args.enabled,
             lan_listen_enabled: args.lan_listen_enabled,
             lan_advertise_ip: args.lan_advertise_ip,
+            // The full base-URL override (reverse-proxy / HTTPS front-end) is
+            // a CLI-only provisioning option for now (`mobile-sync lan enable
+            // --advertise-url`). The GUI never touches it: `None` = leave the
+            // persisted value untouched, so a CLI-set override survives GUI
+            // edits to the other fields.
+            lan_advertise_base_url: None,
             lan_port: args.lan_port,
         };
         let out = facade.update_settings(input).await?;


### PR DESCRIPTION
## Summary

- Mobile-sync provisioning can now advertise a **full base URL** (scheme + host + optional port) so the generated install URL / QR points at an HTTPS reverse proxy (e.g. Caddy) instead of the internal plaintext `http://<ip>:<lan_port>`. The `mobile_lan` listener itself stays plain HTTP on the internal network (464cbb67).
- **core**: add `MobileSyncSettings.lan_advertise_base_url` (`Option<String>`). Doc comments are kept domain-focused — no protocol/tool/topology names — so the field stays consistent with the existing settings aggregate without leaking implementation detail into `uc-core`.
- **app**: `update_settings` validates + normalizes the URL (http/https, host required, trailing slash stripped); `get_settings` surfaces it; `register_device` honors it **over** the IP form when set (and skips LAN-interface auto-pick, so it works on a node with no RFC1918 NIC).
- **cli**: `mobile-sync lan enable --advertise-url <URL>` — mutually exclusive with `--advertise` and one of them required (clap `ArgGroup`). Setting one clears the other in storage, so base-URL-vs-IP precedence is never ambiguous. `mobile-sync status` / `settings show` reflect the advertised base URL.
- The legacy `--advertise <ip>` path still produces the LAN `http://<ip>:<port>` URL.

Scope note: the GUI (React) does **not** expose this option yet — it is CLI-only provisioning (matches ADR-007 §2.5's `lan enable --advertise-url` + `devices add` runbook). The Tauri `update_settings` passes `None` (leave untouched), so a CLI-set override survives GUI edits to the other fields.

Closes #901.

## Test plan

- [x] `cargo test` green: uc-core (573), uc-application, uc-cli (42), uc-tauri (75), uc-desktop (118).
- [x] `cargo check -p uc-cli -p uc-tauri` and `cargo fmt --check` clean.
- [x] `uniclip mobile-sync lan enable --help` shows the required mutually-exclusive group: `<--advertise <IP>|--advertise-url <URL>>`.
- [ ] End-to-end (reviewer): with the daemon stopped, run `mobile-sync lan enable --advertise-url https://<host> --accept-network-risk` then `devices add --label X`; confirm the QR encodes `https://<host>` and a phone connects through the reverse proxy while the internal listener stays plain HTTP.
- [ ] Decide whether the GUI should also expose `--advertise-url` (currently CLI-only; would need specta binding regeneration + a settings-panel field).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Mobile sync can now be exposed publicly via HTTPS reverse proxy (using tools like Caddy/nginx), with new `--advertise-url` CLI option.
  * Mutually exclusive configuration: use `--advertise <IP>` for plain LAN HTTP or `--advertise-url <URL>` for HTTPS reverse proxy.
  * Settings and status commands now report the configured advertise URL.

* **Documentation**
  * Updated guides and CLI reference with HTTPS reverse-proxy setup instructions and examples for both LAN and public exposure scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/UniClipboard/UniClipboard/pull/906?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->