### PR TITLE
fix(bootstrap): surface typed failure to frontend so error screen replaces blank loading

### DIFF
--- a/src-tauri/crates/uc-tauri/src/commands/startup.rs
+++ b/src-tauri/crates/uc-tauri/src/commands/startup.rs
@@ -2,12 +2,14 @@
 //! 启动流程编排命令
 
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
 
 use serde::Serialize;
 use tauri::AppHandle;
 use tracing::{info, info_span, Instrument};
 use uc_daemon_client::{DaemonClientContext, DaemonConnectionState};
 use uc_daemon_contract::api::auth::DaemonConnectionInfo;
+use uc_daemon_local::contract::DaemonBootstrapError;
 use uc_platform::ports::observability::TraceMetadata;
 
 use crate::commands::record_trace_fields;
@@ -104,6 +106,109 @@ pub async fn get_daemon_session(
     .await
 }
 
+/// Machine-readable classification of a daemon-bootstrap failure, surfaced to
+/// the frontend so it can show an actionable message instead of an endless
+/// loading screen. `bootstrap_daemon_in_process` only populates the daemon
+/// connection state on success; on failure the connection stays unset, so
+/// without this signal the frontend's `get_daemon_connection_info` poll would
+/// just spin until its own timeout.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub enum DaemonBootstrapFailureKind {
+    /// The running daemon is a strictly-newer version than this GUI client.
+    /// ADR-008 P4-7 downgrade protection refuses to take it over, so the fix is
+    /// to update the app — a distinct kind so the UI can say "update" rather
+    /// than "restart".
+    VersionTooOld,
+    /// Any other terminal bootstrap failure (spawn failure, health-check
+    /// timeout, probe error, or an older-or-equal daemon that couldn't be
+    /// replaced).
+    Unavailable,
+}
+
+/// Frontend-facing daemon-bootstrap failure payload. `detail` carries the
+/// original error message (English, already user-safe) for diagnostics; the
+/// version fields are populated only for
+/// [`DaemonBootstrapFailureKind::VersionTooOld`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct DaemonBootstrapFailure {
+    pub kind: DaemonBootstrapFailureKind,
+    pub detail: String,
+    pub observed_version: Option<String>,
+    pub expected_version: Option<String>,
+}
+
+/// Classify a [`DaemonBootstrapError`] into the frontend-facing payload.
+///
+/// Only `RefusedNewerDaemon` maps to `VersionTooOld` (the one case the user
+/// fixes by updating, not restarting); everything else is `Unavailable`.
+pub fn classify_bootstrap_failure(error: &DaemonBootstrapError) -> DaemonBootstrapFailure {
+    match error {
+        DaemonBootstrapError::RefusedNewerDaemon { observed, expected } => DaemonBootstrapFailure {
+            kind: DaemonBootstrapFailureKind::VersionTooOld,
+            detail: error.to_string(),
+            observed_version: Some(observed.clone()),
+            expected_version: Some(expected.clone()),
+        },
+        _ => DaemonBootstrapFailure {
+            kind: DaemonBootstrapFailureKind::Unavailable,
+            detail: error.to_string(),
+            observed_version: None,
+            expected_version: None,
+        },
+    }
+}
+
+/// Shared, GUI-process-local record of a terminal daemon-bootstrap failure.
+///
+/// `bootstrap_daemon_in_process` runs once at startup and only populates the
+/// daemon connection state on success. On failure it leaves the connection
+/// unset; this state carries the failure reason to the frontend over the same
+/// poll loop (via [`get_daemon_bootstrap_failure`]) so the UI can fail fast and
+/// explain why, instead of waiting on a connection that will never arrive.
+#[derive(Default, Clone)]
+pub struct DaemonBootstrapStatus {
+    failure: Arc<Mutex<Option<DaemonBootstrapFailure>>>,
+}
+
+impl DaemonBootstrapStatus {
+    /// Record a terminal bootstrap failure. Overwrites any previous value.
+    pub fn record_failure(&self, failure: DaemonBootstrapFailure) {
+        if let Ok(mut guard) = self.failure.lock() {
+            *guard = Some(failure);
+        }
+    }
+
+    /// Read the recorded failure, if any.
+    pub fn get(&self) -> Option<DaemonBootstrapFailure> {
+        self.failure.lock().ok().and_then(|guard| guard.clone())
+    }
+}
+
+/// Read the recorded daemon-bootstrap failure, if the native bootstrap gave up.
+///
+/// Returns `None` while bootstrap is still in flight or after it succeeded; the
+/// frontend poll treats `Some(_)` as a terminal signal to stop waiting for a
+/// connection and surface the error.
+///
+/// Pure status read from managed state; no usecase orchestration is required.
+#[tauri::command]
+#[specta::specta]
+pub async fn get_daemon_bootstrap_failure(
+    state: tauri::State<'_, DaemonBootstrapStatus>,
+    _trace: Option<TraceMetadata>,
+) -> Result<Option<DaemonBootstrapFailure>, crate::commands::CommandError> {
+    let span = info_span!(
+        "command.startup.get_daemon_bootstrap_failure",
+        trace_id = tracing::field::Empty,
+        trace_ts = tracing::field::Empty,
+    );
+    record_trace_fields(&span, &_trace);
+
+    async move { Ok(state.get()) }.instrument(span).await
+}
+
 /// Startup barrier used to coordinate backend readiness.
 ///
 /// 用于协调后端就绪的启动门闩。
@@ -149,5 +254,45 @@ impl StartupBarrier {
 
         show_main_window(app_handle);
         info!("Main window show requested (startup barrier)");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classify_refused_newer_daemon_is_version_too_old() {
+        let err = DaemonBootstrapError::RefusedNewerDaemon {
+            observed: "0.15.0".to_string(),
+            expected: "0.14.0".to_string(),
+        };
+        let failure = classify_bootstrap_failure(&err);
+        assert_eq!(failure.kind, DaemonBootstrapFailureKind::VersionTooOld);
+        assert_eq!(failure.observed_version.as_deref(), Some("0.15.0"));
+        assert_eq!(failure.expected_version.as_deref(), Some("0.14.0"));
+        // detail keeps the actionable original message (names both versions).
+        assert!(failure.detail.contains("0.15.0") && failure.detail.contains("0.14.0"));
+    }
+
+    #[test]
+    fn classify_other_errors_are_unavailable_without_versions() {
+        let err = DaemonBootstrapError::StartupTimeout { timeout_ms: 8_000 };
+        let failure = classify_bootstrap_failure(&err);
+        assert_eq!(failure.kind, DaemonBootstrapFailureKind::Unavailable);
+        assert!(failure.observed_version.is_none());
+        assert!(failure.expected_version.is_none());
+        assert!(failure.detail.contains("8000"));
+    }
+
+    #[test]
+    fn bootstrap_status_records_and_reads_back_failure() {
+        let status = DaemonBootstrapStatus::default();
+        assert!(status.get().is_none(), "fresh status must have no failure");
+
+        let failure =
+            classify_bootstrap_failure(&DaemonBootstrapError::StartupTimeout { timeout_ms: 1_000 });
+        status.record_failure(failure.clone());
+        assert_eq!(status.get(), Some(failure));
     }
 }

--- a/src-tauri/crates/uc-tauri/src/commands/updater.rs
+++ b/src-tauri/crates/uc-tauri/src/commands/updater.rs
@@ -1054,6 +1054,24 @@ pub async fn dev_open_updater_window(
     }
 }
 
+/// Open (or focus) the Sparkle-style updater window on demand.
+///
+/// Frontend entry for surfacing the updater without waiting for the scheduler —
+/// used by the daemon-bootstrap error screen when the running daemon is newer
+/// than this GUI (`versionTooOld`), so the user can jump straight to updating.
+/// `open_or_focus_updater_window` is idempotent: if the scheduler already
+/// popped the window, this just brings it to the front.
+#[tauri::command]
+#[specta::specta]
+pub async fn open_updater_window(
+    app: AppHandle,
+    _trace: Option<TraceMetadata>,
+) -> Result<(), String> {
+    let _ = _trace;
+    crate::update_scheduler::open_or_focus_updater_window(&app, false)
+        .map_err(|err| format!("failed to open updater window: {err}"))
+}
+
 /// Detect how the current binary was installed.
 ///
 /// Cached after the first call. On Linux the detection asks dpkg/rpm whether

--- a/src-tauri/crates/uc-tauri/src/run.rs
+++ b/src-tauri/crates/uc-tauri/src/run.rs
@@ -209,6 +209,11 @@ pub fn run(tauri_ctx: tauri::Context<tauri::Wry>) -> anyhow::Result<()> {
 
     let daemon_connection_state = DaemonConnectionState::default();
     let daemon_ownership = DaemonOwnership::default();
+    // Records a terminal daemon-bootstrap failure so the frontend poll can fail
+    // fast with an actionable reason instead of spinning until its timeout (the
+    // connection state is only ever set on success). See
+    // `commands::startup::get_daemon_bootstrap_failure`.
+    let daemon_bootstrap_status = crate::commands::startup::DaemonBootstrapStatus::default();
 
     // ADR-008 D20: the daemon is the single authoritative analytics sender.
     // `wire_gui_client_deps` leaves the GUI client with a Noop sink (no
@@ -238,6 +243,7 @@ pub fn run(tauri_ctx: tauri::Context<tauri::Wry>) -> anyhow::Result<()> {
         .manage(runtime.clone())
         .manage(DaemonConnectionState::clone(&daemon_connection_state))
         .manage(DaemonOwnership::clone(&daemon_ownership))
+        .manage(daemon_bootstrap_status.clone())
         .manage(TrayState::default())
         .manage(crate::lightweight::QuitIntent::default())
         .manage(task_registry.clone())
@@ -366,6 +372,7 @@ pub fn run(tauri_ctx: tauri::Context<tauri::Wry>) -> anyhow::Result<()> {
 
             let daemon_connection_state_for_setup = daemon_connection_state.clone();
             let daemon_ownership_for_setup = daemon_ownership.clone();
+            let daemon_bootstrap_status_for_setup = daemon_bootstrap_status.clone();
             tauri::async_runtime::spawn(async move {
                 match bootstrap_daemon_in_process(
                     &daemon_ownership_for_setup,
@@ -392,6 +399,14 @@ pub fn run(tauri_ctx: tauri::Context<tauri::Wry>) -> anyhow::Result<()> {
                             error = %error,
                             error_chain = ?error,
                             "Daemon startup/probe failed during Tauri bootstrap"
+                        );
+                        // Surface the failure to the frontend so it stops polling
+                        // and shows an actionable error (RefusedNewerDaemon →
+                        // "update the app"; everything else → "restart"). Without
+                        // this the connection state stays unset and the main
+                        // window hangs on a blank loading screen until timeout.
+                        daemon_bootstrap_status_for_setup.record_failure(
+                            crate::commands::startup::classify_bootstrap_failure(&error),
                         );
                     }
                 }

--- a/src-tauri/crates/uc-tauri/src/specta_builder.rs
+++ b/src-tauri/crates/uc-tauri/src/specta_builder.rs
@@ -20,7 +20,7 @@
 //!
 //! 所有命令在所有 OS 上都 collect，保证任何 runner 跑 `cargo test
 //! --test specta_export` 得到同一份 binding（CI 可以用单一 Linux runner
-//! 做 schema drift check）。当前 27 条命令都不依赖平台特定 mod 编译。
+//! 做 schema drift check）。当前 29 条命令都不依赖平台特定 mod 编译。
 
 use tauri_specta::{collect_commands, Builder};
 
@@ -48,6 +48,7 @@ pub fn build() -> Builder<tauri::Wry> {
         crate::commands::get_device_meta,
         crate::commands::startup::get_daemon_connection_info,
         crate::commands::startup::get_daemon_session,
+        crate::commands::startup::get_daemon_bootstrap_failure,
         // ── restart (Phase 95) ──────────────────────────────────────────────
         crate::commands::restart::restart_app,
         // ── autostart ───────────────────────────────────────────────────────
@@ -60,6 +61,7 @@ pub fn build() -> Builder<tauri::Wry> {
         crate::commands::updater::install_update,
         crate::commands::updater::get_install_kind,
         crate::commands::updater::dev_open_updater_window,
+        crate::commands::updater::open_updater_window,
         // ── storage ─────────────────────────────────────────────────────────
         crate::commands::storage::open_data_directory,
         crate::commands::storage::open_logs_directory,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,9 +3,11 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { BrowserRouter as Router, Route, Navigate, Outlet, useNavigate } from 'react-router-dom'
 import { signalLifecycleReady } from '@/api/daemon/lifecycle'
 import { unlockEncryptionSession } from '@/api/security'
+import { checkForUpdate, openUpdaterWindow } from '@/api/updater'
 import { TitleBar } from '@/components'
 import { GlobalShortcuts } from '@/components/GlobalShortcuts'
 import StartupModals from '@/components/StartupModals'
+import { Button } from '@/components/ui/button'
 import { Toaster } from '@/components/ui/sonner'
 import { useSearch } from '@/contexts/search-context'
 import { SearchProvider } from '@/contexts/SearchContext'
@@ -16,11 +18,13 @@ import { useEncryptionState } from '@/hooks/useDaemonEvents'
 import { usePlatform } from '@/hooks/usePlatform'
 import { useUINavigateListener } from '@/hooks/useUINavigateListener'
 import { MainLayout, SettingsFullLayout, WindowShell } from '@/layouts'
+import { DaemonBootstrapFailedError } from '@/lib/daemon-connection-info'
 import {
   shouldSignalDaemonLifecycleReady,
   type EncryptionStatusView,
 } from '@/lib/daemon-lifecycle-ready'
 import { connectDaemonWs } from '@/lib/daemon-ws-bootstrap'
+import type { DaemonBootstrapFailure } from '@/lib/ipc'
 import { SentryRoutes } from '@/observability/sentry'
 import DashboardPage from '@/pages/DashboardPage'
 import DevicesPage from '@/pages/DevicesPage'
@@ -83,6 +87,10 @@ const AppContent = ({
   // derived (see below) from this + the query error so we don't have to
   // chain a clear-on-success setEncryptionError(null) behind setEncryptionStatus.
   const [bootEncryptionError, setBootEncryptionError] = useState<string | null>(null)
+  // Typed daemon-bootstrap failure (when the native side gave up reaching the
+  // daemon), so the error screen can branch on `kind` — e.g. tell the user to
+  // update the app on a version mismatch rather than just "restart".
+  const [bootstrapFailure, setBootstrapFailure] = useState<DaemonBootstrapFailure | null>(null)
   const [daemonBootstrapReady, setDaemonBootstrapReady] = useState(false)
   const daemonLifecycleReadySignaledRef = useRef(false)
   // Post-setup auto-unlock is handled by onSetupComplete callback (in AppContentWithBar),
@@ -103,13 +111,16 @@ const AppContent = ({
         if (!cancelled) {
           setDaemonBootstrapReady(true)
           setBootEncryptionError(null)
+          setBootstrapFailure(null)
         }
       })
       .catch(error => {
-        if (!cancelled) {
-          const message = error instanceof Error ? error.message : String(error)
-          setBootEncryptionError(message)
-        }
+        if (cancelled) return
+        const message = error instanceof Error ? error.message : String(error)
+        setBootEncryptionError(message)
+        // Capture the typed failure so the error screen can give an
+        // action-specific message (update vs restart).
+        setBootstrapFailure(error instanceof DaemonBootstrapFailedError ? error.failure : null)
       })
 
     return () => {
@@ -208,10 +219,34 @@ const AppContent = ({
   }
 
   if (encryptionError) {
+    const versionTooOld = bootstrapFailure?.kind === 'versionTooOld'
     return (
       <div className="flex h-full w-full items-center justify-center p-4 text-sm text-foreground">
-        <div className="max-w-sm rounded-md border border-border/20 bg-muted p-4 text-center">
-          Failed to verify encryption status. Please restart the app.
+        <div className="max-w-sm space-y-3 rounded-md border border-border/20 bg-muted p-4 text-center">
+          <p>
+            {versionTooOld
+              ? 'A newer version is already running in the background. Please update this app to continue.'
+              : "Couldn't reach the background service. Please restart the app."}
+          </p>
+          <p className="break-words text-xs text-muted-foreground">{encryptionError}</p>
+          {versionTooOld && (
+            <Button
+              size="sm"
+              onClick={() => {
+                // Best-effort: kick a fresh check so the updater window has data
+                // even if the scheduler hasn't run yet, then surface the window
+                // (idempotent — focuses it if the scheduler already opened it).
+                void checkForUpdate(null).catch(error =>
+                  console.error('Update check from bootstrap error screen failed:', error)
+                )
+                void openUpdaterWindow().catch(error =>
+                  console.error('Failed to open updater window:', error)
+                )
+              }}
+            >
+              Open updater
+            </Button>
+          )}
         </div>
       </div>
     )

--- a/src/__tests__/lib/daemon-auth.test.ts
+++ b/src/__tests__/lib/daemon-auth.test.ts
@@ -28,6 +28,7 @@ vi.mock('@tauri-apps/api/core', () => ({
 vi.mock('@/lib/ipc', () => ({
   commands: {
     getDaemonConnectionInfo: (...args: unknown[]) => mockInvokeWithTrace(...args),
+    getDaemonBootstrapFailure: async () => null,
   },
 }))
 

--- a/src/__tests__/lib/daemon-connection-info.test.ts
+++ b/src/__tests__/lib/daemon-connection-info.test.ts
@@ -1,0 +1,122 @@
+/**
+ * daemon-connection-info polling: timeout, retry, and fail-fast behaviour.
+ *
+ * Guards the fix for the "main window stuck loading forever" bug — when the
+ * native daemon bootstrap never populates the connection state (e.g.
+ * `RefusedNewerDaemon`, spawn failure, health-check timeout), the poll must
+ * either fail fast on a recorded bootstrap failure or eventually time out,
+ * instead of looping indefinitely.
+ *
+ * @vitest-environment node
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  DaemonBootstrapFailedError,
+  DaemonConnectionInfoTimeoutError,
+  resetDaemonConnectionInfoPollingForTests,
+  waitForDaemonConnectionInfo,
+} from '@/lib/daemon-connection-info'
+
+const TEST_PAYLOAD = {
+  baseUrl: 'http://127.0.0.1:42715',
+  wsUrl: 'ws://127.0.0.1:42715/ws',
+}
+
+const VERSION_FAILURE = {
+  kind: 'versionTooOld' as const,
+  detail: 'running daemon 0.15.0 is newer than this client 0.14.0',
+  observedVersion: '0.15.0',
+  expectedVersion: '0.14.0',
+}
+
+// Matches CONNECTION_INFO_TIMEOUT_MS in the module under test (kept local so
+// the test fails loudly if the production ceiling changes without review).
+const TIMEOUT_MS = 60_000
+
+const mockGetDaemonConnectionInfo = vi.fn()
+const mockGetDaemonBootstrapFailure = vi.fn()
+
+vi.mock('@/lib/ipc', () => ({
+  commands: {
+    getDaemonConnectionInfo: (...args: unknown[]) => mockGetDaemonConnectionInfo(...args),
+    getDaemonBootstrapFailure: (...args: unknown[]) => mockGetDaemonBootstrapFailure(...args),
+  },
+}))
+
+describe('waitForDaemonConnectionInfo()', () => {
+  beforeEach(() => {
+    resetDaemonConnectionInfoPollingForTests()
+    mockGetDaemonConnectionInfo.mockReset()
+    mockGetDaemonBootstrapFailure.mockReset()
+    // Default: bootstrap has not failed — the common path.
+    mockGetDaemonBootstrapFailure.mockResolvedValue(null)
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('returns the payload once the daemon reports ready', async () => {
+    mockGetDaemonConnectionInfo.mockResolvedValueOnce(null).mockResolvedValueOnce(TEST_PAYLOAD)
+
+    const promise = waitForDaemonConnectionInfo()
+    await vi.advanceTimersByTimeAsync(500)
+
+    await expect(promise).resolves.toEqual(TEST_PAYLOAD)
+  })
+
+  it('fails fast with the typed failure when the native bootstrap reports a terminal error', async () => {
+    mockGetDaemonConnectionInfo.mockResolvedValue(null)
+    mockGetDaemonBootstrapFailure.mockResolvedValue(VERSION_FAILURE)
+
+    const promise = waitForDaemonConnectionInfo()
+    const expectation = expect(promise).rejects.toBeInstanceOf(DaemonBootstrapFailedError)
+    // First poll: no connection info, but a recorded failure → throw
+    // immediately, no timer/timeout involved.
+    await vi.advanceTimersByTimeAsync(0)
+    await expectation
+  })
+
+  it('carries the typed failure payload on the thrown error', async () => {
+    mockGetDaemonConnectionInfo.mockResolvedValue(null)
+    mockGetDaemonBootstrapFailure.mockResolvedValue(VERSION_FAILURE)
+
+    const promise = waitForDaemonConnectionInfo()
+    const expectation = expect(promise).rejects.toMatchObject({
+      name: 'DaemonBootstrapFailedError',
+      failure: VERSION_FAILURE,
+    })
+    await vi.advanceTimersByTimeAsync(0)
+    await expectation
+  })
+
+  it('rejects with a timeout error when the daemon never becomes reachable', async () => {
+    mockGetDaemonConnectionInfo.mockResolvedValue(null)
+
+    const promise = waitForDaemonConnectionInfo()
+    const expectation = expect(promise).rejects.toBeInstanceOf(DaemonConnectionInfoTimeoutError)
+
+    // Advance past the ceiling (+ one poll interval of slack).
+    await vi.advanceTimersByTimeAsync(TIMEOUT_MS + 500)
+
+    await expectation
+  })
+
+  it('clears the cached promise on timeout so a later call can retry and succeed', async () => {
+    mockGetDaemonConnectionInfo.mockResolvedValue(null)
+
+    const first = waitForDaemonConnectionInfo()
+    const firstExpectation = expect(first).rejects.toBeInstanceOf(DaemonConnectionInfoTimeoutError)
+    await vi.advanceTimersByTimeAsync(TIMEOUT_MS + 500)
+    await firstExpectation
+
+    // Daemon now reachable — a fresh call must start a new polling sequence
+    // rather than re-throwing the cached timeout rejection.
+    mockGetDaemonConnectionInfo.mockReset()
+    mockGetDaemonConnectionInfo.mockResolvedValueOnce(TEST_PAYLOAD)
+
+    await expect(waitForDaemonConnectionInfo()).resolves.toEqual(TEST_PAYLOAD)
+  })
+})

--- a/src/__tests__/lib/daemon-ws-bootstrap.test.ts
+++ b/src/__tests__/lib/daemon-ws-bootstrap.test.ts
@@ -49,6 +49,10 @@ let refreshSessionCallCount = 0
 vi.mock('@/lib/ipc', () => ({
   commands: {
     getDaemonConnectionInfo: (...args: unknown[]) => mockGetDaemonConnectionInfo(...args),
+    // The connection-info poll now also probes for a recorded bootstrap failure
+    // each round; these tests exercise the success/auth paths, so a constant
+    // "no failure" keeps the poll on its happy path.
+    getDaemonBootstrapFailure: async () => null,
   },
 }))
 

--- a/src/api/updater.ts
+++ b/src/api/updater.ts
@@ -86,6 +86,21 @@ export async function cancelDownload(): Promise<void> {
 }
 
 /**
+ * Open (or focus) the standalone updater window on demand. Used by the
+ * daemon-bootstrap error screen to route a "version too old" user straight to
+ * the updater. Idempotent on the native side — focuses the window if it is
+ * already open (e.g. the scheduler already popped it).
+ */
+export async function openUpdaterWindow(): Promise<void> {
+  try {
+    await commands.openUpdaterWindow()
+  } catch (error) {
+    log.error({ err: error }, 'failed to open updater window')
+    throw error
+  }
+}
+
+/**
  * Read the current backend update state. Used on Context mount to sync up
  * before attaching the broadcast listener — avoids races where the user
  * navigated away and back during an in-flight download.

--- a/src/lib/__tests__/daemon-auth.test.ts
+++ b/src/lib/__tests__/daemon-auth.test.ts
@@ -14,6 +14,7 @@ const mockInvokeWithTrace = vi.fn()
 vi.mock('@/lib/ipc', () => ({
   commands: {
     getDaemonConnectionInfo: (...args: unknown[]) => mockInvokeWithTrace(...args),
+    getDaemonBootstrapFailure: async () => null,
   },
 }))
 

--- a/src/lib/daemon-connection-info.ts
+++ b/src/lib/daemon-connection-info.ts
@@ -1,9 +1,64 @@
 import { commands } from '@/lib/ipc'
-import type { DaemonConnectionPayload as GeneratedDaemonConnectionPayload } from '@/lib/ipc'
+import type {
+  DaemonBootstrapFailure,
+  DaemonConnectionPayload as GeneratedDaemonConnectionPayload,
+} from '@/lib/ipc'
 
 const POLL_INTERVAL_MS = 500
 
+/**
+ * Upper bound on how long we poll `get_daemon_connection_info` before giving up.
+ *
+ * The native side sets the daemon connection state only when
+ * `bootstrap_daemon_in_process` succeeds. Its worst-case *successful* path
+ * (detached spawn + health poll, or terminate-and-replace of an older daemon)
+ * completes well under 30s. But when the daemon can never be reached the state
+ * stays unset forever — most notably when the running daemon is a strictly
+ * newer version and the native side returns `RefusedNewerDaemon` *without*
+ * populating the connection state (ADR-008 P4-7 downgrade protection), but also
+ * on spawn failure or a health-check timeout.
+ *
+ * Without a ceiling the poll loops indefinitely and the main window is stuck on
+ * a blank loading screen with no way to recover or even learn why. Timing out
+ * lets `connectDaemonWs()` reject so the UI can surface an error instead of
+ * hanging. The bound is generous (well past the ~30s worst-case success path) so
+ * a slow-but-healthy cold start is never misreported as a failure.
+ */
+const CONNECTION_INFO_TIMEOUT_MS = 60_000
+
 export type DaemonConnectionPayload = GeneratedDaemonConnectionPayload
+
+/**
+ * Thrown when `get_daemon_connection_info` never reports a ready daemon within
+ * {@link CONNECTION_INFO_TIMEOUT_MS}. Distinct type so callers can tell a
+ * connection-bootstrap timeout apart from a malformed-payload / transport error.
+ */
+export class DaemonConnectionInfoTimeoutError extends Error {
+  constructor(timeoutMs: number) {
+    super(
+      `Timed out after ${Math.round(timeoutMs / 1000)}s waiting for the background ` +
+        `service to become reachable. It may have failed to start or be running an ` +
+        `incompatible version.`
+    )
+    this.name = 'DaemonConnectionInfoTimeoutError'
+  }
+}
+
+/**
+ * Thrown when the native daemon bootstrap recorded a terminal failure — the
+ * connection state will never be populated, so there is no point polling until
+ * the timeout. Carries the classified {@link DaemonBootstrapFailure} so the UI
+ * can branch on `failure.kind`: `versionTooOld` → "update the app",
+ * `unavailable` → "restart".
+ */
+export class DaemonBootstrapFailedError extends Error {
+  readonly failure: DaemonBootstrapFailure
+  constructor(failure: DaemonBootstrapFailure) {
+    super(failure.detail || 'The background service failed to start.')
+    this.name = 'DaemonBootstrapFailedError'
+    this.failure = failure
+  }
+}
 
 let connectionInfoPromise: Promise<DaemonConnectionPayload> | null = null
 
@@ -25,11 +80,29 @@ export function resetDaemonConnectionInfoPollingForTests(): void {
 }
 
 async function pollForDaemonConnectionInfo(): Promise<DaemonConnectionPayload> {
+  const deadline = Date.now() + CONNECTION_INFO_TIMEOUT_MS
   while (true) {
     const payload = await commands.getDaemonConnectionInfo()
     if (payload) {
       validatePayload(payload)
       return payload
+    }
+
+    // Fail fast on a terminal failure the native bootstrap recorded — the
+    // connection state will never be populated (e.g. RefusedNewerDaemon), so
+    // there is no point polling until the timeout. This surfaces the typed
+    // failure within one poll interval instead of waiting out the ceiling, and
+    // lets the UI distinguish "update the app" from "restart".
+    const failure = await commands.getDaemonBootstrapFailure()
+    if (failure) {
+      throw new DaemonBootstrapFailedError(failure)
+    }
+
+    // Give up once past the deadline instead of polling forever. `waitFor…`'s
+    // catch clears the cached promise, so a later caller (e.g. a manual retry)
+    // starts a fresh polling sequence rather than re-throwing this stale error.
+    if (Date.now() >= deadline) {
+      throw new DaemonConnectionInfoTimeoutError(CONNECTION_INFO_TIMEOUT_MS)
     }
 
     await sleep(POLL_INTERVAL_MS)

--- a/src/lib/ipc-bindings.generated.ts
+++ b/src/lib/ipc-bindings.generated.ts
@@ -71,6 +71,24 @@ export const commands = {
 	refreshAtSecs: number,
 } | null, CommandError>(__TAURI_INVOKE("get_daemon_session", { trace })),
 	/**
+	 *  Read the recorded daemon-bootstrap failure, if the native bootstrap gave up.
+	 * 
+	 *  Returns `None` while bootstrap is still in flight or after it succeeded; the
+	 *  frontend poll treats `Some(_)` as a terminal signal to stop waiting for a
+	 *  connection and surface the error.
+	 * 
+	 *  Pure status read from managed state; no usecase orchestration is required.
+	 */
+	getDaemonBootstrapFailure: (trace: {
+	trace_id: string,
+	timestamp: number,
+} | null) => typedError<{
+	kind: DaemonBootstrapFailureKind,
+	detail: string,
+	observedVersion: string | null,
+	expectedVersion: string | null,
+} | null, CommandError>(__TAURI_INVOKE("get_daemon_bootstrap_failure", { trace })),
+	/**
 	 *  Restarts the running Tauri application to apply settings changes.
 	 * 
 	 *  流程:
@@ -202,6 +220,19 @@ export const commands = {
 	trace_id: string,
 	timestamp: number,
 } | null) => typedError<null, string>(__TAURI_INVOKE("dev_open_updater_window", { trace })),
+	/**
+	 *  Open (or focus) the Sparkle-style updater window on demand.
+	 * 
+	 *  Frontend entry for surfacing the updater without waiting for the scheduler —
+	 *  used by the daemon-bootstrap error screen when the running daemon is newer
+	 *  than this GUI (`versionTooOld`), so the user can jump straight to updating.
+	 *  `open_or_focus_updater_window` is idempotent: if the scheduler already
+	 *  popped the window, this just brings it to the front.
+	 */
+	openUpdaterWindow: (trace: {
+	trace_id: string,
+	timestamp: number,
+} | null) => typedError<null, string>(__TAURI_INVOKE("open_updater_window", { trace })),
 	/**
 	 *  Open the application data directory in the system file manager.
 	 *  在系统文件管理器中打开应用数据目录。
@@ -348,6 +379,42 @@ export const commands = {
  *  Serializes to {"code": "...", "message": "..."} for frontend discriminated union handling.
  */
 export type CommandError = { code: "NotFound"; message: string } | { code: "InternalError"; message: string } | { code: "Timeout"; message: string } | { code: "Cancelled"; message: string } | { code: "ValidationError"; message: string } | { code: "Conflict"; message: string };
+
+/**
+ *  Frontend-facing daemon-bootstrap failure payload. `detail` carries the
+ *  original error message (English, already user-safe) for diagnostics; the
+ *  version fields are populated only for
+ *  [`DaemonBootstrapFailureKind::VersionTooOld`].
+ */
+export type DaemonBootstrapFailure = {
+	kind: DaemonBootstrapFailureKind,
+	detail: string,
+	observedVersion: string | null,
+	expectedVersion: string | null,
+};
+
+/**
+ *  Machine-readable classification of a daemon-bootstrap failure, surfaced to
+ *  the frontend so it can show an actionable message instead of an endless
+ *  loading screen. `bootstrap_daemon_in_process` only populates the daemon
+ *  connection state on success; on failure the connection stays unset, so
+ *  without this signal the frontend's `get_daemon_connection_info` poll would
+ *  just spin until its own timeout.
+ */
+export type DaemonBootstrapFailureKind = 
+/**
+ *  The running daemon is a strictly-newer version than this GUI client.
+ *  ADR-008 P4-7 downgrade protection refuses to take it over, so the fix is
+ *  to update the app — a distinct kind so the UI can say "update" rather
+ *  than "restart".
+ */
+"versionTooOld" | 
+/**
+ *  Any other terminal bootstrap failure (spawn failure, health-check
+ *  timeout, probe error, or an older-or-equal daemon that couldn't be
+ *  replaced).
+ */
+"unavailable";
 
 export type DaemonConnectionPayload = {
 	baseUrl: string,

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -202,6 +202,7 @@ export const commands: TypedCommands = buildProxy()
 // P3-b when those commands became daemon HTTP endpoints.)
 export type {
   CommandError,
+  DaemonBootstrapFailure,
   DaemonConnectionPayload,
   DeviceMeta,
   DownloadEvent,


### PR DESCRIPTION
## Summary

- **Rust: `DaemonBootstrapStatus` managed state + `get_daemon_bootstrap_failure` command** — when `bootstrap_daemon_in_process` fails terminally (e.g. `RefusedNewerDaemon`), the classified failure is now recorded in shared state and exposed to the frontend via a new Tauri command, so the poll loop can fail fast instead of spinning until timeout (`40b8ced`).
- **Rust: `open_updater_window` command** — exposes the Sparkle-style updater window to the frontend on demand, so the error screen can route version-mismatch users straight to updating (`40b8ced`).
- **Frontend: 60s timeout + fail-fast in `waitForDaemonConnectionInfo`** — the poll now checks `getDaemonBootstrapFailure` each round and throws `DaemonBootstrapFailedError` immediately on a terminal failure; a `DaemonConnectionInfoTimeoutError` fires after 60s if neither success nor failure is recorded (`40b8ced`).
- **Frontend: actionable error screen in `App.tsx`** — replaces the generic "Failed to verify encryption status" message with kind-specific copy: `versionTooOld` → "A newer version is already running, please update" + "Open updater" button; `unavailable` → "Couldn't reach the background service, please restart" (`40b8ced`).

## Test plan

- [x] Rust unit tests: `classify_refused_newer_daemon_is_version_too_old`, `classify_other_errors_are_unavailable_without_versions`, `bootstrap_status_records_and_reads_back_failure`
- [x] New `daemon-connection-info.test.ts`: timeout, fail-fast on bootstrap failure, typed error payload, cache-clear-on-timeout retry
- [x] Existing `daemon-ws-bootstrap.test.ts` updated with `getDaemonBootstrapFailure` mock
- [ ] Manual: kill the daemon, launch an older GUI build against a newer running daemon → confirm "update" error screen + "Open updater" button works
- [ ] Manual: kill daemon + block spawn → confirm "restart" error screen appears within ~60s

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Frontend can detect and display structured daemon bootstrap failures (e.g., version-too-old vs unavailable).
  * "Open updater" action added to the version-mismatch screen to trigger an update check and open the updater window.
  * Frontend can poll and retrieve recorded bootstrap failure status.

* **Bug Fixes**
  * Daemon startup failures are recorded so the UI stops noisy polling and surfaces actionable errors promptly.

* **Tests**
  * Added tests covering bootstrap failure detection, polling timeout, and retry semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->