### PR TITLE
fix(gui): recover from session-token expiry instead of hanging on loading

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { LazyMotion, MotionConfig, domMax } from 'framer-motion'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { BrowserRouter as Router, Route, Navigate, Outlet, useNavigate } from 'react-router-dom'
+import { daemonClient } from '@/api/daemon/client'
 import { signalLifecycleReady } from '@/api/daemon/lifecycle'
 import { unlockEncryptionSession } from '@/api/security'
 import { checkForUpdate, openUpdaterWindow } from '@/api/updater'
@@ -34,6 +35,10 @@ import UnlockPage from '@/pages/UnlockPage'
 import { useGetEncryptionSessionStatusQuery } from '@/store/api'
 import { type SetupFlow, useSetupRealtimeStore } from '@/store/setupRealtimeStore'
 import './App.css'
+
+/** How long the initial encryption-status load may stay blank before the UI
+ *  falls through to the actionable error screen instead of hanging (#995). */
+const LOADING_WATCHDOG_MS = 12_000
 
 // 认证布局包装器 - 保持 Sidebar 持久化
 const AuthenticatedLayout = () => {
@@ -132,9 +137,27 @@ const AppContent = ({
     data: encryptionData,
     isLoading: encryptionLoading,
     error: encryptionQueryError,
+    refetch: refetchEncryption,
   } = useGetEncryptionSessionStatusQuery(undefined, {
     skip: isSetupActive || !daemonBootstrapReady,
   })
+
+  // Watchdog: the daemon session token can expire while the keep-alive timer is
+  // frozen across a sleep; if the initial encryption-status request then stalls
+  // (e.g. a refresh that never resolves), the blank loading gate below would
+  // trap the UI forever — the user had to restart the app to recover (#995).
+  // After LOADING_WATCHDOG_MS without a status or error, surface the actionable
+  // error screen (with Retry) instead of an indefinite blank screen.
+  const [loadingTimedOut, setLoadingTimedOut] = useState(false)
+  const isInitialLoading = encryptionLoading && encryptionStatus === null
+  useEffect(() => {
+    if (!isInitialLoading) {
+      setLoadingTimedOut(false)
+      return
+    }
+    const id = setTimeout(() => setLoadingTimedOut(true), LOADING_WATCHDOG_MS)
+    return () => clearTimeout(id)
+  }, [isInitialLoading])
 
   // Listen for encryption session ready/failed via daemon WebSocket.
   useEncryptionState(
@@ -178,9 +201,34 @@ const AppContent = ({
     : null
   const encryptionError = encryptionData
     ? null
-    : (bootEncryptionError ?? encryptionQueryErrorMessage)
+    : (bootEncryptionError ??
+      encryptionQueryErrorMessage ??
+      (loadingTimedOut ? 'Timed out waiting for the background service.' : null))
 
   const resolvedEncryptionStatus = encryptionStatus ?? encryptionData ?? null
+
+  // Retry without restarting the app: re-run the WS bootstrap (idempotent —
+  // resolves immediately if already connected), force a fresh session token,
+  // then re-pull the encryption status. This recovers the common #995 case
+  // where only the session token had gone stale.
+  const handleBootstrapRetry = useCallback(() => {
+    setLoadingTimedOut(false)
+    setBootEncryptionError(null)
+    setBootstrapFailure(null)
+    connectDaemonWs()
+      .then(() => {
+        setDaemonBootstrapReady(true)
+        return daemonClient.refreshSession()
+      })
+      .then(() => {
+        void refetchEncryption()
+      })
+      .catch(error => {
+        const message = error instanceof Error ? error.message : String(error)
+        setBootEncryptionError(message)
+        setBootstrapFailure(error instanceof DaemonBootstrapFailedError ? error.failure : null)
+      })
+  }, [refetchEncryption])
 
   useEffect(() => {
     if (
@@ -214,7 +262,10 @@ const AppContent = ({
   // Once encryptionStatus is known (from a previous query or SessionReady event), we continue
   // rendering even if RTK Query is re-fetching — this prevents a blank screen flash when
   // isSetupActive transitions from true→false and RTK Query starts a new request.
-  if (encryptionLoading && encryptionStatus === null) {
+  // Stay blank only while genuinely still loading with no error. Once the
+  // watchdog (or the query) produces an error, fall through to the error
+  // screen below instead of short-circuiting to an indefinite blank (#995).
+  if (encryptionLoading && encryptionStatus === null && !encryptionError) {
     return null
   }
 
@@ -229,7 +280,7 @@ const AppContent = ({
               : "Couldn't reach the background service. Please restart the app."}
           </p>
           <p className="break-words text-xs text-muted-foreground">{encryptionError}</p>
-          {versionTooOld && (
+          {versionTooOld ? (
             <Button
               size="sm"
               onClick={() => {
@@ -245,6 +296,10 @@ const AppContent = ({
               }}
             >
               Open updater
+            </Button>
+          ) : (
+            <Button size="sm" onClick={handleBootstrapRetry}>
+              Retry
             </Button>
           )}
         </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -150,16 +150,11 @@ const AppContent = ({
   // error screen (with Retry) instead of an indefinite blank screen.
   const [loadingTimedOut, setLoadingTimedOut] = useState(false)
   const isInitialLoading = encryptionLoading && encryptionStatus === null
-  // Reset the watchdog at every loading-cycle boundary *during render* (React's
-  // "adjusting state when a prop changes" pattern) so the UI never commits a
-  // stale timed-out state between the change and an effect catching up.
-  const [prevInitialLoading, setPrevInitialLoading] = useState(isInitialLoading)
-  if (prevInitialLoading !== isInitialLoading) {
-    setPrevInitialLoading(isInitialLoading)
-    setLoadingTimedOut(false)
-  }
-  // The effect only *arms* the timer (a real side effect); it no longer adjusts
-  // state in response to the loading flag changing.
+  // Arm the watchdog while the initial load is in flight; disarm (clearTimeout)
+  // when it ends. No state is adjusted here on the flag change — a stale
+  // timed-out `true` once loading ends is harmless (any data/error overrides it
+  // in the gates below), and the only way back into a loading cycle is the
+  // Retry handler, which resets the flag explicitly.
   useEffect(() => {
     if (!isInitialLoading) return
     const id = setTimeout(() => setLoadingTimedOut(true), LOADING_WATCHDOG_MS)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -150,11 +150,18 @@ const AppContent = ({
   // error screen (with Retry) instead of an indefinite blank screen.
   const [loadingTimedOut, setLoadingTimedOut] = useState(false)
   const isInitialLoading = encryptionLoading && encryptionStatus === null
+  // Reset the watchdog at every loading-cycle boundary *during render* (React's
+  // "adjusting state when a prop changes" pattern) so the UI never commits a
+  // stale timed-out state between the change and an effect catching up.
+  const [prevInitialLoading, setPrevInitialLoading] = useState(isInitialLoading)
+  if (prevInitialLoading !== isInitialLoading) {
+    setPrevInitialLoading(isInitialLoading)
+    setLoadingTimedOut(false)
+  }
+  // The effect only *arms* the timer (a real side effect); it no longer adjusts
+  // state in response to the loading flag changing.
   useEffect(() => {
-    if (!isInitialLoading) {
-      setLoadingTimedOut(false)
-      return
-    }
+    if (!isInitialLoading) return
     const id = setTimeout(() => setLoadingTimedOut(true), LOADING_WATCHDOG_MS)
     return () => clearTimeout(id)
   }, [isInitialLoading])

--- a/src/api/daemon/client.ts
+++ b/src/api/daemon/client.ts
@@ -27,6 +27,26 @@ const log = createLogger('daemon-client')
 const REFRESH_INTERVAL_MS = 240_000
 
 /**
+ * Re-mint the session on resume when it is within this window of expiry.
+ *
+ * The keep-alive `setInterval` is frozen while the OS suspends the process
+ * (sleep / app backgrounded), so a token can silently expire across a sleep.
+ * On the next wake (`visibilitychange` / `focus` / `online`) we proactively
+ * refresh if the token is gone or about to expire, so the first post-resume
+ * request never fires with a stale token (the daemon would reject it with
+ * `ExpiredSignature`). See issue #995.
+ */
+const WAKE_REFRESH_BUFFER_MS = 30_000
+
+/**
+ * Max time to wait for the native session IPC before treating the refresh as
+ * failed. Without this, a stalled `getDaemonSession()` on resume leaves the
+ * pre-emptive/401-retry refresh hanging forever, which freezes the UI on the
+ * loading screen until the user restarts the app (issue #995).
+ */
+const REFRESH_TIMEOUT_MS = 10_000
+
+/**
  * Options for `request<T>()`.
  *
  * 请求选项，允许调用方自定义 HTTP 方法、请求体和请求头。
@@ -46,6 +66,8 @@ class DaemonClient {
   private session: SessionToken | null = null
   private refreshTimer: ReturnType<typeof setInterval> | null = null
   private refreshPromise: Promise<SessionToken> | null = null
+  /** Bound wake handler, registered while initialized (see {@link WAKE_REFRESH_BUFFER_MS}). */
+  private wakeHandler: (() => void) | null = null
 
   /**
    * Whether the client has been initialized with daemon connection config.
@@ -85,6 +107,7 @@ class DaemonClient {
   initialize(config: DaemonConfig): void {
     this.config = config
     this.startKeepAlive()
+    this.setupWakeListeners()
     // Wire the @hey-api generated fetch client to this session lifecycle
     // (baseUrl + ?auth= query token + 401 observability). Makes the typed SDK
     // AVAILABLE; nothing routes through it yet (ADR-008 P5; consumers in P6).
@@ -281,6 +304,7 @@ class DaemonClient {
    */
   destroy(): void {
     this.stopKeepAlive()
+    this.teardownWakeListeners()
     this.session = null
     this.config = null
     this.refreshPromise = null
@@ -289,7 +313,7 @@ class DaemonClient {
   // ── Private helpers ──────────────────────────────────────────
 
   private async doRefreshSession(): Promise<SessionToken> {
-    const data = await commands.getDaemonSession()
+    const data = await this.fetchDaemonSession()
     if (!data) {
       throw new DaemonApiError(DaemonErrorCode.UNAUTHORIZED, 'Daemon session is not available yet')
     }
@@ -352,6 +376,70 @@ class DaemonClient {
     }
 
     return JSON.parse(body) as T
+  }
+
+  /**
+   * Ask native Tauri for a session, racing the IPC against a timeout so a
+   * stalled native side can't hang the refresh forever. On timeout we reject
+   * with a {@link DaemonApiError}; the caller surfaces it (loading-screen
+   * watchdog / 401 retry) instead of waiting indefinitely.
+   */
+  private async fetchDaemonSession(): Promise<
+    Awaited<ReturnType<typeof commands.getDaemonSession>>
+  > {
+    let timer: ReturnType<typeof setTimeout> | undefined
+    const timeout = new Promise<never>((_, reject) => {
+      timer = setTimeout(() => {
+        reject(
+          new DaemonApiError(
+            DaemonErrorCode.INTERNAL_ERROR,
+            `Daemon session request timed out after ${REFRESH_TIMEOUT_MS}ms`
+          )
+        )
+      }, REFRESH_TIMEOUT_MS)
+    })
+    try {
+      return await Promise.race([commands.getDaemonSession(), timeout])
+    } finally {
+      if (timer !== undefined) clearTimeout(timer)
+    }
+  }
+
+  /**
+   * Re-mint the session when the app resumes (tab visible / window focused /
+   * network back) and the current token is gone or near expiry. The keep-alive
+   * timer is frozen while suspended, so this is the path that recovers a token
+   * that expired across a sleep before any request fires (issue #995).
+   */
+  private setupWakeListeners(): void {
+    if (typeof window === 'undefined' || this.wakeHandler) return
+    const handler = () => {
+      // Ignore the "hidden" half of a visibilitychange — only act on resume.
+      if (typeof document !== 'undefined' && document.visibilityState === 'hidden') return
+      if (!isSessionExpired(this.session, WAKE_REFRESH_BUFFER_MS)) return
+      // refreshSession() coalesces concurrent calls, so this is cheap.
+      this.refreshSession().catch(err => {
+        log.error({ err }, 'wake refresh failed')
+      })
+    }
+    this.wakeHandler = handler
+    if (typeof document !== 'undefined') {
+      document.addEventListener('visibilitychange', handler)
+    }
+    window.addEventListener('focus', handler)
+    window.addEventListener('online', handler)
+  }
+
+  private teardownWakeListeners(): void {
+    if (!this.wakeHandler) return
+    if (typeof document !== 'undefined') {
+      document.removeEventListener('visibilitychange', this.wakeHandler)
+    }
+    if (typeof window !== 'undefined') {
+      window.removeEventListener('focus', this.wakeHandler)
+      window.removeEventListener('online', this.wakeHandler)
+    }
+    this.wakeHandler = null
   }
 
   private startKeepAlive(): void {


### PR DESCRIPTION
## Summary

Diagnosed from the daemon log attached to #995. The daemon stays healthy the whole time; the GUI is what gets stuck on the loading page. Root cause: the session JWT (TTL 300s) is refreshed by a 4-minute `setInterval` that is **frozen while the OS suspends the process**. Across a sleep the token expires, and on resume the GUI's first request is rejected by the daemon with `ExpiredSignature`. The log shows this twice — once it self-recovered, once it stalled for ~13 min until the user restarted ("需要重启方可恢复").

- **Wake-triggered refresh** (`client.ts`): on `visibilitychange`/`focus`/`online`, re-mint the session if the token is gone or within 30s of expiry, so the first post-resume request never carries a stale token. (eddc00e5)
- **IPC timeout guard** (`client.ts`): race the native `getDaemonSession()` against a 10s timeout. A stalled native side previously left the pre-emptive/401-retry `await refreshSession()` hanging forever — the real reason the loading screen never recovered. Now it rejects and surfaces. (eddc00e5)
- **Loading-screen watchdog + Retry** (`App.tsx`): the blank `return null` gate could trap the UI indefinitely. Added a 12s watchdog that falls through to the actionable error screen, made the error branch reachable while still "loading", and added a Retry button that re-runs bootstrap → forces a refresh → refetches — recovering the common stale-token case without an app restart. (eddc00e5)

Ref #995.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `eslint` on changed files — 0 errors
- [x] `vitest run` for daemon client + bootstrap suites — 43 passed
- [ ] Manual: let the app idle past 5 min / sleep the machine, then wake — confirm the dashboard reappears without a restart (cannot reproduce sleep on this Linux/WSL box).
- [ ] Manual: simulate a stalled `getDaemonSession()` and confirm the loading screen shows the error + working Retry after ~12s.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added in-app retry for bootstrap failures so users can recover without restarting.
  * Proactively refreshes session when the app resumes, regains focus, or comes back online.

* **Bug Fixes**
  * Prevents indefinite blank screen during startup by timing out stalled loads.
  * Session refreshes now time out instead of hanging, improving recovery and responsiveness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->