### PR TITLE
fix(release-notes): list Windows x64/arm64 installer + portable separately

### DIFF
--- a/scripts/__tests__/generate-release-notes.test.ts
+++ b/scripts/__tests__/generate-release-notes.test.ts
@@ -1,0 +1,68 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { buildInstallerTable } from '../generate-release-notes.js'
+
+const BASE_URL = 'https://example.com/dl'
+
+let artifactsDir: string
+
+function seed(fileNames: string[]) {
+  for (const name of fileNames) {
+    fs.writeFileSync(path.join(artifactsDir, name), '')
+  }
+}
+
+beforeEach(() => {
+  artifactsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'uc-release-notes-'))
+})
+
+afterEach(() => {
+  fs.rmSync(artifactsDir, { recursive: true, force: true })
+})
+
+describe('buildInstallerTable Windows rows', () => {
+  it('lists x64/arm64 setup and portable separately with correct arch labels', () => {
+    // Regression: a release shipping both x64 and arm64 installers. Files sort
+    // alphabetically, so arm64-setup.exe precedes x64-setup.exe — the old code
+    // picked the first .exe and hard-labeled it x86_64, mislabeling arm64.
+    seed([
+      'UniClipboard_0.13.0-alpha.4_arm64-portable.zip',
+      'UniClipboard_0.13.0-alpha.4_arm64-setup.exe',
+      'UniClipboard_0.13.0-alpha.4_x64-portable.zip',
+      'UniClipboard_0.13.0-alpha.4_x64-setup.exe',
+    ])
+
+    const table = buildInstallerTable({ artifactsDir, baseUrl: BASE_URL })
+
+    expect(table).toContain(
+      '| Windows | x86_64 (Installer) | [UniClipboard_0.13.0-alpha.4_x64-setup.exe]'
+    )
+    expect(table).toContain(
+      '| Windows | ARM64 (Installer) | [UniClipboard_0.13.0-alpha.4_arm64-setup.exe]'
+    )
+    expect(table).toContain(
+      '| Windows | x86_64 (Portable) | [UniClipboard_0.13.0-alpha.4_x64-portable.zip]'
+    )
+    expect(table).toContain(
+      '| Windows | ARM64 (Portable) | [UniClipboard_0.13.0-alpha.4_arm64-portable.zip]'
+    )
+    // The arm64 installer must never be advertised under an x86_64 label.
+    expect(table).not.toContain(
+      '| Windows | x86_64 (Installer) | [UniClipboard_0.13.0-alpha.4_arm64-setup.exe]'
+    )
+  })
+
+  it('emits a single x86_64 installer row for legacy x64-only releases', () => {
+    seed(['UniClipboard_0.13.0-alpha.3_x64-setup.exe'])
+
+    const table = buildInstallerTable({ artifactsDir, baseUrl: BASE_URL })
+
+    expect(table).toContain(
+      '| Windows | x86_64 (Installer) | [UniClipboard_0.13.0-alpha.3_x64-setup.exe]'
+    )
+    expect(table).not.toContain('ARM64')
+    expect(table).not.toContain('Portable')
+  })
+})

--- a/scripts/generate-release-notes.js
+++ b/scripts/generate-release-notes.js
@@ -100,7 +100,7 @@ function findFirstFile(artifactsDir, predicate) {
   return files.find(predicate) || ''
 }
 
-function buildInstallerTable({ artifactsDir, baseUrl }) {
+export function buildInstallerTable({ artifactsDir, baseUrl }) {
   // Tauri v2 Linux 产物命名约定:
   //   .deb       — `<lower-product>_<version>_<amd64|arm64>.deb`        (Debian arch)
   //   .rpm       — `<ProductName>-<version>-1.<x86_64|aarch64>.rpm`     (RPM arch)
@@ -123,7 +123,22 @@ function buildInstallerTable({ artifactsDir, baseUrl }) {
     artifactsDir,
     file => file.endsWith('.AppImage') && isArm(file)
   )
-  const windowsExe = findFirstFile(artifactsDir, file => file.endsWith('.exe'))
+  // Windows 产物命名约定 (Tauri NSIS + 自定义 portable 打包):
+  //   安装包  — `<ProductName>_<version>_<x64|arm64>-setup.exe`
+  //   便携版  — `<ProductName>_<version>_<x64|arm64>-portable.zip`
+  // 必须按架构分别匹配:文件按字母序排序时 arm64 会排在 x64 前面,
+  // 若只取第一个 .exe 会把 arm64 安装包误标成 x86_64。
+  const isPortable = file => /portable/.test(file)
+  const windowsSetupX64 = findFirstFile(artifactsDir, file => file.endsWith('.exe') && isX64(file))
+  const windowsSetupArm = findFirstFile(artifactsDir, file => file.endsWith('.exe') && isArm(file))
+  const windowsPortableX64 = findFirstFile(
+    artifactsDir,
+    file => file.endsWith('.zip') && isPortable(file) && isX64(file)
+  )
+  const windowsPortableArm = findFirstFile(
+    artifactsDir,
+    file => file.endsWith('.zip') && isPortable(file) && isArm(file)
+  )
 
   const makeRow = (platform, arch, fileName) =>
     `| ${platform} | ${arch} | [${fileName}](${baseUrl}/${fileName}) |`
@@ -137,7 +152,10 @@ function buildInstallerTable({ artifactsDir, baseUrl }) {
   if (linuxRpmArm) rows.push(makeRow('Linux', 'Fedora/RHEL aarch64 (.rpm)', linuxRpmArm))
   if (linuxAppImageX64) rows.push(makeRow('Linux', 'AppImage x86_64', linuxAppImageX64))
   if (linuxAppImageArm) rows.push(makeRow('Linux', 'AppImage aarch64', linuxAppImageArm))
-  if (windowsExe) rows.push(makeRow('Windows', 'x86_64', windowsExe))
+  if (windowsSetupX64) rows.push(makeRow('Windows', 'x86_64 (Installer)', windowsSetupX64))
+  if (windowsSetupArm) rows.push(makeRow('Windows', 'ARM64 (Installer)', windowsSetupArm))
+  if (windowsPortableX64) rows.push(makeRow('Windows', 'x86_64 (Portable)', windowsPortableX64))
+  if (windowsPortableArm) rows.push(makeRow('Windows', 'ARM64 (Portable)', windowsPortableArm))
 
   if (rows.length === 0) {
     return 'No installer artifacts found for this release.'


### PR DESCRIPTION
## Summary

- The release-notes generator built the Windows installer row by grabbing the **first** `.exe` and hard-labeling it `x86_64`. As soon as an arm64 `setup.exe` ships alongside x64 (first time in v0.13.0-alpha.4), alphabetical sort puts `arm64-setup.exe` first — so the arm64 installer was advertised under an `x86_64` label, and the x64 installer plus both portable zips were dropped from the table entirely (`b91e5076`).
- Now match Windows setup `.exe` and portable `.zip` per-architecture and emit a row for each: `x86_64 (Installer)`, `ARM64 (Installer)`, `x86_64 (Portable)`, `ARM64 (Portable)`. Backward compatible — a legacy x64-only release still produces a single correct row (`b91e5076`).
- Added `scripts/__tests__/generate-release-notes.test.ts` covering the dual-arch release and the legacy x64-only case (`b91e5076`).

The already-published v0.13.0-alpha.4 release notes have been corrected in place via `gh release edit`; this PR fixes the generator so future releases are correct.

## Test plan

- [x] `npx vitest run scripts/__tests__/` — 6 files / 29 tests pass (incl. the new regression test)
- [x] Ran the generator against the real v0.13.0-alpha.4 artifact names; App Installation table now lists all four Windows rows with correct arch labels
- [x] eslint + prettier clean on changed files
- [ ] Confirm on the next real release run that the CI-generated notes render the four Windows rows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Windows releases now provide ARM64 installer and portable builds in addition to x86_64 variants.

* **Tests**
  * Added comprehensive test suite for release artifact table generation, verifying correct handling and labeling of Windows installer and portable packages across architectures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->