### PR TITLE
feat(mobile-sync): restore existing entry to clipboard on duplicate push

### DIFF
--- a/src-tauri/crates/uc-application/src/facade/mobile_sync/facade.rs
+++ b/src-tauri/crates/uc-application/src/facade/mobile_sync/facade.rs
@@ -53,10 +53,14 @@ use uc_core::ports::{
 use uc_observability::analytics::AnalyticsPort;
 
 use crate::facade::clipboard_outbound::ClipboardOutboundFacade;
+use crate::facade::clipboard_restore::ClipboardRestoreFacade;
 use crate::facade::file_transfer::FileTransferFacade;
 use crate::facade::mobile_sync::outbound_adapter::ClipboardOutboundFanOutAdapter;
+use crate::facade::mobile_sync::restore_adapter::ClipboardRestoreOnDuplicateAdapter;
 use crate::usecases::clipboard_sync::apply_inbound::ApplyInboundClipboardUseCase;
-use crate::usecases::mobile_sync::apply_incoming::MobileInboundFanOutPort;
+use crate::usecases::mobile_sync::apply_incoming::{
+    MobileDuplicateRestorePort, MobileInboundFanOutPort,
+};
 use crate::usecases::mobile_sync::{
     apply_incoming::ApplyIncomingMobileClipUseCase,
     authenticate_basic::AuthenticateBasicAuthUseCase, get_file::GetMobileSyncFileUseCase,
@@ -207,6 +211,13 @@ pub struct MobileSyncFacadeDeps {
     /// `GatedAnalyticsSink`，运行时按用户 `usage_analytics_enabled` 切换
     /// noop / 真实 sink）。测试装配传 `NoopAnalyticsSink`。
     pub analytics: Arc<dyn AnalyticsPort>,
+    /// 可选剪贴板 restore facade。装配处提供时, 移动端 PUT 触发的
+    /// `DuplicateSkipped` 分支会把已有 entry 恢复到系统剪贴板 ——
+    /// 用户从手机推送已有内容的语义是"我想粘贴", 而不是"仅同步"。
+    ///
+    /// daemon 装配传 `Some(clipboard_restore_facade)`;CLI fallback /
+    /// 单测传 `None`, 行为与本字段引入前一致。
+    pub clipboard_restore: Option<Arc<ClipboardRestoreFacade>>,
 }
 
 // ─── Facade ─────────────────────────────────────────────────────────────
@@ -263,6 +274,7 @@ impl MobileSyncFacade {
             clipboard_outbound,
             lan_lifecycle,
             analytics,
+            clipboard_restore,
         } = deps;
 
         let snapshot_port: Arc<dyn LatestClipboardSnapshotPort> =
@@ -313,6 +325,10 @@ impl MobileSyncFacade {
                         as Arc<dyn MobileInboundFanOutPort>
                 }),
                 analytics,
+                clipboard_restore.map(|facade| {
+                    Arc::new(ClipboardRestoreOnDuplicateAdapter::new(facade))
+                        as Arc<dyn MobileDuplicateRestorePort>
+                }),
             ),
             get_latest_doc: GetLatestMobileSyncDocUseCase::new(snapshot_port.clone()),
             get_file: GetMobileSyncFileUseCase::new(snapshot_port, file_staging.clone()),
@@ -983,6 +999,7 @@ mod tests {
             clipboard_outbound: None,
             lan_lifecycle: None,
             analytics: Arc::new(uc_observability::analytics::NoopAnalyticsSink::default()),
+            clipboard_restore: None,
         })
     }
 
@@ -1139,6 +1156,7 @@ mod tests {
             clipboard_outbound: None,
             lan_lifecycle: None,
             analytics: Arc::new(uc_observability::analytics::NoopAnalyticsSink::default()),
+            clipboard_restore: None,
         });
 
         // happy path
@@ -1219,6 +1237,7 @@ mod tests {
             clipboard_outbound: None,
             lan_lifecycle: None,
             analytics: Arc::new(uc_observability::analytics::NoopAnalyticsSink::default()),
+            clipboard_restore: None,
         });
 
         // 1. 旧密码可用
@@ -1328,6 +1347,7 @@ mod tests {
             clipboard_outbound: None,
             lan_lifecycle: Some(lifecycle),
             analytics: Arc::new(uc_observability::analytics::NoopAnalyticsSink::default()),
+            clipboard_restore: None,
         })
     }
 
@@ -1474,6 +1494,7 @@ mod tests {
             clipboard_outbound: None,
             lan_lifecycle: Some(lifecycle),
             analytics: Arc::new(uc_observability::analytics::NoopAnalyticsSink::default()),
+            clipboard_restore: None,
         });
 
         // enable 两开关 → lifecycle.apply(Enabled) → endpoint = BindFailed

--- a/src-tauri/crates/uc-application/src/facade/mobile_sync/mod.rs
+++ b/src-tauri/crates/uc-application/src/facade/mobile_sync/mod.rs
@@ -10,6 +10,7 @@
 
 mod facade;
 mod outbound_adapter;
+mod restore_adapter;
 
 pub use facade::streaming_scope_nonce as mobile_sync_streaming_scope_nonce;
 pub use facade::{

--- a/src-tauri/crates/uc-application/src/facade/mobile_sync/restore_adapter.rs
+++ b/src-tauri/crates/uc-application/src/facade/mobile_sync/restore_adapter.rs
@@ -1,0 +1,53 @@
+//! `ClipboardRestoreOnDuplicateAdapter` —— [`MobileDuplicateRestorePort`]
+//! 的生产实现, 把 mobile 入站去重命中事件接到 [`ClipboardRestoreFacade`]
+//! 的 restore_entry 管线。
+//!
+//! # 设计意图
+//!
+//! `ApplyIncomingMobileClipUseCase` 通过 [`MobileDuplicateRestorePort`]
+//! 这层薄抽象与"如何从 entry_id 恢复到 OS 剪贴板"解耦 ——
+//!
+//! - **测试时**: fake 实现直接 record 调用, 不必拉真实 DB / OS clipboard;
+//! - **生产时**: 本 adapter 委托 `ClipboardRestoreFacade::restore_entry`,
+//!   走完整的 snapshot 重建 → `ClipboardWriteCoordinator` 写 OS 剪贴板。
+//!
+//! # 错误降级
+//!
+//! `restore_entry` 失败仅 `warn!`, 不抛回上层 use case —— mobile 上传
+//! 是否成功只取决于"本机入站管线的 outcome", restore 是让用户能立刻
+//! Cmd-V 的 best-effort 增强。
+//!
+//! [`MobileDuplicateRestorePort`]: crate::usecases::mobile_sync::apply_incoming::MobileDuplicateRestorePort
+//! [`ClipboardRestoreFacade`]: crate::facade::clipboard_restore::ClipboardRestoreFacade
+
+use std::sync::Arc;
+
+use tracing::warn;
+
+use uc_core::ids::EntryId;
+
+use crate::facade::clipboard_restore::ClipboardRestoreFacade;
+use crate::usecases::mobile_sync::apply_incoming::MobileDuplicateRestorePort;
+
+pub(crate) struct ClipboardRestoreOnDuplicateAdapter {
+    restore_facade: Arc<ClipboardRestoreFacade>,
+}
+
+impl ClipboardRestoreOnDuplicateAdapter {
+    pub(crate) fn new(restore_facade: Arc<ClipboardRestoreFacade>) -> Self {
+        Self { restore_facade }
+    }
+}
+
+#[async_trait::async_trait]
+impl MobileDuplicateRestorePort for ClipboardRestoreOnDuplicateAdapter {
+    async fn restore_to_clipboard(&self, entry_id: &EntryId) {
+        if let Err(err) = self.restore_facade.restore_entry(entry_id.as_ref()).await {
+            warn!(
+                entry_id = %entry_id,
+                error = %err,
+                "mobile_sync duplicate restore: failed to restore existing entry to system clipboard"
+            );
+        }
+    }
+}

--- a/src-tauri/crates/uc-application/src/usecases/mobile_sync/apply_incoming.rs
+++ b/src-tauri/crates/uc-application/src/usecases/mobile_sync/apply_incoming.rs
@@ -99,6 +99,33 @@ pub(crate) trait MobileInboundFanOutPort: Send + Sync {
     );
 }
 
+/// 移动端入站去重命中时, 把已有 entry 恢复到系统剪贴板的能力抽象。
+///
+/// ## 为什么需要
+///
+/// 用户从手机推送一条"本机已存在"的内容, 语义是"我现在想在桌面粘贴
+/// 这条内容"。`ApplyInboundClipboardUseCase` 的 `DuplicateSkipped` 只
+/// 意味着"不需要再持久化", 但不等于"不需要写系统剪贴板"。如果静默
+/// 跳过, 用户 Cmd-V 粘出来的仍是上一次复制的内容, 与预期不符。
+///
+/// ## 设计 (与 `MobileInboundFanOutPort` 同模式)
+///
+/// - use case 持 trait 而非具体 facade, 测试可注入 fake;
+/// - 生产 adapter 在 `facade/mobile_sync/restore_adapter.rs`, 委托
+///   `ClipboardRestoreFacade::restore_entry`;
+/// - 失败仅 `warn!`, 不回灌成 HTTP 错误 —— mobile 上传是否"成功"
+///   只取决于本机入站管线的 outcome, restore 是 best-effort 增强。
+///
+/// ## 仅 `DuplicateSkipped` 分支调用
+///
+/// - `Applied`: 入站管线已经写了系统剪贴板, 不需要再 restore;
+/// - `DecodeFailed` / `Err(...)`: 本机入站没成功, 没有 entry 可恢复;
+/// - `Buffered`: 两步 PUT 中间态, 还没有 entry。
+#[async_trait::async_trait]
+pub(crate) trait MobileDuplicateRestorePort: Send + Sync {
+    async fn restore_to_clipboard(&self, entry_id: &EntryId);
+}
+
 // ─── Public types (pub(crate) per AGENTS.md §11.4) ──────────────────────
 
 /// Input to [`ApplyIncomingMobileClipUseCase::execute`].
@@ -341,6 +368,13 @@ pub(crate) struct ApplyIncomingMobileClipUseCase {
     /// `Buffered` / `DuplicateSkipped` / `DecodeFailed` / `Err` 都不上报，
     /// 沿用 `ClipboardEntryCaptured` 防 RemotePush 双计的红线哲学。
     analytics: Arc<dyn AnalyticsPort>,
+    /// 可选 restore port。装配处提供实现时, `DuplicateSkipped` 分支在
+    /// 确认本机已有该记录后, 把它恢复到系统剪贴板 —— 用户从手机推送已
+    /// 有内容的语义是"我想在桌面粘贴这个", 不能静默跳过。
+    ///
+    /// `None` 时静默降级(测试装配 / CLI fallback): 行为与本字段引入前
+    /// 完全一致(DuplicateSkipped 不写 OS 剪贴板)。
+    restore: Option<Arc<dyn MobileDuplicateRestorePort>>,
 }
 
 impl ApplyIncomingMobileClipUseCase {
@@ -352,6 +386,7 @@ impl ApplyIncomingMobileClipUseCase {
         file_transfer: Option<Arc<FileTransferFacade>>,
         fan_out: Option<Arc<dyn MobileInboundFanOutPort>>,
         analytics: Arc<dyn AnalyticsPort>,
+        restore: Option<Arc<dyn MobileDuplicateRestorePort>>,
     ) -> Self {
         Self {
             inbound,
@@ -361,6 +396,7 @@ impl ApplyIncomingMobileClipUseCase {
             file_transfer,
             fan_out,
             analytics,
+            restore,
         }
     }
 
@@ -456,6 +492,7 @@ impl ApplyIncomingMobileClipUseCase {
                     &dispatch_outcome,
                     snapshot_for_fanout,
                 );
+                self.maybe_restore_duplicate(&dispatch_outcome).await;
                 self.finalize_transfer_lifecycle(transfer_id, source_device_id, &dispatch_outcome)
                     .await;
                 dispatch_outcome
@@ -520,6 +557,31 @@ impl ApplyIncomingMobileClipUseCase {
             return;
         };
         fan_out.fan_out(entry_id.clone(), snapshot, source_device_id.clone());
+    }
+
+    /// `DuplicateSkipped` 分支: 把已存在的 entry 恢复到系统剪贴板。
+    ///
+    /// 用户从手机推送的语义是"我想在桌面粘贴这条内容", 即使本机已经
+    /// 持久化过相同的 entry, 系统剪贴板可能早已被后续复制操作覆盖,
+    /// 需要显式 restore 才能让 Cmd-V 粘出正确内容。
+    async fn maybe_restore_duplicate(
+        &self,
+        outcome: &Result<ApplyIncomingMobileClipOutcome, ApplyIncomingMobileClipError>,
+    ) {
+        let Some(restore) = self.restore.as_ref() else {
+            return;
+        };
+        let Ok(ApplyIncomingMobileClipOutcome::DuplicateSkipped {
+            existing_entry_id, ..
+        }) = outcome
+        else {
+            return;
+        };
+        info!(
+            entry_id = %existing_entry_id,
+            "mobile_sync apply_incoming: duplicate detected, restoring existing entry to system clipboard"
+        );
+        restore.restore_to_clipboard(existing_entry_id).await;
     }
 
     /// SyncDoc apply 完成后把 mobile_lan 路径预先打开的 transfer 关闭。
@@ -951,6 +1013,7 @@ mod tests {
             None,
             None,
             noop_analytics(),
+            None,
         )
     }
 
@@ -971,6 +1034,7 @@ mod tests {
             None,
             None,
             noop_analytics(),
+            None,
         )
     }
 
@@ -1007,6 +1071,7 @@ mod tests {
             None,
             None,
             noop_analytics(),
+            None,
         );
         (uc, buffer)
     }
@@ -1042,6 +1107,7 @@ mod tests {
             None,
             None,
             noop_analytics(),
+            None,
         );
         (uc, buffer)
     }
@@ -1066,6 +1132,7 @@ mod tests {
             None,
             None,
             noop_analytics(),
+            None,
         )
     }
 
@@ -1156,6 +1223,7 @@ mod tests {
             None,
             None,
             noop_analytics(),
+            None,
         );
         assert_eq!(buffer.len(), 0);
 
@@ -1387,6 +1455,7 @@ mod tests {
             None,
             None,
             noop_analytics(),
+            None,
         );
 
         // BufferFile event 注入 Windows-shape URI
@@ -1451,6 +1520,7 @@ mod tests {
             None,
             None,
             noop_analytics(),
+            None,
         );
 
         let outcome = uc
@@ -1532,6 +1602,7 @@ mod tests {
             None,
             Some(Arc::clone(&recorder) as Arc<dyn MobileInboundFanOutPort>),
             noop_analytics(),
+            None,
         );
 
         let outcome = uc
@@ -1581,6 +1652,7 @@ mod tests {
             None,
             Some(Arc::clone(&recorder) as Arc<dyn MobileInboundFanOutPort>),
             noop_analytics(),
+            None,
         );
 
         let outcome = uc
@@ -1621,6 +1693,7 @@ mod tests {
             None,
             Some(Arc::clone(&recorder) as Arc<dyn MobileInboundFanOutPort>),
             noop_analytics(),
+            None,
         );
 
         let outcome = uc
@@ -1661,6 +1734,7 @@ mod tests {
             None,
             Some(Arc::clone(&recorder) as Arc<dyn MobileInboundFanOutPort>),
             noop_analytics(),
+            None,
         );
 
         let outcome = uc
@@ -1711,6 +1785,7 @@ mod tests {
             None,
             None,
             noop_analytics(),
+            None,
         );
 
         let outcome = uc
@@ -1753,6 +1828,7 @@ mod tests {
             None,
             None,
             analytics,
+            None,
         )
     }
 
@@ -1779,6 +1855,7 @@ mod tests {
             None,
             None,
             analytics,
+            None,
         )
     }
 
@@ -1799,6 +1876,7 @@ mod tests {
             None,
             None,
             analytics,
+            None,
         )
     }
 
@@ -1877,5 +1955,153 @@ mod tests {
             .expect("buffer file returns Ok");
         assert!(matches!(outcome, ApplyIncomingMobileClipOutcome::Buffered));
         assert!(analytics.events().is_empty(), "{:?}", analytics.events());
+    }
+
+    // ── restore-on-duplicate trait wire-up ────────────────────────────────
+    //
+    // 验证 `ApplyIncomingMobileClipUseCase` 与 `MobileDuplicateRestorePort`
+    // 之间的接线契约。use case 只该保证"DuplicateSkipped 分支以正确的
+    // entry_id 调一次 trait, 其它分支不调"。
+
+    #[derive(Default)]
+    struct RecordingRestore {
+        calls: std::sync::Mutex<Vec<EntryId>>,
+    }
+
+    impl RecordingRestore {
+        fn calls(&self) -> Vec<EntryId> {
+            self.calls.lock().unwrap().clone()
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl MobileDuplicateRestorePort for RecordingRestore {
+        async fn restore_to_clipboard(&self, entry_id: &EntryId) {
+            self.calls.lock().unwrap().push(entry_id.clone());
+        }
+    }
+
+    /// `DuplicateSkipped` 命中 → 必须以 `existing_entry_id` 调一次 restore。
+    #[tokio::test]
+    async fn duplicate_skipped_invokes_restore_with_existing_entry_id() {
+        let mut repo = MockEntryRepo::new();
+        let existing = EntryId::from("entry-existing");
+        let existing_clone = existing.clone();
+        repo.expect_find_entry_id_by_snapshot_hash()
+            .times(1)
+            .returning(move |_| Ok(Some(existing_clone.clone())));
+        let capture = MockCapture::new();
+        let write = MockWrite::new();
+        let inbound =
+            ApplyInboundClipboardUseCase::new(Arc::new(repo), Arc::new(capture), Arc::new(write));
+
+        let recorder = Arc::new(RecordingRestore::default());
+        let uc = ApplyIncomingMobileClipUseCase::new(
+            Arc::new(inbound),
+            Arc::new(IncomingMobileBuffer::new()),
+            staging_never_called(),
+            Arc::new(FixedClock),
+            None,
+            None,
+            noop_analytics(),
+            Some(Arc::clone(&recorder) as Arc<dyn MobileDuplicateRestorePort>),
+        );
+
+        let outcome = uc
+            .execute(input_sync_doc(
+                SyncClipboardItemType::Text,
+                "already-here",
+                None,
+            ))
+            .await
+            .expect("dedup hit ok");
+        assert!(matches!(
+            outcome,
+            ApplyIncomingMobileClipOutcome::DuplicateSkipped { .. }
+        ));
+
+        let calls = recorder.calls();
+        assert_eq!(calls.len(), 1, "DuplicateSkipped 必须触发 restore 一次");
+        assert_eq!(calls[0], existing);
+    }
+
+    /// `Applied` 分支不调 restore —— 入站管线已经写了系统剪贴板。
+    #[tokio::test]
+    async fn applied_does_not_invoke_restore() {
+        let mut repo = MockEntryRepo::new();
+        repo.expect_find_entry_id_by_snapshot_hash()
+            .times(1)
+            .returning(|_| Ok(None));
+        let mut capture = MockCapture::new();
+        capture
+            .expect_capture()
+            .times(1)
+            .returning(|_, _, _| Ok(Some(EntryId::from("entry-new"))));
+        let mut write = MockWrite::new();
+        write.expect_write().times(1).returning(|_| Ok(()));
+        let inbound =
+            ApplyInboundClipboardUseCase::new(Arc::new(repo), Arc::new(capture), Arc::new(write));
+
+        let recorder = Arc::new(RecordingRestore::default());
+        let uc = ApplyIncomingMobileClipUseCase::new(
+            Arc::new(inbound),
+            Arc::new(IncomingMobileBuffer::new()),
+            staging_never_called(),
+            Arc::new(FixedClock),
+            None,
+            None,
+            noop_analytics(),
+            Some(Arc::clone(&recorder) as Arc<dyn MobileDuplicateRestorePort>),
+        );
+
+        let outcome = uc
+            .execute(input_sync_doc(
+                SyncClipboardItemType::Text,
+                "new content",
+                None,
+            ))
+            .await
+            .expect("applied ok");
+        assert!(matches!(
+            outcome,
+            ApplyIncomingMobileClipOutcome::Applied { .. }
+        ));
+        assert_eq!(recorder.calls().len(), 0, "Applied 分支不得触发 restore");
+    }
+
+    /// `DecodeFailed` 分支不调 restore —— 本机入站没成功, 没有 entry 可恢复。
+    #[tokio::test]
+    async fn decode_failed_does_not_invoke_restore() {
+        let repo = MockEntryRepo::new();
+        let capture = MockCapture::new();
+        let write = MockWrite::new();
+        let inbound =
+            ApplyInboundClipboardUseCase::new(Arc::new(repo), Arc::new(capture), Arc::new(write));
+
+        let recorder = Arc::new(RecordingRestore::default());
+        let uc = ApplyIncomingMobileClipUseCase::new(
+            Arc::new(inbound),
+            Arc::new(IncomingMobileBuffer::new()),
+            staging_never_called(),
+            Arc::new(FixedClock),
+            None,
+            None,
+            noop_analytics(),
+            Some(Arc::clone(&recorder) as Arc<dyn MobileDuplicateRestorePort>),
+        );
+
+        let outcome = uc
+            .execute(input_sync_doc(SyncClipboardItemType::Text, "", None))
+            .await
+            .expect("decode failure surfaces as outcome");
+        assert!(matches!(
+            outcome,
+            ApplyIncomingMobileClipOutcome::DecodeFailed { .. }
+        ));
+        assert_eq!(
+            recorder.calls().len(),
+            0,
+            "DecodeFailed 分支不得触发 restore"
+        );
     }
 }

--- a/src-tauri/crates/uc-bootstrap/src/non_gui_runtime.rs
+++ b/src-tauri/crates/uc-bootstrap/src/non_gui_runtime.rs
@@ -257,6 +257,7 @@ pub fn build_mobile_sync_facade(
     // CLI fallback / 不接 P2P 出站的入口传 `None`, mobile 上传仅落地本机,
     // 不传播。
     clipboard_outbound: Option<Arc<ClipboardOutboundFacade>>,
+    clipboard_restore: Option<Arc<ClipboardRestoreFacade>>,
 ) -> Arc<MobileSyncFacade> {
     Arc::new(MobileSyncFacade::new(MobileSyncFacadeDeps {
         clock: deps.system.clock.clone(),
@@ -286,6 +287,7 @@ pub fn build_mobile_sync_facade(
         // sink。bootstrap 已把 GatedAnalyticsSink 包好，runtime 切换 noop / 真
         // 实 sink 是 sink 自身职责，不在此装配。
         analytics: deps.analytics.clone(),
+        clipboard_restore,
     }))
 }
 
@@ -385,6 +387,8 @@ pub fn build_app_facade_from_deps(
                 // `build_daemon_lifecycle_facades` 那条路径, 在那里以
                 // `Some(clipboard_outbound)` 装入完整 fan-out 能力(含文件 blob
                 // 发布)。
+                None,
+                // CLI fallback 不接 restore (无 OS clipboard 写能力)。
                 None,
             )
         });

--- a/src-tauri/crates/uc-daemon/src/daemon/app_facade_assembly.rs
+++ b/src-tauri/crates/uc-daemon/src/daemon/app_facade_assembly.rs
@@ -13,8 +13,8 @@ use std::sync::Arc;
 
 use uc_application::deps::AppDeps;
 use uc_application::facade::{
-    AppPaths, BlobTransferFacade, ClipboardOutboundFacade, ClipboardSyncFacade,
-    DaemonLifecycleFacades, FileTransferFacade,
+    AppPaths, BlobTransferFacade, ClipboardOutboundFacade, ClipboardRestoreFacade,
+    ClipboardSyncFacade, DaemonLifecycleFacades, FileTransferFacade,
 };
 use uc_application::ApplyInboundClipboardUseCase;
 use uc_bootstrap::{build_mobile_sync_facade, SpaceSetupAssembly};
@@ -49,6 +49,9 @@ pub struct DaemonLifecycleFacadesInput<'a> {
     /// 喂给 `MobileSyncFacade`(本字段) 与 daemon `run()`(`DaemonApp`),
     /// 两条链路共用单点状态机。
     pub lan_lifecycle: Arc<dyn MobileLanLifecyclePort>,
+    /// 进程级 `ClipboardRestoreFacade`。移动端 PUT 去重命中时恢复已有
+    /// entry 到系统剪贴板。
+    pub clipboard_restore: Option<Arc<ClipboardRestoreFacade>>,
 }
 
 /// 构造 5 个 daemon-lifecycle 子 facade。返回的 [`DaemonLifecycleFacades`]
@@ -67,6 +70,7 @@ pub fn build_daemon_lifecycle_facades(
         mobile_sync_apply_inbound,
         clipboard_outbound,
         lan_lifecycle,
+        clipboard_restore,
     } = input;
 
     let mobile_sync = build_mobile_sync_facade(
@@ -82,6 +86,7 @@ pub fn build_daemon_lifecycle_facades(
         // 写 file-list rep。daemon 这条装配路径必装,CLI fallback 与其他
         // 无 outbound dispatcher 的入口走 `None`。
         Some(Arc::clone(&clipboard_outbound)),
+        clipboard_restore,
     );
 
     let local_device_id = deps.device.device_identity.current_device_id().to_string();

--- a/src-tauri/crates/uc-daemon/src/daemon/host.rs
+++ b/src-tauri/crates/uc-daemon/src/daemon/host.rs
@@ -297,6 +297,7 @@ pub async fn start_in_process(
             clipboard_outbound: runtime_workers.clipboard_outbound.clone(),
             lan_lifecycle: Arc::clone(&mobile_lan_lifecycle)
                 as Arc<dyn uc_core::ports::MobileLanLifecyclePort>,
+            clipboard_restore: app_facade.clipboard_restore.clone(),
         });
 
     app_facade.install_daemon_lifecycle(lifecycle_facades);

--- a/src-tauri/crates/uc-webserver/src/mobile_lan/test_support.rs
+++ b/src-tauri/crates/uc-webserver/src/mobile_lan/test_support.rs
@@ -246,6 +246,7 @@ pub(crate) async fn build_facade_with_seeded_device(
         lan_lifecycle: None,
         // schema doc §7.6 / §12.2 P1：测试装配走 noop sink，不污染 capture。
         analytics: Arc::new(uc_observability::analytics::NoopAnalyticsSink::default()),
+        clipboard_restore: None,
     }))
 }
 


### PR DESCRIPTION
## Summary

- When a mobile device pushes content that already exists locally (dedup hit → `DuplicateSkipped`), the system clipboard likely holds stale content from a later copy. Previously this was silently skipped — user would Cmd-V the wrong content. Now the existing entry is restored to the OS clipboard via `RestoreClipboardSelectionUseCase`, matching the user's intent of "I want to paste this now." (ea6f568)
- Follows the established `MobileInboundFanOutPort` pattern: new `MobileDuplicateRestorePort` async trait in the use case layer, with a `ClipboardRestoreOnDuplicateAdapter` in the facade layer wrapping `ClipboardRestoreFacade`
- Only affects the mobile sync inbound path; P2P inbound dedup is unchanged (no echo-loop risk)
- Restore failure is best-effort: logged as `warn!`, does not backpressure into HTTP 4xx/5xx

## Test plan

- [x] `cargo check --lib -p uc-application -p uc-bootstrap -p uc-daemon -p uc-webserver` — all pass
- [x] `cargo test --lib -p uc-application -- mobile_sync::apply_incoming` — 24/24 pass (3 new restore tests)
- [x] `cargo test --lib -p uc-application -- facade::mobile_sync` — 10/10 pass
- [ ] Manual verification: push same text/image twice from iOS Shortcut, confirm Cmd-V pastes the expected content on second push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Mobile sync now restores clipboard entries when duplicate items are detected, preserving clipboard data during synchronization from mobile devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->