### PR TITLE
fix(npm): handle nested paths in the windows CLI zip

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -264,9 +264,12 @@ jobs:
             if [ ! -f "$BIN_SRC" ]; then
               BIN_SRC="src-tauri/target/${TARGET}/release/uniclip.exe"
             fi
-            DAEMON_SRC="$(dirname "$BIN_SRC")/uniclipd.exe"
             ARCHIVE="uniclipboard-cli-${VERSION}-${TARGET}.zip"
-            7z a "$ARCHIVE" "$BIN_SRC" "$DAEMON_SRC"
+            # 7z stores paths as given on the command line, so add the exes
+            # from inside their directory to keep the archive root flat
+            # (matching the tar.gz layout).
+            WORKDIR="$(pwd)"
+            (cd "$(dirname "$BIN_SRC")" && 7z a "${WORKDIR}/${ARCHIVE}" uniclip.exe uniclipd.exe)
           else
             BIN_DIR="src-tauri/target/${TARGET}/release"
             # Fallback for non-cross builds

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -159,7 +159,7 @@ jobs:
           VERSION: ${{ steps.resolve.outputs.version }}
         run: |
           # Platform packages first, main package last (publish-order.txt),
-          # so `npm install uniclipboard` never sees missing optional deps.
+          # so `npm install @uniclipboard/cli` never sees missing optional deps.
           while IFS= read -r dir; do
             NAME=$(node -p "require('./npm-dist/${dir}/package.json').name")
             if npm view "${NAME}@${VERSION}" version >/dev/null 2>&1; then
@@ -185,8 +185,8 @@ jobs:
             echo "**dist-tag:** ${DIST_TAG}"
             echo ""
             echo "\`\`\`sh"
-            echo "npm install -g uniclipboard@${VERSION}"
+            echo "npm install -g @uniclipboard/cli@${VERSION}"
             echo "\`\`\`"
             echo ""
-            echo "https://www.npmjs.com/package/uniclipboard"
+            echo "https://www.npmjs.com/package/@uniclipboard/cli"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -91,6 +91,11 @@ jobs:
           node-version: lts/*
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Update npm for trusted publishing
+        # OIDC trusted publishing requires npm >= 11.5.1; pin to latest to be
+        # explicit rather than relying on whatever the runner image bundles.
+        run: npm install -g npm@latest && npm --version
+
       - name: Download CLI release assets
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -142,16 +147,17 @@ jobs:
           fi
 
       - name: Publish to npm
+        # Auth is OIDC trusted publishing (id-token: write + npm >= 11.5.1) —
+        # no NPM_TOKEN. Tokens are a dead end here: npm requires 2FA/OTP for
+        # token publishes and the granular-token "bypass 2FA" flag is broken
+        # server-side (npm/cli#8869, npm/cli#9268). Each of the six packages
+        # must have this repo + workflow configured as a Trusted Publisher on
+        # npmjs.com (Settings → Trusted Publisher), which is only possible
+        # after the package's first (manual, local) publish.
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           DIST_TAG: ${{ steps.resolve.outputs.dist_tag }}
           VERSION: ${{ steps.resolve.outputs.version }}
         run: |
-          if [ -z "$NODE_AUTH_TOKEN" ]; then
-            echo "::error::NPM_TOKEN secret is not configured" >&2
-            exit 1
-          fi
-
           # Platform packages first, main package last (publish-order.txt),
           # so `npm install uniclipboard` never sees missing optional deps.
           while IFS= read -r dir; do

--- a/npm/README.md
+++ b/npm/README.md
@@ -9,12 +9,16 @@ Six packages per release, following the esbuild/biome pattern:
 
 | Package | Contents |
 | --- | --- |
-| `uniclipboard` | JS launcher only (`launcher.js`); selects the platform package via `optionalDependencies` |
+| `@uniclipboard/cli` | JS launcher only (`launcher.mjs`); selects the platform package via `optionalDependencies` |
 | `@uniclipboard/cli-darwin-arm64` | `bin/uniclip` + `bin/uniclipd` (aarch64-apple-darwin) |
 | `@uniclipboard/cli-darwin-x64` | same (x86_64-apple-darwin) |
 | `@uniclipboard/cli-linux-arm64` | same (aarch64-unknown-linux-musl, static) |
 | `@uniclipboard/cli-linux-x64` | same (x86_64-unknown-linux-musl, static) |
 | `@uniclipboard/cli-win32-x64` | `bin/uniclip.exe` + `bin/uniclipd.exe` (x86_64-pc-windows-msvc) |
+
+The main package is scoped because the unscoped name `uniclipboard` is
+permanently rejected by npm's typosquatting rule (E403: too similar to the
+existing `uni-clipboard` — names are compared with punctuation stripped).
 
 Only `npm/uniclipboard/` is checked in (with `0.0.0-dev` placeholders).
 Platform packages are generated at publish time by
@@ -40,16 +44,22 @@ manually for any published release, including prereleases. dist-tag is
 derived from the version suffix: `0.15.0-alpha.3` → `alpha`, stable →
 `latest`. Re-runs are idempotent (already-published versions are skipped).
 
-## One-time setup
+## Auth: OIDC trusted publishing (no token)
 
-1. Create the npm org `uniclipboard` (needed for the `@uniclipboard` scope):
-   https://www.npmjs.com/org/create
-2. Create a granular automation token with read/write access to the
-   `uniclipboard` package and the `@uniclipboard` scope.
-3. Add it as the `NPM_TOKEN` repository secret.
+CI auth is npm [trusted publishing](https://docs.npmjs.com/trusted-publishers/)
+via GitHub Actions OIDC — there is no NPM_TOKEN. Token-based publishing is a
+dead end: npm requires 2FA/OTP for token publishes and the granular-token
+"bypass 2FA" flag is broken server-side (npm/cli#8869, npm/cli#9268).
 
-The very first publish of each package must create it; after that, consider
-enabling npm "trusted publishing" (OIDC) per package and dropping the token.
+Each of the six packages must have a Trusted Publisher configured at
+`https://www.npmjs.com/package/<name>/access`:
+Organization `UniClipboard`, repository `UniClipboard`, workflow
+`npm-publish.yml`, environment empty.
+
+Trusted publishing cannot create a package (npm/cli#8544), so the first
+version of any NEW package must be published manually from a maintainer
+machine (interactive 2FA), after which its Trusted Publisher can be
+configured. This was done for all six packages with 0.15.0-alpha.1.
 
 ## Local testing
 

--- a/npm/uniclipboard/README.md
+++ b/npm/uniclipboard/README.md
@@ -4,7 +4,7 @@ Cross-platform clipboard sync. This package installs the `uniclip` command
 and the `uniclipd` daemon for your platform via optional dependencies.
 
 ```sh
-npm install -g uniclipboard
+npm install -g @uniclipboard/cli
 uniclip --help
 uniclip start
 ```

--- a/npm/uniclipboard/launcher.mjs
+++ b/npm/uniclipboard/launcher.mjs
@@ -46,7 +46,7 @@ function resolveBinary() {
         `This usually means optional dependencies were skipped ` +
         `(e.g. --no-optional / --omit=optional) or the package manager ` +
         `cache is stale.\n` +
-        `Try reinstalling: npm install uniclipboard`
+        `Try reinstalling: npm install @uniclipboard/cli`
     )
     process.exit(1)
   }

--- a/npm/uniclipboard/package.json
+++ b/npm/uniclipboard/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "uniclipboard",
+  "name": "@uniclipboard/cli",
   "version": "0.0.0-dev",
   "description": "Cross-platform clipboard sync CLI. Installs the `uniclip` command and the `uniclipd` daemon for your platform.",
   "keywords": [

--- a/scripts/build-npm-packages.mjs
+++ b/scripts/build-npm-packages.mjs
@@ -85,7 +85,9 @@ for (const target of TARGETS) {
   fs.mkdirSync(binDir, { recursive: true })
 
   if (target.ext === 'zip') {
-    execFileSync('unzip', ['-o', '-q', archive, '-d', binDir])
+    // -j junks directory components: zips produced before build-cli.yml
+    // flattened them nest the exes under src-tauri/target/release/.
+    execFileSync('unzip', ['-j', '-o', '-q', archive, '-d', binDir])
   } else {
     execFileSync('tar', ['-xzf', archive, '-C', binDir])
   }

--- a/scripts/build-npm-packages.mjs
+++ b/scripts/build-npm-packages.mjs
@@ -163,7 +163,7 @@ if (fs.existsSync(licenseSrc)) {
 console.log(`assembled uniclipboard@${version}`)
 
 // Publish order matters: platform packages first, the main package last, so
-// there is no window where `npm install uniclipboard` resolves but its
+// there is no window where `npm install @uniclipboard/cli` resolves but its
 // optional dependencies 404.
 const order = [...TARGETS.map(t => `cli-${t.node}`), 'uniclipboard']
 fs.writeFileSync(path.join(outDir, 'publish-order.txt'), order.join('\n') + '\n')


### PR DESCRIPTION
## Summary

- First real npm-publish run (27332886190, for v0.15.0-alpha.1) failed assembling `cli-win32-x64`: `7z a <archive> <path>` stores paths as given, so the release zip nests the exes under `src-tauri/target/release/` and the assembler found no `uniclip.exe` at the archive root. The four tar.gz targets assembled fine.
- `build-cli.yml`: add the exes from inside their directory so new release zips are flat, matching the tar.gz layout (also nicer for users downloading the zip directly).
- `build-npm-packages.mjs`: extract zips with `unzip -j` (junk paths), tolerating both the old nested layout and the new flat one — so v0.15.0-alpha.1 can be published as-is after this merges, without cutting a new release.

Docs impact: none (internal packaging layout only; the flattened zip is strictly an improvement for direct downloads).

## Test plan

- [x] Local: assembler run against a nested zip replicating the real v0.15.0-alpha.1 layout and against a flat zip — both produce `bin/uniclip.exe` + `bin/uniclipd.exe` at the package root.
- [ ] After merge: re-run `gh workflow run npm-publish.yml -f version=0.15.0-alpha.1` (dispatch path checks out main, so it picks up the fixed assembler against the existing release).
- [ ] The build-cli.yml change is exercised by the next release build; verify the new zip is flat.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved Windows binary packaging to produce flat ZIPs for simpler installation.
  * Updated extraction to flatten directory components when unpacking Windows archives.
  * Switched publishing to OIDC-based trusted publishing for improved provenance.

* **Documentation**
  * Clarified npm release layout and updated install instructions to recommend the scoped `@uniclipboard/cli` package.

* **UX**
  * Updated launcher error guidance to direct users to install the scoped CLI package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->