### PR TITLE
fix(adr-008): stop uniclipd bouncing in the macOS Dock

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -9876,6 +9876,8 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "mockall 0.13.1",
+ "objc2",
+ "objc2-app-kit",
  "rustls",
  "serde",
  "serde_json",

--- a/src-tauri/crates/uc-daemon/Cargo.toml
+++ b/src-tauri/crates/uc-daemon/Cargo.toml
@@ -34,6 +34,12 @@ chrono = { version = "0.4", features = ["serde"] }
 tracing = "0.1"
 rustls = { version = "0.23", default-features = false, features = ["ring", "std"] }
 
+# macOS: the headless daemon loads AppKit (for `NSPasteboard`) and must then
+# demote its activation policy so it never shows a (forever-bouncing) Dock tile.
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2 = "0.6"
+objc2-app-kit = { version = "0.3", features = ["NSApplication", "NSResponder"] }
+
 [dev-dependencies]
 uc-daemon-local = { path = "../uc-daemon-local", features = ["test-helpers"] }
 tempfile = "3"

--- a/src-tauri/crates/uc-daemon/src/main.rs
+++ b/src-tauri/crates/uc-daemon/src/main.rs
@@ -8,13 +8,31 @@
 /// `clipboard-rs` eagerly calls `+[NSPasteboard generalPasteboard]` during
 /// `wire_dependencies`, which panics without AppKit loaded. `NSApplicationLoad`
 /// is the documented way to bootstrap AppKit in non-`.app` processes.
+///
+/// Loading AppKit promotes this headless process to a foreground application,
+/// so macOS hands it a Dock tile. Because the daemon never runs an
+/// `NSApplication` event loop, that tile would bounce forever in a perpetual
+/// "launching" state (and duplicates the GUI's icon, since both binaries share
+/// one bundle). Immediately demoting the activation policy to `Prohibited`
+/// keeps AppKit available — pasteboard access still works — while removing the
+/// Dock tile, menu bar, and activation eligibility.
 #[cfg(target_os = "macos")]
 fn init_macos_appkit() {
+    use objc2::MainThreadMarker;
+    use objc2_app_kit::{NSApplication, NSApplicationActivationPolicy};
+
     extern "C" {
         fn NSApplicationLoad() -> bool;
     }
     unsafe {
         let _ = NSApplicationLoad();
+    }
+
+    // `main()` runs on the process's main thread, so this marker is always
+    // available here. `setActivationPolicy` must run on the main thread.
+    if let Some(mtm) = MainThreadMarker::new() {
+        let app = NSApplication::sharedApplication(mtm);
+        app.setActivationPolicy(NSApplicationActivationPolicy::Prohibited);
     }
 }
 #[cfg(not(target_os = "macos"))]


### PR DESCRIPTION
## Summary

- The standalone `uniclipd` daemon calls `NSApplicationLoad()` so `clipboard-rs` can reach `+[NSPasteboard generalPasteboard]` during dependency wiring. That promotes the **headless** process to a **foreground app**, so macOS hands it a Dock tile — and because the daemon never runs an `NSApplication` event loop to finish "launching", the tile **bounces forever**. Since `uniclipd` and the GUI share one bundle (and icon), it looks exactly like the app itself is stuck opening. (6eaa6df5c)
- **Fix:** right after loading AppKit, demote the daemon's activation policy to `NSApplicationActivationPolicy::Prohibited`. The pasteboard stays reachable (AppKit is still loaded), but the process drops out of the Dock, menu bar, and activation eligibility. macOS-only — the `objc2` / `objc2-app-kit` deps are scoped under `[target.'cfg(target_os = "macos")'.dependencies]` so Linux/Windows/musl builds are untouched. (6eaa6df5c)
- Regression introduced by the **ADR-008 daemon split**: the daemon became a standalone `uniclipd` sidecar that bootstraps AppKit on its own, which is what surfaces the Dock tile.

No `docs-site/` changes — no user-facing surface (CLI, settings, errors) changed; the only adjacent doc (`zh/cli/reference.mdx` noting `uniclipd` is visible in `ps`) stays accurate.

## Test plan

- [x] `cargo check -p uc-daemon --bin uniclipd` passes on macOS (typed `objc2-app-kit` API compiles).
- [ ] Rebuild + install the app; confirm `uniclipd` no longer registers as `type="Foreground"` in LaunchServices (`lsappinfo info <uniclipd-pid>`) and its Dock icon no longer bounces.
- [ ] Confirm clipboard capture/sync still works (AppKit/pasteboard access intact under `Prohibited`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the daemon appearing in the macOS Dock and menu bar, ensuring it remains properly headless on macOS.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->