### PR TITLE
fix(e2e): kill orphaned invite child process on timeout or panic

### DIFF
--- a/src-tauri/tests/e2e/tests/clipboard_sync.rs
+++ b/src-tauri/tests/e2e/tests/clipboard_sync.rs
@@ -29,6 +29,31 @@ const PASSPHRASE: &str = "clipboard-sync-e2e-passphrase";
 // Shared helpers
 // ---------------------------------------------------------------------------
 
+/// RAII guard that kills a process by PID on drop.
+/// Prevents orphaned child processes when tests panic or time out.
+#[cfg(unix)]
+struct PidGuard(u32, bool);
+
+#[cfg(unix)]
+impl PidGuard {
+    fn new(pid: u32) -> Self {
+        Self(pid, false)
+    }
+
+    fn disarm(&mut self) {
+        self.1 = true;
+    }
+}
+
+#[cfg(unix)]
+impl Drop for PidGuard {
+    fn drop(&mut self) {
+        if !self.1 {
+            unsafe { libc::kill(self.0 as libc::pid_t, libc::SIGKILL) };
+        }
+    }
+}
+
 /// Auth helper: read daemon file token, exchange for JWT session token.
 async fn get_session_token(daemon: &TestDaemon, client: &reqwest::Client) -> String {
     let file_token = read_daemon_file_token(daemon);
@@ -123,6 +148,8 @@ async fn pair_two_nodes(test_prefix: &str) -> (TestDaemon, TestCli, TestDaemon, 
         .stderr(Stdio::piped())
         .spawn()
         .expect("alice invite spawn");
+    #[cfg(unix)]
+    let mut invite_guard = PidGuard::new(invite_child.id());
 
     // Read stdout lines to find INVITATION_CODE=
     let invite_stdout = invite_child.stdout.take().expect("invite stdout");
@@ -171,14 +198,22 @@ async fn pair_two_nodes(test_prefix: &str) -> (TestDaemon, TestCli, TestDaemon, 
         join_out.stderr,
     );
 
-    // Wait for invite process to complete (it unblocks after joiner connects)
-    let _ = tokio::time::timeout(Duration::from_secs(15), async {
+    // Wait for invite process to complete (it unblocks after joiner connects).
+    // If it finishes in time, disarm the guard. Otherwise the guard kills the
+    // process on drop (covers both timeout AND early panic paths).
+    let finished = tokio::time::timeout(Duration::from_secs(15), async {
         tokio::task::spawn_blocking(move || {
             let _ = invite_child.wait();
         })
         .await
     })
-    .await;
+    .await
+    .is_ok();
+
+    #[cfg(unix)]
+    if finished {
+        invite_guard.disarm();
+    }
 
     // Brief settle time for both daemons to update their member/device lists
     tokio::time::sleep(Duration::from_secs(2)).await;


### PR DESCRIPTION
## Summary

- **Fix orphaned `uniclipd` processes after E2E tests**: `pair_two_nodes()` spawns `uniclip invite` via `Command::new` but never kills it when the 15s wait times out. Rust's `std::process::Child` does NOT kill on drop — only closes pipe handles — so the process becomes an orphan. This caused 6+ zombie daemons to accumulate after running clipboard sync tests, which could block the GUI app from bootstrapping (perpetual loading screen). (060c04c)

- **Add `PidGuard` RAII struct**: captures the child PID at spawn time and sends `SIGKILL` on drop. The guard is disarmed only when the invite process exits normally. This covers all failure paths: timeout, test panic, and assertion failure.

## Test plan

- [x] `pair_invite_join_full_handshake` — passes, zero orphaned processes after
- [x] `paired_text_sync_alice_to_bob` — passes, zero orphaned processes after
- [x] `paired_resend_entry_does_not_crash` — passes, zero orphaned processes after
- [x] `cargo check --manifest-path tests/e2e/Cargo.toml --tests` — compiles cleanly
- [ ] Run the full `--ignored` clipboard_sync suite on CI to confirm no regressions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test infrastructure to properly clean up child processes in Unix environments, preventing orphaned processes during test execution and ensuring reliable test teardown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->