### PR TITLE
feat(cli): add `uniclip get` to read already-synced clipboard entries

### DIFF
--- a/docs-site/content/docs/en/cli/reference.mdx
+++ b/docs-site/content/docs/en/cli/reference.mdx
@@ -63,6 +63,32 @@ uniclip recv --out ./inbox
 The daemon handles blob storage and peer-to-peer transfer, so the CLI
 can exit as soon as the dispatch is confirmed.
 
+### Reading already-synced entries
+
+`recv` waits for the _next_ inbound file. To read what is **already** in
+the daemon's history — the common case on a headless / SSH box with no
+system clipboard to paste from — use `get`, which returns immediately.
+
+```bash
+# Newest usable entry (text/link prints to stdout)
+uniclip get
+
+# Newest entry of a kind: image | file | text | link
+uniclip get --type image
+
+# A specific entry by id (from `uniclip search query`), into a directory
+uniclip get --id <ENTRY_ID> --out ./inbox
+
+# Browse recent entries instead of materializing one
+uniclip get --list -n 20
+```
+
+Output contract: **text / link** content is printed to stdout
+(pipe-friendly); **image / file** bytes are written to `--out` (a
+directory, defaulting to a per-user cache dir) and the absolute path is
+printed to stdout, or streamed to stdout with `--out -`. Status lines go
+to stderr, so stdout stays clean. Unlike `recv`, `get` never blocks.
+
 ## Search
 
 `uniclip search` exposes the encrypted full-text index that backs the
@@ -211,6 +237,10 @@ seeing things in `ps` or in commit history.
 distinct failure classes (configuration, network, pairing, etc.) and
 are stable across releases. Scripts should branch on exit code rather
 than parse human-readable output.
+
+`uniclip get` additionally uses `6` when no entry matched the selector,
+and `7` when an entry matched but its payload is unavailable (`Lost` or
+not yet downloaded — re-send it from the source device).
 
 For the most up-to-date list of subcommands, run `uniclip --help` —
 the binary's help is the source of truth.

--- a/docs-site/content/docs/zh/cli/reference.mdx
+++ b/docs-site/content/docs/zh/cli/reference.mdx
@@ -55,6 +55,29 @@ uniclip recv --out ./inbox
 `send -f` 与 positional text 和 `--resend` 互斥。
 守护进程负责 blob 存储和 peer 间传输，CLI 在 dispatch 确认后即可退出。
 
+### 读取已同步的条目
+
+`recv` 等待**下一个**入站文件。要读取守护进程历史里**已经存在**的内容
+（无头 / SSH 机器没有系统剪贴板可粘贴时的常见场景），用 `get`，它会立即返回。
+
+```bash
+# 最新一条可用条目（文本/链接打到 stdout）
+uniclip get
+
+# 最新一条指定类型：image | file | text | link
+uniclip get --type image
+
+# 按 id 取指定条目（id 来自 `uniclip search query`），落地到目录
+uniclip get --id <ENTRY_ID> --out ./inbox
+
+# 仅列出最近条目，不取回
+uniclip get --list -n 20
+```
+
+输出约定：**文本 / 链接**内容打到 stdout（可管道）；**图片 / 文件**字节写入
+`--out`（目录，默认 per-user 缓存目录）并把绝对路径打到 stdout，或用 `--out -`
+直接写到 stdout。状态行走 stderr，stdout 保持干净。与 `recv` 不同，`get` 不阻塞。
+
 ## 搜索
 
 `uniclip search` 是 GUI 仪表盘搜索框背后那个加密全文索引的命令行入口。
@@ -176,5 +199,7 @@ uniclip upgrade advance
 
 `uniclip` 使用稳定的退出码（在 `src/exit_codes.rs` 中定义）。`0` 表示成功，非零值对应不同的失败类别
 （配置、网络、配对等）且跨版本保持稳定。脚本应基于退出码判断成败，而不是解析人类可读输出。
+
+`uniclip get` 额外使用 `6`（没有条目匹配 selector）和 `7`（条目存在但 payload 不可用——`Lost` 或尚未下载，需在源设备重发）。
 
 最新的子命令列表请直接运行 `uniclip --help` —— 二进制自带的 help 是权威来源。

--- a/src-tauri/crates/uc-cli/README.md
+++ b/src-tauri/crates/uc-cli/README.md
@@ -45,6 +45,37 @@ cargo build -p uc-cli
 | `uniclip members` | 列出空间成员和在线状态。 |
 | `uniclip send [TEXT]` | 向在线配对设备发送一段文本；省略 `TEXT` 时从 stdin 读取。 |
 | `uniclip watch` | 监听并打印收到的剪贴板 payload；不会写入系统剪贴板。 |
+| `uniclip recv` | 阻塞等待 **下一个** 入站文件并落盘；不会写入系统剪贴板。 |
+| `uniclip get` | 读取 **已同步** 的剪贴板条目并立即返回（headless / 脚本 / agent 友好）。 |
+
+## 取回已同步内容（`get`）
+
+无头 / SSH 机器没有系统剪贴板，`Ctrl+V` 无法粘贴已同步的图片或文件。`get`
+直接从 daemon 历史里取出已同步的条目并立即返回（区别于 `recv` 的「阻塞等下一个入站」）：
+
+```bash
+uniclip get                      # 取最新一条可用条目
+uniclip get --type image         # 取最新一张图片
+uniclip get --type file -o ~/in  # 取最新一个文件并落地到 ~/in
+uniclip get --id <ENTRY-ID>      # 取指定条目（id 来自 search query）
+uniclip get --list -n 20         # 仅列出最近 20 条，不取回
+```
+
+输出契约：
+
+- **文本 / 链接**：内容打到 **stdout**（可管道）；状态行走 stderr。
+- **图片 / 文件**：字节写入 `--out` 目录（默认 per-user cache 目录），并把**绝对
+  路径**打到 stdout；`--out -` 则把原始字节直接写到 stdout。
+
+退出码：`0` 成功；`6` 无条目匹配 selector；`7` 条目存在但 payload 不可用
+（`Lost` / 未下载——需在源设备重发）。
+
+典型的 agent 闭环（在 SSH 机器上把图片喂给工具）：
+
+```bash
+path=$(uniclip get --type image)   # 落地并拿到路径
+# 把 $path 交给读取文件的工具即可
+```
 
 ## 搜索命令
 

--- a/src-tauri/crates/uc-cli/src/commands/get.rs
+++ b/src-tauri/crates/uc-cli/src/commands/get.rs
@@ -314,24 +314,17 @@ fn write_bytes_outcome(
     let bytes_written = bytes.len() as u64;
 
     if args.out.as_deref() == Some("-") {
+        if json {
+            ui::error(
+                "--json cannot be combined with --out - because the JSON would corrupt the raw byte stream on stdout",
+            );
+            return exit_codes::EXIT_ERROR;
+        }
         if let Err(err) = std::io::stdout().write_all(&bytes) {
             ui::error(&format!("Failed to write bytes to stdout: {err}"));
             return exit_codes::EXIT_ERROR;
         }
         let _ = std::io::stdout().flush();
-        if json {
-            print_json(&GetOutcome {
-                entry_id: &target.id,
-                content_type: category.as_str(),
-                mime_type: &target.content_type,
-                path: None,
-                filename: Some(filename),
-                text: None,
-                bytes_written: Some(bytes_written),
-                captured_at: target.captured_at,
-                outcome: "exported",
-            });
-        }
         return exit_codes::EXIT_SUCCESS;
     }
 
@@ -505,7 +498,7 @@ fn default_out_dir() -> PathBuf {
 fn sanitize_filename(name: &str) -> String {
     let stripped: String = name
         .chars()
-        .filter(|c| !matches!(c, '/' | '\\' | '\0'))
+        .filter(|c| !matches!(c, '/' | '\\') && !c.is_control())
         .collect();
     if stripped.is_empty() || stripped == "." || stripped == ".." {
         "uniclip-get.bin".to_string()
@@ -515,10 +508,9 @@ fn sanitize_filename(name: &str) -> String {
 }
 
 fn short_hash(s: &str) -> &str {
-    if s.len() > 8 {
-        &s[..8]
-    } else {
-        s
+    match s.char_indices().nth(8) {
+        Some((byte_idx, _)) => &s[..byte_idx],
+        None => s,
     }
 }
 

--- a/src-tauri/crates/uc-cli/src/commands/get.rs
+++ b/src-tauri/crates/uc-cli/src/commands/get.rs
@@ -1,0 +1,669 @@
+//! `uniclip get` — one-shot reader for already-synced clipboard entries.
+//!
+//! Unlike `recv` (which subscribes and BLOCKS waiting for the *next* inbound
+//! file), `get` reads what is *already* in the daemon's history and returns
+//! immediately. It is designed to be called by scripts and agents (e.g. an
+//! editor/agent pulling the latest synced image on a headless SSH box, where
+//! there is no system clipboard to paste from).
+//!
+//! Daemon-client mode: connects to a running daemon (or spawns a transient
+//! one), holds a control lease while it fetches, materializes the selected
+//! entry, and exits. It NEVER writes the system clipboard.
+//!
+//! ## Output contract (agent-friendly)
+//!
+//! * **text / link** → content is printed to **stdout** (pipe-friendly).
+//!   `--out` does not apply; redirect with `>` to capture to a file.
+//! * **image / file** → bytes are written to the `--out` directory (default
+//!   cache dir) and the **absolute path** is printed to stdout. `--out -`
+//!   streams the raw bytes to stdout instead.
+//!
+//! All human-readable status lines go to **stderr** (via `ui`), so stdout
+//! stays clean for both the path string and raw binary.
+//!
+//! ## Exit codes
+//!
+//! * `0` — entry materialized successfully (or `--list` printed).
+//! * `EXIT_NO_MATCH` — no entry matched the selector.
+//! * `EXIT_CONTENT_UNAVAILABLE` — entry exists but its payload is `Lost` /
+//!   not materialized; the remedy is to re-send it from the source device.
+
+use std::io::Write;
+use std::path::PathBuf;
+
+use base64::engine::general_purpose::STANDARD;
+use base64::Engine as _;
+use clap::ValueEnum;
+use serde::Serialize;
+use uc_daemon_client::DaemonService;
+use uc_daemon_contract::api::dto::clipboard::EntryProjectionResponseDto;
+
+use crate::exit_codes;
+use crate::ui;
+
+/// Default number of recent entries to scan when selecting / listing.
+const DEFAULT_LIMIT: usize = 50;
+
+/// Content kind selector for `--type`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum GetKind {
+    Image,
+    File,
+    Text,
+    Link,
+}
+
+/// Classified category of an entry, derived from its MIME type. The list
+/// projection's `content_type` is the raw representation MIME (e.g.
+/// `image/png`, `text/uri-list`, `text/plain`), not a category label.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Category {
+    Image,
+    File,
+    Text,
+    Link,
+}
+
+impl Category {
+    fn as_str(self) -> &'static str {
+        match self {
+            Category::Image => "image",
+            Category::File => "file",
+            Category::Text => "text",
+            Category::Link => "link",
+        }
+    }
+}
+
+pub struct GetArgs {
+    /// Restrict selection to the newest entry of this kind.
+    pub kind: Option<GetKind>,
+    /// Select a specific entry by id (from `uniclip search query`).
+    pub id: Option<String>,
+    /// List recent entries instead of materializing one.
+    pub list: bool,
+    /// Number of recent entries to scan / list.
+    pub limit: Option<usize>,
+    /// Output target for image/file bytes: a directory, or `-` for stdout.
+    pub out: Option<String>,
+}
+
+pub async fn run(args: GetArgs, json: bool, verbose: bool) -> i32 {
+    let service = match crate::commands::app_session::connect_or_spawn_oneshot_daemon(verbose).await
+    {
+        Ok(s) => s,
+        Err(code) => return code,
+    };
+
+    // Hold a control lease so a transient Oneshot daemon does not self-terminate
+    // mid-fetch. Bind to a named var (NOT `_`) so it lives to scope end.
+    let _lease = match service.hold_control_lease().await {
+        Ok(guard) => guard,
+        Err(err) => {
+            ui::error(&format!("Failed to hold daemon session lease: {err}"));
+            return exit_codes::EXIT_ERROR;
+        }
+    };
+
+    let limit = args.limit.unwrap_or(DEFAULT_LIMIT).max(1);
+    let entries = match service.list_entries(limit, 0).await {
+        Ok(entries) => entries,
+        Err(err) => {
+            ui::error(&format!("Failed to list clipboard entries: {err}"));
+            return exit_codes::EXIT_ERROR;
+        }
+    };
+
+    if args.list {
+        return print_list(&entries, json);
+    }
+
+    let target = match select_target(&entries, &args) {
+        Ok(t) => t,
+        Err(code) => return code,
+    };
+
+    materialize(&*service, target, &args, json).await
+}
+
+/// Pick the entry to materialize. For `--id`, find that exact entry. For
+/// `--type` / default, take the newest *usable* (non-`Lost`) match.
+fn select_target<'a>(
+    entries: &'a [EntryProjectionResponseDto],
+    args: &GetArgs,
+) -> Result<&'a EntryProjectionResponseDto, i32> {
+    if let Some(id) = &args.id {
+        return match entries.iter().find(|e| &e.id == id) {
+            Some(entry) => {
+                if is_lost(entry) {
+                    ui::error(&format!(
+                        "Entry {} exists but its payload is no longer available (Lost). \
+                         Re-send it from the source device.",
+                        short_hash(id)
+                    ));
+                    Err(exit_codes::EXIT_CONTENT_UNAVAILABLE)
+                } else {
+                    Ok(entry)
+                }
+            }
+            None => {
+                ui::error(&format!(
+                    "No entry with id {} in the latest {} entries. It may be older — \
+                     raise --limit, or find it with `uniclip search query`.",
+                    short_hash(id),
+                    entries.len()
+                ));
+                Err(exit_codes::EXIT_NO_MATCH)
+            }
+        };
+    }
+
+    // newest-first; skip Lost entries so we return something usable.
+    let chosen = entries.iter().find(|e| {
+        !is_lost(e)
+            && match args.kind {
+                Some(kind) => classify(e) == kind_to_category(kind),
+                None => true,
+            }
+    });
+
+    match chosen {
+        Some(entry) => Ok(entry),
+        None => {
+            let what = match args.kind {
+                Some(kind) => format!("{} entry", kind_to_category(kind).as_str()),
+                None => "usable entry".to_string(),
+            };
+            ui::error(&format!(
+                "No {what} found in the latest {} entries.",
+                entries.len()
+            ));
+            Err(exit_codes::EXIT_NO_MATCH)
+        }
+    }
+}
+
+async fn materialize(
+    service: &dyn DaemonService,
+    target: &EntryProjectionResponseDto,
+    args: &GetArgs,
+    json: bool,
+) -> i32 {
+    let category = classify(target);
+    match category {
+        Category::Text | Category::Link => emit_text(service, target, category, json).await,
+        Category::File => emit_file(service, target, args, json).await,
+        Category::Image => emit_image(service, target, args, json).await,
+    }
+}
+
+async fn emit_text(
+    service: &dyn DaemonService,
+    target: &EntryProjectionResponseDto,
+    category: Category,
+    json: bool,
+) -> i32 {
+    let detail = match service.entry_detail(&target.id).await {
+        Ok(Some(detail)) => detail,
+        Ok(None) => return content_unavailable(&target.id),
+        Err(err) => {
+            ui::error(&format!("Failed to read entry text: {err}"));
+            return exit_codes::EXIT_ERROR;
+        }
+    };
+
+    if json {
+        print_json(&GetOutcome {
+            entry_id: &target.id,
+            content_type: category.as_str(),
+            mime_type: &target.content_type,
+            path: None,
+            filename: None,
+            text: Some(&detail.content),
+            bytes_written: None,
+            captured_at: target.captured_at,
+            outcome: "exported",
+        });
+    } else {
+        // Raw content to stdout (pipe-friendly); no trailing newline injected.
+        print!("{}", detail.content);
+        let _ = std::io::stdout().flush();
+    }
+    exit_codes::EXIT_SUCCESS
+}
+
+async fn emit_file(
+    service: &dyn DaemonService,
+    target: &EntryProjectionResponseDto,
+    args: &GetArgs,
+    json: bool,
+) -> i32 {
+    match service.export_entry_file(&target.id).await {
+        Ok(Some(export)) => write_bytes_outcome(
+            target,
+            Category::File,
+            &sanitize_filename(&export.filename),
+            export.bytes,
+            args,
+            json,
+        ),
+        Ok(None) => content_unavailable(&target.id),
+        Err(err) => {
+            ui::error(&format!("Failed to export file: {err}"));
+            exit_codes::EXIT_ERROR
+        }
+    }
+}
+
+async fn emit_image(
+    service: &dyn DaemonService,
+    target: &EntryProjectionResponseDto,
+    args: &GetArgs,
+    json: bool,
+) -> i32 {
+    let resource = match service.entry_resource(&target.id).await {
+        Ok(Some(resource)) => resource,
+        Ok(None) => return content_unavailable(&target.id),
+        Err(err) => {
+            ui::error(&format!("Failed to read image resource: {err}"));
+            return exit_codes::EXIT_ERROR;
+        }
+    };
+
+    let mime = resource
+        .mime_type
+        .clone()
+        .unwrap_or_else(|| target.content_type.clone());
+
+    // Small images are stored inline (base64); larger ones live in a blob.
+    let bytes = if let Some(b64) = resource.inline_data.as_deref() {
+        match STANDARD.decode(b64) {
+            Ok(bytes) => bytes,
+            Err(err) => {
+                ui::error(&format!("Failed to decode inline image data: {err}"));
+                return exit_codes::EXIT_ERROR;
+            }
+        }
+    } else if let Some(blob_id) = resource.blob_id.as_deref() {
+        match service.fetch_blob(blob_id).await {
+            Ok(Some(bytes)) => bytes,
+            Ok(None) => return content_unavailable(&target.id),
+            Err(err) => {
+                ui::error(&format!("Failed to fetch image blob: {err}"));
+                return exit_codes::EXIT_ERROR;
+            }
+        }
+    } else {
+        return content_unavailable(&target.id);
+    };
+
+    let filename = format!("clip-{}.{}", short_hash(&target.id), ext_from_mime(&mime));
+    write_bytes_outcome(target, Category::Image, &filename, bytes, args, json)
+}
+
+/// Common sink for image/file bytes: stdout (`--out -`) or a file under the
+/// resolved output directory.
+fn write_bytes_outcome(
+    target: &EntryProjectionResponseDto,
+    category: Category,
+    filename: &str,
+    bytes: Vec<u8>,
+    args: &GetArgs,
+    json: bool,
+) -> i32 {
+    let bytes_written = bytes.len() as u64;
+
+    if args.out.as_deref() == Some("-") {
+        if let Err(err) = std::io::stdout().write_all(&bytes) {
+            ui::error(&format!("Failed to write bytes to stdout: {err}"));
+            return exit_codes::EXIT_ERROR;
+        }
+        let _ = std::io::stdout().flush();
+        if json {
+            print_json(&GetOutcome {
+                entry_id: &target.id,
+                content_type: category.as_str(),
+                mime_type: &target.content_type,
+                path: None,
+                filename: Some(filename),
+                text: None,
+                bytes_written: Some(bytes_written),
+                captured_at: target.captured_at,
+                outcome: "exported",
+            });
+        }
+        return exit_codes::EXIT_SUCCESS;
+    }
+
+    let out_dir = match resolve_out_dir(args.out.as_deref()) {
+        Ok(dir) => dir,
+        Err(msg) => {
+            ui::error(&msg);
+            return exit_codes::EXIT_ERROR;
+        }
+    };
+    let target_path = out_dir.join(filename);
+    if let Err(err) = std::fs::write(&target_path, &bytes) {
+        ui::error(&format!("Failed to write file: {err}"));
+        return exit_codes::EXIT_ERROR;
+    }
+    let path_str = target_path.display().to_string();
+
+    if json {
+        print_json(&GetOutcome {
+            entry_id: &target.id,
+            content_type: category.as_str(),
+            mime_type: &target.content_type,
+            path: Some(&path_str),
+            filename: Some(filename),
+            text: None,
+            bytes_written: Some(bytes_written),
+            captured_at: target.captured_at,
+            outcome: "exported",
+        });
+    } else {
+        // The path is the one machine-readable line on stdout; status on stderr.
+        println!("{path_str}");
+        ui::info("type", category.as_str());
+        ui::info("bytes", &bytes_written.to_string());
+        ui::end("Done");
+    }
+    exit_codes::EXIT_SUCCESS
+}
+
+fn print_list(entries: &[EntryProjectionResponseDto], json: bool) -> i32 {
+    if json {
+        let rows: Vec<ListRow> = entries
+            .iter()
+            .map(|e| ListRow {
+                entry_id: &e.id,
+                content_type: classify(e).as_str(),
+                mime_type: &e.content_type,
+                captured_at: e.captured_at,
+                preview: &e.preview,
+                lost: is_lost(e),
+            })
+            .collect();
+        if let Ok(s) = serde_json::to_string_pretty(&rows) {
+            println!("{s}");
+        }
+        return exit_codes::EXIT_SUCCESS;
+    }
+
+    if entries.is_empty() {
+        ui::info("status", "clipboard history is empty");
+        return exit_codes::EXIT_SUCCESS;
+    }
+    ui::header("Recent clipboard entries");
+    for entry in entries {
+        let tag = classify(entry).as_str();
+        let lost = if is_lost(entry) { " [lost]" } else { "" };
+        let preview = first_line(&entry.preview, 48);
+        ui::info(short_hash(&entry.id), &format!("[{tag}]{lost} {preview}"));
+    }
+    ui::end("Done");
+    exit_codes::EXIT_SUCCESS
+}
+
+fn content_unavailable(entry_id: &str) -> i32 {
+    ui::error(&format!(
+        "Entry {} has no materialized payload yet (Lost or not downloaded). \
+         Re-send it from the source device.",
+        short_hash(entry_id)
+    ));
+    exit_codes::EXIT_CONTENT_UNAVAILABLE
+}
+
+// ── Classification helpers ──────────────────────────────────────────
+
+fn classify(entry: &EntryProjectionResponseDto) -> Category {
+    let mime = entry.content_type.to_ascii_lowercase();
+    if mime.starts_with("image/") {
+        Category::Image
+    } else if mime == "text/uri-list" || mime == "file/uri-list" {
+        Category::File
+    } else if entry
+        .link_urls
+        .as_ref()
+        .is_some_and(|urls| !urls.is_empty())
+    {
+        Category::Link
+    } else {
+        Category::Text
+    }
+}
+
+fn kind_to_category(kind: GetKind) -> Category {
+    match kind {
+        GetKind::Image => Category::Image,
+        GetKind::File => Category::File,
+        GetKind::Text => Category::Text,
+        GetKind::Link => Category::Link,
+    }
+}
+
+fn is_lost(entry: &EntryProjectionResponseDto) -> bool {
+    entry
+        .payload_state
+        .as_deref()
+        .is_some_and(|s| s.eq_ignore_ascii_case("lost"))
+}
+
+fn ext_from_mime(mime: &str) -> &'static str {
+    match mime.to_ascii_lowercase().as_str() {
+        "image/png" => "png",
+        "image/jpeg" | "image/jpg" => "jpg",
+        "image/gif" => "gif",
+        "image/webp" => "webp",
+        "image/bmp" => "bmp",
+        "image/tiff" => "tiff",
+        "image/svg+xml" => "svg",
+        _ => "bin",
+    }
+}
+
+// ── Filesystem / formatting helpers ─────────────────────────────────
+
+/// Resolve the output directory: the user-chosen `--out`, or the default
+/// per-user cache dir. Creates it if missing.
+fn resolve_out_dir(out: Option<&str>) -> Result<PathBuf, String> {
+    let dir = match out {
+        Some(p) => PathBuf::from(p),
+        None => default_out_dir(),
+    };
+    if !dir.exists() {
+        std::fs::create_dir_all(&dir)
+            .map_err(|err| format!("Failed to create output directory: {err}"))?;
+    } else if !dir.is_dir() {
+        return Err(format!("Output path is not a directory: {}", dir.display()));
+    }
+    dir.canonicalize()
+        .map_err(|err| format!("Failed to canonicalize output directory: {err}"))
+}
+
+/// Default landing directory: `$XDG_CACHE_HOME/uniclip/get`, else
+/// `$HOME/.cache/uniclip/get`, else a temp-dir fallback.
+fn default_out_dir() -> PathBuf {
+    if let Ok(xdg) = std::env::var("XDG_CACHE_HOME") {
+        if !xdg.is_empty() {
+            return PathBuf::from(xdg).join("uniclip").join("get");
+        }
+    }
+    if let Ok(home) = std::env::var("HOME") {
+        if !home.is_empty() {
+            return PathBuf::from(home)
+                .join(".cache")
+                .join("uniclip")
+                .join("get");
+        }
+    }
+    std::env::temp_dir().join("uniclip-get")
+}
+
+/// Strip path separators a malicious sender might inject. Never trust the
+/// remote-supplied filename verbatim. Mirrors `recv::sanitize_filename`.
+fn sanitize_filename(name: &str) -> String {
+    let stripped: String = name
+        .chars()
+        .filter(|c| !matches!(c, '/' | '\\' | '\0'))
+        .collect();
+    if stripped.is_empty() || stripped == "." || stripped == ".." {
+        "uniclip-get.bin".to_string()
+    } else {
+        stripped
+    }
+}
+
+fn short_hash(s: &str) -> &str {
+    if s.len() > 8 {
+        &s[..8]
+    } else {
+        s
+    }
+}
+
+fn first_line(s: &str, max: usize) -> String {
+    let line = s.lines().next().unwrap_or("");
+    if line.chars().count() > max {
+        let truncated: String = line.chars().take(max).collect();
+        format!("{truncated}…")
+    } else {
+        line.to_string()
+    }
+}
+
+// ── JSON output shapes (snake_case, mirroring `recv`) ────────────────
+
+#[derive(Serialize)]
+struct GetOutcome<'a> {
+    entry_id: &'a str,
+    /// Classified kind: `text` | `link` | `image` | `file`.
+    content_type: &'a str,
+    /// Raw representation MIME, e.g. `image/png`.
+    mime_type: &'a str,
+    /// Absolute path of the written file; null for text or `--out -`.
+    path: Option<&'a str>,
+    filename: Option<&'a str>,
+    /// Text content; null for image/file.
+    text: Option<&'a str>,
+    bytes_written: Option<u64>,
+    captured_at: i64,
+    outcome: &'static str,
+}
+
+#[derive(Serialize)]
+struct ListRow<'a> {
+    entry_id: &'a str,
+    content_type: &'a str,
+    mime_type: &'a str,
+    captured_at: i64,
+    preview: &'a str,
+    lost: bool,
+}
+
+fn print_json<T: Serialize>(value: &T) {
+    if let Ok(s) = serde_json::to_string_pretty(value) {
+        println!("{s}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a projection with sane defaults; tests override the fields they
+    /// care about (content_type, link_urls, payload_state).
+    fn projection(content_type: &str) -> EntryProjectionResponseDto {
+        EntryProjectionResponseDto {
+            id: "ent-test".to_string(),
+            preview: "preview".to_string(),
+            has_detail: true,
+            size_bytes: 0,
+            captured_at: 0,
+            content_type: content_type.to_string(),
+            thumbnail_url: None,
+            is_encrypted: false,
+            is_favorited: false,
+            updated_at: 0,
+            active_time: 0,
+            file_transfer_status: None,
+            file_transfer_reason: None,
+            link_urls: None,
+            link_domains: None,
+            file_sizes: None,
+            image_width: None,
+            image_height: None,
+            payload_state: None,
+        }
+    }
+
+    #[test]
+    fn classify_uses_mime_prefix() {
+        assert_eq!(classify(&projection("image/png")), Category::Image);
+        assert_eq!(classify(&projection("image/jpeg")), Category::Image);
+        assert_eq!(classify(&projection("text/uri-list")), Category::File);
+        assert_eq!(classify(&projection("text/plain")), Category::Text);
+        // Unknown / empty mime falls back to text.
+        assert_eq!(classify(&projection("unknown")), Category::Text);
+    }
+
+    #[test]
+    fn classify_detects_link_via_link_urls() {
+        let mut entry = projection("text/plain");
+        entry.link_urls = Some(vec!["https://example.com".to_string()]);
+        assert_eq!(classify(&entry), Category::Link);
+        // Empty link_urls is NOT a link.
+        entry.link_urls = Some(vec![]);
+        assert_eq!(classify(&entry), Category::Text);
+    }
+
+    #[test]
+    fn image_mime_wins_over_link_urls() {
+        // An image entry that happens to carry link_urls is still an image.
+        let mut entry = projection("image/png");
+        entry.link_urls = Some(vec!["https://x".to_string()]);
+        assert_eq!(classify(&entry), Category::Image);
+    }
+
+    #[test]
+    fn ext_from_mime_maps_known_image_types() {
+        assert_eq!(ext_from_mime("image/png"), "png");
+        assert_eq!(ext_from_mime("image/jpeg"), "jpg");
+        assert_eq!(ext_from_mime("IMAGE/PNG"), "png");
+        assert_eq!(ext_from_mime("image/heic"), "bin");
+    }
+
+    #[test]
+    fn is_lost_is_case_insensitive() {
+        let mut entry = projection("image/png");
+        assert!(!is_lost(&entry));
+        entry.payload_state = Some("Lost".to_string());
+        assert!(is_lost(&entry));
+        entry.payload_state = Some("lost".to_string());
+        assert!(is_lost(&entry));
+        entry.payload_state = Some("Available".to_string());
+        assert!(!is_lost(&entry));
+    }
+
+    #[test]
+    fn sanitize_filename_strips_separators() {
+        assert_eq!(sanitize_filename("../../etc/passwd"), "....etcpasswd");
+        assert_eq!(sanitize_filename("a/b\\c"), "abc");
+        assert_eq!(sanitize_filename(""), "uniclip-get.bin");
+        assert_eq!(sanitize_filename(".."), "uniclip-get.bin");
+        assert_eq!(sanitize_filename("photo.png"), "photo.png");
+    }
+
+    #[test]
+    fn short_hash_truncates_to_eight() {
+        assert_eq!(short_hash("0123456789abcdef"), "01234567");
+        assert_eq!(short_hash("abc"), "abc");
+    }
+
+    #[test]
+    fn first_line_truncates_and_takes_first_line() {
+        assert_eq!(first_line("hello\nworld", 80), "hello");
+        assert_eq!(first_line("abcdef", 3), "abc…");
+        assert_eq!(first_line("", 10), "");
+    }
+}

--- a/src-tauri/crates/uc-cli/src/commands/mod.rs
+++ b/src-tauri/crates/uc-cli/src/commands/mod.rs
@@ -6,6 +6,7 @@ pub mod dev;
 pub mod devices;
 #[cfg(feature = "dev-tools")]
 pub mod dump_clipboard;
+pub mod get;
 pub mod init;
 pub mod invite;
 pub mod join;

--- a/src-tauri/crates/uc-cli/src/exit_codes.rs
+++ b/src-tauri/crates/uc-cli/src/exit_codes.rs
@@ -6,3 +6,11 @@ pub const EXIT_ERROR: i32 = 1;
 
 /// Exit code when the daemon is not running or unreachable.
 pub const EXIT_DAEMON_UNREACHABLE: i32 = 5;
+
+/// Exit code when no clipboard entry matched the selector (`uniclip get`).
+pub const EXIT_NO_MATCH: i32 = 6;
+
+/// Exit code when a matched entry exists but its payload is unavailable —
+/// e.g. `payloadState == "Lost"` or the file/blob is no longer present
+/// (`uniclip get`). Distinct from a hard error so scripts can branch on it.
+pub const EXIT_CONTENT_UNAVAILABLE: i32 = 7;

--- a/src-tauri/crates/uc-cli/src/main.rs
+++ b/src-tauri/crates/uc-cli/src/main.rs
@@ -214,6 +214,44 @@ enum Commands {
         #[arg(short = 'o', long = "out", value_name = "DIR")]
         out: Option<std::path::PathBuf>,
     },
+    /// Read an already-synced clipboard entry and return immediately.
+    ///
+    /// Unlike `recv` (which blocks waiting for the NEXT inbound file), `get`
+    /// reads what is already in the daemon's history — ideal for headless /
+    /// SSH boxes with no system clipboard, and for scripts / agents.
+    ///
+    /// Selection (default: the newest usable entry):
+    /// * `--type <image|file|text|link>` — newest entry of that kind.
+    /// * `--id <ENTRY-ID>` — a specific entry (see `uniclip search query`).
+    /// * `--list` — list recent entries instead of materializing one.
+    ///
+    /// Output: text/link content prints to stdout; image/file bytes are
+    /// written to `--out` (default cache dir) with the absolute path printed
+    /// to stdout, or streamed to stdout with `--out -`. Status lines go to
+    /// stderr, so stdout stays clean for piping.
+    ///
+    /// EXIT CODES: `0` materialized; `6` no entry matched the selector;
+    /// `7` matched but payload unavailable (Lost / not downloaded — re-send
+    /// from the source device).
+    Get {
+        /// Restrict selection to the newest entry of this kind.
+        #[arg(long = "type", value_name = "KIND", value_enum)]
+        kind: Option<commands::get::GetKind>,
+        /// Select a specific entry by id (from `uniclip search query`).
+        #[arg(long, value_name = "ENTRY-ID", conflicts_with = "kind")]
+        id: Option<String>,
+        /// List recent entries instead of materializing one.
+        #[arg(long, conflicts_with_all = ["kind", "id"])]
+        list: bool,
+        /// Number of recent entries to scan / list (default 50).
+        #[arg(short = 'n', long, value_name = "N")]
+        limit: Option<usize>,
+        /// Output for image/file bytes: a directory, or `-` for stdout.
+        /// Defaults to a per-user cache directory. Ignored for text/link
+        /// (those always print to stdout).
+        #[arg(short = 'o', long = "out", value_name = "DIR|-")]
+        out: Option<String>,
+    },
     /// Publish or fetch encrypted large payload blobs
     #[cfg(feature = "dev-tools")]
     Blob {
@@ -361,6 +399,26 @@ fn main() -> anyhow::Result<()> {
             }
             Commands::Watch => commands::watch::run(cli.json, cli.verbose).await,
             Commands::Recv { out } => commands::recv::run(out, cli.json, cli.verbose).await,
+            Commands::Get {
+                kind,
+                id,
+                list,
+                limit,
+                out,
+            } => {
+                commands::get::run(
+                    commands::get::GetArgs {
+                        kind,
+                        id,
+                        list,
+                        limit,
+                        out,
+                    },
+                    cli.json,
+                    cli.verbose,
+                )
+                .await
+            }
             #[cfg(feature = "dev-tools")]
             Commands::Blob { subcommand } => {
                 commands::blob::run(subcommand, cli.json, cli.verbose).await
@@ -734,6 +792,52 @@ mod tests {
         );
         let r2 = Cli::try_parse_from(["uniclip", "send", "--resend", "ent-1", "--peer", "dev-a"]);
         assert!(r2.is_ok(), "expected resend mode with --peer to parse");
+    }
+
+    #[test]
+    fn get_parses_with_no_args() {
+        // `uniclip get` 默认取最新一条 —— 不带任何 selector 必须能解析。
+        let r = Cli::try_parse_from(["uniclip", "get"]);
+        assert!(r.is_ok(), "expected bare `get` to parse");
+    }
+
+    #[test]
+    fn get_accepts_type_selector() {
+        for kind in ["image", "file", "text", "link"] {
+            let r = Cli::try_parse_from(["uniclip", "get", "--type", kind]);
+            assert!(r.is_ok(), "expected `get --type {kind}` to parse");
+        }
+        // 非法 kind 必须被 value_enum 拒绝。
+        let bad = Cli::try_parse_from(["uniclip", "get", "--type", "video"]);
+        assert!(bad.is_err(), "expected `get --type video` to be rejected");
+    }
+
+    #[test]
+    fn get_type_and_id_are_mutually_exclusive() {
+        // 选最新某类型 与 选指定 id 互斥 —— 两者语义冲突。
+        let r = Cli::try_parse_from(["uniclip", "get", "--type", "image", "--id", "ent-1"]);
+        assert!(
+            r.is_err(),
+            "expected `get --type … --id …` to be rejected by clap"
+        );
+    }
+
+    #[test]
+    fn get_list_conflicts_with_selectors() {
+        // `--list` 只列出, 不能同时带 selector。
+        assert!(Cli::try_parse_from(["uniclip", "get", "--list", "--type", "image"]).is_err());
+        assert!(Cli::try_parse_from(["uniclip", "get", "--list", "--id", "ent-1"]).is_err());
+        assert!(
+            Cli::try_parse_from(["uniclip", "get", "--list"]).is_ok(),
+            "expected bare `get --list` to parse"
+        );
+    }
+
+    #[test]
+    fn get_accepts_out_dash_for_stdout() {
+        // `--out -` 是把二进制导到 stdout 的契约。
+        let r = Cli::try_parse_from(["uniclip", "get", "--type", "image", "--out", "-"]);
+        assert!(r.is_ok(), "expected `get --type image --out -` to parse");
     }
 
     #[test]

--- a/src-tauri/crates/uc-daemon-client/src/http/clipboard.rs
+++ b/src-tauri/crates/uc-daemon-client/src/http/clipboard.rs
@@ -2,6 +2,9 @@ use std::sync::Arc;
 
 use anyhow::{anyhow, Context, Result};
 use reqwest::Method;
+use uc_daemon_contract::api::dto::clipboard::{
+    EntryDetailDto, EntryProjectionResponseDto, EntryResourceDto,
+};
 use uc_daemon_contract::api::dto::clipboard_command::{
     CancelTransferRequest, CancelTransferResponse, DispatchOutcomeResponse, DispatchTextRequest,
     ResendRequest, ResendResponse,
@@ -275,6 +278,179 @@ impl DaemonClipboardClient {
             .to_vec();
 
         Ok(Some(FileExport { filename, bytes }))
+    }
+
+    /// List clipboard history entry projections, newest first.
+    ///
+    /// Calls `GET /clipboard/entries?limit={limit}&offset={offset}`, which
+    /// returns the canonical `ApiEnvelope<Vec<EntryProjectionResponseDto>>`.
+    /// The daemon clamps `limit` to 1000. This is the real-time list view (not
+    /// the search index), so it is the reliable source for "the latest synced
+    /// entry" on a headless node.
+    pub async fn list_entries(
+        &self,
+        limit: usize,
+        offset: usize,
+    ) -> Result<Vec<EntryProjectionResponseDto>> {
+        let connection = self
+            .connection_state
+            .get()
+            .ok_or_else(|| anyhow!("daemon connection info is not available"))?;
+        let path = format!(
+            "{}?limit={limit}&offset={offset}",
+            http_route::CLIPBOARD_ENTRIES
+        );
+        let request = authorized_daemon_request_with_type(
+            &self.http,
+            &self.connection_state,
+            Method::GET,
+            &path,
+            connection.pid,
+            &self.client_type,
+        )
+        .await?;
+
+        let response = request
+            .send()
+            .await
+            .with_context(|| format!("failed to call daemon entries route {path}"))?;
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            anyhow::bail!("list entries failed ({}): {}", status, body);
+        }
+
+        let envelope = response
+            .json::<ApiEnvelope<Vec<EntryProjectionResponseDto>>>()
+            .await
+            .context("failed to decode entries response")?;
+        Ok(envelope.data)
+    }
+
+    /// Fetch an entry's full text detail (ADR-008 §H envelope).
+    ///
+    /// Calls `GET /clipboard/entries/{id}`. Returns `Ok(Some(_))` on 200,
+    /// `Ok(None)` on 404 (no such entry), and `Err` for any other status
+    /// (notably 422 when the entry is not text content) or transport failure.
+    pub async fn entry_detail(&self, entry_id: &str) -> Result<Option<EntryDetailDto>> {
+        let connection = self
+            .connection_state
+            .get()
+            .ok_or_else(|| anyhow!("daemon connection info is not available"))?;
+        let path = format!("{}/{entry_id}", http_route::CLIPBOARD_ENTRIES);
+        let request = authorized_daemon_request_with_type(
+            &self.http,
+            &self.connection_state,
+            Method::GET,
+            &path,
+            connection.pid,
+            &self.client_type,
+        )
+        .await?;
+
+        let response = request
+            .send()
+            .await
+            .with_context(|| format!("failed to call daemon entry-detail route {path}"))?;
+        let status = response.status();
+        if status == reqwest::StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            anyhow::bail!("entry-detail fetch failed ({}): {}", status, body);
+        }
+
+        let envelope = response
+            .json::<ApiEnvelope<EntryDetailDto>>()
+            .await
+            .context("failed to decode entry-detail response")?;
+        Ok(Some(envelope.data))
+    }
+
+    /// Fetch an entry's resource metadata (blob pointer or inline data).
+    ///
+    /// Calls `GET /clipboard/entries/{id}/resource`. Used to materialize image
+    /// entries (which are NOT free-files): the returned DTO carries either
+    /// `inline_data` (base64) for small images stored inline, or a `blob_id`
+    /// to fetch the bytes with [`fetch_blob`](Self::fetch_blob). Returns
+    /// `Ok(None)` on 404.
+    pub async fn entry_resource(&self, entry_id: &str) -> Result<Option<EntryResourceDto>> {
+        let connection = self
+            .connection_state
+            .get()
+            .ok_or_else(|| anyhow!("daemon connection info is not available"))?;
+        let path = format!("{}/{entry_id}/resource", http_route::CLIPBOARD_ENTRIES);
+        let request = authorized_daemon_request_with_type(
+            &self.http,
+            &self.connection_state,
+            Method::GET,
+            &path,
+            connection.pid,
+            &self.client_type,
+        )
+        .await?;
+
+        let response = request
+            .send()
+            .await
+            .with_context(|| format!("failed to call daemon entry-resource route {path}"))?;
+        let status = response.status();
+        if status == reqwest::StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            anyhow::bail!("entry-resource fetch failed ({}): {}", status, body);
+        }
+
+        let envelope = response
+            .json::<ApiEnvelope<EntryResourceDto>>()
+            .await
+            .context("failed to decode entry-resource response")?;
+        Ok(Some(envelope.data))
+    }
+
+    /// Fetch raw blob bytes by blob id.
+    ///
+    /// Calls the binary endpoint `GET /clipboard/blobs/{blob_id}` (raw bytes,
+    /// exempt from the JSON envelope). Returns `Ok(Some(_))` on 200,
+    /// `Ok(None)` on 404, and `Err` on any other status / transport failure.
+    pub async fn fetch_blob(&self, blob_id: &str) -> Result<Option<Vec<u8>>> {
+        let connection = self
+            .connection_state
+            .get()
+            .ok_or_else(|| anyhow!("daemon connection info is not available"))?;
+        let path = format!("{}/{blob_id}", http_route::CLIPBOARD_BLOBS);
+        let request = authorized_daemon_request_with_type(
+            &self.http,
+            &self.connection_state,
+            Method::GET,
+            &path,
+            connection.pid,
+            &self.client_type,
+        )
+        .await?;
+
+        let response = request
+            .send()
+            .await
+            .with_context(|| format!("failed to call daemon blob route {path}"))?;
+        let status = response.status();
+        if status == reqwest::StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            anyhow::bail!("blob fetch failed ({}): {}", status, body);
+        }
+
+        let bytes = response
+            .bytes()
+            .await
+            .context("failed to read blob bytes")?
+            .to_vec();
+        Ok(Some(bytes))
     }
 }
 

--- a/src-tauri/crates/uc-daemon-client/src/http_ws_service.rs
+++ b/src-tauri/crates/uc-daemon-client/src/http_ws_service.rs
@@ -6,6 +6,9 @@ use futures_util::{SinkExt, StreamExt};
 use tokio::sync::mpsc;
 use tokio_tungstenite::tungstenite::{client::IntoClientRequest, Message};
 use tracing::{debug, warn};
+use uc_daemon_contract::api::dto::clipboard::{
+    EntryDetailDto, EntryProjectionResponseDto, EntryResourceDto,
+};
 use uc_daemon_contract::api::dto::clipboard_command::{
     CancelTransferResponse, DispatchOutcomeResponse, InboundEntryEvent, InboundNoticeEvent,
     ResendResponse,
@@ -64,6 +67,29 @@ impl DaemonService for HttpWsDaemonService {
             .clipboard_client()
             .export_entry_file(entry_id)
             .await
+    }
+
+    async fn list_entries(
+        &self,
+        limit: usize,
+        offset: usize,
+    ) -> Result<Vec<EntryProjectionResponseDto>> {
+        self.ctx
+            .clipboard_client()
+            .list_entries(limit, offset)
+            .await
+    }
+
+    async fn entry_detail(&self, entry_id: &str) -> Result<Option<EntryDetailDto>> {
+        self.ctx.clipboard_client().entry_detail(entry_id).await
+    }
+
+    async fn entry_resource(&self, entry_id: &str) -> Result<Option<EntryResourceDto>> {
+        self.ctx.clipboard_client().entry_resource(entry_id).await
+    }
+
+    async fn fetch_blob(&self, blob_id: &str) -> Result<Option<Vec<u8>>> {
+        self.ctx.clipboard_client().fetch_blob(blob_id).await
     }
 
     async fn subscribe_inbound_notices(&self) -> Result<mpsc::Receiver<InboundNoticeEvent>> {

--- a/src-tauri/crates/uc-daemon-client/src/service.rs
+++ b/src-tauri/crates/uc-daemon-client/src/service.rs
@@ -8,6 +8,9 @@
 use anyhow::Result;
 use async_trait::async_trait;
 use tokio::sync::mpsc;
+use uc_daemon_contract::api::dto::clipboard::{
+    EntryDetailDto, EntryProjectionResponseDto, EntryResourceDto,
+};
 use uc_daemon_contract::api::dto::clipboard_command::{
     CancelTransferResponse, DispatchOutcomeResponse, InboundEntryEvent, InboundNoticeEvent,
     ResendResponse,
@@ -63,6 +66,29 @@ pub trait DaemonService: Send + Sync {
     /// should keep waiting), and `Err` for any other status or transport
     /// failure.
     async fn export_entry_file(&self, entry_id: &str) -> Result<Option<FileExport>>;
+
+    /// List clipboard history entry projections, newest first, by calling
+    /// `GET /clipboard/entries?limit&offset`. This is the real-time list view
+    /// (NOT the search index), so it reliably reflects "the latest synced
+    /// entry" — the basis for `uniclip get` on a headless node.
+    async fn list_entries(
+        &self,
+        limit: usize,
+        offset: usize,
+    ) -> Result<Vec<EntryProjectionResponseDto>>;
+
+    /// Fetch an entry's full text detail via `GET /clipboard/entries/{id}`.
+    /// `Ok(None)` on 404; `Err` for other statuses (e.g. 422 non-text).
+    async fn entry_detail(&self, entry_id: &str) -> Result<Option<EntryDetailDto>>;
+
+    /// Fetch an entry's resource metadata via
+    /// `GET /clipboard/entries/{id}/resource` (used to materialize images,
+    /// which are not free-files). `Ok(None)` on 404.
+    async fn entry_resource(&self, entry_id: &str) -> Result<Option<EntryResourceDto>>;
+
+    /// Fetch raw blob bytes via `GET /clipboard/blobs/{blob_id}`.
+    /// `Ok(None)` on 404.
+    async fn fetch_blob(&self, blob_id: &str) -> Result<Option<Vec<u8>>>;
 
     /// Subscribe to `setup.pairingCompleted` events (ADR-008 P5-2b).
     ///

--- a/src-tauri/crates/uc-daemon-contract/src/api/dto/clipboard.rs
+++ b/src-tauri/crates/uc-daemon-contract/src/api/dto/clipboard.rs
@@ -10,7 +10,7 @@ use utoipa::ToSchema;
 
 /// Clipboard entry projection — lightweight summary for list views.
 /// Matches the frontend `ClipboardEntryDto` interface.
-#[derive(Debug, Clone, Serialize, ToSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct EntryProjectionResponseDto {
     pub id: String,
@@ -51,7 +51,7 @@ pub struct EntryProjectionResponseDto {
 
 /// Full entry detail (text content).
 /// Matches the frontend `EntryDetail` interface.
-#[derive(Debug, Serialize, ToSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct EntryDetailDto {
     pub id: String,
@@ -66,7 +66,7 @@ pub struct EntryDetailDto {
 
 /// Resource metadata (blob URL or inline data).
 /// Matches the frontend `ClipboardEntryResource` interface.
-#[derive(Debug, Serialize, ToSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct EntryResourceDto {
     pub blob_id: Option<String>,

--- a/src-tauri/tests/e2e/tests/get_entry.rs
+++ b/src-tauri/tests/e2e/tests/get_entry.rs
@@ -1,0 +1,284 @@
+//! E2E tests for `uniclip get` — the one-shot reader for already-synced
+//! clipboard entries (issue #1025).
+//!
+//! `get` is the non-blocking counterpart to `recv`: instead of subscribing and
+//! waiting for the *next* inbound file, it reads what is *already* in the
+//! daemon's history and returns immediately. These tests verify the contract
+//! that scripts / agents depend on:
+//!
+//! - argument-level guards (invalid `--type`, mutually-exclusive selectors);
+//! - empty-history behaviour and the dedicated exit codes;
+//! - `--list` output (human + JSON);
+//! - the signature property: `get` does NOT block (unlike `recv`).
+//!
+//! **Headless limitation** (see `clipboard_history.rs`): in this environment
+//! there is no OS clipboard capture and pairing is not wired up, so the history
+//! starts empty. We therefore cannot exercise the happy-path materialization of
+//! a real image/file/text entry here — that path is covered by unit tests in
+//! `uc-cli` and must be validated on a real paired node. What we CAN pin down
+//! end-to-end is every selection / contract / exit-code branch around it.
+//!
+//! Exit codes (mirrors `uc-cli/src/exit_codes.rs`):
+//! - `6` = EXIT_NO_MATCH — no entry matched the selector.
+//! - `7` = EXIT_CONTENT_UNAVAILABLE — matched but payload Lost / not downloaded.
+//!
+//! Run with: cargo test -p uc-e2e-tests -- --ignored
+
+use std::time::Duration;
+
+use uc_e2e_tests::{TestCli, TestDaemon, TestProfile};
+
+const EXIT_NO_MATCH: i32 = 6;
+
+/// Start a daemon and init a space, returning (daemon, cli). The daemon stays
+/// alive (held by the returned handle) so `get` reuses it as a running peer.
+async fn setup_initialized_node(name: &str) -> (TestDaemon, TestCli) {
+    let profile = TestProfile::new(name);
+    let daemon = TestDaemon::start(profile)
+        .await
+        .expect("daemon start failed");
+    let cli = TestCli::new(&daemon.profile);
+
+    let out = cli.run_capture(&[
+        "init",
+        "--passphrase",
+        "get-test-passphrase-e2e",
+        "--device-name",
+        "get-e2e-device",
+    ]);
+    assert!(
+        out.success(),
+        "init failed (exit={}): {}",
+        out.exit_code,
+        out.stderr
+    );
+
+    (daemon, cli)
+}
+
+// ── Empty-history selection / exit codes ─────────────────────────────
+
+/// `get` (no selector) on an empty history returns EXIT_NO_MATCH rather than
+/// blocking or erroring — there simply is no entry to return.
+#[tokio::test]
+#[ignore]
+async fn get_empty_history_returns_no_match() {
+    let (_daemon, cli) = setup_initialized_node("get-empty").await;
+
+    let out = cli.run_capture(&["get"]);
+    assert_eq!(
+        out.exit_code, EXIT_NO_MATCH,
+        "expected EXIT_NO_MATCH on empty history; stdout={}, stderr={}",
+        out.stdout, out.stderr
+    );
+}
+
+/// `get --type image` on an empty history returns EXIT_NO_MATCH and the error
+/// names the kind that was not found.
+#[tokio::test]
+#[ignore]
+async fn get_type_image_empty_history_returns_no_match() {
+    let (_daemon, cli) = setup_initialized_node("get-type-empty").await;
+
+    let out = cli.run_capture(&["get", "--type", "image"]);
+    assert_eq!(
+        out.exit_code, EXIT_NO_MATCH,
+        "expected EXIT_NO_MATCH for --type image on empty history; stderr={}",
+        out.stderr
+    );
+    assert!(
+        out.stderr.to_lowercase().contains("image"),
+        "error should mention the requested kind 'image', got stderr={}",
+        out.stderr
+    );
+}
+
+/// `get --id <nonexistent>` returns EXIT_NO_MATCH — the id is not in the
+/// scanned window.
+#[tokio::test]
+#[ignore]
+async fn get_nonexistent_id_returns_no_match() {
+    let (_daemon, cli) = setup_initialized_node("get-bad-id").await;
+
+    let out = cli.run_capture(&["get", "--id", "ent-does-not-exist"]);
+    assert_eq!(
+        out.exit_code, EXIT_NO_MATCH,
+        "expected EXIT_NO_MATCH for a nonexistent --id; stderr={}",
+        out.stderr
+    );
+}
+
+/// In `--json` mode, a no-match must NOT print anything to stdout (errors go to
+/// stderr). Scripts can rely on "empty stdout ⇒ nothing materialized".
+#[tokio::test]
+#[ignore]
+async fn get_json_no_match_emits_no_stdout() {
+    let (_daemon, cli) = setup_initialized_node("get-json-nomatch").await;
+
+    let out = cli.run_capture(&["--json", "get"]);
+    assert_eq!(
+        out.exit_code, EXIT_NO_MATCH,
+        "expected EXIT_NO_MATCH; stderr={}",
+        out.stderr
+    );
+    assert!(
+        out.stdout.trim().is_empty(),
+        "no-match must leave stdout empty in --json mode, got stdout={}",
+        out.stdout
+    );
+}
+
+// ── --list output ────────────────────────────────────────────────────
+
+/// `get --list` on an empty history exits 0 (listing nothing is not a failure).
+#[tokio::test]
+#[ignore]
+async fn get_list_empty_history_succeeds() {
+    let (_daemon, cli) = setup_initialized_node("get-list-empty").await;
+
+    let out = cli.run_capture(&["get", "--list"]);
+    assert!(
+        out.success(),
+        "get --list should exit 0 on empty history; exit={}, stderr={}",
+        out.exit_code,
+        out.stderr
+    );
+}
+
+/// `get --list --json` emits a well-formed JSON array on stdout (empty when the
+/// history is empty), so callers can parse it unconditionally.
+#[tokio::test]
+#[ignore]
+async fn get_list_json_outputs_valid_array() {
+    let (_daemon, cli) = setup_initialized_node("get-list-json").await;
+
+    let out = cli.run_capture(&["--json", "get", "--list"]);
+    assert!(
+        out.success(),
+        "get --list --json should exit 0; exit={}, stderr={}",
+        out.exit_code,
+        out.stderr
+    );
+
+    let parsed: serde_json::Value = serde_json::from_str(out.stdout.trim()).unwrap_or_else(|e| {
+        panic!(
+            "stdout should be valid JSON, got err={e}, stdout={}",
+            out.stdout
+        )
+    });
+    assert!(
+        parsed.is_array(),
+        "get --list --json stdout should be a JSON array, got: {parsed}"
+    );
+}
+
+// ── Signature behaviour: get does NOT block ──────────────────────────
+
+/// The defining contrast with `recv`: `get` must return promptly instead of
+/// waiting for an inbound entry. We spawn it against an empty history and assert
+/// it terminates well within a timeout (and with EXIT_NO_MATCH).
+#[tokio::test]
+#[ignore]
+async fn get_is_non_blocking() {
+    let (_daemon, cli) = setup_initialized_node("get-nonblock").await;
+
+    let mut child = std::process::Command::new(cli.binary_path())
+        .env("UC_PROFILE", &cli.profile_name)
+        .args(["get"])
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .expect("failed to spawn get");
+
+    // Poll for exit; `get` should finish quickly (one-shot, no waiting).
+    let deadline = std::time::Instant::now() + Duration::from_secs(15);
+    let status = loop {
+        match child.try_wait().expect("try_wait failed") {
+            Some(status) => break Some(status),
+            None => {
+                if std::time::Instant::now() >= deadline {
+                    break None;
+                }
+                std::thread::sleep(Duration::from_millis(100));
+            }
+        }
+    };
+
+    let status = match status {
+        Some(s) => s,
+        None => {
+            let _ = child.kill();
+            let _ = child.wait();
+            panic!("get blocked: it did not exit within 15s on an empty history");
+        }
+    };
+    assert_eq!(
+        status.code(),
+        Some(EXIT_NO_MATCH),
+        "non-blocking get on empty history should exit EXIT_NO_MATCH"
+    );
+}
+
+// ── Argument-level contracts (clap; no daemon needed) ────────────────
+
+/// `--type` only accepts the four known kinds; an unknown value is rejected by
+/// clap before any runtime logic.
+#[tokio::test]
+#[ignore]
+async fn get_invalid_type_rejected() {
+    let profile = TestProfile::new("get-bad-type");
+    let cli = TestCli::new(&profile);
+
+    let out = cli.run_capture(&["get", "--type", "video"]);
+    assert!(
+        !out.success(),
+        "get --type video should be rejected; exit={}",
+        out.exit_code
+    );
+    let combined = format!("{}{}", out.stdout, out.stderr);
+    assert!(
+        combined.contains("invalid value") || combined.contains("possible values"),
+        "expected a clap value-enum rejection, got: {combined}"
+    );
+}
+
+/// `--type` and `--id` are mutually exclusive (select-newest-of-kind vs
+/// select-specific-id). clap rejects the combination.
+#[tokio::test]
+#[ignore]
+async fn get_type_and_id_mutually_exclusive() {
+    let profile = TestProfile::new("get-type-id-mutex");
+    let cli = TestCli::new(&profile);
+
+    let out = cli.run_capture(&["get", "--type", "image", "--id", "ent-1"]);
+    assert!(
+        !out.success(),
+        "get --type … --id … should be rejected; exit={}",
+        out.exit_code
+    );
+    let combined = format!("{}{}", out.stdout, out.stderr);
+    assert!(
+        combined.contains("cannot be used with") || combined.contains("conflict"),
+        "expected a clap conflict error, got: {combined}"
+    );
+}
+
+/// `--list` cannot be combined with a selector.
+#[tokio::test]
+#[ignore]
+async fn get_list_conflicts_with_selectors() {
+    let profile = TestProfile::new("get-list-mutex");
+    let cli = TestCli::new(&profile);
+
+    let out = cli.run_capture(&["get", "--list", "--type", "image"]);
+    assert!(
+        !out.success(),
+        "get --list --type … should be rejected; exit={}",
+        out.exit_code
+    );
+    let combined = format!("{}{}", out.stdout, out.stderr);
+    assert!(
+        combined.contains("cannot be used with") || combined.contains("conflict"),
+        "expected a clap conflict error, got: {combined}"
+    );
+}


### PR DESCRIPTION
## Summary

- **New `uniclip get` subcommand** (`72b96d3d`): a one-shot, non-blocking reader for entries **already** in the daemon's history — the case `recv` can't serve (it blocks waiting for the *next* inbound file). This is the missing piece for headless / SSH boxes that have no system clipboard to paste from. It selects an entry (newest usable by default, or `--type <image|file|text|link>` / `--id` / `--list`) and materializes by kind: text/link → stdout, file → free-file export, **image → resource (inline base64 or blob fetch)** which `recv`/`export_entry_file` cannot do. Image/file bytes land in `--out` (default per-user cache dir) with the absolute path printed to stdout, or stream to stdout via `--out -`; status lines go to stderr so stdout stays clean. Stable exit codes: `6` no match, `7` payload unavailable (Lost / not downloaded).
- **Daemon-client facade extension** (`72b96d3d`): four read methods (`list_entries`, `entry_detail`, `entry_resource`, `fetch_blob`) over existing HTTP routes, plus `Deserialize` on three response DTOs. No wire-format change.
- **E2E coverage** (`58f06f2e`): 10 black-box tests against a real daemon — empty-history exit codes, `--json` no-match emits no stdout, `--list` (human + JSON), the signature non-blocking property, and the clap contracts.
- **Docs** (`cb6e7682`): CLI reference (en + zh) gets a "Reading already-synced entries" section and the new exit codes.

Closes #1025.

## Test plan

- [x] `cargo test -p uc-cli` → 69 passed (incl. 13 new: classify / ext / lost / sanitize + clap parse contracts)
- [x] E2E: `cargo build -p uc-cli -p uc-daemon` then `cargo test --manifest-path tests/e2e/Cargo.toml --test get_entry -- --ignored` → **10 passed** (real daemon instances)
- [x] `cargo check` for uc-webserver / uc-daemon-client / uc-daemon-contract; clippy clean on changed files
- [ ] **Happy-path materialization on a real paired node** — copy an image/file on device A, then `uniclip get --type image` on device B lands the correct bytes. Not reachable in the E2E harness (no OS clipboard capture, pairing not wired), so it's covered by unit tests only; please verify manually on real hardware before relying on it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `uniclip get`: non-blocking retrieval of synced entries (by type or id), listing, and flexible output for text, links, images, and files; documented distinct exit codes for no-match (6) and unavailable payload (7).
* **Documentation**
  * Updated CLI reference and README with usage examples, output behavior (stdout/stderr semantics, `--out -`), and exit-code descriptions (including `recv` vs `get` behavior).
* **Tests**
  * Added end-to-end tests validating selection, exit codes, argument contracts, `--list` output, and non-blocking guarantee.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->