### PR TITLE
fix(snap): drop externalBin sidecar requirement to unblock release build

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -103,6 +103,14 @@ parts:
       # 字符串注入,$HOME 不会展开。PATH 在 override-build 内用 export 设。
       - CARGO_TERM_COLOR: never
       - SNAP_BUILD: '1'
+      # ADR-008 D13 给 tauri.conf.json 加了 externalBin: ["binaries/uniclipd"],
+      # build.rs 里的 tauri_build::build() 会在编 GUI 时强制要求
+      # src-tauri/binaries/uniclipd-<triple> 存在并把它拷进 bundle。但 snap 用
+      # 纯 cargo build(不走 tauri-cli bundling),且下面是把 uniclipd 从
+      # target/release 直接 install 到 usr/bin —— 根本不依赖 Tauri 的 sidecar
+      # 暂存机制。用 JSON Merge Patch 把 externalBin 清空(空数组替换整个列表),
+      # 让 build script 既不要求也不拷贝它。与 coverage.yml / pr-check.yml 同款。
+      - TAURI_CONFIG: '{"bundle":{"externalBin":[]}}'
     override-pull: |
       craftctl default
       # snap 版本号 = package.json.version + "-snap" 后缀,snap store


### PR DESCRIPTION
## Summary

- The snap release job was failing with `resource path 'binaries/uniclipd-x86_64-unknown-linux-gnu' doesn't exist`. Root cause: ADR-008 D13 (`5e9f3de0b`) added `externalBin: ["binaries/uniclipd"]` to `src-tauri/tauri.conf.json`, so the GUI's `tauri_build::build()` (build.rs) hard-fails during plain `cargo build` unless `src-tauri/binaries/uniclipd-<triple>` is staged first. That commit updated CLI/APP/AUR packaging but missed the snap build step (`973715279`).
- The snap doesn't use Tauri's sidecar mechanism at all — it builds `uniclipd` separately and `install`s it directly to `usr/bin/uniclipd`, where the GUI spawns it as a sibling. So the fix sets `TAURI_CONFIG: '{"bundle":{"externalBin":[]}}'` in the snapcraft `build-environment`, emptying the externalBin list via JSON Merge Patch so the build script neither requires nor copies the sidecar. This is the same override `coverage.yml` and `pr-check.yml` already use for their plain-cargo builds.

This unblocks the v0.14.0-alpha.5 snap release (GHA run [27054533361](https://github.com/UniClipboard/UniClipboard/actions/runs/27054533361/job/79856276352)).

## Test plan

- [x] Verified the `TAURI_CONFIG` value parses as valid JSON and the merge patch empties `externalBin` (`[]`).
- [x] Confirmed the fix matches the established pattern in `coverage.yml` / `pr-check.yml`, and that `snap.yml` sets no conflicting `TAURI_CONFIG`.
- [ ] Re-run the snap release workflow and confirm the snap packs successfully on both amd64 and arm64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated snap package build configuration to ensure the daemon binary is correctly bundled and installed in the snap distribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->