### PR TITLE
fix(updater): make update popup a native, independent window

### DIFF
--- a/src-tauri/capabilities/updater.json
+++ b/src-tauri/capabilities/updater.json
@@ -1,12 +1,11 @@
 {
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "updater",
-  "description": "Narrow capability for the Sparkle-style updater window. Grants only the updater plugin commands plus the IPC/event/window primitives the window actually uses (custom command invoke, event listen for update broadcasts, drag-region, and close).",
+  "description": "Narrow capability for the native updater window. Grants only the updater plugin commands plus the IPC/event/window primitives the window actually uses (custom command invoke, event listen for update broadcasts, and close).",
   "windows": ["updater"],
   "permissions": [
     "core:default",
     "core:window:allow-close",
-    "core:window:allow-start-dragging",
     "core:event:allow-listen",
     "updater:default"
   ]

--- a/src-tauri/crates/uc-bootstrap/tests/mdns_only_pairing_e2e.rs
+++ b/src-tauri/crates/uc-bootstrap/tests/mdns_only_pairing_e2e.rs
@@ -314,6 +314,7 @@ async fn build_side(name: &'static str, rendezvous_base_url: String) -> Side {
             disable_relays: true,
             allow_overlay_network_addrs: false,
             custom_relay_urls: Vec::new(),
+            ..Default::default()
         },
     )
     .await

--- a/src-tauri/crates/uc-tauri/src/update_scheduler/window.rs
+++ b/src-tauri/crates/uc-tauri/src/update_scheduler/window.rs
@@ -39,17 +39,15 @@ pub fn open_or_focus_updater_window(app: &AppHandle, dev: bool) -> Result<(), ta
     };
     let url = WebviewUrl::App(path.into());
 
+    // Standard decorated window so it behaves like a first-class OS window:
+    // native title bar + traffic lights, system shadow, independent lifecycle.
+    // A borderless/transparent window with CSS-drawn chrome looked non-native
+    // and got tied to the main window's miniaturize; native decorations fix
+    // both (the frontend drops its custom border/shadow/drag-region to match).
     let builder = WebviewWindowBuilder::new(app, UPDATER_WINDOW_LABEL, url)
         .title(WINDOW_TITLE)
         .inner_size(WINDOW_WIDTH, WINDOW_HEIGHT)
         .resizable(false)
-        .decorations(false)
-        .transparent(true)
-        // OS shadow draws a rectangle outside the webview; combined with
-        // transparent + CSS border-radius it bleeds past the rounded corners
-        // (tauri-apps/tauri#9287 macOS, #11321 Win10). CSS shadow-2xl on the
-        // root div already paints a corner-aware shadow.
-        .shadow(false)
         .center()
         .focused(true)
         .visible(true);

--- a/src/updater/UpdaterWindow.tsx
+++ b/src/updater/UpdaterWindow.tsx
@@ -1,5 +1,5 @@
 import { getCurrentWindow } from '@tauri-apps/api/window'
-import { Download, Loader2 } from 'lucide-react'
+import { Loader2 } from 'lucide-react'
 import React, { useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import {
@@ -230,15 +230,10 @@ const UpdaterWindow: React.FC = () => {
       : ''
 
   return (
-    <div className="flex h-screen w-screen flex-col overflow-hidden rounded-xl border border-border/50 bg-background text-foreground shadow-2xl">
-      <div data-tauri-drag-region className="flex items-start gap-4 px-6 pt-6">
-        <div className="flex size-14 shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-primary to-primary/60 text-primary-foreground shadow-lg shadow-primary/20">
-          <Download className="size-7" />
-        </div>
-        <div className="flex-1 space-y-1">
-          <h1 className="text-base font-semibold leading-tight">{headline}</h1>
-          {subtitle && <p className="text-sm text-muted-foreground">{subtitle}</p>}
-        </div>
+    <div className="flex h-screen w-screen flex-col overflow-hidden bg-background text-foreground">
+      <div className="flex flex-col gap-1 px-6 pt-5">
+        <h1 className="text-base font-semibold leading-tight">{headline}</h1>
+        {subtitle && <p className="text-sm text-muted-foreground">{subtitle}</p>}
       </div>
 
       {!upToDate && info && (

--- a/updater.html
+++ b/updater.html
@@ -1,11 +1,11 @@
 <!doctype html>
-<html lang="en" style="background: transparent">
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>UniClipboard Update</title>
   </head>
-  <body style="background: transparent">
+  <body>
     <div id="root"></div>
     <script type="module" src="/src/updater/main.tsx"></script>
   </body>


### PR DESCRIPTION
## Summary

- The software-update popup was a borderless, transparent webview window with all chrome (rounded corners, shadow, drag region) drawn in CSS. Lacking a titled `NSWindow` style mask, macOS treated it as an auxiliary window of the main window — so it followed the main window's miniaturize and never felt native (89d11d14).
- Switched it to a **standard decorated window**: native title bar + traffic lights, system shadow, independent lifecycle. It no longer follows the main window's minimize and has its own minimize button (`update_scheduler/window.rs`).
- Frontend dropped its custom border/shadow/`data-tauri-drag-region` and the transparent `<body>` to match, and removed the now-redundant gradient header icon so the content reads as a clean native update pane (`UpdaterWindow.tsx`, `updater.html`).
- Dropped the now-unused `core:window:allow-start-dragging` permission from the updater capability (`capabilities/updater.json`).

No `docs-site` changes: the docs describe update *behavior* and *settings* (e.g. "a dedicated update window with release notes"), which still hold — only the window chrome changed.

## Test plan

- [x] `cargo check -p uc-tauri` passes.
- [x] `tsc --noEmit` and `eslint` pass on the touched frontend.
- [ ] On macOS: open the updater (debug `dev_open_updater_window`), confirm it has a native title bar + traffic lights, a system shadow, can be dragged by the title bar, and does **not** minimize when the main window is minimized.
- [ ] On Windows: confirm the updater window gets a standard frame and is independent on the taskbar.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updater window now uses native OS window decorations and standard background (no transparency), matching system appearance.
  * Simplified updater UI: streamlined header, removed decorative icon and custom drag-area, and cleaner full-viewport layout.

* **Tests**
  * Minor test config cleanup to rely on default values for unspecified settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/UniClipboard/UniClipboard/pull/916?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->