### PR TITLE
fix(linux): stop prettier from reverting the desktop-entry template fix

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -32,6 +32,17 @@ src/lib/error-severity.generated.ts
 # Markdown — not formatted by prettier per project policy
 **/*.md
 
+# Linux desktop-entry template. Prettier's glimmer/handlebars parser treats
+# this .hbs as an Ember template and reflows it — joining the group header
+# onto the first key (`[Desktop Entry] Categories=...`), indenting keys inside
+# {{#if}} blocks, and merging `Terminal=false`/`Type=Application` onto one
+# line. That yields an invalid desktop entry that appimagetool's
+# desktop-file-validate rejects, breaking AppImage bundling (`failed to run
+# linuxdeploy`). deb/rpm don't validate, so it slipped through. The release
+# PR's `prettier --write .` auto-format step kept reverting the hand-fix
+# (#942 fixed it, #943's auto-format reverted it), so exclude it outright.
+packaging/linux/uniclipboard.desktop.hbs
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/packaging/linux/uniclipboard.desktop.hbs
+++ b/packaging/linux/uniclipboard.desktop.hbs
@@ -1,12 +1,14 @@
-[Desktop Entry] Categories=Network;Utility;
+[Desktop Entry]
+Categories=Network;Utility;
 {{#if comment}}
-  Comment={{comment}}
+Comment={{comment}}
 {{/if}}
 Exec={{exec}}
 StartupWMClass={{exec}}
 Icon={{icon}}
 Name={{name}}
-Terminal=false Type=Application
+Terminal=false
+Type=Application
 {{#if mime_type}}
-  MimeType={{mime_type}}
+MimeType={{mime_type}}
 {{/if}}


### PR DESCRIPTION
## Summary

- alpha-3 的 AppImage 又挂在同样的 `failed to run linuxdeploy`,但这次根因不是模板内容,而是**格式化工具回退了 #942 的修复**。
- release 流程的 `* style: auto-format code` 步骤跑 `prettier --write .`,而 Prettier 的 glimmer/handlebars parser 把这个 `.hbs` 当 Ember 模板重排:把 `[Desktop Entry]` 和 `Categories=` 并行、给 `{{#if}}` 块内的键加缩进、把 `Terminal=false`/`Type=Application` 合并 —— 精确重现了 appimagetool 拒绝的非法 desktop entry。
- 佐证:对**畸形版**跑 `prettier --check` 会报告"符合 Prettier 风格",说明 Prettier 会持续把任何手工修复改回去。
- 修复:把模板加入 `.prettierignore` 让 formatter 不再碰它,并恢复合法布局。

## 完整根因链(四层)

| PR | 诊断 | 判定 |
|----|------|------|
| #938 | 容器无 FUSE | ❌ 误诊 |
| #941 | 缺 GTK 运行时工具 | ✅ 真实必需(让 gtk 插件跑通) |
| #942 | desktop 模板格式非法 | ✅ 内容根因 |
| **本 PR** | **Prettier 持续把模板改回畸形** | ✅ **为何 #942 没生效** |

## Test plan

- [x] 模拟 release 的 `prettier --write .`:模板**保持不变**(此前会被改坏)。
- [x] `desktop-file-validate` 渲染后的 entry:通过(仅一条非致命 \"more than one main category\" hint)。
- [ ] 合并后发 alpha-4 / 触发 build.yml 确认 AppImage 产出。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration and template formatting to improve code consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->