### PR TITLE
feat(cli): normalize join invite code (case-insensitive, hyphen-optional)

### DIFF
--- a/src-tauri/crates/uc-cli/src/commands/join.rs
+++ b/src-tauri/crates/uc-cli/src/commands/join.rs
@@ -21,6 +21,34 @@ use crate::ui;
 
 const EXIT_SIGINT: i32 = 130;
 
+/// Number of base32 chars in an invitation-code body (the `XXXX-XXXX`
+/// shape carries 8 chars plus one middle hyphen).
+const CODE_BODY_LEN: usize = 8;
+
+/// Fold a typed invitation code into the canonical `XXXX-XXXX` form the
+/// sponsor minted and published.
+///
+/// Codes use an all-uppercase Crockford base32 alphabet and are compared
+/// byte-for-byte (rendezvous lookup key + handshake), so loose typing
+/// would otherwise fail to pair. We drop separators (whitespace, hyphens),
+/// uppercase, and — when exactly the 8-char body remains — re-insert the
+/// single middle hyphen. Anything else is passed through compacted and
+/// uppercased so a genuinely malformed code still surfaces a real
+/// resolution error instead of being silently "fixed".
+fn normalize_invitation_code(raw: &str) -> String {
+    let compact: String = raw
+        .chars()
+        .filter(|c| !c.is_whitespace() && *c != '-')
+        .collect::<String>()
+        .to_ascii_uppercase();
+    if compact.is_ascii() && compact.len() == CODE_BODY_LEN {
+        let mid = CODE_BODY_LEN / 2;
+        format!("{}-{}", &compact[..mid], &compact[mid..])
+    } else {
+        compact
+    }
+}
+
 pub struct JoinArgs {
     pub code: Option<String>,
     pub passphrase: Option<String>,
@@ -39,15 +67,19 @@ pub async fn run(args: JoinArgs, verbose: bool) -> i32 {
         Err(code) => return code,
     };
 
+    // Invitation codes are minted from an all-uppercase Crockford base32
+    // alphabet and matched by an exact string compare (rendezvous lookup
+    // key + handshake). Fold typed input to the canonical `XXXX-XXXX`
+    // form here so a lowercased or hyphen-less code still pairs.
     let code_str = match args.code {
-        Some(c) if !c.trim().is_empty() => c.trim().to_string(),
+        Some(c) if !c.trim().is_empty() => normalize_invitation_code(&c),
         Some(_) => {
             ui::error("--code is empty");
             bundle.shutdown().await;
             return exit_codes::EXIT_ERROR;
         }
         None => match ui::password("Invitation code") {
-            Ok(c) if !c.trim().is_empty() => c.trim().to_string(),
+            Ok(c) if !c.trim().is_empty() => normalize_invitation_code(&c),
             Ok(_) => {
                 ui::error("Invitation code cannot be empty");
                 bundle.shutdown().await;
@@ -174,4 +206,48 @@ pub async fn run(args: JoinArgs, verbose: bool) -> i32 {
 
     bundle.shutdown().await;
     exit
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_invitation_code;
+
+    #[test]
+    fn already_canonical_code_is_unchanged() {
+        assert_eq!(normalize_invitation_code("ABCD-1234"), "ABCD-1234");
+    }
+
+    #[test]
+    fn lowercase_is_uppercased() {
+        assert_eq!(normalize_invitation_code("abcd-1234"), "ABCD-1234");
+    }
+
+    #[test]
+    fn hyphenless_eight_chars_get_canonical_hyphen() {
+        assert_eq!(normalize_invitation_code("abcd1234"), "ABCD-1234");
+        assert_eq!(normalize_invitation_code("ABCD1234"), "ABCD-1234");
+    }
+
+    #[test]
+    fn surrounding_and_inner_whitespace_is_dropped() {
+        assert_eq!(normalize_invitation_code("  abcd 1234 "), "ABCD-1234");
+        assert_eq!(normalize_invitation_code("ABCD - 1234"), "ABCD-1234");
+    }
+
+    #[test]
+    fn malformed_length_is_passed_through_compacted() {
+        // Not 8 body chars → no hyphen reconstruction, but still
+        // separator-stripped + uppercased so resolution fails on the
+        // real value rather than a half-normalised one.
+        assert_eq!(normalize_invitation_code("abc123"), "ABC123");
+        assert_eq!(normalize_invitation_code("abcde-12345"), "ABCDE12345");
+    }
+
+    #[test]
+    fn non_ascii_input_is_passed_through_without_slicing() {
+        // Non-ASCII means the `is_ascii()` guard skips hyphen
+        // reconstruction (and byte-slicing), so we never panic on a char
+        // boundary. ASCII letters still uppercase; `é` is left as-is.
+        assert_eq!(normalize_invitation_code("abcdé123"), "ABCDé123");
+    }
 }


### PR DESCRIPTION
## Summary

- `uniclip join` now folds the typed invitation code to the canonical `XXXX-XXXX` form before using it, so lowercase, missing-hyphen, or space-separated input still pairs (546fd57d). Codes are minted from an all-uppercase Crockford base32 alphabet and matched byte-for-byte at both the rendezvous lookup key and the handshake, so previously `abcd1234` / `abcd-1234` failed with a misleading `InvitationNotFound`.
- Normalization is a strict superset of prior behavior: drop separators (whitespace, hyphens) and uppercase, then re-insert the middle hyphen **only** when exactly the 8-char body remains. Malformed-length input is passed through compacted+uppercased so genuine errors still surface rather than being silently "fixed". An `is_ascii()` guard avoids slicing on a char boundary.
- Passphrase is left untouched — it stays a case-sensitive secret.
- Lives entirely in the CLI input layer (`uc-cli`), matching the `code_mint.rs` note that the typing-input layer owns normalization.

## Test plan

- [x] `cargo test -p uc-cli` — 52 passed / 0 failed, including 6 new `normalize_invitation_code` unit tests (canonical, lowercase, hyphen-less, inner/outer whitespace, malformed length, non-ASCII).
- [x] `cargo check -p uc-cli` clean.
- [ ] Manual: `uniclip invite` on a sponsor, then `uniclip join abcd1234` (lowercase, no hyphen) on a joiner — confirm it pairs.

Docs left as-is — input tolerance is a superset of prior behavior; no documented contract (`cli/reference.mdx`, `guides/pairing.mdx`) changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Invitation codes now accept flexible formatting—input can be lowercase, include extra spaces, omit hyphens, or use alternative separators. Codes are automatically normalized before processing, improving usability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/UniClipboard/UniClipboard/pull/917?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->