### PR TITLE
fix(linux): repair malformed desktop template breaking AppImage bundling

### DIFF
--- a/packaging/linux/uniclipboard.desktop.hbs
+++ b/packaging/linux/uniclipboard.desktop.hbs
@@ -1,12 +1,14 @@
-[Desktop Entry] Categories=Network;Utility;
+[Desktop Entry]
+Categories=Network;Utility;
 {{#if comment}}
-  Comment={{comment}}
+Comment={{comment}}
 {{/if}}
 Exec={{exec}}
 StartupWMClass={{exec}}
 Icon={{icon}}
 Name={{name}}
-Terminal=false Type=Application
+Terminal=false
+Type=Application
 {{#if mime_type}}
-  MimeType={{mime_type}}
+MimeType={{mime_type}}
 {{/if}}


### PR DESCRIPTION
## Summary

- alpha-2 起 AppImage 打包持续失败、只报笼统的 `failed to run linuxdeploy`。用 `tauri build --verbose` 逼出被 tauri 吞掉的子进程输出后,真因水落石出:**#934 引入的 Handlebars desktop 模板本身格式非法**,appimagetool 的 `desktop-file-validate` 拒绝它 → appimage 输出插件 exit 1。deb/rpm 不跑严格校验,所以那边一直没暴露。
- 模板三处违规(均来自校验器原文):
  - `[Desktop Entry] Categories=Network;Utility;` —— group 头和首个键写在同一行("entry … before the first group")
  - `Comment=` / `MimeType=` 行首有两个空格("line starts with a space")
  - `Terminal=false Type=Application` —— 两个键挤在一行
- 修复:每个键独立成行、不带行首空格、group 头单独一行、补行尾换行,对齐 Tauri 默认 entry 布局 (`packaging/linux/uniclipboard.desktop.hbs`)。

## 与 #938 / #941 的关系

- **#938(FUSE)是误诊** —— 同一容器 2026-05-10 无 FUSE 也能打 AppImage。
- **#941(GTK 运行时工具)是真实且必需的修复** —— 它让 linuxdeploy 的 gtk 插件得以完整跑通(rpath / copy files 全过),失败点才前进到 appimagetool,从而暴露出本 PR 这个 desktop 模板 bug。两个修复叠加才完整。
- 本 PR 是 AppImage 失败的**根因**修复。

## Test plan

- [x] 本地 `desktop-file-validate` 校验渲染后的 entry:通过(仅一条 \"more than one main category\" hint,非 error,退出 0;该双类别是 #934 为与 snap/AUR 同步而有意保留)。
- [ ] 从本分支触发 build.yml(ubuntu-22.04 x86_64)确认 AppImage 成功产出(已触发,见下)。
- [ ] 合并后建议补一次 aarch64 验证。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved formatting and structure of the Linux desktop package configuration for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->