### PR TITLE
fix(mobile-sync): match device revoke/rotate routes on axum 0.7

### DIFF
--- a/src-tauri/crates/uc-webserver/src/api/mobile_sync.rs
+++ b/src-tauri/crates/uc-webserver/src/api/mobile_sync.rs
@@ -405,11 +405,11 @@ pub fn router() -> Router<DaemonApiState> {
             get(list_mobile_devices_handler).post(register_mobile_device_handler),
         )
         .route(
-            "/mobile-sync/devices/{device_id}",
+            "/mobile-sync/devices/:device_id",
             delete(revoke_mobile_device_handler),
         )
         .route(
-            "/mobile-sync/devices/{device_id}/rotate-password",
+            "/mobile-sync/devices/:device_id/rotate-password",
             post(rotate_mobile_password_handler),
         )
         .route(


### PR DESCRIPTION
## Summary

- **Mobile-end device revoke and password rotation returned 404** because the two `.route()` paths in `uc-webserver` used axum **0.8** `{device_id}` syntax while the crate is pinned to **axum 0.7.9**, where path params must be `:device_id`. Under 0.7 the braces are treated as a *literal* path segment (no compile error), so `DELETE /mobile-sync/devices/<id>` and `POST .../rotate-password` never matched any route and fell through to a generic 404 — diagnosed from production logs + DB cross-check (records existed with exact-matching `device_id`, so it wasn't a data/logic bug). (`7e95e58`)
- Fix: switch both `.route()` paths to `:device_id`, matching the established pattern in `blob.rs` / `clipboard.rs`. The `#[utoipa::path]` annotations keep the OpenAPI `{device_id}` form, which is correct and routing-independent.
- Regression introduced in `3ddc48e30` (2026-06-03, "migrate mobile-sync commands onto daemon loopback API"); present in `v0.14.0-alpha.5` / `alpha.6`.

No docs-site changes: `core-features/mobile-sync.mdx` (en/zh) already documents revoke/rotate as working — this PR restores that documented behavior, no user-facing contract changed.

> Follow-up (not in this PR): upgrading to axum 0.8 would make `{param}` the correct syntax and align routing with the OpenAPI annotations, but it's a larger migration (all `:param` routes + shared route constants, WebSocket `Message`/`Utf8Bytes`, utoipa-swagger-ui 7→8/9, `Option<T>` extractor semantics, uc-cli/p2p-bench). Deferred to a dedicated PR.

## Test plan

- [x] `cargo check -p uc-webserver` passes.
- [ ] Manual: register a mobile device via GUI, then **Revoke** it — expect success (was 404). Re-run **Change password** on a device — expect success (was 404).
- [ ] Consider adding a route-matching regression test (DELETE/POST with a path param reaches the handler) — best landed alongside the axum 0.8 upgrade, since a state-backed router test needs the full `DaemonApiState`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the mobile device revocation API endpoint to properly parse device identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->