### PR TITLE
fix(ci): install GTK runtime tools so linuxdeploy can bundle AppImage

### DIFF
--- a/.github/docker/build-bookworm.Dockerfile
+++ b/.github/docker/build-bookworm.Dockerfile
@@ -13,6 +13,15 @@ FROM debian:bookworm-slim
 
 ENV DEBIAN_FRONTEND=noninteractive
 
+# libglib2.0-bin / libgdk-pixbuf2.0-bin / libgtk-3-bin 是 AppImage 打包必需的
+# 运行时工具包:新版 tauri-bundler 的 AppImage 流程会跑 linuxdeploy-plugin-gtk.sh,
+# 该脚本 `set -e` 下调用 glib-compile-schemas / gdk-pixbuf-query-loaders /
+# gtk-query-immodules-3.0,缺失会让脚本中途 sed 一个没生成的 cache 文件而失败,
+# 最终 tauri 只吐一句笼统的 `failed to run linuxdeploy`。这些工具仅出现在上面
+# -dev 包的 Recommends 里,被 --no-install-recommends 滤掉,所以必须显式装。
+# 2026-05-10 的旧 bundler 不跑这个插件,所以同一镜像当时能成功(详见 #938 的
+# FUSE 误诊:APPIMAGE_EXTRACT_AND_RUN 只让 linuxdeploy 自身能启动,真正的失败
+# 在它调用的 gtk 插件里)。
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
       git curl wget ca-certificates xz-utils unzip sudo \
@@ -24,4 +33,5 @@ RUN apt-get update \
       xdg-utils \
       rpm \
       musl-tools \
+      libglib2.0-bin libgdk-pixbuf2.0-bin libgtk-3-bin \
  && rm -rf /var/lib/apt/lists/*

--- a/.github/workflows/alpha-build.yml
+++ b/.github/workflows/alpha-build.yml
@@ -60,6 +60,10 @@ jobs:
         if: matrix.container != ''
         run: |
           apt-get update
+          # libglib2.0-bin / libgdk-pixbuf2.0-bin / libgtk-3-bin:AppImage 打包时
+          # 新版 tauri-bundler 跑的 linuxdeploy-plugin-gtk.sh 在 set -e 下要用
+          # glib-compile-schemas / gdk-pixbuf-query-loaders / gtk-query-immodules-3.0,
+          # 缺失即报笼统的 `failed to run linuxdeploy`。详见 build-bookworm.Dockerfile 注释。
           apt-get install -y --no-install-recommends \
             git curl wget ca-certificates xz-utils unzip sudo \
             build-essential pkg-config cmake clang \
@@ -67,7 +71,8 @@ jobs:
             libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf \
             libgtk-3-dev libsoup-3.0-dev libjavascriptcoregtk-4.1-dev \
             file desktop-file-utils \
-            xdg-utils
+            xdg-utils \
+            libglib2.0-bin libgdk-pixbuf2.0-bin libgtk-3-bin
 
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary

- AppImage 打包持续失败、报笼统的 `failed to run linuxdeploy`。#938 把原因诊断为"容器无 FUSE",但那是误判:**同一个 bookworm 容器在 2026-05-10 的 run #58 成功打过 AppImage**,当时既没装 FUSE 也没设 `APPIMAGE_EXTRACT_AND_RUN`。
- 真正变化的是 tauri-bundler 版本(`tauri-action@v0` 是浮动 tag):新版 AppImage 流程会执行 `linuxdeploy-plugin-gtk.sh`。该脚本在 `set -e` 下调用 `glib-compile-schemas` / `gdk-pixbuf-query-loaders` / `gtk-query-immodules-3.0`,工具缺失时后续会对一个根本没生成的 cache 文件做 `sed -i` 而中断 —— tauri 吞掉 stderr,只回一句 `failed to run linuxdeploy`(deb/rpm 正常)。这些运行时工具只在 `-dev` 包的 Recommends 里,被 `--no-install-recommends` 滤掉了;旧 bundler 不跑这个插件,所以同一镜像以前能成功。
- 显式安装 `libglib2.0-bin` / `libgdk-pixbuf2.0-bin` / `libgtk-3-bin`,覆盖预构建基础镜像(build.yml 用)和 alpha-build.yml 的内联 apt 列表 (f9feb9a4)。`APPIMAGE_EXTRACT_AND_RUN` 保留 —— 它仍是 linuxdeploy 这个 AppImage 在容器内自身启动所需。

## 合并须知

`build.yml` 拉的是 `ghcr.io/uniclipboard/build-bookworm:latest`。本 PR 改了 Dockerfile,合并到 `main` 会自动触发 `build-base-image.yml` 重推镜像 —— **必须等该 workflow 跑完**,后续 release 才会用上带新包的镜像。

## Test plan

- [x] 拉取 `linuxdeploy-plugin-gtk.sh` 源码确认 `set -e` + 无保护调用上述工具,以及 cache 文件缺失时的 `sed -i` 硬失败路径。
- [x] 对比 run #58(成功,旧 bundler)与 alpha-2 release(失败,新 bundler)日志,确认插件下载与文案差异。
- [ ] 合并后等 `build-base-image.yml` 重建镜像,再跑一次 build.yml(Linux x86_64 + aarch64),确认 AppImage 成功产出。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build environment configuration to enhance Linux application bundling reliability and support for AppImage generation with improved runtime dependency management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->