### PR TITLE
fix(vps): include `uniclipd` binary in Docker image

### DIFF
--- a/deploy/vps/Dockerfile
+++ b/deploy/vps/Dockerfile
@@ -3,7 +3,9 @@
 # Headless UniClipboard server node for VPS deployment (ADR-007).
 #
 # Two stages:
-#   1. builder  — compiles the `uniclip` binary as a static musl executable.
+#   1. builder  — compiles the `uniclip` + `uniclipd` binaries as static musl
+#                 executables. `uniclip start` spawns `uniclipd` as a child
+#                 process even in `--foreground` mode, so both must be present.
 #   2. runtime  — minimal Alpine image that runs the binary as a non-root
 #                 user with HOME=/data anchoring all state on a mounted volume.
 #
@@ -54,8 +56,9 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
       *) echo "unsupported build arch: $(uname -m)" >&2; exit 1 ;; \
     esac; \
     rustup target add "$TARGET"; \
-    cargo build --locked --release -p uc-cli --target "$TARGET"; \
-    cp "target/$TARGET/release/uniclip" /uniclip
+    cargo build --locked --release -p uc-cli -p uc-daemon --target "$TARGET"; \
+    cp "target/$TARGET/release/uniclip" /uniclip; \
+    cp "target/$TARGET/release/uniclipd" /uniclipd
 
 # ── runtime ──────────────────────────────────────────────────────────────────
 FROM alpine:3.20 AS runtime
@@ -68,6 +71,7 @@ RUN apk add --no-cache ca-certificates \
  && chown uniclip:uniclip /data
 
 COPY --from=builder /uniclip /usr/local/bin/uniclip
+COPY --from=builder /uniclipd /usr/local/bin/uniclipd
 
 # HOME=/data anchors ALL persistent state under the mounted volume — iroh
 # identity, vault/keyslot, file-based KEK, sqlite db, blob cache and settings —


### PR DESCRIPTION
## Summary

- VPS Docker 容器启动 crash-loop，错误信息：`failed to resolve `uniclipd` binary for spawn`
- 根因：Dockerfile 只构建了 `uniclip`（uc-cli），但 `uniclip start --foreground` 通过 `resolve_daemon_exe_path()` 查找并 spawn `uniclipd`（uc-daemon）作为子进程
- 修复：builder 阶段同时构建 `uc-cli` + `uc-daemon`，runtime 阶段将两个二进制都拷贝到 `/usr/local/bin/`

## Test plan

- [ ] VPS 上 `docker compose build --no-cache && docker compose up -d` 后容器正常启动，`docker logs` 无报错
- [ ] `docker exec <container> ls -la /usr/local/bin/uniclip*` 确认两个二进制都存在

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container build configuration to package the daemon service alongside the main application, allowing it to be spawned and managed by the primary executable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->