### PR TITLE
fix(updater): surface popup on top on macOS when main window is hidden

### DIFF
--- a/src-tauri/crates/uc-tauri/src/tray.rs
+++ b/src-tauri/crates/uc-tauri/src/tray.rs
@@ -84,17 +84,36 @@ impl TrayState {
         let restart = MenuItem::with_id(app, "tray.restart", labels.restart, true, None::<&str>)?;
         let quit = MenuItem::with_id(app, "tray.quit", labels.quit, true, None::<&str>)?;
 
+        // Debug-only: open the updater window straight from the tray (with dev
+        // mock data). Lets us trigger the popup while the app is a no-Dock
+        // Accessory background process (main window hidden) — the exact state
+        // needed to verify the popup surfaces on top. Not created in release.
+        #[cfg(debug_assertions)]
+        let dev_open_updater = MenuItem::with_id(
+            app,
+            "tray.dev_open_updater",
+            "打开更新窗 (dev)",
+            true,
+            None::<&str>,
+        )?;
+
         // Build the context menu.
         // 布局意图:
         //   - "检查更新" 紧贴 "设置",语义上属于"应用维护"组
         //   - "重启" 与 "退出" 同组(都是进程级动作),但用分隔符与上方拉开
         //     一些距离,降低"想点退出却点到重启"的误触
-        let menu = MenuBuilder::new(app)
+        #[cfg_attr(not(debug_assertions), allow(unused_mut))]
+        let mut menu_builder = MenuBuilder::new(app)
             .item(&status)
             .separator()
             .item(&open)
             .item(&settings)
-            .item(&check_update)
+            .item(&check_update);
+        #[cfg(debug_assertions)]
+        {
+            menu_builder = menu_builder.separator().item(&dev_open_updater);
+        }
+        let menu = menu_builder
             .separator()
             .item(&restart)
             .item(&quit)
@@ -125,6 +144,17 @@ impl TrayState {
                     tauri::async_runtime::spawn(async move {
                         crate::commands::updater::perform_manual_check_from_tray(&app).await;
                     });
+                }
+                #[cfg(debug_assertions)]
+                "tray.dev_open_updater" => {
+                    // Debug aid: surface the updater window (dev mock data) so we
+                    // can verify it pops to the top even from the no-Dock
+                    // Accessory state. Mirrors the `dev_open_updater_window`
+                    // command but reachable from the tray without the main window.
+                    if let Err(e) = crate::update_scheduler::open_or_focus_updater_window(app, true)
+                    {
+                        warn!("Failed to open updater window from tray (dev): {}", e);
+                    }
                 }
                 "tray.restart" => {
                     // Fire-and-forget。`perform_restart` 内部走 graceful

--- a/src-tauri/crates/uc-tauri/src/update_scheduler/window.rs
+++ b/src-tauri/crates/uc-tauri/src/update_scheduler/window.rs
@@ -29,6 +29,8 @@ pub fn open_or_focus_updater_window(app: &AppHandle, dev: bool) -> Result<(), ta
         existing.unminimize()?;
         existing.show()?;
         existing.set_focus()?;
+        #[cfg(target_os = "macos")]
+        surface_above_apps_macos(app, &existing);
         return Ok(());
     }
 
@@ -53,8 +55,17 @@ pub fn open_or_focus_updater_window(app: &AppHandle, dev: bool) -> Result<(), ta
         .visible(true);
 
     match builder.build() {
-        Ok(_) => {
+        Ok(window) => {
             debug!(target: "update_scheduler::window", dev, "updater window created");
+            // macOS: actively surface + activate so the popup lands on top even
+            // when the app is a no-Dock Accessory background process with no
+            // visible windows. Without this, a freshly built window stays behind
+            // other apps — which manifested as "the update popup only shows after
+            // you open the main window". See `surface_above_apps_macos`.
+            #[cfg(target_os = "macos")]
+            surface_above_apps_macos(app, &window);
+            #[cfg(not(target_os = "macos"))]
+            let _ = window;
             Ok(())
         }
         Err(err) => {
@@ -65,5 +76,84 @@ pub fn open_or_focus_updater_window(app: &AppHandle, dev: bool) -> Result<(), ta
             );
             Err(err)
         }
+    }
+}
+
+/// macOS: force the updater window above every other app and activate this app,
+/// even when it is a no-Dock `Accessory` background process with no visible
+/// windows.
+///
+/// Why `set_focus` / `.focused(true)` isn't enough: for an LSUIElement /
+/// `Accessory` background app the system ignores Tauri's activation request, so
+/// the window gets built but stays behind whatever app is frontmost — the user
+/// thinks "nothing popped up". That is the root cause of the old behavior where
+/// the popup only appeared after opening the main window (the main-window path
+/// runs `set_dock_visibility(true)`, flipping the app to `Regular`).
+///
+/// This takes the native AppKit route (same as Sparkle), never touching the
+/// activation policy and never showing a Dock icon:
+/// - `NSRunningApplication::activate(ActivateAllWindows)` brings this app to the
+///   front so the window can become key and take keyboard focus;
+/// - `makeKeyAndOrderFront` makes it the key window;
+/// - `orderFrontRegardless` is the fallback — on macOS 14+ the system may
+///   downgrade a background app's activation request (the old `ignoringOtherApps`
+///   override was deprecated to a no-op), so this orders the window above other
+///   apps regardless, keeping it visible even when activation didn't fully take.
+///
+/// AppKit calls must run on the main thread. `open_or_focus_updater_window` is
+/// invoked from the scheduler / window_show_check on a tokio worker thread, so
+/// this dispatches fire-and-forget to the main thread. The `NSWindow` pointer is
+/// re-fetched inside the main-thread closure (raw pointers aren't `Send`), the
+/// same pattern as `commands::window_chrome`.
+#[cfg(target_os = "macos")]
+fn surface_above_apps_macos(app: &AppHandle, window: &tauri::WebviewWindow) {
+    use objc2_app_kit::{NSApplicationActivationOptions, NSRunningApplication, NSWindow};
+
+    let window = window.clone();
+    if let Err(err) = app.run_on_main_thread(move || {
+        let ns_window_ptr = match window.ns_window() {
+            Ok(ptr) if !ptr.is_null() => ptr,
+            Ok(_) => {
+                warn!(
+                    target: "update_scheduler::window",
+                    "ns_window pointer is null; updater window may stay behind other apps"
+                );
+                return;
+            }
+            Err(err) => {
+                warn!(
+                    target: "update_scheduler::window",
+                    error = %err,
+                    "failed to read ns_window; updater window may stay behind other apps"
+                );
+                return;
+            }
+        };
+
+        // Bring this app to the front first (no Dock icon, no policy change), so
+        // the updater window can become key and take keyboard focus. macOS 14+
+        // may still downgrade a background activation request — the
+        // `orderFrontRegardless` below is the fallback that keeps the window
+        // visible regardless.
+        NSRunningApplication::currentApplication()
+            .activateWithOptions(NSApplicationActivationOptions::ActivateAllWindows);
+
+        // SAFETY: `ns_window_ptr` points at the NSWindow owned by Tauri; this
+        // closure runs on the main thread and its lifetime is kept alive by the
+        // captured `WebviewWindow`. We only send order/key messages — no
+        // ownership transfer.
+        unsafe {
+            let ns_window: &NSWindow = &*(ns_window_ptr as *const NSWindow);
+            ns_window.makeKeyAndOrderFront(None);
+            // Fallback for when activation was downgraded by the system: order
+            // above other apps regardless of this app's active state.
+            ns_window.orderFrontRegardless();
+        }
+    }) {
+        warn!(
+            target: "update_scheduler::window",
+            error = %err,
+            "failed to dispatch updater window surfacing to the main thread"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- On macOS the software-update popup never came to the front when the app was a no-Dock `Accessory` background process (silent start, or after the main window was hidden to the tray). The window got built but stayed behind the frontmost app, so it only surfaced after opening the main window — whose show path flips the app to `Regular` via `set_dock_visibility(true)`. #916 only stopped the popup from following the main window's miniaturize; it never touched activation. (5fa37aa4)
- Fix it the native AppKit way (same as Sparkle), **without touching the activation policy or showing a Dock icon**: `NSRunningApplication::activate(ActivateAllWindows)` brings the app forward and `orderFrontRegardless` orders the `NSWindow` on top regardless of background state. macOS 14+ may downgrade a background activation request, so `orderFrontRegardless` is the fallback that keeps it visible. AppKit calls are dispatched to the main thread. (`update_scheduler/window.rs`)
- Add a **debug-only** tray item (`打开更新窗 (dev)`) to open the updater window straight from the tray while the main window is hidden, so the Accessory-state behavior can be verified without first opening the main window. Not built in release (`#[cfg(debug_assertions)]`). (`tray.rs`)

Scoped to macOS; Windows/Linux paths are unchanged.

## Test plan

- [x] `cargo +1.95.0 check` (debug) + `clippy` clean for `uc-tauri` — no new warnings from the changed files.
- [ ] Manual (macOS, debug build via `pnpm tauri:dev`): hide the main window (red traffic-light → hide-to-tray, Dock icon disappears), switch to another app, then tray → `打开更新窗 (dev)`. Expect the updater window to pop to the very front and take focus, with **no** Dock icon appearing.
- [ ] Same surfacing on the real scheduler path (background check finds a new version while the main window is hidden).
- [ ] CI release build covers the `cfg(debug_assertions)`-gated dev tray item (not run locally).

## Docs

Scanned `docs-site/`; `guides/settings.mdx` describes the auto-update popup but only states the intended behavior (a new version opens a dedicated update window). This PR makes reality match that description rather than changing the contract, so docs are left as-is.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Debug builds now include a tray menu option to open and focus the updater window directly.

* **Bug Fixes**
  * Improved updater window behavior on macOS. The updater window now properly stays visible above other applications when opened or restored from a minimized state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->