### PR TITLE
refactor(logging): demote noisy warn! to debug! across daemon crates

### DIFF
--- a/src-tauri/crates/uc-application/src/clipboard_capture/usecase.rs
+++ b/src-tauri/crates/uc-application/src/clipboard_capture/usecase.rs
@@ -573,7 +573,7 @@ async fn resurface_existing_entry(
     match entry_repo.touch_entry(&existing, captured_at_ms).await {
         Ok(true) => Some(existing),
         Ok(false) => {
-            warn!(
+            debug!(
                 entry_id = %existing,
                 "Dedup target vanished before resurface (0 rows touched); creating new entry"
             );

--- a/src-tauri/crates/uc-application/src/facade/host_event/publisher.rs
+++ b/src-tauri/crates/uc-application/src/facade/host_event/publisher.rs
@@ -3,7 +3,7 @@ use std::sync::{Arc, Mutex, PoisonError};
 
 use anyhow::Result;
 use async_trait::async_trait;
-use tracing::warn;
+use tracing::{debug, warn};
 
 /// 显式恢复 poisoned mutex 守卫,并 log 警告。
 ///
@@ -153,7 +153,7 @@ impl FileTransferEventPublisherPort for FileTransferHostEventPublisher {
                         .lock()
                         .unwrap_or_else(|p| recover_poisoned(p, "progress_no_entry_warned"));
                     if warned.insert(transfer_id.clone()) {
-                        warn!(
+                        debug!(
                             transfer_id = %transfer_id,
                             "buffered-phase progress: no real entry_id; front-end indexes via transferId only"
                         );

--- a/src-tauri/crates/uc-application/src/pairing_inbound/orchestrator.rs
+++ b/src-tauri/crates/uc-application/src/pairing_inbound/orchestrator.rs
@@ -319,7 +319,7 @@ impl PairingInboundOrchestrator {
                 Some(invitation.code().clone())
             }
             Err(TakeMatchingError::NotFound) => {
-                warn!(
+                info!(
                     session = %session,
                     code = %request.invitation_code.as_str(),
                     "inbound pairing request for unknown code; rejecting"
@@ -330,7 +330,7 @@ impl PairingInboundOrchestrator {
                 None
             }
             Err(TakeMatchingError::Expired) => {
-                warn!(
+                info!(
                     session = %session,
                     code = %request.invitation_code.as_str(),
                     "inbound pairing request after invitation expired; rejecting"
@@ -370,7 +370,7 @@ impl PairingInboundOrchestrator {
             // protocol violation. Log without closing — the session
             // naturally resolves via a later Close or the joiner's own
             // Reject.
-            warn!(
+            info!(
                 session = %session,
                 variant = variant_name(&message),
                 "unexpected mid-handshake message from joiner"
@@ -379,7 +379,7 @@ impl PairingInboundOrchestrator {
         };
 
         let Some(verdict) = self.handshake.verify_challenge(&session, response).await else {
-            warn!(
+            debug!(
                 session = %session,
                 "ChallengeResponse arrived with no parked handshake ctx; ignoring"
             );

--- a/src-tauri/crates/uc-application/src/pairing_inbound/sponsor_handshake.rs
+++ b/src-tauri/crates/uc-application/src/pairing_inbound/sponsor_handshake.rs
@@ -304,7 +304,7 @@ impl SponsorHandshakeCoordinator {
         if !removed {
             return;
         }
-        warn!(
+        info!(
             session = %session,
             ttl_ms = %self.handshake_ttl.as_millis(),
             "handshake TTL expired; rejecting joiner with Timeout"
@@ -365,7 +365,7 @@ impl SponsorHandshakeCoordinator {
             );
             Verdict::Verified(facts)
         } else {
-            warn!(
+            info!(
                 session = %session,
                 joiner_device_id = %facts.device_id.as_str(),
                 "joiner proof rejected"

--- a/src-tauri/crates/uc-application/src/proof.rs
+++ b/src-tauri/crates/uc-application/src/proof.rs
@@ -158,7 +158,7 @@ impl ProofPort for HmacProofAdapter {
                     (Some(master_key_bytes), "space_access")
                 }
                 Ok(None) => {
-                    tracing::warn!(
+                    tracing::info!(
                         session_id = %proof.pairing_session_id,
                         "proof verification failed: space session is locked"
                     );

--- a/src-tauri/crates/uc-application/src/usecases/clipboard_sync/dispatch_entry.rs
+++ b/src-tauri/crates/uc-application/src/usecases/clipboard_sync/dispatch_entry.rs
@@ -923,7 +923,7 @@ fn classify_dispatch_result(
             }
         }
         Ok((device_id, Err(ClipboardDispatchError::Offline))) => {
-            warn!(device_id = %device_id.as_str(), "dispatch → Offline");
+            debug!(device_id = %device_id.as_str(), "dispatch → Offline");
             let delivery_record = entry_id.map(|eid| EntryDeliveryRecord {
                 entry_id: eid.clone(),
                 target_device_id: device_id.clone(),

--- a/src-tauri/crates/uc-application/src/usecases/mobile_sync/register_device.rs
+++ b/src-tauri/crates/uc-application/src/usecases/mobile_sync/register_device.rs
@@ -22,7 +22,7 @@
 
 use std::sync::Arc;
 
-use tracing::{instrument, warn};
+use tracing::{info, instrument, warn};
 
 use uc_core::mobile_sync::{
     LanInterface, MintedCredentials, MobileClientType, MobileDevice, MobileDeviceError,
@@ -584,7 +584,7 @@ fn translate_device_error(err: MobileDeviceError) -> RegisterMobileShortcutDevic
             // 自动模式下 minter 8 hex 碰撞概率极低;custom 模式下我们已
             // 在 save 之前 check 过 find_by_username,这里只可能是 race
             // (并发 register)—— 翻译为 UsernameTaken 让 UI 提示用户换名。
-            warn!("username collision at save time (likely concurrent register race)");
+            info!("username collision at save time (likely concurrent register race)");
             RegisterMobileShortcutDeviceError::UsernameTaken(
                 "username taken at save time (concurrent registration)".to_string(),
             )

--- a/src-tauri/crates/uc-application/src/usecases/mobile_sync/rotate_password.rs
+++ b/src-tauri/crates/uc-application/src/usecases/mobile_sync/rotate_password.rs
@@ -33,7 +33,7 @@
 
 use std::sync::Arc;
 
-use tracing::{instrument, warn};
+use tracing::{debug, instrument};
 
 use uc_core::mobile_sync::{MintedCredentials, MobileDeviceError, MobileDeviceId};
 use uc_core::ports::{
@@ -149,7 +149,7 @@ impl RotateMobilePasswordUseCase {
             .await
             .map_err(translate_device_error)?;
         if !updated {
-            warn!(
+            debug!(
                 device_id = %device.device_id,
                 "device disappeared between find and update_password_hash (concurrent revoke)"
             );

--- a/src-tauri/crates/uc-application/src/usecases/setup/switch_space/mod.rs
+++ b/src-tauri/crates/uc-application/src/usecases/setup/switch_space/mod.rs
@@ -311,7 +311,7 @@ impl SwitchSpaceUseCase {
         };
         match phase {
             MigrationPhase::Prepared { run_id } => {
-                warn!(
+                info!(
                     run_id = %run_id,
                     "found stranded Prepared migration; aborting and cleaning up"
                 );

--- a/src-tauri/crates/uc-bootstrap/src/analytics.rs
+++ b/src-tauri/crates/uc-bootstrap/src/analytics.rs
@@ -97,7 +97,7 @@ pub async fn compose_event_context(
         Ok(Some(id)) => AnalyticsPersonId::SpaceShared(id),
         Ok(None) => AnalyticsPersonId::Solo(ids.anonymous_user_id),
         Err(err) => {
-            tracing::warn!(
+            tracing::info!(
                 error = %err,
                 "analytics: 读取 space_person_id 失败，退化为 Solo"
             );
@@ -185,7 +185,7 @@ async fn read_active_device_count(deps: &AppDeps) -> u32 {
     match deps.device.member_repo.list().await {
         Ok(members) => members.len() as u32,
         Err(err) => {
-            tracing::warn!(
+            tracing::info!(
                 error = %err,
                 "analytics: 读取 member_repo 失败，active_device_count 退化为 0"
             );
@@ -206,7 +206,7 @@ async fn read_space_id_hash(deps: &AppDeps) -> Option<String> {
             .as_ref()
             .map(|sid| hash_space_id_for_telemetry(sid.as_str())),
         Err(err) => {
-            tracing::warn!(
+            tracing::info!(
                 error = %err,
                 "analytics: 读取 setup_status 失败，space_id_hash 退化为 None"
             );

--- a/src-tauri/crates/uc-bootstrap/src/assembly.rs
+++ b/src-tauri/crates/uc-bootstrap/src/assembly.rs
@@ -17,7 +17,7 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use tracing::warn;
+use tracing::{info, warn};
 
 use uc_application::deps::{
     AppDeps, ClipboardPorts, DevicePorts, MobileSyncPorts, SearchPorts, SecurityPorts,
@@ -1167,7 +1167,7 @@ pub async fn resolve_pairing_device_name(settings: Arc<dyn SettingsPort>) -> Str
             }
         }
         Err(err) => {
-            warn!(error = %err, "Failed to load settings for pairing device name");
+            info!(error = %err, "Failed to load settings for pairing device name");
             DEFAULT_PAIRING_DEVICE_NAME.to_string()
         }
     }

--- a/src-tauri/crates/uc-bootstrap/src/background_tasks.rs
+++ b/src-tauri/crates/uc-bootstrap/src/background_tasks.rs
@@ -139,7 +139,7 @@ pub async fn spawn_blob_processing_tasks(
     task_registry
         .spawn("blob_worker", |_token| async move {
             worker.run().await;
-            warn!("BackgroundBlobWorker stopped");
+            info!("BackgroundBlobWorker stopped");
         })
         .await;
 

--- a/src-tauri/crates/uc-bootstrap/src/file_transfer_lifecycle.rs
+++ b/src-tauri/crates/uc-bootstrap/src/file_transfer_lifecycle.rs
@@ -137,7 +137,7 @@ impl FileTransferLifecycle {
                         continue;
                     }
 
-                    warn!(
+                    info!(
                         count = expired.len(),
                         "Timeout sweep found expired in-flight transfers"
                     );
@@ -229,7 +229,7 @@ impl FileTransferLifecycle {
             return;
         }
 
-        warn!(
+        info!(
             count = cleanup_targets.len(),
             "Reconciled orphaned in-flight transfers at startup"
         );

--- a/src-tauri/crates/uc-bootstrap/src/space_setup.rs
+++ b/src-tauri/crates/uc-bootstrap/src/space_setup.rs
@@ -26,7 +26,7 @@ use tracing::{info, instrument};
 
 use tokio::sync::broadcast;
 use tokio::task::JoinHandle;
-use tracing::warn;
+use tracing::debug;
 
 /// 反向 progress 翻译器对前端 emit 的硬上限(<=5/sec per transfer)。
 ///
@@ -231,7 +231,7 @@ fn spawn_outbound_progress_translator(
                     }
                 }
                 Err(broadcast::error::RecvError::Lagged(n)) => {
-                    warn!(
+                    debug!(
                         skipped = n,
                         "outbound progress translator: lagged; some frames skipped"
                     );

--- a/src-tauri/crates/uc-bootstrap/src/tracing.rs
+++ b/src-tauri/crates/uc-bootstrap/src/tracing.rs
@@ -137,7 +137,7 @@ pub fn init_tracing_subscriber() -> anyhow::Result<()> {
     let scope_ctx =
         uc_observability::ScopeContext::resolve(device_id.clone(), env!("CARGO_PKG_VERSION"));
     if !uc_observability::set_global_scope(scope_ctx.clone()) {
-        ::tracing::warn!("ScopeContext already initialized; keeping existing global scope");
+        ::tracing::debug!("ScopeContext already initialized; keeping existing global scope");
     }
 
     // Step 2: Select log profile
@@ -464,7 +464,7 @@ pub fn init_tracing_subscriber() -> anyhow::Result<()> {
             // [Codex Review R1+R2] Only swallow on genuine re-entry (TRACING_INITIALIZED already set).
             // If this is the first call and try_init() fails, propagate the error.
             if TRACING_INITIALIZED.get().is_some() {
-                ::tracing::warn!("Tracing subscriber already set ({}), skipping re-init", e);
+                ::tracing::debug!("Tracing subscriber already set ({}), skipping re-init", e);
                 return Ok(());
             } else {
                 return Err(anyhow::anyhow!(

--- a/src-tauri/crates/uc-daemon/src/daemon/app.rs
+++ b/src-tauri/crates/uc-daemon/src/daemon/app.rs
@@ -533,7 +533,7 @@ impl DaemonApp {
                     );
                 }
                 (None, uc_core::ports::MobileLanTarget::Disabled) => {
-                    warn!("mobile_sync settings unreadable at daemon boot; LAN listener stays Disabled until next update_settings");
+                    info!("mobile_sync settings unreadable at daemon boot; LAN listener stays Disabled until next update_settings");
                 }
             }
             controller.apply(target).await;

--- a/src-tauri/crates/uc-daemon/src/daemon/peers/presence_monitor.rs
+++ b/src-tauri/crates/uc-daemon/src/daemon/peers/presence_monitor.rs
@@ -201,13 +201,13 @@ impl DaemonService for PresenceMonitor {
                             self.publish_snapshot().await;
                         }
                         Err(AppPresenceSubscriptionError::Lagged(skipped)) => {
-                            warn!(
+                            debug!(
                                 skipped,
                                 "presence monitor: dropped events (lagged); next event will re-publish snapshot"
                             );
                         }
                         Err(AppPresenceSubscriptionError::Closed) => {
-                            warn!("presence monitor: subscription closed; exiting loop");
+                            info!("presence monitor: subscription closed; exiting loop");
                             return Ok(());
                         }
                     }

--- a/src-tauri/crates/uc-daemon/src/daemon/run_loop.rs
+++ b/src-tauri/crates/uc-daemon/src/daemon/run_loop.rs
@@ -125,7 +125,7 @@ async fn record_upgrade_status_at_startup(app_facade: &AppFacade) {
             );
         }
         UpgradeStatus::Downgraded { from, to } => {
-            tracing::warn!(
+            tracing::info!(
                 target: "upgrade",
                 from = %from,
                 to = %to,

--- a/src-tauri/crates/uc-daemon/src/daemon/search/coordinator.rs
+++ b/src-tauri/crates/uc-daemon/src/daemon/search/coordinator.rs
@@ -48,7 +48,7 @@ impl DaemonService for SearchCoordinatorService {
                         match event {
                             Ok(event) => forward_search_event(&event_tx, event),
                             Err(broadcast::error::RecvError::Lagged(skipped)) => {
-                                warn!(skipped, "search coordinator service dropped application events");
+                                debug!(skipped, "search coordinator service dropped application events");
                             }
                             Err(broadcast::error::RecvError::Closed) => return,
                         }

--- a/src-tauri/crates/uc-daemon/src/daemon/startup_recovery.rs
+++ b/src-tauri/crates/uc-daemon/src/daemon/startup_recovery.rs
@@ -99,7 +99,7 @@ pub fn spawn_startup_recovery(input: StartupRecoveryInput) {
             match input.space_setup.try_resume_session().await {
                 Ok(true) => {
                     if let Err(error) = input.space_setup.refresh_presence().await {
-                        tracing::warn!(error = %error, "background unlock: presence probe failed");
+                        tracing::debug!(error = %error, "background unlock: presence probe failed");
                     }
                 }
                 Ok(false) => {

--- a/src-tauri/crates/uc-daemon/src/daemon/workers/inbound_clipboard_sync.rs
+++ b/src-tauri/crates/uc-daemon/src/daemon/workers/inbound_clipboard_sync.rs
@@ -109,7 +109,7 @@ impl InboundClipboardSyncWorker {
                 );
             }
             Ok(InboundClipboardApplyOutcome::DecodeFailed { reason }) => {
-                warn!(reason, "inbound dropped: V3 envelope decode failed");
+                debug!(reason, "inbound dropped: V3 envelope decode failed");
             }
             Err(e) => {
                 warn!(error = %e, "inbound apply failed");
@@ -210,7 +210,7 @@ impl DaemonService for InboundClipboardSyncWorker {
                     match recv {
                         Ok(notice) => self.handle_one(notice).await,
                         Err(broadcast::error::RecvError::Lagged(missed)) => {
-                            warn!(
+                            debug!(
                                 missed,
                                 "inbound clipboard sync lagged; dropped frames. \
                                  Next frame catches up."

--- a/src-tauri/crates/uc-daemon/src/daemon/workers/peer_keepalive.rs
+++ b/src-tauri/crates/uc-daemon/src/daemon/workers/peer_keepalive.rs
@@ -438,14 +438,14 @@ async fn next_presence_event(rx: &mut Option<AppPresenceSubscription>) -> Option
     match r.recv().await {
         Ok(event) => Some(event),
         Err(AppPresenceSubscriptionError::Lagged(skipped)) => {
-            warn!(
+            debug!(
                 skipped,
                 "presence subscription lagged; backoff state may briefly mis-bookkeep",
             );
             None
         }
         Err(AppPresenceSubscriptionError::Closed) => {
-            warn!("presence subscription closed; keepalive falling back to time-only mode");
+            info!("presence subscription closed; keepalive falling back to time-only mode");
             *rx = None;
             None
         }
@@ -477,7 +477,7 @@ impl DaemonService for PeerKeepAliveWorker {
             match self.app_facade.subscribe_peer_presence_events() {
                 Ok(rx) => Some(rx),
                 Err(err) => {
-                    warn!(
+                    info!(
                         error = %err,
                         "presence subscription unavailable; keepalive degraded to time-only mode",
                     );

--- a/src-tauri/crates/uc-infra/src/blob/filesystem_store.rs
+++ b/src-tauri/crates/uc-infra/src/blob/filesystem_store.rs
@@ -3,7 +3,7 @@
 
 use anyhow::{Context, Result};
 use std::path::{Path, PathBuf};
-use tracing::{debug, warn};
+use tracing::debug;
 use uc_core::blob::ports::BlobReaderPort;
 use uc_core::BlobId;
 
@@ -82,7 +82,7 @@ impl BlobStorePort for FilesystemBlobStore {
                 return Ok((dest, None));
             }
             Err(err) => {
-                warn!(
+                debug!(
                     blob_id = %blob_id,
                     source = %source.display(),
                     dest = %dest.display(),

--- a/src-tauri/crates/uc-infra/src/clipboard/background_blob_worker.rs
+++ b/src-tauri/crates/uc-infra/src/clipboard/background_blob_worker.rs
@@ -184,14 +184,14 @@ impl BackgroundBlobWorker {
         {
             Ok(ProcessingUpdateOutcome::Updated(_)) => {}
             Ok(ProcessingUpdateOutcome::StateMismatch) => {
-                warn!(
+                debug!(
                     representation_id = %rep_id,
                     "Skipping processing due to state mismatch"
                 );
                 return Ok(ProcessResult::Completed);
             }
             Ok(ProcessingUpdateOutcome::NotFound) => {
-                warn!(representation_id = %rep_id, "Representation missing");
+                debug!(representation_id = %rep_id, "Representation missing");
                 return Ok(ProcessResult::Completed);
             }
             Err(err) => {
@@ -344,14 +344,14 @@ impl BackgroundBlobWorker {
                 Ok(ProcessResult::Completed)
             }
             Ok(ProcessingUpdateOutcome::StateMismatch) => {
-                warn!(
+                debug!(
                     representation_id = %rep_id,
                     "Skipping update due to state mismatch"
                 );
                 Ok(ProcessResult::Completed)
             }
             Ok(ProcessingUpdateOutcome::NotFound) => {
-                warn!(representation_id = %rep_id, "Representation missing");
+                debug!(representation_id = %rep_id, "Representation missing");
                 Ok(ProcessResult::Completed)
             }
             Err(err) => {
@@ -381,13 +381,13 @@ impl BackgroundBlobWorker {
         {
             Ok(ProcessingUpdateOutcome::Updated(_)) => {}
             Ok(ProcessingUpdateOutcome::StateMismatch) => {
-                warn!(
+                debug!(
                     representation_id = %rep_id,
                     "Skipping mark_failed due to state mismatch"
                 );
             }
             Ok(ProcessingUpdateOutcome::NotFound) => {
-                warn!(representation_id = %rep_id, "Representation missing");
+                debug!(representation_id = %rep_id, "Representation missing");
             }
             Err(err) => {
                 error!(

--- a/src-tauri/crates/uc-infra/src/clipboard/spool_janitor.rs
+++ b/src-tauri/crates/uc-infra/src/clipboard/spool_janitor.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use tokio::fs;
-use tracing::warn;
+use tracing::{debug, warn};
 use uc_core::clipboard::PayloadAvailability;
 use uc_core::ports::clipboard::ProcessingUpdateOutcome;
 use uc_core::ports::{ClipboardRepresentationRepositoryPort, ClockPort};
@@ -64,14 +64,14 @@ impl SpoolJanitor {
             {
                 Ok(ProcessingUpdateOutcome::Updated(_)) => true,
                 Ok(ProcessingUpdateOutcome::StateMismatch) => {
-                    warn!(
+                    debug!(
                         representation_id = %entry.representation_id,
                         "Skipping spool file delete: state mismatch (rep moved past Staged/Processing)"
                     );
                     false
                 }
                 Ok(ProcessingUpdateOutcome::NotFound) => {
-                    warn!(
+                    debug!(
                         representation_id = %entry.representation_id,
                         "Skipping spool file delete: representation missing from DB"
                     );

--- a/src-tauri/crates/uc-infra/src/clipboard/spool_scanner.rs
+++ b/src-tauri/crates/uc-infra/src/clipboard/spool_scanner.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use anyhow::{Context, Result};
 use tokio::fs;
 use tokio::sync::mpsc;
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 use uc_core::clipboard::PayloadAvailability;
 use uc_core::ids::RepresentationId;
 use uc_core::ports::ClipboardRepresentationRepositoryPort;
@@ -56,12 +56,12 @@ impl SpoolScanner {
 
             let file_name = entry.file_name();
             let Some(file_name_str) = file_name.to_str() else {
-                warn!("Skipping spool entry with non-utf8 filename");
+                debug!("Skipping spool entry with non-utf8 filename");
                 continue;
             };
 
             if file_name_str.is_empty() {
-                warn!("Skipping spool entry with empty filename");
+                debug!("Skipping spool entry with empty filename");
                 continue;
             }
 
@@ -96,7 +96,7 @@ impl SpoolScanner {
                 },
                 None => {
                     let path = entry.path();
-                    warn!(
+                    debug!(
                         representation_id = %rep_id,
                         "Representation missing for spool entry; deleting stale file"
                     );

--- a/src-tauri/crates/uc-infra/src/clipboard/staged_reconciler.rs
+++ b/src-tauri/crates/uc-infra/src/clipboard/staged_reconciler.rs
@@ -32,7 +32,7 @@
 use std::sync::Arc;
 
 use anyhow::Result;
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 use uc_core::clipboard::PayloadAvailability;
 use uc_core::ports::clipboard::ProcessingUpdateOutcome;
@@ -114,13 +114,13 @@ impl StagedReconciler {
                     );
                 }
                 Ok(ProcessingUpdateOutcome::StateMismatch) => {
-                    warn!(
+                    debug!(
                         representation_id = %rep_id,
                         "Staged reconciler: skipped demotion due to state mismatch"
                     );
                 }
                 Ok(ProcessingUpdateOutcome::NotFound) => {
-                    warn!(
+                    debug!(
                         representation_id = %rep_id,
                         "Staged reconciler: representation vanished mid-sweep"
                     );

--- a/src-tauri/crates/uc-infra/src/db/repositories/file_transfer_repo.rs
+++ b/src-tauri/crates/uc-infra/src/db/repositories/file_transfer_repo.rs
@@ -127,7 +127,7 @@ impl<E: DbExecutor> FileTransferRepositoryPort for DieselFileTransferRepository<
                         .optional()?;
                     if let Some(status) = existing_status.as_deref() {
                         if status != TrackedFileTransferStatus::Pending.as_str() {
-                            tracing::warn!(
+                            tracing::debug!(
                                 transfer_id = %row.transfer_id,
                                 existing_status = status,
                                 "upsert_pending_transfer: skipping — existing row is not pending"

--- a/src-tauri/crates/uc-infra/src/network/iroh/transfer_progress_adapter.rs
+++ b/src-tauri/crates/uc-infra/src/network/iroh/transfer_progress_adapter.rs
@@ -159,7 +159,7 @@ impl ProtocolHandler for IrohTransferProgressHandler {
         let from_device = match self.state.resolve_device(&remote_bytes).await {
             Some(d) => d,
             None => {
-                warn!(remote = %remote, "transfer progress: unknown peer fingerprint; dropping");
+                debug!(remote = %remote, "transfer progress: unknown peer fingerprint; dropping");
                 return Ok(());
             }
         };

--- a/src-tauri/crates/uc-infra/src/security/space_access_adapter.rs
+++ b/src-tauri/crates/uc-infra/src/security/space_access_adapter.rs
@@ -223,7 +223,7 @@ impl SpaceAccessPort for DefaultSpaceAccessAdapter {
                 error!(path = PATH, error = %e, "keyslot_exists probe failed");
                 SpaceAccessError::Internal(e.to_string())
             })? {
-                warn!(
+                info!(
                     path = PATH,
                     "initialize rejected: keyslot already exists on disk"
                 );
@@ -260,7 +260,7 @@ impl SpaceAccessPort for DefaultSpaceAccessAdapter {
                 error!(path = PATH, error = %e, "keyslot_exists probe failed");
                 SpaceAccessError::Internal(e.to_string())
             })? {
-                warn!(
+                info!(
                     path = PATH,
                     "unlock rejected: no keyslot on disk (not initialized)"
                 );
@@ -425,7 +425,7 @@ impl SpaceAccessPort for DefaultSpaceAccessAdapter {
             // keyring 被清 / 跨设备 profile 迁移——属于业务正常路径,
             // 上层会回退到要求用户重新输入口令走 unlock。warn 级别即可。
             let kek = self.key_material.load_kek(&scope).await.map_err(|e| {
-                warn!(
+                info!(
                     path = PATH,
                     error = %e,
                     "load_kek from keyring failed; caller will fall back to passphrase unlock"
@@ -482,7 +482,7 @@ impl SpaceAccessPort for DefaultSpaceAccessAdapter {
                     Ok(true)
                 }
                 Err(EncryptionError::PermissionDenied) => {
-                    warn!(path = PATH, "keychain access denied (Always Allow not granted)");
+                    info!(path = PATH, "keychain access denied (Always Allow not granted)");
                     Ok(false)
                 }
                 Err(EncryptionError::KeyringError(msg)) => {

--- a/src-tauri/crates/uc-webserver/src/api/encryption.rs
+++ b/src-tauri/crates/uc-webserver/src/api/encryption.rs
@@ -5,7 +5,7 @@ use axum::http::StatusCode;
 use axum::routing::{get, post};
 use axum::{Json, Router};
 use tokio::sync::broadcast::error::SendError;
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 use uc_application::facade::space_setup::UnlockSpaceError;
 use uc_application::facade::{FactoryResetError, UnlockSpaceInput};
 use uc_daemon_contract::api::dto::envelope::ApiEnvelope;
@@ -212,7 +212,9 @@ async fn unlock_handler(
                 payload: serde_json::to_value(&event_payload).unwrap_or(serde_json::Value::Null),
             };
             if let Err(SendError(_)) = state.event_tx.send(event) {
-                warn!("failed to broadcast encryption.session_ready event — no active subscribers");
+                debug!(
+                    "failed to broadcast encryption.session_ready event — no active subscribers"
+                );
             }
 
             Ok(Json(ApiEnvelope::now(EncryptionActionResponse {

--- a/src-tauri/crates/uc-webserver/src/api/routes.rs
+++ b/src-tauri/crates/uc-webserver/src/api/routes.rs
@@ -256,7 +256,7 @@ fn restore_error_to_response(
     use ClipboardRestoreError as E;
     match error {
         E::NotFound => {
-            tracing::warn!(entry_id = %entry_id, "daemon restore: entry not found");
+            tracing::info!(entry_id = %entry_id, "daemon restore: entry not found");
             (
                 StatusCode::NOT_FOUND,
                 Json(ApiErrorResponse::new(
@@ -273,7 +273,7 @@ fn restore_error_to_response(
             // Known business outcome — content has logically vanished.
             // Use 410 Gone (resource is no longer available) and log at
             // warn level so this does NOT escalate to a Sentry error.
-            tracing::warn!(
+            tracing::info!(
                 entry_id = %e_id,
                 rep_id = %rep_id,
                 payload_state = %state,

--- a/src-tauri/crates/uc-webserver/src/api/server.rs
+++ b/src-tauri/crates/uc-webserver/src/api/server.rs
@@ -374,7 +374,7 @@ pub(crate) async fn request_tracing_middleware(request: Request<Body>, next: Nex
             elapsed_ms,
             "daemon http response 5xx"
         ),
-        "client_error" => tracing::warn!(
+        "client_error" => tracing::info!(
             request_id = %request_id,
             method = %method,
             path = %path,

--- a/src-tauri/crates/uc-webserver/src/api/setup_events.rs
+++ b/src-tauri/crates/uc-webserver/src/api/setup_events.rs
@@ -136,7 +136,7 @@ pub fn spawn_pairing_completion_forwarder(
                         );
                     }
                     Err(broadcast::error::RecvError::Lagged(n)) => {
-                        warn!(
+                        debug!(
                             skipped = n,
                             "pairing-completion forwarder lagged — some events dropped"
                         );

--- a/src-tauri/crates/uc-webserver/src/api/ws.rs
+++ b/src-tauri/crates/uc-webserver/src/api/ws.rs
@@ -255,7 +255,7 @@ async fn handle_connection(socket: WebSocket, state: DaemonApiState, claims: Ses
                         }
                     }
                     Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
-                        warn!(
+                        debug!(
                             skipped,
                             "websocket client lagged behind daemon event stream"
                         );
@@ -385,7 +385,7 @@ async fn handle_connection(socket: WebSocket, state: DaemonApiState, claims: Ses
                 sig = heartbeat_rx.recv() => {
                     match sig {
                         Some(HeartbeatSignal::Stale) => {
-                            warn!("heartbeat: client missed pong, closing stale connection");
+                            debug!("heartbeat: client missed pong, closing stale connection");
                             let _ = send_tx.send(SendMsg::Close).await;
                             break;
                         }


### PR DESCRIPTION
## Summary

- Demote ~35 `warn!` call sites to `debug!` across `uc-application`, `uc-bootstrap`, `uc-daemon`, `uc-infra`, and `uc-webserver` (7d18300). These fire on routine, non-actionable conditions (dedup races, offline peers, buffered-phase progress without an entry, broadcast sends with no subscribers) and flood logs under clipboard stress testing.
- Fix missing `warn` macro imports in `publisher.rs`, `register_device.rs`, and `encryption.rs` where the original `use tracing::warn` was removed but remaining `warn!` call sites still need it.

No behavioral change — only log verbosity.

## Test plan

- [x] `cargo check` passes for all affected crates (`uc-application`, `uc-bootstrap`, `uc-daemon`, `uc-infra`, `uc-webserver`)
- [ ] Run clipboard stress test and verify logs are less noisy at default verbosity
- [ ] Verify genuine warnings still surface at `RUST_LOG=warn`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted logging severity levels across the application for improved clarity. Non-critical transient conditions, network issues, and fallback behaviors now log at appropriate levels, reducing warning spam and making logs easier to parse while preserving all functional behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->