### PR TITLE
feat(npm): distribute the CLI via npm

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,186 @@
+name: 'npm Publish'
+run-name: >-
+  ${{ github.event_name == 'release'
+    && format('npm-publish-{0}', github.event.release.tag_name)
+    || format('npm-publish-manual-{0}', inputs.version) }}
+
+# Publish the CLI to npm only after a release transitions to `published`,
+# mirroring homebrew-tap.yml: the Release workflow leaves stable releases in
+# draft for human review, and npm publishes are irreversible — we must never
+# push a draft that might get discarded.
+#
+# Layout (esbuild/biome pattern): 5 platform packages
+# (@uniclipboard/cli-{platform}-{arch}, each shipping uniclip + uniclipd) and
+# one main package (uniclipboard) whose JS launcher picks the matching one via
+# optionalDependencies. Assembly lives in scripts/build-npm-packages.mjs.
+#
+# Channel mapping: the auto path publishes stable releases only (same policy
+# as homebrew-tap.yml — alpha releases are frequent and npm versions are
+# permanent). Prereleases can still be published via workflow_dispatch; their
+# version suffix maps to the npm dist-tag (X.Y.Z-alpha.N → `alpha`), and only
+# stable gets `latest`.
+#
+# `workflow_dispatch` is exposed for debugging / re-runs against an existing
+# published release. Already-published package versions are skipped, so the
+# whole job is idempotent.
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: '版本号 (不带 v 前缀, e.g. 0.14.1)'
+        required: true
+        type: string
+
+permissions: {}
+
+jobs:
+  publish:
+    name: Publish npm packages
+    # Skip prereleases on the auto path; manual dispatch always runs so any
+    # published release (including prereleases) can be pushed deliberately.
+    if: github.event_name == 'workflow_dispatch' || github.event.release.prerelease == false
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Required for npm provenance attestation (--provenance).
+      id-token: write
+    steps:
+      - name: Resolve version and dist-tag
+        id: resolve
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          TAG: ${{ github.event.release.tag_name }}
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            VERSION="${INPUT_VERSION#v}"
+          else
+            VERSION="${TAG#v}"
+          fi
+          if [ -z "$VERSION" ]; then
+            echo "Could not derive version (event=$EVENT_NAME tag=$TAG input=$INPUT_VERSION)" >&2
+            exit 1
+          fi
+
+          # X.Y.Z-alpha.N → dist-tag "alpha"; plain X.Y.Z → "latest".
+          if [[ "$VERSION" =~ -([a-zA-Z]+) ]]; then
+            DIST_TAG="${BASH_REMATCH[1]}"
+          else
+            DIST_TAG="latest"
+          fi
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "dist_tag=$DIST_TAG" >> "$GITHUB_OUTPUT"
+          echo "Resolved version: $VERSION (dist-tag: $DIST_TAG)"
+
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          # Release path: pin to the release tag so the launcher / assembly
+          # script match the binaries being published. Dispatch path: use the
+          # ref the workflow was dispatched on — older tags predate
+          # scripts/build-npm-packages.mjs and npm/, so checking out the tag
+          # would break exactly the debugging runs dispatch exists for.
+          ref: ${{ github.event_name == 'release' && format('v{0}', steps.resolve.outputs.version) || github.ref }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: lts/*
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Download CLI release assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.resolve.outputs.version }}
+        run: |
+          gh release download "v${VERSION}" \
+            --repo "${{ github.repository }}" \
+            --pattern 'uniclipboard-cli-*' \
+            --pattern 'SHA256SUMS.txt' \
+            --dir release-assets
+          ls -la release-assets
+
+      - name: Verify checksums
+        run: |
+          cd release-assets
+          # SHA256SUMS.txt covers every release asset; we only downloaded the
+          # CLI archives, so ignore the rest.
+          sha256sum -c --ignore-missing SHA256SUMS.txt
+          # --ignore-missing exits 0 even when NOTHING matched; make sure the
+          # CLI archives were actually verified.
+          VERIFIED=$(sha256sum -c --ignore-missing SHA256SUMS.txt 2>/dev/null | grep -c ': OK$')
+          EXPECTED=$(ls uniclipboard-cli-* | wc -l)
+          if [ "$VERIFIED" -ne "$EXPECTED" ]; then
+            echo "Only $VERIFIED of $EXPECTED CLI archives are covered by SHA256SUMS.txt" >&2
+            exit 1
+          fi
+
+      - name: Assemble npm packages
+        env:
+          VERSION: ${{ steps.resolve.outputs.version }}
+        run: |
+          node scripts/build-npm-packages.mjs \
+            --version "$VERSION" \
+            --artifacts-dir release-assets \
+            --out npm-dist
+          ls -R npm-dist
+
+      - name: Smoke test linux-x64 binary
+        env:
+          VERSION: ${{ steps.resolve.outputs.version }}
+        run: |
+          # The linux-x64 binary is a static (non-PIE) musl ELF, so it runs on
+          # the glibc runner directly.
+          REPORTED=$(./npm-dist/cli-linux-x64/bin/uniclip --version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?' | head -1)
+          echo "uniclip --version reports: $REPORTED (expected: $VERSION)"
+          if [ "$REPORTED" != "$VERSION" ]; then
+            echo "Binary version does not match release version" >&2
+            exit 1
+          fi
+
+      - name: Publish to npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          DIST_TAG: ${{ steps.resolve.outputs.dist_tag }}
+          VERSION: ${{ steps.resolve.outputs.version }}
+        run: |
+          if [ -z "$NODE_AUTH_TOKEN" ]; then
+            echo "::error::NPM_TOKEN secret is not configured" >&2
+            exit 1
+          fi
+
+          # Platform packages first, main package last (publish-order.txt),
+          # so `npm install uniclipboard` never sees missing optional deps.
+          while IFS= read -r dir; do
+            NAME=$(node -p "require('./npm-dist/${dir}/package.json').name")
+            if npm view "${NAME}@${VERSION}" version >/dev/null 2>&1; then
+              echo "${NAME}@${VERSION} already published — skipping"
+              continue
+            fi
+            echo "Publishing ${NAME}@${VERSION} (dist-tag: ${DIST_TAG})"
+            npm publish "./npm-dist/${dir}" \
+              --provenance \
+              --access public \
+              --tag "$DIST_TAG"
+          done < npm-dist/publish-order.txt
+
+      - name: Summary
+        env:
+          VERSION: ${{ steps.resolve.outputs.version }}
+          DIST_TAG: ${{ steps.resolve.outputs.dist_tag }}
+        run: |
+          {
+            echo "## npm Publish :package:"
+            echo ""
+            echo "**Version:** ${VERSION}"
+            echo "**dist-tag:** ${DIST_TAG}"
+            echo ""
+            echo "\`\`\`sh"
+            echo "npm install -g uniclipboard@${VERSION}"
+            echo "\`\`\`"
+            echo ""
+            echo "https://www.npmjs.com/package/uniclipboard"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/npm/README.md
+++ b/npm/README.md
@@ -1,0 +1,59 @@
+# npm distribution
+
+Maintainer notes for the npm packages. End-user docs live in
+`uniclipboard/README.md` (shipped with the main package).
+
+## Layout
+
+Six packages per release, following the esbuild/biome pattern:
+
+| Package | Contents |
+| --- | --- |
+| `uniclipboard` | JS launcher only (`launcher.js`); selects the platform package via `optionalDependencies` |
+| `@uniclipboard/cli-darwin-arm64` | `bin/uniclip` + `bin/uniclipd` (aarch64-apple-darwin) |
+| `@uniclipboard/cli-darwin-x64` | same (x86_64-apple-darwin) |
+| `@uniclipboard/cli-linux-arm64` | same (aarch64-unknown-linux-musl, static) |
+| `@uniclipboard/cli-linux-x64` | same (x86_64-unknown-linux-musl, static) |
+| `@uniclipboard/cli-win32-x64` | `bin/uniclip.exe` + `bin/uniclipd.exe` (x86_64-pc-windows-msvc) |
+
+Only `npm/uniclipboard/` is checked in (with `0.0.0-dev` placeholders).
+Platform packages are generated at publish time by
+`scripts/build-npm-packages.mjs` from the `uniclipboard-cli-*` release
+archives — the binaries are byte-identical to the GitHub release assets and
+covered by the same signed `SHA256SUMS.txt`.
+
+Invariants the script enforces:
+
+- `uniclip` and `uniclipd` ship side by side in `bin/` — `uniclip start`
+  resolves the daemon as a sibling of `current_exe()` (ADR-008 D13). This is
+  also why the launcher spawns the binary by real path instead of letting npm
+  symlink/shim it.
+- Platform packages are pinned to the **exact** release version in the main
+  package's `optionalDependencies` (no `^`/`~`).
+- Platform packages publish before the main package (`publish-order.txt`).
+
+## Publish flow
+
+`.github/workflows/npm-publish.yml` listens for `release: published`
+(stable only — same policy as homebrew-tap.yml) and can be dispatched
+manually for any published release, including prereleases. dist-tag is
+derived from the version suffix: `0.15.0-alpha.3` → `alpha`, stable →
+`latest`. Re-runs are idempotent (already-published versions are skipped).
+
+## One-time setup
+
+1. Create the npm org `uniclipboard` (needed for the `@uniclipboard` scope):
+   https://www.npmjs.com/org/create
+2. Create a granular automation token with read/write access to the
+   `uniclipboard` package and the `@uniclipboard` scope.
+3. Add it as the `NPM_TOKEN` repository secret.
+
+The very first publish of each package must create it; after that, consider
+enabling npm "trusted publishing" (OIDC) per package and dropping the token.
+
+## Local testing
+
+```sh
+node scripts/build-npm-packages.mjs \
+  --version <X.Y.Z> --artifacts-dir <dir-with-cli-archives> --out npm-dist
+```

--- a/npm/uniclipboard/README.md
+++ b/npm/uniclipboard/README.md
@@ -1,0 +1,37 @@
+# UniClipboard CLI
+
+Cross-platform clipboard sync. This package installs the `uniclip` command
+and the `uniclipd` daemon for your platform via optional dependencies.
+
+```sh
+npm install -g uniclipboard
+uniclip --help
+uniclip start
+```
+
+## Supported platforms
+
+| Platform | Arch | Package |
+| --- | --- | --- |
+| macOS | arm64 | `@uniclipboard/cli-darwin-arm64` |
+| macOS | x64 | `@uniclipboard/cli-darwin-x64` |
+| Linux (static musl, works on glibc/musl) | arm64 | `@uniclipboard/cli-linux-arm64` |
+| Linux (static musl, works on glibc/musl) | x64 | `@uniclipboard/cli-linux-x64` |
+| Windows | x64 | `@uniclipboard/cli-win32-x64` |
+
+Only the package matching your platform is downloaded. If your platform is
+not listed, prebuilt binaries and other install channels (Homebrew, Snap,
+COPR, AUR) are available at
+[github.com/UniClipboard/UniClipboard](https://github.com/UniClipboard/UniClipboard/releases).
+
+## Verifying binaries
+
+The binaries shipped in the platform packages are byte-identical to the
+`uniclipboard-cli-*` archives attached to the corresponding GitHub release,
+which are covered by a minisign-signed `SHA256SUMS.txt`. npm packages are
+published with [provenance](https://docs.npmjs.com/generating-provenance-statements)
+from GitHub Actions.
+
+## License
+
+AGPL-3.0-only

--- a/npm/uniclipboard/launcher.mjs
+++ b/npm/uniclipboard/launcher.mjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+// Thin launcher for the platform-specific `uniclip` binary.
+//
+// The real binaries (`uniclip` + `uniclipd`) live in the matching
+// @uniclipboard/cli-{platform}-{arch} optional dependency. We must spawn the
+// binary by its real path inside that package — NOT symlink it through npm's
+// `bin` machinery — because `uniclip start` resolves the `uniclipd` daemon as
+// a sibling of `current_exe()` (ADR-008 D13). npm bin shims/symlinks would
+// break that sibling lookup, especially on Windows where npm generates .cmd
+// wrappers.
+
+import { spawnSync } from 'node:child_process'
+import { createRequire } from 'node:module'
+import path from 'node:path'
+import process from 'node:process'
+
+const PLATFORM_PACKAGES = {
+  'darwin-arm64': '@uniclipboard/cli-darwin-arm64',
+  'darwin-x64': '@uniclipboard/cli-darwin-x64',
+  'linux-arm64': '@uniclipboard/cli-linux-arm64',
+  'linux-x64': '@uniclipboard/cli-linux-x64',
+  'win32-x64': '@uniclipboard/cli-win32-x64',
+}
+
+function resolveBinary() {
+  const key = `${process.platform}-${process.arch}`
+  const pkg = PLATFORM_PACKAGES[key]
+
+  if (!pkg) {
+    console.error(
+      `uniclipboard: unsupported platform "${key}".\n` +
+        `Supported platforms: ${Object.keys(PLATFORM_PACKAGES).join(', ')}.\n` +
+        `Prebuilt binaries are also available at ` +
+        `https://github.com/UniClipboard/UniClipboard/releases`
+    )
+    process.exit(1)
+  }
+
+  const require = createRequire(import.meta.url)
+  let pkgDir
+  try {
+    pkgDir = path.dirname(require.resolve(`${pkg}/package.json`))
+  } catch {
+    console.error(
+      `uniclipboard: platform package "${pkg}" is not installed.\n` +
+        `This usually means optional dependencies were skipped ` +
+        `(e.g. --no-optional / --omit=optional) or the package manager ` +
+        `cache is stale.\n` +
+        `Try reinstalling: npm install uniclipboard`
+    )
+    process.exit(1)
+  }
+
+  const exe = process.platform === 'win32' ? 'uniclip.exe' : 'uniclip'
+  return path.join(pkgDir, 'bin', exe)
+}
+
+const binary = resolveBinary()
+const result = spawnSync(binary, process.argv.slice(2), { stdio: 'inherit' })
+
+if (result.error) {
+  console.error(`uniclipboard: failed to run ${binary}: ${result.error.message}`)
+  process.exit(1)
+}
+if (result.signal) {
+  // Propagate the child's fatal signal so callers see the same termination.
+  process.kill(process.pid, result.signal)
+}
+process.exit(result.status ?? 1)

--- a/npm/uniclipboard/package.json
+++ b/npm/uniclipboard/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "uniclipboard",
+  "version": "0.0.0-dev",
+  "description": "Cross-platform clipboard sync CLI. Installs the `uniclip` command and the `uniclipd` daemon for your platform.",
+  "keywords": [
+    "clipboard",
+    "sync",
+    "cli",
+    "cross-platform",
+    "uniclipboard"
+  ],
+  "homepage": "https://github.com/UniClipboard/UniClipboard",
+  "bugs": "https://github.com/UniClipboard/UniClipboard/issues",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/UniClipboard/UniClipboard.git"
+  },
+  "license": "AGPL-3.0-only",
+  "bin": {
+    "uniclip": "launcher.mjs"
+  },
+  "files": [
+    "launcher.mjs"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
+  "optionalDependencies": {
+    "@uniclipboard/cli-darwin-arm64": "0.0.0-dev",
+    "@uniclipboard/cli-darwin-x64": "0.0.0-dev",
+    "@uniclipboard/cli-linux-arm64": "0.0.0-dev",
+    "@uniclipboard/cli-linux-x64": "0.0.0-dev",
+    "@uniclipboard/cli-win32-x64": "0.0.0-dev"
+  }
+}

--- a/scripts/build-npm-packages.mjs
+++ b/scripts/build-npm-packages.mjs
@@ -1,0 +1,162 @@
+#!/usr/bin/env node
+// Assemble publishable npm packages from the CLI release archives.
+//
+// Input:  the `uniclipboard-cli-<version>-<target>.{tar.gz,zip}` archives
+//         produced by build-cli.yml (each contains `uniclip` + `uniclipd`).
+// Output: <out>/cli-<platform>-<arch>/  — 5 platform packages with binaries
+//         <out>/uniclipboard/          — main package with the JS launcher
+//
+// Platform packages MUST ship `uniclip` and `uniclipd` side by side in bin/:
+// `uniclip start` resolves the daemon as a sibling of current_exe()
+// (ADR-008 D13). The main package pins platform packages to the exact same
+// version so a partially-upgraded install can never mix versions.
+//
+// Usage:
+//   node scripts/build-npm-packages.mjs \
+//     --version 0.14.1 --artifacts-dir release-assets --out npm-dist
+
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+const TARGETS = [
+  { rust: "aarch64-apple-darwin", node: "darwin-arm64", os: "darwin", cpu: "arm64", ext: "tar.gz" },
+  { rust: "x86_64-apple-darwin", node: "darwin-x64", os: "darwin", cpu: "x64", ext: "tar.gz" },
+  { rust: "aarch64-unknown-linux-musl", node: "linux-arm64", os: "linux", cpu: "arm64", ext: "tar.gz" },
+  { rust: "x86_64-unknown-linux-musl", node: "linux-x64", os: "linux", cpu: "x64", ext: "tar.gz" },
+  { rust: "x86_64-pc-windows-msvc", node: "win32-x64", os: "win32", cpu: "x64", ext: "zip" },
+];
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 2; i < argv.length; i++) {
+    const flag = argv[i];
+    if (!flag.startsWith("--")) fail(`unexpected argument: ${flag}`);
+    args[flag.slice(2)] = argv[++i];
+  }
+  return args;
+}
+
+function fail(msg) {
+  console.error(`build-npm-packages: ${msg}`);
+  process.exit(1);
+}
+
+const { version, "artifacts-dir": artifactsDir, out: outDir } = parseArgs(process.argv);
+
+if (!version || !/^\d+\.\d+\.\d+(-[0-9A-Za-z.-]+)?$/.test(version)) {
+  fail(`--version is required and must be a valid semver version (got "${version}")`);
+}
+if (!artifactsDir || !fs.existsSync(artifactsDir)) {
+  fail(`--artifacts-dir is required and must exist (got "${artifactsDir}")`);
+}
+if (!outDir) {
+  fail("--out is required");
+}
+
+fs.rmSync(outDir, { recursive: true, force: true });
+fs.mkdirSync(outDir, { recursive: true });
+
+const licenseSrc = path.join(REPO_ROOT, "LICENSE");
+
+// --- Platform packages -----------------------------------------------------
+
+for (const target of TARGETS) {
+  const archive = path.join(
+    artifactsDir,
+    `uniclipboard-cli-${version}-${target.rust}.${target.ext}`
+  );
+  if (!fs.existsSync(archive)) {
+    fail(`missing CLI archive for ${target.rust}: ${archive}`);
+  }
+
+  const pkgName = `@uniclipboard/cli-${target.node}`;
+  const pkgDir = path.join(outDir, `cli-${target.node}`);
+  const binDir = path.join(pkgDir, "bin");
+  fs.mkdirSync(binDir, { recursive: true });
+
+  if (target.ext === "zip") {
+    execFileSync("unzip", ["-o", "-q", archive, "-d", binDir]);
+  } else {
+    execFileSync("tar", ["-xzf", archive, "-C", binDir]);
+  }
+
+  const exeSuffix = target.os === "win32" ? ".exe" : "";
+  for (const bin of ["uniclip", "uniclipd"]) {
+    const binPath = path.join(binDir, `${bin}${exeSuffix}`);
+    if (!fs.existsSync(binPath)) {
+      fail(`archive ${path.basename(archive)} does not contain ${bin}${exeSuffix}`);
+    }
+    if (!exeSuffix) fs.chmodSync(binPath, 0o755);
+  }
+
+  fs.writeFileSync(
+    path.join(pkgDir, "package.json"),
+    JSON.stringify(
+      {
+        name: pkgName,
+        version,
+        description: `UniClipboard CLI binaries (uniclip + uniclipd) for ${target.node}. Install the "uniclipboard" package instead of this one.`,
+        homepage: "https://github.com/UniClipboard/UniClipboard",
+        repository: {
+          type: "git",
+          url: "git+https://github.com/UniClipboard/UniClipboard.git",
+        },
+        license: "AGPL-3.0-only",
+        // Yarn PnP: binaries must exist on the real filesystem to be spawned.
+        preferUnplugged: true,
+        os: [target.os],
+        cpu: [target.cpu],
+        files: ["bin"],
+      },
+      null,
+      2
+    ) + "\n"
+  );
+
+  if (fs.existsSync(licenseSrc)) {
+    fs.copyFileSync(licenseSrc, path.join(pkgDir, "LICENSE"));
+  }
+
+  console.log(`assembled ${pkgName}@${version} from ${path.basename(archive)}`);
+}
+
+// --- Main package ----------------------------------------------------------
+
+const mainSrc = path.join(REPO_ROOT, "npm", "uniclipboard");
+const mainDir = path.join(outDir, "uniclipboard");
+fs.cpSync(mainSrc, mainDir, { recursive: true });
+
+const mainPkgPath = path.join(mainDir, "package.json");
+const mainPkg = JSON.parse(fs.readFileSync(mainPkgPath, "utf8"));
+mainPkg.version = version;
+for (const dep of Object.keys(mainPkg.optionalDependencies)) {
+  // Exact pin — no ^/~ — so the main package and platform packages can never
+  // resolve to different versions.
+  mainPkg.optionalDependencies[dep] = version;
+}
+const declared = Object.keys(mainPkg.optionalDependencies).sort();
+const assembled = TARGETS.map((t) => `@uniclipboard/cli-${t.node}`).sort();
+if (JSON.stringify(declared) !== JSON.stringify(assembled)) {
+  fail(
+    `optionalDependencies in npm/uniclipboard/package.json (${declared.join(", ")}) ` +
+      `do not match assembled platform packages (${assembled.join(", ")})`
+  );
+}
+fs.writeFileSync(mainPkgPath, JSON.stringify(mainPkg, null, 2) + "\n");
+
+if (fs.existsSync(licenseSrc)) {
+  fs.copyFileSync(licenseSrc, path.join(mainDir, "LICENSE"));
+}
+
+console.log(`assembled uniclipboard@${version}`);
+
+// Publish order matters: platform packages first, the main package last, so
+// there is no window where `npm install uniclipboard` resolves but its
+// optional dependencies 404.
+const order = [...TARGETS.map((t) => `cli-${t.node}`), "uniclipboard"];
+fs.writeFileSync(path.join(outDir, "publish-order.txt"), order.join("\n") + "\n");
+console.log(`publish order written to ${path.join(outDir, "publish-order.txt")}`);


### PR DESCRIPTION
## Summary

- Add npm distribution for the CLI using the esbuild/biome layout: a main `uniclipboard` package whose ESM launcher selects one of five `@uniclipboard/cli-{platform}-{arch}` platform packages via `optionalDependencies` (cee5a1bd). The launcher spawns `uniclip` by its real path inside the platform package — never through npm bin shims/symlinks — because `uniclip start` resolves `uniclipd` as a sibling of `current_exe()` (ADR-008 D13); both binaries ship side by side in each platform package's `bin/`.
- `scripts/build-npm-packages.mjs` assembles the six publish-ready packages at publish time from the existing `uniclipboard-cli-*` release archives, so npm binaries are byte-identical to the GitHub release assets. It enforces exact version pinning (no `^`/`~`) and emits `publish-order.txt` (platform packages before the main package, so `npm install uniclipboard` never sees missing optional deps) (cee5a1bd).
- `npm-publish.yml` listens for `release: published` like homebrew-tap.yml — stable releases sit in draft until a human publishes, and npm publishes are irreversible. The auto path publishes stable only; prereleases go out via `workflow_dispatch` with the dist-tag derived from the version suffix (`X.Y.Z-alpha.N` → `alpha`). The job verifies the archives against `SHA256SUMS.txt` (guarding the `--ignore-missing` matched-nothing case), smoke-tests the static linux-x64 binary against the release version, and publishes with npm provenance. Already-published versions are skipped, so re-runs are idempotent (46003060).

Closes #1022.

Docs left as-is deliberately: `getting-started/install.mdx` should gain an npm section only after the first stable version is actually on npm (alpha validation is the next step).

## Test plan

- [x] Local e2e with fake archives: assembler produces all 6 packages, exact version pinning verified, launcher resolves the platform package, finds the sibling `uniclipd`, and propagates the child exit code (7) and `--version` output.
- [x] Launcher error paths: unsupported platform and missing optional dependency both print actionable messages and exit 1.
- [x] `npm pack --dry-run` file lists are clean (LICENSE + bin/ + launcher only); eslint passes on the launcher.
- [ ] One-time setup before first publish: create the npm org `uniclipboard` and set the `NPM_TOKEN` secret.
- [ ] Alpha validation after merge: cut a new alpha (old alphas predate SHA256SUMS.txt), run `gh workflow run npm-publish.yml -f version=<X.Y.Z-alpha.N>`, then `npm install -g uniclipboard@alpha && uniclip start` on at least one platform.
- [ ] After the first stable npm publish: add the npm install section to `docs-site/content/docs/{en,zh}/getting-started/install.mdx`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * UniClipboard is now available on npm with cross-platform binary distributions for macOS, Linux, and Windows across multiple architectures.

* **Documentation**
  * Added comprehensive installation and usage guides, including platform/architecture support details and binary verification procedures for published releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
