### PR TITLE
fix(tray): restrict monochrome template icon to macOS only

### DIFF
--- a/src-tauri/crates/uc-tauri/src/tray.rs
+++ b/src-tauri/crates/uc-tauri/src/tray.rs
@@ -199,14 +199,19 @@ impl TrayState {
                 }
             });
 
-        // Use a dedicated monochrome tray icon; on macOS it is marked as a
-        // template image so the system auto-tints it for light/dark menu bar.
-        let tray_icon =
-            tauri::image::Image::from_bytes(include_bytes!("../../../icons/tray-icon@2x.png"))?;
-        builder = builder.icon(tray_icon);
         #[cfg(target_os = "macos")]
         {
-            builder = builder.icon_as_template(true);
+            let tray_icon =
+                tauri::image::Image::from_bytes(include_bytes!("../../../icons/tray-icon@2x.png"))?;
+            builder = builder.icon(tray_icon).icon_as_template(true);
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            if let Some(icon) = app.default_window_icon() {
+                builder = builder.icon(icon.clone());
+            } else {
+                warn!("No default window icon available for tray icon");
+            }
         }
 
         // Linux 上 tauri 的 tray-icon → libappindicator-rs 在 dlopen 失败时


### PR DESCRIPTION
## Summary

- **macOS**: continue using the dedicated monochrome template icon (`tray-icon@2x.png`) with `icon_as_template(true)` so the system auto-tints it for light/dark menu bar (`46c87fb64`)
- **Windows / Linux**: restore the original `default_window_icon` (full-color app icon) instead of the monochrome template, which looked out of place on these platforms

#974 applied the monochrome icon to all platforms; this PR scopes it back to macOS only.

## Test plan

- [x] `cargo check -p uc-tauri` passes
- [ ] Verify macOS tray icon remains monochrome and adapts to light/dark mode
- [ ] Verify Windows tray icon shows the full-color app icon (not monochrome)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tray icon configuration across platforms. macOS now properly handles the icon as a template, while non-macOS systems correctly use the default window icon or gracefully handle unavailable icons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->