### PR TITLE
ci(release): sign artifacts (SHA256SUMS) and document verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -274,6 +274,49 @@ jobs:
           echo "Release assets:"
           ls -lh release-assets
 
+      - name: Sign release assets (SHA256SUMS + minisign)
+        env:
+          MINISIGN_RELEASE_PRIVATE_KEY: ${{ secrets.MINISIGN_RELEASE_PRIVATE_KEY }}
+          MINISIGN_RELEASE_PASSWORD: ${{ secrets.MINISIGN_RELEASE_PASSWORD }}
+          VERSION: ${{ needs.validate.outputs.version }}
+        run: |
+          cd release-assets
+
+          # Checksum every release artifact. Exclude the checksum files themselves
+          # (the .minisig won't exist yet, but guard against re-runs anyway).
+          : > SHA256SUMS.txt
+          while IFS= read -r f; do
+            sha256sum "$f" >> SHA256SUMS.txt
+          done < <(find . -maxdepth 1 -type f \
+            ! -name 'SHA256SUMS.txt' ! -name 'SHA256SUMS.txt.minisig' \
+            -printf '%P\n' | sort)
+
+          echo "=== SHA256SUMS.txt ==="
+          cat SHA256SUMS.txt
+
+          # Sign the checksum file with the dedicated release-artifact minisign key.
+          # Skipped (with a warning) when the secret isn't configured yet, so a
+          # release never hard-fails during rollout — SHA256SUMS.txt is still shipped.
+          if [ -z "${MINISIGN_RELEASE_PRIVATE_KEY}" ]; then
+            echo "::warning::MINISIGN_RELEASE_PRIVATE_KEY not set — publishing SHA256SUMS.txt without a signature."
+            exit 0
+          fi
+
+          sudo apt-get update
+          sudo apt-get install -y minisign
+
+          umask 077
+          printf '%s\n' "${MINISIGN_RELEASE_PRIVATE_KEY}" > minisign-release.key
+          # minisign reads the key password from stdin when stdin is not a TTY; a
+          # passwordless key simply ignores the piped line.
+          printf '%s\n' "${MINISIGN_RELEASE_PASSWORD:-}" | \
+            minisign -S -s minisign-release.key -m SHA256SUMS.txt \
+              -t "UniClipboard v${VERSION} release artifacts (SHA256SUMS)"
+          rm -f minisign-release.key
+
+          echo "=== SHA256SUMS.txt.minisig ==="
+          cat SHA256SUMS.txt.minisig
+
       - name: Create git tag
         if: github.event_name == 'workflow_dispatch'
         run: |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,21 +1,85 @@
 # Security Policy
 
+UniClipboard is a security-oriented, end-to-end-encrypted clipboard sync tool.
+This document explains how to report vulnerabilities and how to verify the
+integrity and authenticity of the binaries we publish.
+
 ## Supported Versions
 
-Use this section to tell people about which versions of your project are
-currently being supported with security updates.
+UniClipboard is pre-1.0 and ships from a single active release line. Security
+fixes land on the latest released minor; older builds are not maintained.
+Please update to the latest release before reporting an issue.
 
-| Version | Supported          |
-| ------- | ------------------ |
-| 5.1.x   | :white_check_mark: |
-| 5.0.x   | :x:                |
-| 4.0.x   | :white_check_mark: |
-| < 4.0   | :x:                |
+| Version         | Supported          |
+| --------------- | ------------------ |
+| Latest `0.14.x` | :white_check_mark: |
+| Older `0.x`     | :x:                |
 
 ## Reporting a Vulnerability
 
-Use this section to tell people how to report a vulnerability.
+Please report security issues **privately** — do **not** open a public issue for
+an unfixed vulnerability.
 
-Tell them where to go, how often they can expect to get an update on a
-reported vulnerability, what to expect if the vulnerability is accepted or
-declined, etc.
+- Preferred: open a private report through GitHub Security Advisories on this
+  repository (the **"Report a vulnerability"** button under the **Security**
+  tab). This keeps the disclosure private until a fix is available.
+
+We aim to acknowledge new reports within a few business days and will keep you
+updated through triage, the fix, and coordinated disclosure. Thank you for
+helping keep UniClipboard users safe.
+
+## Verifying Release Downloads
+
+UniClipboard uses two **independent** signing mechanisms, both built on
+[minisign](https://jedisct1.github.io/minisign/)-compatible Ed25519 keys. The
+two keys are intentionally separate so they can be rotated independently.
+
+### 1. In-app auto-updater (always on)
+
+The Tauri auto-updater cryptographically verifies every update bundle it
+downloads against a public key embedded in the application. You do not need to
+do anything: an update whose signature is missing or invalid is rejected
+automatically.
+
+For reference, the updater public key is:
+
+```
+untrusted comment: minisign public key: B2680836865C2738
+RWQ4J1yGNghostY9tL54b8pVCWvFIc7ebO9iD11Hvf2fqcMYemYwtIWb
+```
+
+This key signs the **updater payloads only** — `*.app.tar.gz` (macOS),
+`*.AppImage.tar.gz` (Linux) and `*.nsis.zip` (Windows) — whose detached `*.sig`
+files are attached to every GitHub release. It is the same key shipped in the
+application configuration, so it is fully public.
+
+> On macOS, release builds are additionally Apple-notarized and code-signed, so
+> Gatekeeper (`spctl --assess --type execute`) validates the `.app` directly.
+
+### 2. Release artifacts (`SHA256SUMS`)
+
+Starting with the first signed release, every GitHub release includes:
+
+- `SHA256SUMS.txt` — SHA-256 checksums of every release artifact, and
+- `SHA256SUMS.txt.minisig` — a minisign signature over that checksum file.
+
+The release-artifact public key is:
+
+```
+untrusted comment: minisign public key: 0659AAD44E7EB54C
+RWRMtX5O1KpZBhZHfGaa4gqlbwnzJMINb65be0QNzl8RKwK7VOwkMvO8
+```
+
+To verify a download:
+
+```sh
+# 1. Authenticate the checksum list against the release key
+minisign -Vm SHA256SUMS.txt -P 'RWRMtX5O1KpZBhZHfGaa4gqlbwnzJMINb65be0QNzl8RKwK7VOwkMvO8'
+
+# 2. Check your download's integrity against the (now-trusted) list
+sha256sum --ignore-missing -c SHA256SUMS.txt          # Linux
+# macOS: brew install coreutils, then:
+# gsha256sum --ignore-missing -c SHA256SUMS.txt
+```
+
+If both checks pass, the file you downloaded is authentic and untampered.

--- a/docs-site/content/docs/en/getting-started/install.mdx
+++ b/docs-site/content/docs/en/getting-started/install.mdx
@@ -352,6 +352,15 @@ pairing flow.
   The App itself only talks to your desktop over the local network and doesn't depend on the proxy.
 </Callout>
 
+## Verify your download (optional)
+
+Security-conscious users can cryptographically verify a release download
+before installing it. Each signed release publishes a `SHA256SUMS.txt` and a
+[minisign](https://jedisct1.github.io/minisign/) signature
+(`SHA256SUMS.txt.minisig`); checking them confirms the file is authentic and
+untampered. The signing public key and step-by-step instructions live in the
+[security policy](https://github.com/UniClipboard/UniClipboard/blob/main/SECURITY.md#verifying-release-downloads).
+
 ## Verify the install
 
 After installing, confirm the CLI is on your `PATH`:

--- a/docs-site/content/docs/zh/getting-started/install.mdx
+++ b/docs-site/content/docs/zh/getting-started/install.mdx
@@ -324,6 +324,13 @@ App 默认走与桌面端的局域网同步（也可经 server 节点或 Tailsca
   内的桌面通信，不依赖代理。
 </Callout>
 
+## 验证下载（可选）
+
+注重安全的用户可以在安装前对下载的发布文件做密码学校验。每个签名版本都会附带
+`SHA256SUMS.txt` 及其 [minisign](https://jedisct1.github.io/minisign/) 签名
+（`SHA256SUMS.txt.minisig`），校验通过即可确认文件未被篡改、来源可信。签名公钥与
+逐步操作说明见[安全策略](https://github.com/UniClipboard/UniClipboard/blob/main/SECURITY.md#verifying-release-downloads)。
+
 ## 验证安装
 
 安装完成后，确认 CLI 已在 `PATH` 中：


### PR DESCRIPTION
## Summary

Adds verifiable authenticity for **manually downloaded** release artifacts — closing the gap an external user (Ray Schmitz) hit when looking for a way to verify downloads (only the in-app updater bundles were signed before).

- **CI signing** (`7763326bb`): the release job now generates `SHA256SUMS.txt` over every release asset and signs it with a dedicated minisign release key → `SHA256SUMS.txt.minisig`. The step is guarded on the `MINISIGN_RELEASE_PRIVATE_KEY` secret, so a release never hard-fails if the key isn't configured (the checksum file still ships, just unsigned).
- **Security policy** (`863d7fb8e`): `SECURITY.md` rewritten from the placeholder template — real supported-versions table, private vulnerability reporting, and a "Verifying Release Downloads" section documenting **both** keys (the existing Tauri updater key `B2680836865C2738` and the new release-artifact key `0659AAD44E7EB54C`), kept separate so they rotate independently.
- **Install guide** (`4e8a9dcfc`): a "Verify your download" pointer added to `install.mdx` (en + zh), linking to `SECURITY.md`.

Part of #1018 (remaining: store the signing secret, AUR/PKGBUILD upstream-signature verification, cosign + Windows code-signing follow-ups).

## Test plan

- [x] `release.yml` parses (js-yaml); signing step sits between "Prepare release assets" and "Create git tag".
- [x] `assemble-update-manifest.js` is unaffected — it only matches `*.sig`, so `SHA256SUMS.txt` / `.minisig` are ignored.
- [x] minisign release key generated (rsign2, minisign-compatible); public key published in `SECURITY.md`.
- [ ] Maintainer: set repo secret `MINISIGN_RELEASE_PRIVATE_KEY` (+ optional `MINISIGN_RELEASE_PASSWORD`). Until then, releases publish `SHA256SUMS.txt` unsigned (warning only).
- [ ] Cut one signed release and verify end-to-end: `minisign -Vm SHA256SUMS.txt -P 'RWRMtX5O1KpZBhZHfGaa4gqlbwnzJMINb65be0QNzl8RKwK7VOwkMvO8'` then `sha256sum --ignore-missing -c SHA256SUMS.txt`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release artifacts now published with cryptographic checksums and signatures for secure download verification.

* **Documentation**
  * Added step-by-step guide for verifying release downloads.
  * Updated security policy with pre-1.0 support timeline and release verification instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->