### PR TITLE
feat(deploy): headless VPS server node — Docker, Caddy, image CI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,27 @@
+# Build context hygiene for the VPS server image (deploy/vps/Dockerfile).
+#
+# The image only compiles the `uc-cli` crate from the `src-tauri/` Rust
+# workspace, so everything below is irrelevant to the build. Excluding it
+# keeps the context transfer small and avoids shipping huge artifact trees
+# (Rust `target/`, node_modules) into the daemon.
+#
+# IMPORTANT: do NOT exclude `src-tauri/` or `src-tauri/vendor/` — the build
+# needs the workspace and the vendored `iroh-blobs` submodule.
+
+.git
+.github
+node_modules
+**/node_modules
+**/target
+dist
+dist-ssr
+docs-site
+e2e
+public
+assets
+snap
+coverage
+.superset
+.planning
+.husky
+*.log

--- a/.github/workflows/build-server-image.yml
+++ b/.github/workflows/build-server-image.yml
@@ -1,0 +1,183 @@
+name: 'Build server image'
+run-name: "build-server-image-${{ github.ref_name }}-${{ github.run_number }}"
+
+# 无头 VPS server 节点镜像 (deploy/vps/Dockerfile)。
+#
+# 触发:
+#   - push tag v* → 跟 release.yml 同一个 tag 触发,并行产出多 arch 镜像并
+#     推到 GHCR(不阻塞 release.yml 的二进制发布,二者相互独立)。
+#   - 手动 dispatch → 临时构建某个 ref,可用 `tag` 覆盖镜像 tag。
+#
+# 多 arch 策略:server 镜像在 Dockerfile 里编 Rust(aws-lc/iroh/sqlx),QEMU
+# 模拟 arm64 编译会慢到不可用,因此每个 arch 在各自的 native runner 上构建,
+# push by digest,最后用 buildx imagetools 合并成一个 manifest list。这与
+# build-cli.yml 的 native 多 arch 思路一致。
+#
+# 首次推送后请到 GitHub Packages 设置里把 uniclipboard-server 的 visibility
+# 调成 public,否则用户 `docker compose pull` 会 401。
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: '要构建的 git ref(分支/tag/sha),留空用当前 ref'
+        required: false
+        type: string
+        default: ''
+      tag:
+        description: '覆盖镜像 tag(留空时由 ref 推导)'
+        required: false
+        type: string
+        default: ''
+
+# 同一 ref 的新一轮取消旧的在途构建,省 runner。
+concurrency:
+  group: server-image-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  REGISTRY: ghcr.io
+  # GHCR path 必须小写,owner 大小写不一定一致,merge 时再 lowercase。
+  IMAGE_NAME: ${{ github.repository_owner }}/uniclipboard-server
+
+jobs:
+  build:
+    name: Build ${{ matrix.platform }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-22.04
+          - platform: linux/arm64
+            runner: ubuntu-22.04-arm
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Lowercase image name
+        id: img
+        run: echo "image=${REGISTRY}/${IMAGE_NAME,,}" >> "$GITHUB_OUTPUT"
+
+      - name: Sanitize platform pair
+        run: echo "PLATFORM_PAIR=${platform//\//-}" >> "$GITHUB_ENV"
+        env:
+          platform: ${{ matrix.platform }}
+
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+          # The musl build needs the vendored iroh-blobs submodule.
+          submodules: recursive
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          # Context is the repo root so the Dockerfile reaches the src-tauri/
+          # workspace + the vendored submodule. .dockerignore trims it.
+          context: .
+          file: deploy/vps/Dockerfile
+          platforms: ${{ matrix.platform }}
+          cache-from: type=gha,scope=server-${{ env.PLATFORM_PAIR }}
+          cache-to: type=gha,mode=max,scope=server-${{ env.PLATFORM_PAIR }}
+          outputs: type=image,name=${{ steps.img.outputs.image }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p "${{ runner.temp }}/digests"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    name: Merge manifest + push tags
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Lowercase image name
+        id: img
+        run: echo "image=${REGISTRY}/${IMAGE_NAME,,}" >> "$GITHUB_OUTPUT"
+
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ steps.img.outputs.image }}
+          # v0.13.0 → 0.13.0 + 0.13 (+ latest for stable). Prereleases
+          # (v0.13.0-alpha.1) get the full version tag but NOT latest.
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix=sha-,format=short
+            type=raw,value=${{ inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' && inputs.tag != '' }}
+          flavor: |
+            latest=auto
+
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          # Intentional word splitting: the jq/printf substitutions must expand
+          # into separate `-t <tag>` flags and `<image>@sha256:<digest>` args.
+          # shellcheck disable=SC2046
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ steps.img.outputs.image }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: docker buildx imagetools inspect "${{ steps.img.outputs.image }}:${{ steps.meta.outputs.version }}"
+
+      - name: Summary
+        run: |
+          {
+            echo "## Server image pushed :package:"
+            echo ""
+            echo "Multi-arch (amd64 + arm64) manifest list:"
+            echo '```'
+            echo "${{ steps.meta.outputs.tags }}"
+            echo '```'
+            echo ""
+            echo "Deploy: see \`deploy/vps/README.md\` (Option A — pull the prebuilt image)."
+            echo "> First push only: set the package visibility to public so anonymous \`docker compose pull\` works."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/deploy/vps/.env.example
+++ b/deploy/vps/.env.example
@@ -1,0 +1,23 @@
+# UniClipboard VPS server — deployment configuration.
+# Copy to `.env` (same directory) and fill in your values:
+#   cp .env.example .env
+# docker compose automatically loads `.env` from this directory.
+
+# Public DNS name pointing at this VPS (A / AAAA record). Caddy obtains a TLS
+# certificate for it, and it becomes the phone's install URL base.
+UC_DOMAIN=clip.example.com
+
+# Public IP address of this VPS. Advertised to desktop peers so they can dial
+# this node directly over iroh (RelayMode is disabled — there is no relay
+# fallback). Use the IPv4 address reachable from the public internet.
+UC_PUBLIC_IP=203.0.113.7
+
+# Fixed UDP port for iroh direct connections. Published to the host and
+# advertised as part of UC_IROH_PUBLIC_ADDR. Open it in the VPS firewall.
+UC_IROH_BIND_PORT=42999
+
+# Optional: prebuilt image to run. Defaults to the latest published image.
+# Pin a specific release for reproducibility, e.g.:
+#   UC_IMAGE=ghcr.io/uniclipboard/uniclipboard-server:v0.13.0
+# Leave unset to track :latest, or ignore entirely when building from source.
+# UC_IMAGE=ghcr.io/uniclipboard/uniclipboard-server:latest

--- a/deploy/vps/Caddyfile
+++ b/deploy/vps/Caddyfile
@@ -1,0 +1,16 @@
+# UniClipboard mobile-sync gateway — TLS termination + reverse proxy (ADR-007 §2.5).
+#
+# Caddy obtains and renews a certificate for $UC_DOMAIN automatically
+# (ACME HTTP-01 / TLS-ALPN), then proxies every request to the app container's
+# mobile_lan listener over the internal Docker network. The plaintext mobile_lan
+# port is never published to the host — only Caddy's 80/443 are. The phone's
+# install URL must point at https://$UC_DOMAIN (set via `mobile-sync lan enable
+# --advertise-url`).
+#
+# mobile_lan is plain HTTP + Basic Auth with no websockets, so a default
+# reverse_proxy (which forwards the Authorization header and streams bodies) is
+# all that is required. Caddy adds X-Forwarded-* automatically.
+
+{$UC_DOMAIN} {
+	reverse_proxy app:42720
+}

--- a/deploy/vps/Dockerfile
+++ b/deploy/vps/Dockerfile
@@ -1,0 +1,85 @@
+# syntax=docker/dockerfile:1
+#
+# Headless UniClipboard server node for VPS deployment (ADR-007).
+#
+# Two stages:
+#   1. builder  — compiles the `uniclip` binary as a static musl executable.
+#   2. runtime  — minimal Alpine image that runs the binary as a non-root
+#                 user with HOME=/data anchoring all state on a mounted volume.
+#
+# Build context is the repository ROOT (see deploy/vps/docker-compose.yml),
+# so paths below are repo-relative. Initialize submodules before building:
+#   git submodule update --init --recursive
+
+# ── builder ──────────────────────────────────────────────────────────────────
+# uc-cli's dependency graph is ring + rustls (no openssl-sys / aws-lc-sys), so
+# the musl target links fully statically with zero C-runtime dependencies — the
+# resulting binary runs on the Alpine runtime stage (and anywhere else) as-is.
+FROM rust:1.95-bookworm AS builder
+
+# musl-tools provides musl-gcc, the static C linker that `ring`/`cc` invoke for
+# the *-musl target. cmake + clang/libclang build aws-lc-sys (pulled into the
+# uc-cli graph via aws-lc-rs). This mirrors .github/docker/build-bookworm.Dockerfile
+# minus the GUI libs. `Acquire::Retries` rides out transient Debian mirror 5xx.
+RUN echo 'Acquire::Retries "5";' > /etc/apt/apt.conf.d/80-retries \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends musl-tools cmake clang \
+ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+
+# The whole Rust workspace lives under src-tauri/. The vendored iroh-blobs fork
+# (src-tauri/vendor/iroh-blobs) is consumed via [patch.crates-io] and must be
+# present in the context — that is why submodules must be initialized first.
+COPY src-tauri/ ./src-tauri/
+WORKDIR /build/src-tauri
+
+# Pick the musl target matching the build host arch (native compile, no cross).
+# Build and copy the binary out within a single RUN: the target/ dir is a
+# cache mount (not persisted into the image), so the copy must happen here.
+#
+# On aarch64, GCC compiles the vendored C in libdbus-sys / libsqlite3-sys / etc.
+# with __aarch64_*_sync outline-atomic helpers that live in libgcc. A static
+# musl link with -nodefaultlibs cannot resolve them, so we tell GCC to inline
+# the atomics (-mno-outline-atomics) via the cc crate's CFLAGS env. This is a
+# no-op on x86_64 (the flag is aarch64-only and GCC there emits no such helpers).
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/build/src-tauri/target \
+    set -eux; \
+    case "$(uname -m)" in \
+      x86_64)  TARGET=x86_64-unknown-linux-musl ;; \
+      aarch64) TARGET=aarch64-unknown-linux-musl; \
+               export TARGET_CFLAGS="-mno-outline-atomics" \
+                      CFLAGS_aarch64_unknown_linux_musl="-mno-outline-atomics" ;; \
+      *) echo "unsupported build arch: $(uname -m)" >&2; exit 1 ;; \
+    esac; \
+    rustup target add "$TARGET"; \
+    cargo build --locked --release -p uc-cli --target "$TARGET"; \
+    cp "target/$TARGET/release/uniclip" /uniclip
+
+# ── runtime ──────────────────────────────────────────────────────────────────
+FROM alpine:3.20 AS runtime
+
+# ca-certificates: TLS roots for outbound HTTPS (pairing rendezvous, etc.).
+# busybox `wget` backs the compose healthcheck against the daemon control port.
+RUN apk add --no-cache ca-certificates \
+ && adduser -D -u 10001 -h /data uniclip \
+ && mkdir -p /data \
+ && chown uniclip:uniclip /data
+
+COPY --from=builder /uniclip /usr/local/bin/uniclip
+
+# HOME=/data anchors ALL persistent state under the mounted volume — iroh
+# identity, vault/keyslot, file-based KEK, sqlite db, blob cache and settings —
+# so the node never needs re-pairing across restarts. See deploy/vps/README.md.
+ENV HOME=/data
+USER uniclip
+WORKDIR /data
+
+# Default: run the headless server daemon in the foreground as the container's
+# main process. `start --server` sets UC_DAEMON_RUN_MODE=server (no system
+# clipboard, no watcher); `--foreground` keeps it attached. The compose `app`
+# service overrides this explicitly, and one-off provisioning commands replace
+# it entirely (e.g. `docker compose run --rm app uniclip join`). No ENTRYPOINT
+# so `docker compose run app uniclip <cmd>` works without arg duplication.
+CMD ["uniclip", "start", "--server", "--foreground"]

--- a/deploy/vps/README.md
+++ b/deploy/vps/README.md
@@ -1,0 +1,231 @@
+# UniClipboard headless server node — VPS deployment
+
+Run UniClipboard headless on your own VPS as an always-online Space member. The
+node syncs clipboard over iroh like any desktop peer and serves the mobile-sync
+gateway to your phone behind a TLS reverse proxy. There is **no system
+clipboard** — it is a relay/online member, not a desktop.
+
+This stack is the implementation of
+[ADR-007](../../docs/architecture/adr-007-headless-server-node-deployment.md).
+
+## Topology
+
+```text
+          desktop peers (other networks)
+                  │  iroh direct (UDP, RelayMode=Disabled)
+                  ▼
+   ┌─────────────────────────────────────────────┐  VPS
+   │  app container (uniclip start --server)       │
+   │   • iroh member  → published UDP :42999/udp   │◀── public internet
+   │   • mobile_lan   → expose :42720 (internal)   │
+   │   • HOME=/data   → volume `uniclip-state`     │
+   └──────────────────────┬──────────────────────┘
+                           │ http  app:42720  (internal Docker net only)
+   ┌──────────────────────▼──────────────────────┐
+   │  caddy container                              │
+   │   • TLS termination + auto cert for $UC_DOMAIN│◀── phone https://$UC_DOMAIN
+   │   • published :80 / :443                       │
+   └─────────────────────────────────────────────┘
+```
+
+The plaintext `mobile_lan` port (`42720`) is **never** published to the host —
+only Caddy's `80`/`443` and the iroh `42999/udp` port reach the public internet.
+
+### Ports
+
+| Port           | Where        | Purpose                                        |
+| -------------- | ------------ | ---------------------------------------------- |
+| `42999/udp`    | host public  | iroh direct connections from desktop peers     |
+| `443` (+`/udp`)| host public  | HTTPS for the phone (Caddy → mobile_lan)        |
+| `80`           | host public  | ACME challenge + HTTPS redirect (Caddy)         |
+| `42720`        | internal only| `mobile_lan` plaintext HTTP (Caddy upstream)    |
+| `42715`        | container    | daemon loopback control server (healthcheck)    |
+
+## Prerequisites
+
+- A VPS with a public IPv4 address and **Docker + Docker Compose v2**.
+- A domain whose **A/AAAA record points at the VPS** (Caddy needs this to issue
+  a certificate). DNS must resolve before you bring up Caddy.
+- VPS firewall / security group open for: `80/tcp`, `443/tcp`, `443/udp`,
+  `42999/udp`.
+- An existing Space with another device online to pair with (you run `invite`
+  on a desktop, and `join` here). This node *joins* — it does not create a Space.
+
+## Image: pull or build
+
+**Option A — pull the prebuilt image (recommended).** Every release publishes a
+multi-arch (amd64 + arm64) image to the GitHub Container Registry, built by
+`.github/workflows/build-server-image.yml`. No source checkout or compiler
+needed — just this `deploy/vps/` directory and a `.env`:
+
+```bash
+docker compose pull
+```
+
+Track `:latest` by default, or pin a release in `.env` with
+`UC_IMAGE=ghcr.io/uniclipboard/uniclipboard-server:vX.Y.Z`.
+
+**Option B — build from source.** Requires the repository checked out **with
+submodules** (the build needs the vendored `iroh-blobs` fork) and ~4 GB RAM:
+
+```bash
+git submodule update --init --recursive   # or: git clone --recursive <repo-url>
+docker compose build
+```
+
+On a small droplet, build elsewhere and ship it — e.g.
+`docker save ghcr.io/uniclipboard/uniclipboard-server:latest | ssh vps 'docker load'`,
+or push to your own registry and set `UC_IMAGE` accordingly.
+
+## 1. Configure
+
+```bash
+cd deploy/vps
+cp .env.example .env
+# edit .env: UC_DOMAIN, UC_PUBLIC_IP, UC_IROH_BIND_PORT
+```
+
+## 2. Provision (one-time, interactive — BEFORE the daemon)
+
+`join` and the `mobile-sync` write commands refuse to run while a daemon is up,
+so all provisioning happens in one-off containers first. They share the same
+`uniclip-state` volume, so what they write is exactly what the long-running
+daemon reads in step 3.
+
+Make sure the image is available first — `docker compose pull` (Option A) or
+`docker compose build` (Option B), per [Image: pull or build](#image-pull-or-build).
+
+**a. Join the Space.** On a desktop already in the Space, run `uniclip invite`
+(or use the desktop UI) to get an invitation code, then:
+
+```bash
+docker compose run --rm app uniclip join
+```
+
+This prompts interactively for the **invitation code** and the **Space
+passphrase** (run it from an interactive terminal). For a fully non-interactive
+run you can pass them as flags instead — note these land in your shell history:
+
+```bash
+docker compose run --rm app uniclip join --code <CODE> --passphrase <PASSPHRASE>
+```
+
+**b. Enable the mobile-sync gateway for the public domain.** `--advertise-url`
+makes the phone's install URL/QR point at Caddy instead of a LAN IP:
+
+```bash
+docker compose run --rm app \
+  uniclip mobile-sync lan enable \
+  --advertise-url https://${UC_DOMAIN:-clip.example.com} \
+  --accept-network-risk
+```
+
+**c. Register your phone.** Mints credentials and prints the install QR/URL:
+
+```bash
+docker compose run --rm app uniclip mobile-sync devices add --label "My iPhone"
+```
+
+Scan the QR (or open the printed `https://<domain>` URL) in the SyncClipboard /
+UniClipboard mobile client. Repeat for each phone.
+
+## 3. Start the stack
+
+```bash
+docker compose up -d
+```
+
+`app` runs `uniclip start --server --foreground` as its main process (headless,
+no system clipboard). Caddy starts once `app` reports healthy, issues the
+certificate for `UC_DOMAIN`, and begins proxying.
+
+## 4. Verify
+
+```bash
+# Daemon healthy and in server mode:
+docker compose ps                       # app should be "healthy"
+docker compose logs -f app
+
+# TLS + gateway reachable from the public internet (401 = listener up, auth
+# required — that is expected without credentials):
+curl -i https://<your-domain>/SyncClipboard.json
+
+# The plaintext port is NOT exposed on the host (should fail / refuse):
+curl -i http://<your-domain>:42720/SyncClipboard.json
+```
+
+Acceptance walk-through:
+
+- Copy something on a paired desktop on another network → it lands here over
+  iroh (visible in `docker compose logs app`).
+- On the phone, pull the latest clipboard and push new content → it fans out to
+  the desktops through Caddy.
+
+## State & backups
+
+Everything needed to keep identity + membership + mobile credentials lives under
+`HOME=/data` on the `uniclip-state` volume, so the node **never re-pairs** across
+restarts. Under `/data/.local/share/app.uniclipboard.desktop/`:
+
+| State                         | Path                                  |
+| ----------------------------- | ------------------------------------- |
+| iroh identity (node secret)   | `iroh-identity/` (file secure storage)|
+| file-based KEK                | `keyring/`                            |
+| keyslot + device id           | `vault/keyslot.json`, `vault/device_id.txt` |
+| database                      | `uniclipboard.db`                     |
+| iroh blob cache               | `iroh-blobs/blobs.db`                 |
+| settings (mobile creds, LAN)  | `settings.json`                       |
+
+The daemon falls back to file-based secure storage automatically (no D-Bus /
+keyring on a headless box), so the iroh secret and KEK are on the volume — keep
+the volume and you keep the node.
+
+Back up both named volumes — `uniclip-state` (re-pairing if lost) and
+`caddy-data` (TLS certificates / ACME account; losing it forces re-issuance and
+risks Let's Encrypt rate limits):
+
+```bash
+docker run --rm -v uniclip-state:/data -v "$PWD":/backup alpine \
+  tar czf /backup/uniclip-state.tgz -C /data .
+```
+
+## Operations
+
+```bash
+docker compose logs -f app             # follow daemon logs
+docker compose restart app             # restart the daemon (state preserved)
+docker compose down                    # stop the stack (volumes preserved)
+docker compose pull && docker compose up -d    # update (Option A: prebuilt image)
+docker compose up -d --build           # update (Option B: rebuild from source)
+```
+
+Updates keep the `uniclip-state` volume, so no re-pairing — a new image just
+swaps the binary. To move to a pinned release, bump `UC_IMAGE` in `.env` before
+`docker compose pull`.
+
+To change the advertised domain or add devices later, **stop the daemon first**
+(`docker compose down`), rerun the relevant `docker compose run --rm app
+uniclip mobile-sync …` command, then `docker compose up -d` — the write commands
+still refuse to run while the daemon is up.
+
+## Security notes
+
+- `mobile_lan` is plaintext HTTP + Basic Auth, designed for trusted LANs. On the
+  public internet it is **only** reachable through Caddy's TLS — keep `42720` on
+  the internal network (this compose does; do not add a host port mapping for it).
+- There is no relay fallback (`RelayMode::Disabled`). If a desktop's network
+  blocks outbound UDP to `UC_IROH_BIND_PORT`, it cannot reach this node directly.
+- The healthcheck assumes no `UC_PROFILE` is set (daemon control port `42715`).
+  If you set `UC_PROFILE`, the control port changes — update the healthcheck.
+
+## Troubleshooting
+
+- **`setup not complete` on `up -d`** — provisioning (step 2a `join`) did not
+  persist to the volume. Confirm you ran the `docker compose run` commands
+  against this same project/volume, then retry.
+- **Caddy cannot get a certificate** — DNS for `UC_DOMAIN` must resolve to this
+  VPS and `80`/`443` must be open before `up -d`. Check `docker compose logs caddy`.
+- **Phone gets the wrong URL** — re-run step 2b with the correct
+  `--advertise-url https://<domain>` (daemon stopped), then `up -d`.
+- **Desktop on another network won't connect** — verify `42999/udp` is open in
+  the VPS firewall and that `UC_PUBLIC_IP` in `.env` is the real public IP.

--- a/deploy/vps/docker-compose.yml
+++ b/deploy/vps/docker-compose.yml
@@ -1,0 +1,94 @@
+# UniClipboard headless server node + Caddy TLS reverse proxy (ADR-007 §2.8).
+#
+# Topology:
+#   - app   : the headless daemon. Joins the Space over iroh as a normal member
+#             and serves the mobile_lan gateway. State persists on a named
+#             volume mounted at /data (HOME). The iroh UDP port is published to
+#             the host for direct desktop dialing; the plaintext mobile_lan port
+#             is only `expose`d on the internal network — never to the host.
+#   - caddy : terminates TLS on 443 with an automatic certificate for your
+#             domain and reverse-proxies to app's mobile_lan port.
+#
+# Configure deploy/vps/.env first (copy from .env.example). Provisioning
+# (join + mobile-sync) runs via `docker compose run` BEFORE `up -d` — see README.
+
+services:
+  app:
+    # Option A (recommended): pull the prebuilt multi-arch image published on
+    # release (`docker compose pull`). Pin a version via UC_IMAGE in .env.
+    # Option B: build from source (`docker compose build` / `up -d --build`) —
+    # the build: block below tags the result under this same name.
+    image: ${UC_IMAGE:-ghcr.io/uniclipboard/uniclipboard-server:latest}
+    build:
+      # Context is the repo root so the Dockerfile can reach the src-tauri/
+      # workspace and the vendored iroh-blobs submodule.
+      context: ../..
+      dockerfile: deploy/vps/Dockerfile
+    restart: unless-stopped
+    # tini as PID 1: reaps the daemon's children and forwards signals cleanly.
+    init: true
+    stop_grace_period: 30s
+    environment:
+      # Anchor all state on the volume (redundant with the image ENV, kept
+      # explicit so the contract is visible at the orchestration layer).
+      HOME: /data
+      # No system clipboard on a headless box. `start --server` and the
+      # provisioning commands (join / mobile-sync) already enable Noop on their
+      # own paths; setting it service-wide also keeps ad-hoc debugging commands
+      # (e.g. `uniclip status`) from trying to open a non-existent display.
+      UC_DISABLE_SYSTEM_CLIPBOARD: "1"
+      # Pin the iroh UDP port and advertise this VPS's public socket so
+      # desktops on other networks can dial directly (RelayMode::Disabled).
+      UC_IROH_BIND_PORT: ${UC_IROH_BIND_PORT:-42999}
+      UC_IROH_PUBLIC_ADDR: ${UC_PUBLIC_IP}:${UC_IROH_BIND_PORT:-42999}
+    volumes:
+      - uniclip-state:/data
+    ports:
+      # iroh direct-connection UDP port — MUST be reachable from the public
+      # internet (open it in the VPS firewall / security group too).
+      - "${UC_IROH_BIND_PORT:-42999}:${UC_IROH_BIND_PORT:-42999}/udp"
+    expose:
+      # mobile_lan plaintext HTTP — internal Docker network ONLY. Caddy reaches
+      # it as app:42720. Never published to the host.
+      - "42720"
+    networks:
+      - uniclip
+    command: ["uniclip", "start", "--server", "--foreground"]
+    healthcheck:
+      # The daemon's loopback control server answers /health on 42715 when no
+      # UC_PROFILE is set (the recommended VPS config). Proves the daemon is
+      # alive and serving; Caddy waits for this before starting.
+      test: ["CMD", "wget", "-q", "-O", "-", "http://127.0.0.1:42715/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
+
+  caddy:
+    image: caddy:2-alpine
+    restart: unless-stopped
+    depends_on:
+      app:
+        condition: service_healthy
+    environment:
+      # Consumed by the Caddyfile via {$UC_DOMAIN}.
+      UC_DOMAIN: ${UC_DOMAIN}
+    ports:
+      - "80:80"        # ACME HTTP-01 challenge + HTTPS redirect
+      - "443:443"      # TLS (HTTP/1.1, HTTP/2)
+      - "443:443/udp"  # HTTP/3 (optional)
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy-data:/data      # certificates + ACME account (persist these!)
+      - caddy-config:/config
+    networks:
+      - uniclip
+
+volumes:
+  uniclip-state: # iroh identity, vault/KEK, sqlite db, blob cache, settings
+  caddy-data: # issued TLS certificates — keep to avoid re-issuance/rate limits
+  caddy-config:
+
+networks:
+  uniclip:
+    driver: bridge

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,10 @@ When documentation conflicts with code, treat the code as the source of truth an
 - [Error Handling](guides/error-handling.md) - Error handling strategy
 - [GitHub Releases Updater](guides/github-releases-updater.md) - Auto-update pipeline with latest.json
 
+**For Operators / Deployment:**
+
+- [Headless VPS Server Node](../deploy/vps/README.md) - Docker + Caddy stack and provisioning runbook for a self-hosted always-online member ([ADR-007](architecture/adr-007-headless-server-node-deployment.md))
+
 **For Code Review:**
 
 - [Coding Standards](guides/coding-standards.md) - Code style and conventions


### PR DESCRIPTION
## Summary

Package the headless server node (`docs/architecture/adr-007-headless-server-node-deployment.md`) for public VPS deployment, runnable from a prebuilt image or built from source.

- **VPS stack + runbook** (`56b8d17a`): multi-stage `Dockerfile` (static-musl `uniclip` on a minimal Alpine runtime, `HOME=/data`), `docker-compose` (headless daemon + Caddy TLS reverse proxy), `Caddyfile`, and a provisioning `README`. One state volume covers iroh identity, vault/keyslot, file KEK, db and blob cache, so the node never re-pairs. The plaintext `mobile_lan` port stays internal-only — only Caddy's `443` and the iroh UDP port are published.
- **Release image publishing** (`60957058`): `build-server-image` workflow builds the image natively per-arch (amd64 on `ubuntu-22.04`, arm64 on `ubuntu-22.04-arm` — no QEMU since it compiles Rust), pushes by digest, and merges into one manifest list at `ghcr.io/uniclipboard/uniclipboard-server` on `v*` tags. Compose defaults to the published image (`UC_IMAGE` override) with the source build kept as a fallback.

Refs #902. Final acceptance (cross-network iroh + a real ACME certificate) is HITL — it needs a real VPS + domain, so I did not auto-close the issue.

docs-site left as-is: this PR changes no user-facing CLI/env/behavior contract. The surface it relies on (`uniclip start --server`, `UC_IROH_BIND_PORT`, `UC_IROH_PUBLIC_ADDR`, `mobile-sync lan enable --advertise-url`) is already documented and unchanged.

## Test plan

- [x] Image builds (multi-stage static-musl) → 57 MB Alpine image. Fixed an aarch64 musl link failure in `libdbus-sys`'s vendored C (`__aarch64_*_sync` outline atomics) via `-mno-outline-atomics`.
- [x] Local end-to-end on Docker: headless `init` + `mobile-sync lan enable` + `devices add`; `up -d` → daemon healthy in server mode; `https://localhost` → Caddy TLS → `mobile_lan` returns `401`; host `:42720` connection refused; state persists across `down`/`up` with no re-pairing.
- [x] `actionlint` clean; `docker compose config` valid.
- [ ] Real VPS: a paired desktop on another network syncs over iroh via the published UDP port + advertised public address.
- [ ] Real VPS: a phone via `https://<domain>` pulls and pushes through Caddy with a real certificate.
- [ ] First image push only: set the GHCR package visibility to public so anonymous `docker compose pull` works.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added GitHub Actions workflow for automated multi-architecture Docker image building and publishing (amd64, arm64)
  * Configured Docker build optimization

* **Documentation**
  * Added comprehensive VPS deployment guide with configuration, setup steps, and operational instructions
  * Added deployment topology and prerequisites documentation
  * Updated main documentation navigation with deployment resources

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/UniClipboard/UniClipboard/pull/910?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->