### PR TITLE
style(settings): apply thin scrollbar to release notes panel

### DIFF
--- a/src/components/setting/AboutSection.tsx
+++ b/src/components/setting/AboutSection.tsx
@@ -435,7 +435,7 @@ const AboutSection: React.FC = () => {
                   <div className="text-sm font-medium text-foreground">
                     {t('update.releaseNotes')}
                   </div>
-                  <div className="max-h-48 overflow-auto rounded-md border border-border/60 bg-muted/30 px-3 py-2 text-sm text-muted-foreground">
+                  <div className="scrollbar-thin max-h-48 overflow-auto rounded-md border border-border/60 bg-muted/30 px-3 py-2 text-sm text-muted-foreground">
                     <ReleaseNotes content={updateInfo?.body ?? ''} fallback={t('update.noNotes')} />
                   </div>
                 </div>


### PR DESCRIPTION
## Summary

- Apply the project-wide `scrollbar-thin` utility (defined in `src/styles/globals.css`) to the release notes container in the About settings section, so its overflow scrollbar matches the rest of the app instead of the heavy native scrollbar (7781f399).

Docs left as-is — no user-facing surface changed (pure visual styling tweak).

## Test plan

- [x] `eslint --fix` / `prettier` passed via pre-commit hook.
- [ ] Open Settings → About, trigger an update check with release notes long enough to overflow, and confirm the panel shows the thin themed scrollbar.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Refined scrollbar appearance in the update dialog for improved visual consistency when viewing extended release notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->