### PR TITLE
docs(docs-site): headless VPS server-node deployment guide

### DIFF
--- a/docs-site/content/docs/en/guides/meta.json
+++ b/docs-site/content/docs/en/guides/meta.json
@@ -2,5 +2,5 @@
   "title": "Guides",
   "icon": "BookOpen",
   "defaultOpen": true,
-  "pages": ["pairing", "settings", "self-host-relay"]
+  "pages": ["pairing", "settings", "self-host-relay", "self-host-server-node"]
 }

--- a/docs-site/content/docs/en/guides/self-host-server-node.mdx
+++ b/docs-site/content/docs/en/guides/self-host-server-node.mdx
@@ -1,0 +1,282 @@
+---
+title: Self-hosting a headless server node
+description: Run UniClipboard headless on a VPS as an always-online Space member with a phone gateway.
+---
+
+Since 0.13, UniClipboard can run on a server (VPS or container) as an
+**always-online member** of your Space — a background service with **no
+GUI and no system clipboard** (a "headless" node). It syncs clipboard
+over iroh exactly like a desktop peer, and serves the mobile-sync gateway
+to your phone behind TLS.
+
+Use it when you want clipboard sync to keep working even when all your
+desktops are asleep, and a stable HTTPS endpoint your phone can always reach.
+
+This guide covers:
+
+- What a server node is and isn't
+- Deploying with Docker Compose (prebuilt image, or build from source)
+- Provisioning: joining your Space and registering your phone
+- TLS via the bundled Caddy, or behind a reverse proxy you already run
+- Verifying, operating, and backing it up
+
+## What it is and isn't
+
+A server node is a **normal iroh member** that happens to be always
+online and has no display:
+
+- **Is**: an online peer that receives clipboard pushed by your desktops
+  and persists it; a phone gateway that serves
+  `GET /SyncClipboard.json` (pull) and `PUT` (push, fanned out back to
+  your desktops over iroh).
+- **Is not**: a relay, and **not** a central store-and-forward mailbox.
+  It only keeps what it received **while it was online** — it is not an
+  offline inbox. When a peer is offline, undelivered data stays on the
+  sender, consistent with UniClipboard's P2P model.
+
+If what you actually want is a transit point for NAT hole-punching
+failures, that's a different thing — see
+[Self-hosting an iroh relay](./self-host-relay).
+
+The node never writes a system clipboard (there's no display on a VPS);
+inbound items are persisted and fanned out, which is all a background
+member needs to do.
+
+## Prerequisites
+
+- A VPS with a public IPv4 address, **Docker + Docker Compose v2**.
+- A **domain name** whose A/AAAA record points at the VPS — the phone
+  reaches the node over HTTPS, and the bundled Caddy needs it to obtain
+  a certificate. DNS must resolve **before** you start the stack.
+- The following inbound ports open in the VPS firewall / security group:
+  - **TCP/443** (and optionally **UDP/443** for HTTP/3) — the phone's
+    HTTPS gateway.
+  - **TCP/80** — the ACME HTTP-01 challenge Caddy uses to issue the cert.
+  - A fixed **UDP** port for iroh direct connections (e.g. `42999/udp`) —
+    so desktops on other networks can dial the node directly.
+- An existing Space with **another device online** to pair with. The
+  server node *joins* a Space; it does not create one. Run `uniclip
+  invite` on a desktop already in the Space to get an invitation code.
+
+## Get the stack
+
+Everything lives in the repository under `deploy/vps/`:
+
+```bash
+git clone https://github.com/UniClipboard/UniClipboard.git
+cd UniClipboard/deploy/vps
+```
+
+There are two ways to get the image. Pick one:
+
+**Option A — pull the prebuilt image (recommended).** Every release
+publishes a multi-arch (amd64 + arm64) image to the GitHub Container
+Registry. No compiler, and you only need this `deploy/vps/` directory:
+
+```bash
+docker compose pull
+```
+
+Pin a release in `.env` with
+`UC_IMAGE=ghcr.io/uniclipboard/uniclipboard-server:vX.Y.Z` (defaults to
+`:latest`).
+
+**Option B — build from source.** Needs the repo checked out **with
+submodules** (the build uses the vendored `iroh-blobs` fork) and ~4 GB
+of RAM:
+
+```bash
+git submodule update --init --recursive
+docker compose build
+```
+
+<Callout type="info">
+  A small VPS (≤ 2 GB RAM) cannot build from source — it will OOM. Use Option A, or build the image
+  on a bigger machine of the same architecture and ship it with `docker save … | ssh vps 'docker
+  load'`.
+</Callout>
+
+## Configure
+
+Copy the env template and fill in your values:
+
+```bash
+cp .env.example .env
+```
+
+```bash
+# .env
+UC_DOMAIN=clip.example.com      # A/AAAA record → this VPS; Caddy gets a cert for it
+UC_PUBLIC_IP=203.0.113.7        # this VPS's public IPv4, advertised to desktop peers
+UC_IROH_BIND_PORT=42999         # fixed UDP port for iroh direct connections
+```
+
+Under the hood these map to the daemon's networking knobs documented in
+[CLI — environment variables](../cli/environment): `UC_IROH_BIND_PORT`
+pins the iroh UDP port and `UC_IROH_PUBLIC_ADDR`
+(`${UC_PUBLIC_IP}:${UC_IROH_BIND_PORT}`) advertises this node's public
+socket so peers can dial it directly.
+
+## Provision (one-time, before the daemon)
+
+`join` and the `mobile-sync` write commands **refuse to run while a
+daemon is up**, so all provisioning happens in one-off containers first.
+They share the same state volume the long-running daemon will read.
+
+**1. Join your Space.** On a desktop already in the Space, run `uniclip
+invite` to get a code, then:
+
+```bash
+docker compose run --rm app uniclip join
+```
+
+This prompts interactively for the **invitation code** and the **Space
+passphrase** (run it from an interactive terminal so the passphrase
+never lands in your shell history).
+
+**2. Enable the mobile-sync gateway for your domain.** `--advertise-url`
+makes the phone's install URL/QR point at your HTTPS endpoint:
+
+```bash
+docker compose run --rm app \
+  uniclip mobile-sync lan enable \
+  --advertise-url https://clip.example.com \
+  --accept-network-risk
+```
+
+**3. Register your phone.** Mints credentials and renders the install QR:
+
+```bash
+docker compose run --rm app uniclip mobile-sync devices add --label "My iPhone"
+```
+
+Copy the one-time password it prints — it is not shown again.
+
+## Start the stack
+
+```bash
+docker compose up -d
+```
+
+This brings up two containers:
+
+- **`app`** — the headless daemon (`uniclip start --server`). Joins the
+  Space over iroh and serves the mobile-sync gateway. The iroh UDP port
+  is published to the host; the plaintext gateway port is **only** on
+  the internal Docker network.
+- **`caddy`** — terminates TLS on `443`, obtains a certificate for
+  `UC_DOMAIN` automatically, and reverse-proxies to the app's gateway.
+
+The first start runs the ACME flow; tail `docker compose logs -f caddy`
+to confirm the certificate was issued.
+
+## Connect your phone
+
+Scan the QR from step 3 (or open the printed `https://<domain>` install
+URL) in the UniClipboard / SyncClipboard mobile client. The phone now
+pulls the latest clipboard and pushes new content through Caddy; pushes
+fan out to your desktops over iroh. See
+[Mobile sync](../core-features/mobile-sync) for the client side.
+
+## Behind a reverse proxy you already run
+
+If the host already serves `80`/`443` (nginx, Caddy, Traefik, 1Panel's
+OpenResty, …), **don't run the bundled Caddy** — it would conflict.
+Instead, expose the gateway on loopback and let your existing proxy
+front it.
+
+Add an override next to the compose file:
+
+```yaml
+# docker-compose.override.yml
+services:
+  app:
+    ports:
+      - "127.0.0.1:42720:42720"
+```
+
+Start only the daemon (not Caddy):
+
+```bash
+docker compose up -d app
+```
+
+Then add a virtual host on your existing proxy for `clip.example.com`
+that terminates TLS and reverse-proxies to `http://127.0.0.1:42720`,
+forwarding the `Authorization` header. The gateway is plain HTTP +
+Basic Auth, with no websockets, so a default reverse-proxy block is
+enough.
+
+<Callout type="warn">
+  Never publish the plaintext gateway port (`42720`) to a public interface — it's HTTP + Basic Auth,
+  designed to sit behind TLS. Keep it on loopback or the internal Docker network and only expose
+  `443` through your proxy.
+</Callout>
+
+## State and backups
+
+Everything needed to keep identity, Space membership, and mobile
+credentials lives under `HOME=/data` on the `uniclip-state` volume, so
+the node **never re-pairs** across restarts. Under
+`/data/.local/share/app.uniclipboard.desktop/`:
+
+| State                        | Path                                          |
+| ---------------------------- | --------------------------------------------- |
+| iroh identity (node secret)  | `iroh-identity/`                              |
+| file-based KEK               | `keyring/`                                    |
+| keyslot + device id          | `vault/keyslot.json`, `vault/device_id.txt`   |
+| database                     | `uniclipboard.db`                             |
+| iroh blob cache              | `iroh-blobs/blobs.db`                         |
+| settings (mobile creds, LAN) | `settings.json`                               |
+
+On a server with no desktop environment there's no system keyring, so the
+daemon falls back to file-based secure storage automatically — the iroh secret and KEK live
+on the volume. Back it up (and Caddy's volume, which holds the issued
+certificate):
+
+```bash
+docker run --rm -v uniclip-state:/data -v "$PWD":/backup alpine \
+  tar czf /backup/uniclip-state.tgz -C /data .
+```
+
+## Operations
+
+```bash
+docker compose logs -f app                       # follow daemon logs
+docker compose restart app                       # restart the daemon (state kept)
+docker compose down                              # stop the stack (volumes kept)
+docker compose pull && docker compose up -d      # update (Option A: prebuilt image)
+docker compose up -d --build                     # update (Option B: build from source)
+```
+
+Updates keep the state volume, so a new image just swaps the binary — no
+re-pairing. To change the advertised domain or add devices later, **stop
+the daemon first** (`docker compose down`), rerun the relevant
+`mobile-sync` command, then `docker compose up -d` — the write commands
+still refuse to run while the daemon is up.
+
+## Verifying
+
+```bash
+docker compose ps                                # app should be "healthy"
+
+# TLS + gateway reachable; 401 = listener up, auth required (expected without creds):
+curl -i https://clip.example.com/SyncClipboard.json
+
+# The plaintext gateway port is NOT exposed on the host (should refuse):
+curl -i http://clip.example.com:42720/SyncClipboard.json
+```
+
+For an end-to-end check: copy something on a paired desktop on another
+network and watch it land in `docker compose logs app`; then push from
+the phone and confirm it appears on your desktops.
+
+## Troubleshooting
+
+| Symptom                                | Where to look                                                                                          |
+| -------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `setup not complete` on `up -d`        | Provisioning (`join`) didn't persist. Confirm the `docker compose run` commands hit the same volume.   |
+| Caddy never gets a certificate         | DNS for `UC_DOMAIN` must resolve to this VPS and `80`/`443` must be open **before** `up -d`.            |
+| Phone gets the wrong URL               | Re-run `mobile-sync lan enable --advertise-url https://<domain>` (daemon stopped), then `up -d`.        |
+| Desktop on another network won't sync  | Open `UC_IROH_BIND_PORT/udp` in the firewall and check `UC_PUBLIC_IP` is the real public IP.            |
+| `401` through your reverse proxy       | That means the gateway is up and asking for Basic Auth — use the credentials from `devices add`.        |

--- a/docs-site/content/docs/zh/guides/meta.json
+++ b/docs-site/content/docs/zh/guides/meta.json
@@ -2,5 +2,5 @@
   "title": "指南",
   "icon": "BookOpen",
   "defaultOpen": true,
-  "pages": ["pairing", "settings", "self-host-relay"]
+  "pages": ["pairing", "settings", "self-host-relay", "self-host-server-node"]
 }

--- a/docs-site/content/docs/zh/guides/self-host-server-node.mdx
+++ b/docs-site/content/docs/zh/guides/self-host-server-node.mdx
@@ -1,0 +1,254 @@
+---
+title: 自建无头 server 节点
+description: 在 VPS 上把 UniClipboard 以无头方式跑成常驻在线的空间成员，并给手机提供网关。
+---
+
+UniClipboard 自 0.13 起可以**在服务器上常驻运行**（VPS 或容器都行），作为
+你空间里一个**一直在线的成员**：纯后台、没有图形界面，也不读写这台服务器
+自己的剪贴板（这种运行方式就是标题里说的"无头"）。它像桌面端一样通过 iroh
+同步剪贴板，并在 TLS 后面给手机提供 mobile-sync 网关。
+
+适合的场景：希望桌面端都休眠时剪贴板同步仍然在线，并且给手机一个永远可达
+的 HTTPS 端点。
+
+这篇文档解答：
+
+- server 节点是什么、不是什么
+- 怎么用 Docker Compose 部署（拉预构建镜像 / 源码构建两条路径）
+- 置备：加入你的空间、注册你的手机
+- TLS 怎么搞（用自带的 Caddy，或接到你已有的反向代理后面）
+- 怎么验证、运维、备份
+
+## 它是什么、不是什么
+
+server 节点就是一个**普通 iroh 成员**，只是常驻在线、没有显示器：
+
+- **是**：一个在线对端，接收桌面端推来的剪贴板并落库；一个手机网关，提供
+  `GET /SyncClipboard.json`（拉）和 `PUT`（推，推送会经 iroh fan-out 回你
+  的桌面端）。
+- **不是**：它不是中继（relay），也**不是**中央 store-and-forward 信箱。
+  它只持久化 **它在线时收到的** 内容 —— 不是离线信箱。对端离线时未投递的
+  数据留在发送方本地，这与 UniClipboard 的 P2P 模型一致。
+
+如果你要的其实是 NAT 打洞失败时的中转节点，那是另一回事 —— 见
+[自建 iroh relay](./self-host-relay)。
+
+节点永远不会写系统剪贴板（VPS 上没有显示器）；它该做的只是把入站内容
+落库并 fan-out，对一个常驻后台的成员来说，这样就够了。
+
+## 前置条件
+
+- 一台带公网 IPv4 的 VPS，装好 **Docker + Docker Compose v2**。
+- 一个 A/AAAA 记录指向这台 VPS 的 **域名** —— 手机经 HTTPS 访问节点，自带
+  的 Caddy 也要靠它签证书。启动前 DNS **必须**已经能解析。
+- VPS 防火墙 / 安全组放开以下入站端口：
+  - **TCP/443**（HTTP/3 再可选放 **UDP/443**）—— 手机的 HTTPS 网关。
+  - **TCP/80** —— Caddy 走 ACME HTTP-01 签证书要用。
+  - 一个固定的 iroh 直连 **UDP** 端口（如 `42999/udp`）—— 让其它网络的
+    桌面端能直连这个节点。
+- 一个已有的、**还有另一台设备在线** 的空间用来配对。server 节点是**加入**
+  空间，不创建空间。在一台已在空间里的桌面端跑 `uniclip invite` 拿邀请码。
+
+## 拿到部署文件
+
+整套东西在仓库的 `deploy/vps/` 下：
+
+```bash
+git clone https://github.com/UniClipboard/UniClipboard.git
+cd UniClipboard/deploy/vps
+```
+
+镜像有两种拿法，二选一：
+
+**方案 A —— 拉预构建镜像（推荐）。** 每次发版都会把多 arch（amd64 +
+arm64）镜像推到 GitHub Container Registry。不用编译器，只要这个
+`deploy/vps/` 目录：
+
+```bash
+docker compose pull
+```
+
+想锁版本就在 `.env` 里写
+`UC_IMAGE=ghcr.io/uniclipboard/uniclipboard-server:vX.Y.Z`（默认 `:latest`）。
+
+**方案 B —— 源码构建。** 需要带 submodule 检出仓库（构建用到 vendored 的
+`iroh-blobs` 分支）和约 4 GB 内存：
+
+```bash
+git submodule update --init --recursive
+docker compose build
+```
+
+<Callout type="info">
+  小内存 VPS（≤ 2 GB）编不动源码，会 OOM。用方案 A，或者在一台同架构的大内存机器上构建好，再用
+  `docker save … | ssh vps 'docker load'` 传过去。
+</Callout>
+
+## 配置
+
+复制环境变量模板，填上你的值：
+
+```bash
+cp .env.example .env
+```
+
+```bash
+# .env
+UC_DOMAIN=clip.example.com      # A/AAAA 记录指向这台 VPS；Caddy 给它签证书
+UC_PUBLIC_IP=203.0.113.7        # 这台 VPS 的公网 IPv4，广告给桌面端对端
+UC_IROH_BIND_PORT=42999         # iroh 直连用的固定 UDP 端口
+```
+
+这些底层对应守护进程的网络开关，见
+[CLI —— 环境变量](../cli/environment)：`UC_IROH_BIND_PORT` 固定 iroh 的 UDP
+端口，`UC_IROH_PUBLIC_ADDR`（`${UC_PUBLIC_IP}:${UC_IROH_BIND_PORT}`）把这个
+节点的公网 socket 广告出去,让对端可以直连。
+
+## 置备（一次性，先于守护进程）
+
+`join` 和 `mobile-sync` 这些写命令**在 daemon 运行时会拒绝执行**，所以置备
+全部用一次性容器先做完。它们和常驻守护进程共用同一个状态卷。
+
+**1. 加入你的空间。** 在一台已在空间里的桌面端跑 `uniclip invite` 拿邀请码,
+然后：
+
+```bash
+docker compose run --rm app uniclip join
+```
+
+它会交互式提示输入 **邀请码** 和 **空间口令**（在交互式终端里跑，口令就不会
+落进 shell 历史）。
+
+**2. 给你的域名开 mobile-sync 网关。** `--advertise-url` 让手机的安装 URL/QR
+指向你的 HTTPS 端点：
+
+```bash
+docker compose run --rm app \
+  uniclip mobile-sync lan enable \
+  --advertise-url https://clip.example.com \
+  --accept-network-risk
+```
+
+**3. 注册你的手机。** 铸设备凭据并渲染安装 QR：
+
+```bash
+docker compose run --rm app uniclip mobile-sync devices add --label "我的 iPhone"
+```
+
+把它打印的一次性密码记下来 —— 不会再显示第二次。
+
+## 启动
+
+```bash
+docker compose up -d
+```
+
+会拉起两个容器：
+
+- **`app`** —— 无头守护进程（`uniclip start --server`）。通过 iroh 加入
+  空间并提供 mobile-sync 网关。iroh UDP 端口发布到宿主；明文网关端口
+  **只**在 Docker 内网。
+- **`caddy`** —— 在 `443` 终结 TLS，自动给 `UC_DOMAIN` 签证书，反代到 app
+  的网关。
+
+首次启动会跑 ACME 流程；`docker compose logs -f caddy` 看证书是否签发成功。
+
+## 接入手机
+
+在 UniClipboard / SyncClipboard 手机客户端里扫第 3 步的 QR（或打开打印出来的
+`https://<域名>` 安装 URL）。手机此时就能经 Caddy 拉取最新剪贴板、推送新内容;
+推送会经 iroh fan-out 回你的桌面端。客户端那一侧见
+[移动端同步](../core-features/mobile-sync)。
+
+## 接到你已有的反向代理后面
+
+如果宿主上 `80`/`443` 已经被占用（nginx、Caddy、Traefik、1Panel 的
+OpenResty 等），就**别起自带的 Caddy** —— 会冲突。改成把网关绑到 loopback,
+让你已有的代理前置。
+
+在 compose 文件旁边加一个 override：
+
+```yaml
+# docker-compose.override.yml
+services:
+  app:
+    ports:
+      - "127.0.0.1:42720:42720"
+```
+
+只起守护进程（不起 Caddy）：
+
+```bash
+docker compose up -d app
+```
+
+然后在你已有的代理上给 `clip.example.com` 加一个虚拟主机，终结 TLS 并反代到
+`http://127.0.0.1:42720`，把 `Authorization` 头透传过去。网关是明文 HTTP +
+Basic Auth、没有 websocket，一个默认的反代块就够了。
+
+<Callout type="warn">
+  千万别把明文网关端口（`42720`）发布到公网接口 —— 它是 HTTP + Basic Auth，设计上就该待在 TLS
+  后面。让它待在 loopback 或 Docker 内网，只通过你的代理暴露 `443`。
+</Callout>
+
+## 状态与备份
+
+保住身份、空间成员、手机凭据所需的一切都在 `HOME=/data` 的 `uniclip-state`
+卷里，所以节点重启**永不重新配对**。位于
+`/data/.local/share/app.uniclipboard.desktop/` 下：
+
+| 状态                    | 路径                                          |
+| ----------------------- | --------------------------------------------- |
+| iroh 身份（节点私钥）   | `iroh-identity/`                              |
+| 文件式 KEK              | `keyring/`                                    |
+| keyslot + 设备 id       | `vault/keyslot.json`、`vault/device_id.txt`   |
+| 数据库                  | `uniclipboard.db`                             |
+| iroh blob 缓存          | `iroh-blobs/blobs.db`                         |
+| 设置（手机凭据、LAN）   | `settings.json`                               |
+
+这种没有桌面环境的机器上没有系统 keyring，守护进程会自动回退到文件式安全
+存储 —— iroh 私钥和 KEK 都在卷里。把它备份好（顺带 Caddy 的卷，里面是已签发的证书）：
+
+```bash
+docker run --rm -v uniclip-state:/data -v "$PWD":/backup alpine \
+  tar czf /backup/uniclip-state.tgz -C /data .
+```
+
+## 运维
+
+```bash
+docker compose logs -f app                       # 跟随守护进程日志
+docker compose restart app                       # 重启守护进程（状态保留）
+docker compose down                              # 停栈（卷保留）
+docker compose pull && docker compose up -d      # 升级（方案 A：预构建镜像）
+docker compose up -d --build                     # 升级（方案 B：源码构建）
+```
+
+升级保留状态卷，新镜像只是换二进制 —— 不用重新配对。之后要改广告域名或加
+设备，**先停守护进程**（`docker compose down`），重跑对应的 `mobile-sync`
+命令，再 `docker compose up -d` —— 写命令在 daemon 运行时仍然会拒绝。
+
+## 验证
+
+```bash
+docker compose ps                                # app 应为 "healthy"
+
+# TLS + 网关可达；401 = 监听在、需鉴权（不带凭据时就是这样）：
+curl -i https://clip.example.com/SyncClipboard.json
+
+# 明文网关端口没有暴露到宿主（应被拒绝）：
+curl -i http://clip.example.com:42720/SyncClipboard.json
+```
+
+端到端验证：在另一网络的已配对桌面端复制点东西，看它落进
+`docker compose logs app`；再从手机推送，确认它出现在你的桌面端。
+
+## 排错
+
+| 现象                              | 看哪里                                                                            |
+| --------------------------------- | --------------------------------------------------------------------------------- |
+| `up -d` 报 `setup not complete`   | 置备（`join`）没落盘。确认 `docker compose run` 命令打的是同一个卷。               |
+| Caddy 一直签不出证书              | `UC_DOMAIN` 的 DNS 必须解析到这台 VPS，且 `80`/`443` 在 `up -d` **之前**已放开。   |
+| 手机拿到的 URL 不对               | 停掉守护进程重跑 `mobile-sync lan enable --advertise-url https://<域名>`，再 `up -d`。 |
+| 另一网络的桌面端同步不上          | 防火墙放开 `UC_IROH_BIND_PORT/udp`，并确认 `UC_PUBLIC_IP` 是真实公网 IP。          |
+| 经你的反代返回 `401`              | 说明网关在、并在要 Basic Auth —— 用 `devices add` 给出的凭据。                     |


### PR DESCRIPTION
## Summary

Adds a user-facing guide for self-hosting UniClipboard as an always-online headless server node on a VPS — the `deploy/vps/` feature shipped in #902 — as a companion to the existing `self-host-relay` guide.

- New `guides/self-host-server-node.mdx` in **en + zh** (lockstep), registered in both guides `meta.json`. Covers: the Docker Compose stack, prebuilt GHCR image vs source build, the one-time provisioning runbook (`join` + `mobile-sync`), TLS via the bundled Caddy **or** an existing reverse proxy, the state volume (never re-pairs), operations, verification, and troubleshooting.
- Leads with plain language and only glosses the "headless" term (review feedback).

Pure docs — no code or user-facing contract changes, so nothing existing in docs-site is contradicted.

## Test plan

- [x] `bun run check:docs` passes — 21 en / 21 zh, mirror + anchors + autolinks.
- [x] The documented flow was validated end-to-end on a real x86_64 VPS: anonymous pull of the published image, daemon healthy in server mode, joined a real Space, mobile-sync gateway reachable (local + behind a reverse proxy).
- [ ] Reviewer: skim the rendered guide (`cd docs-site && bun run dev`) for tone/formatting in both languages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive guides for self-hosting UniClipboard as a headless server node on a VPS or container, covering deployment, configuration, provisioning, reverse proxy setup, backups, and troubleshooting. Available in English and Chinese.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/UniClipboard/UniClipboard/pull/911?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->