### PR TITLE
docs(docs-site): default Snap install to stable channel

### DIFF
--- a/docs-site/content/docs/en/getting-started/install.mdx
+++ b/docs-site/content/docs/en/getting-started/install.mdx
@@ -176,7 +176,10 @@ See the [COPR deployment notes](https://github.com/UniClipboard/UniClipboard/blo
 The Snap is built with strict confinement on `core22` and bundles its own GTK + WebKit stack, so it runs the same on Ubuntu 20.04+, Debian 11+, RHEL 9, openSUSE Leap, and similar.
 
 ```bash
-# While UniClipboard is in alpha, only the edge channel publishes builds.
+# Stable channel (final releases, amd64 + arm64)
+sudo snap install uniclipboard
+
+# Edge channel (includes pre-releases, updated more often)
 sudo snap install uniclipboard --edge
 ```
 

--- a/docs-site/content/docs/en/help/troubleshooting.mdx
+++ b/docs-site/content/docs/en/help/troubleshooting.mdx
@@ -78,7 +78,7 @@ sudo snap connect uniclipboard:password-manager-service
 
 On older revisions (pre-r118) the same situation crashed the daemon
 with `Daemon startup/probe failed during Tauri bootstrap`. `sudo snap
-refresh uniclipboard --edge` to a current revision fixes that on its
+refresh uniclipboard` to a current revision fixes that on its
 own; connecting the plug is then only about _where_ the KEK is stored,
 not _whether_ the daemon starts.
 

--- a/docs-site/content/docs/zh/getting-started/install.mdx
+++ b/docs-site/content/docs/zh/getting-started/install.mdx
@@ -157,7 +157,10 @@ sudo dnf install uniclipboard
 Snap 包基于 `core22` 严格沙箱构建，自带 GTK + WebKit 运行时，因此在 Ubuntu 20.04+、Debian 11+、RHEL 9、openSUSE Leap 等老发行版上都能正常运行。
 
 ```bash
-# 当前仍处于 alpha 阶段，仅 edge 通道有包。
+# 正式渠道（稳定版，amd64 + arm64 双架构）
+sudo snap install uniclipboard
+
+# Edge 渠道（含预发布版本，更新更频繁）
 sudo snap install uniclipboard --edge
 ```
 

--- a/docs-site/content/docs/zh/help/troubleshooting.mdx
+++ b/docs-site/content/docs/zh/help/troubleshooting.mdx
@@ -59,7 +59,7 @@ sudo snap connect uniclipboard:password-manager-service
 # 接好之后重启应用
 ```
 
-更早的版本（r118 之前）遇到同样情况会直接 `Daemon startup/probe failed during Tauri bootstrap` 崩溃。`sudo snap refresh uniclipboard --edge` 升到最新 edge 就好；这种情况下 plug 只决定 KEK _存在哪里_，不再决定守护进程能不能起。
+更早的版本（r118 之前）遇到同样情况会直接 `Daemon startup/probe failed during Tauri bootstrap` 崩溃。`sudo snap refresh uniclipboard` 升到最新版就好；这种情况下 plug 只决定 KEK _存在哪里_，不再决定守护进程能不能起。
 
 ## 配对失败
 


### PR DESCRIPTION
## Summary

- The Snap Store now ships **0.13.0 on `latest/stable`** for both amd64 (rev 280) and arm64 (rev 281) — same version and day as the GitHub release. The docs still pointed users at `--edge`, which serves `0.14.0-alpha.N`, so new installs were landing on an alpha instead of the stable build. (08fb5808)
- `install.mdx` (en + zh) now presents `sudo snap install uniclipboard` (stable, amd64 + arm64) as the default, with `--edge` kept as an explicit pre-release opt-in — mirroring the COPR alpha/stable split right above it.
- `troubleshooting.mdx` (en + zh) drops `--edge` from the `snap refresh` "fix an old revision" step so it lands on the current stable build.

Note: `scripts/install.sh` was already correct (installs from stable, no `--edge`); this PR only aligns the published docs with it. The manual `snap connect uniclipboard:password-manager-service` step is intentionally left unchanged — Snap Store auto-connect is being pursued separately and the manual step is still required until it is granted.

## Test plan

- [x] `grep -rn -- "--edge" docs-site/` — only the intentional "edge channel" opt-in commands remain.
- [x] Snap Store channel-map confirmed via api.snapcraft.io: `latest/stable` = 0.13.0 (amd64 + arm64).
- [ ] Docs-site preview renders the new code blocks correctly on the en + zh install and troubleshooting pages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added explicit documentation for stable Snap channel alongside existing edge channel for pre-releases.
  * Updated installation guides to provide both stable and edge installation options.
  * Updated troubleshooting guidance to recommend stable release updates.
  * Changes applied to both English and Chinese documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->