### PR TITLE
fix(mobile-sync): use content-only hash to prevent duplicate pulls on iPhone

### DIFF
--- a/src-tauri/crates/uc-application/src/usecases/mobile_sync/get_latest_doc.rs
+++ b/src-tauri/crates/uc-application/src/usecases/mobile_sync/get_latest_doc.rs
@@ -262,13 +262,9 @@ mod tests {
         // Filename uses first 8 chars of entry_id + .png
         assert_eq!(meta.text, "clipboard_entry-im.png");
         assert_eq!(meta.data_name.as_deref(), Some("clipboard_entry-im.png"));
-        // SyncClipboard 的 Image/File profile hash = sha256("filename|SHA256(bytes)")。
-        let content_hash = hex::encode(Sha256::digest(&bytes)).to_ascii_uppercase();
-        let expected_profile_hash = hex::encode(Sha256::digest(format!(
-            "clipboard_entry-im.png|{content_hash}"
-        )))
-        .to_ascii_uppercase();
-        assert_eq!(meta.hash.as_deref(), Some(expected_profile_hash.as_str()));
+        // Hash = SHA-256(bytes) — content-only, no filename component.
+        let expected_hash = hex::encode(Sha256::digest(&bytes)).to_ascii_uppercase();
+        assert_eq!(meta.hash.as_deref(), Some(expected_hash.as_str()));
     }
 
     #[tokio::test]

--- a/src-tauri/crates/uc-application/src/usecases/mobile_sync/sync_clipboard_mapping.rs
+++ b/src-tauri/crates/uc-application/src/usecases/mobile_sync/sync_clipboard_mapping.rs
@@ -79,26 +79,18 @@ pub(super) fn derive_data_name(
     }
 }
 
-/// 按 SyncClipboard profile hash 规则计算 hash。
+/// 按内容字节计算 SHA-256 hash，不混入 dataName。
 ///
-/// Text 直接对 UTF-8 字节算 SHA-256；Image/File 先算内容 SHA-256，再用
-/// `dataName|CONTENT_HASH` 拼接后二次 SHA-256。返回大写十六进制。
+/// 旧实现对 Image/File 用 `dataName|CONTENT_HASH` 二次哈希，导致不同
+/// 客户端为同一份内容派生不同文件名时 hash 不一致（iOS 用 `image.png`，
+/// 本端 GET 用 `clipboard_<id>.png`），造成 iPhone 每次 pull 都认为是
+/// 新内容。改为统一对原始字节算 SHA-256，hash 仅反映内容本身。
 pub(super) fn profile_hash_for_sync(
-    item_type: SyncClipboardItemType,
-    data_name: Option<&str>,
+    _item_type: SyncClipboardItemType,
+    _data_name: Option<&str>,
     bytes: &[u8],
 ) -> String {
-    let content_hash = sha256_hex_upper(bytes);
-    match item_type {
-        SyncClipboardItemType::Image | SyncClipboardItemType::File => {
-            if let Some(name) = data_name.filter(|s| !s.is_empty()) {
-                sha256_hex_upper(format!("{name}|{content_hash}").as_bytes())
-            } else {
-                content_hash
-            }
-        }
-        SyncClipboardItemType::Text | SyncClipboardItemType::Group => content_hash,
-    }
+    sha256_hex_upper(bytes)
 }
 
 // ─── internal filename helpers ──────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **Fix duplicate-pull bug on iPhone.** The `profile_hash_for_sync` function previously hashed Image/File items as `SHA-256(dataName|CONTENT_HASH)`, but iOS and desktop derive different filenames for the same binary content (`image.png` vs `clipboard_<id>.png`). This caused hash mismatches, making iPhone treat every pull as new content. (952665c)
- **Simplify to content-only SHA-256.** Hash now reflects only the raw bytes, regardless of the client-assigned filename. Updated the corresponding test assertion in `get_latest_doc.rs` to match the new scheme.

## Test plan

- [x] Unit test updated and passing (`get_latest_doc::tests`)
- [ ] Manual verification: pair an iPhone, push an image from desktop, confirm iPhone does not re-pull the same image on subsequent syncs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved clipboard synchronization reliability—file and image content hashes are now computed based solely on content bytes, ensuring consistent syncing of identical content regardless of filename variations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->