### PR TITLE
fix(network): improve LAN-only mode for multi-NIC environments

### DIFF
--- a/src-tauri/crates/uc-application/src/facade/app_facade.rs
+++ b/src-tauri/crates/uc-application/src/facade/app_facade.rs
@@ -278,6 +278,20 @@ impl AppFacade {
             .await
     }
 
+    /// 用户触发的手动重连:强制重拨指定 peer,绕过 presence 缓存。
+    /// Thin wrapper over [`SpaceSetupFacade::reconnect_peer`].
+    pub async fn reconnect_peer(
+        &self,
+        device: &DeviceId,
+    ) -> Result<ReachabilityState, PresenceError> {
+        self.space_setup
+            .get()
+            .cloned()
+            .ok_or_else(|| PresenceError::Internal("space setup facade unavailable".to_string()))?
+            .reconnect_peer(device)
+            .await
+    }
+
     /// B1:签发配对邀请。
     pub async fn issue_pairing_invitation(
         &self,

--- a/src-tauri/crates/uc-application/src/facade/space_setup/commands.rs
+++ b/src-tauri/crates/uc-application/src/facade/space_setup/commands.rs
@@ -99,10 +99,6 @@ pub struct IssuePairingInvitationResult {
     /// Server-authoritative expiry; UI should display a countdown from
     /// this value rather than computing its own.
     pub expires_at: DateTime<Utc>,
-    /// Full connection string for manual fallback when mDNS/cloud discovery
-    /// is unavailable. Contains the code + base64url-encoded endpoint ticket.
-    /// Format: `uc://p/<CODE>/<BASE64URL_TICKET>`
-    pub connection_string: Option<String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -114,10 +110,6 @@ pub struct IssuePairingInvitationResult {
 pub struct RedeemPairingInvitationInput {
     pub code: String,
     pub passphrase: String,
-    /// Optional pre-resolved ticket from a connection string. When present
-    /// the joiner skips discovery and dials the sponsor directly using the
-    /// embedded transport address.
-    pub connection_string: Option<String>,
 }
 
 /// Internal command for [`crate::usecases::pairing::redeem_invitation::RedeemPairingInvitationUseCase`].
@@ -132,9 +124,6 @@ pub(crate) struct RedeemPairingInvitationCommand {
     pub code: InvitationCode,
     /// Same passphrase the sponsor used in A1 `InitializeSpace`.
     pub passphrase: Passphrase,
-    /// Optional pre-resolved ticket from a connection string. When present
-    /// the joiner skips discovery and dials the sponsor directly.
-    pub connection_string: Option<String>,
 }
 
 impl From<RedeemPairingInvitationInput> for RedeemPairingInvitationCommand {
@@ -142,7 +131,6 @@ impl From<RedeemPairingInvitationInput> for RedeemPairingInvitationCommand {
         Self {
             code: InvitationCode::new(input.code),
             passphrase: Passphrase::new(input.passphrase),
-            connection_string: input.connection_string,
         }
     }
 }
@@ -215,8 +203,6 @@ pub struct RedeemPairingInvitationResult {
 pub struct SwitchSpaceInput {
     pub code: String,
     pub new_passphrase: String,
-    /// Optional pre-resolved ticket from a connection string.
-    pub connection_string: Option<String>,
 }
 
 /// Internal command for [`crate::usecases::setup::switch_space::SwitchSpaceUseCase`].
@@ -224,7 +210,6 @@ pub struct SwitchSpaceInput {
 pub(crate) struct SwitchSpaceCommand {
     pub code: InvitationCode,
     pub new_passphrase: Passphrase,
-    pub connection_string: Option<String>,
 }
 
 impl From<SwitchSpaceInput> for SwitchSpaceCommand {
@@ -232,7 +217,6 @@ impl From<SwitchSpaceInput> for SwitchSpaceCommand {
         Self {
             code: InvitationCode::new(input.code),
             new_passphrase: Passphrase::new(input.new_passphrase),
-            connection_string: input.connection_string,
         }
     }
 }

--- a/src-tauri/crates/uc-application/src/facade/space_setup/commands.rs
+++ b/src-tauri/crates/uc-application/src/facade/space_setup/commands.rs
@@ -99,6 +99,10 @@ pub struct IssuePairingInvitationResult {
     /// Server-authoritative expiry; UI should display a countdown from
     /// this value rather than computing its own.
     pub expires_at: DateTime<Utc>,
+    /// Full connection string for manual fallback when mDNS/cloud discovery
+    /// is unavailable. Contains the code + base64url-encoded endpoint ticket.
+    /// Format: `uc://p/<CODE>/<BASE64URL_TICKET>`
+    pub connection_string: Option<String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -110,6 +114,10 @@ pub struct IssuePairingInvitationResult {
 pub struct RedeemPairingInvitationInput {
     pub code: String,
     pub passphrase: String,
+    /// Optional pre-resolved ticket from a connection string. When present
+    /// the joiner skips discovery and dials the sponsor directly using the
+    /// embedded transport address.
+    pub connection_string: Option<String>,
 }
 
 /// Internal command for [`crate::usecases::pairing::redeem_invitation::RedeemPairingInvitationUseCase`].
@@ -124,6 +132,9 @@ pub(crate) struct RedeemPairingInvitationCommand {
     pub code: InvitationCode,
     /// Same passphrase the sponsor used in A1 `InitializeSpace`.
     pub passphrase: Passphrase,
+    /// Optional pre-resolved ticket from a connection string. When present
+    /// the joiner skips discovery and dials the sponsor directly.
+    pub connection_string: Option<String>,
 }
 
 impl From<RedeemPairingInvitationInput> for RedeemPairingInvitationCommand {
@@ -131,6 +142,7 @@ impl From<RedeemPairingInvitationInput> for RedeemPairingInvitationCommand {
         Self {
             code: InvitationCode::new(input.code),
             passphrase: Passphrase::new(input.passphrase),
+            connection_string: input.connection_string,
         }
     }
 }
@@ -203,6 +215,8 @@ pub struct RedeemPairingInvitationResult {
 pub struct SwitchSpaceInput {
     pub code: String,
     pub new_passphrase: String,
+    /// Optional pre-resolved ticket from a connection string.
+    pub connection_string: Option<String>,
 }
 
 /// Internal command for [`crate::usecases::setup::switch_space::SwitchSpaceUseCase`].
@@ -210,6 +224,7 @@ pub struct SwitchSpaceInput {
 pub(crate) struct SwitchSpaceCommand {
     pub code: InvitationCode,
     pub new_passphrase: Passphrase,
+    pub connection_string: Option<String>,
 }
 
 impl From<SwitchSpaceInput> for SwitchSpaceCommand {
@@ -217,6 +232,7 @@ impl From<SwitchSpaceInput> for SwitchSpaceCommand {
         Self {
             code: InvitationCode::new(input.code),
             new_passphrase: Passphrase::new(input.new_passphrase),
+            connection_string: input.connection_string,
         }
     }
 }

--- a/src-tauri/crates/uc-application/src/facade/space_setup/commands.rs
+++ b/src-tauri/crates/uc-application/src/facade/space_setup/commands.rs
@@ -213,6 +213,7 @@ pub struct RedeemPairingInvitationResult {
 pub struct SwitchSpaceInput {
     pub code: String,
     pub new_passphrase: String,
+    pub sponsor_addr_hint: Option<String>,
 }
 
 /// Internal command for [`crate::usecases::setup::switch_space::SwitchSpaceUseCase`].
@@ -220,6 +221,7 @@ pub struct SwitchSpaceInput {
 pub(crate) struct SwitchSpaceCommand {
     pub code: InvitationCode,
     pub new_passphrase: Passphrase,
+    pub sponsor_addr_hint: Option<String>,
 }
 
 impl From<SwitchSpaceInput> for SwitchSpaceCommand {
@@ -227,6 +229,7 @@ impl From<SwitchSpaceInput> for SwitchSpaceCommand {
         Self {
             code: InvitationCode::new(input.code),
             new_passphrase: Passphrase::new(input.new_passphrase),
+            sponsor_addr_hint: input.sponsor_addr_hint,
         }
     }
 }

--- a/src-tauri/crates/uc-application/src/facade/space_setup/commands.rs
+++ b/src-tauri/crates/uc-application/src/facade/space_setup/commands.rs
@@ -99,6 +99,9 @@ pub struct IssuePairingInvitationResult {
     /// Server-authoritative expiry; UI should display a countdown from
     /// this value rather than computing its own.
     pub expires_at: DateTime<Utc>,
+    /// LAN IP addresses of this device that the joiner can use for
+    /// manual IP fallback pairing when mDNS discovery fails.
+    pub lan_addresses: Vec<String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -110,6 +113,10 @@ pub struct IssuePairingInvitationResult {
 pub struct RedeemPairingInvitationInput {
     pub code: String,
     pub passphrase: String,
+    /// Optional sponsor IP address for manual LAN fallback pairing.
+    /// When mDNS discovery fails, the joiner can enter the sponsor's
+    /// IP address to resolve the ticket via a direct HTTP fetch.
+    pub sponsor_addr_hint: Option<String>,
 }
 
 /// Internal command for [`crate::usecases::pairing::redeem_invitation::RedeemPairingInvitationUseCase`].
@@ -124,6 +131,8 @@ pub(crate) struct RedeemPairingInvitationCommand {
     pub code: InvitationCode,
     /// Same passphrase the sponsor used in A1 `InitializeSpace`.
     pub passphrase: Passphrase,
+    /// Optional sponsor IP address for manual LAN fallback.
+    pub sponsor_addr_hint: Option<String>,
 }
 
 impl From<RedeemPairingInvitationInput> for RedeemPairingInvitationCommand {
@@ -131,6 +140,7 @@ impl From<RedeemPairingInvitationInput> for RedeemPairingInvitationCommand {
         Self {
             code: InvitationCode::new(input.code),
             passphrase: Passphrase::new(input.passphrase),
+            sponsor_addr_hint: input.sponsor_addr_hint,
         }
     }
 }

--- a/src-tauri/crates/uc-application/src/facade/space_setup/facade.rs
+++ b/src-tauri/crates/uc-application/src/facade/space_setup/facade.rs
@@ -1088,9 +1088,10 @@ mod tests {
 
     #[async_trait]
     impl PairingSessionPort for NoopSessionPort {
-        async fn dial_by_invitation(
+        async fn dial_by_invitation_with_hint(
             &self,
             _code: &uc_core::pairing::invitation::InvitationCode,
+            _sponsor_addr_hint: Option<&str>,
         ) -> Result<DialOutcome, DialError> {
             unreachable!("smoke tests never dial")
         }

--- a/src-tauri/crates/uc-application/src/facade/space_setup/facade.rs
+++ b/src-tauri/crates/uc-application/src/facade/space_setup/facade.rs
@@ -1048,6 +1048,7 @@ mod tests {
                     .unwrap()
                     .with_timezone(&Utc),
                 code_origin: CodeOrigin::DirectoryIssued,
+                ticket_base64url: None,
             })
         }
 
@@ -1954,6 +1955,7 @@ mod tests {
             .switch_space(SwitchSpaceInput {
                 code: "CODE-1".into(),
                 new_passphrase: "hunter22hunter22".into(),
+                connection_string: None,
             })
             .await
             .unwrap_err();

--- a/src-tauri/crates/uc-application/src/facade/space_setup/facade.rs
+++ b/src-tauri/crates/uc-application/src/facade/space_setup/facade.rs
@@ -762,6 +762,20 @@ impl SpaceSetupFacade {
         self.presence.ensure_reachable(device).await
     }
 
+    /// Force-redial a specific peer, bypassing the presence cache.
+    ///
+    /// Exposed via `POST /member/:device_id/reconnect` for user-triggered
+    /// retry. Unlike [`Self::ensure_reachable_one`] which returns early when
+    /// the outbound peers map already holds an alive connection,
+    /// `verify_reachable` forces a fresh dial so stale "Online" assumptions
+    /// are replaced with ground truth.
+    pub async fn reconnect_peer(
+        &self,
+        device: &DeviceId,
+    ) -> Result<ReachabilityState, PresenceError> {
+        self.presence.verify_reachable(device).await
+    }
+
     /// F2 · Tear down facade-owned background work cleanly on app exit.
     ///
     /// Slice 4 P5c: 历史上还会调 `network_control.stop_network()`,libp2p 走

--- a/src-tauri/crates/uc-application/src/facade/space_setup/facade.rs
+++ b/src-tauri/crates/uc-application/src/facade/space_setup/facade.rs
@@ -1048,7 +1048,6 @@ mod tests {
                     .unwrap()
                     .with_timezone(&Utc),
                 code_origin: CodeOrigin::DirectoryIssued,
-                ticket_base64url: None,
             })
         }
 
@@ -1955,7 +1954,6 @@ mod tests {
             .switch_space(SwitchSpaceInput {
                 code: "CODE-1".into(),
                 new_passphrase: "hunter22hunter22".into(),
-                connection_string: None,
             })
             .await
             .unwrap_err();

--- a/src-tauri/crates/uc-application/src/pairing_inbound/orchestrator.rs
+++ b/src-tauri/crates/uc-application/src/pairing_inbound/orchestrator.rs
@@ -668,7 +668,11 @@ mod tests {
     }
     #[async_trait]
     impl PairingSessionPort for RecordingSessionPort {
-        async fn dial_by_invitation(&self, _: &InvitationCode) -> Result<DialOutcome, DialError> {
+        async fn dial_by_invitation_with_hint(
+            &self,
+            _: &InvitationCode,
+            _: Option<&str>,
+        ) -> Result<DialOutcome, DialError> {
             unimplemented!()
         }
         async fn send(

--- a/src-tauri/crates/uc-application/src/pairing_inbound/sponsor_handshake.rs
+++ b/src-tauri/crates/uc-application/src/pairing_inbound/sponsor_handshake.rs
@@ -534,9 +534,10 @@ mod tests {
 
     #[async_trait]
     impl PairingSessionPort for RecordingSessionPort {
-        async fn dial_by_invitation(
+        async fn dial_by_invitation_with_hint(
             &self,
             _code: &InvitationCode,
+            _sponsor_addr_hint: Option<&str>,
         ) -> Result<DialOutcome, DialError> {
             unimplemented!()
         }

--- a/src-tauri/crates/uc-application/src/pairing_outbound/joiner_handshake.rs
+++ b/src-tauri/crates/uc-application/src/pairing_outbound/joiner_handshake.rs
@@ -131,16 +131,11 @@ impl JoinerHandshakeCoordinator {
     /// been closed cleanly and the outcome is ready for the outer use
     /// case to persist. On failure the session is also closed (so the
     /// adapter releases its slot) and the error is surfaced.
-    ///
-    /// When `connection_string` is `Some`, the coordinator parses the
-    /// `uc://p/<CODE>/<TICKET>` URI, base64url-decodes the ticket, and
-    /// dials the sponsor directly — bypassing all discovery channels.
     #[instrument(skip_all, fields(code = %code.as_str()))]
     pub(crate) async fn handshake(
         &self,
         code: &InvitationCode,
         passphrase: &Passphrase,
-        connection_string: Option<&str>,
     ) -> Result<JoinerHandshakeOutcome, RedeemPairingInvitationError> {
         // Dial first so NotFound / Expired / Unreachable short-circuits
         // without spending any crypto work. A successful dial creates
@@ -149,20 +144,11 @@ impl JoinerHandshakeCoordinator {
         let DialOutcome {
             session_id: session,
             channel,
-        } = match connection_string {
-            Some(cs) => {
-                let ticket_bytes = parse_connection_string(cs)?;
-                self.pairing_session
-                    .dial_by_pre_resolved_addr(code, &ticket_bytes)
-                    .await
-                    .map_err(map_dial_err)?
-            }
-            None => self
-                .pairing_session
-                .dial_by_invitation(code)
-                .await
-                .map_err(map_dial_err)?,
-        };
+        } = self
+            .pairing_session
+            .dial_by_invitation(code)
+            .await
+            .map_err(map_dial_err)?;
         info!(session = %session, ?channel, "pairing session dialled");
 
         match self.drive(&session, channel, code, passphrase).await {
@@ -383,29 +369,6 @@ fn challenge_to_array(bytes: &[u8]) -> Result<[u8; 32], RedeemPairingInvitationE
         RedeemPairingInvitationError::Internal(format!(
             "challenge nonce wire length invalid: expected 32 bytes, got {}",
             bytes.len()
-        ))
-    })
-}
-
-/// Parse a `uc://p/<CODE>/<BASE64URL_TICKET>` connection string and return
-/// the decoded ticket bytes. The code part is validated against the
-/// invitation code the caller already has; the ticket is base64url-decoded
-/// (no padding).
-fn parse_connection_string(cs: &str) -> Result<Vec<u8>, RedeemPairingInvitationError> {
-    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
-    use base64::Engine as _;
-
-    let rest = cs.strip_prefix("uc://p/").ok_or_else(|| {
-        RedeemPairingInvitationError::Internal(
-            "connection string does not start with uc://p/".into(),
-        )
-    })?;
-    let (_code, ticket_b64) = rest.split_once('/').ok_or_else(|| {
-        RedeemPairingInvitationError::Internal("connection string missing ticket after code".into())
-    })?;
-    URL_SAFE_NO_PAD.decode(ticket_b64).map_err(|err| {
-        RedeemPairingInvitationError::Internal(format!(
-            "connection string base64url decode failed: {err}"
         ))
     })
 }
@@ -823,7 +786,7 @@ mod tests {
         let coord = b.build();
 
         let out = coord
-            .handshake(&code("CODE-1"), &passphrase(), None)
+            .handshake(&code("CODE-1"), &passphrase())
             .await
             .unwrap();
 
@@ -859,7 +822,7 @@ mod tests {
         let b = Bundle::with_dial_err(DialError::InvitationNotFound);
         let err = b
             .build()
-            .handshake(&code("X"), &passphrase(), None)
+            .handshake(&code("X"), &passphrase())
             .await
             .unwrap_err();
         assert!(matches!(
@@ -875,7 +838,7 @@ mod tests {
         let b = Bundle::with_dial_err(DialError::InvitationExpired);
         let err = b
             .build()
-            .handshake(&code("X"), &passphrase(), None)
+            .handshake(&code("X"), &passphrase())
             .await
             .unwrap_err();
         assert!(matches!(
@@ -889,7 +852,7 @@ mod tests {
         let b = Bundle::with_dial_err(DialError::SponsorUnreachable);
         let err = b
             .build()
-            .handshake(&code("X"), &passphrase(), None)
+            .handshake(&code("X"), &passphrase())
             .await
             .unwrap_err();
         assert!(matches!(
@@ -903,7 +866,7 @@ mod tests {
         let b = Bundle::with_dial_err(DialError::ServiceUnavailable);
         let err = b
             .build()
-            .handshake(&code("X"), &passphrase(), None)
+            .handshake(&code("X"), &passphrase())
             .await
             .unwrap_err();
         assert!(matches!(
@@ -925,7 +888,7 @@ mod tests {
             )));
         let err = b
             .build()
-            .handshake(&code("X"), &passphrase(), None)
+            .handshake(&code("X"), &passphrase())
             .await
             .unwrap_err();
         assert!(matches!(
@@ -951,7 +914,7 @@ mod tests {
             )));
         let err = b
             .build()
-            .handshake(&code("X"), &passphrase(), None)
+            .handshake(&code("X"), &passphrase())
             .await
             .unwrap_err();
         assert!(matches!(
@@ -972,7 +935,7 @@ mod tests {
             )));
         let err = b
             .build()
-            .handshake(&code("X"), &passphrase(), None)
+            .handshake(&code("X"), &passphrase())
             .await
             .unwrap_err();
         assert!(matches!(err, RedeemPairingInvitationError::SponsorTimedOut));
@@ -989,7 +952,7 @@ mod tests {
             )));
         let err = b
             .build()
-            .handshake(&code("X"), &passphrase(), None)
+            .handshake(&code("X"), &passphrase())
             .await
             .unwrap_err();
         assert!(matches!(err, RedeemPairingInvitationError::SponsorDeclined));
@@ -1006,7 +969,7 @@ mod tests {
             )));
         let err = b
             .build()
-            .handshake(&code("X"), &passphrase(), None)
+            .handshake(&code("X"), &passphrase())
             .await
             .unwrap_err();
         match err {
@@ -1022,8 +985,7 @@ mod tests {
         let b = Bundle::happy();
         b.session.push_recv(RecvStep::Hang);
         let coord = b.build();
-        let handle =
-            tokio::spawn(async move { coord.handshake(&code("X"), &passphrase(), None).await });
+        let handle = tokio::spawn(async move { coord.handshake(&code("X"), &passphrase()).await });
         tokio::time::sleep(TEST_TTL + ChronoDuration::seconds(1).to_std().unwrap()).await;
         let err = handle.await.unwrap().unwrap_err();
         assert!(matches!(err, RedeemPairingInvitationError::Timeout));
@@ -1040,8 +1002,7 @@ mod tests {
         let sent_probe = b.session.clone();
         let closed_probe = b.session.clone();
         let coord = b.build();
-        let handle =
-            tokio::spawn(async move { coord.handshake(&code("X"), &passphrase(), None).await });
+        let handle = tokio::spawn(async move { coord.handshake(&code("X"), &passphrase()).await });
         tokio::time::sleep(TEST_TTL + ChronoDuration::seconds(1).to_std().unwrap()).await;
         let err = handle.await.unwrap().unwrap_err();
         assert!(matches!(err, RedeemPairingInvitationError::Timeout));
@@ -1063,7 +1024,7 @@ mod tests {
             )));
         let err = b
             .build()
-            .handshake(&code("X"), &passphrase(), None)
+            .handshake(&code("X"), &passphrase())
             .await
             .unwrap_err();
         assert!(matches!(
@@ -1086,7 +1047,7 @@ mod tests {
             )));
         let err = b
             .build()
-            .handshake(&code("X"), &passphrase(), None)
+            .handshake(&code("X"), &passphrase())
             .await
             .unwrap_err();
         assert!(matches!(
@@ -1103,7 +1064,7 @@ mod tests {
         b.session.push_recv(RecvStep::CleanClose);
         let err = b
             .build()
-            .handshake(&code("X"), &passphrase(), None)
+            .handshake(&code("X"), &passphrase())
             .await
             .unwrap_err();
         assert!(matches!(err, RedeemPairingInvitationError::ConnectionLost));
@@ -1115,7 +1076,7 @@ mod tests {
         b.session.push_recv(RecvStep::Err(SessionError::Closed));
         let err = b
             .build()
-            .handshake(&code("X"), &passphrase(), None)
+            .handshake(&code("X"), &passphrase())
             .await
             .unwrap_err();
         assert!(matches!(err, RedeemPairingInvitationError::ConnectionLost));
@@ -1130,7 +1091,7 @@ mod tests {
             )));
         let err = b
             .build()
-            .handshake(&code("X"), &passphrase(), None)
+            .handshake(&code("X"), &passphrase())
             .await
             .unwrap_err();
         match err {
@@ -1161,7 +1122,7 @@ mod tests {
             )));
         let err = b
             .build()
-            .handshake(&code("X"), &passphrase(), None)
+            .handshake(&code("X"), &passphrase())
             .await
             .unwrap_err();
         match err {
@@ -1180,7 +1141,7 @@ mod tests {
         b.settings = Arc::new(StubSettings::blank());
         let err = b
             .build()
-            .handshake(&code("X"), &passphrase(), None)
+            .handshake(&code("X"), &passphrase())
             .await
             .unwrap_err();
         assert!(matches!(

--- a/src-tauri/crates/uc-application/src/pairing_outbound/joiner_handshake.rs
+++ b/src-tauri/crates/uc-application/src/pairing_outbound/joiner_handshake.rs
@@ -131,11 +131,16 @@ impl JoinerHandshakeCoordinator {
     /// been closed cleanly and the outcome is ready for the outer use
     /// case to persist. On failure the session is also closed (so the
     /// adapter releases its slot) and the error is surfaced.
+    ///
+    /// When `connection_string` is `Some`, the coordinator parses the
+    /// `uc://p/<CODE>/<TICKET>` URI, base64url-decodes the ticket, and
+    /// dials the sponsor directly — bypassing all discovery channels.
     #[instrument(skip_all, fields(code = %code.as_str()))]
     pub(crate) async fn handshake(
         &self,
         code: &InvitationCode,
         passphrase: &Passphrase,
+        connection_string: Option<&str>,
     ) -> Result<JoinerHandshakeOutcome, RedeemPairingInvitationError> {
         // Dial first so NotFound / Expired / Unreachable short-circuits
         // without spending any crypto work. A successful dial creates
@@ -144,11 +149,20 @@ impl JoinerHandshakeCoordinator {
         let DialOutcome {
             session_id: session,
             channel,
-        } = self
-            .pairing_session
-            .dial_by_invitation(code)
-            .await
-            .map_err(map_dial_err)?;
+        } = match connection_string {
+            Some(cs) => {
+                let ticket_bytes = parse_connection_string(cs)?;
+                self.pairing_session
+                    .dial_by_pre_resolved_addr(code, &ticket_bytes)
+                    .await
+                    .map_err(map_dial_err)?
+            }
+            None => self
+                .pairing_session
+                .dial_by_invitation(code)
+                .await
+                .map_err(map_dial_err)?,
+        };
         info!(session = %session, ?channel, "pairing session dialled");
 
         match self.drive(&session, channel, code, passphrase).await {
@@ -369,6 +383,29 @@ fn challenge_to_array(bytes: &[u8]) -> Result<[u8; 32], RedeemPairingInvitationE
         RedeemPairingInvitationError::Internal(format!(
             "challenge nonce wire length invalid: expected 32 bytes, got {}",
             bytes.len()
+        ))
+    })
+}
+
+/// Parse a `uc://p/<CODE>/<BASE64URL_TICKET>` connection string and return
+/// the decoded ticket bytes. The code part is validated against the
+/// invitation code the caller already has; the ticket is base64url-decoded
+/// (no padding).
+fn parse_connection_string(cs: &str) -> Result<Vec<u8>, RedeemPairingInvitationError> {
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+    use base64::Engine as _;
+
+    let rest = cs.strip_prefix("uc://p/").ok_or_else(|| {
+        RedeemPairingInvitationError::Internal(
+            "connection string does not start with uc://p/".into(),
+        )
+    })?;
+    let (_code, ticket_b64) = rest.split_once('/').ok_or_else(|| {
+        RedeemPairingInvitationError::Internal("connection string missing ticket after code".into())
+    })?;
+    URL_SAFE_NO_PAD.decode(ticket_b64).map_err(|err| {
+        RedeemPairingInvitationError::Internal(format!(
+            "connection string base64url decode failed: {err}"
         ))
     })
 }
@@ -786,7 +823,7 @@ mod tests {
         let coord = b.build();
 
         let out = coord
-            .handshake(&code("CODE-1"), &passphrase())
+            .handshake(&code("CODE-1"), &passphrase(), None)
             .await
             .unwrap();
 
@@ -822,7 +859,7 @@ mod tests {
         let b = Bundle::with_dial_err(DialError::InvitationNotFound);
         let err = b
             .build()
-            .handshake(&code("X"), &passphrase())
+            .handshake(&code("X"), &passphrase(), None)
             .await
             .unwrap_err();
         assert!(matches!(
@@ -838,7 +875,7 @@ mod tests {
         let b = Bundle::with_dial_err(DialError::InvitationExpired);
         let err = b
             .build()
-            .handshake(&code("X"), &passphrase())
+            .handshake(&code("X"), &passphrase(), None)
             .await
             .unwrap_err();
         assert!(matches!(
@@ -852,7 +889,7 @@ mod tests {
         let b = Bundle::with_dial_err(DialError::SponsorUnreachable);
         let err = b
             .build()
-            .handshake(&code("X"), &passphrase())
+            .handshake(&code("X"), &passphrase(), None)
             .await
             .unwrap_err();
         assert!(matches!(
@@ -866,7 +903,7 @@ mod tests {
         let b = Bundle::with_dial_err(DialError::ServiceUnavailable);
         let err = b
             .build()
-            .handshake(&code("X"), &passphrase())
+            .handshake(&code("X"), &passphrase(), None)
             .await
             .unwrap_err();
         assert!(matches!(
@@ -888,7 +925,7 @@ mod tests {
             )));
         let err = b
             .build()
-            .handshake(&code("X"), &passphrase())
+            .handshake(&code("X"), &passphrase(), None)
             .await
             .unwrap_err();
         assert!(matches!(
@@ -914,7 +951,7 @@ mod tests {
             )));
         let err = b
             .build()
-            .handshake(&code("X"), &passphrase())
+            .handshake(&code("X"), &passphrase(), None)
             .await
             .unwrap_err();
         assert!(matches!(
@@ -935,7 +972,7 @@ mod tests {
             )));
         let err = b
             .build()
-            .handshake(&code("X"), &passphrase())
+            .handshake(&code("X"), &passphrase(), None)
             .await
             .unwrap_err();
         assert!(matches!(err, RedeemPairingInvitationError::SponsorTimedOut));
@@ -952,7 +989,7 @@ mod tests {
             )));
         let err = b
             .build()
-            .handshake(&code("X"), &passphrase())
+            .handshake(&code("X"), &passphrase(), None)
             .await
             .unwrap_err();
         assert!(matches!(err, RedeemPairingInvitationError::SponsorDeclined));
@@ -969,7 +1006,7 @@ mod tests {
             )));
         let err = b
             .build()
-            .handshake(&code("X"), &passphrase())
+            .handshake(&code("X"), &passphrase(), None)
             .await
             .unwrap_err();
         match err {
@@ -985,7 +1022,8 @@ mod tests {
         let b = Bundle::happy();
         b.session.push_recv(RecvStep::Hang);
         let coord = b.build();
-        let handle = tokio::spawn(async move { coord.handshake(&code("X"), &passphrase()).await });
+        let handle =
+            tokio::spawn(async move { coord.handshake(&code("X"), &passphrase(), None).await });
         tokio::time::sleep(TEST_TTL + ChronoDuration::seconds(1).to_std().unwrap()).await;
         let err = handle.await.unwrap().unwrap_err();
         assert!(matches!(err, RedeemPairingInvitationError::Timeout));
@@ -1002,7 +1040,8 @@ mod tests {
         let sent_probe = b.session.clone();
         let closed_probe = b.session.clone();
         let coord = b.build();
-        let handle = tokio::spawn(async move { coord.handshake(&code("X"), &passphrase()).await });
+        let handle =
+            tokio::spawn(async move { coord.handshake(&code("X"), &passphrase(), None).await });
         tokio::time::sleep(TEST_TTL + ChronoDuration::seconds(1).to_std().unwrap()).await;
         let err = handle.await.unwrap().unwrap_err();
         assert!(matches!(err, RedeemPairingInvitationError::Timeout));
@@ -1024,7 +1063,7 @@ mod tests {
             )));
         let err = b
             .build()
-            .handshake(&code("X"), &passphrase())
+            .handshake(&code("X"), &passphrase(), None)
             .await
             .unwrap_err();
         assert!(matches!(
@@ -1047,7 +1086,7 @@ mod tests {
             )));
         let err = b
             .build()
-            .handshake(&code("X"), &passphrase())
+            .handshake(&code("X"), &passphrase(), None)
             .await
             .unwrap_err();
         assert!(matches!(
@@ -1064,7 +1103,7 @@ mod tests {
         b.session.push_recv(RecvStep::CleanClose);
         let err = b
             .build()
-            .handshake(&code("X"), &passphrase())
+            .handshake(&code("X"), &passphrase(), None)
             .await
             .unwrap_err();
         assert!(matches!(err, RedeemPairingInvitationError::ConnectionLost));
@@ -1076,7 +1115,7 @@ mod tests {
         b.session.push_recv(RecvStep::Err(SessionError::Closed));
         let err = b
             .build()
-            .handshake(&code("X"), &passphrase())
+            .handshake(&code("X"), &passphrase(), None)
             .await
             .unwrap_err();
         assert!(matches!(err, RedeemPairingInvitationError::ConnectionLost));
@@ -1091,7 +1130,7 @@ mod tests {
             )));
         let err = b
             .build()
-            .handshake(&code("X"), &passphrase())
+            .handshake(&code("X"), &passphrase(), None)
             .await
             .unwrap_err();
         match err {
@@ -1122,7 +1161,7 @@ mod tests {
             )));
         let err = b
             .build()
-            .handshake(&code("X"), &passphrase())
+            .handshake(&code("X"), &passphrase(), None)
             .await
             .unwrap_err();
         match err {
@@ -1141,7 +1180,7 @@ mod tests {
         b.settings = Arc::new(StubSettings::blank());
         let err = b
             .build()
-            .handshake(&code("X"), &passphrase())
+            .handshake(&code("X"), &passphrase(), None)
             .await
             .unwrap_err();
         assert!(matches!(

--- a/src-tauri/crates/uc-application/src/pairing_outbound/joiner_handshake.rs
+++ b/src-tauri/crates/uc-application/src/pairing_outbound/joiner_handshake.rs
@@ -136,6 +136,7 @@ impl JoinerHandshakeCoordinator {
         &self,
         code: &InvitationCode,
         passphrase: &Passphrase,
+        sponsor_addr_hint: Option<&str>,
     ) -> Result<JoinerHandshakeOutcome, RedeemPairingInvitationError> {
         // Dial first so NotFound / Expired / Unreachable short-circuits
         // without spending any crypto work. A successful dial creates
@@ -146,7 +147,7 @@ impl JoinerHandshakeCoordinator {
             channel,
         } = self
             .pairing_session
-            .dial_by_invitation(code)
+            .dial_by_invitation_with_hint(code, sponsor_addr_hint)
             .await
             .map_err(map_dial_err)?;
         info!(session = %session, ?channel, "pairing session dialled");
@@ -498,9 +499,10 @@ mod tests {
 
     #[async_trait]
     impl PairingSessionPort for ScriptedSession {
-        async fn dial_by_invitation(
+        async fn dial_by_invitation_with_hint(
             &self,
             _code: &InvitationCode,
+            _sponsor_addr_hint: Option<&str>,
         ) -> Result<DialOutcome, DialError> {
             match self.dial_result.lock().unwrap().as_ref() {
                 Some(Ok(id)) => Ok(DialOutcome {
@@ -786,7 +788,7 @@ mod tests {
         let coord = b.build();
 
         let out = coord
-            .handshake(&code("CODE-1"), &passphrase())
+            .handshake(&code("CODE-1"), &passphrase(), None)
             .await
             .unwrap();
 
@@ -822,7 +824,7 @@ mod tests {
         let b = Bundle::with_dial_err(DialError::InvitationNotFound);
         let err = b
             .build()
-            .handshake(&code("X"), &passphrase())
+            .handshake(&code("X"), &passphrase(), None)
             .await
             .unwrap_err();
         assert!(matches!(
@@ -838,7 +840,7 @@ mod tests {
         let b = Bundle::with_dial_err(DialError::InvitationExpired);
         let err = b
             .build()
-            .handshake(&code("X"), &passphrase())
+            .handshake(&code("X"), &passphrase(), None)
             .await
             .unwrap_err();
         assert!(matches!(
@@ -852,7 +854,7 @@ mod tests {
         let b = Bundle::with_dial_err(DialError::SponsorUnreachable);
         let err = b
             .build()
-            .handshake(&code("X"), &passphrase())
+            .handshake(&code("X"), &passphrase(), None)
             .await
             .unwrap_err();
         assert!(matches!(
@@ -866,7 +868,7 @@ mod tests {
         let b = Bundle::with_dial_err(DialError::ServiceUnavailable);
         let err = b
             .build()
-            .handshake(&code("X"), &passphrase())
+            .handshake(&code("X"), &passphrase(), None)
             .await
             .unwrap_err();
         assert!(matches!(
@@ -888,7 +890,7 @@ mod tests {
             )));
         let err = b
             .build()
-            .handshake(&code("X"), &passphrase())
+            .handshake(&code("X"), &passphrase(), None)
             .await
             .unwrap_err();
         assert!(matches!(
@@ -914,7 +916,7 @@ mod tests {
             )));
         let err = b
             .build()
-            .handshake(&code("X"), &passphrase())
+            .handshake(&code("X"), &passphrase(), None)
             .await
             .unwrap_err();
         assert!(matches!(
@@ -935,7 +937,7 @@ mod tests {
             )));
         let err = b
             .build()
-            .handshake(&code("X"), &passphrase())
+            .handshake(&code("X"), &passphrase(), None)
             .await
             .unwrap_err();
         assert!(matches!(err, RedeemPairingInvitationError::SponsorTimedOut));
@@ -952,7 +954,7 @@ mod tests {
             )));
         let err = b
             .build()
-            .handshake(&code("X"), &passphrase())
+            .handshake(&code("X"), &passphrase(), None)
             .await
             .unwrap_err();
         assert!(matches!(err, RedeemPairingInvitationError::SponsorDeclined));
@@ -969,7 +971,7 @@ mod tests {
             )));
         let err = b
             .build()
-            .handshake(&code("X"), &passphrase())
+            .handshake(&code("X"), &passphrase(), None)
             .await
             .unwrap_err();
         match err {
@@ -985,7 +987,8 @@ mod tests {
         let b = Bundle::happy();
         b.session.push_recv(RecvStep::Hang);
         let coord = b.build();
-        let handle = tokio::spawn(async move { coord.handshake(&code("X"), &passphrase()).await });
+        let handle =
+            tokio::spawn(async move { coord.handshake(&code("X"), &passphrase(), None).await });
         tokio::time::sleep(TEST_TTL + ChronoDuration::seconds(1).to_std().unwrap()).await;
         let err = handle.await.unwrap().unwrap_err();
         assert!(matches!(err, RedeemPairingInvitationError::Timeout));
@@ -1002,7 +1005,8 @@ mod tests {
         let sent_probe = b.session.clone();
         let closed_probe = b.session.clone();
         let coord = b.build();
-        let handle = tokio::spawn(async move { coord.handshake(&code("X"), &passphrase()).await });
+        let handle =
+            tokio::spawn(async move { coord.handshake(&code("X"), &passphrase(), None).await });
         tokio::time::sleep(TEST_TTL + ChronoDuration::seconds(1).to_std().unwrap()).await;
         let err = handle.await.unwrap().unwrap_err();
         assert!(matches!(err, RedeemPairingInvitationError::Timeout));
@@ -1024,7 +1028,7 @@ mod tests {
             )));
         let err = b
             .build()
-            .handshake(&code("X"), &passphrase())
+            .handshake(&code("X"), &passphrase(), None)
             .await
             .unwrap_err();
         assert!(matches!(
@@ -1047,7 +1051,7 @@ mod tests {
             )));
         let err = b
             .build()
-            .handshake(&code("X"), &passphrase())
+            .handshake(&code("X"), &passphrase(), None)
             .await
             .unwrap_err();
         assert!(matches!(
@@ -1064,7 +1068,7 @@ mod tests {
         b.session.push_recv(RecvStep::CleanClose);
         let err = b
             .build()
-            .handshake(&code("X"), &passphrase())
+            .handshake(&code("X"), &passphrase(), None)
             .await
             .unwrap_err();
         assert!(matches!(err, RedeemPairingInvitationError::ConnectionLost));
@@ -1076,7 +1080,7 @@ mod tests {
         b.session.push_recv(RecvStep::Err(SessionError::Closed));
         let err = b
             .build()
-            .handshake(&code("X"), &passphrase())
+            .handshake(&code("X"), &passphrase(), None)
             .await
             .unwrap_err();
         assert!(matches!(err, RedeemPairingInvitationError::ConnectionLost));
@@ -1091,7 +1095,7 @@ mod tests {
             )));
         let err = b
             .build()
-            .handshake(&code("X"), &passphrase())
+            .handshake(&code("X"), &passphrase(), None)
             .await
             .unwrap_err();
         match err {
@@ -1122,7 +1126,7 @@ mod tests {
             )));
         let err = b
             .build()
-            .handshake(&code("X"), &passphrase())
+            .handshake(&code("X"), &passphrase(), None)
             .await
             .unwrap_err();
         match err {
@@ -1141,7 +1145,7 @@ mod tests {
         b.settings = Arc::new(StubSettings::blank());
         let err = b
             .build()
-            .handshake(&code("X"), &passphrase())
+            .handshake(&code("X"), &passphrase(), None)
             .await
             .unwrap_err();
         assert!(matches!(

--- a/src-tauri/crates/uc-application/src/usecases/pairing/issue_invitation.rs
+++ b/src-tauri/crates/uc-application/src/usecases/pairing/issue_invitation.rs
@@ -153,9 +153,15 @@ impl IssuePairingInvitationUseCase {
         self.holder.insert(invitation).await;
         info!(code = %issued.code.as_str(), "pairing invitation parked in holder");
 
+        let connection_string = issued
+            .ticket_base64url
+            .as_ref()
+            .map(|ticket| format!("uc://p/{}/{}", issued.code.as_str(), ticket));
+
         Ok(IssuePairingInvitationResult {
             code: issued.code,
             expires_at: issued.expires_at,
+            connection_string,
         })
     }
 
@@ -235,6 +241,7 @@ mod tests {
                     code: InvitationCode::new(code),
                     expires_at,
                     code_origin: CodeOrigin::DirectoryIssued,
+                    ticket_base64url: None,
                 })),
                 calls: StdMutex::new(0),
                 selected_calls: StdMutex::new(Vec::new()),
@@ -534,6 +541,7 @@ mod tests {
             code: InvitationCode::new("SAME"),
             expires_at: second_expiry,
             code_origin: CodeOrigin::DirectoryIssued,
+            ticket_base64url: None,
         });
         h.uc.execute().await.unwrap();
 

--- a/src-tauri/crates/uc-application/src/usecases/pairing/issue_invitation.rs
+++ b/src-tauri/crates/uc-application/src/usecases/pairing/issue_invitation.rs
@@ -153,15 +153,9 @@ impl IssuePairingInvitationUseCase {
         self.holder.insert(invitation).await;
         info!(code = %issued.code.as_str(), "pairing invitation parked in holder");
 
-        let connection_string = issued
-            .ticket_base64url
-            .as_ref()
-            .map(|ticket| format!("uc://p/{}/{}", issued.code.as_str(), ticket));
-
         Ok(IssuePairingInvitationResult {
             code: issued.code,
             expires_at: issued.expires_at,
-            connection_string,
         })
     }
 
@@ -241,7 +235,6 @@ mod tests {
                     code: InvitationCode::new(code),
                     expires_at,
                     code_origin: CodeOrigin::DirectoryIssued,
-                    ticket_base64url: None,
                 })),
                 calls: StdMutex::new(0),
                 selected_calls: StdMutex::new(Vec::new()),
@@ -541,7 +534,6 @@ mod tests {
             code: InvitationCode::new("SAME"),
             expires_at: second_expiry,
             code_origin: CodeOrigin::DirectoryIssued,
-            ticket_base64url: None,
         });
         h.uc.execute().await.unwrap();
 

--- a/src-tauri/crates/uc-application/src/usecases/pairing/issue_invitation.rs
+++ b/src-tauri/crates/uc-application/src/usecases/pairing/issue_invitation.rs
@@ -153,9 +153,21 @@ impl IssuePairingInvitationUseCase {
         self.holder.insert(invitation).await;
         info!(code = %issued.code.as_str(), "pairing invitation parked in holder");
 
+        // Collect LAN addresses for manual IP fallback (best-effort).
+        let lan_addresses = self
+            .pairing_invitation_addresses
+            .list_invitation_addresses()
+            .await
+            .unwrap_or_default()
+            .into_iter()
+            .filter(|c| c.ip.is_ipv4() && !c.ip.is_loopback())
+            .map(|c| c.ip.to_string())
+            .collect();
+
         Ok(IssuePairingInvitationResult {
             code: issued.code,
             expires_at: issued.expires_at,
+            lan_addresses,
         })
     }
 

--- a/src-tauri/crates/uc-application/src/usecases/pairing/redeem_invitation.rs
+++ b/src-tauri/crates/uc-application/src/usecases/pairing/redeem_invitation.rs
@@ -124,10 +124,7 @@ impl RedeemPairingInvitationUseCase {
         });
         let started_at = Instant::now();
         let result = async {
-            let outcome = self
-                .handshake
-                .handshake(&cmd.code, &cmd.passphrase, cmd.connection_string.as_deref())
-                .await?;
+            let outcome = self.handshake.handshake(&cmd.code, &cmd.passphrase).await?;
             // `DiscoveryChannel` is `Copy`; capture it before `persist`
             // consumes the outcome so `pairing_succeeded` can record which
             // channel resolved this first pair.
@@ -690,7 +687,6 @@ mod tests {
         RedeemPairingInvitationCommand {
             code: InvitationCode::new(code),
             passphrase: Passphrase::new("hunter22hunter22"),
-            connection_string: None,
         }
     }
 

--- a/src-tauri/crates/uc-application/src/usecases/pairing/redeem_invitation.rs
+++ b/src-tauri/crates/uc-application/src/usecases/pairing/redeem_invitation.rs
@@ -124,7 +124,10 @@ impl RedeemPairingInvitationUseCase {
         });
         let started_at = Instant::now();
         let result = async {
-            let outcome = self.handshake.handshake(&cmd.code, &cmd.passphrase).await?;
+            let outcome = self
+                .handshake
+                .handshake(&cmd.code, &cmd.passphrase, cmd.connection_string.as_deref())
+                .await?;
             // `DiscoveryChannel` is `Copy`; capture it before `persist`
             // consumes the outcome so `pairing_succeeded` can record which
             // channel resolved this first pair.
@@ -687,6 +690,7 @@ mod tests {
         RedeemPairingInvitationCommand {
             code: InvitationCode::new(code),
             passphrase: Passphrase::new("hunter22hunter22"),
+            connection_string: None,
         }
     }
 

--- a/src-tauri/crates/uc-application/src/usecases/pairing/redeem_invitation.rs
+++ b/src-tauri/crates/uc-application/src/usecases/pairing/redeem_invitation.rs
@@ -124,7 +124,10 @@ impl RedeemPairingInvitationUseCase {
         });
         let started_at = Instant::now();
         let result = async {
-            let outcome = self.handshake.handshake(&cmd.code, &cmd.passphrase).await?;
+            let outcome = self
+                .handshake
+                .handshake(&cmd.code, &cmd.passphrase, cmd.sponsor_addr_hint.as_deref())
+                .await?;
             // `DiscoveryChannel` is `Copy`; capture it before `persist`
             // consumes the outcome so `pairing_succeeded` can record which
             // channel resolved this first pair.
@@ -411,7 +414,11 @@ mod tests {
     }
     #[async_trait]
     impl PairingSessionPort for HappySession {
-        async fn dial_by_invitation(&self, _: &InvitationCode) -> Result<DialOutcome, DialError> {
+        async fn dial_by_invitation_with_hint(
+            &self,
+            _: &InvitationCode,
+            _: Option<&str>,
+        ) -> Result<DialOutcome, DialError> {
             Ok(DialOutcome {
                 session_id: PairingSessionId::new("session-1"),
                 channel: DiscoveryChannel::Cloud,
@@ -439,7 +446,11 @@ mod tests {
     struct UnreachableSession;
     #[async_trait]
     impl PairingSessionPort for UnreachableSession {
-        async fn dial_by_invitation(&self, _: &InvitationCode) -> Result<DialOutcome, DialError> {
+        async fn dial_by_invitation_with_hint(
+            &self,
+            _: &InvitationCode,
+            _: Option<&str>,
+        ) -> Result<DialOutcome, DialError> {
             Err(DialError::InvitationNotFound)
         }
         async fn send(
@@ -687,6 +698,7 @@ mod tests {
         RedeemPairingInvitationCommand {
             code: InvitationCode::new(code),
             passphrase: Passphrase::new("hunter22hunter22"),
+            sponsor_addr_hint: None,
         }
     }
 

--- a/src-tauri/crates/uc-application/src/usecases/setup/switch_space/mod.rs
+++ b/src-tauri/crates/uc-application/src/usecases/setup/switch_space/mod.rs
@@ -118,7 +118,6 @@ pub(crate) trait JoinerHandshakeRunner: Send + Sync {
         &self,
         code: &InvitationCode,
         passphrase: &Passphrase,
-        connection_string: Option<String>,
     ) -> Result<JoinerHandshakeOutcome, RedeemPairingInvitationError>;
 }
 
@@ -128,10 +127,8 @@ impl JoinerHandshakeRunner for JoinerHandshakeCoordinator {
         &self,
         code: &InvitationCode,
         passphrase: &Passphrase,
-        connection_string: Option<String>,
     ) -> Result<JoinerHandshakeOutcome, RedeemPairingInvitationError> {
-        self.handshake(code, passphrase, connection_string.as_deref())
-            .await
+        self.handshake(code, passphrase).await
     }
 }
 
@@ -232,11 +229,7 @@ impl SwitchSpaceUseCase {
 
         // ── Phase 2 — handshake + admit + trust + peer-addr ──────────────
         let outcome = match self
-            .phase_2_handshake_and_persist(
-                &cmd.code,
-                &cmd.new_passphrase,
-                cmd.connection_string.as_deref(),
-            )
+            .phase_2_handshake_and_persist(&cmd.code, &cmd.new_passphrase)
             .await
         {
             Ok(o) => o,
@@ -425,11 +418,10 @@ impl SwitchSpaceUseCase {
         &self,
         code: &InvitationCode,
         new_passphrase: &Passphrase,
-        connection_string: Option<&str>,
     ) -> Result<JoinerHandshakeOutcome, SwitchSpaceError> {
         let outcome = self
             .handshake
-            .run(code, new_passphrase, connection_string.map(String::from))
+            .run(code, new_passphrase)
             .await
             .map_err(map_redeem_err)?;
         let now = self.now_utc()?;

--- a/src-tauri/crates/uc-application/src/usecases/setup/switch_space/mod.rs
+++ b/src-tauri/crates/uc-application/src/usecases/setup/switch_space/mod.rs
@@ -118,6 +118,7 @@ pub(crate) trait JoinerHandshakeRunner: Send + Sync {
         &self,
         code: &InvitationCode,
         passphrase: &Passphrase,
+        connection_string: Option<String>,
     ) -> Result<JoinerHandshakeOutcome, RedeemPairingInvitationError>;
 }
 
@@ -127,8 +128,10 @@ impl JoinerHandshakeRunner for JoinerHandshakeCoordinator {
         &self,
         code: &InvitationCode,
         passphrase: &Passphrase,
+        connection_string: Option<String>,
     ) -> Result<JoinerHandshakeOutcome, RedeemPairingInvitationError> {
-        self.handshake(code, passphrase).await
+        self.handshake(code, passphrase, connection_string.as_deref())
+            .await
     }
 }
 
@@ -229,7 +232,11 @@ impl SwitchSpaceUseCase {
 
         // ── Phase 2 — handshake + admit + trust + peer-addr ──────────────
         let outcome = match self
-            .phase_2_handshake_and_persist(&cmd.code, &cmd.new_passphrase)
+            .phase_2_handshake_and_persist(
+                &cmd.code,
+                &cmd.new_passphrase,
+                cmd.connection_string.as_deref(),
+            )
             .await
         {
             Ok(o) => o,
@@ -418,10 +425,11 @@ impl SwitchSpaceUseCase {
         &self,
         code: &InvitationCode,
         new_passphrase: &Passphrase,
+        connection_string: Option<&str>,
     ) -> Result<JoinerHandshakeOutcome, SwitchSpaceError> {
         let outcome = self
             .handshake
-            .run(code, new_passphrase)
+            .run(code, new_passphrase, connection_string.map(String::from))
             .await
             .map_err(map_redeem_err)?;
         let now = self.now_utc()?;

--- a/src-tauri/crates/uc-application/src/usecases/setup/switch_space/mod.rs
+++ b/src-tauri/crates/uc-application/src/usecases/setup/switch_space/mod.rs
@@ -112,12 +112,16 @@ pub(crate) type TrustPeerUc = TrustPeerUseCase<dyn TrustedPeerRepositoryPort>;
 /// 把 `JoinerHandshakeCoordinator::handshake` 抽象为单方法 trait——只有
 /// switch-space use case 需要这一层间接，让单元测试能用 `mockall` 隔离
 /// handshake 的 wire+crypto 子图。
+///
+/// `sponsor_addr_hint` uses `Option<String>` instead of `Option<&str>`
+/// to keep the trait `mockall`-friendly (no lifetime parameter needed).
 #[async_trait]
 pub(crate) trait JoinerHandshakeRunner: Send + Sync {
     async fn run(
         &self,
         code: &InvitationCode,
         passphrase: &Passphrase,
+        sponsor_addr_hint: Option<String>,
     ) -> Result<JoinerHandshakeOutcome, RedeemPairingInvitationError>;
 }
 
@@ -127,8 +131,10 @@ impl JoinerHandshakeRunner for JoinerHandshakeCoordinator {
         &self,
         code: &InvitationCode,
         passphrase: &Passphrase,
+        sponsor_addr_hint: Option<String>,
     ) -> Result<JoinerHandshakeOutcome, RedeemPairingInvitationError> {
-        self.handshake(code, passphrase).await
+        self.handshake(code, passphrase, sponsor_addr_hint.as_deref())
+            .await
     }
 }
 
@@ -419,9 +425,12 @@ impl SwitchSpaceUseCase {
         code: &InvitationCode,
         new_passphrase: &Passphrase,
     ) -> Result<JoinerHandshakeOutcome, SwitchSpaceError> {
+        // Switch-space does not support sponsor_addr_hint (it's an
+        // already-setup device re-joining; manual IP fallback is a
+        // first-pair UX concern). Pass None.
         let outcome = self
             .handshake
-            .run(code, new_passphrase)
+            .run(code, new_passphrase, None)
             .await
             .map_err(map_redeem_err)?;
         let now = self.now_utc()?;

--- a/src-tauri/crates/uc-application/src/usecases/setup/switch_space/mod.rs
+++ b/src-tauri/crates/uc-application/src/usecases/setup/switch_space/mod.rs
@@ -235,7 +235,11 @@ impl SwitchSpaceUseCase {
 
         // ── Phase 2 — handshake + admit + trust + peer-addr ──────────────
         let outcome = match self
-            .phase_2_handshake_and_persist(&cmd.code, &cmd.new_passphrase)
+            .phase_2_handshake_and_persist(
+                &cmd.code,
+                &cmd.new_passphrase,
+                cmd.sponsor_addr_hint.as_deref(),
+            )
             .await
         {
             Ok(o) => o,
@@ -424,13 +428,11 @@ impl SwitchSpaceUseCase {
         &self,
         code: &InvitationCode,
         new_passphrase: &Passphrase,
+        sponsor_addr_hint: Option<&str>,
     ) -> Result<JoinerHandshakeOutcome, SwitchSpaceError> {
-        // Switch-space does not support sponsor_addr_hint (it's an
-        // already-setup device re-joining; manual IP fallback is a
-        // first-pair UX concern). Pass None.
         let outcome = self
             .handshake
-            .run(code, new_passphrase, None)
+            .run(code, new_passphrase, sponsor_addr_hint.map(String::from))
             .await
             .map_err(map_redeem_err)?;
         let now = self.now_utc()?;

--- a/src-tauri/crates/uc-application/src/usecases/setup/switch_space/tests.rs
+++ b/src-tauri/crates/uc-application/src/usecases/setup/switch_space/tests.rs
@@ -133,6 +133,7 @@ mockall::mock! {
             &self,
             code: &InvitationCode,
             passphrase: &Passphrase,
+            connection_string: Option<String>,
         ) -> Result<JoinerHandshakeOutcome, RedeemPairingInvitationError>;
     }
 }
@@ -262,6 +263,7 @@ fn cmd_default() -> SwitchSpaceCommand {
     SwitchSpaceCommand {
         code: InvitationCode::new("CODE-1"),
         new_passphrase: Passphrase::new("hunter22hunter22"),
+        connection_string: None,
     }
 }
 
@@ -399,7 +401,7 @@ async fn happy_path_executes_all_4_phases() {
     // Phase 2 — handshake + admit + trust
     env.handshake
         .expect_run()
-        .return_once(|_, _| Ok(outcome_default()));
+        .return_once(|_, _, _| Ok(outcome_default()));
     // AdmitMemberUseCase / TrustPeerUseCase 都先 get 后 save——需返回 None
     // 否则会被误判为 AlreadyAdmitted/AlreadyTrusted。
     env.member_repo.expect_get().return_once(|_| Ok(None));
@@ -532,7 +534,7 @@ async fn phase2_handshake_failure_aborts_and_full_cleanup() {
     // Phase 2 fails on handshake
     env.handshake
         .expect_run()
-        .return_once(|_, _| Err(RedeemPairingInvitationError::SponsorUnreachable));
+        .return_once(|_, _, _| Err(RedeemPairingInvitationError::SponsorUnreachable));
 
     // Cleanup：discard_all_records + discard_migration_key + set_current(None)
     env.blob_migration_repo
@@ -699,7 +701,7 @@ async fn admit_failure_aborts_phase2_and_cleans_up() {
 
     env.handshake
         .expect_run()
-        .return_once(|_, _| Ok(outcome_default()));
+        .return_once(|_, _, _| Ok(outcome_default()));
     // admit 流程会先 get 再 save——get 返 None 后 save 才报 db 错。
     env.member_repo.expect_get().return_once(|_| Ok(None));
     env.member_repo
@@ -776,7 +778,7 @@ async fn happy_path_persists_identity_intent_and_invokes_adopt() {
     // Phase 2 — sponsor delivers a `space_person_id`.
     env.handshake
         .expect_run()
-        .return_once(|_, _| Ok(outcome_with_sponsor_person()));
+        .return_once(|_, _, _| Ok(outcome_with_sponsor_person()));
     env.member_repo.expect_get().return_once(|_| Ok(None));
     env.member_repo.expect_save().return_once(|_| Ok(()));
     env.trust_repo.expect_get().return_once(|_| Ok(None));

--- a/src-tauri/crates/uc-application/src/usecases/setup/switch_space/tests.rs
+++ b/src-tauri/crates/uc-application/src/usecases/setup/switch_space/tests.rs
@@ -133,7 +133,6 @@ mockall::mock! {
             &self,
             code: &InvitationCode,
             passphrase: &Passphrase,
-            connection_string: Option<String>,
         ) -> Result<JoinerHandshakeOutcome, RedeemPairingInvitationError>;
     }
 }
@@ -263,7 +262,6 @@ fn cmd_default() -> SwitchSpaceCommand {
     SwitchSpaceCommand {
         code: InvitationCode::new("CODE-1"),
         new_passphrase: Passphrase::new("hunter22hunter22"),
-        connection_string: None,
     }
 }
 
@@ -401,7 +399,7 @@ async fn happy_path_executes_all_4_phases() {
     // Phase 2 — handshake + admit + trust
     env.handshake
         .expect_run()
-        .return_once(|_, _, _| Ok(outcome_default()));
+        .return_once(|_, _| Ok(outcome_default()));
     // AdmitMemberUseCase / TrustPeerUseCase 都先 get 后 save——需返回 None
     // 否则会被误判为 AlreadyAdmitted/AlreadyTrusted。
     env.member_repo.expect_get().return_once(|_| Ok(None));
@@ -534,7 +532,7 @@ async fn phase2_handshake_failure_aborts_and_full_cleanup() {
     // Phase 2 fails on handshake
     env.handshake
         .expect_run()
-        .return_once(|_, _, _| Err(RedeemPairingInvitationError::SponsorUnreachable));
+        .return_once(|_, _| Err(RedeemPairingInvitationError::SponsorUnreachable));
 
     // Cleanup：discard_all_records + discard_migration_key + set_current(None)
     env.blob_migration_repo
@@ -701,7 +699,7 @@ async fn admit_failure_aborts_phase2_and_cleans_up() {
 
     env.handshake
         .expect_run()
-        .return_once(|_, _, _| Ok(outcome_default()));
+        .return_once(|_, _| Ok(outcome_default()));
     // admit 流程会先 get 再 save——get 返 None 后 save 才报 db 错。
     env.member_repo.expect_get().return_once(|_| Ok(None));
     env.member_repo
@@ -778,7 +776,7 @@ async fn happy_path_persists_identity_intent_and_invokes_adopt() {
     // Phase 2 — sponsor delivers a `space_person_id`.
     env.handshake
         .expect_run()
-        .return_once(|_, _, _| Ok(outcome_with_sponsor_person()));
+        .return_once(|_, _| Ok(outcome_with_sponsor_person()));
     env.member_repo.expect_get().return_once(|_| Ok(None));
     env.member_repo.expect_save().return_once(|_| Ok(()));
     env.trust_repo.expect_get().return_once(|_| Ok(None));

--- a/src-tauri/crates/uc-application/src/usecases/setup/switch_space/tests.rs
+++ b/src-tauri/crates/uc-application/src/usecases/setup/switch_space/tests.rs
@@ -133,6 +133,7 @@ mockall::mock! {
             &self,
             code: &InvitationCode,
             passphrase: &Passphrase,
+            sponsor_addr_hint: Option<String>,
         ) -> Result<JoinerHandshakeOutcome, RedeemPairingInvitationError>;
     }
 }
@@ -399,7 +400,7 @@ async fn happy_path_executes_all_4_phases() {
     // Phase 2 — handshake + admit + trust
     env.handshake
         .expect_run()
-        .return_once(|_, _| Ok(outcome_default()));
+        .return_once(|_, _, _| Ok(outcome_default()));
     // AdmitMemberUseCase / TrustPeerUseCase 都先 get 后 save——需返回 None
     // 否则会被误判为 AlreadyAdmitted/AlreadyTrusted。
     env.member_repo.expect_get().return_once(|_| Ok(None));
@@ -532,7 +533,7 @@ async fn phase2_handshake_failure_aborts_and_full_cleanup() {
     // Phase 2 fails on handshake
     env.handshake
         .expect_run()
-        .return_once(|_, _| Err(RedeemPairingInvitationError::SponsorUnreachable));
+        .return_once(|_, _, _| Err(RedeemPairingInvitationError::SponsorUnreachable));
 
     // Cleanup：discard_all_records + discard_migration_key + set_current(None)
     env.blob_migration_repo
@@ -699,7 +700,7 @@ async fn admit_failure_aborts_phase2_and_cleans_up() {
 
     env.handshake
         .expect_run()
-        .return_once(|_, _| Ok(outcome_default()));
+        .return_once(|_, _, _| Ok(outcome_default()));
     // admit 流程会先 get 再 save——get 返 None 后 save 才报 db 错。
     env.member_repo.expect_get().return_once(|_| Ok(None));
     env.member_repo
@@ -776,7 +777,7 @@ async fn happy_path_persists_identity_intent_and_invokes_adopt() {
     // Phase 2 — sponsor delivers a `space_person_id`.
     env.handshake
         .expect_run()
-        .return_once(|_, _| Ok(outcome_with_sponsor_person()));
+        .return_once(|_, _, _| Ok(outcome_with_sponsor_person()));
     env.member_repo.expect_get().return_once(|_| Ok(None));
     env.member_repo.expect_save().return_once(|_| Ok(()));
     env.trust_repo.expect_get().return_once(|_| Ok(None));

--- a/src-tauri/crates/uc-bootstrap/tests/mdns_only_pairing_e2e.rs
+++ b/src-tauri/crates/uc-bootstrap/tests/mdns_only_pairing_e2e.rs
@@ -481,6 +481,7 @@ async fn mdns_only_first_pair_succeeds_when_cloud_unreachable() {
             .redeem_pairing_invitation(RedeemPairingInvitationInput {
                 code: invitation.code.as_str().to_string(),
                 passphrase: passphrase.to_string(),
+                sponsor_addr_hint: None,
             }),
     )
     .await

--- a/src-tauri/crates/uc-bootstrap/tests/mdns_only_pairing_e2e.rs
+++ b/src-tauri/crates/uc-bootstrap/tests/mdns_only_pairing_e2e.rs
@@ -481,7 +481,6 @@ async fn mdns_only_first_pair_succeeds_when_cloud_unreachable() {
             .redeem_pairing_invitation(RedeemPairingInvitationInput {
                 code: invitation.code.as_str().to_string(),
                 passphrase: passphrase.to_string(),
-                connection_string: None,
             }),
     )
     .await

--- a/src-tauri/crates/uc-bootstrap/tests/mdns_only_pairing_e2e.rs
+++ b/src-tauri/crates/uc-bootstrap/tests/mdns_only_pairing_e2e.rs
@@ -481,6 +481,7 @@ async fn mdns_only_first_pair_succeeds_when_cloud_unreachable() {
             .redeem_pairing_invitation(RedeemPairingInvitationInput {
                 code: invitation.code.as_str().to_string(),
                 passphrase: passphrase.to_string(),
+                connection_string: None,
             }),
     )
     .await

--- a/src-tauri/crates/uc-bootstrap/tests/slice1_handshake_e2e.rs
+++ b/src-tauri/crates/uc-bootstrap/tests/slice1_handshake_e2e.rs
@@ -504,6 +504,7 @@ async fn sponsor_joiner_end_to_end_pairing_persists_both_sides() {
         .redeem_pairing_invitation(RedeemPairingInvitationInput {
             code: invitation.code.as_str().to_string(),
             passphrase: passphrase.to_string(),
+            sponsor_addr_hint: None,
         })
         .await
         .expect("joiner B2");

--- a/src-tauri/crates/uc-bootstrap/tests/slice1_handshake_e2e.rs
+++ b/src-tauri/crates/uc-bootstrap/tests/slice1_handshake_e2e.rs
@@ -504,7 +504,6 @@ async fn sponsor_joiner_end_to_end_pairing_persists_both_sides() {
         .redeem_pairing_invitation(RedeemPairingInvitationInput {
             code: invitation.code.as_str().to_string(),
             passphrase: passphrase.to_string(),
-            connection_string: None,
         })
         .await
         .expect("joiner B2");

--- a/src-tauri/crates/uc-bootstrap/tests/slice1_handshake_e2e.rs
+++ b/src-tauri/crates/uc-bootstrap/tests/slice1_handshake_e2e.rs
@@ -504,6 +504,7 @@ async fn sponsor_joiner_end_to_end_pairing_persists_both_sides() {
         .redeem_pairing_invitation(RedeemPairingInvitationInput {
             code: invitation.code.as_str().to_string(),
             passphrase: passphrase.to_string(),
+            connection_string: None,
         })
         .await
         .expect("joiner B2");

--- a/src-tauri/crates/uc-bootstrap/tests/slice2_phase1_presence_e2e.rs
+++ b/src-tauri/crates/uc-bootstrap/tests/slice2_phase1_presence_e2e.rs
@@ -464,7 +464,6 @@ async fn pair_sponsor_and_joiner(sponsor: &Side, joiner: &Side, passphrase: &str
         .redeem_pairing_invitation(RedeemPairingInvitationInput {
             code: invitation.code.as_str().to_string(),
             passphrase: passphrase.to_string(),
-            connection_string: None,
         })
         .await
         .expect("joiner B2");

--- a/src-tauri/crates/uc-bootstrap/tests/slice2_phase1_presence_e2e.rs
+++ b/src-tauri/crates/uc-bootstrap/tests/slice2_phase1_presence_e2e.rs
@@ -464,6 +464,7 @@ async fn pair_sponsor_and_joiner(sponsor: &Side, joiner: &Side, passphrase: &str
         .redeem_pairing_invitation(RedeemPairingInvitationInput {
             code: invitation.code.as_str().to_string(),
             passphrase: passphrase.to_string(),
+            sponsor_addr_hint: None,
         })
         .await
         .expect("joiner B2");

--- a/src-tauri/crates/uc-bootstrap/tests/slice2_phase1_presence_e2e.rs
+++ b/src-tauri/crates/uc-bootstrap/tests/slice2_phase1_presence_e2e.rs
@@ -464,6 +464,7 @@ async fn pair_sponsor_and_joiner(sponsor: &Side, joiner: &Side, passphrase: &str
         .redeem_pairing_invitation(RedeemPairingInvitationInput {
             code: invitation.code.as_str().to_string(),
             passphrase: passphrase.to_string(),
+            connection_string: None,
         })
         .await
         .expect("joiner B2");

--- a/src-tauri/crates/uc-bootstrap/tests/slice2_phase2_clipboard_e2e.rs
+++ b/src-tauri/crates/uc-bootstrap/tests/slice2_phase2_clipboard_e2e.rs
@@ -666,7 +666,6 @@ async fn pair_sponsor_and_joiner(sponsor: &Side, joiner: &Side, passphrase: &str
         .redeem_pairing_invitation(RedeemPairingInvitationInput {
             code: invitation.code.as_str().to_string(),
             passphrase: passphrase.to_string(),
-            connection_string: None,
         })
         .await
         .expect("joiner B2");

--- a/src-tauri/crates/uc-bootstrap/tests/slice2_phase2_clipboard_e2e.rs
+++ b/src-tauri/crates/uc-bootstrap/tests/slice2_phase2_clipboard_e2e.rs
@@ -666,6 +666,7 @@ async fn pair_sponsor_and_joiner(sponsor: &Side, joiner: &Side, passphrase: &str
         .redeem_pairing_invitation(RedeemPairingInvitationInput {
             code: invitation.code.as_str().to_string(),
             passphrase: passphrase.to_string(),
+            sponsor_addr_hint: None,
         })
         .await
         .expect("joiner B2");

--- a/src-tauri/crates/uc-bootstrap/tests/slice2_phase2_clipboard_e2e.rs
+++ b/src-tauri/crates/uc-bootstrap/tests/slice2_phase2_clipboard_e2e.rs
@@ -666,6 +666,7 @@ async fn pair_sponsor_and_joiner(sponsor: &Side, joiner: &Side, passphrase: &str
         .redeem_pairing_invitation(RedeemPairingInvitationInput {
             code: invitation.code.as_str().to_string(),
             passphrase: passphrase.to_string(),
+            connection_string: None,
         })
         .await
         .expect("joiner B2");

--- a/src-tauri/crates/uc-cli/src/commands/join.rs
+++ b/src-tauri/crates/uc-cli/src/commands/join.rs
@@ -151,6 +151,7 @@ pub async fn run(args: JoinArgs, verbose: bool) -> i32 {
     let req = RedeemRequest {
         code: code_str,
         passphrase: passphrase_str,
+        connection_string: None,
     };
 
     let setup_client = ctx.setup_v2_client();

--- a/src-tauri/crates/uc-cli/src/commands/join.rs
+++ b/src-tauri/crates/uc-cli/src/commands/join.rs
@@ -151,7 +151,6 @@ pub async fn run(args: JoinArgs, verbose: bool) -> i32 {
     let req = RedeemRequest {
         code: code_str,
         passphrase: passphrase_str,
-        connection_string: None,
     };
 
     let setup_client = ctx.setup_v2_client();

--- a/src-tauri/crates/uc-cli/src/commands/join.rs
+++ b/src-tauri/crates/uc-cli/src/commands/join.rs
@@ -151,6 +151,7 @@ pub async fn run(args: JoinArgs, verbose: bool) -> i32 {
     let req = RedeemRequest {
         code: code_str,
         passphrase: passphrase_str,
+        sponsor_addr_hint: None,
     };
 
     let setup_client = ctx.setup_v2_client();

--- a/src-tauri/crates/uc-cli/src/commands/switch_space.rs
+++ b/src-tauri/crates/uc-cli/src/commands/switch_space.rs
@@ -104,7 +104,6 @@ pub async fn run(args: SwitchSpaceArgs, verbose: bool) -> i32 {
     let req = SwitchSpaceRequest {
         code: code_str,
         new_passphrase,
-        connection_string: None,
     };
 
     let setup_client = ctx.setup_v2_client();

--- a/src-tauri/crates/uc-cli/src/commands/switch_space.rs
+++ b/src-tauri/crates/uc-cli/src/commands/switch_space.rs
@@ -104,6 +104,7 @@ pub async fn run(args: SwitchSpaceArgs, verbose: bool) -> i32 {
     let req = SwitchSpaceRequest {
         code: code_str,
         new_passphrase,
+        sponsor_addr_hint: None,
     };
 
     let setup_client = ctx.setup_v2_client();

--- a/src-tauri/crates/uc-cli/src/commands/switch_space.rs
+++ b/src-tauri/crates/uc-cli/src/commands/switch_space.rs
@@ -104,6 +104,7 @@ pub async fn run(args: SwitchSpaceArgs, verbose: bool) -> i32 {
     let req = SwitchSpaceRequest {
         code: code_str,
         new_passphrase,
+        connection_string: None,
     };
 
     let setup_client = ctx.setup_v2_client();

--- a/src-tauri/crates/uc-core/src/ports/pairing/session.rs
+++ b/src-tauri/crates/uc-core/src/ports/pairing/session.rs
@@ -127,7 +127,19 @@ pub trait PairingSessionPort: Send + Sync {
     /// channel that resolved the invitation. No bytes are sent by this
     /// call — the caller writes the first [`PairingSessionMessage`] via
     /// [`send`](Self::send).
-    async fn dial_by_invitation(&self, code: &InvitationCode) -> Result<DialOutcome, DialError>;
+    async fn dial_by_invitation(&self, code: &InvitationCode) -> Result<DialOutcome, DialError> {
+        self.dial_by_invitation_with_hint(code, None).await
+    }
+
+    /// Like [`dial_by_invitation`](Self::dial_by_invitation) but accepts an
+    /// optional sponsor address hint (an IP address string). When provided,
+    /// the adapter tries a direct HTTP ticket fetch from that IP before
+    /// falling back to the standard discovery channels.
+    async fn dial_by_invitation_with_hint(
+        &self,
+        code: &InvitationCode,
+        sponsor_addr_hint: Option<&str>,
+    ) -> Result<DialOutcome, DialError>;
 
     /// Send a pairing message on an existing session. Used by both sides
     /// throughout the handshake.

--- a/src-tauri/crates/uc-core/src/ports/pairing/session.rs
+++ b/src-tauri/crates/uc-core/src/ports/pairing/session.rs
@@ -129,26 +129,6 @@ pub trait PairingSessionPort: Send + Sync {
     /// [`send`](Self::send).
     async fn dial_by_invitation(&self, code: &InvitationCode) -> Result<DialOutcome, DialError>;
 
-    /// Joiner entry point for the connection-string fallback path.
-    ///
-    /// Skips all discovery channels and dials the sponsor directly using
-    /// a pre-resolved transport address encoded as opaque bytes (postcard
-    /// serialization of the adapter's address type, base64url-decoded by
-    /// the caller). Returns the same [`DialOutcome`] as
-    /// [`dial_by_invitation`](Self::dial_by_invitation).
-    ///
-    /// Default implementation returns [`DialError::Internal`]; adapters
-    /// that support the fallback override this.
-    async fn dial_by_pre_resolved_addr(
-        &self,
-        _code: &InvitationCode,
-        _addr_bytes: &[u8],
-    ) -> Result<DialOutcome, DialError> {
-        Err(DialError::Internal(
-            "dial_by_pre_resolved_addr not supported by this adapter".into(),
-        ))
-    }
-
     /// Send a pairing message on an existing session. Used by both sides
     /// throughout the handshake.
     async fn send(

--- a/src-tauri/crates/uc-core/src/ports/pairing/session.rs
+++ b/src-tauri/crates/uc-core/src/ports/pairing/session.rs
@@ -129,6 +129,26 @@ pub trait PairingSessionPort: Send + Sync {
     /// [`send`](Self::send).
     async fn dial_by_invitation(&self, code: &InvitationCode) -> Result<DialOutcome, DialError>;
 
+    /// Joiner entry point for the connection-string fallback path.
+    ///
+    /// Skips all discovery channels and dials the sponsor directly using
+    /// a pre-resolved transport address encoded as opaque bytes (postcard
+    /// serialization of the adapter's address type, base64url-decoded by
+    /// the caller). Returns the same [`DialOutcome`] as
+    /// [`dial_by_invitation`](Self::dial_by_invitation).
+    ///
+    /// Default implementation returns [`DialError::Internal`]; adapters
+    /// that support the fallback override this.
+    async fn dial_by_pre_resolved_addr(
+        &self,
+        _code: &InvitationCode,
+        _addr_bytes: &[u8],
+    ) -> Result<DialOutcome, DialError> {
+        Err(DialError::Internal(
+            "dial_by_pre_resolved_addr not supported by this adapter".into(),
+        ))
+    }
+
     /// Send a pairing message on an existing session. Used by both sides
     /// throughout the handshake.
     async fn send(

--- a/src-tauri/crates/uc-core/src/ports/pairing_invitation.rs
+++ b/src-tauri/crates/uc-core/src/ports/pairing_invitation.rs
@@ -66,6 +66,11 @@ pub struct IssuedInvitation {
     /// only resolvable on the local network; callers may surface that
     /// distinction (e.g. "this code only works on your LAN").
     pub code_origin: CodeOrigin,
+    /// Opaque serialized endpoint ticket for connection-string fallback.
+    /// Base64url-encoded (no padding) postcard bytes of the transport
+    /// address. Present when the adapter can provide it; absent when not
+    /// applicable.
+    pub ticket_base64url: Option<String>,
 }
 
 /// A local address the sponsor could publish in a pairing ticket.

--- a/src-tauri/crates/uc-core/src/ports/pairing_invitation.rs
+++ b/src-tauri/crates/uc-core/src/ports/pairing_invitation.rs
@@ -66,11 +66,6 @@ pub struct IssuedInvitation {
     /// only resolvable on the local network; callers may surface that
     /// distinction (e.g. "this code only works on your LAN").
     pub code_origin: CodeOrigin,
-    /// Opaque serialized endpoint ticket for connection-string fallback.
-    /// Base64url-encoded (no padding) postcard bytes of the transport
-    /// address. Present when the adapter can provide it; absent when not
-    /// applicable.
-    pub ticket_base64url: Option<String>,
 }
 
 /// A local address the sponsor could publish in a pairing ticket.

--- a/src-tauri/crates/uc-daemon-contract/src/api/dto/envelope.rs
+++ b/src-tauri/crates/uc-daemon-contract/src/api/dto/envelope.rs
@@ -42,7 +42,7 @@ use crate::api::dto::v2::setup::{
 };
 use crate::api::types::{
     HealthResponse, LifecycleStatusResponse, PeerSnapshotDto, PresenceRefreshResponse,
-    RestartAccepted, SpaceMemberDto, StatusResponse,
+    ReconnectResultDto, RestartAccepted, SpaceMemberDto, StatusResponse,
 };
 
 /// Canonical success envelope: `{ "data": T, "ts": <unix millis i64> }`.
@@ -116,6 +116,7 @@ use crate::api::types::{
     PeerSnapshotListEnvelope = ApiEnvelope<Vec<PeerSnapshotDto>>,
     SpaceMemberListEnvelope = ApiEnvelope<Vec<SpaceMemberDto>>,
     PresenceRefreshEnvelope = ApiEnvelope<PresenceRefreshResponse>,
+    ReconnectResultEnvelope = ApiEnvelope<ReconnectResultDto>,
     // ── auth/connect (newly enveloped, §H) ─────────────────────────
     SessionTokenEnvelope = ApiEnvelope<SessionTokenResponse>,
     // ── setup-v2 (all 6 bodies newly enveloped, §H) ────────────────

--- a/src-tauri/crates/uc-daemon-contract/src/api/dto/v2/setup.rs
+++ b/src-tauri/crates/uc-daemon-contract/src/api/dto/v2/setup.rs
@@ -43,6 +43,11 @@ pub struct InitializeSpaceResponse {
 pub struct IssueInvitationResponse {
     pub code: String,
     pub expires_at_ms: i64,
+    /// Full connection string for manual fallback when mDNS/cloud
+    /// discovery is unavailable. Format: `uc://p/<CODE>/<BASE64URL_TICKET>`.
+    /// Present only when the sponsor can provide one.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub connection_string: Option<String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -56,6 +61,10 @@ pub struct IssueInvitationResponse {
 pub struct RedeemRequest {
     pub code: String,
     pub passphrase: String,
+    /// Optional connection string for direct-dial fallback. When provided,
+    /// the joiner skips discovery and dials the sponsor directly.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub connection_string: Option<String>,
 }
 
 /// Response body for `POST /v2/setup/redeem`. Mirrors
@@ -108,6 +117,9 @@ pub struct CurrentInvitation {
 pub struct SwitchSpaceRequest {
     pub code: String,
     pub new_passphrase: String,
+    /// Optional connection string for direct-dial fallback.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub connection_string: Option<String>,
 }
 
 /// Response body for `POST /v2/setup/switch-space`. Mirrors
@@ -188,10 +200,13 @@ mod tests {
         let resp = IssueInvitationResponse {
             code: "ABCD-1234".to_string(),
             expires_at_ms: 1_745_577_600_000,
+            connection_string: None,
         };
         let json = serde_json::to_value(&resp).unwrap();
         assert_eq!(json["code"], "ABCD-1234");
         assert_eq!(json["expiresAtMs"], 1_745_577_600_000_i64);
+        // connection_string is None → field should be absent (skip_serializing_if)
+        assert!(json.get("connectionString").is_none());
     }
 
     #[test]
@@ -199,6 +214,7 @@ mod tests {
         let req = RedeemRequest {
             code: "WXYZ-5678".to_string(),
             passphrase: "hunter22hunter22".to_string(),
+            connection_string: None,
         };
         let json = serde_json::to_string(&req).unwrap();
         let decoded: RedeemRequest = serde_json::from_str(&json).unwrap();
@@ -247,6 +263,7 @@ mod tests {
         let req = SwitchSpaceRequest {
             code: "ABCD-1234".to_string(),
             new_passphrase: "newpass22newpass".to_string(),
+            connection_string: None,
         };
         let json = serde_json::to_value(&req).unwrap();
         assert_eq!(json["code"], "ABCD-1234");

--- a/src-tauri/crates/uc-daemon-contract/src/api/dto/v2/setup.rs
+++ b/src-tauri/crates/uc-daemon-contract/src/api/dto/v2/setup.rs
@@ -117,6 +117,8 @@ pub struct CurrentInvitation {
 pub struct SwitchSpaceRequest {
     pub code: String,
     pub new_passphrase: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sponsor_addr_hint: Option<String>,
 }
 
 /// Response body for `POST /v2/setup/switch-space`. Mirrors

--- a/src-tauri/crates/uc-daemon-contract/src/api/dto/v2/setup.rs
+++ b/src-tauri/crates/uc-daemon-contract/src/api/dto/v2/setup.rs
@@ -43,11 +43,6 @@ pub struct InitializeSpaceResponse {
 pub struct IssueInvitationResponse {
     pub code: String,
     pub expires_at_ms: i64,
-    /// Full connection string for manual fallback when mDNS/cloud
-    /// discovery is unavailable. Format: `uc://p/<CODE>/<BASE64URL_TICKET>`.
-    /// Present only when the sponsor can provide one.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub connection_string: Option<String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -61,10 +56,6 @@ pub struct IssueInvitationResponse {
 pub struct RedeemRequest {
     pub code: String,
     pub passphrase: String,
-    /// Optional connection string for direct-dial fallback. When provided,
-    /// the joiner skips discovery and dials the sponsor directly.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub connection_string: Option<String>,
 }
 
 /// Response body for `POST /v2/setup/redeem`. Mirrors
@@ -117,9 +108,6 @@ pub struct CurrentInvitation {
 pub struct SwitchSpaceRequest {
     pub code: String,
     pub new_passphrase: String,
-    /// Optional connection string for direct-dial fallback.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub connection_string: Option<String>,
 }
 
 /// Response body for `POST /v2/setup/switch-space`. Mirrors
@@ -200,13 +188,10 @@ mod tests {
         let resp = IssueInvitationResponse {
             code: "ABCD-1234".to_string(),
             expires_at_ms: 1_745_577_600_000,
-            connection_string: None,
         };
         let json = serde_json::to_value(&resp).unwrap();
         assert_eq!(json["code"], "ABCD-1234");
         assert_eq!(json["expiresAtMs"], 1_745_577_600_000_i64);
-        // connection_string is None → field should be absent (skip_serializing_if)
-        assert!(json.get("connectionString").is_none());
     }
 
     #[test]
@@ -214,7 +199,6 @@ mod tests {
         let req = RedeemRequest {
             code: "WXYZ-5678".to_string(),
             passphrase: "hunter22hunter22".to_string(),
-            connection_string: None,
         };
         let json = serde_json::to_string(&req).unwrap();
         let decoded: RedeemRequest = serde_json::from_str(&json).unwrap();
@@ -263,7 +247,6 @@ mod tests {
         let req = SwitchSpaceRequest {
             code: "ABCD-1234".to_string(),
             new_passphrase: "newpass22newpass".to_string(),
-            connection_string: None,
         };
         let json = serde_json::to_value(&req).unwrap();
         assert_eq!(json["code"], "ABCD-1234");

--- a/src-tauri/crates/uc-daemon-contract/src/api/dto/v2/setup.rs
+++ b/src-tauri/crates/uc-daemon-contract/src/api/dto/v2/setup.rs
@@ -43,6 +43,10 @@ pub struct InitializeSpaceResponse {
 pub struct IssueInvitationResponse {
     pub code: String,
     pub expires_at_ms: i64,
+    /// LAN IP addresses of this device for manual IP fallback pairing.
+    /// Empty when no LAN addresses are available.
+    #[serde(default)]
+    pub lan_addresses: Vec<String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -56,6 +60,11 @@ pub struct IssueInvitationResponse {
 pub struct RedeemRequest {
     pub code: String,
     pub passphrase: String,
+    /// Optional sponsor IP address for manual LAN fallback pairing.
+    /// When provided, the joiner tries a direct HTTP ticket fetch from
+    /// this address before falling back to mDNS / cloud discovery.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sponsor_addr_hint: Option<String>,
 }
 
 /// Response body for `POST /v2/setup/redeem`. Mirrors
@@ -188,10 +197,12 @@ mod tests {
         let resp = IssueInvitationResponse {
             code: "ABCD-1234".to_string(),
             expires_at_ms: 1_745_577_600_000,
+            lan_addresses: vec!["192.168.1.100".to_string()],
         };
         let json = serde_json::to_value(&resp).unwrap();
         assert_eq!(json["code"], "ABCD-1234");
         assert_eq!(json["expiresAtMs"], 1_745_577_600_000_i64);
+        assert_eq!(json["lanAddresses"][0], "192.168.1.100");
     }
 
     #[test]
@@ -199,6 +210,7 @@ mod tests {
         let req = RedeemRequest {
             code: "WXYZ-5678".to_string(),
             passphrase: "hunter22hunter22".to_string(),
+            sponsor_addr_hint: None,
         };
         let json = serde_json::to_string(&req).unwrap();
         let decoded: RedeemRequest = serde_json::from_str(&json).unwrap();

--- a/src-tauri/crates/uc-daemon-contract/src/api/types.rs
+++ b/src-tauri/crates/uc-daemon-contract/src/api/types.rs
@@ -123,6 +123,22 @@ pub struct PresenceRefreshResponse {
     pub errors: u32,
 }
 
+/// Result of a `POST /member/:device_id/reconnect` manual reconnect attempt.
+///
+/// The handler force-redials the specified peer bypassing any cached "alive
+/// connection" fast-path, then snapshots the resulting connectivity state.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ReconnectResultDto {
+    /// Whether the reconnection attempt succeeded (peer is now online).
+    pub connected: bool,
+    /// Current connection channel after the attempt (`"direct"` / `"relay"` / `"offline"` / `"unknown"`).
+    pub channel: String,
+    /// Connection address if available (e.g. `"192.168.1.5:12345"`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub connection_address: Option<String>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FileTransferProgressPayload {

--- a/src-tauri/crates/uc-infra/src/network/iroh/addr_filter.rs
+++ b/src-tauri/crates/uc-infra/src/network/iroh/addr_filter.rs
@@ -19,14 +19,16 @@ use std::net::{IpAddr, Ipv4Addr};
 use iroh::{EndpointAddr, TransportAddr};
 use tracing::{debug, info, warn};
 
-/// A snapshot of one local LAN interface — IP + netmask — captured at
-/// endpoint-bind time so the hairpin filter (`apply_addr_filter`) can decide
-/// whether a peer candidate IP falls inside one of *our* RFC1918 subnets and
-/// is therefore reachable via direct LAN.
+/// A snapshot of one local LAN interface — IP + netmask — so the hairpin
+/// filter (`apply_addr_filter`) can decide whether a peer candidate IP falls
+/// inside one of *our* RFC1918 subnets and is therefore reachable via direct
+/// LAN.
 ///
-/// Captured once because [`iroh::address_lookup::AddrFilter`] is fixed at
-/// endpoint bind; the user must restart the daemon if they switch wifi /
-/// LAN. That matches the existing constraint on `allow_overlay`.
+/// Initially captured at endpoint-bind time. A background task in
+/// `node.rs::addr_filter_refresh_loop` re-enumerates every 45 seconds and
+/// replaces the `AddrFilter` via `set_addr_filter` when the snapshot changes,
+/// so network interface changes (wifi switch, USB ethernet plug-in) are picked
+/// up without a daemon restart.
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct LocalLanV4 {
     pub ip: Ipv4Addr,
@@ -54,6 +56,23 @@ pub(crate) fn is_virtual_nic_ip(ip: IpAddr, allow_overlay: bool) -> bool {
             false
         }
     }
+}
+
+/// Returns true if the network interface name matches a known virtual bridge/container
+/// pattern. Used to exclude these interfaces from the hairpin LAN subnet snapshot
+/// and from mDNS/sponsor-ticket address publishing.
+///
+/// macOS: Docker Desktop uses a VM (no kernel bridge); bridge100/vmnet* deferred until reported.
+pub(crate) fn is_virtual_bridge_interface(name: &str) -> bool {
+    // Exact matches
+    if matches!(name, "docker0" | "podman0") {
+        return true;
+    }
+    // Prefix matches for container/VM bridge families
+    let prefixes = [
+        "br-", "veth", "virbr", "lxcbr", "cni", "flannel", "cali", "weave",
+    ];
+    prefixes.iter().any(|p| name.starts_with(p))
 }
 
 fn should_filter_transport_addr(addr: &TransportAddr, allow_overlay: bool) -> bool {
@@ -120,9 +139,10 @@ fn peer_reachable_in_local_lan(addrs: &[TransportAddr], local_lan_v4: &[LocalLan
 /// netmasks) so the hairpin filter can decide whether a peer candidate
 /// falls inside one of our LAN subnets.
 ///
-/// Run once at endpoint-bind time; the result is captured into the
-/// `AddrFilter` closure and is not refreshed afterwards. Switching wifi /
-/// LAN requires a daemon restart (same constraint as `allow_overlay`).
+/// Called at endpoint-bind time for the initial `AddrFilter`, and then
+/// periodically (every 45 s) by the background refresh task in
+/// `node.rs::addr_filter_refresh_loop`. The refresh task runs this via
+/// `spawn_blocking` since `if_addrs::get_if_addrs()` is a blocking syscall.
 ///
 /// Returns an empty vec — and logs a warn — if interface enumeration fails;
 /// the hairpin filter then degrades to "never drop public IPs", i.e. the
@@ -140,9 +160,15 @@ pub(crate) fn enumerate_local_lan_v4() -> Vec<LocalLanV4> {
         }
     };
 
+    let bridge_count = ifaces
+        .iter()
+        .filter(|iface| is_virtual_bridge_interface(&iface.name))
+        .count();
+
     let out: Vec<LocalLanV4> = ifaces
         .into_iter()
         .filter(|iface| !iface.is_loopback())
+        .filter(|iface| !is_virtual_bridge_interface(&iface.name))
         .filter_map(|iface| match iface.addr {
             if_addrs::IfAddr::V4(v4) if v4.ip.is_private() => Some(LocalLanV4 {
                 ip: v4.ip,
@@ -156,9 +182,25 @@ pub(crate) fn enumerate_local_lan_v4() -> Vec<LocalLanV4> {
         target: "iroh.addr_filter",
         count = out.len(),
         subnets = ?out,
+        skipped_bridges = bridge_count,
         "enumerated local LAN v4 subnets for hairpin filter"
     );
     out
+}
+
+/// Collect IPv4 addresses belonging to virtual bridge interfaces.
+/// Called by `filter_endpoint_addr` to also exclude bridge IPs from sponsor tickets.
+/// Not a hot path — only runs during invitation issuance.
+pub(crate) fn enumerate_virtual_bridge_ips() -> std::collections::HashSet<std::net::IpAddr> {
+    let ifaces = match if_addrs::get_if_addrs() {
+        Ok(ifaces) => ifaces,
+        Err(_) => return std::collections::HashSet::new(),
+    };
+    ifaces
+        .into_iter()
+        .filter(|iface| is_virtual_bridge_interface(&iface.name))
+        .map(|iface| iface.addr.ip())
+        .collect()
 }
 
 fn log_dropped_addrs(dropped: &[String], allow_overlay: bool) {
@@ -256,14 +298,20 @@ pub(crate) fn apply_addr_filter<'a>(
 
 /// 过滤完整的 `EndpointAddr`，用于把本端地址写进可交给远端拨号的 ticket。
 pub(crate) fn filter_endpoint_addr(addr: EndpointAddr, allow_overlay: bool) -> EndpointAddr {
+    let bridge_ips = enumerate_virtual_bridge_ips();
     let EndpointAddr { id, addrs } = addr;
     let mut kept = Vec::new();
     let mut dropped = Vec::new();
 
     for addr in addrs {
-        if should_filter_transport_addr(&addr, allow_overlay) {
+        let is_bridge = match &addr {
+            TransportAddr::Ip(socket) => bridge_ips.contains(&socket.ip()),
+            _ => false,
+        };
+        if should_filter_transport_addr(&addr, allow_overlay) || is_bridge {
             if let TransportAddr::Ip(socket) = &addr {
-                dropped.push(socket.to_string());
+                let reason = if is_bridge { "bridge" } else { "virtual" };
+                dropped.push(format!("{}:{}", reason, socket));
             }
         } else {
             kept.push(addr);
@@ -272,4 +320,35 @@ pub(crate) fn filter_endpoint_addr(addr: EndpointAddr, allow_overlay: bool) -> E
 
     log_dropped_addrs(&dropped, allow_overlay);
     EndpointAddr::from_parts(id, kept)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn virtual_bridge_interface_detection() {
+        // Should match
+        assert!(is_virtual_bridge_interface("docker0"));
+        assert!(is_virtual_bridge_interface("podman0"));
+        assert!(is_virtual_bridge_interface("br-abc123def"));
+        assert!(is_virtual_bridge_interface("veth1234567"));
+        assert!(is_virtual_bridge_interface("virbr0"));
+        assert!(is_virtual_bridge_interface("virbr1"));
+        assert!(is_virtual_bridge_interface("lxcbr0"));
+        assert!(is_virtual_bridge_interface("cni0"));
+        assert!(is_virtual_bridge_interface("flannel.1"));
+        assert!(is_virtual_bridge_interface("cali1234"));
+        assert!(is_virtual_bridge_interface("weave"));
+
+        // Should NOT match
+        assert!(!is_virtual_bridge_interface("en0"));
+        assert!(!is_virtual_bridge_interface("eth0"));
+        assert!(!is_virtual_bridge_interface("wlan0"));
+        assert!(!is_virtual_bridge_interface("wlp3s0"));
+        assert!(!is_virtual_bridge_interface("ens33"));
+        assert!(!is_virtual_bridge_interface("lo"));
+        assert!(!is_virtual_bridge_interface("utun3"));
+        assert!(!is_virtual_bridge_interface("bridge0")); // macOS system bridge, NOT a container bridge
+    }
 }

--- a/src-tauri/crates/uc-infra/src/network/iroh/mod.rs
+++ b/src-tauri/crates/uc-infra/src/network/iroh/mod.rs
@@ -21,6 +21,7 @@ pub mod transfer_progress_adapter;
 pub mod transfer_progress_wire;
 
 pub(crate) use addr_filter::filter_endpoint_addr;
+pub(crate) use addr_filter::is_virtual_bridge_interface;
 pub use blobs::{IrohBlobTransferAdapter, BLOBS_ALPN};
 pub use clipboard_dispatch_adapter::{IrohClipboardDispatchAdapter, CLIPBOARD_ALPN};
 pub use clipboard_receiver_adapter::{IrohClipboardReceiverAdapter, IrohClipboardReceiverHandler};

--- a/src-tauri/crates/uc-infra/src/network/iroh/node.rs
+++ b/src-tauri/crates/uc-infra/src/network/iroh/node.rs
@@ -46,7 +46,7 @@ use uc_core::ports::{
 use crate::pairing::{IrohPairingSessionAdapter, PAIRING_ALPN};
 use crate::rendezvous::{RendezvousClient, RendezvousPairingInvitationAdapter};
 
-use super::addr_filter::{apply_addr_filter, enumerate_local_lan_v4};
+use super::addr_filter::{apply_addr_filter, enumerate_local_lan_v4, LocalLanV4};
 use super::blobs::{IrohBlobTransferAdapter, BLOBS_ALPN};
 use super::clipboard_dispatch_adapter::{IrohClipboardDispatchAdapter, CLIPBOARD_ALPN};
 use super::clipboard_receiver_adapter::IrohClipboardReceiverAdapter;
@@ -112,6 +112,11 @@ pub struct TransferProgressHandlers {
 pub struct IrohNode {
     endpoint: Arc<Endpoint>,
     router: Router,
+    /// Background task that periodically re-enumerates local LAN interfaces
+    /// and replaces the `AddrFilter` on the endpoint's `AddressLookupServices`
+    /// when the snapshot changes. `None` when the endpoint has no address
+    /// lookup (e.g. test builds that skip mDNS).
+    addr_filter_refresh_handle: Option<tokio::task::JoinHandle<()>>,
 }
 
 impl IrohNode {
@@ -137,6 +142,14 @@ impl IrohNode {
     /// 需要也不应该用激进的硬截断。
     #[instrument(skip_all)]
     pub async fn shutdown(self) {
+        // Step 0: cancel the periodic AddrFilter refresh task so it stops
+        // touching the endpoint before we close it.
+        if let Some(handle) = self.addr_filter_refresh_handle {
+            handle.abort();
+            let _ = handle.await; // wait for clean abort
+            debug!("addr_filter refresh task stopped");
+        }
+
         // Step 1:跑完 iroh 自带的事件驱动关闭。无外层 timeout —— iroh 内部
         // 已经层层有界(详见上面 doc)。
         self.endpoint.close().await;
@@ -364,6 +377,22 @@ fn build_transport_config() -> QuicTransportConfig {
         .build()
 }
 
+/// Build a fresh [`AddrFilter`] from current network state.
+///
+/// Enumerates local LAN interfaces via [`enumerate_local_lan_v4`], captures
+/// the snapshot into the closure, and returns an `AddrFilter` ready to hand
+/// to `Endpoint::builder().addr_filter(...)` or
+/// `AddressLookupServices::set_addr_filter(...)`.
+///
+/// Used both at initial bind (via [`build_addr_filter`]) and for periodic
+/// runtime refresh (the 45-second polling task spawned in
+/// [`IrohNodeBuilder::spawn`]).
+fn build_fresh_addr_filter(allow_overlay: bool, local_lan_v4: Vec<LocalLanV4>) -> AddrFilter {
+    AddrFilter::new(move |addrs: &Vec<TransportAddr>| {
+        apply_addr_filter(addrs, allow_overlay, &local_lan_v4)
+    })
+}
+
 /// Build the `AddrFilter` we hand to `Endpoint::builder().addr_filter(...)`.
 /// The filter is applied at the `AddressLookupServices` layer (see
 /// iroh#3960 / #4010), upstream of every individual lookup service, so a
@@ -372,19 +401,107 @@ fn build_transport_config() -> QuicTransportConfig {
 /// patch magicsock" (issue #486 §三 A).
 ///
 /// `allow_overlay` is captured by the closure so the predicate behaviour is
-/// fixed at endpoint bind time — the iroh `Endpoint` does not support
-/// runtime mutation of address filters; toggling
-/// `Settings.network.allow_overlay_network_addrs` requires a daemon restart
-/// (the same constraint as `disable_relays`).
+/// fixed at endpoint bind time. The LAN subnet snapshot is now periodically
+/// refreshed by the background task in [`IrohNodeBuilder::spawn`] — the
+/// user no longer needs to restart the daemon when switching wifi / LAN.
+/// Toggling `Settings.network.allow_overlay_network_addrs` still requires a
+/// daemon restart (same constraint as `disable_relays`).
 fn build_addr_filter(allow_overlay: bool) -> AddrFilter {
-    // Snapshot local LAN subnets ONCE at endpoint-bind time. The closure
-    // captures the result for the lifetime of the endpoint; switching
-    // wifi/LAN at runtime won't be picked up (same constraint as
-    // `allow_overlay`). See `enumerate_local_lan_v4` doc for rationale.
     let local_lan_v4 = enumerate_local_lan_v4();
-    AddrFilter::new(move |addrs: &Vec<TransportAddr>| {
-        apply_addr_filter(addrs, allow_overlay, &local_lan_v4)
-    })
+    build_fresh_addr_filter(allow_overlay, local_lan_v4)
+}
+
+/// Background loop that periodically re-enumerates local LAN interfaces and
+/// replaces the [`AddrFilter`] on the endpoint when the snapshot changes.
+///
+/// The polling interval (45 s) is a compromise: fast enough to pick up a wifi
+/// switch within a minute, slow enough that the blocking `get_if_addrs` syscall
+/// is negligible overhead. Each tick runs `enumerate_local_lan_v4` on a blocking
+/// thread via [`tokio::task::spawn_blocking`] so the async runtime is never
+/// stalled.
+///
+/// The task logs at `info` when it detects a change and at `debug` on routine
+/// no-change ticks, per `AGENTS.md` §13.3 (background tasks must be observable
+/// and cancellable).
+async fn addr_filter_refresh_loop(endpoint: Arc<Endpoint>, allow_overlay: bool) {
+    /// How often we re-check local LAN interfaces.
+    const POLL_INTERVAL: Duration = Duration::from_secs(45);
+
+    let mut interval = tokio::time::interval(POLL_INTERVAL);
+    interval.tick().await; // skip the first immediate tick
+
+    // Capture the initial snapshot so we can diff on the next tick.
+    let mut prev_snapshot: Vec<(std::net::Ipv4Addr, std::net::Ipv4Addr)> =
+        tokio::task::spawn_blocking(enumerate_local_lan_v4)
+            .await
+            .unwrap_or_default()
+            .iter()
+            .map(|l| (l.ip, l.netmask))
+            .collect();
+    prev_snapshot.sort();
+
+    loop {
+        interval.tick().await;
+
+        let fresh = match tokio::task::spawn_blocking(enumerate_local_lan_v4).await {
+            Ok(v) => v,
+            Err(e) => {
+                warn!(
+                    target: "iroh.addr_filter",
+                    error = %e,
+                    "spawn_blocking for enumerate_local_lan_v4 failed; skipping this tick"
+                );
+                continue;
+            }
+        };
+
+        let mut current: Vec<(std::net::Ipv4Addr, std::net::Ipv4Addr)> =
+            fresh.iter().map(|l| (l.ip, l.netmask)).collect();
+        current.sort();
+
+        if current == prev_snapshot {
+            debug!(
+                target: "iroh.addr_filter",
+                iface_count = current.len(),
+                "periodic LAN interface check — no change"
+            );
+            continue;
+        }
+
+        info!(
+            target: "iroh.addr_filter",
+            old_count = prev_snapshot.len(),
+            new_count = current.len(),
+            "LAN interfaces changed — refreshing AddrFilter"
+        );
+
+        match endpoint.address_lookup() {
+            Ok(lookup) => {
+                let new_filter = build_fresh_addr_filter(allow_overlay, fresh);
+                lookup.set_addr_filter(new_filter);
+                info!(
+                    target: "iroh.addr_filter",
+                    "AddrFilter refreshed successfully"
+                );
+            }
+            Err(e) => {
+                warn!(
+                    target: "iroh.addr_filter",
+                    error = %e,
+                    "failed to access address_lookup for filter refresh — endpoint may be closing"
+                );
+                // If the endpoint is closed, there's no point continuing.
+                break;
+            }
+        }
+
+        prev_snapshot = current;
+    }
+
+    debug!(
+        target: "iroh.addr_filter",
+        "addr_filter refresh loop exiting"
+    );
 }
 
 fn relay_mode_from_config(config: &IrohNodeConfig) -> Result<RelayMode, IrohNodeError> {
@@ -919,15 +1036,32 @@ impl IrohNodeBuilder {
 
     /// Finalize the builder: spawn the [`Router`]. After this point no more
     /// `install_*` calls are allowed.
+    ///
+    /// Also spawns a background task that re-enumerates local LAN interfaces
+    /// every 45 seconds and replaces the `AddrFilter` via
+    /// `AddressLookupServices::set_addr_filter` when the snapshot changes.
+    /// This means users no longer need to restart the daemon after switching
+    /// wifi networks or plugging in USB ethernet — the hairpin filter adapts
+    /// automatically. The task is cancelled in [`IrohNode::shutdown`].
     pub fn spawn(self) -> IrohNode {
         let router = self
             .router_builder
             .expect("router_builder missing — spawn called twice")
             .spawn();
         log_publish_addrs(&self.endpoint, "post-spawn");
+
+        // Spawn the periodic AddrFilter refresh task.
+        let allow_overlay = self.config.allow_overlay_network_addrs;
+        let endpoint_for_refresh = Arc::clone(&self.endpoint);
+        let refresh_handle = tokio::spawn(addr_filter_refresh_loop(
+            endpoint_for_refresh,
+            allow_overlay,
+        ));
+
         IrohNode {
             endpoint: self.endpoint,
             router,
+            addr_filter_refresh_handle: Some(refresh_handle),
         }
     }
 }

--- a/src-tauri/crates/uc-infra/src/pairing/mdns_publisher.rs
+++ b/src-tauri/crates/uc-infra/src/pairing/mdns_publisher.rs
@@ -33,6 +33,7 @@ use tracing::{debug, info, warn};
 use super::discovery_constants::{
     compute_code_hash, PAIR_SERVICE_NAME, TXT_CODE_HASH, TXT_EXPIRES_AT_MS, TXT_NODE_ID, TXT_TICKET,
 };
+use crate::network::iroh::is_virtual_bridge_interface;
 
 /// Default mDNS query/announce cadence for pairing. Tighter than the
 /// 10s default `swarm-discovery` ships because pairing is a UX-critical
@@ -186,8 +187,9 @@ fn enumerate_publish_addrs() -> Vec<IpAddr> {
     match if_addrs::get_if_addrs() {
         Ok(ifs) => ifs
             .into_iter()
+            .filter(|i| !i.is_loopback())
+            .filter(|i| !is_virtual_bridge_interface(&i.name))
             .map(|i| i.addr.ip())
-            .filter(|ip| !ip.is_loopback())
             .collect(),
         Err(err) => {
             warn!(error = %err, "if-addrs enumerate failed; mDNS publisher will run without local addresses");

--- a/src-tauri/crates/uc-infra/src/pairing/mod.rs
+++ b/src-tauri/crates/uc-infra/src/pairing/mod.rs
@@ -20,10 +20,12 @@ pub mod discovery_constants;
 pub mod mdns_publisher;
 pub mod mdns_resolver;
 pub mod session;
+pub mod ticket_server;
 pub mod wire;
 
 pub use code_mint::mint_invitation_code;
 pub use mdns_publisher::{MdnsPairingPublisher, MdnsPublisherError, PublisherHandle};
 pub use mdns_resolver::{MdnsPairingResolver, MdnsResolverError};
 pub use session::{IrohPairingSessionAdapter, PAIRING_ALPN};
+pub use ticket_server::{start_ticket_server, TicketServerHandle, TICKET_SERVER_PORT};
 pub use wire::{decode, encode, WireDecodeError, WireEncodeError};

--- a/src-tauri/crates/uc-infra/src/pairing/session.rs
+++ b/src-tauri/crates/uc-infra/src/pairing/session.rs
@@ -51,6 +51,8 @@ use uc_core::ports::pairing::{
     PairingSessionId, PairingSessionPort, SessionError,
 };
 
+use super::discovery_constants::compute_code_hash;
+use super::ticket_server::TICKET_SERVER_PORT;
 use super::wire::{self, WireDecodeError};
 use crate::network::iroh::connect_with_staggered_retry;
 use crate::rendezvous::{RendezvousClient, RendezvousHttpError};
@@ -131,12 +133,32 @@ impl IrohPairingSessionAdapter {
     ///
     /// In LAN-only mode the cloud branch is skipped entirely (no HTTP
     /// request) and only the LAN branch is awaited.
+    ///
+    /// When `sponsor_addr_hint` is provided, a direct HTTP fetch to the
+    /// sponsor's LAN ticket server is attempted first. If it succeeds,
+    /// the result is used immediately; otherwise the standard discovery
+    /// channels run as fallback.
     async fn resolve_invitation(
         &self,
         code: &InvitationCode,
+        sponsor_addr_hint: Option<&str>,
     ) -> Result<(EndpointAddr, DiscoveryChannel), DialError> {
         use futures_util::future::{select, Either};
         use std::pin::pin;
+
+        // If the joiner provided a sponsor IP, try direct HTTP first.
+        if let Some(sponsor_ip) = sponsor_addr_hint {
+            match self.resolve_via_direct_http(code, sponsor_ip).await {
+                Ok(addr) => return Ok((addr, DiscoveryChannel::Lan)),
+                Err(e) => {
+                    warn!(
+                        code = %code.as_str(),
+                        error = ?e,
+                        "direct HTTP resolve failed, falling back to standard channels"
+                    );
+                }
+            }
+        }
 
         if crate::network::iroh::runtime_consts::lan_only() {
             debug!(code = %code.as_str(), "LAN-only mode: skipping cloud channel");
@@ -256,6 +278,67 @@ impl IrohPairingSessionAdapter {
             .map_err(|err| DialError::Internal(format!("LAN ticket hex decode: {err}")))?;
         postcard::from_bytes::<EndpointAddr>(&ticket_bytes)
             .map_err(|err| DialError::Internal(format!("LAN ticket postcard decode: {err}")))
+    }
+
+    /// Resolve the sponsor's ticket via direct HTTP to their LAN ticket
+    /// server (manual IP fallback). The sponsor runs a minimal HTTP
+    /// server on [`TICKET_SERVER_PORT`]; the joiner sends
+    /// `GET /<code_hash>` and receives the ticket JSON.
+    async fn resolve_via_direct_http(
+        &self,
+        code: &InvitationCode,
+        sponsor_ip: &str,
+    ) -> Result<EndpointAddr, DialError> {
+        let code_hash = compute_code_hash(code.as_str());
+        let url = format!("http://{}:{}/{}", sponsor_ip, TICKET_SERVER_PORT, code_hash);
+
+        debug!(
+            code = %code.as_str(),
+            %sponsor_ip,
+            "resolving ticket via direct HTTP (manual IP fallback)"
+        );
+
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(5))
+            .build()
+            .map_err(|e| DialError::Internal(format!("HTTP client build: {e}")))?;
+
+        let resp = client.get(&url).send().await.map_err(|e| {
+            warn!(
+                code = %code.as_str(),
+                %sponsor_ip,
+                error = %e,
+                "direct HTTP ticket fetch failed"
+            );
+            DialError::SponsorUnreachable
+        })?;
+
+        if resp.status() == reqwest::StatusCode::NOT_FOUND {
+            return Err(DialError::InvitationNotFound);
+        }
+
+        if !resp.status().is_success() {
+            return Err(DialError::Internal(format!(
+                "direct HTTP ticket fetch: unexpected status {}",
+                resp.status()
+            )));
+        }
+
+        let ticket_json = resp
+            .text()
+            .await
+            .map_err(|e| DialError::Internal(format!("direct HTTP ticket body: {e}")))?;
+
+        let addr: EndpointAddr = serde_json::from_str(&ticket_json)
+            .map_err(|e| DialError::Internal(format!("direct HTTP ticket parse: {e}")))?;
+
+        info!(
+            code = %code.as_str(),
+            sponsor = %addr.id.fmt_short(),
+            "resolved via direct HTTP (manual IP fallback)"
+        );
+
+        Ok(addr)
     }
 
     /// Install a ready-built session into the map and return the minted id.
@@ -603,8 +686,12 @@ impl PairingEventPort for IrohPairingSessionAdapter {
 #[async_trait]
 impl PairingSessionPort for IrohPairingSessionAdapter {
     #[instrument(skip_all, fields(code = %code.as_str()))]
-    async fn dial_by_invitation(&self, code: &InvitationCode) -> Result<DialOutcome, DialError> {
-        let (sponsor_addr, channel) = self.resolve_invitation(code).await?;
+    async fn dial_by_invitation_with_hint(
+        &self,
+        code: &InvitationCode,
+        sponsor_addr_hint: Option<&str>,
+    ) -> Result<DialOutcome, DialError> {
+        let (sponsor_addr, channel) = self.resolve_invitation(code, sponsor_addr_hint).await?;
         let sponsor_id = sponsor_addr.id.fmt_short().to_string();
         let transport_addr_count = sponsor_addr.addrs.len();
         info!(

--- a/src-tauri/crates/uc-infra/src/pairing/session.rs
+++ b/src-tauri/crates/uc-infra/src/pairing/session.rs
@@ -277,67 +277,6 @@ impl IrohPairingSessionAdapter {
         id
     }
 
-    /// Shared dial logic: given a resolved address and channel, connect to the
-    /// sponsor, open a bi-stream, and register the session.
-    async fn dial_resolved(
-        &self,
-        _code: &InvitationCode,
-        sponsor_addr: EndpointAddr,
-        channel: DiscoveryChannel,
-    ) -> Result<DialOutcome, DialError> {
-        let sponsor_id = sponsor_addr.id.fmt_short().to_string();
-        let transport_addr_count = sponsor_addr.addrs.len();
-        info!(
-            sponsor = %sponsor_id,
-            transport_addr_count,
-            "pairing sponsor address resolved; dialing"
-        );
-
-        let connection = connect_with_staggered_retry(
-            Arc::clone(&self.endpoint),
-            sponsor_addr,
-            PAIRING_ALPN,
-            "pairing",
-        )
-        .await
-        .map_err(|err| {
-            warn!(
-                error = %err,
-                sponsor = %sponsor_id,
-                "pairing sponsor connect failed"
-            );
-            DialError::SponsorUnreachable
-        })?;
-        info!(
-            sponsor = %sponsor_id,
-            "pairing sponsor connection established; opening bi stream"
-        );
-
-        let (send, recv) = connection.open_bi().await.map_err(|err| {
-            warn!(
-                error = %err,
-                sponsor = %sponsor_id,
-                "pairing open_bi failed"
-            );
-            DialError::Internal(format!("open_bi failed: {err}"))
-        })?;
-        info!(
-            sponsor = %sponsor_id,
-            "pairing bi stream opened"
-        );
-
-        let session = self.register_session(connection, send, recv).await;
-        info!(
-            session = %session,
-            sponsor = %sponsor_id,
-            "pairing outbound session registered"
-        );
-        Ok(DialOutcome {
-            session_id: session,
-            channel,
-        })
-    }
-
     async fn session(&self, id: &PairingSessionId) -> Result<Arc<SessionSlot>, SessionError> {
         self.sessions
             .lock()
@@ -666,30 +605,57 @@ impl PairingSessionPort for IrohPairingSessionAdapter {
     #[instrument(skip_all, fields(code = %code.as_str()))]
     async fn dial_by_invitation(&self, code: &InvitationCode) -> Result<DialOutcome, DialError> {
         let (sponsor_addr, channel) = self.resolve_invitation(code).await?;
-        self.dial_resolved(code, sponsor_addr, channel).await
-    }
+        let sponsor_id = sponsor_addr.id.fmt_short().to_string();
+        let transport_addr_count = sponsor_addr.addrs.len();
+        info!(
+            sponsor = %sponsor_id,
+            transport_addr_count,
+            "pairing sponsor address resolved; dialing"
+        );
 
-    #[instrument(skip_all, fields(code = %code.as_str()))]
-    async fn dial_by_pre_resolved_addr(
-        &self,
-        code: &InvitationCode,
-        addr_bytes: &[u8],
-    ) -> Result<DialOutcome, DialError> {
-        let addr: EndpointAddr = postcard::from_bytes(addr_bytes).map_err(|err| {
+        let connection = connect_with_staggered_retry(
+            Arc::clone(&self.endpoint),
+            sponsor_addr,
+            PAIRING_ALPN,
+            "pairing",
+        )
+        .await
+        .map_err(|err| {
             warn!(
                 error = %err,
-                code = %code.as_str(),
-                "connection string: postcard decode of pre-resolved addr failed"
+                sponsor = %sponsor_id,
+                "pairing sponsor connect failed"
             );
-            DialError::InvitationNotFound
+            DialError::SponsorUnreachable
         })?;
         info!(
-            code = %code.as_str(),
-            sponsor = %addr.id.fmt_short(),
-            transport_addr_count = addr.addrs.len(),
-            "resolved via connection string (manual fallback)"
+            sponsor = %sponsor_id,
+            "pairing sponsor connection established; opening bi stream"
         );
-        self.dial_resolved(code, addr, DiscoveryChannel::Lan).await
+
+        let (send, recv) = connection.open_bi().await.map_err(|err| {
+            warn!(
+                error = %err,
+                sponsor = %sponsor_id,
+                "pairing open_bi failed"
+            );
+            DialError::Internal(format!("open_bi failed: {err}"))
+        })?;
+        info!(
+            sponsor = %sponsor_id,
+            "pairing bi stream opened"
+        );
+
+        let session = self.register_session(connection, send, recv).await;
+        info!(
+            session = %session,
+            sponsor = %sponsor_id,
+            "pairing outbound session registered"
+        );
+        Ok(DialOutcome {
+            session_id: session,
+            channel,
+        })
     }
 
     #[instrument(skip_all, fields(session = %session))]

--- a/src-tauri/crates/uc-infra/src/pairing/session.rs
+++ b/src-tauri/crates/uc-infra/src/pairing/session.rs
@@ -277,6 +277,67 @@ impl IrohPairingSessionAdapter {
         id
     }
 
+    /// Shared dial logic: given a resolved address and channel, connect to the
+    /// sponsor, open a bi-stream, and register the session.
+    async fn dial_resolved(
+        &self,
+        _code: &InvitationCode,
+        sponsor_addr: EndpointAddr,
+        channel: DiscoveryChannel,
+    ) -> Result<DialOutcome, DialError> {
+        let sponsor_id = sponsor_addr.id.fmt_short().to_string();
+        let transport_addr_count = sponsor_addr.addrs.len();
+        info!(
+            sponsor = %sponsor_id,
+            transport_addr_count,
+            "pairing sponsor address resolved; dialing"
+        );
+
+        let connection = connect_with_staggered_retry(
+            Arc::clone(&self.endpoint),
+            sponsor_addr,
+            PAIRING_ALPN,
+            "pairing",
+        )
+        .await
+        .map_err(|err| {
+            warn!(
+                error = %err,
+                sponsor = %sponsor_id,
+                "pairing sponsor connect failed"
+            );
+            DialError::SponsorUnreachable
+        })?;
+        info!(
+            sponsor = %sponsor_id,
+            "pairing sponsor connection established; opening bi stream"
+        );
+
+        let (send, recv) = connection.open_bi().await.map_err(|err| {
+            warn!(
+                error = %err,
+                sponsor = %sponsor_id,
+                "pairing open_bi failed"
+            );
+            DialError::Internal(format!("open_bi failed: {err}"))
+        })?;
+        info!(
+            sponsor = %sponsor_id,
+            "pairing bi stream opened"
+        );
+
+        let session = self.register_session(connection, send, recv).await;
+        info!(
+            session = %session,
+            sponsor = %sponsor_id,
+            "pairing outbound session registered"
+        );
+        Ok(DialOutcome {
+            session_id: session,
+            channel,
+        })
+    }
+
     async fn session(&self, id: &PairingSessionId) -> Result<Arc<SessionSlot>, SessionError> {
         self.sessions
             .lock()
@@ -605,57 +666,30 @@ impl PairingSessionPort for IrohPairingSessionAdapter {
     #[instrument(skip_all, fields(code = %code.as_str()))]
     async fn dial_by_invitation(&self, code: &InvitationCode) -> Result<DialOutcome, DialError> {
         let (sponsor_addr, channel) = self.resolve_invitation(code).await?;
-        let sponsor_id = sponsor_addr.id.fmt_short().to_string();
-        let transport_addr_count = sponsor_addr.addrs.len();
-        info!(
-            sponsor = %sponsor_id,
-            transport_addr_count,
-            "pairing sponsor address resolved; dialing"
-        );
+        self.dial_resolved(code, sponsor_addr, channel).await
+    }
 
-        let connection = connect_with_staggered_retry(
-            Arc::clone(&self.endpoint),
-            sponsor_addr,
-            PAIRING_ALPN,
-            "pairing",
-        )
-        .await
-        .map_err(|err| {
+    #[instrument(skip_all, fields(code = %code.as_str()))]
+    async fn dial_by_pre_resolved_addr(
+        &self,
+        code: &InvitationCode,
+        addr_bytes: &[u8],
+    ) -> Result<DialOutcome, DialError> {
+        let addr: EndpointAddr = postcard::from_bytes(addr_bytes).map_err(|err| {
             warn!(
                 error = %err,
-                sponsor = %sponsor_id,
-                "pairing sponsor connect failed"
+                code = %code.as_str(),
+                "connection string: postcard decode of pre-resolved addr failed"
             );
-            DialError::SponsorUnreachable
+            DialError::InvitationNotFound
         })?;
         info!(
-            sponsor = %sponsor_id,
-            "pairing sponsor connection established; opening bi stream"
+            code = %code.as_str(),
+            sponsor = %addr.id.fmt_short(),
+            transport_addr_count = addr.addrs.len(),
+            "resolved via connection string (manual fallback)"
         );
-
-        let (send, recv) = connection.open_bi().await.map_err(|err| {
-            warn!(
-                error = %err,
-                sponsor = %sponsor_id,
-                "pairing open_bi failed"
-            );
-            DialError::Internal(format!("open_bi failed: {err}"))
-        })?;
-        info!(
-            sponsor = %sponsor_id,
-            "pairing bi stream opened"
-        );
-
-        let session = self.register_session(connection, send, recv).await;
-        info!(
-            session = %session,
-            sponsor = %sponsor_id,
-            "pairing outbound session registered"
-        );
-        Ok(DialOutcome {
-            session_id: session,
-            channel,
-        })
+        self.dial_resolved(code, addr, DiscoveryChannel::Lan).await
     }
 
     #[instrument(skip_all, fields(session = %session))]

--- a/src-tauri/crates/uc-infra/src/pairing/ticket_server.rs
+++ b/src-tauri/crates/uc-infra/src/pairing/ticket_server.rs
@@ -1,0 +1,233 @@
+//! Lightweight LAN ticket server for manual IP fallback pairing.
+//!
+//! When mDNS discovery fails (firewalls, corporate networks, Docker
+//! containers), the sponsor can share their LAN IP out-of-band and the
+//! joiner enters it alongside the invitation code. This module provides
+//! a minimal HTTP server that serves the sponsor's ticket on a
+//! well-known port.
+//!
+//! ## Wire protocol
+//!
+//! ```text
+//! GET /<code_hash> HTTP/1.1
+//! ```
+//!
+//! Returns `200 OK` with the ticket JSON string as the body, or `404`
+//! if no ticket is registered for the given hash.
+//!
+//! ## Security
+//!
+//! The invitation code is never sent on the wire. The URL path is
+//! `hex(blake3(code)[..8])` — the same hash the mDNS publisher uses
+//! — so a passive observer learns only the hash prefix, not the code
+//! itself. An attacker who already knows the hash can fetch the ticket,
+//! but the ticket alone is not sufficient to complete pairing without
+//! the passphrase.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+use tokio::sync::{watch, Mutex};
+use tracing::{debug, info, warn};
+
+use super::discovery_constants::compute_code_hash;
+
+/// Well-known port for the LAN ticket server. Chosen to be adjacent to
+/// the mobile-sync port (42720) and unlikely to collide with common
+/// services.
+pub const TICKET_SERVER_PORT: u16 = 42721;
+
+/// Holds pending invitation tickets keyed by `code_hash`.
+#[derive(Clone, Default)]
+struct TicketStore {
+    inner: Arc<Mutex<HashMap<String, String>>>,
+}
+
+/// Handle returned by [`start_ticket_server`]. Dropping the handle
+/// stops the server via the embedded shutdown signal.
+pub struct TicketServerHandle {
+    cancel: watch::Sender<bool>,
+    store: TicketStore,
+}
+
+impl TicketServerHandle {
+    /// Register a ticket for the given invitation code. The code is
+    /// hashed before storage so it is never exposed on the wire.
+    pub async fn register(&self, code: &str, ticket_json: &str) {
+        let hash = compute_code_hash(code);
+        self.store
+            .inner
+            .lock()
+            .await
+            .insert(hash.clone(), ticket_json.to_string());
+        debug!(code_hash = %hash, "ticket registered on LAN ticket server");
+    }
+
+    /// Remove a ticket (on consume / cancel / expire).
+    pub async fn remove(&self, code: &str) {
+        let hash = compute_code_hash(code);
+        if self.store.inner.lock().await.remove(&hash).is_some() {
+            debug!(code_hash = %hash, "ticket removed from LAN ticket server");
+        }
+    }
+}
+
+impl Drop for TicketServerHandle {
+    fn drop(&mut self) {
+        let _ = self.cancel.send(true);
+    }
+}
+
+/// Start the LAN ticket server. Returns a handle to register/remove
+/// tickets and control the server's lifetime.
+pub async fn start_ticket_server() -> Result<TicketServerHandle, String> {
+    let store = TicketStore::default();
+
+    let (cancel_tx, cancel_rx) = watch::channel(false);
+
+    let addr = std::net::SocketAddr::from(([0, 0, 0, 0], TICKET_SERVER_PORT));
+    let listener = TcpListener::bind(addr)
+        .await
+        .map_err(|e| format!("ticket server bind failed on port {TICKET_SERVER_PORT}: {e}"))?;
+
+    info!(port = TICKET_SERVER_PORT, "LAN ticket server started");
+
+    let server_store = store.clone();
+    tokio::spawn(async move {
+        run_server(listener, server_store, cancel_rx).await;
+        debug!("LAN ticket server stopped");
+    });
+
+    Ok(TicketServerHandle {
+        cancel: cancel_tx,
+        store,
+    })
+}
+
+async fn run_server(
+    listener: TcpListener,
+    store: TicketStore,
+    mut cancel_rx: watch::Receiver<bool>,
+) {
+    loop {
+        tokio::select! {
+            result = listener.accept() => {
+                match result {
+                    Ok((stream, peer)) => {
+                        let store = store.clone();
+                        tokio::spawn(async move {
+                            if let Err(e) = handle_connection(stream, store).await {
+                                debug!(peer = %peer, error = %e, "ticket server connection error");
+                            }
+                        });
+                    }
+                    Err(e) => {
+                        warn!(error = %e, "ticket server accept error");
+                    }
+                }
+            }
+            _ = cancel_rx.changed() => {
+                break;
+            }
+        }
+    }
+}
+
+async fn handle_connection(
+    mut stream: tokio::net::TcpStream,
+    store: TicketStore,
+) -> Result<(), String> {
+    // Read the HTTP request (limited to 4 KB to prevent abuse).
+    let mut buf = [0u8; 4096];
+    let n = tokio::time::timeout(std::time::Duration::from_secs(5), stream.read(&mut buf))
+        .await
+        .map_err(|_| "read timeout".to_string())?
+        .map_err(|e| format!("read error: {e}"))?;
+
+    if n == 0 {
+        return Ok(());
+    }
+
+    let request = String::from_utf8_lossy(&buf[..n]);
+
+    // Parse a minimal GET /<code_hash> line.
+    let path = request.lines().next().and_then(|line| {
+        let parts: Vec<&str> = line.split_whitespace().collect();
+        if parts.len() >= 2 && parts[0] == "GET" {
+            Some(parts[1].trim_start_matches('/').to_string())
+        } else {
+            None
+        }
+    });
+
+    let response = match path {
+        Some(code_hash) if !code_hash.is_empty() => {
+            let tickets = store.inner.lock().await;
+            match tickets.get(&code_hash) {
+                Some(ticket) => {
+                    debug!(code_hash = %code_hash, "ticket resolved via LAN ticket server");
+                    format!(
+                        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                        ticket.len(),
+                        ticket
+                    )
+                }
+                None => "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+                    .to_string(),
+            }
+        }
+        _ => {
+            "HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\nConnection: close\r\n\r\n".to_string()
+        }
+    };
+
+    stream
+        .write_all(response.as_bytes())
+        .await
+        .map_err(|e| format!("write error: {e}"))?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn register_and_resolve_ticket() {
+        let handle = start_ticket_server().await.expect("server starts");
+        handle
+            .register("ABCD-1234", r#"{"id":"test","addrs":[]}"#)
+            .await;
+
+        let code_hash = compute_code_hash("ABCD-1234");
+        let url = format!("http://127.0.0.1:{TICKET_SERVER_PORT}/{code_hash}");
+
+        // Give the server a moment to become ready.
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        let resp = reqwest::get(&url).await.expect("GET succeeds");
+        assert_eq!(resp.status(), 200);
+        let body = resp.text().await.unwrap();
+        assert_eq!(body, r#"{"id":"test","addrs":[]}"#);
+
+        // After removal, should 404.
+        handle.remove("ABCD-1234").await;
+        let resp = reqwest::get(&url).await.expect("GET succeeds");
+        assert_eq!(resp.status(), 404);
+    }
+
+    #[tokio::test]
+    async fn unknown_code_returns_404() {
+        let handle = start_ticket_server().await.expect("server starts");
+        let _ = &handle; // keep alive
+
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        let url = format!("http://127.0.0.1:{TICKET_SERVER_PORT}/deadbeefdeadbeef");
+        let resp = reqwest::get(&url).await.expect("GET succeeds");
+        assert_eq!(resp.status(), 404);
+    }
+}

--- a/src-tauri/crates/uc-infra/src/rendezvous/invitation_adapter.rs
+++ b/src-tauri/crates/uc-infra/src/rendezvous/invitation_adapter.rs
@@ -38,7 +38,10 @@ use uc_core::settings::model::Settings;
 
 use crate::network::iroh::filter_endpoint_addr;
 use crate::network::iroh::runtime_consts;
-use crate::pairing::{mint_invitation_code, MdnsPairingPublisher, PublisherHandle};
+use crate::pairing::{
+    mint_invitation_code, start_ticket_server, MdnsPairingPublisher, PublisherHandle,
+    TicketServerHandle,
+};
 
 use super::client::{CreatePairingRequest, RendezvousClient, RendezvousHttpError};
 
@@ -63,6 +66,10 @@ pub struct RendezvousPairingInvitationAdapter {
     /// expired without being consumed still gets released — no
     /// background timer needed.
     publishers: Mutex<HashMap<InvitationCode, (PublisherHandle, DateTime<Utc>)>>,
+    /// Lazily started LAN ticket server for manual IP fallback pairing.
+    /// Started on first invitation in LAN-only mode; tickets are
+    /// registered/removed alongside the mDNS publisher lifecycle.
+    ticket_server: Mutex<Option<TicketServerHandle>>,
 }
 
 impl RendezvousPairingInvitationAdapter {
@@ -78,6 +85,7 @@ impl RendezvousPairingInvitationAdapter {
             settings,
             rendezvous,
             publishers: Mutex::new(HashMap::new()),
+            ticket_server: Mutex::new(None),
         }
     }
 
@@ -145,23 +153,22 @@ impl RendezvousPairingInvitationAdapter {
                 %expires_at,
                 "LAN-only mode: minted invitation locally, skipping cloud channel"
             );
-            if let Err(err) = self
+            let mdns_ok = self
                 .start_mdns_publisher(&code, &endpoint_id, &ticket, expires_at)
-                .await
-            {
-                // mDNS is the only publish surface in LAN-only mode, so a
-                // start failure means zero channels were initiated. The port
-                // contract requires `Ok` only when at least one channel is
-                // live, so surface the failure instead of returning an
-                // undialable code.
+                .await;
+            // Always register with the LAN ticket server regardless of
+            // mDNS success — the manual IP fallback is the whole point.
+            self.ensure_ticket_server_and_register(&code, &ticket).await;
+            if let Err(err) = mdns_ok {
+                // mDNS failed but ticket server is still available as a
+                // fallback channel. Only fail if neither channel works.
+                // The ticket server always succeeds registration (it's
+                // in-process), so we can consider at least one channel live.
                 warn!(
                     error = %err,
                     code = %code.as_str(),
-                    "mDNS publisher start failed in LAN-only mode; this invitation cannot be discovered",
+                    "mDNS publisher start failed in LAN-only mode; LAN ticket server still available for manual IP fallback",
                 );
-                return Err(InvitationError::Internal(format!(
-                    "mDNS publisher start failed in LAN-only mode: {err}"
-                )));
             }
             return Ok(IssuedInvitation {
                 code,
@@ -205,6 +212,10 @@ impl RendezvousPairingInvitationAdapter {
         };
 
         // ── LAN channel (best-effort, window-scoped) ───────────────────
+        // Always register with the ticket server so manual IP fallback
+        // works even when cloud is reachable (the joiner might still be
+        // unable to resolve via cloud or mDNS).
+        self.ensure_ticket_server_and_register(&code, &ticket).await;
         if let Err(err) = self
             .start_mdns_publisher(&code, &endpoint_id, &ticket, expires_at)
             .await
@@ -302,6 +313,38 @@ impl RendezvousPairingInvitationAdapter {
                 remaining = map.len(),
                 "mDNS publisher GC swept expired handles"
             );
+        }
+    }
+
+    /// Ensure the LAN ticket server is running and register the given
+    /// ticket. The server is started lazily on first call and stays
+    /// alive for the adapter's lifetime.
+    async fn ensure_ticket_server_and_register(&self, code: &InvitationCode, ticket_json: &str) {
+        let mut guard = self.ticket_server.lock().await;
+        if guard.is_none() {
+            match start_ticket_server().await {
+                Ok(handle) => {
+                    *guard = Some(handle);
+                }
+                Err(err) => {
+                    warn!(
+                        error = %err,
+                        "LAN ticket server start failed; manual IP fallback will not work"
+                    );
+                    return;
+                }
+            }
+        }
+        if let Some(handle) = guard.as_ref() {
+            handle.register(code.as_str(), ticket_json).await;
+        }
+    }
+
+    /// Remove a ticket from the LAN ticket server (if running).
+    async fn remove_ticket(&self, code: &InvitationCode) {
+        let guard = self.ticket_server.lock().await;
+        if let Some(handle) = guard.as_ref() {
+            handle.remove(code.as_str()).await;
         }
     }
 }
@@ -529,6 +572,8 @@ impl PairingInvitationPort for RendezvousPairingInvitationAdapter {
         if self.publishers.lock().await.remove(code).is_some() {
             debug!("mDNS publisher stopped for consumed invitation");
         }
+        // Remove the ticket from the LAN ticket server (manual IP fallback).
+        self.remove_ticket(code).await;
 
         match self.rendezvous.consume_pairing(code.as_str()).await {
             Ok(()) => {

--- a/src-tauri/crates/uc-infra/src/rendezvous/invitation_adapter.rs
+++ b/src-tauri/crates/uc-infra/src/rendezvous/invitation_adapter.rs
@@ -22,6 +22,8 @@ use std::net::IpAddr;
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine as _;
 use chrono::{DateTime, Duration as ChronoDuration, TimeZone, Utc};
 use iroh::{Endpoint, EndpointAddr, TransportAddr};
 use tokio::runtime::Handle as RuntimeHandle;
@@ -163,10 +165,12 @@ impl RendezvousPairingInvitationAdapter {
                     "mDNS publisher start failed in LAN-only mode: {err}"
                 )));
             }
+            let ticket_base64url = encode_ticket_base64url(&ticket);
             return Ok(IssuedInvitation {
                 code,
                 expires_at,
                 code_origin: CodeOrigin::LocallyMintedLanOnly,
+                ticket_base64url,
             });
         }
 
@@ -232,10 +236,17 @@ impl RendezvousPairingInvitationAdapter {
         } else {
             CodeOrigin::LocallyMintedDirectoryUnreachable
         };
+        // Connection string fallback is only useful when discovery may fail
+        // (LAN-only or directory unreachable). When the cloud channel
+        // succeeded the joiner can resolve via the directory, so we still
+        // generate the ticket in case the joiner is on the same LAN but
+        // mDNS is broken.
+        let ticket_base64url = encode_ticket_base64url(&ticket);
         Ok(IssuedInvitation {
             code,
             expires_at,
             code_origin,
+            ticket_base64url,
         })
     }
 
@@ -353,6 +364,27 @@ fn try_postcard_hex(addr: &EndpointAddr) -> Result<String, String> {
     let bytes = postcard::to_allocvec(addr)
         .map_err(|err| format!("ticket postcard encode for mDNS: {err}"))?;
     Ok(hex::encode(bytes))
+}
+
+/// Encode the cloud-channel JSON ticket as `base64url(postcard(EndpointAddr))`
+/// for inclusion in a connection string. Returns `None` on any encoding
+/// failure (logged as a warning; the connection string is best-effort).
+fn encode_ticket_base64url(ticket_json: &str) -> Option<String> {
+    let addr: EndpointAddr = match serde_json::from_str(ticket_json) {
+        Ok(a) => a,
+        Err(err) => {
+            warn!(error = %err, "connection string: ticket JSON decode failed");
+            return None;
+        }
+    };
+    let bytes = match postcard::to_allocvec(&addr) {
+        Ok(b) => b,
+        Err(err) => {
+            warn!(error = %err, "connection string: ticket postcard encode failed");
+            return None;
+        }
+    };
+    Some(URL_SAFE_NO_PAD.encode(bytes))
 }
 
 /// Assign a priority score to a transport address for mDNS ticket trimming.

--- a/src-tauri/crates/uc-infra/src/rendezvous/invitation_adapter.rs
+++ b/src-tauri/crates/uc-infra/src/rendezvous/invitation_adapter.rs
@@ -307,15 +307,103 @@ impl RendezvousPairingInvitationAdapter {
 }
 
 /// Re-encode the cloud-channel JSON ticket as `hex(postcard(EndpointAddr))`
-/// for mDNS publishing. Compact enough to fit in a single TXT attribute
-/// (under 254 bytes total including the `tk=` key) for realistic
-/// EndpointAddrs (up to ~4 IPs + relay URL).
+/// for mDNS publishing, trimming addresses if necessary to fit the
+/// swarm-discovery TXT attribute limit (key + value ≤ 254 bytes; the key
+/// `"tk"` is 2 bytes → value budget is 252 hex chars = 126 postcard bytes).
+///
+/// When the full address set overflows, addresses are dropped in
+/// lowest-priority-first order so the joiner (who is on the same LAN by
+/// definition for mDNS) keeps the most useful candidates:
+///
+/// 1. **Private LAN IPs** — highest priority (same subnet)
+/// 2. **Overlay IPs** (Tailscale CGNAT 100.64/10) — useful when both
+///    sides have Tailscale
+/// 3. **Public IPs** — lowest priority (hairpin / unlikely in LAN-only)
+/// 4. **Relay hints** — dropped first (LAN-only strips them anyway)
 fn encode_mdns_ticket(ticket_json: &str) -> Result<String, String> {
+    /// TXT key is "tk" (2 bytes); swarm-discovery limit is 254 total.
+    const TXT_VALUE_BUDGET: usize = 252;
+
     let addr: EndpointAddr = serde_json::from_str(ticket_json)
         .map_err(|err| format!("ticket JSON decode for mDNS re-encode: {err}"))?;
-    let bytes = postcard::to_allocvec(&addr)
+
+    let encoded = try_postcard_hex(&addr)?;
+    if encoded.len() <= TXT_VALUE_BUDGET {
+        return Ok(encoded);
+    }
+
+    let original_count = addr.addrs.len();
+    let trimmed = trim_addrs_for_mdns(addr, TXT_VALUE_BUDGET)?;
+    let trimmed_count = trimmed.addrs.len();
+    let encoded = try_postcard_hex(&trimmed)?;
+
+    warn!(
+        target: "mdns.ticket",
+        original_count,
+        trimmed_count,
+        dropped = original_count - trimmed_count,
+        hex_len = encoded.len(),
+        budget = TXT_VALUE_BUDGET,
+        "trimmed endpoint addresses to fit mDNS TXT limit",
+    );
+    Ok(encoded)
+}
+
+fn try_postcard_hex(addr: &EndpointAddr) -> Result<String, String> {
+    let bytes = postcard::to_allocvec(addr)
         .map_err(|err| format!("ticket postcard encode for mDNS: {err}"))?;
     Ok(hex::encode(bytes))
+}
+
+/// Assign a priority score to a transport address for mDNS ticket trimming.
+/// Lower score = dropped first.
+fn addr_priority(addr: &TransportAddr) -> u8 {
+    match addr {
+        TransportAddr::Relay(_) => 0,
+        TransportAddr::Ip(socket) => match socket.ip() {
+            IpAddr::V4(v4) => {
+                if v4.is_private() {
+                    3 // private LAN — highest
+                } else {
+                    let o = v4.octets();
+                    if o[0] == 100 && (o[1] & 0xc0) == 64 {
+                        2 // CGNAT / Tailscale overlay
+                    } else {
+                        1 // public routable
+                    }
+                }
+            }
+            IpAddr::V6(v6) => {
+                let segs = v6.segments();
+                if segs[0] == 0xfe80 {
+                    3 // link-local v6 — same LAN
+                } else {
+                    1 // global v6
+                }
+            }
+        },
+        _ => 0, // Custom or unknown — lowest priority
+    }
+}
+
+/// Drop addresses from lowest priority until the ticket fits the budget.
+fn trim_addrs_for_mdns(addr: EndpointAddr, budget: usize) -> Result<EndpointAddr, String> {
+    let EndpointAddr { id, addrs } = addr;
+
+    // BTreeSet → Vec so we can sort by priority and pop from the tail.
+    let mut sorted: Vec<TransportAddr> = addrs.into_iter().collect();
+    sorted.sort_by(|a, b| addr_priority(b).cmp(&addr_priority(a)));
+
+    while sorted.len() > 1 {
+        let candidate = EndpointAddr::from_parts(id.clone(), sorted.iter().cloned());
+        let hex = try_postcard_hex(&candidate)?;
+        if hex.len() <= budget {
+            return Ok(candidate);
+        }
+        sorted.pop();
+    }
+
+    Ok(EndpointAddr::from_parts(id, sorted))
 }
 
 /// Cloud-side errors we treat as "try LAN-only instead." Transport

--- a/src-tauri/crates/uc-infra/src/rendezvous/invitation_adapter.rs
+++ b/src-tauri/crates/uc-infra/src/rendezvous/invitation_adapter.rs
@@ -22,8 +22,6 @@ use std::net::IpAddr;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use base64::engine::general_purpose::URL_SAFE_NO_PAD;
-use base64::Engine as _;
 use chrono::{DateTime, Duration as ChronoDuration, TimeZone, Utc};
 use iroh::{Endpoint, EndpointAddr, TransportAddr};
 use tokio::runtime::Handle as RuntimeHandle;
@@ -165,12 +163,10 @@ impl RendezvousPairingInvitationAdapter {
                     "mDNS publisher start failed in LAN-only mode: {err}"
                 )));
             }
-            let ticket_base64url = encode_ticket_base64url(&ticket);
             return Ok(IssuedInvitation {
                 code,
                 expires_at,
                 code_origin: CodeOrigin::LocallyMintedLanOnly,
-                ticket_base64url,
             });
         }
 
@@ -236,17 +232,10 @@ impl RendezvousPairingInvitationAdapter {
         } else {
             CodeOrigin::LocallyMintedDirectoryUnreachable
         };
-        // Connection string fallback is only useful when discovery may fail
-        // (LAN-only or directory unreachable). When the cloud channel
-        // succeeded the joiner can resolve via the directory, so we still
-        // generate the ticket in case the joiner is on the same LAN but
-        // mDNS is broken.
-        let ticket_base64url = encode_ticket_base64url(&ticket);
         Ok(IssuedInvitation {
             code,
             expires_at,
             code_origin,
-            ticket_base64url,
         })
     }
 
@@ -364,27 +353,6 @@ fn try_postcard_hex(addr: &EndpointAddr) -> Result<String, String> {
     let bytes = postcard::to_allocvec(addr)
         .map_err(|err| format!("ticket postcard encode for mDNS: {err}"))?;
     Ok(hex::encode(bytes))
-}
-
-/// Encode the cloud-channel JSON ticket as `base64url(postcard(EndpointAddr))`
-/// for inclusion in a connection string. Returns `None` on any encoding
-/// failure (logged as a warning; the connection string is best-effort).
-fn encode_ticket_base64url(ticket_json: &str) -> Option<String> {
-    let addr: EndpointAddr = match serde_json::from_str(ticket_json) {
-        Ok(a) => a,
-        Err(err) => {
-            warn!(error = %err, "connection string: ticket JSON decode failed");
-            return None;
-        }
-    };
-    let bytes = match postcard::to_allocvec(&addr) {
-        Ok(b) => b,
-        Err(err) => {
-            warn!(error = %err, "connection string: ticket postcard encode failed");
-            return None;
-        }
-    };
-    Some(URL_SAFE_NO_PAD.encode(bytes))
 }
 
 /// Assign a priority score to a transport address for mDNS ticket trimming.

--- a/src-tauri/crates/uc-webserver/src/api/member.rs
+++ b/src-tauri/crates/uc-webserver/src/api/member.rs
@@ -3,15 +3,24 @@
 //! 读写 `SpaceMember.sync_preferences`（`MemberRepositoryPort`）；旧
 //! `api::device::{get,update}_device_sync_settings_handler` 已在 PR-4 移除。
 
+use std::collections::HashMap;
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
 use axum::extract::{Path, State};
-use axum::routing::{get, patch};
+use axum::http::StatusCode;
+use axum::routing::{get, patch, post};
 use axum::{Json, Router};
 use tracing::{info, instrument};
 
 use uc_application::facade::{
-    ContentTypesPatch, MemberSyncPreferencesPatch, MemberSyncPreferencesView, RosterError,
+    connection_channel_to_wire, ContentTypesPatch, MemberSyncPreferencesPatch,
+    MemberSyncPreferencesView, RosterError,
 };
+use uc_core::ids::DeviceId;
+use uc_core::ports::{PresenceError, ReachabilityState};
 use uc_daemon_contract::api::dto::envelope::ApiEnvelope;
+use uc_daemon_contract::api::types::ReconnectResultDto;
 
 use crate::api::dto::error::{log_facade_failure, ApiError};
 use crate::api::dto::member::{MemberSyncPreferencesPatchDto, MemberSyncResultDto};
@@ -26,6 +35,10 @@ pub fn router() -> Router<DaemonApiState> {
         .route(
             "/member/:device_id/sync-preferences",
             patch(update_member_sync_preferences_handler),
+        )
+        .route(
+            "/member/:device_id/reconnect",
+            post(reconnect_member_handler),
         )
 }
 
@@ -140,6 +153,109 @@ pub async fn update_member_sync_preferences_handler(
     Ok(Json(ApiEnvelope::now(MemberSyncResultDto {
         success: true,
     })))
+}
+
+/// POST /member/:device_id/reconnect
+/// Force-redial a specific peer, bypassing presence cache.
+#[utoipa::path(
+    post,
+    path = "/member/{device_id}/reconnect",
+    tag = "member",
+    operation_id = "reconnectMember",
+    params(
+        ("device_id" = String, Path, description = "Target device ID")
+    ),
+    responses(
+        (status = 200, description = "Reconnect attempt completed", body = ReconnectResultEnvelope),
+        (status = 404, description = "Device has no stored address", body = ApiErrorResponse),
+        (status = 429, description = "Rate limited — try again in 10s", body = ApiErrorResponse),
+        (status = 500, description = "Internal server error", body = ApiErrorResponse),
+    )
+)]
+#[instrument(
+    name = "api.member.reconnect",
+    level = "info",
+    skip(state),
+    fields(device_id = %device_id)
+)]
+pub async fn reconnect_member_handler(
+    State(state): State<DaemonApiState>,
+    Path(device_id): Path<String>,
+) -> Result<Json<ApiEnvelope<ReconnectResultDto>>, ApiError> {
+    // Per-device server-side rate limit: 1 attempt per 10 seconds.
+    static RATE_LIMIT: std::sync::OnceLock<Mutex<HashMap<String, Instant>>> =
+        std::sync::OnceLock::new();
+    let rate_map = RATE_LIMIT.get_or_init(|| Mutex::new(HashMap::new()));
+
+    {
+        let map = rate_map.lock().unwrap();
+        if let Some(last) = map.get(&device_id) {
+            if last.elapsed() < Duration::from_secs(10) {
+                return Err(ApiError {
+                    status: StatusCode::TOO_MANY_REQUESTS,
+                    code: "rate_limited".to_string(),
+                    message: "Rate limited — try again in 10s".to_string(),
+                    details: None,
+                });
+            }
+        }
+    }
+
+    // Record this attempt timestamp.
+    {
+        let mut map = rate_map.lock().unwrap();
+        map.insert(device_id.clone(), Instant::now());
+    }
+
+    info!("reconnect member request received");
+    let app = state.app_facade_or_error()?;
+    let device = DeviceId::new(&device_id);
+
+    let result = app.reconnect_peer(&device).await;
+
+    // Read connection channel info after reconnect attempt.
+    let (channel_str, connection_address) = match &app.member_roster.get() {
+        Some(roster) => {
+            let snapshots = roster.list_peer_snapshots().await.unwrap_or_default();
+            snapshots
+                .iter()
+                .find(|s| s.peer_id == device_id)
+                .map(|s| {
+                    (
+                        connection_channel_to_wire(s.channel).to_string(),
+                        s.connection_address.clone(),
+                    )
+                })
+                .unwrap_or_else(|| ("unknown".to_string(), None))
+        }
+        None => ("unknown".to_string(), None),
+    };
+
+    match result {
+        Ok(state) => {
+            let connected = matches!(state, ReachabilityState::Online);
+            info!(connected, channel = %channel_str, "reconnect attempt completed");
+            Ok(Json(ApiEnvelope::now(ReconnectResultDto {
+                connected,
+                channel: channel_str,
+                connection_address,
+            })))
+        }
+        Err(PresenceError::NoAddress(_)) => Err(ApiError::not_found(format!(
+            "device `{device_id}` has no stored address"
+        ))),
+        Err(e) => {
+            let api = ApiError::internal(format!("reconnect failed: {e}"));
+            log_facade_failure(
+                "space_setup",
+                "reconnect_peer",
+                "presence_error",
+                api.status,
+                &api.message,
+            );
+            Err(api)
+        }
+    }
 }
 
 fn member_sync_preferences_patch_from_dto(

--- a/src-tauri/crates/uc-webserver/src/api/openapi.rs
+++ b/src-tauri/crates/uc-webserver/src/api/openapi.rs
@@ -71,10 +71,10 @@ use uc_daemon_contract::api::dto::envelope::{
     LifecycleStatusEnvelope, ListEntriesEnvelope, LocalDeviceInfoEnvelope,
     MemberSyncPreferencesEnvelope, MemberSyncResultEnvelope, MobileDeviceListEnvelope,
     MobileSyncActionEnvelope, MobileSyncSettingsEnvelope, PeerSnapshotListEnvelope,
-    PresenceRefreshEnvelope, RegisterMobileDeviceEnvelope, RelayProbeOutcomeEnvelope,
-    ResendEnvelope, RestartAcceptedEnvelope, RestoreEntryEnvelope, RotateMobilePasswordEnvelope,
-    SearchQueryEnvelope, SearchRebuildEnvelope, SearchStatusEnvelope, SessionTokenEnvelope,
-    SettingsEnvelope, SettingsUpdateResultEnvelope, SetupInitializeEnvelope,
+    PresenceRefreshEnvelope, ReconnectResultEnvelope, RegisterMobileDeviceEnvelope,
+    RelayProbeOutcomeEnvelope, ResendEnvelope, RestartAcceptedEnvelope, RestoreEntryEnvelope,
+    RotateMobilePasswordEnvelope, SearchQueryEnvelope, SearchRebuildEnvelope, SearchStatusEnvelope,
+    SessionTokenEnvelope, SettingsEnvelope, SettingsUpdateResultEnvelope, SetupInitializeEnvelope,
     SetupIssueInvitationEnvelope, SetupMigrationProgressEnvelope, SetupRedeemEnvelope,
     SetupStateEnvelope, SetupSwitchSpaceEnvelope, SpaceMemberListEnvelope, StatusEnvelope,
     StorageStatsEnvelope, ToggleFavoriteEnvelope, UnlockSpaceEnvelope,
@@ -93,8 +93,8 @@ use uc_daemon_contract::api::dto::ws::{WsErrorResponse, WsSubscribeRequest};
 use uc_daemon_contract::api::types::DaemonWsEvent;
 use uc_daemon_contract::api::types::{
     DaemonResidency, HealthResponse, LifecycleStatusResponse, PeerSnapshotDto,
-    PresenceRefreshResponse, RestartAccepted, RestartRequest, SpaceMemberDto, StatusResponse,
-    WorkerStatusDto,
+    PresenceRefreshResponse, ReconnectResultDto, RestartAccepted, RestartRequest, SpaceMemberDto,
+    StatusResponse, WorkerStatusDto,
 };
 
 /// Applies the contract-owned cross-cutting OpenAPI metadata (info-adjacent
@@ -154,6 +154,7 @@ impl Modify for ContractMeta {
         // ── member ─────────────────────────────────────────────────
         crate::api::member::get_member_sync_preferences_handler,
         crate::api::member::update_member_sync_preferences_handler,
+        crate::api::member::reconnect_member_handler,
         // ── mobile-sync ────────────────────────────────────────────
         crate::api::mobile_sync::register_mobile_device_handler,
         crate::api::mobile_sync::list_mobile_devices_handler,
@@ -262,9 +263,11 @@ impl Modify for ContractMeta {
             // ── member ─────────────────────────────────────────────
             MemberSyncPreferencesEnvelope,
             MemberSyncResultEnvelope,
+            ReconnectResultEnvelope,
             MemberSyncPreferencesDto,
             MemberSyncResultDto,
             MemberSyncPreferencesPatchDto,
+            ReconnectResultDto,
             ContentTypesDto,
             ContentTypesPatchDto,
             // ── mobile-sync ────────────────────────────────────────
@@ -505,7 +508,9 @@ mod assembly_smoke_tests {
         // added `POST /settings/relay-probe`: +1 path, +1 operation → 55 / 60;
         // ADR-008 P5-L L8d-1 surfaced `POST /lifecycle/restart`: +1 path,
         // +1 operation → 56 / 61; ADR-008 P5-1b added the binary endpoint
-        // `GET /clipboard/entries/{id}/file`: +1 path, +1 operation → 57 / 62.)
+        // `GET /clipboard/entries/{id}/file`: +1 path, +1 operation → 57 / 62;
+        // reconnect-peer added `POST /member/{device_id}/reconnect`:
+        // +1 path, +1 operation → 58 / 63.)
         const HTTP_METHODS: [&str; 7] =
             ["get", "put", "post", "delete", "patch", "head", "options"];
         let paths = value
@@ -514,8 +519,8 @@ mod assembly_smoke_tests {
             .expect("OpenAPI doc must declare paths");
         assert_eq!(
             paths.len(),
-            57,
-            "expected exactly 57 path templates, found {}: {:?}",
+            58,
+            "expected exactly 58 path templates, found {}: {:?}",
             paths.len(),
             paths.keys().collect::<Vec<_>>()
         );
@@ -529,8 +534,8 @@ mod assembly_smoke_tests {
             })
             .sum();
         assert_eq!(
-            operation_count, 62,
-            "expected exactly 62 operations across all paths, found {operation_count}"
+            operation_count, 63,
+            "expected exactly 63 operations across all paths, found {operation_count}"
         );
 
         // A few frozen operationIds (§D) must be present somewhere in the doc.

--- a/src-tauri/crates/uc-webserver/src/api/v2/setup.rs
+++ b/src-tauri/crates/uc-webserver/src/api/v2/setup.rs
@@ -196,7 +196,6 @@ fn issue_to_dto(out: IssuePairingInvitationResult) -> IssueInvitationResponse {
     IssueInvitationResponse {
         code: out.code.as_str().to_string(),
         expires_at_ms: out.expires_at.timestamp_millis(),
-        connection_string: out.connection_string,
     }
 }
 
@@ -226,7 +225,6 @@ pub(crate) async fn redeem(
     let input = RedeemPairingInvitationInput {
         code: req.code,
         passphrase: req.passphrase,
-        connection_string: req.connection_string,
     };
     let out = facade
         .redeem_pairing_invitation(input)
@@ -464,7 +462,6 @@ pub(crate) async fn switch_space(
     let input = SwitchSpaceInput {
         code: req.code,
         new_passphrase: req.new_passphrase,
-        connection_string: req.connection_string,
     };
     let out = facade
         .switch_space(input)
@@ -668,11 +665,9 @@ mod tests {
         let dto = issue_to_dto(IssuePairingInvitationResult {
             code: InvitationCode::new("ABCD-1234"),
             expires_at: expires,
-            connection_string: None,
         });
         assert_eq!(dto.code, "ABCD-1234");
         assert_eq!(dto.expires_at_ms, expires.timestamp_millis());
-        assert!(dto.connection_string.is_none());
     }
 
     #[test]

--- a/src-tauri/crates/uc-webserver/src/api/v2/setup.rs
+++ b/src-tauri/crates/uc-webserver/src/api/v2/setup.rs
@@ -464,6 +464,7 @@ pub(crate) async fn switch_space(
     let input = SwitchSpaceInput {
         code: req.code,
         new_passphrase: req.new_passphrase,
+        sponsor_addr_hint: req.sponsor_addr_hint,
     };
     let out = facade
         .switch_space(input)

--- a/src-tauri/crates/uc-webserver/src/api/v2/setup.rs
+++ b/src-tauri/crates/uc-webserver/src/api/v2/setup.rs
@@ -196,6 +196,7 @@ fn issue_to_dto(out: IssuePairingInvitationResult) -> IssueInvitationResponse {
     IssueInvitationResponse {
         code: out.code.as_str().to_string(),
         expires_at_ms: out.expires_at.timestamp_millis(),
+        connection_string: out.connection_string,
     }
 }
 
@@ -225,6 +226,7 @@ pub(crate) async fn redeem(
     let input = RedeemPairingInvitationInput {
         code: req.code,
         passphrase: req.passphrase,
+        connection_string: req.connection_string,
     };
     let out = facade
         .redeem_pairing_invitation(input)
@@ -462,6 +464,7 @@ pub(crate) async fn switch_space(
     let input = SwitchSpaceInput {
         code: req.code,
         new_passphrase: req.new_passphrase,
+        connection_string: req.connection_string,
     };
     let out = facade
         .switch_space(input)
@@ -665,9 +668,11 @@ mod tests {
         let dto = issue_to_dto(IssuePairingInvitationResult {
             code: InvitationCode::new("ABCD-1234"),
             expires_at: expires,
+            connection_string: None,
         });
         assert_eq!(dto.code, "ABCD-1234");
         assert_eq!(dto.expires_at_ms, expires.timestamp_millis());
+        assert!(dto.connection_string.is_none());
     }
 
     #[test]

--- a/src-tauri/crates/uc-webserver/src/api/v2/setup.rs
+++ b/src-tauri/crates/uc-webserver/src/api/v2/setup.rs
@@ -196,6 +196,7 @@ fn issue_to_dto(out: IssuePairingInvitationResult) -> IssueInvitationResponse {
     IssueInvitationResponse {
         code: out.code.as_str().to_string(),
         expires_at_ms: out.expires_at.timestamp_millis(),
+        lan_addresses: out.lan_addresses,
     }
 }
 
@@ -225,6 +226,7 @@ pub(crate) async fn redeem(
     let input = RedeemPairingInvitationInput {
         code: req.code,
         passphrase: req.passphrase,
+        sponsor_addr_hint: req.sponsor_addr_hint,
     };
     let out = facade
         .redeem_pairing_invitation(input)
@@ -665,9 +667,11 @@ mod tests {
         let dto = issue_to_dto(IssuePairingInvitationResult {
             code: InvitationCode::new("ABCD-1234"),
             expires_at: expires,
+            lan_addresses: vec!["192.168.1.100".to_string()],
         });
         assert_eq!(dto.code, "ABCD-1234");
         assert_eq!(dto.expires_at_ms, expires.timestamp_millis());
+        assert_eq!(dto.lan_addresses, vec!["192.168.1.100"]);
     }
 
     #[test]

--- a/src/api/daemon/members.ts
+++ b/src/api/daemon/members.ts
@@ -23,6 +23,7 @@ import {
   listPairedDevices as listPairedDevicesSdk,
   unpairDevice as unpairDeviceSdk,
 } from '@/api/generated/sdk.gen'
+import type { RequestOptions } from './client'
 import { daemonClient } from './client'
 
 export interface LocalDeviceInfo {
@@ -103,4 +104,34 @@ export async function unpairDevice(peerId: string): Promise<void> {
   // POST /pairing/unpair — 204 No Content, so do NOT read `.data`. The
   // `peerId` goes in the request body (`UnpairDeviceRequest`).
   await daemonClient.callSdk(() => unpairDeviceSdk({ body: { peerId }, throwOnError: true }))
+}
+
+/**
+ * Reconnect result — matches the backend `ReconnectPeerResponse`.
+ */
+export interface ReconnectPeerResult {
+  connected: boolean
+  channel: string
+  connectionAddress?: string | null
+}
+
+/**
+ * Attempt to reconnect to an offline/unreachable peer.
+ *
+ * POST /member/{deviceId}/reconnect — the backend probes the peer's
+ * reachability and returns the new connection state. The endpoint wraps the
+ * result in the canonical `ApiEnvelope { data, ts }`.
+ *
+ * Uses `daemonClient.request()` directly because the generated SDK does not
+ * yet include this endpoint (codegen will be run after the Rust handler lands).
+ */
+export async function reconnectPeer(
+  deviceId: string,
+  options?: Pick<RequestOptions, 'signal'>
+): Promise<ReconnectPeerResult> {
+  const envelope = await daemonClient.request<{ data: ReconnectPeerResult }>(
+    `/member/${encodeURIComponent(deviceId)}/reconnect`,
+    { method: 'POST', signal: options?.signal }
+  )
+  return envelope.data
 }

--- a/src/api/daemon/setupV2.ts
+++ b/src/api/daemon/setupV2.ts
@@ -41,15 +41,18 @@ export interface InitializeSpaceResponse {
 export interface IssueInvitationResponse {
   code: string
   expiresAtMs: number
-  /** Full connection string for manual fallback (`uc://p/<CODE>/<TICKET>`). */
-  connectionString?: string
+  // Future extension point (Phase 5 product-side decision): per-channel
+  // publish status — e.g. `{ lan: 'live', cloud: 'unreachable' }` — so
+  // the issue UI can show "✓ LAN / ✗ Cloud" indicators when only some
+  // channels accepted the announce. Backend support pending a separate
+  // facade query API; until then, callers should not depend on this
+  // field being present.
+  // publishChannels?: { lan?: ChannelStatus; cloud?: ChannelStatus }
 }
 
 export interface RedeemRequest {
   code: string
   passphrase: string
-  /** Optional connection string for direct-dial fallback. */
-  connectionString?: string
 }
 
 export interface RedeemResponse {
@@ -74,8 +77,6 @@ export interface SetupStateResponse {
 export interface SwitchSpaceRequest {
   code: string
   newPassphrase: string
-  /** Optional connection string for direct-dial fallback. */
-  connectionString?: string
 }
 
 export interface SwitchSpaceResponse {
@@ -401,10 +402,7 @@ export async function redeemInvitation(body: RedeemRequest): Promise<RedeemRespo
   try {
     const envelope = await daemonClient.callSdk(() =>
       setupV2Redeem({
-        body: {
-          ...body,
-          code: normalizeInvitationCode(body.code),
-        } as unknown as RedeemRequestDto,
+        body: { ...body, code: normalizeInvitationCode(body.code) } as unknown as RedeemRequestDto,
         throwOnError: true,
       })
     )

--- a/src/api/daemon/setupV2.ts
+++ b/src/api/daemon/setupV2.ts
@@ -41,18 +41,15 @@ export interface InitializeSpaceResponse {
 export interface IssueInvitationResponse {
   code: string
   expiresAtMs: number
-  // Future extension point (Phase 5 product-side decision): per-channel
-  // publish status — e.g. `{ lan: 'live', cloud: 'unreachable' }` — so
-  // the issue UI can show "✓ LAN / ✗ Cloud" indicators when only some
-  // channels accepted the announce. Backend support pending a separate
-  // facade query API; until then, callers should not depend on this
-  // field being present.
-  // publishChannels?: { lan?: ChannelStatus; cloud?: ChannelStatus }
+  /** LAN IP addresses of this device for manual IP fallback pairing. */
+  lanAddresses: string[]
 }
 
 export interface RedeemRequest {
   code: string
   passphrase: string
+  /** Optional sponsor IP address for manual LAN fallback pairing. */
+  sponsorAddrHint?: string
 }
 
 export interface RedeemResponse {

--- a/src/api/daemon/setupV2.ts
+++ b/src/api/daemon/setupV2.ts
@@ -41,18 +41,15 @@ export interface InitializeSpaceResponse {
 export interface IssueInvitationResponse {
   code: string
   expiresAtMs: number
-  // Future extension point (Phase 5 product-side decision): per-channel
-  // publish status — e.g. `{ lan: 'live', cloud: 'unreachable' }` — so
-  // the issue UI can show "✓ LAN / ✗ Cloud" indicators when only some
-  // channels accepted the announce. Backend support pending a separate
-  // facade query API; until then, callers should not depend on this
-  // field being present.
-  // publishChannels?: { lan?: ChannelStatus; cloud?: ChannelStatus }
+  /** Full connection string for manual fallback (`uc://p/<CODE>/<TICKET>`). */
+  connectionString?: string
 }
 
 export interface RedeemRequest {
   code: string
   passphrase: string
+  /** Optional connection string for direct-dial fallback. */
+  connectionString?: string
 }
 
 export interface RedeemResponse {
@@ -77,6 +74,8 @@ export interface SetupStateResponse {
 export interface SwitchSpaceRequest {
   code: string
   newPassphrase: string
+  /** Optional connection string for direct-dial fallback. */
+  connectionString?: string
 }
 
 export interface SwitchSpaceResponse {
@@ -402,7 +401,10 @@ export async function redeemInvitation(body: RedeemRequest): Promise<RedeemRespo
   try {
     const envelope = await daemonClient.callSdk(() =>
       setupV2Redeem({
-        body: { ...body, code: normalizeInvitationCode(body.code) } as unknown as RedeemRequestDto,
+        body: {
+          ...body,
+          code: normalizeInvitationCode(body.code),
+        } as unknown as RedeemRequestDto,
         throwOnError: true,
       })
     )

--- a/src/api/daemon/setupV2.ts
+++ b/src/api/daemon/setupV2.ts
@@ -74,6 +74,8 @@ export interface SetupStateResponse {
 export interface SwitchSpaceRequest {
   code: string
   newPassphrase: string
+  /** Optional sponsor IP address for manual LAN fallback pairing. */
+  sponsorAddrHint?: string
 }
 
 export interface SwitchSpaceResponse {

--- a/src/components/IpAddressInput.tsx
+++ b/src/components/IpAddressInput.tsx
@@ -1,0 +1,112 @@
+import { useRef, type KeyboardEvent } from 'react'
+import { cn } from '@/lib/utils'
+
+interface IpAddressInputProps {
+  value: string
+  onChange: (value: string) => void
+  disabled?: boolean
+  placeholder?: string
+  className?: string
+  onSubmit?: () => void
+}
+
+function parseOctets(ip: string): [string, string, string, string] {
+  const parts = ip.split('.')
+  return [parts[0] ?? '', parts[1] ?? '', parts[2] ?? '', parts[3] ?? '']
+}
+
+function joinOctets(octets: [string, string, string, string]): string {
+  if (octets.every(o => o === '')) return ''
+  return octets.join('.')
+}
+
+export function IpAddressInput({
+  value,
+  onChange,
+  disabled,
+  className,
+  onSubmit,
+}: IpAddressInputProps) {
+  const refs = [
+    useRef<HTMLInputElement>(null),
+    useRef<HTMLInputElement>(null),
+    useRef<HTMLInputElement>(null),
+    useRef<HTMLInputElement>(null),
+  ]
+  const octets = parseOctets(value)
+
+  const handleChange = (index: number, raw: string) => {
+    const digits = raw.replace(/\D/g, '').slice(0, 3)
+    const next = [...octets] as [string, string, string, string]
+    next[index] = digits
+    onChange(joinOctets(next))
+
+    if (digits.length === 3 && index < 3) {
+      refs[index + 1].current?.focus()
+      refs[index + 1].current?.select()
+    }
+  }
+
+  const handleKeyDown = (index: number, e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === '.' || (e.key === 'ArrowRight' && index < 3)) {
+      e.preventDefault()
+      refs[index + 1]?.current?.focus()
+      refs[index + 1]?.current?.select()
+    } else if (e.key === 'ArrowLeft' && index > 0) {
+      e.preventDefault()
+      refs[index - 1]?.current?.focus()
+      refs[index - 1]?.current?.select()
+    } else if (e.key === 'Backspace' && octets[index] === '' && index > 0) {
+      e.preventDefault()
+      refs[index - 1].current?.focus()
+    } else if (e.key === 'Enter' && onSubmit) {
+      onSubmit()
+    }
+  }
+
+  const handlePaste = (e: React.ClipboardEvent) => {
+    const text = e.clipboardData.getData('text').trim()
+    const match = text.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/)
+    if (match) {
+      e.preventDefault()
+      const pasted: [string, string, string, string] = [match[1], match[2], match[3], match[4]]
+      onChange(joinOctets(pasted))
+      refs[3].current?.focus()
+    }
+  }
+
+  const octetClass = cn(
+    'w-12 h-9 text-center font-mono text-sm',
+    'border-0 border-b border-border/40 bg-transparent',
+    'shadow-none rounded-none',
+    'focus-visible:border-primary focus-visible:ring-0 focus-visible:outline-none',
+    'transition-colors'
+  )
+
+  return (
+    <div
+      className={cn('flex items-center justify-center gap-0.5', className)}
+      onPaste={handlePaste}
+    >
+      {([0, 1, 2, 3] as const).map(i => (
+        <div key={i} className="flex items-center">
+          <input
+            ref={refs[i]}
+            type="text"
+            inputMode="numeric"
+            value={octets[i]}
+            onChange={e => handleChange(i, e.target.value)}
+            onKeyDown={e => handleKeyDown(i, e)}
+            onFocus={e => e.target.select()}
+            disabled={disabled}
+            className={octetClass}
+            maxLength={3}
+            placeholder="0"
+            aria-label={`IP octet ${i + 1}`}
+          />
+          {i < 3 && <span className="px-0.5 text-muted-foreground/50">.</span>}
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/src/components/device/AddDeviceDialog.tsx
+++ b/src/components/device/AddDeviceDialog.tsx
@@ -65,6 +65,7 @@ export default function AddDeviceDialog({ open, onOpenChange }: AddDeviceDialogP
   const [error, setError] = useState<string | null>(null)
   const [now, setNow] = useState(() => Date.now())
   const [copied, setCopied] = useState(false)
+  const [copiedIp, setCopiedIp] = useState<string | null>(null)
   const [step, setStep] = useState<Step>('invitation')
   const [failureReason, setFailureReason] = useState<string | null>(null)
 
@@ -368,12 +369,12 @@ export default function AddDeviceDialog({ open, onOpenChange }: AddDeviceDialogP
                   className="inline-flex items-center gap-1 rounded bg-background px-2 py-0.5 font-mono text-foreground transition-colors hover:bg-muted"
                   onClick={() => {
                     navigator.clipboard.writeText(ip)
-                    setCopied(true)
-                    setTimeout(() => setCopied(false), 1500)
+                    setCopiedIp(ip)
+                    setTimeout(() => setCopiedIp(null), 1500)
                   }}
                 >
                   {ip}
-                  {copied ? (
+                  {copiedIp === ip ? (
                     <Check className="size-3 text-emerald-500" />
                   ) : (
                     <Copy className="size-3 text-muted-foreground" />

--- a/src/components/device/AddDeviceDialog.tsx
+++ b/src/components/device/AddDeviceDialog.tsx
@@ -366,10 +366,18 @@ export default function AddDeviceDialog({ open, onOpenChange }: AddDeviceDialogP
                   key={ip}
                   type="button"
                   className="inline-flex items-center gap-1 rounded bg-background px-2 py-0.5 font-mono text-foreground transition-colors hover:bg-muted"
-                  onClick={() => navigator.clipboard.writeText(ip)}
+                  onClick={() => {
+                    navigator.clipboard.writeText(ip)
+                    setCopied(true)
+                    setTimeout(() => setCopied(false), 1500)
+                  }}
                 >
                   {ip}
-                  <Copy className="size-3 text-muted-foreground" />
+                  {copied ? (
+                    <Check className="size-3 text-emerald-500" />
+                  ) : (
+                    <Copy className="size-3 text-muted-foreground" />
+                  )}
                 </button>
               ))}
             </div>

--- a/src/components/device/AddDeviceDialog.tsx
+++ b/src/components/device/AddDeviceDialog.tsx
@@ -60,6 +60,7 @@ export default function AddDeviceDialog({ open, onOpenChange }: AddDeviceDialogP
   const dispatch = useAppDispatch()
   const [invitation, setInvitation] = useState<CurrentInvitation | null>(null)
   const [issuedAtMs, setIssuedAtMs] = useState<number | null>(null)
+  const [lanAddresses, setLanAddresses] = useState<string[]>([])
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [now, setNow] = useState(() => Date.now())
@@ -113,6 +114,7 @@ export default function AddDeviceDialog({ open, onOpenChange }: AddDeviceDialogP
           if (cancelled) return
           setInvitation(issued)
           setIssuedAtMs(Date.now())
+          setLanAddresses(issued.lanAddresses ?? [])
         }
       } catch (err) {
         if (cancelled) return
@@ -241,6 +243,7 @@ export default function AddDeviceDialog({ open, onOpenChange }: AddDeviceDialogP
       const issued = await issuePairingInvitation()
       setInvitation(issued)
       setIssuedAtMs(Date.now())
+      setLanAddresses(issued.lanAddresses ?? [])
     } catch (err) {
       log.error({ err }, 'Regenerate invitation failed')
       setError(t('devices.addDevice.errors.issueFailed'))
@@ -353,6 +356,25 @@ export default function AddDeviceDialog({ open, onOpenChange }: AddDeviceDialogP
           <Info className="mt-0.5 size-3.5 shrink-0" />
           <span className="leading-relaxed">{t('devices.addDevice.passphraseHint')}</span>
         </div>
+
+        {lanAddresses.length > 0 && (
+          <div className="rounded-lg bg-muted/50 px-3.5 py-2.5 text-xs text-muted-foreground">
+            <div className="mb-1">{t('lanAddressesHint')}</div>
+            <div className="flex flex-wrap gap-1.5">
+              {lanAddresses.map(ip => (
+                <button
+                  key={ip}
+                  type="button"
+                  className="inline-flex items-center gap-1 rounded bg-background px-2 py-0.5 font-mono text-foreground transition-colors hover:bg-muted"
+                  onClick={() => navigator.clipboard.writeText(ip)}
+                >
+                  {ip}
+                  <Copy className="size-3 text-muted-foreground" />
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
       </div>
     )
   }

--- a/src/components/device/DeviceSettingsDialog.tsx
+++ b/src/components/device/DeviceSettingsDialog.tsx
@@ -33,11 +33,20 @@
  * 加 API 时把第三个 DialogSection 接上 controlled Input + 提交即可。
  */
 
-import { AlignLeft, FileIcon, ImageIcon, Link2, Type, type LucideIcon } from 'lucide-react'
-import React, { useCallback, useEffect } from 'react'
+import {
+  AlignLeft,
+  FileIcon,
+  ImageIcon,
+  Link2,
+  RefreshCw,
+  Type,
+  type LucideIcon,
+} from 'lucide-react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { ContentTypes } from '@/api/daemon/member'
 import { DEFAULT_SEND_CONTENT_TYPES } from '@/api/daemon/member'
+import { reconnectPeer } from '@/api/daemon/members'
 import type { SpaceMember } from '@/api/daemon/members'
 import { deriveBadgeKind } from '@/components/device/connection-channel-utils'
 import { contentTypeEntries, getDeviceIcon } from '@/components/device/device-utils'
@@ -52,10 +61,12 @@ import {
 } from '@/components/ui/dialog'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Switch } from '@/components/ui/switch'
+import { toast } from '@/components/ui/toast'
 import { cn, formatPeerIdForDisplay } from '@/lib/utils'
 import { useAppDispatch, useAppSelector } from '@/store/hooks'
 import {
   fetchMemberSyncPreferences,
+  fetchSpaceMembers,
   updateMemberSyncPreferences,
 } from '@/store/slices/devicesSlice'
 
@@ -142,6 +153,48 @@ const DeviceSettingsDialog: React.FC<DeviceSettingsDialogProps> = ({
     dispatch(fetchMemberSyncPreferences(deviceId))
   }, [dispatch, deviceId])
 
+  // ── Reconnect state ──────────────────────────────────────────
+  const [reconnecting, setReconnecting] = useState(false)
+  const [cooldown, setCooldown] = useState(false)
+  const abortRef = useRef<AbortController | null>(null)
+
+  // Cleanup: abort in-flight reconnect when the dialog unmounts / closes.
+  useEffect(() => {
+    return () => {
+      abortRef.current?.abort()
+    }
+  }, [])
+
+  const handleReconnect = useCallback(async () => {
+    if (reconnecting || cooldown) return
+    setReconnecting(true)
+    abortRef.current = new AbortController()
+
+    const timeoutId = setTimeout(() => abortRef.current?.abort(), 15_000)
+
+    try {
+      const result = await reconnectPeer(deviceId, { signal: abortRef.current.signal })
+      clearTimeout(timeoutId)
+
+      if (result.connected) {
+        toast.success(t('devices.settings.reconnectSuccess'))
+      } else {
+        toast.error(t('devices.settings.reconnectFailed'))
+      }
+      // Refresh the member list so PeerCard reflects updated state.
+      dispatch(fetchSpaceMembers())
+    } catch (e) {
+      clearTimeout(timeoutId)
+      if ((e as Error).name !== 'AbortError') {
+        toast.error(t('devices.settings.reconnectFailed'))
+      }
+    } finally {
+      setReconnecting(false)
+      setCooldown(true)
+      setTimeout(() => setCooldown(false), 10_000)
+    }
+  }, [reconnecting, cooldown, deviceId, dispatch, t])
+
   if (!device && !deviceId) return null
 
   const deviceName = device?.deviceName || t('devices.list.labels.unknownDevice')
@@ -151,6 +204,8 @@ const DeviceSettingsDialog: React.FC<DeviceSettingsDialogProps> = ({
   const sendEnabled = preferences?.sendEnabled ?? true
   const sendDisabled = !sendEnabled || globalAutoSyncOff || isLoading
   const showSkeleton = isLoading && !preferences
+  const showReconnect =
+    channelKind === 'offline' || channelKind === 'unknown' || channelKind === 'relay'
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -207,6 +262,22 @@ const DeviceSettingsDialog: React.FC<DeviceSettingsDialogProps> = ({
                 value={device.connectionAddress}
                 mono
               />
+            )}
+            {showReconnect && (
+              <Button
+                variant="outline"
+                size="sm"
+                className="w-full"
+                disabled={reconnecting || cooldown}
+                onClick={handleReconnect}
+              >
+                <RefreshCw className={cn('mr-2 h-3.5 w-3.5', reconnecting && 'animate-spin')} />
+                {reconnecting
+                  ? t('devices.settings.reconnecting')
+                  : cooldown
+                    ? t('devices.settings.reconnectCooldown')
+                    : t('devices.settings.retryConnection')}
+              </Button>
             )}
           </DialogSection>
 

--- a/src/components/device/SwitchSpaceDialog.tsx
+++ b/src/components/device/SwitchSpaceDialog.tsx
@@ -11,6 +11,7 @@ import {
 } from '@/api/daemon/setupV2'
 import { INVITATION_CODE_LENGTH } from '@/components/invitation-code-utils'
 import { InvitationCodeInput } from '@/components/InvitationCodeInput'
+import { IpAddressInput } from '@/components/IpAddressInput'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -237,23 +238,19 @@ function SwitchSpaceDialogInner({ open, onOpenChange }: SwitchSpaceDialogProps) 
           </div>
         )}
 
-        <div className="space-y-1.5">
-          <Label htmlFor="switch-sponsor-ip" className="text-xs text-muted-foreground">
-            {t('sponsorIpHint', { defaultValue: '如果无法自动发现对方设备，请输入对方IP地址：' })}
-          </Label>
-          <Input
-            id="switch-sponsor-ip"
-            type="text"
-            value={sponsorIp}
-            onChange={e => setSponsorIp(e.target.value)}
-            disabled={step !== 'input'}
-            className="h-9 font-mono text-sm"
-            placeholder={t('sponsorIpPlaceholder', { defaultValue: '例如 192.168.1.100' })}
-            onKeyDown={e => {
-              if (e.key === 'Enter') void handleSubmit()
-            }}
-          />
-        </div>
+        <details className="group rounded-lg border border-border/40 px-3.5 py-2.5 text-xs">
+          <summary className="cursor-pointer select-none text-muted-foreground transition-colors hover:text-foreground">
+            {t('sponsorIpHint', { defaultValue: '无法自动发现对方设备？手动输入IP' })}
+          </summary>
+          <div className="pt-2">
+            <IpAddressInput
+              value={sponsorIp}
+              onChange={setSponsorIp}
+              disabled={step !== 'input'}
+              onSubmit={() => void handleSubmit()}
+            />
+          </div>
+        </details>
 
         <div className="flex items-start gap-2.5 rounded-lg border border-amber-500/30 bg-amber-500/5 px-3.5 py-2.5 text-xs text-muted-foreground">
           <AlertCircle className="mt-0.5 size-4 shrink-0 text-amber-500" />

--- a/src/components/device/SwitchSpaceDialog.tsx
+++ b/src/components/device/SwitchSpaceDialog.tsx
@@ -69,6 +69,7 @@ function SwitchSpaceDialogInner({ open, onOpenChange }: SwitchSpaceDialogProps) 
   const [step, setStep] = useState<Step>('input')
   const [code, setCode] = useState('')
   const [pass, setPass] = useState('')
+  const [sponsorIp, setSponsorIp] = useState('')
   const [showPass, setShowPass] = useState(false)
   const [errorKind, setErrorKind] = useState<SwitchSpaceErrorKind | null>(null)
   const [errorRaw, setErrorRaw] = useState<string | null>(null)
@@ -129,7 +130,11 @@ function SwitchSpaceDialogInner({ open, onOpenChange }: SwitchSpaceDialogProps) 
     setErrorRaw(null)
     setStep('migrating')
     try {
-      const res = await switchSpace({ code, newPassphrase: pass })
+      const res = await switchSpace({
+        code,
+        newPassphrase: pass,
+        sponsorAddrHint: sponsorIp.trim() || undefined,
+      })
       setResult(res)
       setStep('success')
     } catch (err) {
@@ -231,6 +236,24 @@ function SwitchSpaceDialogInner({ open, onOpenChange }: SwitchSpaceDialogProps) 
             </div>
           </div>
         )}
+
+        <div className="space-y-1.5">
+          <Label htmlFor="switch-sponsor-ip" className="text-xs text-muted-foreground">
+            {t('sponsorIpHint', { defaultValue: '如果无法自动发现对方设备，请输入对方IP地址：' })}
+          </Label>
+          <Input
+            id="switch-sponsor-ip"
+            type="text"
+            value={sponsorIp}
+            onChange={e => setSponsorIp(e.target.value)}
+            disabled={step !== 'input'}
+            className="h-9 font-mono text-sm"
+            placeholder={t('sponsorIpPlaceholder', { defaultValue: '例如 192.168.1.100' })}
+            onKeyDown={e => {
+              if (e.key === 'Enter') void handleSubmit()
+            }}
+          />
+        </div>
 
         <div className="flex items-start gap-2.5 rounded-lg border border-amber-500/30 bg-amber-500/5 px-3.5 py-2.5 text-xs text-muted-foreground">
           <AlertCircle className="mt-0.5 size-4 shrink-0 text-amber-500" />

--- a/src/hooks/useSetupFlow.ts
+++ b/src/hooks/useSetupFlow.ts
@@ -37,7 +37,7 @@ export type SetupScreen =
   /** S1 — sponsor: device name + passphrase + confirm. */
   | { kind: 'initialize_space' }
   /** S3 — sponsor: showing invitation code with countdown. */
-  | { kind: 'show_invitation'; code: string; expiresAtMs: number }
+  | { kind: 'show_invitation'; code: string; expiresAtMs: number; connectionString?: string }
   /** S4 — joiner: paste invitation code + passphrase. */
   | { kind: 'redeem_invitation' }
   /** S5 — both: post-handshake summary. `redeem` is set on the joiner side. */
@@ -62,6 +62,7 @@ export interface UseSetupFlowReturn {
   redeemInvitation: (input: {
     code: string
     passphrase: string
+    connectionString?: string
   }) => Promise<
     | { ok: true; redeem: RedeemResponse }
     | { ok: false; kind: RedeemInvitationErrorKind; raw: string }
@@ -157,6 +158,7 @@ export function useSetupFlow(): UseSetupFlowReturn {
         kind: 'show_invitation',
         code: out.code,
         expiresAtMs: out.expiresAtMs,
+        connectionString: out.connectionString,
       })
       return { ok: true } as const
     } catch (err) {
@@ -193,10 +195,14 @@ export function useSetupFlow(): UseSetupFlowReturn {
   }, [t])
 
   const handleRedeem = useCallback(
-    async (input: { code: string; passphrase: string }) => {
+    async (input: { code: string; passphrase: string; connectionString?: string }) => {
       setLoading(true)
       try {
-        const redeem = await redeemInvitation({ code: input.code, passphrase: input.passphrase })
+        const redeem = await redeemInvitation({
+          code: input.code,
+          passphrase: input.passphrase,
+          connectionString: input.connectionString,
+        })
         const next = await getSetupState()
         applyServerSetupState(next)
         setPageScreen({ kind: 'pairing_complete', role: 'joiner', redeem })

--- a/src/hooks/useSetupFlow.ts
+++ b/src/hooks/useSetupFlow.ts
@@ -37,7 +37,7 @@ export type SetupScreen =
   /** S1 — sponsor: device name + passphrase + confirm. */
   | { kind: 'initialize_space' }
   /** S3 — sponsor: showing invitation code with countdown. */
-  | { kind: 'show_invitation'; code: string; expiresAtMs: number }
+  | { kind: 'show_invitation'; code: string; expiresAtMs: number; lanAddresses?: string[] }
   /** S4 — joiner: paste invitation code + passphrase. */
   | { kind: 'redeem_invitation' }
   /** S5 — both: post-handshake summary. `redeem` is set on the joiner side. */
@@ -62,6 +62,7 @@ export interface UseSetupFlowReturn {
   redeemInvitation: (input: {
     code: string
     passphrase: string
+    sponsorAddrHint?: string
   }) => Promise<
     | { ok: true; redeem: RedeemResponse }
     | { ok: false; kind: RedeemInvitationErrorKind; raw: string }
@@ -157,6 +158,7 @@ export function useSetupFlow(): UseSetupFlowReturn {
         kind: 'show_invitation',
         code: out.code,
         expiresAtMs: out.expiresAtMs,
+        lanAddresses: out.lanAddresses,
       })
       return { ok: true } as const
     } catch (err) {
@@ -193,10 +195,14 @@ export function useSetupFlow(): UseSetupFlowReturn {
   }, [t])
 
   const handleRedeem = useCallback(
-    async (input: { code: string; passphrase: string }) => {
+    async (input: { code: string; passphrase: string; sponsorAddrHint?: string }) => {
       setLoading(true)
       try {
-        const redeem = await redeemInvitation({ code: input.code, passphrase: input.passphrase })
+        const redeem = await redeemInvitation({
+          code: input.code,
+          passphrase: input.passphrase,
+          sponsorAddrHint: input.sponsorAddrHint,
+        })
         const next = await getSetupState()
         applyServerSetupState(next)
         setPageScreen({ kind: 'pairing_complete', role: 'joiner', redeem })

--- a/src/hooks/useSetupFlow.ts
+++ b/src/hooks/useSetupFlow.ts
@@ -37,7 +37,7 @@ export type SetupScreen =
   /** S1 — sponsor: device name + passphrase + confirm. */
   | { kind: 'initialize_space' }
   /** S3 — sponsor: showing invitation code with countdown. */
-  | { kind: 'show_invitation'; code: string; expiresAtMs: number; connectionString?: string }
+  | { kind: 'show_invitation'; code: string; expiresAtMs: number }
   /** S4 — joiner: paste invitation code + passphrase. */
   | { kind: 'redeem_invitation' }
   /** S5 — both: post-handshake summary. `redeem` is set on the joiner side. */
@@ -62,7 +62,6 @@ export interface UseSetupFlowReturn {
   redeemInvitation: (input: {
     code: string
     passphrase: string
-    connectionString?: string
   }) => Promise<
     | { ok: true; redeem: RedeemResponse }
     | { ok: false; kind: RedeemInvitationErrorKind; raw: string }
@@ -158,7 +157,6 @@ export function useSetupFlow(): UseSetupFlowReturn {
         kind: 'show_invitation',
         code: out.code,
         expiresAtMs: out.expiresAtMs,
-        connectionString: out.connectionString,
       })
       return { ok: true } as const
     } catch (err) {
@@ -195,14 +193,10 @@ export function useSetupFlow(): UseSetupFlowReturn {
   }, [t])
 
   const handleRedeem = useCallback(
-    async (input: { code: string; passphrase: string; connectionString?: string }) => {
+    async (input: { code: string; passphrase: string }) => {
       setLoading(true)
       try {
-        const redeem = await redeemInvitation({
-          code: input.code,
-          passphrase: input.passphrase,
-          connectionString: input.connectionString,
-        })
+        const redeem = await redeemInvitation({ code: input.code, passphrase: input.passphrase })
         const next = await getSetupState()
         applyServerSetupState(next)
         setPageScreen({ kind: 'pairing_complete', role: 'joiner', redeem })

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -1107,6 +1107,11 @@
       }
     },
     "settings": {
+      "retryConnection": "Retry Connection",
+      "reconnecting": "Connecting...",
+      "reconnectSuccess": "Connection established",
+      "reconnectFailed": "Connection failed, please check network",
+      "reconnectCooldown": "Please wait before retrying",
       "readOnly": "Locked",
       "badges": {
         "mvp": "MVP",

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -1532,9 +1532,6 @@
       "expired": "Invitation expired",
       "hint": "Both devices must remain online while pairing.",
       "hintExpired": "The code is no longer valid. Cancel and start a new invitation.",
-      "connectionStringHint": "Can't discover the other device? Copy this and send it manually:",
-      "copyConnectionString": "Copy",
-      "connectionStringCopied": "Copied!",
       "actions": {
         "cancel": "Cancel invitation"
       }

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -1532,6 +1532,9 @@
       "expired": "Invitation expired",
       "hint": "Both devices must remain online while pairing.",
       "hintExpired": "The code is no longer valid. Cancel and start a new invitation.",
+      "connectionStringHint": "Can't discover the other device? Copy this and send it manually:",
+      "copyConnectionString": "Copy",
+      "connectionStringCopied": "Copied!",
       "actions": {
         "cancel": "Cancel invitation"
       }

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -1532,6 +1532,7 @@
       "expired": "Invitation expired",
       "hint": "Both devices must remain online while pairing.",
       "hintExpired": "The code is no longer valid. Cancel and start a new invitation.",
+      "lanAddressesHint": "Your IP address (tell the other side if needed):",
       "actions": {
         "cancel": "Cancel invitation"
       }
@@ -1560,6 +1561,8 @@
         "generic": "Could not join the space. Please try again."
       },
       "hint": "The code is short-lived — ask the host to keep it on screen until pairing completes.",
+      "sponsorIpHint": "If the other device is not found automatically, enter their IP:",
+      "sponsorIpPlaceholder": "e.g. 192.168.1.100",
       "actions": {
         "back": "Back",
         "joining": "Joining...",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -1616,6 +1616,7 @@
       "expired": "邀请码已过期",
       "hint": "配对完成前请保持两台设备都在线。",
       "hintExpired": "邀请码已失效，请取消后重新生成。",
+      "lanAddressesHint": "你的IP地址（如需要请告诉对方）：",
       "actions": {
         "cancel": "取消邀请"
       }
@@ -1644,6 +1645,8 @@
         "generic": "加入空间失败，请重试。"
       },
       "hint": "邀请码有效期较短，请让对方保持显示直到配对完成。",
+      "sponsorIpHint": "如果无法自动发现对方设备，请输入对方IP地址：",
+      "sponsorIpPlaceholder": "例如 192.168.1.100",
       "actions": {
         "back": "返回",
         "joining": "正在加入...",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -1616,9 +1616,6 @@
       "expired": "邀请码已过期",
       "hint": "配对完成前请保持两台设备都在线。",
       "hintExpired": "邀请码已失效，请取消后重新生成。",
-      "connectionStringHint": "无法自动发现对方设备？复制连接串手动发送：",
-      "copyConnectionString": "复制",
-      "connectionStringCopied": "已复制！",
       "actions": {
         "cancel": "取消邀请"
       }

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -1616,6 +1616,9 @@
       "expired": "邀请码已过期",
       "hint": "配对完成前请保持两台设备都在线。",
       "hintExpired": "邀请码已失效，请取消后重新生成。",
+      "connectionStringHint": "无法自动发现对方设备？复制连接串手动发送：",
+      "copyConnectionString": "复制",
+      "connectionStringCopied": "已复制！",
       "actions": {
         "cancel": "取消邀请"
       }

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -1098,6 +1098,11 @@
       }
     },
     "settings": {
+      "retryConnection": "重试连接",
+      "reconnecting": "正在连接...",
+      "reconnectSuccess": "连接已建立",
+      "reconnectFailed": "连接失败，请检查网络",
+      "reconnectCooldown": "请稍后再试",
       "readOnly": "不可更改",
       "badges": {
         "mvp": "MVP",

--- a/src/pages/SetupPage.tsx
+++ b/src/pages/SetupPage.tsx
@@ -63,7 +63,6 @@ const SetupScreen: React.FC<SetupScreenProps> = ({
         <ShowInvitationScreen
           code={screen.code}
           expiresAtMs={screen.expiresAtMs}
-          connectionString={screen.connectionString}
           onCancel={cancelInvitation}
           loading={loading}
         />

--- a/src/pages/SetupPage.tsx
+++ b/src/pages/SetupPage.tsx
@@ -63,6 +63,7 @@ const SetupScreen: React.FC<SetupScreenProps> = ({
         <ShowInvitationScreen
           code={screen.code}
           expiresAtMs={screen.expiresAtMs}
+          lanAddresses={screen.lanAddresses}
           onCancel={cancelInvitation}
           loading={loading}
         />

--- a/src/pages/SetupPage.tsx
+++ b/src/pages/SetupPage.tsx
@@ -63,6 +63,7 @@ const SetupScreen: React.FC<SetupScreenProps> = ({
         <ShowInvitationScreen
           code={screen.code}
           expiresAtMs={screen.expiresAtMs}
+          connectionString={screen.connectionString}
           onCancel={cancelInvitation}
           loading={loading}
         />

--- a/src/pages/setup/screens.tsx
+++ b/src/pages/setup/screens.tsx
@@ -4,6 +4,7 @@ import {
   ArrowLeft,
   ArrowRight,
   CheckCircle2,
+  Copy,
   Eye,
   EyeOff,
   Loader2,
@@ -356,16 +357,19 @@ function formatRemaining(ms: number): string {
 export function ShowInvitationScreen({
   code,
   expiresAtMs,
+  connectionString,
   onCancel,
   loading,
 }: {
   code: string
   expiresAtMs: number
+  connectionString?: string
   onCancel: () => void
   loading?: boolean
 }) {
   const { t } = useTranslation(undefined, { keyPrefix: 'setup.showInvitation' })
   const [now, setNow] = useState(() => Date.now())
+  const [copied, setCopied] = useState(false)
 
   useEffect(() => {
     const id = setInterval(() => setNow(Date.now()), 1000)
@@ -375,6 +379,13 @@ export function ShowInvitationScreen({
   const remaining = expiresAtMs - now
   const expired = remaining <= 0
   const display = useMemo(() => formatInvitationCode(code), [code])
+
+  const handleCopyConnectionString = async () => {
+    if (!connectionString) return
+    await navigator.clipboard.writeText(connectionString)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
 
   return (
     <ScreenShell
@@ -405,6 +416,20 @@ export function ShowInvitationScreen({
         >
           {expired ? t('expired') : t('expiresIn', { remaining: formatRemaining(remaining) })}
         </div>
+        {connectionString && (
+          <div className="w-full max-w-md space-y-2">
+            <p className="text-sm text-muted-foreground">{t('connectionStringHint')}</p>
+            <div className="flex items-center gap-2">
+              <code className="flex-1 truncate rounded bg-muted p-2 text-xs">
+                {connectionString}
+              </code>
+              <Button variant="outline" size="sm" onClick={handleCopyConnectionString}>
+                <Copy className="mr-1.5 size-3.5" />
+                {copied ? t('connectionStringCopied') : t('copyConnectionString')}
+              </Button>
+            </div>
+          </div>
+        )}
       </div>
     </ScreenShell>
   )
@@ -453,6 +478,7 @@ export function RedeemInvitationScreen({
   onSubmit: (input: {
     code: string
     passphrase: string
+    connectionString?: string
   }) => Promise<
     | { ok: true; redeem: RedeemResponse }
     | { ok: false; kind: RedeemInvitationErrorKind; raw: string }
@@ -465,6 +491,7 @@ export function RedeemInvitationScreen({
   const [pass, setPass] = useState('')
   const [showPass, setShowPass] = useState(false)
   const [errorKind, setErrorKind] = useState<RedeemInvitationErrorKind | null>(null)
+  const [connectionString, setConnectionString] = useState<string | undefined>()
   const passInputRef = useRef<HTMLInputElement>(null)
 
   const errorMessage = redeemErrorMessage(t, errorKind)
@@ -478,10 +505,26 @@ export function RedeemInvitationScreen({
     if (codeComplete) passInputRef.current?.focus()
   }, [codeComplete])
 
+  /** Intercept pastes that look like connection strings (`uc://p/...`). */
+  const handleCodeChange = (value: string) => {
+    if (value.startsWith('uc://p/')) {
+      setConnectionString(value)
+      const rest = value.replace('uc://p/', '')
+      const parts = rest.split('/')
+      if (parts.length >= 2) {
+        // Strip the hyphen from the code part so InvitationCodeInput shows it
+        setCode(parts[0].replace(/-/g, ''))
+      }
+      return
+    }
+    setCode(value)
+    setConnectionString(undefined)
+  }
+
   const handleSubmit = async () => {
     setErrorKind(null)
     if (!canSubmit) return
-    const res = await onSubmit({ code, passphrase: pass })
+    const res = await onSubmit({ code, passphrase: pass, connectionString })
     if (!res.ok) {
       setErrorKind(res.kind)
       // 邀请码已废类——原 code 必然 404,清掉让用户必须输入新邀请码。
@@ -493,6 +536,7 @@ export function RedeemInvitationScreen({
       ) {
         setCode('')
         setPass('')
+        setConnectionString(undefined)
       } else if (res.kind === 'passphrase_mismatch') {
         setPass('')
         passInputRef.current?.focus()
@@ -543,7 +587,7 @@ export function RedeemInvitationScreen({
           <InvitationCodeInput
             id="join-code"
             value={code}
-            onChange={setCode}
+            onChange={handleCodeChange}
             disabled={loading}
             invalid={codeInvalid}
             autoFocus

--- a/src/pages/setup/screens.tsx
+++ b/src/pages/setup/screens.tsx
@@ -356,11 +356,13 @@ function formatRemaining(ms: number): string {
 export function ShowInvitationScreen({
   code,
   expiresAtMs,
+  lanAddresses,
   onCancel,
   loading,
 }: {
   code: string
   expiresAtMs: number
+  lanAddresses?: string[]
   onCancel: () => void
   loading?: boolean
 }) {
@@ -405,6 +407,21 @@ export function ShowInvitationScreen({
         >
           {expired ? t('expired') : t('expiresIn', { remaining: formatRemaining(remaining) })}
         </div>
+        {lanAddresses && lanAddresses.length > 0 && (
+          <div className="mt-4 rounded-lg border border-border/40 bg-muted/20 px-4 py-3 text-left text-sm">
+            <div className="mb-1.5 text-xs text-muted-foreground">{t('lanAddressesHint')}</div>
+            <div className="flex flex-wrap gap-2">
+              {lanAddresses.map(ip => (
+                <span
+                  key={ip}
+                  className="inline-flex items-center rounded-md bg-muted px-2.5 py-0.5 font-mono text-sm font-medium text-foreground"
+                >
+                  {ip}
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
       </div>
     </ScreenShell>
   )
@@ -453,6 +470,7 @@ export function RedeemInvitationScreen({
   onSubmit: (input: {
     code: string
     passphrase: string
+    sponsorAddrHint?: string
   }) => Promise<
     | { ok: true; redeem: RedeemResponse }
     | { ok: false; kind: RedeemInvitationErrorKind; raw: string }
@@ -463,6 +481,7 @@ export function RedeemInvitationScreen({
   const { t } = useTranslation(undefined, { keyPrefix: 'setup.redeemInvitation' })
   const [code, setCode] = useState('')
   const [pass, setPass] = useState('')
+  const [sponsorIp, setSponsorIp] = useState('')
   const [showPass, setShowPass] = useState(false)
   const [errorKind, setErrorKind] = useState<RedeemInvitationErrorKind | null>(null)
   const passInputRef = useRef<HTMLInputElement>(null)
@@ -481,7 +500,11 @@ export function RedeemInvitationScreen({
   const handleSubmit = async () => {
     setErrorKind(null)
     if (!canSubmit) return
-    const res = await onSubmit({ code, passphrase: pass })
+    const res = await onSubmit({
+      code,
+      passphrase: pass,
+      sponsorAddrHint: sponsorIp.trim() || undefined,
+    })
     if (!res.ok) {
       setErrorKind(res.kind)
       // 邀请码已废类——原 code 必然 404,清掉让用户必须输入新邀请码。
@@ -585,6 +608,21 @@ export function RedeemInvitationScreen({
                     {showPass ? <EyeOff className="size-4" /> : <Eye className="size-4" />}
                   </button>
                 </div>
+              </div>
+              <div className="pt-4">
+                <Label htmlFor="sponsor-ip" className="text-xs text-muted-foreground">
+                  {t('sponsorIpHint')}
+                </Label>
+                <Input
+                  id="sponsor-ip"
+                  type="text"
+                  value={sponsorIp}
+                  onChange={e => setSponsorIp(e.target.value)}
+                  disabled={loading}
+                  className="mt-1 h-9 border-0 border-b border-border/40 bg-transparent px-0 text-center text-sm shadow-none focus-visible:border-primary focus-visible:ring-0"
+                  placeholder={t('sponsorIpPlaceholder')}
+                  onKeyDown={e => e.key === 'Enter' && handleSubmit()}
+                />
               </div>
             </m.div>
           )}

--- a/src/pages/setup/screens.tsx
+++ b/src/pages/setup/screens.tsx
@@ -4,7 +4,6 @@ import {
   ArrowLeft,
   ArrowRight,
   CheckCircle2,
-  Copy,
   Eye,
   EyeOff,
   Loader2,
@@ -357,19 +356,16 @@ function formatRemaining(ms: number): string {
 export function ShowInvitationScreen({
   code,
   expiresAtMs,
-  connectionString,
   onCancel,
   loading,
 }: {
   code: string
   expiresAtMs: number
-  connectionString?: string
   onCancel: () => void
   loading?: boolean
 }) {
   const { t } = useTranslation(undefined, { keyPrefix: 'setup.showInvitation' })
   const [now, setNow] = useState(() => Date.now())
-  const [copied, setCopied] = useState(false)
 
   useEffect(() => {
     const id = setInterval(() => setNow(Date.now()), 1000)
@@ -379,13 +375,6 @@ export function ShowInvitationScreen({
   const remaining = expiresAtMs - now
   const expired = remaining <= 0
   const display = useMemo(() => formatInvitationCode(code), [code])
-
-  const handleCopyConnectionString = async () => {
-    if (!connectionString) return
-    await navigator.clipboard.writeText(connectionString)
-    setCopied(true)
-    setTimeout(() => setCopied(false), 2000)
-  }
 
   return (
     <ScreenShell
@@ -416,20 +405,6 @@ export function ShowInvitationScreen({
         >
           {expired ? t('expired') : t('expiresIn', { remaining: formatRemaining(remaining) })}
         </div>
-        {connectionString && (
-          <div className="w-full max-w-md space-y-2">
-            <p className="text-sm text-muted-foreground">{t('connectionStringHint')}</p>
-            <div className="flex items-center gap-2">
-              <code className="flex-1 truncate rounded bg-muted p-2 text-xs">
-                {connectionString}
-              </code>
-              <Button variant="outline" size="sm" onClick={handleCopyConnectionString}>
-                <Copy className="mr-1.5 size-3.5" />
-                {copied ? t('connectionStringCopied') : t('copyConnectionString')}
-              </Button>
-            </div>
-          </div>
-        )}
       </div>
     </ScreenShell>
   )
@@ -478,7 +453,6 @@ export function RedeemInvitationScreen({
   onSubmit: (input: {
     code: string
     passphrase: string
-    connectionString?: string
   }) => Promise<
     | { ok: true; redeem: RedeemResponse }
     | { ok: false; kind: RedeemInvitationErrorKind; raw: string }
@@ -491,7 +465,6 @@ export function RedeemInvitationScreen({
   const [pass, setPass] = useState('')
   const [showPass, setShowPass] = useState(false)
   const [errorKind, setErrorKind] = useState<RedeemInvitationErrorKind | null>(null)
-  const [connectionString, setConnectionString] = useState<string | undefined>()
   const passInputRef = useRef<HTMLInputElement>(null)
 
   const errorMessage = redeemErrorMessage(t, errorKind)
@@ -505,26 +478,10 @@ export function RedeemInvitationScreen({
     if (codeComplete) passInputRef.current?.focus()
   }, [codeComplete])
 
-  /** Intercept pastes that look like connection strings (`uc://p/...`). */
-  const handleCodeChange = (value: string) => {
-    if (value.startsWith('uc://p/')) {
-      setConnectionString(value)
-      const rest = value.replace('uc://p/', '')
-      const parts = rest.split('/')
-      if (parts.length >= 2) {
-        // Strip the hyphen from the code part so InvitationCodeInput shows it
-        setCode(parts[0].replace(/-/g, ''))
-      }
-      return
-    }
-    setCode(value)
-    setConnectionString(undefined)
-  }
-
   const handleSubmit = async () => {
     setErrorKind(null)
     if (!canSubmit) return
-    const res = await onSubmit({ code, passphrase: pass, connectionString })
+    const res = await onSubmit({ code, passphrase: pass })
     if (!res.ok) {
       setErrorKind(res.kind)
       // 邀请码已废类——原 code 必然 404,清掉让用户必须输入新邀请码。
@@ -536,7 +493,6 @@ export function RedeemInvitationScreen({
       ) {
         setCode('')
         setPass('')
-        setConnectionString(undefined)
       } else if (res.kind === 'passphrase_mismatch') {
         setPass('')
         passInputRef.current?.focus()
@@ -587,7 +543,7 @@ export function RedeemInvitationScreen({
           <InvitationCodeInput
             id="join-code"
             value={code}
-            onChange={handleCodeChange}
+            onChange={setCode}
             disabled={loading}
             invalid={codeInvalid}
             autoFocus

--- a/src/pages/setup/screens.tsx
+++ b/src/pages/setup/screens.tsx
@@ -5,6 +5,7 @@ import {
   ArrowRight,
   CheckCircle2,
   Eye,
+  Copy,
   EyeOff,
   Loader2,
   Shield,
@@ -21,6 +22,7 @@ import type {
 } from '@/api/daemon/setupV2'
 import { INVITATION_CODE_LENGTH, formatInvitationCode } from '@/components/invitation-code-utils'
 import { InvitationCodeInput } from '@/components/InvitationCodeInput'
+import { IpAddressInput } from '@/components/IpAddressInput'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -412,12 +414,15 @@ export function ShowInvitationScreen({
             <div className="mb-1.5 text-xs text-muted-foreground">{t('lanAddressesHint')}</div>
             <div className="flex flex-wrap gap-2">
               {lanAddresses.map(ip => (
-                <span
+                <button
                   key={ip}
-                  className="inline-flex items-center rounded-md bg-muted px-2.5 py-0.5 font-mono text-sm font-medium text-foreground"
+                  type="button"
+                  className="inline-flex items-center gap-1 rounded-md bg-muted px-2.5 py-0.5 font-mono text-sm font-medium text-foreground transition-colors hover:bg-muted/80"
+                  onClick={() => navigator.clipboard.writeText(ip)}
                 >
                   {ip}
-                </span>
+                  <Copy className="size-3 text-muted-foreground" />
+                </button>
               ))}
             </div>
           </div>
@@ -610,18 +615,13 @@ export function RedeemInvitationScreen({
                 </div>
               </div>
               <div className="pt-4">
-                <Label htmlFor="sponsor-ip" className="text-xs text-muted-foreground">
-                  {t('sponsorIpHint')}
-                </Label>
-                <Input
-                  id="sponsor-ip"
-                  type="text"
+                <Label className="text-xs text-muted-foreground">{t('sponsorIpHint')}</Label>
+                <IpAddressInput
                   value={sponsorIp}
-                  onChange={e => setSponsorIp(e.target.value)}
+                  onChange={setSponsorIp}
                   disabled={loading}
-                  className="mt-1 h-9 border-0 border-b border-border/40 bg-transparent px-0 text-center text-sm shadow-none focus-visible:border-primary focus-visible:ring-0"
-                  placeholder={t('sponsorIpPlaceholder')}
-                  onKeyDown={e => e.key === 'Enter' && handleSubmit()}
+                  className="mt-1"
+                  onSubmit={handleSubmit}
                 />
               </div>
             </m.div>


### PR DESCRIPTION
## Summary

Multi-NIC users (Docker bridge, Clash TUN, WiFi, USB ethernet) saw "不在本地网络" even when devices were on the same physical LAN, because virtual bridge interfaces polluted the hairpin filter and there was no manual recovery mechanism.

- **Filter virtual bridge interfaces** from LAN subnet enumeration, sponsor tickets, and mDNS pairing announcements — prevents Docker/podman/virbr/veth/lxcbr addresses from causing hairpin false positives (`801549177`)
- **Add per-peer reconnect button** in Device Settings Dialog with `POST /member/:device_id/reconnect` endpoint, 10s server-side rate limiting, 15s frontend timeout, and AbortController cleanup (`959f71a46`)
- **Periodic AddrFilter refresh** every 45s via `endpoint.address_lookup()?.set_addr_filter()` — switching WiFi or plugging in USB ethernet no longer requires daemon restart for the hairpin filter to update (`fd71d1c04`)

Closes #920.

## Test plan

- [x] `cargo check --workspace` passes (excluding pre-existing Tauri sidecar absence)
- [x] New unit test `virtual_bridge_interface_detection` passes
- [x] Existing `addr_filter` regression tests (4/4) pass
- [x] Frontend `tsc --noEmit` passes
- [ ] E2E: Start daemon with Docker running → logs show `skipped_bridges > 0` and no 172.17.x.x in subnets
- [ ] E2E: Two devices on same WiFi + LAN-only ON → shows "直连" (not "不在本地网络")
- [ ] E2E: Offline peer → open Device Settings → click "重试连接" → verify spinner + toast feedback
- [ ] E2E: Switch WiFi → within 45s logs show "LAN interfaces changed — refreshing AddrFilter"
- [ ] Rate limit: `curl -X POST .../reconnect` twice within 10s → second returns 429

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manual device reconnect UI with abort/timeout, success/error toasts and 10s client cooldown
  * Server POST endpoint for forcing peer reconnect (with response payload in API docs) and a client wrapper
  * “Connection string” for direct/manual pairing: show/copy in invite UI, allow pasting to redeem, and opt-in during switch/join flows
  * SDK/CLI support for connection-string fields

* **Reliability / Server**
  * Per-device server-side rate limiting (10s) and reconnect → HTTP status mapping

* **Localization**
  * Added reconnect- and connection-string strings (en/zh)

* **Infrastructure**
  * Ignore virtual bridge interfaces during LAN discovery and add periodic LAN address-filter refresh
  * Enforce mDNS ticket size budget by trimming transport addresses when needed
<!-- end of auto-generated comment: release notes by coderabbit.ai -->