### PR TITLE
ci(react-doctor): pin action and CLI to a compatible pair

### DIFF
--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -20,6 +20,6 @@ jobs:
       # "error: too many arguments. Expected 1 argument but got 2." Pin the action commit and
       # the CLI version to a compatible pre-consolidation pair (blocking defaults to advisory).
       # Revisit once upstream ships a release where the action and CLI flag interfaces agree.
-      - uses: millionco/react-doctor@486c68f65511 # interface-compatible with react-doctor@0.5.1
+      - uses: millionco/react-doctor@486c68f655117819dc268f2b0715ed5b5bebce84 # interface-compatible with react-doctor@0.5.1
         with:
           version: "0.5.1"

--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -13,7 +13,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: millionco/react-doctor@main
+      # Pinned to stop CI breakage from upstream float. Both `millionco/react-doctor@main`
+      # and the npm package it runs drift independently; on 2026-06-11 the action switched
+      # to the consolidated `--scope` CLI flag (millionco/react-doctor#769) while the
+      # published `react-doctor@latest` (0.5.1) still spoke `--diff`, so every PR failed with
+      # "error: too many arguments. Expected 1 argument but got 2." Pin the action commit and
+      # the CLI version to a compatible pre-consolidation pair (blocking defaults to advisory).
+      # Revisit once upstream ships a release where the action and CLI flag interfaces agree.
+      - uses: millionco/react-doctor@486c68f65511 # interface-compatible with react-doctor@0.5.1
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          diff: main
+          version: "0.5.1"


### PR DESCRIPTION
## Why

The `React Doctor` check has been **failing on every PR repo-wide since 2026-06-11** (e.g. `feat/mobile-sync-qr-multi-url` #1026, `fix/re-pair-after-one-sided-unpair`, `feat/cli-get-synced-entry`, `release/v0.15.0-alpha.1`, …). The 2026-06-10 runs were green; nothing in any PR's own code caused it.

Root cause is upstream version float. The workflow pinned neither side:

- the action `millionco/react-doctor@main`, and
- the npm package it shells out to (`react-doctor@latest`).

On 2026-06-11 the action moved to the consolidated `--scope` CLI flag (millionco/react-doctor#769, commit `2f26228`) and started invoking:

```
react-doctor . --json --json-compact --blocking none --scope changed --changed-files-from <file>
```

but the published `react-doctor@latest` (`0.5.1`, released 2026-06-09) still only understands the old `--diff` interface, so it treats the `--scope` value as a stray positional argument and aborts:

```
error: too many arguments. Expected 1 argument but got 2.
```

`errorCount=0 / warningCount=0` in the report confirms the scanner crashed rather than finding anything in our code.

## Fix

Pin both sides to a compatible, pre-consolidation pair so they stop drifting:

- action → `millionco/react-doctor@486c68f65511` (2026-06-10, still on the `--diff` interface; this is also the commit that made `blocking` default to **advisory**, so findings never fail a PR)
- CLI → `version: "0.5.1"` (same `--diff` interface — the exact pairing that ran green on 2026-06-10)

Also dropped the `github-token` / `diff` inputs: the action's `action.yml` has never declared either (they only produced `Unexpected input(s) 'github-token', 'diff'` warnings). The composite action obtains its token from `github.token`, and the workflow already grants `pull-requests: write`.

## Notes

- `main` has no branch protection, so this check is **not required** and was never blocking merges — this just makes the signal green/trustworthy again.
- Other open PRs pick this up automatically once they rebase onto `main` (the `pull_request` workflow definition is read from the PR ref).
- Revisit once upstream ships a release where the action and CLI flag interfaces agree, then we can move back toward a floating-but-aligned setup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow to pin the external action to a specific commit and provide an explicit action version for stable behavior.
  * Removed prior token/diff configuration and added inline comments clarifying the pin/version pairing to prevent CI failures from mismatched tool versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->