### PR TITLE
fix(restart): re-unlock keychain after daemon restart and restore GUI tracing

### DIFF
--- a/.claude/skills/babysit-pr/SKILL.md
+++ b/.claude/skills/babysit-pr/SKILL.md
@@ -54,9 +54,12 @@ gh pr view --json statusCheckRollup --jq '.statusCheckRollup[] | {context: .cont
 ```
 
 Classify:
-- **All checks passed (and no new unprocessed review comments)** → go to **Cleanup (success)**
 - **Some checks still PENDING** → schedule wakeup (180s), do NOT increment round
 - **Some checks FAILED** → proceed to Step 2
+- **All checks passed** → proceed to Step 2 anyway to collect review comments.
+  Only go to **Cleanup (success)** if Step 2b also finds zero unprocessed
+  actionable comments. Never short-circuit before checking comments — bots
+  like CodeRabbit post asynchronously and may finish after CI passes.
 
 ### Step 2 — Gather failures and review comments
 
@@ -69,19 +72,36 @@ From the checks output in Step 1, collect all checks with `conclusion == "failur
   gh run view <run_id> --log-failed 2>/dev/null | tail -100
   ```
 
-#### 2b — Review comments from coderabbitai and github-actions
+#### 2b — Review comments from bots
+
+GitHub bots post comments in **three** different locations. You must check all three
+to avoid missing feedback. Bot usernames always end with `[bot]` — use `contains`
+matching, never exact equality.
 
 ```bash
-# Inline review comments
-gh api repos/UniClipboard/UniClipboard/pulls/<PR_NUMBER>/comments \
-  --jq '[.[] | select(.user.login == "coderabbitai" or .user.login == "github-actions[bot]" or .user.login == "github-actions") | {id, user: .user.login, body, path, line, diff_hunk, created_at}]'
+BOT_FILTER='select(.user.login | test("coderabbitai|github-actions|codecov"))'
 
-# Top-level review bodies
+# 1. Inline review comments (attached to specific diff lines)
+gh api repos/UniClipboard/UniClipboard/pulls/<PR_NUMBER>/comments \
+  --jq "[.[] | ${BOT_FILTER} | {id, user: .user.login, body, path, line, diff_hunk, created_at}]"
+
+# 2. Review bodies (the top-level text of a review submission)
 gh api repos/UniClipboard/UniClipboard/pulls/<PR_NUMBER>/reviews \
-  --jq '[.[] | select(.user.login == "coderabbitai" or .user.login == "github-actions[bot]" or .user.login == "github-actions") | {id, user: .user.login, body, state}]'
+  --jq "[.[] | ${BOT_FILTER} | {id, user: .user.login, body, state}]"
+
+# 3. Issue comments (general PR comments — where CodeRabbit posts its
+#    walkthrough summary; also used by codecov, react-doctor, vercel, etc.)
+gh api repos/UniClipboard/UniClipboard/issues/<PR_NUMBER>/comments \
+  --jq "[.[] | ${BOT_FILTER} | {id, user: .user.login, body: (.body | .[0:2000]), created_at}]"
 ```
 
 Filter out IDs already in `processed_comment_ids`.
+
+> **Why all three?** CodeRabbit posts its walkthrough + actionable findings as
+> an *issue* comment, not a review comment. If you only check `pulls/comments`
+> and `pulls/reviews`, you will miss it entirely. The `[bot]` suffix on
+> usernames is added by GitHub for app-installed bots — filtering on the bare
+> name (e.g. `"coderabbitai"`) silently drops every match.
 
 ### Step 3 — Analyze and fix
 
@@ -190,3 +210,6 @@ This helps the user understand what was deliberately not addressed.
 - Running indefinitely when CI is stuck on an infrastructure issue (not a code problem)
 - Modifying files unrelated to the review feedback
 - Ignoring CI failures and only processing review comments (or vice versa)
+- Only checking `pulls/comments` + `pulls/reviews` and skipping `issues/comments` — CodeRabbit's main comment lives there
+- Filtering bot usernames with exact match (`== "coderabbitai"`) instead of substring/regex (`test("coderabbitai")`) — GitHub appends `[bot]` to app-installed bot names
+- Declaring success when CI passes without first scanning all three comment endpoints for unprocessed actionable feedback

--- a/src-tauri/crates/uc-desktop/src/daemon_recovery.rs
+++ b/src-tauri/crates/uc-desktop/src/daemon_recovery.rs
@@ -1,0 +1,139 @@
+//! Daemon recovery orchestration for desktop hosts.
+
+use async_trait::async_trait;
+use uc_daemon_client::{DaemonConnectionState, DaemonQueryClient};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UnlockRecoveryOutcome {
+    Unlocked,
+    Unavailable,
+    Failed,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DaemonRecoveryReport {
+    pub unlock: UnlockRecoveryOutcome,
+    pub lifecycle_ready: bool,
+}
+
+#[async_trait]
+trait DaemonRecoveryClient: Send + Sync {
+    async fn unlock_encryption(&self) -> anyhow::Result<bool>;
+    async fn lifecycle_retry(&self) -> anyhow::Result<()>;
+}
+
+#[async_trait]
+impl DaemonRecoveryClient for DaemonQueryClient {
+    async fn unlock_encryption(&self) -> anyhow::Result<bool> {
+        DaemonQueryClient::unlock_encryption(self).await
+    }
+
+    async fn lifecycle_retry(&self) -> anyhow::Result<()> {
+        DaemonQueryClient::lifecycle_retry(self).await
+    }
+}
+
+pub async fn recover_after_restart(
+    connection_state: DaemonConnectionState,
+) -> DaemonRecoveryReport {
+    let client = DaemonQueryClient::new(connection_state);
+    recover_after_restart_with(&client).await
+}
+
+async fn recover_after_restart_with(
+    client: &(impl DaemonRecoveryClient + ?Sized),
+) -> DaemonRecoveryReport {
+    let unlock = match client.unlock_encryption().await {
+        Ok(true) => {
+            tracing::info!("encryption re-unlocked after daemon restart");
+            UnlockRecoveryOutcome::Unlocked
+        }
+        Ok(false) => {
+            tracing::info!("encryption not initialized or keyring miss after restart");
+            UnlockRecoveryOutcome::Unavailable
+        }
+        Err(error) => {
+            tracing::warn!(error = %error, "post-restart keyring unlock failed");
+            UnlockRecoveryOutcome::Failed
+        }
+    };
+
+    let lifecycle_ready = match client.lifecycle_retry().await {
+        Ok(()) => {
+            tracing::info!("post-restart lifecycle boot completed");
+            true
+        }
+        Err(error) => {
+            tracing::warn!(error = %error, "post-restart lifecycle retry failed");
+            false
+        }
+    };
+
+    DaemonRecoveryReport {
+        unlock,
+        lifecycle_ready,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use anyhow::anyhow;
+
+    use super::*;
+
+    #[derive(Clone)]
+    struct RecordingClient {
+        unlock_result: Result<bool, String>,
+        calls: Arc<Mutex<Vec<&'static str>>>,
+    }
+
+    #[async_trait]
+    impl DaemonRecoveryClient for RecordingClient {
+        async fn unlock_encryption(&self) -> anyhow::Result<bool> {
+            self.calls.lock().unwrap().push("unlock");
+            self.unlock_result
+                .as_ref()
+                .map(|value| *value)
+                .map_err(|error| anyhow!(error.clone()))
+        }
+
+        async fn lifecycle_retry(&self) -> anyhow::Result<()> {
+            self.calls.lock().unwrap().push("lifecycle_retry");
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn lifecycle_retry_runs_when_unlock_returns_false() {
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let client = RecordingClient {
+            unlock_result: Ok(false),
+            calls: calls.clone(),
+        };
+
+        recover_after_restart_with(&client).await;
+
+        assert_eq!(
+            calls.lock().unwrap().as_slice(),
+            ["unlock", "lifecycle_retry"]
+        );
+    }
+
+    #[tokio::test]
+    async fn lifecycle_retry_runs_when_unlock_fails() {
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let client = RecordingClient {
+            unlock_result: Err("keyring unavailable".to_string()),
+            calls: calls.clone(),
+        };
+
+        recover_after_restart_with(&client).await;
+
+        assert_eq!(
+            calls.lock().unwrap().as_slice(),
+            ["unlock", "lifecycle_retry"]
+        );
+    }
+}

--- a/src-tauri/crates/uc-desktop/src/lib.rs
+++ b/src-tauri/crates/uc-desktop/src/lib.rs
@@ -16,6 +16,7 @@ pub use uc_daemon_contract::DAEMON_API_REVISION;
 pub mod background;
 pub mod daemon;
 pub mod daemon_probe;
+pub mod daemon_recovery;
 pub mod file_ports;
 pub mod gui_wiring;
 pub mod runtime;

--- a/src-tauri/crates/uc-tauri/src/commands/restart.rs
+++ b/src-tauri/crates/uc-tauri/src/commands/restart.rs
@@ -111,31 +111,9 @@ pub async fn restart_daemon(
         uc_daemon_client::http::clear_session_token_cache().await;
         info!("daemon restarted, connection state refreshed, session cache cleared");
 
-        // Unconditionally re-unlock via keyring + lifecycle retry.
-        // Unlike cold-boot auto-unlock (which respects `auto_unlock_enabled`),
-        // a settings-triggered restart must preserve the encryption session
-        // the user already had — locking them out after their own settings
-        // change is a UX bug.
         let conn: DaemonConnectionState = (*connection_state).clone();
         tauri::async_runtime::spawn(async move {
-            let client = uc_daemon_client::DaemonQueryClient::new(conn);
-            match client.unlock_encryption().await {
-                Ok(true) => info!("encryption re-unlocked after daemon restart"),
-                Ok(false) => {
-                    info!("encryption not initialized or keyring miss after restart");
-                    return;
-                }
-                Err(e) => {
-                    warn!(error = %e, "post-restart keyring unlock failed");
-                    return;
-                }
-            }
-
-            if let Err(e) = client.lifecycle_retry().await {
-                warn!("post-restart lifecycle retry failed: {e}");
-            } else {
-                info!("post-restart lifecycle boot completed");
-            }
+            uc_desktop::daemon_recovery::recover_after_restart(conn).await;
         });
 
         Ok(())

--- a/src-tauri/crates/uc-tauri/src/commands/restart.rs
+++ b/src-tauri/crates/uc-tauri/src/commands/restart.rs
@@ -106,7 +106,38 @@ pub async fn restart_daemon(
             })?;
 
         connection_state.set(new_info);
-        info!("daemon restarted, connection state refreshed");
+        // The static JWT cache holds a token minted by the OLD daemon —
+        // the new daemon has a fresh JWT secret and will reject it.
+        uc_daemon_client::http::clear_session_token_cache().await;
+        info!("daemon restarted, connection state refreshed, session cache cleared");
+
+        // Unconditionally re-unlock via keyring + lifecycle retry.
+        // Unlike cold-boot auto-unlock (which respects `auto_unlock_enabled`),
+        // a settings-triggered restart must preserve the encryption session
+        // the user already had — locking them out after their own settings
+        // change is a UX bug.
+        let conn: DaemonConnectionState = (*connection_state).clone();
+        tauri::async_runtime::spawn(async move {
+            let client = uc_daemon_client::DaemonQueryClient::new(conn);
+            match client.unlock_encryption().await {
+                Ok(true) => info!("encryption re-unlocked after daemon restart"),
+                Ok(false) => {
+                    info!("encryption not initialized or keyring miss after restart");
+                    return;
+                }
+                Err(e) => {
+                    warn!(error = %e, "post-restart keyring unlock failed");
+                    return;
+                }
+            }
+
+            if let Err(e) = client.lifecycle_retry().await {
+                warn!("post-restart lifecycle retry failed: {e}");
+            } else {
+                info!("post-restart lifecycle boot completed");
+            }
+        });
+
         Ok(())
     }
     .instrument(span)

--- a/src-tauri/crates/uc-tauri/src/run.rs
+++ b/src-tauri/crates/uc-tauri/src/run.rs
@@ -198,6 +198,13 @@ async fn wait_for_terminate_signal() {
 /// crate::run(ctx).expect("failed to start tauri application");
 /// ```
 pub fn run(tauri_ctx: tauri::Context<tauri::Wry>) -> anyhow::Result<()> {
+    // Tracing must be initialized before anything else so all subsequent
+    // log calls (including build_gui_client_context) are captured.
+    // ADR-008 P3-3 severed the uc-bootstrap dependency that previously
+    // handled this; the GUI now initializes its own lightweight subscriber
+    // (console + JSON file, no Sentry — daemon owns telemetry export).
+    init_gui_tracing();
+
     // ADR-008 P3-3 (B2'-3): the GUI is a pure client of an external `uniclipd`.
     // It assembles ONLY the file-backed ports it needs (settings / setup-status /
     // analytics / device-id / storage paths) via `build_gui_client_context` —
@@ -823,4 +830,24 @@ pub fn run(tauri_ctx: tauri::Context<tauri::Wry>) -> anyhow::Result<()> {
         });
 
     Ok(())
+}
+
+/// Lightweight tracing init for the GUI process.
+///
+/// Sets up console (stdout) + JSON file (`uniclipboard-gui.json.<date>`)
+/// output, matching the daemon's dual-output approach. No Sentry layer —
+/// the daemon is the single authoritative telemetry exporter.
+///
+/// Must be called before any `tracing::info!` / `warn!` / `error!`.
+/// Silently no-ops if a subscriber is already registered (idempotent).
+fn init_gui_tracing() {
+    let Some(app_data_root) = uc_app_paths::app_data_root() else {
+        eprintln!("[GUI] unable to resolve app data root; tracing disabled");
+        return;
+    };
+    let logs_dir = app_data_root.join("logs");
+    let profile = uc_observability::LogProfile::from_env();
+    if let Err(e) = uc_observability::init_tracing_subscriber(&logs_dir, profile) {
+        eprintln!("[GUI] tracing init failed: {e}");
+    }
 }

--- a/src-tauri/crates/uc-tauri/src/run.rs
+++ b/src-tauri/crates/uc-tauri/src/run.rs
@@ -842,12 +842,9 @@ pub fn run(tauri_ctx: tauri::Context<tauri::Wry>) -> anyhow::Result<()> {
 /// Silently no-ops if a subscriber is already registered (idempotent).
 fn init_gui_tracing() {
     let Some(app_data_root) = uc_app_paths::app_data_root() else {
-        eprintln!("[GUI] unable to resolve app data root; tracing disabled");
         return;
     };
     let logs_dir = app_data_root.join("logs");
     let profile = uc_observability::LogProfile::from_env();
-    if let Err(e) = uc_observability::init_tracing_subscriber(&logs_dir, profile) {
-        eprintln!("[GUI] tracing init failed: {e}");
-    }
+    let _ = uc_observability::init_tracing_subscriber(&logs_dir, profile);
 }


### PR DESCRIPTION
## Summary

- **GUI tracing restored** — ADR-008 P3-3 severed the `uc-bootstrap` dependency from the GUI process, silently dropping `init_tracing_subscriber()`. All `tracing::info!/warn!/error!` in the GUI wrote to void — no console output, no `uniclipboard-gui.json` log file. Added `init_gui_tracing()` at the top of `run()` using `uc-observability` directly (`0348cbc41`).

- **Keychain re-unlock after daemon restart** — `restart_daemon` only did kill→spawn→health-check without re-unlocking the encryption session. With `auto_unlock_enabled = false`, the daemon's own startup recovery also skipped unlock, leaving the GUI locked out of clipboard history after a settings change. Now unconditionally calls `POST /encryption/unlock` + `POST /lifecycle/retry` after restart (`0b1de18fe`).

- **Stale JWT cache cleared** — the static `SESSION_TOKEN_CACHE` held a JWT minted by the old daemon. The new daemon has a fresh JWT secret, causing `401 Unauthorized` on all post-restart API calls. Now calls `clear_session_token_cache()` immediately after updating connection state (`0b1de18fe`).

## Test plan

- [x] `cargo check -p uc-tauri` passes
- [x] Verified `uniclipboard-gui.json.2026-06-09` created after rebuild — GUI tracing output restored
- [x] Verified daemon log shows `encryption session auto-unlocked via keyring` and `clipboard watcher thread started` after restart
- [ ] Verify clipboard history is accessible in GUI after network settings change triggers daemon restart
- [ ] Verify the fix works with both `auto_unlock_enabled = true` and `false`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic recovery sequence runs after daemon restarts to re-establish encryption unlocking and lifecycle readiness.

* **Bug Fixes**
  * Session/JWT cache is cleared after daemon restart to prevent reuse of stale tokens, improving restart reliability.

* **Chores**
  * Tracing/logging initialized earlier with file + console output to capture startup diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->