### PR TITLE
fix: Windows update-loop fixes + diagnostics for the failing auto-update

### DIFF
--- a/src-tauri/AGENTS.md
+++ b/src-tauri/AGENTS.md
@@ -85,6 +85,7 @@ src-tauri/
 - Introducing `unwrap()/expect()` in production paths.
 - Emitting snake_case payload fields to frontend events.
 - Putting test-only crates in `crates/` as workspace members — use `tests/e2e/` + `[workspace.exclude]` to avoid polluting `cargo check --workspace`.
+- Parking RAII guards (e.g. `WorkerGuard`) in library statics + adding host-specific flush/shutdown APIs — init returns the guard; the host shell owns the drop (`process::exit` skips static destructors, losing the buffered tail).
 
 ## COMPLEXITY HOTSPOTS
 

--- a/src-tauri/crates/uc-daemon/src/daemon/run_loop.rs
+++ b/src-tauri/crates/uc-daemon/src/daemon/run_loop.rs
@@ -123,6 +123,31 @@ async fn record_upgrade_status_at_startup(app_facade: &AppFacade) {
                 to = %to,
                 "upgrade detected"
             );
+            // Seal the cursor for a *known* upgrade (`from = Some`).
+            //
+            // 这条路径没有任何需要用户交互的提示：前端 StartupModals 只在
+            // `Upgraded { from: None }`（跨未知旧版本）时弹"重新配对"提示，并在
+            // 用户确认后回调 `POST /upgrade/ack` 推进游标；`from = Some` 时前端
+            // 直接跳过，于是没有任何人 ack —— 游标永远停在旧版本，每次启动都被
+            // 重新判定为 "upgrade"（线上实测 from=0.11.1 反复出现，且 headless /
+            // server-node 场景根本没有 GUI 来调 ack）。由 daemon 在这里自行推进，
+            // 既修掉重复判定，也让无 GUI 的部署能正常收敛。
+            //
+            // 故意 **不** 处理 `from = None`：那条路径必须先让前端把"重新配对"
+            // 提示展示给用户，daemon 若抢先 ack 会让随后的 detect 立即返回
+            // NoChange、提示永远不弹。`None` 的游标推进留给前端 UpgradeNotice 的
+            // dismiss 回调。失败仅警告，不阻塞启动；下次启动会重试。
+            if from.is_some() {
+                if let Err(error) = app_facade.upgrade.acknowledge(DAEMON_VERSION).await {
+                    tracing::warn!(
+                        target: "upgrade",
+                        error = %error,
+                        to = %to,
+                        "known upgrade detected but failed to seal version cursor; \
+                         upgrade will be re-detected next boot"
+                    );
+                }
+            }
         }
         UpgradeStatus::Downgraded { from, to } => {
             tracing::info!(

--- a/src-tauri/crates/uc-daemon/src/main.rs
+++ b/src-tauri/crates/uc-daemon/src/main.rs
@@ -1,3 +1,13 @@
+// Prevents an extra console window on Windows in release, DO NOT REMOVE!!
+//
+// `uniclipd` is a console-subsystem binary by default. In production it is only
+// ever spawned detached (`DETACHED_PROCESS`, stdio nulled) by the GUI/CLI, but
+// any launch path that forgets those flags — an installer relaunch, the update
+// flow, a stray double-click — flashes a black console window. Promoting the
+// release build to the Windows GUI subsystem suppresses that window regardless
+// of how the process is started. Debug builds keep the console for dev logs.
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+
 //! `uniclipd` — standalone UniClipboard daemon binary.
 //!
 //! Thin entry point that initializes platform prerequisites and delegates to

--- a/src-tauri/crates/uc-observability/src/init.rs
+++ b/src-tauri/crates/uc-observability/src/init.rs
@@ -16,7 +16,6 @@
 //! builders and registers a global subscriber without any extra layers.
 
 use std::path::Path;
-use std::sync::OnceLock;
 
 use tracing::Subscriber;
 use tracing_appender::non_blocking::WorkerGuard;
@@ -27,11 +26,6 @@ use tracing_subscriber::{fmt, registry};
 
 use crate::format::FlatJsonFormat;
 use crate::profile::LogProfile;
-
-/// Static storage for the JSON file writer guard.
-/// The guard must live for the application's lifetime to ensure the non-blocking
-/// writer flushes all pending log entries.
-static JSON_GUARD: OnceLock<WorkerGuard> = OnceLock::new();
 
 /// Build the console (pretty) layer with per-layer filtering.
 ///
@@ -113,8 +107,14 @@ where
 /// Both layers get independent `EnvFilter`s from the given profile.
 /// If `RUST_LOG` is set, it overrides the profile filters for both layers.
 ///
-/// The `WorkerGuard` for the JSON file writer is stored in a static `OnceLock`
-/// to prevent early drop.
+/// Returns the [`WorkerGuard`] for the JSON file writer. **Ownership is the
+/// caller's** — this is `tracing_appender`'s native RAII contract: keep the
+/// guard alive for the process lifetime, and drop it as the final step of a
+/// clean shutdown to drain buffered lines to disk. This matters for hosts that
+/// exit via `process::exit` (e.g. Tauri's `app.restart()` after an update
+/// install), which skips static destructors: a guard parked in a static would
+/// never drop, silently losing the most recent — and most diagnostically
+/// valuable — buffered lines.
 ///
 /// # Arguments
 ///
@@ -127,19 +127,18 @@ where
 /// Returns `Err` if:
 /// - The global subscriber is already registered
 /// - The logs directory cannot be created
-pub fn init_tracing_subscriber(logs_dir: &Path, profile: LogProfile) -> anyhow::Result<()> {
+#[must_use = "dropping the guard stops the JSON file writer; hold it for the process lifetime"]
+pub fn init_tracing_subscriber(
+    logs_dir: &Path,
+    profile: LogProfile,
+) -> anyhow::Result<WorkerGuard> {
     let console_layer = build_console_layer(&profile);
     let (json_layer, guard) = build_json_layer(logs_dir, &profile)?;
-
-    // Store guard to keep writer alive for app lifetime
-    if JSON_GUARD.set(guard).is_err() {
-        anyhow::bail!("JSON log guard already initialized (init_tracing_subscriber called twice?)");
-    }
 
     // Compose and register the global subscriber
     registry().with(console_layer).with(json_layer).try_init()?;
 
     tracing::info!(profile = %profile, "Tracing initialized with dual output");
 
-    Ok(())
+    Ok(guard)
 }

--- a/src-tauri/crates/uc-tauri/src/run.rs
+++ b/src-tauri/crates/uc-tauri/src/run.rs
@@ -203,7 +203,10 @@ pub fn run(tauri_ctx: tauri::Context<tauri::Wry>) -> anyhow::Result<()> {
     // ADR-008 P3-3 severed the uc-bootstrap dependency that previously
     // handled this; the GUI now initializes its own lightweight subscriber
     // (console + JSON file, no Sentry — daemon owns telemetry export).
-    init_gui_tracing();
+    // The returned guard owns the JSON writer thread; it is moved into the
+    // run-loop closure below and dropped at `RunEvent::Exit` so buffered log
+    // lines reach disk before tao's destructor-skipping `process::exit`.
+    let mut json_log_guard = init_gui_tracing();
 
     // ADR-008 P3-3 (B2'-3): the GUI is a pure client of an external `uniclipd`.
     // It assembles ONLY the file-backed ports it needs (settings / setup-status /
@@ -815,6 +818,13 @@ pub fn run(tauri_ctx: tauri::Context<tauri::Wry>) -> anyhow::Result<()> {
                         let stopped = uc_desktop::daemon_probe::stop_local_daemon_on_full_quit();
                         info!(stopped, "full quit: local daemon stop attempt complete");
                     }
+                    // LAST step before tao calls `process::exit` (which skips
+                    // destructors): drop the JSON writer guard, blocking until
+                    // buffered log lines are on disk. This preserves the tail of
+                    // the log across an updater `app.restart()` — and every other
+                    // clean exit — instead of losing the most diagnostically
+                    // valuable lines (e.g. the update install failure string).
+                    drop(json_log_guard.take());
                 }
                 // macOS: 点击 Dock 图标时，若没有可见窗口则恢复主窗口。
                 #[cfg(target_os = "macos")]
@@ -840,11 +850,16 @@ pub fn run(tauri_ctx: tauri::Context<tauri::Wry>) -> anyhow::Result<()> {
 ///
 /// Must be called before any `tracing::info!` / `warn!` / `error!`.
 /// Silently no-ops if a subscriber is already registered (idempotent).
-fn init_gui_tracing() {
-    let Some(app_data_root) = uc_app_paths::app_data_root() else {
-        return;
-    };
+///
+/// Returns the JSON writer's [`uc_observability::WorkerGuard`]. The caller must
+/// keep it alive for the process lifetime and drop it on clean shutdown
+/// (`RunEvent::Exit`) to drain buffered lines before tao's `process::exit`
+/// skips destructors — otherwise the tail of the log (e.g. an update install
+/// failure) is lost. `None` when the app-data root is unavailable or a
+/// subscriber was already registered.
+fn init_gui_tracing() -> Option<uc_observability::WorkerGuard> {
+    let app_data_root = uc_app_paths::app_data_root()?;
     let logs_dir = app_data_root.join("logs");
     let profile = uc_observability::LogProfile::from_env();
-    let _ = uc_observability::init_tracing_subscriber(&logs_dir, profile);
+    uc_observability::init_tracing_subscriber(&logs_dir, profile).ok()
 }

--- a/src-tauri/crates/uc-webserver/src/api/analytics.rs
+++ b/src-tauri/crates/uc-webserver/src/api/analytics.rs
@@ -185,6 +185,69 @@ fn event_kind_tag(req: &CaptureUiEventRequest) -> &'static str {
     }
 }
 
+/// Emit a structured, body-safe diagnostic line for update-lifecycle events.
+///
+/// The generic `analytics ui event captured` line above is intentionally
+/// body-free for privacy. But the update enums (`action` / `outcome` /
+/// `error_kind` / `failure_kind` / `phase` / `delivery_status`) carry **no**
+/// user data — `error_kind` is a bounded `<32`-char identifier (schema doc
+/// §6.1), the rest are fixed discriminants — so recording them is safe.
+///
+/// Why duplicate them into the daemon JSON log when they already flow to
+/// PostHog: when the user has telemetry **off** (the common case) nothing
+/// reaches PostHog, and the GUI's own local log can be lost when an updater
+/// `app.restart()` exits the process before its non-blocking writer flushes.
+/// The daemon log is a separate file that survives the GUI restart, so mirroring
+/// these fields here is the only durable on-device signal for diagnosing a
+/// failing auto-update (e.g. the loop observed in `uniclipboard-daemon.json`:
+/// repeated `check_performed=available` → `action_invoked` → daemon bounce).
+fn log_update_diag(req: &CaptureUiEventRequest) {
+    match req {
+        CaptureUiEventRequest::ActionInvoked {
+            action,
+            outcome,
+            error_kind,
+        } => info!(
+            target: "update_diag",
+            action = ?action,
+            outcome = ?outcome,
+            error_kind = error_kind.as_deref().unwrap_or("-"),
+            "update action invoked"
+        ),
+        CaptureUiEventRequest::CheckPerformed {
+            source,
+            outcome,
+            failure_kind,
+            ..
+        } => info!(
+            target: "update_diag",
+            source = ?source,
+            outcome = ?outcome,
+            failure_kind = ?failure_kind,
+            "update check performed"
+        ),
+        CaptureUiEventRequest::DialogOpened { source, phase, .. } => info!(
+            target: "update_diag",
+            source = ?source,
+            phase = ?phase,
+            "update dialog opened"
+        ),
+        CaptureUiEventRequest::Dismissed { phase, source } => info!(
+            target: "update_diag",
+            phase = ?phase,
+            source = ?source,
+            "update dialog dismissed"
+        ),
+        CaptureUiEventRequest::NotificationShown {
+            delivery_status, ..
+        } => info!(
+            target: "update_diag",
+            delivery_status = ?delivery_status,
+            "update notification shown"
+        ),
+    }
+}
+
 /// POST /analytics/capture
 ///
 /// Decode a GUI UI-interaction event and hand it to the daemon's analytics sink.
@@ -206,6 +269,10 @@ async fn capture_handler(
 ) -> Result<Json<ApiEnvelope<CaptureUiEventResponse>>, ApiError> {
     // Tag only — never log the event body.
     info!(kind = event_kind_tag(&req), "analytics ui event captured");
+    // Additionally mirror the body-safe update fields (outcome / error_kind /
+    // failure_kind / …) into the durable daemon log so a failing auto-update is
+    // diagnosable even with telemetry off and the GUI log lost on restart.
+    log_update_diag(&req);
     state.analytics.capture(into_event(req));
     Ok(Json(ApiEnvelope::now(CaptureUiEventResponse {
         accepted: true,


### PR DESCRIPTION
## Context

A Windows user on v0.14.0-alpha.9 reported persistent terminal-window popups and an auto-update that never succeeds. The daemon log for the day (`uniclipboard-daemon.json.2026-06-10`) shows the shape clearly:

- **8 daemon starts** in ~4h (6 of them within 20 minutes), each preceded by `previous daemon run exited abnormally (no clean shutdown)`
- `upgrade detected from=0.11.1 to=0.14.0-alpha.9` on **every** start — the version cursor never advances, and the binary never gets replaced
- Each daemon start is followed within seconds by GUI update-lifecycle analytics (`check_performed` / `action_invoked` / two `dialog_opened`), i.e. the user repeatedly attempting the update: stop daemon (hard kill) → NSIS fails to replace → daemon respawned → loop

The **actual NSIS failure string is missing**: the GUI log for the day was never flushed (non-blocking writer buffer lost on `app.restart()` / `process::exit`), and telemetry is off so `error_kind` never left the device. This PR fixes the two confirmed bugs and closes both observability gaps so the next occurrence is diagnosable.

## Changes

1. **fix(daemon): suppress console window for `uniclipd` on Windows release builds**
   `uniclipd.exe` was a console-subsystem binary; any launch path missing `DETACHED_PROCESS` flashes a console window. Release builds now use the GUI subsystem (same attribute as the main binary); debug keeps the console.

2. **fix(upgrade): seal version cursor for known upgrades at daemon startup**
   `Upgraded { from: Some(v) }` had no owner for the ack: the daemon only logged it, and the frontend only acks the `from: None` re-pair-notice path. The daemon now seals the cursor for known upgrades; `from: None` is deliberately left to the frontend so the re-pair notice isn't suppressed. Also covers headless deployments with no GUI to call `/upgrade/ack`.

3. **fix(logging): return the JSON writer guard to the host so clean exits flush the log tail**
   `init_tracing_subscriber` parked the `WorkerGuard` in a library static, so destructor-skipping exits (`app.restart()` after update install, full-quit) lost the buffered tail — exactly the install-failure line we need. Restored tracing_appender's native RAII contract: init returns the guard, the GUI drops it at `RunEvent::Exit`. Library surface shrinks (no static, no bespoke flush API); anti-pattern recorded in AGENTS.md.

4. **feat(webserver): mirror body-safe update lifecycle fields into the daemon log**
   `/analytics/capture` now logs `action` / `outcome` / `error_kind` / `failure_kind` under the `update_diag` target. Fixed enum discriminants and bounded `<32`-char identifiers only — no user data. This is the durable on-device evidence when telemetry is off and the GUI log is lost.

## What this does NOT fix

The root cause of the NSIS install failure itself is still unknown (candidates: `uniclipd.exe` re-locked between stop and install, GUI exe/DLL lock, AV interference). Items 3+4 exist precisely to capture it on the next occurrence. Affected users need to install this build manually once to escape the loop.

## Verification

- `cargo build -p uc-daemon --bin uniclipd` ✓
- `cargo check -p uc-observability -p uc-webserver -p uc-tauri` ✓
- `cargo test -p uc-application upgrade` — 12 passed ✓
- macOS HUD/console behavior untouched; `windows_subsystem` attribute is a no-op off Windows