### PR TITLE
fix(bootstrap): fall back to port-based PID lookup when daemon PID file is missing

### DIFF
--- a/src-tauri/crates/uc-daemon-process/src/process_metadata.rs
+++ b/src-tauri/crates/uc-daemon-process/src/process_metadata.rs
@@ -426,6 +426,60 @@ fn read_process_exe_platform(_pid: u32) -> Option<String> {
     None
 }
 
+// ── Port-based PID lookup (fallback when PID file is missing) ────────
+
+/// Find the PID of a process listening on the given TCP port.
+///
+/// Best-effort fallback for when the daemon PID file is missing but a
+/// health probe confirms something is listening on the daemon's port.
+/// Uses platform-native tools (`netstat` on Windows, `lsof` on macOS/Linux).
+///
+/// Returns `None` if no listener is found or the platform tool is unavailable.
+pub fn find_pid_by_port(port: u16) -> Option<u32> {
+    find_pid_by_port_platform(port)
+}
+
+#[cfg(windows)]
+fn find_pid_by_port_platform(port: u16) -> Option<u32> {
+    let output = std::process::Command::new("netstat")
+        .args(["-ano"])
+        .output()
+        .ok()?;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for line in stdout.lines() {
+        let line = line.trim();
+        if !line.contains("LISTENING") {
+            continue;
+        }
+        let parts: Vec<&str> = line.split_whitespace().collect();
+        if parts.len() < 5 {
+            continue;
+        }
+        // Local address format: "127.0.0.1:PORT" or "[::1]:PORT"
+        if let Some(colon_idx) = parts[1].rfind(':') {
+            if parts[1][colon_idx + 1..].parse::<u16>().ok() == Some(port) {
+                return parts[4].parse::<u32>().ok().filter(|&p| p != 0);
+            }
+        }
+    }
+    None
+}
+
+#[cfg(unix)]
+fn find_pid_by_port_platform(port: u16) -> Option<u32> {
+    let output = std::process::Command::new("lsof")
+        .args(["-ti", &format!("tcp:{port}"), "-sTCP:LISTEN"])
+        .output()
+        .ok()?;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    stdout.trim().lines().next()?.parse::<u32>().ok()
+}
+
+#[cfg(not(any(unix, windows)))]
+fn find_pid_by_port_platform(_port: u16) -> Option<u32> {
+    None
+}
+
 // Backward-compatible standalone functions for external callers.
 
 /// Read the full daemon PID metadata (pid + mode + started_at_ms) from disk.
@@ -561,5 +615,29 @@ mod tests {
         assert_eq!(DaemonSpawnOrigin::from_env(), DaemonSpawnOrigin::Unknown);
         std::env::remove_var(SPAWN_ORIGIN_ENV);
         assert_eq!(DaemonSpawnOrigin::from_env(), DaemonSpawnOrigin::Unknown);
+    }
+
+    #[test]
+    fn find_pid_by_port_finds_own_listener() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let found = find_pid_by_port(port);
+        assert_eq!(
+            found,
+            Some(std::process::id()),
+            "must find the current process as the listener on port {port}"
+        );
+    }
+
+    #[test]
+    fn find_pid_by_port_returns_none_for_closed_port() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        drop(listener);
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        assert!(
+            find_pid_by_port(port).is_none(),
+            "must return None when no process is listening on port {port}"
+        );
     }
 }

--- a/src-tauri/crates/uc-desktop/src/daemon_probe.rs
+++ b/src-tauri/crates/uc-desktop/src/daemon_probe.rs
@@ -24,7 +24,7 @@ use uc_daemon_process::contract::{
 };
 use uc_daemon_process::health_wait::{wait_for_daemon_health, wait_for_endpoint_absent};
 use uc_daemon_process::process_metadata::{
-    read_pid_metadata, DaemonPidMetadata, DaemonProcessMode, DaemonSpawnOrigin,
+    find_pid_by_port, read_pid_metadata, DaemonPidMetadata, DaemonProcessMode, DaemonSpawnOrigin,
 };
 use uc_daemon_process::socket::try_resolve_daemon_http_addr;
 use uc_daemon_process::spawn::spawn_detached_daemon;
@@ -190,7 +190,7 @@ pub async fn bootstrap_daemon_in_process(
                     expected: expected_package_version.to_string(),
                 });
             }
-            terminate_incompatible_daemon_from_pid_file()?;
+            terminate_incompatible_daemon()?;
             let mut probe_fn =
                 || async { probe_daemon_health(&client, expected_package_version).await };
             wait_for_endpoint_absent(
@@ -268,6 +268,76 @@ pub fn terminate_incompatible_daemon_from_pid_file() -> Result<(), DaemonBootstr
     }
 
     terminate_incompatible_daemon_with(|| Ok(Some(metadata)), terminate_local_daemon_pid)
+}
+
+/// Terminate an incompatible daemon: PID file first, port-based PID lookup as fallback.
+///
+/// The PID-file path preserves all safety checks (InProcess refusal, D22
+/// identity verification). The port-based fallback fires only when the PID
+/// file is missing or unreadable — a scenario observed in the wild when a
+/// daemon from an older/different installation runs without leaving a PID
+/// file, blocking the current GUI from starting.
+fn terminate_incompatible_daemon() -> Result<(), DaemonBootstrapError> {
+    match read_pid_metadata() {
+        Ok(Some(_)) => terminate_incompatible_daemon_from_pid_file(),
+        Ok(None) => {
+            tracing::warn!("daemon PID file missing; trying port-based PID lookup");
+            terminate_incompatible_daemon_by_port()
+        }
+        Err(error) => {
+            tracing::warn!(%error, "daemon PID file unreadable; trying port-based PID lookup");
+            terminate_incompatible_daemon_by_port()
+        }
+    }
+}
+
+/// Port-based fallback: resolve the daemon's configured port, find the
+/// listening PID via OS tools (`netstat` / `lsof`), verify identity (D22),
+/// and terminate.
+fn terminate_incompatible_daemon_by_port() -> Result<(), DaemonBootstrapError> {
+    use uc_daemon_process::process_metadata::{verify_pid_identity, PidVerification};
+
+    let addr = try_resolve_daemon_http_addr().map_err(|error| {
+        DaemonBootstrapError::IncompatibleDaemon {
+            details: format!("port fallback: failed to resolve daemon address: {error}"),
+        }
+    })?;
+    let port = addr.port();
+
+    let pid = find_pid_by_port(port).ok_or_else(|| DaemonBootstrapError::IncompatibleDaemon {
+        details: format!(
+            "incompatible daemon has no PID file and no process found listening on port {port}"
+        ),
+    })?;
+
+    tracing::info!(
+        pid,
+        port,
+        "found incompatible daemon PID via port lookup (PID file missing)"
+    );
+
+    // D22: verify PID identity before signaling. Construct synthetic metadata
+    // assuming Standalone mode — an InProcess daemon would have a PID file
+    // from the hosting GUI, so reaching this fallback implies Standalone.
+    let synthetic = DaemonPidMetadata {
+        pid,
+        mode: DaemonProcessMode::Standalone,
+        started_at_ms: 0,
+        spawned_by: DaemonSpawnOrigin::Unknown,
+    };
+
+    if let PidVerification::Stale(reason) = verify_pid_identity(&synthetic) {
+        tracing::info!(
+            pid,
+            %reason,
+            "port-based daemon PID is stale — skipping terminate"
+        );
+        return Ok(());
+    }
+
+    terminate_local_daemon_pid(pid).map_err(|e| DaemonBootstrapError::IncompatibleDaemon {
+        details: format!("failed to terminate daemon (pid {pid}, found via port {port}): {e}"),
+    })
 }
 
 /// ADR-008 D3 (P4-3, revised 2026-06-03): on an explicit full GUI quit


### PR DESCRIPTION
## Summary

- When an incompatible daemon is running but has no `.daemon-pid` file, the GUI bootstrap would fail immediately and leave the main window stuck on a loading screen indefinitely. This was observed in the wild on a Windows portable installation where users tried both `uniclipboard` and `uniclipboard-gui` binaries — all launches hit the same `IncompatibleDaemon { "expected incompatible daemon pid metadata was missing" }` error. (55e7112)
- Add `find_pid_by_port()` — uses `netstat -ano` on Windows and `lsof` on Unix to find the PID listening on the daemon's configured port. The PID-file path remains primary (preserves InProcess refusal + D22 identity verification); the port fallback fires only when the PID file is missing or unreadable.

## Test plan

- [x] `cargo check -p uc-daemon-process -p uc-desktop` — compiles cleanly
- [x] `cargo test -p uc-daemon-process --lib -- process_metadata` — 8/8 pass, including new `find_pid_by_port_finds_own_listener` and `find_pid_by_port_returns_none_for_closed_port`
- [x] `cargo test -p uc-desktop --lib -- daemon_probe` — 14/14 pass, all existing safety tests (InProcess refusal, D22 stale PID skip, full-quit teardown) unaffected
- [ ] Manual test on Windows: launch a daemon without a PID file, then launch the GUI — should terminate and replace instead of hanging

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced daemon compatibility checking during startup with improved detection and termination of incompatible daemons. Added fallback mechanisms that activate when standard metadata is unavailable, ensuring more reliable daemon recovery and system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->