### PR TITLE
fix(ci): extract-and-run AppImage tools to avoid FUSE in container

### DIFF
--- a/.github/workflows/alpha-build.yml
+++ b/.github/workflows/alpha-build.yml
@@ -128,6 +128,10 @@ jobs:
       - name: build alpha release
         uses: tauri-apps/tauri-action@v0
         env:
+          # 见 build.yml 同名变量注释:容器内无 FUSE,linuxdeploy(AppImage)
+          # 无法挂载自身,AppImage 打包报 `failed to run linuxdeploy`。设此变量
+          # 让 AppImage runtime 自解压运行,绕开 FUSE。非 Linux 平台忽略。
+          APPIMAGE_EXTRACT_AND_RUN: "1"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -267,6 +267,13 @@ jobs:
         if: matrix.platform != 'macos-latest'
         shell: bash
         env:
+          # Linux AppImage 打包用的 linuxdeploy / linuxdeploy-plugin-appimage
+          # 本身是 AppImage,运行时默认靠 FUSE 把自己挂载起来。GitHub Actions
+          # 的 container job 跑在非特权容器里,没有 /dev/fuse,linuxdeploy 起
+          # 不来,只吐一句笼统的 `failed to run linuxdeploy`。设这个变量让
+          # AppImage runtime 改成自解压到临时目录再执行,绕开 FUSE。Windows
+          # 构建忽略此变量,无副作用。
+          APPIMAGE_EXTRACT_AND_RUN: "1"
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
           VITE_APP_VERSION: ${{ steps.app-version.outputs.version }}


### PR DESCRIPTION
## Summary

- Linux AppImage bundling failed in CI with the terse `failed to run linuxdeploy` (5d06cc5d). `linuxdeploy` and `linuxdeploy-plugin-appimage` are themselves AppImages that FUSE-mount to run; GitHub Actions container jobs are unprivileged with no `/dev/fuse`, so they can't start. The `deb`/`rpm` bundles succeed (no FUSE needed) — only AppImage breaks.
- Set `APPIMAGE_EXTRACT_AND_RUN=1` in the AppImage-producing build steps so the AppImage runtime self-extracts to a temp dir instead of FUSE-mounting — the canonical CI/container workaround.
- Applied to both Linux build paths: `build.yml` (release, runs `bun run tauri build` in the `build-bookworm` image) and `alpha-build.yml` (alpha, `tauri-action` in raw `debian:bookworm`).

Set at the workflow `env` level rather than in the base-image Dockerfile so it (a) takes effect immediately without rebuilding/publishing the base image, and (b) covers alpha-build's raw `debian:bookworm` container, which the custom image's `ENV` would never reach. Windows builds ignore the variable — no side effect.

## Test plan

- [x] YAML syntax of both workflows validated.
- [ ] Trigger the Linux build (`build.yml` ubuntu-22.04) and confirm the `*.AppImage` is produced alongside `*.deb` / `*.rpm`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build reliability for Linux container environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->