### PR TITLE
fix(clipboard): forward-port #957 storm-guard + cache-quota to main

### DIFF
--- a/src-tauri/crates/uc-application/src/clipboard_capture/mod.rs
+++ b/src-tauri/crates/uc-application/src/clipboard_capture/mod.rs
@@ -12,4 +12,4 @@
 
 mod usecase;
 
-pub use usecase::CaptureClipboardUseCase;
+pub use usecase::{CaptureClipboardUseCase, CaptureOutcome};

--- a/src-tauri/crates/uc-application/src/clipboard_capture/usecase.rs
+++ b/src-tauri/crates/uc-application/src/clipboard_capture/usecase.rs
@@ -23,7 +23,7 @@ use std::sync::Arc;
 use std::time::SystemTime;
 
 use anyhow::Result;
-use tracing::{debug, info, info_span, Instrument};
+use tracing::{debug, info, info_span, warn, Instrument};
 use uc_observability::analytics::{
     AnalyticsPort, CaptureOrigin, Event, PayloadSizeBucket, PayloadType,
 };
@@ -41,6 +41,18 @@ use uc_core::{
     ClipboardChangeOrigin, ClipboardEntry, ClipboardEvent, ClipboardSelectionDecision,
     ObservedClipboardRepresentation, PayloadAvailability, SystemClipboardSnapshot,
 };
+
+/// Result of a capture attempt.
+///
+/// `deduplicated == true` means the snapshot matched an existing entry's
+/// content hash and that entry was resurfaced (its active time was bumped to
+/// the top of history) instead of persisting a duplicate row. Callers should
+/// refresh the UI for the entry but must NOT re-index or re-dispatch it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CaptureOutcome {
+    pub entry_id: EntryId,
+    pub deduplicated: bool,
+}
 
 /// Capture clipboard content and create persistent entries.
 ///
@@ -98,6 +110,7 @@ impl CaptureClipboardUseCase {
     pub async fn execute(&self, snapshot: SystemClipboardSnapshot) -> Result<EntryId> {
         self.execute_with_origin(snapshot, ClipboardChangeOrigin::LocalCapture, None)
             .await?
+            .map(|outcome| outcome.entry_id)
             .ok_or_else(|| anyhow::anyhow!("local capture should always persist an entry"))
     }
 
@@ -111,7 +124,7 @@ impl CaptureClipboardUseCase {
         snapshot: SystemClipboardSnapshot,
         origin: ClipboardChangeOrigin,
         preset_entry_id: Option<EntryId>,
-    ) -> Result<Option<EntryId>> {
+    ) -> Result<Option<CaptureOutcome>> {
         // Root span: all pipeline stages are children of clipboard.flow.
         // The origin field distinguishes local capture from remote push.
         //
@@ -168,6 +181,32 @@ impl CaptureClipboardUseCase {
                 .entered();
                 snapshot.snapshot_hash()
             };
+
+            // Local-capture dedup: if this exact content already exists,
+            // resurface the existing entry (bump it to the top of history)
+            // instead of persisting a duplicate row and re-dispatching it.
+            // Gated to `LocalCapture` — `RemotePush` runs its own dedup
+            // upstream, and `LocalRestore` already short-circuits above.
+            //
+            // Non-fatal: a lookup failure must not drop the capture, so on
+            // error we degrade to the prior no-dedup behavior (create a new
+            // entry) rather than propagating.
+            if origin == ClipboardChangeOrigin::LocalCapture {
+                let hash_str = snapshot_hash.to_string();
+                if let Some(existing) =
+                    resurface_existing_entry(self.entry_repo.as_ref(), &hash_str, captured_at_ms)
+                        .await
+                {
+                    info!(
+                        entry_id = %existing,
+                        "Local capture matched existing content; resurfaced instead of duplicating"
+                    );
+                    return Ok(Some(CaptureOutcome {
+                        entry_id: existing,
+                        deduplicated: true,
+                    }));
+                }
+            }
 
             // 1. 生成 event + snapshot representations
             let new_event = ClipboardEvent::new(
@@ -400,7 +439,10 @@ impl CaptureClipboardUseCase {
                 });
             }
 
-            Ok(Some(entry_id))
+            Ok(Some(CaptureOutcome {
+                entry_id,
+                deduplicated: false,
+            }))
         }
         .instrument(root)
         .await
@@ -494,6 +536,57 @@ impl CaptureClipboardUseCase {
             || rep.format_id.eq_ignore_ascii_case("public.utf8-plain-text")
             || rep.format_id.eq_ignore_ascii_case("public.text")
             || rep.format_id.eq_ignore_ascii_case("NSStringPboardType")
+    }
+}
+
+/// Resolve a local-capture dedup hit into the entry that should be
+/// resurfaced, or `None` when the capture must be persisted as a new entry.
+///
+/// Returns `Some(entry_id)` only when an entry carrying this `snapshot_hash`
+/// exists AND its active time was successfully bumped (`touch_entry` updated a
+/// row). Three cases yield `None` so the caller degrades to creating a fresh
+/// entry instead of returning a stale id:
+///   - no entry matches the hash (`Ok(None)`),
+///   - the lookup itself failed (`Err`), and
+///   - `touch_entry` updated no rows (`Ok(false)`) — the entry was deleted
+///     between the lookup and the touch (e.g. a concurrent cleanup), so the
+///     id would dangle if returned as `deduplicated: true`.
+///
+/// All failure paths are non-fatal: a dedup miss must never drop the capture.
+async fn resurface_existing_entry(
+    entry_repo: &dyn ClipboardEntryRepositoryPort,
+    snapshot_hash: &str,
+    captured_at_ms: i64,
+) -> Option<EntryId> {
+    let existing = match entry_repo
+        .find_entry_id_by_snapshot_hash(snapshot_hash)
+        .await
+    {
+        Ok(Some(existing)) => existing,
+        Ok(None) => return None,
+        Err(e) => {
+            warn!(error = %e, "Local-capture dedup lookup failed; proceeding to create entry");
+            return None;
+        }
+    };
+
+    match entry_repo.touch_entry(&existing, captured_at_ms).await {
+        Ok(true) => Some(existing),
+        Ok(false) => {
+            warn!(
+                entry_id = %existing,
+                "Dedup target vanished before resurface (0 rows touched); creating new entry"
+            );
+            None
+        }
+        Err(e) => {
+            warn!(
+                entry_id = %existing,
+                error = %e,
+                "Failed to resurface existing entry; creating new entry"
+            );
+            None
+        }
     }
 }
 
@@ -715,5 +808,129 @@ mod tests {
             &[0xff, 0xfe, 0xfd],
         )]);
         assert_eq!(CaptureClipboardUseCase::generate_title(&snap), None);
+    }
+
+    // --- resurface_existing_entry: local-capture dedup decision ---------
+
+    /// What the fake repo's `touch_entry` should simulate.
+    enum Touch {
+        /// A row was updated — the entry still exists.
+        Updated,
+        /// 0 rows updated — the entry was deleted between find and touch.
+        NoRows,
+        /// The update itself failed.
+        Err,
+    }
+
+    /// Minimal `ClipboardEntryRepositoryPort` exercising only the two methods
+    /// `resurface_existing_entry` calls; everything else is unreachable here.
+    struct DedupFakeRepo {
+        /// `Ok(_)` value returned by `find_entry_id_by_snapshot_hash`.
+        found: Option<EntryId>,
+        /// When true, the lookup returns `Err` instead of `Ok(found)`.
+        find_err: bool,
+        touch: Touch,
+    }
+
+    #[async_trait::async_trait]
+    impl ClipboardEntryRepositoryPort for DedupFakeRepo {
+        async fn save_entry_and_selection(
+            &self,
+            _entry: &ClipboardEntry,
+            _selection: &ClipboardSelectionDecision,
+        ) -> Result<()> {
+            unreachable!("not exercised by resurface_existing_entry tests")
+        }
+        async fn get_entry(&self, _entry_id: &EntryId) -> Result<Option<ClipboardEntry>> {
+            unreachable!("not exercised by resurface_existing_entry tests")
+        }
+        async fn list_entries(&self, _limit: usize, _offset: usize) -> Result<Vec<ClipboardEntry>> {
+            unreachable!("not exercised by resurface_existing_entry tests")
+        }
+        async fn delete_entry(&self, _entry_id: &EntryId) -> Result<()> {
+            unreachable!("not exercised by resurface_existing_entry tests")
+        }
+        async fn find_entry_id_by_snapshot_hash(
+            &self,
+            _snapshot_hash: &str,
+        ) -> Result<Option<EntryId>> {
+            if self.find_err {
+                anyhow::bail!("simulated dedup lookup failure");
+            }
+            Ok(self.found.clone())
+        }
+        async fn touch_entry(&self, _entry_id: &EntryId, _active_time_ms: i64) -> Result<bool> {
+            match self.touch {
+                Touch::Updated => Ok(true),
+                Touch::NoRows => Ok(false),
+                Touch::Err => anyhow::bail!("simulated touch failure"),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn resurface_returns_entry_when_found_and_touched() {
+        let repo = DedupFakeRepo {
+            found: Some(EntryId::from("e1")),
+            find_err: false,
+            touch: Touch::Updated,
+        };
+        let out = resurface_existing_entry(&repo, "blake3v1:abc", 123).await;
+        assert_eq!(out, Some(EntryId::from("e1")));
+    }
+
+    #[tokio::test]
+    async fn resurface_degrades_when_touch_updates_no_rows() {
+        // Entry was deleted between find and touch (concurrent cleanup):
+        // returning a stale id would broadcast a non-existent entry, so the
+        // capture must degrade to creating a fresh entry instead.
+        let repo = DedupFakeRepo {
+            found: Some(EntryId::from("e1")),
+            find_err: false,
+            touch: Touch::NoRows,
+        };
+        assert_eq!(
+            resurface_existing_entry(&repo, "blake3v1:abc", 123).await,
+            None
+        );
+    }
+
+    #[tokio::test]
+    async fn resurface_degrades_when_touch_errors() {
+        let repo = DedupFakeRepo {
+            found: Some(EntryId::from("e1")),
+            find_err: false,
+            touch: Touch::Err,
+        };
+        assert_eq!(
+            resurface_existing_entry(&repo, "blake3v1:abc", 123).await,
+            None
+        );
+    }
+
+    #[tokio::test]
+    async fn resurface_returns_none_when_no_match() {
+        let repo = DedupFakeRepo {
+            found: None,
+            find_err: false,
+            touch: Touch::Updated,
+        };
+        assert_eq!(
+            resurface_existing_entry(&repo, "blake3v1:abc", 123).await,
+            None
+        );
+    }
+
+    #[tokio::test]
+    async fn resurface_returns_none_when_lookup_errors() {
+        let repo = DedupFakeRepo {
+            found: None,
+            find_err: true,
+            touch: Touch::Updated,
+        };
+        assert_eq!(
+            resurface_existing_entry(&repo, "blake3v1:abc", 123).await,
+            None
+        );
     }
 }

--- a/src-tauri/crates/uc-application/src/facade/clipboard_capture/mod.rs
+++ b/src-tauri/crates/uc-application/src/facade/clipboard_capture/mod.rs
@@ -11,6 +11,10 @@ use crate::clipboard_capture::CaptureClipboardUseCase;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CapturedClipboardEntryView {
     pub entry_id: String,
+    /// True when the snapshot matched existing content and the existing entry
+    /// was resurfaced instead of a new one being created. Callers should
+    /// refresh the UI but skip re-indexing / re-dispatching this entry.
+    pub deduplicated: bool,
 }
 
 #[derive(Debug, Error)]
@@ -37,12 +41,13 @@ impl ClipboardCapturePort for CaptureClipboardUseCase {
         origin: ClipboardChangeOrigin,
         preset_entry_id: Option<EntryId>,
     ) -> Result<Option<CapturedClipboardEntryView>, ClipboardCaptureFacadeError> {
-        let entry_id = self
+        let outcome = self
             .execute_with_origin(snapshot, origin, preset_entry_id)
             .await
             .map_err(|err| ClipboardCaptureFacadeError::Internal(err.to_string()))?;
-        Ok(entry_id.map(|entry_id| CapturedClipboardEntryView {
-            entry_id: entry_id.to_string(),
+        Ok(outcome.map(|outcome| CapturedClipboardEntryView {
+            entry_id: outcome.entry_id.to_string(),
+            deduplicated: outcome.deduplicated,
         }))
     }
 }
@@ -86,6 +91,7 @@ mod tests {
         ) -> Result<Option<CapturedClipboardEntryView>, ClipboardCaptureFacadeError> {
             Ok(Some(CapturedClipboardEntryView {
                 entry_id: "entry-a".to_string(),
+                deduplicated: false,
             }))
         }
     }
@@ -108,7 +114,8 @@ mod tests {
         assert_eq!(
             outcome,
             Some(CapturedClipboardEntryView {
-                entry_id: "entry-a".to_string()
+                entry_id: "entry-a".to_string(),
+                deduplicated: false,
             })
         );
     }

--- a/src-tauri/crates/uc-application/src/facade/clipboard_history/mod.rs
+++ b/src-tauri/crates/uc-application/src/facade/clipboard_history/mod.rs
@@ -259,6 +259,8 @@ impl ClipboardHistoryFacade {
         // 共享同一组底层 ports，所以这里把 Arc clone 一份给 cleanup，原始
         // ownership 留给 reconcile（后写入字段）。
         let cleanup_uc = file_cache_dir.clone().map(|dir| {
+            // Clone cache_fs here since reconcile (built below) takes ownership
+            // of the original. All of cleanup's on-disk work routes through it.
             let mut uc = CleanupExpiredFilesUseCase::new(
                 settings,
                 dir,
@@ -266,6 +268,7 @@ impl ClipboardHistoryFacade {
                 selection_repo.clone(),
                 event_writer.clone(),
                 representation_repo.clone(),
+                cache_fs.clone(),
             );
             if let Some(idx) = search_index.clone() {
                 uc = uc.with_search_index(idx);

--- a/src-tauri/crates/uc-application/src/facade/storage/mod.rs
+++ b/src-tauri/crates/uc-application/src/facade/storage/mod.rs
@@ -195,6 +195,43 @@ mod tests {
             }
             Ok(total)
         }
+
+        async fn read_file(&self, path: &std::path::Path) -> Result<Option<Vec<u8>>> {
+            match fs::read(path).await {
+                Ok(bytes) => Ok(Some(bytes)),
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+                Err(e) => Err(e.into()),
+            }
+        }
+
+        async fn write_file(&self, path: &std::path::Path, contents: &[u8]) -> Result<()> {
+            fs::write(path, contents).await?;
+            Ok(())
+        }
+
+        async fn metadata(
+            &self,
+            path: &std::path::Path,
+        ) -> Result<Option<uc_core::ports::cache_fs::FileMetadata>> {
+            match fs::metadata(path).await {
+                Ok(m) => Ok(Some(uc_core::ports::cache_fs::FileMetadata {
+                    size_bytes: m.len(),
+                    is_dir: m.is_dir(),
+                    modified_unix_ms: m
+                        .modified()
+                        .ok()
+                        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+                        .map(|d| d.as_millis() as i64),
+                })),
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+                Err(e) => Err(e.into()),
+            }
+        }
+
+        async fn remove_dir(&self, path: &std::path::Path) -> Result<()> {
+            fs::remove_dir(path).await?;
+            Ok(())
+        }
     }
 
     async fn write_bytes(path: &std::path::Path, len: usize) {

--- a/src-tauri/crates/uc-application/src/usecases/clipboard_history/cleanup.rs
+++ b/src-tauri/crates/uc-application/src/usecases/clipboard_history/cleanup.rs
@@ -20,6 +20,18 @@
 //! decrypting representations on the order of a few thousand entries is
 //! fine. If cleanup frequency ever grows (e.g. per-hour sweep), revisit
 //! this trade-off.
+//!
+//! `execute` runs two passes:
+//!   1. the file-cache TTL sweep described above (copied files only), and
+//!   2. a total-size quota over disk-backed entries — the only pass that
+//!      bounds the content-addressed image-blob store, which the TTL sweep
+//!      never sees (issue #957).
+//!
+//! The quota pass is **quota-only** (no age rule for image blobs) and
+//! **grandfathers** everything that predates the persisted quota baseline, so
+//! it never retroactively reclaims a user's pre-upgrade history — the failure
+//! mode that got the earlier age-retention variant reverted (#957). See
+//! `CleanupExpiredFilesUseCase::run_quota`.
 
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
@@ -28,12 +40,13 @@ use std::sync::Arc;
 use anyhow::Result;
 use tracing::{info, info_span, warn, Instrument};
 
+use uc_core::clipboard::PayloadAvailability;
 use uc_core::ids::EntryId;
 use uc_core::ports::blob::BlobTransferPort;
 use uc_core::ports::search::search_index::SearchIndexPort;
 use uc_core::ports::{
-    ClipboardEntryRepositoryPort, ClipboardEventWriterPort, ClipboardRepresentationRepositoryPort,
-    ClipboardSelectionRepositoryPort, SettingsPort,
+    CacheFsPort, ClipboardEntryRepositoryPort, ClipboardEventWriterPort,
+    ClipboardRepresentationRepositoryPort, ClipboardSelectionRepositoryPort, SettingsPort,
 };
 
 use super::delete_entry::DeleteClipboardEntryUseCase;
@@ -55,6 +68,10 @@ pub struct CleanupResult {
 
 const ENTRY_LIST_BATCH_SIZE: usize = 1000;
 
+/// Hidden marker file (in the app-data root) holding the cache-quota baseline
+/// timestamp in milliseconds. See `CleanupExpiredFilesUseCase::quota_baseline_path`.
+const QUOTA_BASELINE_FILE: &str = ".cache-quota-baseline";
+
 pub(crate) struct CleanupExpiredFilesUseCase {
     settings: Arc<dyn SettingsPort>,
     file_cache_dir: PathBuf,
@@ -64,6 +81,10 @@ pub(crate) struct CleanupExpiredFilesUseCase {
     representation_repo: Arc<dyn ClipboardRepresentationRepositoryPort>,
     blob_transfer: Option<Arc<dyn BlobTransferPort>>,
     search_index: Option<Arc<dyn SearchIndexPort>>,
+    /// Filesystem port — every on-disk access this use case makes (the TTL
+    /// sweep, orphan/empty-dir removal, and the quota baseline marker) routes
+    /// through it rather than `std::fs`, keeping the use case infra-agnostic.
+    cache_fs: Arc<dyn CacheFsPort>,
 }
 
 impl CleanupExpiredFilesUseCase {
@@ -74,6 +95,7 @@ impl CleanupExpiredFilesUseCase {
         selection_repo: Arc<dyn ClipboardSelectionRepositoryPort>,
         event_writer: Arc<dyn ClipboardEventWriterPort>,
         representation_repo: Arc<dyn ClipboardRepresentationRepositoryPort>,
+        cache_fs: Arc<dyn CacheFsPort>,
     ) -> Self {
         Self {
             settings,
@@ -84,6 +106,7 @@ impl CleanupExpiredFilesUseCase {
             representation_repo,
             blob_transfer: None,
             search_index: None,
+            cache_fs,
         }
     }
 
@@ -106,30 +129,19 @@ impl CleanupExpiredFilesUseCase {
             return Ok(CleanupResult::default());
         }
 
-        let retention_secs = settings.file_sync.file_retention_hours as u64 * 3600;
-        let now = std::time::SystemTime::now();
+        let retention_hours = settings.file_sync.file_retention_hours;
+        // `file_cache_quota_per_device` is enforced here as a *total* on-disk
+        // budget for cached payloads. The per-device layout it was named for
+        // never materialized: clipboard image blobs land in a single
+        // content-addressed iroh-blobs store that is not partitioned by source
+        // device, so a total cap is the only practical interpretation.
+        let quota_bytes = settings.file_sync.file_cache_quota_per_device;
 
-        if !self.file_cache_dir.exists() {
-            info!(
-                path = %self.file_cache_dir.display(),
-                "File cache directory does not exist, nothing to clean"
-            );
-            return Ok(CleanupResult::default());
-        }
+        let mut result = CleanupResult::default();
 
-        let expired_files = collect_expired_files(&self.file_cache_dir, now, retention_secs)?;
-        if expired_files.is_empty() {
-            info!("No expired cache files to clean up");
-            return Ok(CleanupResult::default());
-        }
-
-        let path_to_entry = self.build_reverse_index().await?;
-        info!(
-            expired_files = expired_files.len(),
-            indexed_paths = path_to_entry.len(),
-            "Reverse index built; routing expired files to entry-level delete or orphan removal"
-        );
-
+        // One entry-aware delete path, shared by both passes. For blob-backed
+        // entries this untags the blob; iroh-blobs GC reclaims the bytes on its
+        // next sweep (see DeleteClipboardEntryUseCase).
         let mut delete_uc = DeleteClipboardEntryUseCase::from_ports(
             self.entry_repo.clone(),
             self.selection_repo.clone(),
@@ -144,7 +156,78 @@ impl CleanupExpiredFilesUseCase {
             delete_uc = delete_uc.with_blob_transfer(bt);
         }
 
-        let mut result = CleanupResult::default();
+        // Pass 1: TTL sweep of the on-disk file cache (copied files only).
+        // Non-fatal: a file-cache sweep failure must not block the quota pass
+        // below, which is the only one that bounds the image-blob store.
+        if let Err(e) = self
+            .run_file_cache_ttl(retention_hours, &delete_uc, &mut result)
+            .await
+        {
+            warn!(error = %e, "File-cache TTL sweep failed; continuing to quota pass");
+            result.errors += 1;
+        }
+
+        // Pass 2: total-size quota over disk-backed entries (blob-backed images
+        // and file-cache files alike). This is the ONLY pass that bounds the
+        // image-blob store — pass 1 walks `file-cache/` and never sees the
+        // iroh-blobs store, so without this an image-only workload grows the
+        // blob store without bound (issue #957).
+        //
+        // Quota-only by design (NO age rule for image blobs) and grandfathering
+        // pre-baseline data: the earlier age-retention variant retroactively
+        // deleted image-heavy users' history on first upgrade and was reverted
+        // (#957); this pass only ever touches data created after the quota
+        // baseline was established. See `run_quota`.
+        self.run_quota(quota_bytes, &delete_uc, &mut result).await;
+
+        info!(
+            files_removed = result.files_removed,
+            entries_deleted = result.entries_deleted,
+            orphans_removed = result.orphans_removed,
+            errors = result.errors,
+            bytes_reclaimed_mb = result.bytes_reclaimed / (1024 * 1024),
+            "File cache cleanup complete"
+        );
+        Ok(result)
+    }
+
+    /// Pass 1: delete file-cache entries whose on-disk files have aged past
+    /// `retention_hours`. Routes each expired file through the entry-aware
+    /// delete path (or removes it as an orphan when no owning entry exists).
+    /// This sweep only ever touches `file-cache/` (copied files referenced by
+    /// `text/uri-list` reps); it never sees the image-blob store.
+    async fn run_file_cache_ttl(
+        &self,
+        retention_hours: u32,
+        delete_uc: &DeleteClipboardEntryUseCase,
+        result: &mut CleanupResult,
+    ) -> Result<()> {
+        let retention_secs = retention_hours as u64 * 3600;
+        let now_ms = now_millis();
+        let cache_fs = self.cache_fs.as_ref();
+
+        if !cache_fs.exists(&self.file_cache_dir).await {
+            info!(
+                path = %self.file_cache_dir.display(),
+                "File cache directory does not exist, skipping TTL sweep"
+            );
+            return Ok(());
+        }
+
+        let expired_files =
+            collect_expired_files(cache_fs, &self.file_cache_dir, now_ms, retention_secs).await?;
+        if expired_files.is_empty() {
+            info!("No expired cache files to clean up");
+            return Ok(());
+        }
+
+        let path_to_entry = self.build_reverse_index().await?;
+        info!(
+            expired_files = expired_files.len(),
+            indexed_paths = path_to_entry.len(),
+            "Reverse index built; routing expired files to entry-level delete or orphan removal"
+        );
+
         // Multiple cache paths can map to the same entry_id (an entry with
         // several files); only invoke delete_entry once per entry.
         let mut handled_entries: HashSet<EntryId> = HashSet::new();
@@ -177,43 +260,264 @@ impl CleanupExpiredFilesUseCase {
                         }
                     }
                 }
-                None => match tokio::fs::remove_file(path).await {
-                    Ok(()) => {
-                        info!(
-                            path = %path.display(),
-                            "Removed orphan cache file (no owning entry in DB)"
-                        );
+                None => {
+                    // Vanished between the directory walk and here (e.g. a
+                    // sibling sweep): nothing to free, count it as gone rather
+                    // than an error. The port's `remove_file` doesn't expose
+                    // `NotFound`, so probe existence first.
+                    if !cache_fs.exists(path).await {
                         result.orphans_removed += 1;
                         result.files_removed += 1;
-                        result.bytes_reclaimed += size;
+                    } else {
+                        match cache_fs.remove_file(path).await {
+                            Ok(()) => {
+                                info!(
+                                    path = %path.display(),
+                                    "Removed orphan cache file (no owning entry in DB)"
+                                );
+                                result.orphans_removed += 1;
+                                result.files_removed += 1;
+                                result.bytes_reclaimed += size;
+                            }
+                            Err(e) => {
+                                warn!(
+                                    path = %path.display(),
+                                    error = %e,
+                                    "Failed to remove orphan cache file"
+                                );
+                                result.errors += 1;
+                            }
+                        }
                     }
-                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                        result.orphans_removed += 1;
-                        result.files_removed += 1;
-                    }
-                    Err(e) => {
-                        warn!(
-                            path = %path.display(),
-                            error = %e,
-                            "Failed to remove orphan cache file"
-                        );
-                        result.errors += 1;
-                    }
-                },
+                }
             }
         }
 
-        cleanup_empty_dirs(&self.file_cache_dir).await;
+        cleanup_empty_dirs(cache_fs, &self.file_cache_dir).await;
+        Ok(())
+    }
+
+    /// Pass 2: enforce a total-size quota over disk-backed entries (blob-backed
+    /// images and file-cache files alike), evicting oldest-first. This is the
+    /// only pass that reclaims clipboard image blobs.
+    ///
+    /// Two safety rules distinguish this from the reverted age-retention
+    /// variant (#957) that deleted users' history on first upgrade:
+    ///
+    ///   - **Quota-only, no age rule.** Entries are evicted purely to bring the
+    ///     managed total under `quota_bytes`; an entry is never deleted merely
+    ///     for being old.
+    ///   - **Grandfathering.** A baseline timestamp is persisted the first time
+    ///     this pass runs. Only entries created at/after the baseline are
+    ///     quota-managed; everything that predates the quota feature is exempt
+    ///     (never evicted, never counted toward the budget). This bounds *new*
+    ///     growth without retroactively reclaiming pre-upgrade payloads.
+    ///
+    /// Additional guards: the single most-recent managed entry is never evicted
+    /// (so a freshly copied over-quota payload doesn't vanish from history), and
+    /// every failure path is fail-safe — if the baseline can't be read or
+    /// written, the pass evicts nothing rather than risk deleting un-baselined
+    /// data. Eviction routes through the entry-aware delete path, which untags
+    /// blobs so iroh-blobs GC reclaims the bytes on its next sweep.
+    ///
+    /// Pinned/favorited entries are a future exemption: the schema does not yet
+    /// persist a favorite flag (see `ToggleFavoriteClipboardEntryUseCase`), so
+    /// there is nothing to exempt today. When `is_favorited` lands, filter such
+    /// entries out of the managed set before calling the eviction policy.
+    async fn run_quota(
+        &self,
+        quota_bytes: u64,
+        delete_uc: &DeleteClipboardEntryUseCase,
+        result: &mut CleanupResult,
+    ) {
+        if quota_bytes == 0 {
+            info!("Cache quota disabled (quota = 0); skipping quota enforcement");
+            return;
+        }
+
+        // Baseline persistence runs through the cache-fs port.
+        let cache_fs = self.cache_fs.as_ref();
+
+        let Some(baseline_path) = self.quota_baseline_path() else {
+            warn!(
+                file_cache_dir = %self.file_cache_dir.display(),
+                "Cannot locate app-data root for the quota baseline; skipping quota enforcement (fail-safe)"
+            );
+            return;
+        };
+
+        let baseline_ms = match read_quota_baseline(cache_fs, &baseline_path).await {
+            Ok(Some(ms)) => ms,
+            Ok(None) => {
+                // First run of the quota feature: record the baseline and
+                // grandfather everything that already exists. Evict nothing
+                // this pass — pre-baseline data must never be reclaimed.
+                let now_ms = now_millis();
+                match write_quota_baseline(cache_fs, &baseline_path, now_ms).await {
+                    Ok(()) => info!(
+                        baseline_ms = now_ms,
+                        path = %baseline_path.display(),
+                        "Established cache-quota baseline; existing payloads grandfathered (exempt from quota)"
+                    ),
+                    Err(e) => warn!(
+                        error = %e,
+                        path = %baseline_path.display(),
+                        "Failed to persist cache-quota baseline; skipping quota enforcement (fail-safe)"
+                    ),
+                }
+                return;
+            }
+            Err(e) => {
+                warn!(
+                    error = %e,
+                    path = %baseline_path.display(),
+                    "Cache-quota baseline unreadable; skipping quota enforcement (fail-safe, baseline left intact)"
+                );
+                return;
+            }
+        };
+
+        let entries = match self.collect_disk_backed_entries().await {
+            Ok(e) => e,
+            Err(e) => {
+                warn!(error = %e, "Failed to enumerate disk-backed entries for quota; skipping");
+                return;
+            }
+        };
+
+        // Only post-baseline entries are quota-managed; pre-baseline payloads
+        // are grandfathered (exempt from both the budget total and eviction).
+        let grandfathered = entries
+            .iter()
+            .filter(|e| e.created_at_ms < baseline_ms)
+            .count();
+        let managed: Vec<DiskBackedEntry> = entries
+            .into_iter()
+            .filter(|e| e.created_at_ms >= baseline_ms)
+            .collect();
+        if managed.is_empty() {
+            return;
+        }
+
+        let managed_total: u64 = managed.iter().map(|e| e.disk_bytes).sum();
+        let victims = select_entries_to_evict_for_quota(managed, quota_bytes);
+
+        if victims.is_empty() {
+            info!(
+                managed_total_mb = managed_total / (1024 * 1024),
+                quota_mb = quota_bytes / (1024 * 1024),
+                grandfathered,
+                "Cache quota: managed payloads within budget, nothing to evict"
+            );
+            return;
+        }
+
+        let candidates = victims.len();
+        for entry_id in &victims {
+            match delete_uc.execute(entry_id).await {
+                Ok(()) => {
+                    result.entries_deleted += 1;
+                }
+                Err(e) => {
+                    warn!(
+                        entry_id = %entry_id,
+                        error = %e,
+                        "Quota delete failed for disk-backed entry"
+                    );
+                    result.errors += 1;
+                }
+            }
+        }
 
         info!(
-            files_removed = result.files_removed,
-            entries_deleted = result.entries_deleted,
-            orphans_removed = result.orphans_removed,
-            errors = result.errors,
-            bytes_reclaimed_mb = result.bytes_reclaimed / (1024 * 1024),
-            "File cache cleanup complete"
+            candidates,
+            managed_total_mb = managed_total / (1024 * 1024),
+            quota_mb = quota_bytes / (1024 * 1024),
+            grandfathered,
+            baseline_ms,
+            "Cache quota enforcement complete (oldest-first; pre-baseline data grandfathered; disk reclaimed by iroh-blobs GC on its next sweep)"
         );
-        Ok(result)
+    }
+
+    /// Baseline marker path: a hidden file in the app-data root (the parent of
+    /// the file cache, e.g. `<app_data>/file-cache` → `<app_data>`), alongside
+    /// the other app-data markers. Deliberately NOT inside `file_cache_dir`, so
+    /// the TTL sweep never treats it as an orphan and removes it. `None` when
+    /// the cache dir has no parent (a layout that should never occur in
+    /// practice), in which case the quota pass fails safe and evicts nothing.
+    fn quota_baseline_path(&self) -> Option<PathBuf> {
+        self.file_cache_dir
+            .parent()
+            .map(|root| root.join(QUOTA_BASELINE_FILE))
+    }
+
+    /// Enumerate every entry whose payload occupies disk (blob store or file
+    /// cache), paired with its creation time and on-disk byte estimate. An
+    /// entry counts as disk-backed when any representation is `BlobReady`,
+    /// `Staged`, or `Processing` (i.e. its bytes live outside the DB);
+    /// `Inline` reps live in the DB and `Lost`/`Failed` reps hold no bytes.
+    async fn collect_disk_backed_entries(&self) -> Result<Vec<DiskBackedEntry>> {
+        let mut out = Vec::new();
+        let mut offset = 0usize;
+
+        loop {
+            let batch = self
+                .entry_repo
+                .list_entries(ENTRY_LIST_BATCH_SIZE, offset)
+                .await
+                .map_err(|e| anyhow::anyhow!("list entries for quota: {e}"))?;
+
+            if batch.is_empty() {
+                break;
+            }
+            let batch_len = batch.len();
+
+            for entry in &batch {
+                let reps = match self
+                    .representation_repo
+                    .get_representations_for_event(&entry.event_id)
+                    .await
+                {
+                    Ok(reps) => reps,
+                    Err(e) => {
+                        warn!(
+                            event_id = %entry.event_id,
+                            error = %e,
+                            "Failed to load representations for quota — skipping entry"
+                        );
+                        continue;
+                    }
+                };
+
+                let disk_bytes: u64 = reps
+                    .iter()
+                    .filter(|r| {
+                        matches!(
+                            r.payload_state,
+                            PayloadAvailability::BlobReady
+                                | PayloadAvailability::Staged
+                                | PayloadAvailability::Processing
+                        )
+                    })
+                    .map(|r| r.size_bytes.max(0) as u64)
+                    .sum();
+
+                if disk_bytes > 0 {
+                    out.push(DiskBackedEntry {
+                        entry_id: entry.entry_id.clone(),
+                        created_at_ms: entry.created_at_ms,
+                        disk_bytes,
+                    });
+                }
+            }
+
+            offset += batch_len;
+            if batch_len < ENTRY_LIST_BATCH_SIZE {
+                break;
+            }
+        }
+
+        Ok(out)
     }
 
     /// Walk every entry in the DB and build a `cache_path → entry_id`
@@ -297,23 +601,110 @@ impl CleanupExpiredFilesUseCase {
     }
 }
 
-fn collect_expired_files(
+/// A clipboard entry whose payload occupies disk, with the inputs the quota
+/// policy needs.
+#[derive(Debug, Clone)]
+struct DiskBackedEntry {
+    entry_id: EntryId,
+    created_at_ms: i64,
+    disk_bytes: u64,
+}
+
+/// Decide which disk-backed entries to evict, oldest-first, to bring the total
+/// down to `quota_bytes`. Pure and deterministic so the policy can be
+/// unit-tested without any I/O.
+///
+/// Quota-only: there is no age rule here — an entry is evicted solely to free
+/// budget. Entries are processed oldest-first by `created_at_ms`; eviction
+/// stops as soon as the projected remaining total is `<= quota_bytes`. The
+/// single newest entry is never evicted, so a freshly copied payload that on
+/// its own exceeds the quota is kept rather than instantly reclaimed.
+/// `quota_bytes == 0` disables the quota and evicts nothing.
+fn select_entries_to_evict_for_quota(
+    mut entries: Vec<DiskBackedEntry>,
+    quota_bytes: u64,
+) -> Vec<EntryId> {
+    if quota_bytes == 0 || entries.is_empty() {
+        return Vec::new();
+    }
+    entries.sort_by_key(|e| e.created_at_ms);
+
+    let total: u64 = entries.iter().map(|e| e.disk_bytes).sum();
+    let last_idx = entries.len() - 1;
+
+    let mut freed: u64 = 0;
+    let mut victims = Vec::new();
+    for (idx, entry) in entries.into_iter().enumerate() {
+        if total.saturating_sub(freed) <= quota_bytes {
+            break;
+        }
+        // Never evict the single most-recent managed entry: a just-captured
+        // payload that alone exceeds the quota should stay in history rather
+        // than disappear the instant it is copied.
+        if idx == last_idx {
+            break;
+        }
+        freed += entry.disk_bytes;
+        victims.push(entry.entry_id);
+    }
+    victims
+}
+
+fn now_millis() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}
+
+/// Parse a quota-baseline marker's raw contents into epoch milliseconds.
+/// Kept separate from I/O so the parse/validation stays unit-testable.
+fn parse_quota_baseline(contents: &[u8]) -> Result<i64> {
+    let text = std::str::from_utf8(contents)
+        .map_err(|e| anyhow::anyhow!("quota baseline is not valid UTF-8: {e}"))?;
+    text.trim()
+        .parse::<i64>()
+        .map_err(|e| anyhow::anyhow!("parse quota baseline {:?}: {e}", text.trim()))
+}
+
+/// Read the persisted quota baseline (epoch milliseconds) through the cache-fs
+/// port.
+///
+/// `Ok(None)` means the marker file does not exist yet (first run); `Ok(Some)`
+/// is a valid baseline; `Err` means the file exists but could not be read or
+/// parsed. Callers treat `Err` as fail-safe (skip eviction) and must NOT
+/// overwrite the file, so a transient read glitch can't silently reset the
+/// baseline and un-grandfather existing data.
+async fn read_quota_baseline(cache_fs: &dyn CacheFsPort, path: &Path) -> Result<Option<i64>> {
+    match cache_fs.read_file(path).await? {
+        Some(bytes) => Ok(Some(parse_quota_baseline(&bytes)?)),
+        None => Ok(None),
+    }
+}
+
+async fn write_quota_baseline(cache_fs: &dyn CacheFsPort, path: &Path, ms: i64) -> Result<()> {
+    cache_fs.write_file(path, ms.to_string().as_bytes()).await
+}
+
+async fn collect_expired_files(
+    cache_fs: &dyn CacheFsPort,
     cache_dir: &Path,
-    now: std::time::SystemTime,
+    now_ms: i64,
     retention_secs: u64,
 ) -> Result<Vec<(PathBuf, u64)>> {
     let mut expired = Vec::new();
-    collect_expired_recursive(cache_dir, now, retention_secs, &mut expired)?;
+    collect_expired_recursive(cache_fs, cache_dir, now_ms, retention_secs, &mut expired).await?;
     Ok(expired)
 }
 
-fn collect_expired_recursive(
+async fn collect_expired_recursive(
+    cache_fs: &dyn CacheFsPort,
     dir: &Path,
-    now: std::time::SystemTime,
+    now_ms: i64,
     retention_secs: u64,
     out: &mut Vec<(PathBuf, u64)>,
 ) -> Result<()> {
-    let entries = match std::fs::read_dir(dir) {
+    let entries = match cache_fs.read_dir(dir).await {
         Ok(entries) => entries,
         Err(e) => {
             warn!(
@@ -325,20 +716,29 @@ fn collect_expired_recursive(
         }
     };
 
-    for entry in entries {
-        let entry = match entry {
-            Ok(e) => e,
-            Err(e) => {
-                warn!(error = %e, "Failed to read directory entry");
-                continue;
-            }
-        };
+    let retention_ms = (retention_secs as i64).saturating_mul(1000);
 
-        let meta = match entry.metadata() {
-            Ok(m) => m,
+    for entry in entries {
+        if entry.is_dir {
+            // Recursive async call must be boxed.
+            Box::pin(collect_expired_recursive(
+                cache_fs,
+                &entry.path,
+                now_ms,
+                retention_secs,
+                out,
+            ))
+            .await?;
+            continue;
+        }
+
+        let meta = match cache_fs.metadata(&entry.path).await {
+            Ok(Some(m)) => m,
+            // Vanished between the listing and the metadata read — nothing to do.
+            Ok(None) => continue,
             Err(e) => {
                 warn!(
-                    path = %entry.path().display(),
+                    path = %entry.path.display(),
                     error = %e,
                     "Failed to read file metadata"
                 );
@@ -346,40 +746,262 @@ fn collect_expired_recursive(
             }
         };
 
-        if meta.is_dir() {
-            collect_expired_recursive(&entry.path(), now, retention_secs, out)?;
-        } else if meta.is_file() {
-            let modified = meta.modified().unwrap_or(now);
-            let age = now.duration_since(modified).unwrap_or_default();
-            if age.as_secs() >= retention_secs {
-                out.push((entry.path(), meta.len()));
-            }
+        if meta.is_dir {
+            continue;
+        }
+        // `None` modified time → treat as age 0 (not expired), matching the
+        // prior `modified().unwrap_or(now)` behavior.
+        let age_ms = meta.modified_unix_ms.map(|m| now_ms - m).unwrap_or(0);
+        if age_ms >= retention_ms {
+            out.push((entry.path, meta.size_bytes));
         }
     }
 
     Ok(())
 }
 
-async fn cleanup_empty_dirs(cache_dir: &Path) {
-    let entries = match std::fs::read_dir(cache_dir) {
+async fn cleanup_empty_dirs(cache_fs: &dyn CacheFsPort, cache_dir: &Path) {
+    let entries = match cache_fs.read_dir(cache_dir).await {
         Ok(e) => e,
         Err(_) => return,
     };
 
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if path.is_dir() {
-            if let Ok(mut contents) = std::fs::read_dir(&path) {
-                if contents.next().is_none() {
-                    if let Err(e) = tokio::fs::remove_dir(&path).await {
-                        warn!(
-                            path = %path.display(),
-                            error = %e,
-                            "Failed to remove empty cache directory"
-                        );
-                    }
+    for entry in entries {
+        if !entry.is_dir {
+            continue;
+        }
+        match cache_fs.read_dir(&entry.path).await {
+            Ok(contents) if contents.is_empty() => {
+                if let Err(e) = cache_fs.remove_dir(&entry.path).await {
+                    warn!(
+                        path = %entry.path.display(),
+                        error = %e,
+                        "Failed to remove empty cache directory"
+                    );
                 }
             }
+            _ => {}
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(id: &str, created_at_ms: i64, disk_bytes: u64) -> DiskBackedEntry {
+        DiskBackedEntry {
+            entry_id: EntryId::from(id),
+            created_at_ms,
+            disk_bytes,
+        }
+    }
+
+    fn ids(v: &[EntryId]) -> Vec<String> {
+        v.iter().map(|e| e.to_string()).collect()
+    }
+
+    // --- select_entries_to_evict_for_quota: pure quota policy --------------
+
+    #[test]
+    fn quota_disabled_evicts_nothing() {
+        let entries = vec![entry("a", 1, 5_000), entry("b", 2, 5_000)];
+        assert!(select_entries_to_evict_for_quota(entries, 0).is_empty());
+    }
+
+    #[test]
+    fn quota_keeps_everything_when_already_under_budget() {
+        let entries = vec![entry("a", 1, 40), entry("b", 2, 40)];
+        assert!(select_entries_to_evict_for_quota(entries, 100).is_empty());
+    }
+
+    #[test]
+    fn quota_evicts_oldest_until_under_budget() {
+        // total = 180; quota = 100. Oldest-first until <= 100.
+        let entries = vec![entry("a", 1, 60), entry("b", 2, 60), entry("c", 3, 60)];
+        let victims = select_entries_to_evict_for_quota(entries, 100);
+        // drop a (180→120) and b (120→60); c kept.
+        assert_eq!(ids(&victims), vec!["a", "b"]);
+    }
+
+    #[test]
+    fn quota_processes_oldest_first_regardless_of_input_order() {
+        let entries = vec![
+            entry("newest", 300, 60),
+            entry("oldest", 100, 60),
+            entry("middle", 200, 60),
+        ];
+        // quota 100, total 180 → evict the two oldest by created_at.
+        let victims = select_entries_to_evict_for_quota(entries, 100);
+        assert_eq!(ids(&victims), vec!["oldest", "middle"]);
+    }
+
+    #[test]
+    fn quota_never_evicts_the_single_newest_entry() {
+        // The newest entry alone (200) exceeds the quota (100). Everything
+        // older is evicted, but the newest is kept rather than reclaimed the
+        // instant it was copied — so the total stays above quota by design.
+        let entries = vec![
+            entry("old1", 1, 50),
+            entry("old2", 2, 50),
+            entry("newest", 3, 200),
+        ];
+        let victims = select_entries_to_evict_for_quota(entries, 100);
+        assert_eq!(ids(&victims), vec!["old1", "old2"]);
+    }
+
+    #[test]
+    fn quota_single_entry_is_never_evicted() {
+        let entries = vec![entry("only", 1, 10_000)];
+        assert!(select_entries_to_evict_for_quota(entries, 100).is_empty());
+    }
+
+    // --- quota baseline parsing (pure) ------------------------------------
+
+    #[test]
+    fn parse_baseline_accepts_trimmed_integer() {
+        assert_eq!(
+            parse_quota_baseline(b"  1700000000000\n").unwrap(),
+            1_700_000_000_000
+        );
+    }
+
+    #[test]
+    fn parse_baseline_rejects_garbage() {
+        // A garbage marker must surface as Err so the caller fails safe and
+        // leaves the file intact, rather than parsing it as a fresh baseline
+        // and un-grandfathering existing data.
+        assert!(parse_quota_baseline(b"not-a-number").is_err());
+    }
+
+    // --- quota baseline persistence (via cache-fs port) -------------------
+
+    /// In-memory `CacheFsPort` exercising only the file read/write methods the
+    /// baseline helpers call; everything else is unreachable here.
+    #[derive(Default)]
+    struct InMemoryCacheFs {
+        files: std::sync::Mutex<HashMap<PathBuf, Vec<u8>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl CacheFsPort for InMemoryCacheFs {
+        async fn read_file(&self, path: &Path) -> Result<Option<Vec<u8>>> {
+            Ok(self.files.lock().unwrap().get(path).cloned())
+        }
+        async fn write_file(&self, path: &Path, contents: &[u8]) -> Result<()> {
+            self.files
+                .lock()
+                .unwrap()
+                .insert(path.to_path_buf(), contents.to_vec());
+            Ok(())
+        }
+        async fn exists(&self, path: &Path) -> bool {
+            self.files.lock().unwrap().contains_key(path)
+        }
+        async fn read_dir(&self, _path: &Path) -> Result<Vec<uc_core::ports::cache_fs::DirEntry>> {
+            unreachable!("not exercised by baseline tests")
+        }
+        async fn remove_dir_all(&self, _path: &Path) -> Result<()> {
+            unreachable!("not exercised by baseline tests")
+        }
+        async fn remove_file(&self, _path: &Path) -> Result<()> {
+            unreachable!("not exercised by baseline tests")
+        }
+        async fn dir_size(&self, _path: &Path) -> Result<u64> {
+            unreachable!("not exercised by baseline tests")
+        }
+        async fn metadata(
+            &self,
+            _path: &Path,
+        ) -> Result<Option<uc_core::ports::cache_fs::FileMetadata>> {
+            unreachable!("not exercised by baseline tests")
+        }
+        async fn remove_dir(&self, _path: &Path) -> Result<()> {
+            unreachable!("not exercised by baseline tests")
+        }
+    }
+
+    #[tokio::test]
+    async fn baseline_absent_reads_as_none() {
+        let fs = InMemoryCacheFs::default();
+        let path = PathBuf::from("/app-data").join(QUOTA_BASELINE_FILE);
+        assert_eq!(read_quota_baseline(&fs, &path).await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn baseline_round_trips() {
+        let fs = InMemoryCacheFs::default();
+        let path = PathBuf::from("/app-data").join(QUOTA_BASELINE_FILE);
+        write_quota_baseline(&fs, &path, 1_700_000_000_000)
+            .await
+            .unwrap();
+        assert_eq!(
+            read_quota_baseline(&fs, &path).await.unwrap(),
+            Some(1_700_000_000_000)
+        );
+    }
+
+    #[tokio::test]
+    async fn baseline_corrupt_content_is_an_error_not_a_silent_reset() {
+        let fs = InMemoryCacheFs::default();
+        let path = PathBuf::from("/app-data").join(QUOTA_BASELINE_FILE);
+        fs.write_file(&path, b"not-a-number").await.unwrap();
+        assert!(read_quota_baseline(&fs, &path).await.is_err());
+    }
+
+    // --- TTL sweep over the cache-fs port (real adapter + tempdir) --------
+
+    #[tokio::test]
+    async fn collect_expired_files_walks_recursively_and_respects_retention() {
+        let fs = uc_infra::fs::TokioCacheFsAdapter::new();
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        tokio::fs::write(root.join("a.bin"), vec![0u8; 10])
+            .await
+            .unwrap();
+        tokio::fs::create_dir(root.join("sub")).await.unwrap();
+        tokio::fs::write(root.join("sub").join("b.bin"), vec![0u8; 20])
+            .await
+            .unwrap();
+
+        let now_ms = now_millis();
+
+        // retention 0 → every file is "expired"; the recursive walk finds both
+        // (one at the root, one nested) with their real sizes.
+        let mut all = collect_expired_files(&fs, root, now_ms, 0).await.unwrap();
+        all.sort_by_key(|(_, size)| *size);
+        assert_eq!(
+            all.iter().map(|(_, s)| *s).collect::<Vec<_>>(),
+            vec![10, 20]
+        );
+
+        // A huge retention window → nothing is old enough to sweep yet.
+        let none = collect_expired_files(&fs, root, now_ms, 10_000_000_000)
+            .await
+            .unwrap();
+        assert!(none.is_empty());
+    }
+
+    #[tokio::test]
+    async fn cleanup_empty_dirs_removes_only_empty_subdirs() {
+        let fs = uc_infra::fs::TokioCacheFsAdapter::new();
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        tokio::fs::create_dir(root.join("empty")).await.unwrap();
+        tokio::fs::create_dir(root.join("full")).await.unwrap();
+        tokio::fs::write(root.join("full").join("f.bin"), b"x")
+            .await
+            .unwrap();
+
+        cleanup_empty_dirs(&fs, root).await;
+
+        assert!(
+            !fs.exists(&root.join("empty")).await,
+            "empty subdir should be removed"
+        );
+        assert!(
+            fs.exists(&root.join("full")).await,
+            "non-empty subdir must be kept"
+        );
     }
 }

--- a/src-tauri/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/ports.rs
+++ b/src-tauri/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/ports.rs
@@ -56,6 +56,9 @@ impl InboundCapture for CaptureClipboardUseCase {
             Some(preset_entry_id),
         )
         .await
+        // RemotePush never takes the local dedup branch, so the outcome is
+        // always a fresh entry; the inbound contract only needs its id.
+        .map(|outcome| outcome.map(|o| o.entry_id))
     }
 }
 

--- a/src-tauri/crates/uc-core/src/clipboard/system.rs
+++ b/src-tauri/crates/uc-core/src/clipboard/system.rs
@@ -464,6 +464,20 @@ impl SystemClipboardSnapshot {
         self.representations.iter().map(|r| r.size_bytes()).sum()
     }
 
+    /// Byte size of the dominant image representation — the first image
+    /// representation, the one [`Self::meaningful_origin_key`] keys an
+    /// `image:` snapshot on — or `None` when the snapshot carries no image
+    /// representation. Unlike [`Self::total_size_bytes`] this isolates the
+    /// image's own size from any co-resident metadata representations, so a
+    /// size comparison tracks the image identity rather than the whole
+    /// snapshot.
+    pub fn primary_image_size_bytes(&self) -> Option<i64> {
+        self.representations
+            .iter()
+            .find(|rep| is_image_representation(rep))
+            .map(|rep| rep.size_bytes())
+    }
+
     /// 是否为空快照（没有任何 representation）
     pub fn is_empty(&self) -> bool {
         self.representations.is_empty()

--- a/src-tauri/crates/uc-core/src/ports/cache_fs.rs
+++ b/src-tauri/crates/uc-core/src/ports/cache_fs.rs
@@ -14,6 +14,19 @@ pub struct DirEntry {
     pub is_dir: bool,
 }
 
+/// Metadata for a single filesystem path.
+/// 单个文件系统路径的元数据。
+#[derive(Debug, Clone)]
+pub struct FileMetadata {
+    /// Size in bytes (meaningful for regular files).
+    pub size_bytes: u64,
+    /// Whether the path is a directory.
+    pub is_dir: bool,
+    /// Last-modified time as milliseconds since the Unix epoch, or `None`
+    /// when the platform/filesystem does not expose a modified time.
+    pub modified_unix_ms: Option<i64>,
+}
+
 /// Port for filesystem operations needed by cache management use cases.
 /// 缓存管理用例所需的文件系统操作端口。
 #[async_trait]
@@ -40,4 +53,33 @@ pub trait CacheFsPort: Send + Sync {
     /// Returns `Ok(0)` for non-existent paths. Returns an error if a path
     /// exists but cannot be read (e.g. permission denied).
     async fn dir_size(&self, path: &Path) -> Result<u64>;
+
+    /// Read a file's entire contents.
+    /// 读取文件的全部内容。
+    ///
+    /// Returns `Ok(None)` when the file does not exist, `Ok(Some(bytes))`
+    /// with its contents otherwise, and `Err` for any other read failure
+    /// (e.g. permission denied, or the path is a directory). The
+    /// absent-vs-unreadable split lets callers treat a missing file as a
+    /// distinct, non-error state.
+    async fn read_file(&self, path: &Path) -> Result<Option<Vec<u8>>>;
+
+    /// Write `contents` to a file, creating it or truncating an existing
+    /// file. Parent directories are assumed to exist.
+    /// 将内容写入文件，文件不存在则创建、已存在则截断覆盖。假定父目录已存在。
+    async fn write_file(&self, path: &Path, contents: &[u8]) -> Result<()>;
+
+    /// Read metadata for a single path.
+    /// 读取单个路径的元数据。
+    ///
+    /// Returns `Ok(None)` when the path does not exist; `Err` for any other
+    /// failure (e.g. permission denied).
+    async fn metadata(&self, path: &Path) -> Result<Option<FileMetadata>>;
+
+    /// Remove a single empty directory.
+    /// 删除单个空目录。
+    ///
+    /// Errors if the directory is not empty (callers that want a recursive
+    /// delete use [`Self::remove_dir_all`]).
+    async fn remove_dir(&self, path: &Path) -> Result<()>;
 }

--- a/src-tauri/crates/uc-daemon/src/daemon/workers/clipboard_watcher.rs
+++ b/src-tauri/crates/uc-daemon/src/daemon/workers/clipboard_watcher.rs
@@ -181,7 +181,8 @@ impl ClipboardChangeHandler for DaemonClipboardChangeHandler {
         match self.clipboard_capture.capture(snapshot, origin, None).await {
             Ok(Some(captured)) => {
                 let entry_id = EntryId::from(captured.entry_id.as_str());
-                debug!(entry_id = %entry_id, ?origin, "Daemon clipboard capture succeeded");
+                let deduplicated = captured.deduplicated;
+                debug!(entry_id = %entry_id, ?origin, deduplicated, "Daemon clipboard capture succeeded");
 
                 let payload = ClipboardNewContentPayload {
                     entry_id: captured.entry_id,
@@ -210,24 +211,38 @@ impl ClipboardChangeHandler for DaemonClipboardChangeHandler {
                     debug!(error = %e, "No WS subscribers for clipboard.new_content");
                 }
 
-                let search_span = tracing::info_span!("search.live_index", entry_id = %entry_id);
-                match self
-                    .clipboard_live_index
-                    .index_capture(ClipboardLiveIndexInput {
-                        entry_id: entry_id.to_string(),
-                        snapshot: Arc::clone(&outbound_snapshot),
-                    })
-                    .instrument(search_span)
-                    .await
-                {
-                    Ok(ClipboardLiveIndexOutcome::Indexed) => {
-                        debug!(entry_id = %entry_id, "search: indexed captured entry");
-                    }
-                    Ok(ClipboardLiveIndexOutcome::Skipped { reason }) => {
-                        debug!(entry_id = %entry_id, reason, "search: skipped live index");
-                    }
-                    Err(e) => {
-                        warn!(error = %e, entry_id = %entry_id, "search: live index failed");
+                // Local dedup resurfaced an existing entry: it is already in
+                // the search index, so skip the live-index pass. We still
+                // dispatch below — a peer that was offline during the first
+                // copy never received this entry, and the outbound/inbound
+                // paths dedup byte-identical content, so re-dispatching on a
+                // re-copy is how an offline-then-rejoined peer catches up.
+                if deduplicated {
+                    debug!(
+                        entry_id = %entry_id,
+                        "watcher: resurfaced existing entry; skipping re-index, still dispatching for offline-peer catch-up"
+                    );
+                } else {
+                    let search_span =
+                        tracing::info_span!("search.live_index", entry_id = %entry_id);
+                    match self
+                        .clipboard_live_index
+                        .index_capture(ClipboardLiveIndexInput {
+                            entry_id: entry_id.to_string(),
+                            snapshot: Arc::clone(&outbound_snapshot),
+                        })
+                        .instrument(search_span)
+                        .await
+                    {
+                        Ok(ClipboardLiveIndexOutcome::Indexed) => {
+                            debug!(entry_id = %entry_id, "search: indexed captured entry");
+                        }
+                        Ok(ClipboardLiveIndexOutcome::Skipped { reason }) => {
+                            debug!(entry_id = %entry_id, reason, "search: skipped live index");
+                        }
+                        Err(e) => {
+                            warn!(error = %e, entry_id = %entry_id, "search: live index failed");
+                        }
                     }
                 }
 

--- a/src-tauri/crates/uc-infra/src/fs/cache_fs.rs
+++ b/src-tauri/crates/uc-infra/src/fs/cache_fs.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 
 use anyhow::{Context, Result};
 use async_trait::async_trait;
-use uc_core::ports::cache_fs::{CacheFsPort, DirEntry};
+use uc_core::ports::cache_fs::{CacheFsPort, DirEntry, FileMetadata};
 
 /// Tokio filesystem adapter for cache operations.
 /// 用于缓存操作的 Tokio 文件系统适配器。
@@ -59,6 +59,42 @@ impl CacheFsPort for TokioCacheFsAdapter {
 
     async fn dir_size(&self, path: &Path) -> Result<u64> {
         compute_dir_size(path).await
+    }
+
+    async fn read_file(&self, path: &Path) -> Result<Option<Vec<u8>>> {
+        match tokio::fs::read(path).await {
+            Ok(bytes) => Ok(Some(bytes)),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(e) => Err(anyhow::anyhow!("Failed to read file: {}", e)),
+        }
+    }
+
+    async fn write_file(&self, path: &Path, contents: &[u8]) -> Result<()> {
+        tokio::fs::write(path, contents)
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to write file: {}", e))
+    }
+
+    async fn metadata(&self, path: &Path) -> Result<Option<FileMetadata>> {
+        match tokio::fs::metadata(path).await {
+            Ok(m) => Ok(Some(FileMetadata {
+                size_bytes: m.len(),
+                is_dir: m.is_dir(),
+                modified_unix_ms: m
+                    .modified()
+                    .ok()
+                    .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+                    .map(|d| d.as_millis() as i64),
+            })),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(e) => Err(anyhow::anyhow!("Failed to read metadata: {}", e)),
+        }
+    }
+
+    async fn remove_dir(&self, path: &Path) -> Result<()> {
+        tokio::fs::remove_dir(path)
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to remove directory: {}", e))
     }
 }
 

--- a/src-tauri/crates/uc-platform/src/clipboard/watcher.rs
+++ b/src-tauri/crates/uc-platform/src/clipboard/watcher.rs
@@ -29,11 +29,35 @@ pub type PlatformEventSender = tokio::sync::mpsc::Sender<PlatformEvent>;
 /// where content bytes may differ slightly.
 const FILE_DEDUP_WINDOW: std::time::Duration = std::time::Duration::from_millis(500);
 
+/// Time window to suppress a rapid burst of same-size image clipboard events.
+///
+/// On X11 a clipboard owner (or a desktop clipboard manager such as Klipper /
+/// CopyQ / GPaste) can re-assert selection ownership several times per second,
+/// and some sources serialize the *same* image with non-deterministic padding /
+/// alpha bytes on every read. The content hash — and therefore
+/// `meaningful_origin_key` (`image:<hash>`) — then differs on every read, so
+/// the key-based dedup above never fires and each read becomes a brand-new
+/// entry + blob + outbound sync. Observed in the wild as a ~400 ms self-feeding
+/// storm (see issue #957) that filled disk with hundreds of identical-looking
+/// images.
+///
+/// Byte size is a cheap, stable proxy for image identity here: the storm keeps
+/// identical dimensions while only the hash churns. A genuinely different image
+/// (different byte size) passes through immediately; only a same-size image
+/// arriving within this window of the previous image is suppressed. The window
+/// is refreshed on every suppressed event so a sustained burst stays muted as
+/// long as it keeps firing faster than the window.
+const IMAGE_DEDUP_WINDOW: std::time::Duration = std::time::Duration::from_millis(1500);
+
 pub struct ClipboardWatcher {
     local_clipboard: Arc<dyn SystemClipboardPort>,
     sender: PlatformEventSender,
     last_meaningful_dedupe_key: Option<String>,
     last_file_emit_time: Option<Instant>,
+    /// `(observed_at, size_bytes)` of the most recent image-dominant snapshot,
+    /// updated on every image observation (emitted or suppressed). Drives the
+    /// [`IMAGE_DEDUP_WINDOW`] storm guard.
+    last_image_seen: Option<(Instant, i64)>,
 }
 
 impl ClipboardWatcher {
@@ -43,6 +67,7 @@ impl ClipboardWatcher {
             sender,
             last_meaningful_dedupe_key: None,
             last_file_emit_time: None,
+            last_image_seen: None,
         }
     }
 }
@@ -106,6 +131,34 @@ impl ClipboardWatcher {
             }
         }
 
+        // Image storm guard: an image-dominant snapshot whose image byte size
+        // matches the previous image within `IMAGE_DEDUP_WINDOW` is treated as a
+        // re-read of the same image (the hash churns under us; see
+        // `IMAGE_DEDUP_WINDOW`). Keyed off the image representation's own size
+        // (not the whole-snapshot total) so co-resident metadata reps can't make
+        // two genuinely different images look identically sized, nor mask the
+        // storm's stable image size. Computed before the value moves into
+        // `try_send`.
+        let image_size = current_dedupe_key
+            .as_ref()
+            .filter(|k| k.starts_with("image:"))
+            .and_then(|_| snapshot.primary_image_size_bytes());
+        if let Some(size) = image_size {
+            let now = Instant::now();
+            if let Some((last, last_size)) = self.last_image_seen {
+                if last_size == size && now.duration_since(last) < IMAGE_DEDUP_WINDOW {
+                    // Refresh the window so a sustained burst stays suppressed.
+                    self.last_image_seen = Some((now, size));
+                    debug!(
+                        size_bytes = size,
+                        elapsed_ms = now.duration_since(last).as_millis(),
+                        "Suppressing rapid same-size image clipboard event (storm guard)"
+                    );
+                    return;
+                }
+            }
+        }
+
         // Time-window suppression for file snapshots: macOS fires
         // multiple clipboard events when copying files (APFS→resolved
         // path transition) where content bytes may differ slightly.
@@ -139,6 +192,9 @@ impl ClipboardWatcher {
             {
                 self.last_file_emit_time = Some(Instant::now());
             }
+            if let Some(size) = image_size {
+                self.last_image_seen = Some((Instant::now(), size));
+            }
             if let Some(key) = current_dedupe_key {
                 self.last_meaningful_dedupe_key = Some(key);
             }
@@ -155,5 +211,155 @@ impl ClipboardWatcher {
 impl ClipboardHandler for ClipboardWatcher {
     fn on_clipboard_change(&mut self) {
         self.notify_change();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use uc_core::clipboard::{MimeType, ObservedClipboardRepresentation};
+    use uc_core::ids::{FormatId, RepresentationId};
+
+    /// `local_clipboard` is unused on the `notify_with_snapshot` path that
+    /// these tests exercise, so a do-nothing stub suffices.
+    struct StubClipboard;
+    impl SystemClipboardPort for StubClipboard {
+        fn read_snapshot(&self) -> anyhow::Result<SystemClipboardSnapshot> {
+            Ok(SystemClipboardSnapshot {
+                ts_ms: 0,
+                representations: vec![],
+            })
+        }
+        fn write_snapshot(&self, _snapshot: SystemClipboardSnapshot) -> anyhow::Result<()> {
+            Ok(())
+        }
+    }
+
+    fn watcher() -> (ClipboardWatcher, tokio::sync::mpsc::Receiver<PlatformEvent>) {
+        let (tx, rx) = tokio::sync::mpsc::channel(64);
+        (ClipboardWatcher::new(Arc::new(StubClipboard), tx), rx)
+    }
+
+    /// Image snapshot of exactly `size` bytes filled with `fill`. Varying
+    /// `fill` keeps the byte size constant while changing the blake3 hash —
+    /// exactly the #957 storm shape where the same image serializes to
+    /// different bytes on every read.
+    fn image(size: usize, fill: u8) -> SystemClipboardSnapshot {
+        let rep = ObservedClipboardRepresentation::new(
+            RepresentationId::new(),
+            FormatId::from("image"),
+            Some(MimeType("image/bmp".to_string())),
+            vec![fill; size],
+        );
+        SystemClipboardSnapshot {
+            ts_ms: 0,
+            representations: vec![rep],
+        }
+    }
+
+    /// Image-dominant snapshot carrying a primary image rep plus a second
+    /// (image) representation, so the whole-snapshot total differs from the
+    /// primary image's own size. `meaningful_origin_key` keys on the first
+    /// image rep, so the key stays `image:`.
+    fn image_with_secondary(
+        primary_size: usize,
+        primary_fill: u8,
+        secondary_size: usize,
+        secondary_fill: u8,
+    ) -> SystemClipboardSnapshot {
+        let primary = ObservedClipboardRepresentation::new(
+            RepresentationId::new(),
+            FormatId::from("image"),
+            Some(MimeType("image/bmp".to_string())),
+            vec![primary_fill; primary_size],
+        );
+        let secondary = ObservedClipboardRepresentation::new(
+            RepresentationId::new(),
+            FormatId::from("image"),
+            Some(MimeType("image/png".to_string())),
+            vec![secondary_fill; secondary_size],
+        );
+        SystemClipboardSnapshot {
+            ts_ms: 0,
+            representations: vec![primary, secondary],
+        }
+    }
+
+    fn drain(rx: &mut tokio::sync::mpsc::Receiver<PlatformEvent>) -> usize {
+        let mut n = 0;
+        while rx.try_recv().is_ok() {
+            n += 1;
+        }
+        n
+    }
+
+    #[test]
+    fn same_size_image_with_churning_hash_is_storm_guarded() {
+        // Reproduces issue #957: an X11 source re-emits the *same* image with
+        // a different byte pattern (different hash) every few hundred ms, so
+        // the meaningful-key dedup never fires. The storm guard must collapse
+        // the burst to a single emit.
+        let (mut w, mut rx) = watcher();
+        for fill in 0u8..16 {
+            w.notify_with_snapshot(image(4096, fill));
+        }
+        assert_eq!(
+            drain(&mut rx),
+            1,
+            "same-size image burst with churning hash must collapse to one emit"
+        );
+    }
+
+    #[test]
+    fn differently_sized_images_all_pass() {
+        // Genuinely different images (different byte size) must not be dropped.
+        let (mut w, mut rx) = watcher();
+        w.notify_with_snapshot(image(1000, 1));
+        w.notify_with_snapshot(image(2000, 2));
+        w.notify_with_snapshot(image(3000, 3));
+        assert_eq!(drain(&mut rx), 3, "distinct-size images must all emit");
+    }
+
+    #[test]
+    fn identical_image_collapses_via_key_dedup() {
+        // Byte-identical images share a hash and collapse via the pre-existing
+        // meaningful-key dedup; the storm guard must not regress this.
+        let (mut w, mut rx) = watcher();
+        w.notify_with_snapshot(image(1000, 7));
+        w.notify_with_snapshot(image(1000, 7));
+        assert_eq!(drain(&mut rx), 1);
+    }
+
+    #[test]
+    fn different_images_with_equal_total_size_both_pass() {
+        // Two genuinely different images whose *primary image* sizes differ
+        // (100 vs 120) but whose whole-snapshot totals coincide (both 150).
+        // Keying the guard off the snapshot total would wrongly suppress the
+        // second; keying off the image's own size lets both through.
+        let (mut w, mut rx) = watcher();
+        w.notify_with_snapshot(image_with_secondary(100, 1, 50, 9)); // total 150, image 100
+        w.notify_with_snapshot(image_with_secondary(120, 2, 30, 8)); // total 150, image 120
+        assert_eq!(
+            drain(&mut rx),
+            2,
+            "different images must emit even when snapshot totals match"
+        );
+    }
+
+    #[test]
+    fn same_image_size_with_churning_secondary_is_storm_guarded() {
+        // The image's own size is stable across the burst (the #957 shape)
+        // while a co-resident rep's size + content churn. Keying off the stable
+        // image size still collapses the burst; keying off the (churning) total
+        // would let every event through.
+        let (mut w, mut rx) = watcher();
+        for fill in 0u8..8 {
+            w.notify_with_snapshot(image_with_secondary(4096, fill, 100 + fill as usize, fill));
+        }
+        assert_eq!(
+            drain(&mut rx),
+            1,
+            "stable image size must storm-guard despite a churning secondary rep"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Forward-ports the three #957 fixes to `main` (0.14), adapting them to the post-v0.13.0 refactors (adr-008 daemon split, Arc-snapshot sharing). v0.13.1 shipped Fix 1 + Fix 3; Fix 4 was reverted there for first-upgrade data loss and is re-implemented here safely.

- **Image-recapture storm guard** (53f6f078) — on X11 a source re-serializes the *same* image with churning bytes, so hash-based dedup never fired and each read spawned a fresh entry + blob + outbound sync (~400ms self-feeding storm that filled disk). Adds a time-window guard keyed on the primary image rep's own byte size (`primary_image_size_bytes`).
- **Local-capture content dedup** (19add38d) — re-copying content already in history now resurfaces the existing entry (bumped to top) instead of persisting a duplicate and re-syncing; degrades to a fresh entry if the target vanished, and still dispatches so an offline-then-rejoined peer catches up. Adapted to main's adr-008 Arc-snapshot sharing.
- **Safe cache quota** (1057a6fe) — the content-addressed image-blob store was never swept and `file_cache_quota_per_device` was dead code, so disk grew unbounded (#957). Adds a quota-only, oldest-first eviction pass that **grandfathers** pre-upgrade data via a persisted baseline (so it never retroactively deletes existing history — the exact regression that got the original reverted in v0.13.1), is fail-safe when the baseline can't be read/written, and never evicts the newest entry. Pinned exemption is left as a hook (no `is_favorited` column exists yet).
- **CacheFsPort file ops** (e6af1068) — adds `read_file` / `write_file` / `metadata` / `remove_dir` so the cleanup use case runs entirely through the port; `cleanup.rs` is now free of direct `std::fs`.

Closes #959. Root cause / hotfix: #957.

**Docs:** left as-is. The cache quota is now enforced (it was dead code before), but its `docs-site` description *and* the GUI label both still say "per-device". Bringing them in line with the real total-budget + grandfather semantics is the "surface in the UI" follow-up explicitly deferred from #957's revert — out of scope for this code forward-port.

## Test plan

- [x] `cargo test -p uc-application -p uc-core` — 591 / 118 passing, 0 failed. Includes 19 new tests across the three fixes (storm guard ×5, resurface ×5, quota policy + baseline + TTL sweep ×9).
- [x] `cargo test -p uc-platform` — the 5 new watcher storm-guard tests pass. (Note: `clipboard::common::...effective_mime` and two doctests fail on this branch, but they also fail on `main` — pre-existing, unrelated to this PR; verified by stashing this PR's changes.)
- [x] `cargo test -p uc-infra` — 345 passing (the new `CacheFsPort` file ops).
- [x] `cargo check -p uc-daemon -p uc-bootstrap -p uc-webserver --tests` — downstream wiring compiles.
- [x] Each of the 4 commits verified to build in isolation (bisectable).
- [ ] Manual repro on Linux/X11: copy an image, confirm no recapture storm and the blob store stays bounded across restarts.
- [ ] Confirm first startup after upgrade does **not** delete existing image history (grandfathering), and that new captures past the quota are bounded oldest-first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Clipboard deduplication detection: System now recognizes when captured content matches existing entries and handles duplicates efficiently
  * Image storm suppression: Rapid consecutive copies of the same image are consolidated to prevent history clutter
  * Storage quota management: Enhanced cleanup policies with age-based removal and total-size quota enforcement for clipboard data

<!-- end of auto-generated comment: release notes by coderabbit.ai -->