### PR TITLE
fix(updater): stop daemon before update install to prevent stale binary

### DIFF
--- a/src-tauri/crates/uc-daemon-process/src/contract.rs
+++ b/src-tauri/crates/uc-daemon-process/src/contract.rs
@@ -98,6 +98,65 @@ pub fn terminate_local_daemon_pid(pid: u32) -> Result<(), TerminateDaemonError> 
     )))
 }
 
+/// Terminate a daemon PID and block until the process has fully exited.
+///
+/// On Windows, `taskkill /F` sends `TerminateProcess` which is immediate, but
+/// the OS may keep the process object (and its file locks) alive briefly while
+/// reclaiming resources. This function polls until the PID is no longer present,
+/// so callers can safely overwrite the daemon binary afterwards.
+///
+/// On Unix this is a no-op after sending SIGTERM — the kernel allows overwriting
+/// a running binary (the old inode stays alive until the process exits).
+pub fn terminate_and_wait(
+    pid: u32,
+    timeout: std::time::Duration,
+) -> Result<(), TerminateDaemonError> {
+    terminate_local_daemon_pid(pid)?;
+
+    #[cfg(windows)]
+    {
+        use std::time::Instant;
+
+        let deadline = Instant::now() + timeout;
+        let poll_interval = std::time::Duration::from_millis(100);
+
+        loop {
+            if !is_pid_running_win(pid) {
+                return Ok(());
+            }
+            if Instant::now() >= deadline {
+                return Err(TerminateDaemonError(format!(
+                    "daemon pid {pid} did not exit within {}ms after taskkill",
+                    timeout.as_millis()
+                )));
+            }
+            std::thread::sleep(poll_interval);
+        }
+    }
+
+    #[cfg(not(windows))]
+    {
+        let _ = timeout;
+        Ok(())
+    }
+}
+
+#[cfg(windows)]
+fn is_pid_running_win(pid: u32) -> bool {
+    let output = Command::new("tasklist")
+        .args(["/FI", &format!("PID eq {pid}"), "/NH"])
+        .output();
+    match output {
+        Ok(output) => {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            // When PID is absent, tasklist prints a line containing "INFO:".
+            // When PID is present, it prints the process row (no "INFO:").
+            !stdout.contains("INFO:")
+        }
+        Err(_) => false,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src-tauri/crates/uc-desktop/src/daemon_probe.rs
+++ b/src-tauri/crates/uc-desktop/src/daemon_probe.rs
@@ -367,8 +367,10 @@ where
 /// failure).  This lets the caller abort the install on Windows where the
 /// NSIS installer cannot overwrite a locked `uniclipd.exe`.
 ///
-/// Safe no-ops (no PID file, stale PID, InProcess legacy, unreadable
-/// metadata) return `Ok(false)`.  Successful termination returns `Ok(true)`.
+/// Safe no-ops (no PID file, stale PID, InProcess legacy) return
+/// `Ok(false)`.  Successful termination returns `Ok(true)`.  Unreadable
+/// PID metadata (file exists but corrupt/inaccessible) returns `Err` — the
+/// daemon may still be running and we cannot identify its PID to kill it.
 pub fn stop_daemon_before_update() -> Result<bool, String> {
     use uc_daemon_process::contract::terminate_and_wait;
     use uc_daemon_process::process_metadata::{verify_pid_identity, PidVerification};
@@ -377,8 +379,9 @@ pub fn stop_daemon_before_update() -> Result<bool, String> {
         Ok(Some(m)) => m,
         Ok(None) => return Ok(false),
         Err(e) => {
-            tracing::warn!(%e, "pre-update: failed to read daemon pid metadata");
-            return Ok(false);
+            return Err(format!(
+                "pre-update: failed to read daemon pid metadata: {e}"
+            ));
         }
     };
 

--- a/src-tauri/crates/uc-desktop/src/daemon_probe.rs
+++ b/src-tauri/crates/uc-desktop/src/daemon_probe.rs
@@ -361,19 +361,46 @@ where
 
 /// Stop the local daemon before an in-place update.
 ///
-/// Reuses the same PID-identity + InProcess safety checks as
-/// [`stop_local_daemon_on_full_quit`], but swaps the fire-and-forget
-/// `terminate_local_daemon_pid` for [`terminate_and_wait`] so the daemon
-/// process is fully dead before the installer overwrites the binary.
-/// On Windows this releases the file lock on `uniclipd.exe`; on Unix the
-/// wait is a no-op (kernel allows overwriting a running binary).
-pub fn stop_daemon_before_update() -> bool {
+/// Applies the same PID-identity + InProcess safety checks as
+/// [`stop_local_daemon_on_full_quit`], but returns `Err` when the daemon was
+/// identified as running yet could not be terminated (timeout / signal
+/// failure).  This lets the caller abort the install on Windows where the
+/// NSIS installer cannot overwrite a locked `uniclipd.exe`.
+///
+/// Safe no-ops (no PID file, stale PID, InProcess legacy, unreadable
+/// metadata) return `Ok(false)`.  Successful termination returns `Ok(true)`.
+pub fn stop_daemon_before_update() -> Result<bool, String> {
     use uc_daemon_process::contract::terminate_and_wait;
-    use uc_daemon_process::process_metadata::verify_pid_identity;
+    use uc_daemon_process::process_metadata::{verify_pid_identity, PidVerification};
 
-    stop_local_daemon_on_full_quit_with(read_pid_metadata, verify_pid_identity, |pid| {
-        terminate_and_wait(pid, std::time::Duration::from_secs(10))
-    })
+    let metadata = match read_pid_metadata() {
+        Ok(Some(m)) => m,
+        Ok(None) => return Ok(false),
+        Err(e) => {
+            tracing::warn!(%e, "pre-update: failed to read daemon pid metadata");
+            return Ok(false);
+        }
+    };
+
+    if let PidVerification::Stale(reason) = verify_pid_identity(&metadata) {
+        tracing::info!(pid = metadata.pid, %reason, "pre-update: daemon PID stale");
+        return Ok(false);
+    }
+
+    if matches!(metadata.mode, DaemonProcessMode::InProcess) {
+        tracing::info!(
+            pid = metadata.pid,
+            "pre-update: in-process daemon — skipping"
+        );
+        return Ok(false);
+    }
+
+    let pid = metadata.pid;
+    terminate_and_wait(pid, std::time::Duration::from_secs(10))
+        .map_err(|e| format!("pre-update: failed to stop daemon pid {pid}: {e}"))?;
+
+    tracing::info!(pid, "pre-update: daemon stopped");
+    Ok(true)
 }
 
 /// Inner implementation that takes injected reader/terminator closures so the

--- a/src-tauri/crates/uc-desktop/src/daemon_probe.rs
+++ b/src-tauri/crates/uc-desktop/src/daemon_probe.rs
@@ -359,6 +359,23 @@ where
     }
 }
 
+/// Stop the local daemon before an in-place update.
+///
+/// Reuses the same PID-identity + InProcess safety checks as
+/// [`stop_local_daemon_on_full_quit`], but swaps the fire-and-forget
+/// `terminate_local_daemon_pid` for [`terminate_and_wait`] so the daemon
+/// process is fully dead before the installer overwrites the binary.
+/// On Windows this releases the file lock on `uniclipd.exe`; on Unix the
+/// wait is a no-op (kernel allows overwriting a running binary).
+pub fn stop_daemon_before_update() -> bool {
+    use uc_daemon_process::contract::terminate_and_wait;
+    use uc_daemon_process::process_metadata::verify_pid_identity;
+
+    stop_local_daemon_on_full_quit_with(read_pid_metadata, verify_pid_identity, |pid| {
+        terminate_and_wait(pid, std::time::Duration::from_secs(10))
+    })
+}
+
 /// Inner implementation that takes injected reader/terminator closures so the
 /// `InProcess` refusal can be unit-tested without touching the real PID file
 /// or sending real signals.

--- a/src-tauri/crates/uc-tauri/src/commands/updater.rs
+++ b/src-tauri/crates/uc-tauri/src/commands/updater.rs
@@ -917,6 +917,12 @@ pub async fn install_update(
             }
         };
 
+        // Stop the old daemon before install so the new GUI bootstraps the
+        // new version. On Windows this also releases the file lock on
+        // uniclipd.exe that would block the NSIS installer.
+        let stopped = uc_desktop::daemon_probe::stop_daemon_before_update();
+        info!(stopped, "pre-update: daemon stop attempt complete");
+
         match state {
             PendingUpdateState::None | PendingUpdateState::Downloading { .. } => {
                 unreachable!("filtered above while holding the lock")

--- a/src-tauri/crates/uc-tauri/src/commands/updater.rs
+++ b/src-tauri/crates/uc-tauri/src/commands/updater.rs
@@ -920,8 +920,20 @@ pub async fn install_update(
         // Stop the old daemon before install so the new GUI bootstraps the
         // new version. On Windows this also releases the file lock on
         // uniclipd.exe that would block the NSIS installer.
-        let stopped = uc_desktop::daemon_probe::stop_daemon_before_update();
-        info!(stopped, "pre-update: daemon stop attempt complete");
+        match uc_desktop::daemon_probe::stop_daemon_before_update() {
+            Ok(stopped) => info!(stopped, "pre-update: daemon stop complete"),
+            Err(e) => {
+                // On Windows the daemon holds a file lock — install will
+                // fail if it's still running. Abort early with a clear
+                // error rather than letting NSIS fail inscrutably.
+                // On Unix the kernel allows overwriting, so just warn.
+                if cfg!(windows) {
+                    error!(error = %e, "pre-update: daemon still running, aborting");
+                    return Err(e);
+                }
+                warn!(error = %e, "pre-update: daemon stop failed, proceeding");
+            }
+        }
 
         match state {
             PendingUpdateState::None | PendingUpdateState::Downloading { .. } => {

--- a/src/components/device/__tests__/MobileSyncCredentialModal.test.tsx
+++ b/src/components/device/__tests__/MobileSyncCredentialModal.test.tsx
@@ -49,6 +49,7 @@ const mockPayload: RegisterMobileDeviceResult = {
   installQrCodePngBase64: 'aW5zdGFsbFFy',
   connectUri:
     'uniclipboard://connect?v=1&svc=mobile-sync&p=eyJ2IjoxLCJ1cmwiOiJodHRwOi8vMTkyLjE2OC4xLjEwOjQyNzIwIn0',
+  qrCodeAscii: '██████████',
   qrCodePngBase64: 'iVBORw0KGgo=',
 }
 


### PR DESCRIPTION
## Summary

- Stop the running `uniclipd` daemon before `update.install()` so the new GUI bootstraps the new daemon version after restart. On Windows this also releases the file lock on `uniclipd.exe` that would otherwise block the NSIS installer from overwriting it. (0b9dcf512)
- Add `terminate_and_wait(pid, timeout)` primitive to `uc-daemon-process` — sends `taskkill /F` then polls `tasklist` until the process fully exits (Windows); no-op after SIGTERM on Unix.
- `stop_daemon_before_update()` in `uc-desktop` reuses the existing `stop_local_daemon_on_full_quit_with()` safety checks (D22 PID identity verification, InProcess refusal), only swapping the fire-and-forget terminator for the wait variant.

## Test plan

- [x] `cargo check -p uc-daemon-process -p uc-desktop -p uc-tauri` passes
- [x] `cargo test -p uc-daemon-process -- contract` — all 10 tests pass
- [x] `cargo test -p uc-desktop -- daemon_probe` — all 14 tests pass (includes existing `stop_local_daemon_on_full_quit_with` safety tests)
- [ ] Windows: trigger an in-app update with `uniclipd.exe` running — verify the installer no longer fails with a file-in-use error
- [ ] macOS/Linux: trigger an in-app update — verify the new GUI bootstraps the new daemon version (no stale old daemon persists)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Installer now stops the desktop daemon before updating and waits for it to fully exit, preventing Windows file-lock issues.
  * Adds a bounded timeout for daemon termination to avoid indefinite hangs; on non-Windows platforms the update proceeds if stop fails.

* **New Features**
  * Adds a public helper to synchronously stop the daemon ahead of in-place updates and report success/failure.

* **Tests**
  * Updated mobile sync modal test payload to include QR code data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->