### PR TITLE
refactor: centralize ApiEnvelope unwrapping into one seam per side

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10032,6 +10032,7 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-tungstenite",
  "tokio-util",

--- a/apps/cli/src/commands/init.rs
+++ b/apps/cli/src/commands/init.rs
@@ -87,7 +87,7 @@ pub async fn run(args: InitArgs, verbose: bool) -> i32 {
             exit_codes::EXIT_SUCCESS
         }
         Err(err) => {
-            ui::spinner_finish_error(&spinner, &format!("{err}"));
+            ui::spinner_finish_error(&spinner, &crate::commands::daemon_error_message(&err));
             exit_codes::EXIT_ERROR
         }
     }

--- a/apps/cli/src/commands/invite.rs
+++ b/apps/cli/src/commands/invite.rs
@@ -73,7 +73,7 @@ pub async fn run(verbose: bool) -> i32 {
             inv
         }
         Err(err) => {
-            ui::spinner_finish_error(&spinner, &format!("{err}"));
+            ui::spinner_finish_error(&spinner, &crate::commands::daemon_error_message(&err));
             return exit_codes::EXIT_ERROR;
         }
     };

--- a/apps/cli/src/commands/join.rs
+++ b/apps/cli/src/commands/join.rs
@@ -170,7 +170,10 @@ pub async fn run(args: JoinArgs, verbose: bool) -> i32 {
                 exit_codes::EXIT_SUCCESS
             }
             Err(err) => {
-                ui::spinner_finish_error(&spinner, &format!("Join failed: {err}"));
+                ui::spinner_finish_error(
+                    &spinner,
+                    &format!("Join failed: {}", crate::commands::daemon_error_message(&err)),
+                );
                 exit_codes::EXIT_ERROR
             }
         },

--- a/apps/cli/src/commands/mod.rs
+++ b/apps/cli/src/commands/mod.rs
@@ -25,3 +25,14 @@ pub mod stop;
 pub mod switch_space;
 pub mod upgrade;
 pub mod watch;
+
+/// Render a daemon-call failure for terminal output: prefer the daemon's
+/// human-readable error message (`DaemonRequestError::Status.message`) over
+/// the full "daemon request <path> failed with status ..." string, which is
+/// noise in a user-facing error line.
+pub(crate) fn daemon_error_message(err: &anyhow::Error) -> String {
+    err.downcast_ref::<uc_daemon_client::DaemonRequestError>()
+        .and_then(uc_daemon_client::DaemonRequestError::message)
+        .map(str::to_string)
+        .unwrap_or_else(|| err.to_string())
+}

--- a/apps/cli/src/commands/search.rs
+++ b/apps/cli/src/commands/search.rs
@@ -7,7 +7,7 @@ use crate::commands::app_session::connect_or_spawn_oneshot_daemon;
 use crate::exit_codes;
 use crate::ui;
 
-use uc_daemon_client::{DaemonClientContext, DaemonSearchRequestError, SearchQueryRequest};
+use uc_daemon_client::{DaemonClientContext, DaemonRequestError, SearchQueryRequest};
 use uc_daemon_contract::api::dto::search::{
     SearchQueryResultDto, SearchResultDto, SearchStatusData,
 };
@@ -185,10 +185,13 @@ pub async fn run(subcommand: SearchCommands, json: bool, verbose: bool) -> i32 {
 
 fn render_search_error(action: &str, err: anyhow::Error, json: bool) -> i32 {
     if json {
-        let (code, message) = match err.downcast_ref::<DaemonSearchRequestError>() {
-            Some(search_err) => (
-                search_err.code.as_deref().unwrap_or("unknown"),
-                search_err.message.clone(),
+        let (code, message) = match err.downcast_ref::<DaemonRequestError>() {
+            Some(req_err) => (
+                req_err.code().unwrap_or("unknown"),
+                req_err
+                    .message()
+                    .map(|m| m.to_string())
+                    .unwrap_or_else(|| err.to_string()),
             ),
             None => ("unknown", err.to_string()),
         };
@@ -202,8 +205,8 @@ fn render_search_error(action: &str, err: anyhow::Error, json: bool) -> i32 {
     } else {
         // Check for session_locked code in the structured error.
         let is_locked = err
-            .downcast_ref::<DaemonSearchRequestError>()
-            .and_then(|e| e.code.as_deref())
+            .downcast_ref::<DaemonRequestError>()
+            .and_then(|e| e.code())
             .map(|c| c == "session_locked")
             .unwrap_or(false);
 

--- a/apps/cli/src/commands/switch_space.rs
+++ b/apps/cli/src/commands/switch_space.rs
@@ -123,7 +123,13 @@ pub async fn run(args: SwitchSpaceArgs, verbose: bool) -> i32 {
                 exit_codes::EXIT_SUCCESS
             }
             Err(err) => {
-                ui::spinner_finish_error(&spinner, &format!("Switch-space failed: {err}"));
+                ui::spinner_finish_error(
+                    &spinner,
+                    &format!(
+                        "Switch-space failed: {}",
+                        crate::commands::daemon_error_message(&err)
+                    ),
+                );
                 exit_codes::EXIT_ERROR
             }
         },

--- a/crates/uc-daemon-client/Cargo.toml
+++ b/crates/uc-daemon-client/Cargo.toml
@@ -39,6 +39,7 @@ url = "2"
 
 # Error handling + logging
 anyhow = "1.0"
+thiserror = "2.0"
 tracing = "0.1"
 
 [dev-dependencies]

--- a/crates/uc-daemon-client/src/http/analytics.rs
+++ b/crates/uc-daemon-client/src/http/analytics.rs
@@ -1,9 +1,9 @@
 use std::sync::Arc;
 
-use anyhow::{anyhow, Context, Result};
-use reqwest::{Method, RequestBuilder};
+use anyhow::Result;
+use reqwest::Method;
 
-use crate::http::authorized_daemon_request_with_type;
+use crate::http::enveloped::empty_request;
 use crate::DaemonConnectionState;
 use uc_daemon_contract::api::dto::analytics::CaptureUiEventRequest;
 
@@ -38,42 +38,14 @@ impl DaemonAnalyticsClient {
     /// missing connection, transport failure, or non-2xx status — callers
     /// treat analytics as best-effort and should only `debug`-log the error.
     pub async fn capture(&self, event: CaptureUiEventRequest) -> Result<()> {
-        let response = self
-            .authorized_request(Method::POST, "/analytics/capture")
-            .await?
-            .json(&event)
-            .send()
-            .await
-            .with_context(|| "failed to call daemon /analytics/capture")?;
-
-        if response.status().is_success() {
-            return Ok(());
-        }
-        let status = response.status();
-        let body = response
-            .text()
-            .await
-            .unwrap_or_else(|_| "<failed to read body>".to_string());
-        Err(anyhow!(
-            "daemon /analytics/capture failed with status {}: {}",
-            status,
-            body,
-        ))
-    }
-
-    async fn authorized_request(&self, method: Method, path: &str) -> Result<RequestBuilder> {
-        let connection = self
-            .connection_state
-            .get()
-            .ok_or_else(|| anyhow!("daemon connection info is not available"))?;
-        authorized_daemon_request_with_type(
+        Ok(empty_request(
             &self.http,
             &self.connection_state,
-            method,
-            path,
-            connection.pid,
             &self.client_type,
+            Method::POST,
+            "/analytics/capture",
+            |r| r.json(&event),
         )
-        .await
+        .await?)
     }
 }

--- a/crates/uc-daemon-client/src/http/clipboard.rs
+++ b/crates/uc-daemon-client/src/http/clipboard.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::Result;
 use reqwest::Method;
 use uc_daemon_contract::api::dto::clipboard::{
     EntryDetailDto, EntryProjectionResponseDto, EntryResourceDto,
@@ -9,10 +9,9 @@ use uc_daemon_contract::api::dto::clipboard_command::{
     CancelTransferRequest, CancelTransferResponse, DispatchOutcomeResponse, DispatchTextRequest,
     ResendRequest, ResendResponse,
 };
-use uc_daemon_contract::api::dto::envelope::ApiEnvelope;
 use uc_daemon_contract::constants::http_route;
 
-use crate::http::authorized_daemon_request_with_type;
+use crate::http::enveloped::{empty_request, enveloped_request, send_checked, DaemonRequestError};
 use crate::service::FileExport;
 use crate::DaemonConnectionState;
 
@@ -47,51 +46,19 @@ impl DaemonClipboardClient {
     /// Restore a clipboard entry to the OS clipboard via daemon.
     /// Returns Ok(()) on success. The daemon handles origin tracking; no outbound sync
     /// occurs because CaptureClipboardUseCase skips capture for LocalRestore origin.
+    /// A 404 surfaces as `DaemonRequestError::Status` (downcastable from anyhow).
     pub async fn restore_clipboard_entry(&self, entry_id: &str) -> Result<()> {
-        let connection = self
-            .connection_state
-            .get()
-            .ok_or_else(|| anyhow!("daemon connection info is not available"))?;
-        let path = format!(
-            "{}/{entry_id}",
-            uc_daemon_contract::constants::http_route::CLIPBOARD_RESTORE
-        );
-        let request = authorized_daemon_request_with_type(
-            &*self.http,
+        let path = format!("{}/{entry_id}", http_route::CLIPBOARD_RESTORE);
+        empty_request(
+            &self.http,
             &self.connection_state,
+            &self.client_type,
             Method::POST,
             &path,
-            connection.pid,
-            &self.client_type,
+            |r| r,
         )
         .await?;
-
-        let response = request
-            .send()
-            .await
-            .with_context(|| format!("failed to call daemon clipboard restore route {path}"))?;
-        let status = response.status();
-
-        if status.is_success() {
-            return Ok(());
-        }
-
-        let body = response
-            .text()
-            .await
-            .unwrap_or_else(|_| "<failed to read body>".to_string());
-
-        // Use structured error prefix so callers can distinguish 404 from other errors
-        // without parsing free-form text (F-2 round 3).
-        if status == reqwest::StatusCode::NOT_FOUND {
-            Err(anyhow::anyhow!("[NOT_FOUND] {path}: {body}"))
-        } else {
-            Err(anyhow::anyhow!(
-                "daemon clipboard restore request {path} failed with status {}: {}",
-                status,
-                body
-            ))
-        }
+        Ok(())
     }
 
     pub async fn dispatch_text(
@@ -99,43 +66,19 @@ impl DaemonClipboardClient {
         text: &str,
         peers: Option<Vec<String>>,
     ) -> Result<DispatchOutcomeResponse> {
-        let connection = self
-            .connection_state
-            .get()
-            .ok_or_else(|| anyhow!("daemon connection info is not available"))?;
         let req_body = DispatchTextRequest {
             text: text.to_string(),
             peers,
         };
-        let request = authorized_daemon_request_with_type(
-            &*self.http,
+        Ok(enveloped_request(
+            &self.http,
             &self.connection_state,
+            &self.client_type,
             Method::POST,
             http_route::CLIPBOARD_DISPATCH,
-            connection.pid,
-            &self.client_type,
+            |r| r.json(&req_body),
         )
-        .await?;
-
-        let response = request
-            .json(&req_body)
-            .send()
-            .await
-            .context("failed to call daemon clipboard dispatch")?;
-
-        let status = response.status();
-        if !status.is_success() {
-            let body = response.text().await.unwrap_or_default();
-            anyhow::bail!("clipboard dispatch failed ({}): {}", status, body);
-        }
-
-        // Wire shape (ADR-008 §H): `{ data: DispatchOutcomeResponse, ts }`.
-        // Unwrap the envelope; the public return type stays `DispatchOutcomeResponse`.
-        let envelope = response
-            .json::<ApiEnvelope<DispatchOutcomeResponse>>()
-            .await
-            .context("failed to decode dispatch response")?;
-        Ok(envelope.data)
+        .await?)
     }
 
     pub async fn resend_entry(
@@ -143,42 +86,19 @@ impl DaemonClipboardClient {
         entry_id: &str,
         peers: Option<Vec<String>>,
     ) -> Result<ResendResponse> {
-        let connection = self
-            .connection_state
-            .get()
-            .ok_or_else(|| anyhow!("daemon connection info is not available"))?;
         let req_body = ResendRequest {
             entry_id: entry_id.to_string(),
             peers,
         };
-        let request = authorized_daemon_request_with_type(
-            &*self.http,
+        Ok(enveloped_request(
+            &self.http,
             &self.connection_state,
+            &self.client_type,
             Method::POST,
             http_route::CLIPBOARD_RESEND,
-            connection.pid,
-            &self.client_type,
+            |r| r.json(&req_body),
         )
-        .await?;
-
-        let response = request
-            .json(&req_body)
-            .send()
-            .await
-            .context("failed to call daemon clipboard resend")?;
-
-        let status = response.status();
-        if !status.is_success() {
-            let body = response.text().await.unwrap_or_default();
-            anyhow::bail!("clipboard resend failed ({}): {}", status, body);
-        }
-
-        // Wire shape (ADR-008 §H): `{ data: ResendResponse, ts }`.
-        let envelope = response
-            .json::<ApiEnvelope<ResendResponse>>()
-            .await
-            .context("failed to decode resend response")?;
-        Ok(envelope.data)
+        .await?)
     }
 
     pub async fn cancel_transfer(
@@ -186,42 +106,19 @@ impl DaemonClipboardClient {
         transfer_id: &str,
         reason: &str,
     ) -> Result<CancelTransferResponse> {
-        let connection = self
-            .connection_state
-            .get()
-            .ok_or_else(|| anyhow!("daemon connection info is not available"))?;
         let path = format!("{}/{transfer_id}", http_route::CLIPBOARD_CANCEL_TRANSFER);
         let req_body = CancelTransferRequest {
             reason: reason.to_string(),
         };
-        let request = authorized_daemon_request_with_type(
-            &*self.http,
+        Ok(enveloped_request(
+            &self.http,
             &self.connection_state,
+            &self.client_type,
             Method::POST,
             &path,
-            connection.pid,
-            &self.client_type,
+            |r| r.json(&req_body),
         )
-        .await?;
-
-        let response = request
-            .json(&req_body)
-            .send()
-            .await
-            .context("failed to call daemon cancel transfer")?;
-
-        let status = response.status();
-        if !status.is_success() {
-            let body = response.text().await.unwrap_or_default();
-            anyhow::bail!("cancel transfer failed ({}): {}", status, body);
-        }
-
-        // Wire shape (ADR-008 §H): `{ data: CancelTransferResponse, ts }`.
-        let envelope = response
-            .json::<ApiEnvelope<CancelTransferResponse>>()
-            .await
-            .context("failed to decode cancel transfer response")?;
-        Ok(envelope.data)
+        .await?)
     }
 
     /// Export an entry's first materialized free-file (ADR-008 P5-1b).
@@ -233,36 +130,23 @@ impl DaemonClipboardClient {
     /// from `Content-Disposition`; it falls back to `entry_id` when the header
     /// is absent or unparseable.
     pub async fn export_entry_file(&self, entry_id: &str) -> Result<Option<FileExport>> {
-        let connection = self
-            .connection_state
-            .get()
-            .ok_or_else(|| anyhow!("daemon connection info is not available"))?;
         // The entry-file endpoint is `GET /clipboard/entries/:id/file`; build it
         // off the shared entries base so the route lives in one place.
         let path = format!("{}/{entry_id}/file", http_route::CLIPBOARD_ENTRIES);
-        let request = authorized_daemon_request_with_type(
+        let response = match send_checked(
             &self.http,
             &self.connection_state,
+            &self.client_type,
             Method::GET,
             &path,
-            connection.pid,
-            &self.client_type,
+            |r| r,
         )
-        .await?;
-
-        let response = request
-            .send()
-            .await
-            .with_context(|| format!("failed to call daemon entry-file route {path}"))?;
-        let status = response.status();
-
-        if status == reqwest::StatusCode::NOT_FOUND {
-            return Ok(None);
-        }
-        if !status.is_success() {
-            let body = response.text().await.unwrap_or_default();
-            anyhow::bail!("entry-file export failed ({}): {}", status, body);
-        }
+        .await
+        {
+            Ok(response) => response,
+            Err(err) if err.is_not_found() => return Ok(None),
+            Err(err) => return Err(err.into()),
+        };
 
         let filename = response
             .headers()
@@ -274,7 +158,7 @@ impl DaemonClipboardClient {
         let bytes = response
             .bytes()
             .await
-            .context("failed to read entry-file bytes")?
+            .map_err(|source| DaemonRequestError::Decode { path, source })?
             .to_vec();
 
         Ok(Some(FileExport { filename, bytes }))
@@ -292,39 +176,19 @@ impl DaemonClipboardClient {
         limit: usize,
         offset: usize,
     ) -> Result<Vec<EntryProjectionResponseDto>> {
-        let connection = self
-            .connection_state
-            .get()
-            .ok_or_else(|| anyhow!("daemon connection info is not available"))?;
         let path = format!(
             "{}?limit={limit}&offset={offset}",
             http_route::CLIPBOARD_ENTRIES
         );
-        let request = authorized_daemon_request_with_type(
+        Ok(enveloped_request(
             &self.http,
             &self.connection_state,
+            &self.client_type,
             Method::GET,
             &path,
-            connection.pid,
-            &self.client_type,
+            |r| r,
         )
-        .await?;
-
-        let response = request
-            .send()
-            .await
-            .with_context(|| format!("failed to call daemon entries route {path}"))?;
-        let status = response.status();
-        if !status.is_success() {
-            let body = response.text().await.unwrap_or_default();
-            anyhow::bail!("list entries failed ({}): {}", status, body);
-        }
-
-        let envelope = response
-            .json::<ApiEnvelope<Vec<EntryProjectionResponseDto>>>()
-            .await
-            .context("failed to decode entries response")?;
-        Ok(envelope.data)
+        .await?)
     }
 
     /// Fetch an entry's full text detail (ADR-008 §H envelope).
@@ -333,39 +197,21 @@ impl DaemonClipboardClient {
     /// `Ok(None)` on 404 (no such entry), and `Err` for any other status
     /// (notably 422 when the entry is not text content) or transport failure.
     pub async fn entry_detail(&self, entry_id: &str) -> Result<Option<EntryDetailDto>> {
-        let connection = self
-            .connection_state
-            .get()
-            .ok_or_else(|| anyhow!("daemon connection info is not available"))?;
         let path = format!("{}/{entry_id}", http_route::CLIPBOARD_ENTRIES);
-        let request = authorized_daemon_request_with_type(
+        match enveloped_request::<EntryDetailDto>(
             &self.http,
             &self.connection_state,
+            &self.client_type,
             Method::GET,
             &path,
-            connection.pid,
-            &self.client_type,
+            |r| r,
         )
-        .await?;
-
-        let response = request
-            .send()
-            .await
-            .with_context(|| format!("failed to call daemon entry-detail route {path}"))?;
-        let status = response.status();
-        if status == reqwest::StatusCode::NOT_FOUND {
-            return Ok(None);
+        .await
+        {
+            Ok(detail) => Ok(Some(detail)),
+            Err(err) if err.is_not_found() => Ok(None),
+            Err(err) => Err(err.into()),
         }
-        if !status.is_success() {
-            let body = response.text().await.unwrap_or_default();
-            anyhow::bail!("entry-detail fetch failed ({}): {}", status, body);
-        }
-
-        let envelope = response
-            .json::<ApiEnvelope<EntryDetailDto>>()
-            .await
-            .context("failed to decode entry-detail response")?;
-        Ok(Some(envelope.data))
     }
 
     /// Fetch an entry's resource metadata (blob pointer or inline data).
@@ -376,39 +222,21 @@ impl DaemonClipboardClient {
     /// to fetch the bytes with [`fetch_blob`](Self::fetch_blob). Returns
     /// `Ok(None)` on 404.
     pub async fn entry_resource(&self, entry_id: &str) -> Result<Option<EntryResourceDto>> {
-        let connection = self
-            .connection_state
-            .get()
-            .ok_or_else(|| anyhow!("daemon connection info is not available"))?;
         let path = format!("{}/{entry_id}/resource", http_route::CLIPBOARD_ENTRIES);
-        let request = authorized_daemon_request_with_type(
+        match enveloped_request::<EntryResourceDto>(
             &self.http,
             &self.connection_state,
+            &self.client_type,
             Method::GET,
             &path,
-            connection.pid,
-            &self.client_type,
+            |r| r,
         )
-        .await?;
-
-        let response = request
-            .send()
-            .await
-            .with_context(|| format!("failed to call daemon entry-resource route {path}"))?;
-        let status = response.status();
-        if status == reqwest::StatusCode::NOT_FOUND {
-            return Ok(None);
+        .await
+        {
+            Ok(resource) => Ok(Some(resource)),
+            Err(err) if err.is_not_found() => Ok(None),
+            Err(err) => Err(err.into()),
         }
-        if !status.is_success() {
-            let body = response.text().await.unwrap_or_default();
-            anyhow::bail!("entry-resource fetch failed ({}): {}", status, body);
-        }
-
-        let envelope = response
-            .json::<ApiEnvelope<EntryResourceDto>>()
-            .await
-            .context("failed to decode entry-resource response")?;
-        Ok(Some(envelope.data))
     }
 
     /// Fetch raw blob bytes by blob id.
@@ -417,38 +245,26 @@ impl DaemonClipboardClient {
     /// exempt from the JSON envelope). Returns `Ok(Some(_))` on 200,
     /// `Ok(None)` on 404, and `Err` on any other status / transport failure.
     pub async fn fetch_blob(&self, blob_id: &str) -> Result<Option<Vec<u8>>> {
-        let connection = self
-            .connection_state
-            .get()
-            .ok_or_else(|| anyhow!("daemon connection info is not available"))?;
         let path = format!("{}/{blob_id}", http_route::CLIPBOARD_BLOBS);
-        let request = authorized_daemon_request_with_type(
+        let response = match send_checked(
             &self.http,
             &self.connection_state,
+            &self.client_type,
             Method::GET,
             &path,
-            connection.pid,
-            &self.client_type,
+            |r| r,
         )
-        .await?;
-
-        let response = request
-            .send()
-            .await
-            .with_context(|| format!("failed to call daemon blob route {path}"))?;
-        let status = response.status();
-        if status == reqwest::StatusCode::NOT_FOUND {
-            return Ok(None);
-        }
-        if !status.is_success() {
-            let body = response.text().await.unwrap_or_default();
-            anyhow::bail!("blob fetch failed ({}): {}", status, body);
-        }
+        .await
+        {
+            Ok(response) => response,
+            Err(err) if err.is_not_found() => return Ok(None),
+            Err(err) => return Err(err.into()),
+        };
 
         let bytes = response
             .bytes()
             .await
-            .context("failed to read blob bytes")?
+            .map_err(|source| DaemonRequestError::Decode { path, source })?
             .to_vec();
         Ok(Some(bytes))
     }

--- a/crates/uc-daemon-client/src/http/enveloped.rs
+++ b/crates/uc-daemon-client/src/http/enveloped.rs
@@ -1,0 +1,250 @@
+//! Single seam for enveloped daemon HTTP requests (ADR-008 §H).
+//!
+//! Every enveloped endpoint's success body is the canonical
+//! `ApiEnvelope<T> { data, ts }`. This module owns the full request ritual —
+//! connection check, session-token authorization, transport, status/error
+//! normalization, envelope decode — so feature clients declare only the
+//! payload type `T`. Endpoints exempt from the envelope (binary bodies,
+//! empty 2xx responses) use [`send_checked`] / [`empty_request`] to share
+//! everything but the decode.
+
+use reqwest::{Method, RequestBuilder, Response, StatusCode};
+use serde::de::DeserializeOwned;
+use uc_daemon_contract::api::dto::envelope::ApiEnvelope;
+
+use crate::http::authorized_daemon_request_with_type;
+use crate::DaemonConnectionState;
+
+/// Structured error for a daemon HTTP request.
+///
+/// Callers branch on variants/fields instead of scraping message strings:
+/// `Status.code` carries the daemon's stable error code (e.g.
+/// `session_locked`, `restart_in_progress`) parsed from the JSON error body,
+/// and `Status.message` the human-readable server text (falling back to the
+/// raw body when it isn't the canonical `{ code, message }` shape).
+#[derive(Debug, thiserror::Error)]
+pub enum DaemonRequestError {
+    #[error("daemon connection info is not available")]
+    NotConnected,
+
+    #[error("failed to authorize daemon request {path}: {error}")]
+    Auth {
+        path: String,
+        // Named `error`, not `source`: anyhow::Error does not implement
+        // std::error::Error, so it cannot be a thiserror #[source].
+        error: anyhow::Error,
+    },
+
+    #[error("failed to call daemon route {path}: {source}")]
+    Transport {
+        path: String,
+        source: reqwest::Error,
+    },
+
+    #[error("daemon request {path} failed with status {status}{}: {message}", code_suffix(.code))]
+    Status {
+        path: String,
+        status: StatusCode,
+        code: Option<String>,
+        message: String,
+    },
+
+    #[error("failed to decode daemon response for {path}: {source}")]
+    Decode {
+        path: String,
+        source: reqwest::Error,
+    },
+}
+
+impl DaemonRequestError {
+    /// HTTP status of a non-2xx response, if that is what failed.
+    pub fn status(&self) -> Option<StatusCode> {
+        match self {
+            Self::Status { status, .. } => Some(*status),
+            _ => None,
+        }
+    }
+
+    /// Stable daemon error code (e.g. `session_locked`) from the error body.
+    pub fn code(&self) -> Option<&str> {
+        match self {
+            Self::Status { code, .. } => code.as_deref(),
+            _ => None,
+        }
+    }
+
+    /// Human-readable server message from the error body.
+    pub fn message(&self) -> Option<&str> {
+        match self {
+            Self::Status { message, .. } => Some(message),
+            _ => None,
+        }
+    }
+
+    /// True when the daemon answered 404 (commonly mapped to `Ok(None)`).
+    pub fn is_not_found(&self) -> bool {
+        self.status() == Some(StatusCode::NOT_FOUND)
+    }
+}
+
+fn code_suffix(code: &Option<String>) -> String {
+    code.as_deref()
+        .map(|c| format!(" [{c}]"))
+        .unwrap_or_default()
+}
+
+/// Parse the daemon's canonical `{ code, message }` error body. Falls back to
+/// the raw body as the message when the shape doesn't match.
+fn parse_error_body(body: &str) -> (Option<String>, String) {
+    #[derive(serde::Deserialize)]
+    struct ErrorBody {
+        code: Option<String>,
+        message: Option<String>,
+    }
+    match serde_json::from_str::<ErrorBody>(body) {
+        Ok(parsed) => (
+            parsed.code,
+            parsed.message.unwrap_or_else(|| body.to_string()),
+        ),
+        Err(_) => (None, body.to_string()),
+    }
+}
+
+/// Build, authorize, and send a daemon request; normalize non-2xx into
+/// [`DaemonRequestError::Status`]. Returns the raw 2xx [`Response`] for
+/// callers that read binary bodies or headers.
+pub(crate) async fn send_checked(
+    http: &reqwest::Client,
+    connection_state: &DaemonConnectionState,
+    client_type: &str,
+    method: Method,
+    path: &str,
+    customize: impl FnOnce(RequestBuilder) -> RequestBuilder,
+) -> Result<Response, DaemonRequestError> {
+    let connection = connection_state
+        .get()
+        .ok_or(DaemonRequestError::NotConnected)?;
+    let request = authorized_daemon_request_with_type(
+        http,
+        connection_state,
+        method,
+        path,
+        connection.pid,
+        client_type,
+    )
+    .await
+    .map_err(|error| DaemonRequestError::Auth {
+        path: path.to_string(),
+        error,
+    })?;
+
+    let response =
+        customize(request)
+            .send()
+            .await
+            .map_err(|source| DaemonRequestError::Transport {
+                path: path.to_string(),
+                source,
+            })?;
+
+    let status = response.status();
+    if !status.is_success() {
+        let body = response
+            .text()
+            .await
+            .unwrap_or_else(|_| "<failed to read body>".to_string());
+        let (code, message) = parse_error_body(&body);
+        return Err(DaemonRequestError::Status {
+            path: path.to_string(),
+            status,
+            code,
+            message,
+        });
+    }
+
+    Ok(response)
+}
+
+/// Send an enveloped request and return the unwrapped payload `T`.
+///
+/// `customize` attaches the request body / query params (use the identity
+/// closure `|r| r` for plain requests). The `ts` half of the envelope is
+/// intentionally dropped — no client consumes it.
+pub(crate) async fn enveloped_request<T>(
+    http: &reqwest::Client,
+    connection_state: &DaemonConnectionState,
+    client_type: &str,
+    method: Method,
+    path: &str,
+    customize: impl FnOnce(RequestBuilder) -> RequestBuilder,
+) -> Result<T, DaemonRequestError>
+where
+    T: DeserializeOwned,
+{
+    let response =
+        send_checked(http, connection_state, client_type, method, path, customize).await?;
+    let envelope: ApiEnvelope<T> =
+        response
+            .json()
+            .await
+            .map_err(|source| DaemonRequestError::Decode {
+                path: path.to_string(),
+                source,
+            })?;
+    Ok(envelope.data)
+}
+
+/// Send a request whose success body is empty (or ignored). Shares the full
+/// ritual with [`enveloped_request`] minus the envelope decode.
+pub(crate) async fn empty_request(
+    http: &reqwest::Client,
+    connection_state: &DaemonConnectionState,
+    client_type: &str,
+    method: Method,
+    path: &str,
+    customize: impl FnOnce(RequestBuilder) -> RequestBuilder,
+) -> Result<(), DaemonRequestError> {
+    send_checked(http, connection_state, client_type, method, path, customize).await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_canonical_error_body() {
+        let (code, message) =
+            parse_error_body(r#"{"code":"session_locked","message":"unlock first"}"#);
+        assert_eq!(code.as_deref(), Some("session_locked"));
+        assert_eq!(message, "unlock first");
+    }
+
+    #[test]
+    fn falls_back_to_raw_body_when_message_missing() {
+        let (code, message) = parse_error_body(r#"{"code":"oops"}"#);
+        assert_eq!(code.as_deref(), Some("oops"));
+        assert_eq!(message, r#"{"code":"oops"}"#);
+    }
+
+    #[test]
+    fn falls_back_to_raw_body_on_non_json() {
+        let (code, message) = parse_error_body("<html>502</html>");
+        assert_eq!(code, None);
+        assert_eq!(message, "<html>502</html>");
+    }
+
+    #[test]
+    fn status_error_display_includes_code() {
+        let err = DaemonRequestError::Status {
+            path: "/search/rebuild".to_string(),
+            status: StatusCode::CONFLICT,
+            code: Some("rebuild_already_running".to_string()),
+            message: "rebuild in progress".to_string(),
+        };
+        assert_eq!(
+            err.to_string(),
+            "daemon request /search/rebuild failed with status 409 Conflict [rebuild_already_running]: rebuild in progress"
+        );
+    }
+}

--- a/crates/uc-daemon-client/src/http/lifecycle.rs
+++ b/crates/uc-daemon-client/src/http/lifecycle.rs
@@ -1,12 +1,11 @@
 use std::sync::Arc;
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::Result;
 use reqwest::Method;
-use uc_daemon_contract::api::dto::envelope::ApiEnvelope;
 use uc_daemon_contract::api::types::{DaemonResidency, RestartAccepted, RestartRequest};
 use uc_daemon_contract::constants::http_route;
 
-use crate::http::authorized_daemon_request_with_type;
+use crate::http::enveloped::enveloped_request;
 use crate::DaemonConnectionState;
 
 /// Loopback HTTP client for the daemon's `/lifecycle/*` control endpoints.
@@ -47,40 +46,18 @@ impl DaemonLifecycleClient {
     /// (ADR-008 P5-L). Returns the accepted {generation, targetMode}. The daemon
     /// raises quiescing + drains + self-terminates; the requester then spawns the
     /// target. Errors carry a stable `code` (restart_in_progress / not_promotable /
-    /// restart_disabled / invalid_target) for the caller to branch on.
+    /// restart_disabled / invalid_target) on `DaemonRequestError::Status` for the
+    /// caller to branch on.
     pub async fn restart(&self, target_mode: DaemonResidency) -> Result<RestartAccepted> {
-        let connection = self
-            .connection_state
-            .get()
-            .ok_or_else(|| anyhow!("daemon connection info is not available"))?;
         let req_body = RestartRequest { target_mode };
-        let request = authorized_daemon_request_with_type(
+        Ok(enveloped_request(
             &self.http,
             &self.connection_state,
+            &self.client_type,
             Method::POST,
             http_route::LIFECYCLE_RESTART,
-            connection.pid,
-            &self.client_type,
+            |r| r.json(&req_body),
         )
-        .await?;
-
-        let response = request
-            .json(&req_body)
-            .send()
-            .await
-            .context("failed to call daemon lifecycle restart")?;
-
-        let status = response.status();
-        if !status.is_success() {
-            let body = response.text().await.unwrap_or_default();
-            anyhow::bail!("lifecycle restart failed ({}): {}", status, body);
-        }
-
-        // Wire shape (ADR-008 P5-L L8d-1): `{ data: RestartAccepted, ts }`.
-        let envelope = response
-            .json::<ApiEnvelope<RestartAccepted>>()
-            .await
-            .context("failed to decode lifecycle restart response")?;
-        Ok(envelope.data)
+        .await?)
     }
 }

--- a/crates/uc-daemon-client/src/http/mobile_sync.rs
+++ b/crates/uc-daemon-client/src/http/mobile_sync.rs
@@ -1,11 +1,10 @@
 use std::sync::Arc;
 
-use anyhow::{anyhow, Context, Result};
-use reqwest::{Method, RequestBuilder};
+use anyhow::Result;
+use reqwest::Method;
 
-use crate::http::authorized_daemon_request_with_type;
+use crate::http::enveloped::enveloped_request;
 use crate::DaemonConnectionState;
-use uc_daemon_contract::api::dto::envelope::ApiEnvelope;
 use uc_daemon_contract::api::dto::mobile_sync::{
     LanInterfaceViewDto, MobileDeviceViewDto, MobileSyncActionResultDto, MobileSyncSettingsViewDto,
     RegisterMobileDeviceRequest, RegisterMobileDeviceResultDto, UpdateMobileSyncSettingsRequest,
@@ -44,7 +43,7 @@ impl DaemonMobileSyncClient {
 
     /// GET /mobile-sync/settings
     pub async fn get_settings(&self) -> Result<MobileSyncSettingsViewDto> {
-        self.get_json("/mobile-sync/settings").await
+        self.enveloped(Method::GET, "/mobile-sync/settings").await
     }
 
     /// PATCH /mobile-sync/settings
@@ -52,13 +51,20 @@ impl DaemonMobileSyncClient {
         &self,
         req: &UpdateMobileSyncSettingsRequest,
     ) -> Result<UpdateMobileSyncSettingsResultDto> {
-        self.request_json(Method::PATCH, "/mobile-sync/settings", req)
-            .await
+        Ok(enveloped_request(
+            &self.http,
+            &self.connection_state,
+            &self.client_type,
+            Method::PATCH,
+            "/mobile-sync/settings",
+            |r| r.json(req),
+        )
+        .await?)
     }
 
     /// GET /mobile-sync/devices
     pub async fn list_devices(&self) -> Result<Vec<MobileDeviceViewDto>> {
-        self.get_json("/mobile-sync/devices").await
+        self.enveloped(Method::GET, "/mobile-sync/devices").await
     }
 
     /// POST /mobile-sync/devices
@@ -66,125 +72,44 @@ impl DaemonMobileSyncClient {
         &self,
         req: &RegisterMobileDeviceRequest,
     ) -> Result<RegisterMobileDeviceResultDto> {
-        self.request_json(Method::POST, "/mobile-sync/devices", req)
-            .await
+        Ok(enveloped_request(
+            &self.http,
+            &self.connection_state,
+            &self.client_type,
+            Method::POST,
+            "/mobile-sync/devices",
+            |r| r.json(req),
+        )
+        .await?)
     }
 
     /// DELETE /mobile-sync/devices/{device_id}
     pub async fn revoke_device(&self, device_id: &str) -> Result<MobileSyncActionResultDto> {
         let path = format!("/mobile-sync/devices/{device_id}");
-        let response = self
-            .authorized_request(Method::DELETE, &path)
-            .await?
-            .send()
-            .await
-            .with_context(|| format!("failed to call DELETE {path}"))?;
-
-        let status = response.status();
-        if status.is_success() {
-            let envelope = response
-                .json::<ApiEnvelope<MobileSyncActionResultDto>>()
-                .await
-                .with_context(|| format!("failed to decode response for DELETE {path}"))?;
-            return Ok(envelope.data);
-        }
-
-        let body = response
-            .text()
-            .await
-            .unwrap_or_else(|_| "<failed to read body>".to_string());
-        Err(anyhow!("{}", extract_error_message(status, &body)))
+        self.enveloped(Method::DELETE, &path).await
     }
 
     /// GET /mobile-sync/lan-interfaces
     pub async fn list_lan_interfaces(&self) -> Result<Vec<LanInterfaceViewDto>> {
-        self.get_json("/mobile-sync/lan-interfaces").await
+        self.enveloped(Method::GET, "/mobile-sync/lan-interfaces")
+            .await
     }
 
     // ── Private helpers ────────────────────────────────────────────────
 
-    async fn authorized_request(&self, method: Method, path: &str) -> Result<RequestBuilder> {
-        let connection = self
-            .connection_state
-            .get()
-            .ok_or_else(|| anyhow!("daemon connection info is not available"))?;
-        authorized_daemon_request_with_type(
+    /// Body-less enveloped request.
+    async fn enveloped<T>(&self, method: Method, path: &str) -> Result<T>
+    where
+        T: serde::de::DeserializeOwned,
+    {
+        Ok(enveloped_request(
             &self.http,
             &self.connection_state,
+            &self.client_type,
             method,
             path,
-            connection.pid,
-            &self.client_type,
+            |r| r,
         )
-        .await
+        .await?)
     }
-
-    /// GET helper: send request, unwrap `ApiEnvelope<T>`.
-    async fn get_json<T>(&self, path: &str) -> Result<T>
-    where
-        T: serde::de::DeserializeOwned,
-    {
-        let response = self
-            .authorized_request(Method::GET, path)
-            .await?
-            .send()
-            .await
-            .with_context(|| format!("failed to call GET {path}"))?;
-
-        let status = response.status();
-        if status.is_success() {
-            let envelope = response
-                .json::<ApiEnvelope<T>>()
-                .await
-                .with_context(|| format!("failed to decode response for GET {path}"))?;
-            return Ok(envelope.data);
-        }
-
-        let body = response
-            .text()
-            .await
-            .unwrap_or_else(|_| "<failed to read body>".to_string());
-        Err(anyhow!("{}", extract_error_message(status, &body)))
-    }
-
-    /// Body-bearing request helper: attach `.json(body)`, send, unwrap `ApiEnvelope<T>`.
-    async fn request_json<B, T>(&self, method: Method, path: &str, body: &B) -> Result<T>
-    where
-        B: serde::Serialize,
-        T: serde::de::DeserializeOwned,
-    {
-        let response = self
-            .authorized_request(method.clone(), path)
-            .await?
-            .json(body)
-            .send()
-            .await
-            .with_context(|| format!("failed to call {method} {path}"))?;
-
-        let status = response.status();
-        if status.is_success() {
-            let envelope = response
-                .json::<ApiEnvelope<T>>()
-                .await
-                .with_context(|| format!("failed to decode response for {method} {path}"))?;
-            return Ok(envelope.data);
-        }
-
-        let body_text = response
-            .text()
-            .await
-            .unwrap_or_else(|_| "<failed to read body>".to_string());
-        Err(anyhow!("{}", extract_error_message(status, &body_text)))
-    }
-}
-
-fn extract_error_message(status: reqwest::StatusCode, body: &str) -> String {
-    serde_json::from_str::<serde_json::Value>(body)
-        .ok()
-        .and_then(|v| {
-            v.get("message")
-                .and_then(|m| m.as_str())
-                .map(|s| s.to_string())
-        })
-        .unwrap_or_else(|| format!("request failed ({status}): {body}"))
 }

--- a/crates/uc-daemon-client/src/http/mod.rs
+++ b/crates/uc-daemon-client/src/http/mod.rs
@@ -1,5 +1,6 @@
 pub mod analytics;
 pub mod clipboard;
+pub mod enveloped;
 pub mod lifecycle;
 pub mod mobile_sync;
 pub mod pairing;
@@ -12,11 +13,12 @@ pub mod upgrade;
 
 pub use analytics::DaemonAnalyticsClient;
 pub use clipboard::DaemonClipboardClient;
+pub use enveloped::DaemonRequestError;
 pub use lifecycle::DaemonLifecycleClient;
 pub use mobile_sync::DaemonMobileSyncClient;
 pub use pairing::{DaemonPairingClient, DaemonPairingRequestError};
 pub use query::DaemonQueryClient;
-pub use search::{DaemonSearchClient, DaemonSearchRequestError, SearchQueryRequest};
+pub use search::{DaemonSearchClient, SearchQueryRequest};
 pub use settings::DaemonSettingsClient;
 pub use setup::DaemonSetupClient;
 pub use setup_v2::DaemonSetupV2Client;

--- a/crates/uc-daemon-client/src/http/query.rs
+++ b/crates/uc-daemon-client/src/http/query.rs
@@ -1,15 +1,14 @@
 use std::sync::Arc;
 
-use anyhow::{anyhow, Context, Result};
-use reqwest::{Method, RequestBuilder};
-
-use crate::http::authorized_daemon_request_with_type;
-use crate::DaemonConnectionState;
+use anyhow::Result;
+use reqwest::Method;
 use uc_daemon_contract::api::dto::device::LocalDeviceInfoDto;
-use uc_daemon_contract::api::dto::envelope::ApiEnvelope;
 use uc_daemon_contract::api::types::{
     PeerSnapshotDto, PresenceRefreshResponse, SpaceMemberDto, StatusResponse,
 };
+
+use crate::http::enveloped::{empty_request, enveloped_request};
+use crate::DaemonConnectionState;
 
 #[derive(Clone)]
 pub struct DaemonQueryClient {
@@ -40,154 +39,77 @@ impl DaemonQueryClient {
     }
 
     pub async fn get_peers(&self) -> Result<Vec<PeerSnapshotDto>> {
-        self.get_json(Method::GET, "/peers").await
+        self.enveloped(Method::GET, "/peers").await
     }
 
     pub async fn get_paired_devices(&self) -> Result<Vec<SpaceMemberDto>> {
-        self.get_json(Method::GET, "/paired-devices").await
+        self.enveloped(Method::GET, "/paired-devices").await
     }
 
     pub async fn get_status(&self) -> Result<StatusResponse> {
-        self.get_json(Method::GET, "/status").await
+        self.enveloped(Method::GET, "/status").await
     }
 
     pub async fn get_local_device_info(&self) -> Result<LocalDeviceInfoDto> {
-        self.get_json(Method::GET, "/device/me").await
+        self.enveloped(Method::GET, "/device/me").await
     }
 
     pub async fn refresh_presence(&self) -> Result<PresenceRefreshResponse> {
-        self.get_json(Method::POST, "/presence/refresh").await
+        self.enveloped(Method::POST, "/presence/refresh").await
     }
 
     /// Unlock the encryption session via the daemon keyring (auto-unlock).
+    ///
+    /// Decodes the payload tolerantly (`serde_json::Value`): older daemons may
+    /// omit `success`, which defaults to `true`.
     pub async fn unlock_encryption(&self) -> Result<bool> {
-        let response = self
-            .authorized_request(Method::POST, "/encryption/unlock")
-            .await?
-            .send()
-            .await
-            .with_context(|| "failed to call daemon /encryption/unlock")?;
-
-        if response.status().is_success() {
-            let body: serde_json::Value = response
-                .json()
-                .await
-                .with_context(|| "failed to decode /encryption/unlock response")?;
-            let success = body
-                .pointer("/data/success")
-                .and_then(|v| v.as_bool())
-                .unwrap_or(true);
-            return Ok(success);
-        }
-        let status = response.status();
-        let body = response
-            .text()
-            .await
-            .unwrap_or_else(|_| "<failed to read body>".to_string());
-        Err(anyhow!(
-            "daemon /encryption/unlock failed with status {}: {}",
-            status,
-            body,
-        ))
+        let data: serde_json::Value = self.enveloped(Method::POST, "/encryption/unlock").await?;
+        Ok(data
+            .get("success")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(true))
     }
 
     /// Retry the lifecycle boot on the daemon (starts network, opens clipboard capture gate).
     pub async fn lifecycle_retry(&self) -> Result<()> {
-        let response = self
-            .authorized_request(Method::POST, "/lifecycle/retry")
-            .await?
-            .send()
-            .await
-            .with_context(|| "failed to call daemon /lifecycle/retry")?;
-
-        if response.status().is_success() {
-            return Ok(());
-        }
-        let status = response.status();
-        let body = response
-            .text()
-            .await
-            .unwrap_or_else(|_| "<failed to read body>".to_string());
-        Err(anyhow!(
-            "daemon /lifecycle/retry failed with status {}: {}",
-            status,
-            body,
-        ))
+        Ok(empty_request(
+            &self.http,
+            &self.connection_state,
+            &self.client_type,
+            Method::POST,
+            "/lifecycle/retry",
+            |r| r,
+        )
+        .await?)
     }
 
     /// Signal the daemon that the GUI has unlocked and clipboard capture can begin.
     pub async fn signal_lifecycle_ready(&self) -> Result<()> {
-        let response = self
-            .authorized_request(Method::POST, "/lifecycle/ready")
-            .await?
-            .send()
-            .await
-            .with_context(|| "failed to call daemon /lifecycle/ready")?;
-
-        if response.status().is_success() {
-            return Ok(());
-        }
-        let status = response.status();
-        let body = response
-            .text()
-            .await
-            .unwrap_or_else(|_| "<failed to read body>".to_string());
-        Err(anyhow!(
-            "daemon /lifecycle/ready failed with status {}: {}",
-            status,
-            body,
-        ))
-    }
-
-    async fn authorized_request(&self, method: Method, path: &str) -> Result<RequestBuilder> {
-        let connection = self
-            .connection_state
-            .get()
-            .ok_or_else(|| anyhow!("daemon connection info is not available"))?;
-        authorized_daemon_request_with_type(
-            &*self.http,
+        Ok(empty_request(
+            &self.http,
             &self.connection_state,
-            method,
-            path,
-            connection.pid,
             &self.client_type,
+            Method::POST,
+            "/lifecycle/ready",
+            |r| r,
         )
-        .await
+        .await?)
     }
 
-    /// GET a query route whose body is the canonical `ApiEnvelope<T>` (ADR-008 §H:
-    /// `/peers`, `/paired-devices`, `/status` are all enveloped now). Decodes
-    /// `{ data: T, ts }` and returns the unwrapped `T`; the public method return
-    /// types (`Vec<PeerSnapshotDto>`, `Vec<SpaceMemberDto>`, `StatusResponse`)
-    /// stay the inner payload.
-    async fn get_json<T>(&self, method: Method, path: &str) -> Result<T>
+    /// Body-less enveloped request (ADR-008 §H: query routes are all enveloped;
+    /// the public method return types stay the inner payload).
+    async fn enveloped<T>(&self, method: Method, path: &str) -> Result<T>
     where
         T: serde::de::DeserializeOwned,
     {
-        let response = self
-            .authorized_request(method, path)
-            .await?
-            .send()
-            .await
-            .with_context(|| format!("failed to call daemon query route {path}"))?;
-
-        let status = response.status();
-        if status.is_success() {
-            let envelope = response
-                .json::<ApiEnvelope<T>>()
-                .await
-                .with_context(|| format!("failed to decode daemon query response for {path}"))?;
-            return Ok(envelope.data);
-        }
-
-        let body = response
-            .text()
-            .await
-            .unwrap_or_else(|_| "<failed to read body>".to_string());
-        Err(anyhow!(
-            "daemon query request {path} failed with status {}: {}",
-            status,
-            body
-        ))
+        Ok(enveloped_request(
+            &self.http,
+            &self.connection_state,
+            &self.client_type,
+            method,
+            path,
+            |r| r,
+        )
+        .await?)
     }
 }

--- a/crates/uc-daemon-client/src/http/search.rs
+++ b/crates/uc-daemon-client/src/http/search.rs
@@ -6,12 +6,11 @@
 
 use std::sync::Arc;
 
-use anyhow::{anyhow, Context, Result};
-use reqwest::{Method, RequestBuilder, StatusCode};
+use anyhow::Result;
+use reqwest::Method;
 
-use crate::http::authorized_daemon_request_with_type;
+use crate::http::enveloped::enveloped_request;
 use crate::DaemonConnectionState;
-use uc_daemon_contract::api::dto::envelope::ApiEnvelope;
 use uc_daemon_contract::api::dto::search::{
     SearchQueryResultDto, SearchRebuildAcceptedData, SearchStatusData,
 };
@@ -34,43 +33,15 @@ pub struct SearchQueryRequest {
     pub offset: u32,
 }
 
-/// Structured error from a failed daemon search request.
-///
-/// Preserves the HTTP status code and the daemon's JSON error body so the CLI
-/// can distinguish `session_locked`, `invalid_query`, and `rebuild_already_running`
-/// without string scraping.
-#[derive(Debug, Clone)]
-pub struct DaemonSearchRequestError {
-    pub path: String,
-    pub status: StatusCode,
-    pub code: Option<String>,
-    pub message: String,
-}
-
-impl std::fmt::Display for DaemonSearchRequestError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if let Some(code) = self.code.as_deref() {
-            write!(
-                f,
-                "daemon search request {} failed with status {} [{}]: {}",
-                self.path, self.status, code, self.message
-            )
-        } else {
-            write!(
-                f,
-                "daemon search request {} failed with status {}: {}",
-                self.path, self.status, self.message
-            )
-        }
-    }
-}
-
-impl std::error::Error for DaemonSearchRequestError {}
-
 /// Feature-specific daemon search client.
 ///
 /// Shares connection state and HTTP client with `DaemonClientContext`.
 /// Constructed via `DaemonClientContext::search_client()`.
+///
+/// Failed requests carry `DaemonRequestError::Status` (downcastable from the
+/// returned `anyhow::Error`) with the daemon's stable `code` — e.g.
+/// `session_locked`, `invalid_query`, `rebuild_already_running` — so callers
+/// can branch without string scraping.
 #[derive(Clone)]
 pub struct DaemonSearchClient {
     http: Arc<reqwest::Client>,
@@ -104,7 +75,6 @@ impl DaemonSearchClient {
     /// Sends `GET /search/query` with camelCase query params.
     /// Does NOT strip inline AND/OR or infer operators locally.
     pub async fn query(&self, request: SearchQueryRequest) -> Result<SearchQueryResultDto> {
-        let path = http_route::SEARCH_QUERY;
         let mut params: Vec<(&str, String)> = vec![
             ("query", request.query),
             ("limit", request.limit.to_string()),
@@ -129,105 +99,46 @@ impl DaemonSearchClient {
             params.push(("extensions", request.extensions.join(",")));
         }
 
-        let response = self
-            .authorized_request(Method::GET, path)
-            .await?
-            .query(&params)
-            .send()
-            .await
-            .with_context(|| format!("failed to call daemon search route {path}"))?;
-
-        Self::decode_json_response(response, path).await
+        Ok(enveloped_request(
+            &self.http,
+            &self.connection_state,
+            &self.client_type,
+            Method::GET,
+            http_route::SEARCH_QUERY,
+            |r| r.query(&params),
+        )
+        .await?)
     }
 
     /// Fetch the current search index availability status.
     ///
     /// Sends `GET /search/status`.
     pub async fn status(&self) -> Result<SearchStatusData> {
-        let path = http_route::SEARCH_STATUS;
-        let response = self
-            .authorized_request(Method::GET, path)
-            .await?
-            .send()
-            .await
-            .with_context(|| format!("failed to call daemon search route {path}"))?;
-
-        Self::decode_json_response(response, path).await
+        Ok(enveloped_request(
+            &self.http,
+            &self.connection_state,
+            &self.client_type,
+            Method::GET,
+            http_route::SEARCH_STATUS,
+            |r| r,
+        )
+        .await?)
     }
 
     /// Trigger a manual search index rebuild on the daemon.
     ///
     /// Sends `POST /search/rebuild`. A `rebuild_already_running` daemon response
-    /// is returned as a structured `DaemonSearchRequestError` rather than a plain string
-    /// so callers can distinguish it from other failures.
+    /// surfaces as `DaemonRequestError::Status` with that code so callers can
+    /// distinguish it from other failures.
     pub async fn rebuild(&self) -> Result<SearchRebuildAcceptedData> {
-        let path = http_route::SEARCH_REBUILD;
-        let response = self
-            .authorized_request(Method::POST, path)
-            .await?
-            .send()
-            .await
-            .with_context(|| format!("failed to call daemon search route {path}"))?;
-
-        Self::decode_json_response(response, path).await
-    }
-
-    async fn authorized_request(&self, method: Method, path: &str) -> Result<RequestBuilder> {
-        let connection = self
-            .connection_state
-            .get()
-            .ok_or_else(|| anyhow!("daemon connection info is not available"))?;
-        authorized_daemon_request_with_type(
-            &*self.http,
+        Ok(enveloped_request(
+            &self.http,
             &self.connection_state,
-            method,
-            path,
-            connection.pid,
             &self.client_type,
+            Method::POST,
+            http_route::SEARCH_REBUILD,
+            |r| r,
         )
-        .await
-    }
-
-    /// Decode an enveloped search success body (ADR-008 §H: query/status/rebuild
-    /// are all `ApiEnvelope<T>` now) and return the unwrapped payload `T`, or map
-    /// a non-success body to a structured `DaemonSearchRequestError`.
-    async fn decode_json_response<T: serde::de::DeserializeOwned>(
-        response: reqwest::Response,
-        path: &str,
-    ) -> Result<T> {
-        let status = response.status();
-        if status.is_success() {
-            let envelope = response
-                .json::<ApiEnvelope<T>>()
-                .await
-                .with_context(|| format!("failed to decode daemon search response for {path}"))?;
-            return Ok(envelope.data);
-        }
-
-        Err(Self::decode_error_response(response, path).await)
-    }
-
-    async fn decode_error_response(response: reqwest::Response, path: &str) -> anyhow::Error {
-        let status = response.status();
-        let body = response
-            .text()
-            .await
-            .unwrap_or_else(|_| "<unreadable response body>".to_string());
-
-        #[derive(serde::Deserialize)]
-        struct SearchApiErrorBody {
-            code: Option<String>,
-            message: Option<String>,
-        }
-
-        let maybe_error = serde_json::from_str::<SearchApiErrorBody>(&body).ok();
-        let error = DaemonSearchRequestError {
-            path: path.to_string(),
-            status,
-            code: maybe_error.as_ref().and_then(|e| e.code.clone()),
-            message: maybe_error.and_then(|e| e.message).unwrap_or(body),
-        };
-
-        anyhow!(error)
+        .await?)
     }
 }

--- a/crates/uc-daemon-client/src/http/settings.rs
+++ b/crates/uc-daemon-client/src/http/settings.rs
@@ -1,15 +1,14 @@
 use std::sync::Arc;
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::Result;
 use reqwest::Method;
-use uc_daemon_contract::api::dto::envelope::ApiEnvelope;
 use uc_daemon_contract::api::dto::settings::{
     RelayProbeOutcomeDto, RelayProbeRequestDto, SettingsDto, SettingsPatchDto,
     SettingsUpdateResultDto,
 };
 use uc_daemon_contract::constants::http_route;
 
-use crate::http::authorized_daemon_request_with_type;
+use crate::http::enveloped::enveloped_request;
 use crate::DaemonConnectionState;
 
 /// Loopback HTTP client for the daemon's `/settings` endpoints.
@@ -48,37 +47,15 @@ impl DaemonSettingsClient {
 
     /// `GET /settings` — read the current persisted settings.
     pub async fn get_settings(&self) -> Result<SettingsDto> {
-        let connection = self
-            .connection_state
-            .get()
-            .ok_or_else(|| anyhow!("daemon connection info is not available"))?;
-        let request = authorized_daemon_request_with_type(
+        Ok(enveloped_request(
             &self.http,
             &self.connection_state,
+            &self.client_type,
             Method::GET,
             http_route::SETTINGS,
-            connection.pid,
-            &self.client_type,
+            |r| r,
         )
-        .await?;
-
-        let response = request
-            .send()
-            .await
-            .context("failed to call daemon get settings")?;
-
-        let status = response.status();
-        if !status.is_success() {
-            let body = response.text().await.unwrap_or_default();
-            anyhow::bail!("get settings failed ({}): {}", status, body);
-        }
-
-        // Wire shape (ADR-008 §H): `{ data: SettingsDto, ts }`.
-        let envelope = response
-            .json::<ApiEnvelope<SettingsDto>>()
-            .await
-            .context("failed to decode settings response")?;
-        Ok(envelope.data)
+        .await?)
     }
 
     /// `PUT /settings` — persist a settings patch. Unlike the Tauri command this
@@ -87,38 +64,15 @@ impl DaemonSettingsClient {
         &self,
         patch: SettingsPatchDto,
     ) -> Result<SettingsUpdateResultDto> {
-        let connection = self
-            .connection_state
-            .get()
-            .ok_or_else(|| anyhow!("daemon connection info is not available"))?;
-        let request = authorized_daemon_request_with_type(
+        Ok(enveloped_request(
             &self.http,
             &self.connection_state,
+            &self.client_type,
             Method::PUT,
             http_route::SETTINGS,
-            connection.pid,
-            &self.client_type,
+            |r| r.json(&patch),
         )
-        .await?;
-
-        let response = request
-            .json(&patch)
-            .send()
-            .await
-            .context("failed to call daemon update settings")?;
-
-        let status = response.status();
-        if !status.is_success() {
-            let body = response.text().await.unwrap_or_default();
-            anyhow::bail!("update settings failed ({}): {}", status, body);
-        }
-
-        // Wire shape (ADR-008 §H): `{ data: SettingsUpdateResultDto, ts }`.
-        let envelope = response
-            .json::<ApiEnvelope<SettingsUpdateResultDto>>()
-            .await
-            .context("failed to decode update settings response")?;
-        Ok(envelope.data)
+        .await?)
     }
 
     /// `POST /settings/relay-probe` — probe a candidate relay URL. A probe that
@@ -126,40 +80,17 @@ impl DaemonSettingsClient {
     /// `RelayProbeOutcomeDto`), not an error; only adapter-missing / transport
     /// faults surface as `Err`.
     pub async fn probe_relay_url(&self, url: &str) -> Result<RelayProbeOutcomeDto> {
-        let connection = self
-            .connection_state
-            .get()
-            .ok_or_else(|| anyhow!("daemon connection info is not available"))?;
         let req_body = RelayProbeRequestDto {
             url: url.to_string(),
         };
-        let request = authorized_daemon_request_with_type(
+        Ok(enveloped_request(
             &self.http,
             &self.connection_state,
+            &self.client_type,
             Method::POST,
             http_route::SETTINGS_RELAY_PROBE,
-            connection.pid,
-            &self.client_type,
+            |r| r.json(&req_body),
         )
-        .await?;
-
-        let response = request
-            .json(&req_body)
-            .send()
-            .await
-            .context("failed to call daemon relay probe")?;
-
-        let status = response.status();
-        if !status.is_success() {
-            let body = response.text().await.unwrap_or_default();
-            anyhow::bail!("relay probe failed ({}): {}", status, body);
-        }
-
-        // Wire shape (ADR-008 §H): `{ data: RelayProbeOutcomeDto, ts }`.
-        let envelope = response
-            .json::<ApiEnvelope<RelayProbeOutcomeDto>>()
-            .await
-            .context("failed to decode relay probe response")?;
-        Ok(envelope.data)
+        .await?)
     }
 }

--- a/crates/uc-daemon-client/src/http/setup_v2.rs
+++ b/crates/uc-daemon-client/src/http/setup_v2.rs
@@ -1,11 +1,10 @@
 use std::sync::Arc;
 
-use anyhow::{anyhow, Context, Result};
-use reqwest::{Method, RequestBuilder};
+use anyhow::Result;
+use reqwest::Method;
 
-use crate::http::authorized_daemon_request_with_type;
+use crate::http::enveloped::enveloped_request;
 use crate::DaemonConnectionState;
-use uc_daemon_contract::api::dto::envelope::ApiEnvelope;
 use uc_daemon_contract::api::dto::v2::setup::{
     InitializeSpaceRequest, InitializeSpaceResponse, IssueInvitationResponse, RedeemRequest,
     RedeemResponse, SwitchSpaceRequest, SwitchSpaceResponse,
@@ -32,131 +31,53 @@ impl DaemonSetupV2Client {
     }
 
     pub async fn issue_invitation(&self) -> Result<IssueInvitationResponse> {
-        let response = self
-            .authorized_request(Method::POST, "/v2/setup/issue-invitation")
-            .await?
-            .send()
-            .await
-            .with_context(|| "failed to call POST /v2/setup/issue-invitation")?;
-
-        let status = response.status();
-        if status.is_success() {
-            let envelope = response
-                .json::<ApiEnvelope<IssueInvitationResponse>>()
-                .await
-                .with_context(|| "failed to decode issue-invitation response")?;
-            return Ok(envelope.data);
-        }
-
-        let body = response
-            .text()
-            .await
-            .unwrap_or_else(|_| "<failed to read body>".to_string());
-        Err(anyhow!("{}", extract_error_message(status, &body)))
+        Ok(enveloped_request(
+            &self.http,
+            &self.connection_state,
+            &self.client_type,
+            Method::POST,
+            "/v2/setup/issue-invitation",
+            |r| r,
+        )
+        .await?)
     }
 
     pub async fn initialize_space(
         &self,
         req: &InitializeSpaceRequest,
     ) -> Result<InitializeSpaceResponse> {
-        let response = self
-            .authorized_request(Method::POST, "/v2/setup/initialize")
-            .await?
-            .json(req)
-            .send()
-            .await
-            .with_context(|| "failed to call POST /v2/setup/initialize")?;
-
-        let status = response.status();
-        if status.is_success() {
-            let envelope = response
-                .json::<ApiEnvelope<InitializeSpaceResponse>>()
-                .await
-                .with_context(|| "failed to decode initialize-space response")?;
-            return Ok(envelope.data);
-        }
-
-        let body = response
-            .text()
-            .await
-            .unwrap_or_else(|_| "<failed to read body>".to_string());
-        Err(anyhow!("{}", extract_error_message(status, &body)))
+        Ok(enveloped_request(
+            &self.http,
+            &self.connection_state,
+            &self.client_type,
+            Method::POST,
+            "/v2/setup/initialize",
+            |r| r.json(req),
+        )
+        .await?)
     }
 
     pub async fn redeem_invitation(&self, req: &RedeemRequest) -> Result<RedeemResponse> {
-        let response = self
-            .authorized_request(Method::POST, "/v2/setup/redeem")
-            .await?
-            .json(req)
-            .send()
-            .await
-            .with_context(|| "failed to call POST /v2/setup/redeem")?;
-
-        let status = response.status();
-        if status.is_success() {
-            let envelope = response
-                .json::<ApiEnvelope<RedeemResponse>>()
-                .await
-                .with_context(|| "failed to decode redeem response")?;
-            return Ok(envelope.data);
-        }
-
-        let body = response
-            .text()
-            .await
-            .unwrap_or_else(|_| "<failed to read body>".to_string());
-        Err(anyhow!("{}", extract_error_message(status, &body)))
+        Ok(enveloped_request(
+            &self.http,
+            &self.connection_state,
+            &self.client_type,
+            Method::POST,
+            "/v2/setup/redeem",
+            |r| r.json(req),
+        )
+        .await?)
     }
 
     pub async fn switch_space(&self, req: &SwitchSpaceRequest) -> Result<SwitchSpaceResponse> {
-        let response = self
-            .authorized_request(Method::POST, "/v2/setup/switch-space")
-            .await?
-            .json(req)
-            .send()
-            .await
-            .with_context(|| "failed to call POST /v2/setup/switch-space")?;
-
-        let status = response.status();
-        if status.is_success() {
-            let envelope = response
-                .json::<ApiEnvelope<SwitchSpaceResponse>>()
-                .await
-                .with_context(|| "failed to decode switch-space response")?;
-            return Ok(envelope.data);
-        }
-
-        let body = response
-            .text()
-            .await
-            .unwrap_or_else(|_| "<failed to read body>".to_string());
-        Err(anyhow!("{}", extract_error_message(status, &body)))
-    }
-
-    async fn authorized_request(&self, method: Method, path: &str) -> Result<RequestBuilder> {
-        let connection = self
-            .connection_state
-            .get()
-            .ok_or_else(|| anyhow!("daemon connection info is not available"))?;
-        authorized_daemon_request_with_type(
+        Ok(enveloped_request(
             &self.http,
             &self.connection_state,
-            method,
-            path,
-            connection.pid,
             &self.client_type,
+            Method::POST,
+            "/v2/setup/switch-space",
+            |r| r.json(req),
         )
-        .await
+        .await?)
     }
-}
-
-fn extract_error_message(status: reqwest::StatusCode, body: &str) -> String {
-    serde_json::from_str::<serde_json::Value>(body)
-        .ok()
-        .and_then(|v| {
-            v.get("message")
-                .and_then(|m| m.as_str())
-                .map(|s| s.to_string())
-        })
-        .unwrap_or_else(|| format!("request failed ({status}): {body}"))
 }

--- a/crates/uc-daemon-client/src/http/upgrade.rs
+++ b/crates/uc-daemon-client/src/http/upgrade.rs
@@ -6,12 +6,11 @@
 
 use std::sync::Arc;
 
-use anyhow::{anyhow, Context, Result};
-use reqwest::{Method, RequestBuilder};
+use anyhow::Result;
+use reqwest::Method;
 
-use crate::http::authorized_daemon_request_with_type;
+use crate::http::enveloped::enveloped_request;
 use crate::DaemonConnectionState;
-use uc_daemon_contract::api::dto::envelope::ApiEnvelope;
 use uc_daemon_contract::api::dto::upgrade::{AckUpgradePayload, UpgradeStatusDto};
 use uc_daemon_contract::constants::http_route;
 
@@ -52,25 +51,15 @@ impl DaemonUpgradeClient {
     /// The daemon compares its running build version against the persisted
     /// cursor and returns a discriminated status DTO.
     pub async fn status(&self) -> Result<UpgradeStatusDto> {
-        let path = http_route::UPGRADE_STATUS;
-        let response = self
-            .authorized_request(Method::GET, path)
-            .await?
-            .send()
-            .await
-            .with_context(|| format!("failed to call daemon upgrade route {path}"))?;
-
-        let status = response.status();
-        if !status.is_success() {
-            let body = response.text().await.unwrap_or_default();
-            anyhow::bail!("upgrade status request failed ({}): {}", status, body);
-        }
-
-        let envelope = response
-            .json::<ApiEnvelope<UpgradeStatusDto>>()
-            .await
-            .with_context(|| format!("failed to decode upgrade status response for {path}"))?;
-        Ok(envelope.data)
+        Ok(enveloped_request(
+            &self.http,
+            &self.connection_state,
+            &self.client_type,
+            Method::GET,
+            http_route::UPGRADE_STATUS,
+            |r| r,
+        )
+        .await?)
     }
 
     /// Acknowledge the current daemon version by calling `POST /upgrade/ack`.
@@ -78,40 +67,14 @@ impl DaemonUpgradeClient {
     /// Advances the version cursor to the running build. Subsequent `status`
     /// calls will report `NoChange` until the binary version moves again.
     pub async fn acknowledge(&self) -> Result<AckUpgradePayload> {
-        let path = http_route::UPGRADE_ACK;
-        let response = self
-            .authorized_request(Method::POST, path)
-            .await?
-            .send()
-            .await
-            .with_context(|| format!("failed to call daemon upgrade route {path}"))?;
-
-        let status = response.status();
-        if !status.is_success() {
-            let body = response.text().await.unwrap_or_default();
-            anyhow::bail!("upgrade ack request failed ({}): {}", status, body);
-        }
-
-        let envelope = response
-            .json::<ApiEnvelope<AckUpgradePayload>>()
-            .await
-            .with_context(|| format!("failed to decode upgrade ack response for {path}"))?;
-        Ok(envelope.data)
-    }
-
-    async fn authorized_request(&self, method: Method, path: &str) -> Result<RequestBuilder> {
-        let connection = self
-            .connection_state
-            .get()
-            .ok_or_else(|| anyhow!("daemon connection info is not available"))?;
-        authorized_daemon_request_with_type(
+        Ok(enveloped_request(
             &self.http,
             &self.connection_state,
-            method,
-            path,
-            connection.pid,
             &self.client_type,
+            Method::POST,
+            http_route::UPGRADE_ACK,
+            |r| r,
         )
-        .await
+        .await?)
     }
 }

--- a/crates/uc-daemon-client/src/lib.rs
+++ b/crates/uc-daemon-client/src/lib.rs
@@ -21,8 +21,8 @@ use uc_daemon_process::socket::resolve_daemon_http_addr;
 pub use connection::DaemonConnectionState;
 pub use http::{
     DaemonAnalyticsClient, DaemonClipboardClient, DaemonLifecycleClient, DaemonMobileSyncClient,
-    DaemonPairingClient, DaemonPairingRequestError, DaemonQueryClient, DaemonSearchClient,
-    DaemonSearchRequestError, DaemonSettingsClient, DaemonSetupClient, DaemonSetupV2Client,
+    DaemonPairingClient, DaemonPairingRequestError, DaemonQueryClient, DaemonRequestError,
+    DaemonSearchClient, DaemonSettingsClient, DaemonSetupClient, DaemonSetupV2Client,
     DaemonUpgradeClient, ExchangedSessionToken, SearchQueryRequest,
 };
 pub use http_ws_service::HttpWsDaemonService;

--- a/src/__tests__/api/daemon/_test-helpers.ts
+++ b/src/__tests__/api/daemon/_test-helpers.ts
@@ -29,12 +29,18 @@ const mockRefreshSession = vi.fn()
 // resolve to `{ data: <envelope> }` flow straight through. Tests that don't use
 // callSdk are unaffected.
 const mockCallSdk = vi.fn((call: () => Promise<{ data: unknown }>) => call().then(r => r.data))
+// Enveloped endpoints route through callEnveloped, which additionally unwraps
+// the canonical `{ data, ts }` envelope down to the payload.
+const mockCallEnveloped = vi.fn((call: () => Promise<{ data: { data: unknown } }>) =>
+  call().then(r => r.data.data)
+)
 
 export const mockDaemonClient = {
   initialize: vi.fn(),
   destroy: vi.fn(),
   request: mockRequest,
   callSdk: mockCallSdk,
+  callEnveloped: mockCallEnveloped,
   refreshSession: mockRefreshSession,
   session: null as { token: string; expiresAt: number; encryptionReady: boolean } | null,
   get initialized() {

--- a/src/__tests__/lib/daemon-auth.test.ts
+++ b/src/__tests__/lib/daemon-auth.test.ts
@@ -78,6 +78,12 @@ vi.mock('@/api/daemon/client', () => ({
       const { data } = await call()
       return data
     },
+    // Replay callEnveloped: unwrap the SDK `{ data }` AND the `{ data, ts }`
+    // envelope, mirroring the real implementation.
+    async callEnveloped<T>(call: () => Promise<{ data: { data: T; ts: number } }>): Promise<T> {
+      const { data } = await call()
+      return data.data
+    },
     destroy() {
       _session = null
       _fetchQueue = []

--- a/src/api/__tests__/file_transfer.test.ts
+++ b/src/api/__tests__/file_transfer.test.ts
@@ -9,6 +9,10 @@ import { cancelClipboardTransfer } from '@/api/generated/sdk.gen'
 vi.mock('@/api/daemon/client', () => ({
   daemonClient: {
     callSdk: vi.fn((call: () => Promise<{ data: unknown }>) => call().then(r => r.data)),
+    // 复刻 callEnveloped 快乐路径：连拆 SDK { data } 与 { data, ts } 信封。
+    callEnveloped: vi.fn((call: () => Promise<{ data: { data: unknown } }>) =>
+      call().then(r => r.data.data)
+    ),
   },
 }))
 

--- a/src/api/daemon/__tests__/clipboard.test.ts
+++ b/src/api/daemon/__tests__/clipboard.test.ts
@@ -17,6 +17,10 @@ vi.mock('../client', () => ({
   daemonClient: {
     request: vi.fn(),
     callSdk: vi.fn((call: () => Promise<{ data: unknown }>) => call().then(r => r.data)),
+    // 复刻 callEnveloped 快乐路径：连拆 SDK { data } 与 { data, ts } 信封。
+    callEnveloped: vi.fn((call: () => Promise<{ data: { data: unknown } }>) =>
+      call().then(r => r.data.data)
+    ),
     initialized: true,
   },
 }))

--- a/src/api/daemon/__tests__/settings.test.ts
+++ b/src/api/daemon/__tests__/settings.test.ts
@@ -22,6 +22,10 @@ vi.mock('@/api/daemon/client', () => ({
   daemonClient: {
     // 复刻 callSdk 快乐路径：调用 SDK thunk，解包其 { data }（= ApiEnvelope）。
     callSdk: vi.fn((call: () => Promise<{ data: unknown }>) => call().then(r => r.data)),
+    // 复刻 callEnveloped 快乐路径：连拆 SDK { data } 与 { data, ts } 信封。
+    callEnveloped: vi.fn((call: () => Promise<{ data: { data: unknown } }>) =>
+      call().then(r => r.data.data)
+    ),
   },
 }))
 

--- a/src/api/daemon/client.ts
+++ b/src/api/daemon/client.ts
@@ -232,6 +232,25 @@ class DaemonClient {
   }
 
   /**
+   * Run a generated SDK call against an ENVELOPED endpoint and return the
+   * unwrapped payload. The single place that knows the daemon's canonical
+   * success shape `ApiEnvelope<T> = { data: T, ts }` (ADR-008 §H): wrappers
+   * declare only the payload type instead of unwrapping `envelope.data` by
+   * hand. Session lifecycle and error normalization come from {@link callSdk}.
+   *
+   * 信封端点的唯一拆封入口:连拆 SDK 传输包装与 `{ data, ts }` 信封,
+   * wrapper 只声明 payload 类型。`ts` 无消费方,直接丢弃。
+   *
+   * @param call Thunk invoking a generated SDK fn for an enveloped endpoint.
+   * @returns The envelope's `data` payload.
+   * @throws {DaemonApiError} Same contract as {@link callSdk}.
+   */
+  async callEnveloped<T>(call: () => Promise<{ data: { data: T; ts: number } }>): Promise<T> {
+    const envelope = await this.callSdk(call)
+    return envelope.data
+  }
+
+  /**
    * Normalize a thrown SDK error into the same {@link DaemonApiError} shape that
    * {@link request} / {@link handleResponse} produce, so SDK-routed wrappers keep
    * the legacy error contract: `code` from the HTTP status, the full normalized

--- a/src/api/daemon/clipboard.ts
+++ b/src/api/daemon/clipboard.ts
@@ -150,10 +150,10 @@ export async function getClipboardEntries(
   limit: number = 50,
   offset: number = 0
 ): Promise<ClipboardEntriesResponse> {
-  const envelope = await daemonClient.callSdk(() =>
+  const data = await daemonClient.callEnveloped(() =>
     listClipboardEntriesSdk({ query: { limit, offset }, throwOnError: true })
   )
-  return { status: 'ready', entries: envelope.data as unknown as ClipboardEntryDto[] }
+  return { status: 'ready', entries: data as unknown as ClipboardEntryDto[] }
 }
 
 /**
@@ -170,13 +170,13 @@ export async function getClipboardEntry(id: string): Promise<ClipboardEntryDto |
   // path-param GET, which returns full text detail). The generated
   // `ListClipboardEntriesData.query` type only declares `limit`/`offset`, so the
   // `id` filter is cast at the boundary — the daemon still honors it on the wire.
-  const envelope = await daemonClient.callSdk(() =>
+  const data = await daemonClient.callEnveloped(() =>
     listClipboardEntriesSdk({
       query: { id } as unknown as NonNullable<ListClipboardEntriesData['query']>,
       throwOnError: true,
     })
   )
-  return (envelope.data as unknown as ClipboardEntryDto[])?.[0] ?? null
+  return (data as unknown as ClipboardEntryDto[])?.[0] ?? null
 }
 
 /**
@@ -260,10 +260,10 @@ export async function toggleFavorite(id: string, favorited: boolean): Promise<vo
  * @throws {DaemonApiError} On HTTP errors or session failures.
  */
 export async function clearClipboardHistory(): Promise<ClearHistoryResult> {
-  const envelope = await daemonClient.callSdk(() =>
+  const data = await daemonClient.callEnveloped(() =>
     clearClipboardHistorySdk({ throwOnError: true })
   )
-  return envelope.data as unknown as ClearHistoryResult
+  return data as unknown as ClearHistoryResult
 }
 
 /**
@@ -279,10 +279,10 @@ export async function clearClipboardHistory(): Promise<ClearHistoryResult> {
  */
 export async function getEntryDetail(id: string): Promise<EntryDetail | null> {
   try {
-    const envelope = await daemonClient.callSdk(() =>
+    const data = await daemonClient.callEnveloped(() =>
       getClipboardEntrySdk({ path: { id }, throwOnError: true })
     )
-    return envelope.data as unknown as EntryDetail
+    return data as unknown as EntryDetail
   } catch (error) {
     if (
       error instanceof Error &&
@@ -304,8 +304,8 @@ export async function getEntryDetail(id: string): Promise<EntryDetail | null> {
  * @throws {DaemonApiError} On HTTP errors or session failures.
  */
 export async function getClipboardStats(): Promise<ClipboardStats> {
-  const envelope = await daemonClient.callSdk(() => getClipboardStatsSdk({ throwOnError: true }))
-  return envelope.data as unknown as ClipboardStats
+  const data = await daemonClient.callEnveloped(() => getClipboardStatsSdk({ throwOnError: true }))
+  return data as unknown as ClipboardStats
 }
 
 /**
@@ -324,10 +324,10 @@ export async function getClipboardEntryResource(
   id: string
 ): Promise<ClipboardEntryResource | null> {
   try {
-    const envelope = await daemonClient.callSdk(() =>
+    const data = await daemonClient.callEnveloped(() =>
       getClipboardEntryResourceSdk({ path: { id }, throwOnError: true })
     )
-    return envelope.data as unknown as ClipboardEntryResource
+    return data as unknown as ClipboardEntryResource
   } catch (error) {
     // Return null for not-found rather than throwing
     if (

--- a/src/api/daemon/encryption.ts
+++ b/src/api/daemon/encryption.ts
@@ -49,12 +49,12 @@ export interface EncryptionStateResponse {
  * @throws {DaemonApiError} On HTTP or session errors.
  */
 export async function getEncryptionState(): Promise<EncryptionStateResponse> {
-  // Route through the generated SDK; `callSdk` unwraps the SDK's outer `{ data }`
-  // to the `EncryptionStateEnvelope`, and we unwrap `.data` to the payload. The
-  // generated `EncryptionStateResponse` DTO is structurally equivalent to the
+  // Route through the generated SDK; `callEnveloped` unwraps the canonical
+  // `{ data, ts }` envelope down to the payload. The generated
+  // `EncryptionStateResponse` DTO is structurally equivalent to the
   // hand-written interface, bridged here to keep the public return type stable.
-  const envelope = await daemonClient.callSdk(() => getEncryptionStateSdk({ throwOnError: true }))
-  return envelope.data as unknown as EncryptionStateResponse
+  const data = await daemonClient.callEnveloped(() => getEncryptionStateSdk({ throwOnError: true }))
+  return data as unknown as EncryptionStateResponse
 }
 
 /**
@@ -95,10 +95,12 @@ export async function lockEncryption(): Promise<void> {
  * @throws {DaemonApiError} On HTTP or permission check errors.
  */
 export async function verifyKeychainAccess(): Promise<boolean> {
-  // Route through the generated SDK; `callSdk` unwraps to the
-  // `KeychainAccessEnvelope`, then `.data.granted` is the boolean payload.
-  const envelope = await daemonClient.callSdk(() => verifyKeychainAccessSdk({ throwOnError: true }))
-  return envelope.data.granted
+  // Route through the generated SDK; `callEnveloped` unwraps down to the
+  // payload, whose `.granted` is the boolean we surface.
+  const data = await daemonClient.callEnveloped(() =>
+    verifyKeychainAccessSdk({ throwOnError: true })
+  )
+  return data.granted
 }
 
 /**
@@ -112,10 +114,10 @@ export async function verifyKeychainAccess(): Promise<boolean> {
  *          so the caller can fall back to prompting for the passphrase.
  */
 export async function trySilentUnlock(): Promise<boolean> {
-  const envelope = await daemonClient.callSdk(() =>
+  const data = await daemonClient.callEnveloped(() =>
     unlockEncryptionSessionSdk({ throwOnError: true })
   )
-  return envelope.data.success
+  return data.success
 }
 
 /**
@@ -130,10 +132,10 @@ export async function trySilentUnlock(): Promise<boolean> {
  *          `security.ts` classifier to translate.
  */
 export async function unlockSpaceWithPassphrase(passphrase: string): Promise<{ spaceId: string }> {
-  const envelope = await daemonClient.callSdk(() =>
+  const data = await daemonClient.callEnveloped(() =>
     unlockSpaceWithPassphraseSdk({ body: { passphrase }, throwOnError: true })
   )
-  return { spaceId: envelope.data.spaceId }
+  return { spaceId: data.spaceId }
 }
 
 /**

--- a/src/api/daemon/lifecycle.ts
+++ b/src/api/daemon/lifecycle.ts
@@ -7,12 +7,13 @@
  * - `POST /lifecycle/retry` → retry lifecycle initialization
  *
  * # Transport / 传输 (ADR-008 P7)
- * Routes through the @hey-api generated SDK via `daemonClient.callSdk`, which
+ * Routes through the @hey-api generated SDK via the daemon client, which
  * drives the daemon session lifecycle (pre-emptive refresh + one-shot 401
- * retry). `callSdk` unwraps the SDK's outer `{ data }` to the `ApiEnvelope`;
- * for value-returning endpoints the payload is `envelope.data`. The public
- * wrapper signatures and the hand-written `LifecycleStatusDto` domain type are
- * preserved verbatim for downstream consumers.
+ * retry). Value-returning endpoints use `daemonClient.callEnveloped`, which
+ * unwraps the `ApiEnvelope` down to the payload; 204 endpoints use
+ * `daemonClient.callSdk`. The public wrapper signatures and the hand-written
+ * `LifecycleStatusDto` domain type are preserved verbatim for downstream
+ * consumers.
  */
 
 import {
@@ -41,12 +42,12 @@ export async function signalLifecycleReady(): Promise<void> {
  */
 export async function getLifecycleStatus(): Promise<LifecycleStatusDto> {
   // `/lifecycle/status` returns the canonical `{ data, ts }` envelope
-  // (ADR-008 §H). `callSdk` unwraps the SDK's outer `{ data }` to the envelope;
-  // the payload lives at `envelope.data`. The generated `LifecycleStatusResponse`
-  // (`{ state: string }`) is bridged to the hand-written `LifecycleStatusDto`
-  // (union-typed `state`) so the public return type stays unchanged.
-  const envelope = await daemonClient.callSdk(() => getLifecycleStatusSdk({ throwOnError: true }))
-  return envelope.data as unknown as LifecycleStatusDto
+  // (ADR-008 §H). `callEnveloped` unwraps down to the payload. The generated
+  // `LifecycleStatusResponse` (`{ state: string }`) is bridged to the
+  // hand-written `LifecycleStatusDto` (union-typed `state`) so the public
+  // return type stays unchanged.
+  const data = await daemonClient.callEnveloped(() => getLifecycleStatusSdk({ throwOnError: true }))
+  return data as unknown as LifecycleStatusDto
 }
 
 /**

--- a/src/api/daemon/member.ts
+++ b/src/api/daemon/member.ts
@@ -67,15 +67,15 @@ export interface MemberSyncPreferencesPatch {
 // ── Public API ──────────────────────────────────────────────────
 
 export async function getMemberSyncPreferences(deviceId: string): Promise<MemberSyncPreferences> {
-  // Route through the generated SDK; `callSdk` unwraps the SDK's `{ data }` to the
-  // `MemberSyncPreferencesEnvelope`, then we unwrap `.data` to the preferences
-  // payload. The generated `MemberSyncPreferencesDto` is structurally equivalent to
-  // the hand-written `MemberSyncPreferences` (camelCase wire fields), bridged here to
-  // keep the public return type stable for downstream consumers.
-  const envelope = await daemonClient.callSdk(() =>
+  // Route through the generated SDK; `callEnveloped` unwraps the SDK's `{ data }`
+  // envelope down to the preferences payload. The generated
+  // `MemberSyncPreferencesDto` is structurally equivalent to the hand-written
+  // `MemberSyncPreferences` (camelCase wire fields), bridged here to keep the
+  // public return type stable for downstream consumers.
+  const data = await daemonClient.callEnveloped(() =>
     getMemberSyncPreferencesSdk({ path: { device_id: deviceId }, throwOnError: true })
   )
-  return envelope.data as unknown as MemberSyncPreferences
+  return data as unknown as MemberSyncPreferences
 }
 
 export async function updateMemberSyncPreferences(

--- a/src/api/daemon/members.ts
+++ b/src/api/daemon/members.ts
@@ -10,8 +10,9 @@
  * # Transport / 传输 (ADR-008 P7)
  * The three wrappers route through the @hey-api generated SDK
  * (`getLocalDeviceInfo` / `listPairedDevices` / `unpairDevice`) via
- * `daemonClient.callSdk`, which drives the daemon session lifecycle and
- * normalizes thrown SDK errors back into the shared `DaemonApiError` shape.
+ * `daemonClient.callEnveloped` / `callSdk`, which drive the daemon session
+ * lifecycle and normalize thrown SDK errors back into the shared
+ * `DaemonApiError` shape.
  * Every endpoint returns the canonical `ApiEnvelope { data, ts }`; the public
  * wrapper signatures and the hand-written domain types below are preserved
  * verbatim for downstream consumers, with the generated DTOs bridged at the
@@ -65,12 +66,12 @@ export interface SpaceMember {
  * 获取本地设备信息（peer ID + 解析后的设备名称）。
  */
 export async function getLocalDeviceInfo(): Promise<LocalDeviceInfo> {
-  // `callSdk` unwraps the SDK's `{ data }` to the `LocalDeviceInfoEnvelope`,
-  // then we unwrap `.data` to the payload. The generated `LocalDeviceInfoDto`
-  // is structurally equivalent to the hand-written `LocalDeviceInfo`, bridged
-  // here to keep the public return type stable for consumers.
-  const envelope = await daemonClient.callSdk(() => getLocalDeviceInfoSdk({ throwOnError: true }))
-  return envelope.data as unknown as LocalDeviceInfo
+  // `callEnveloped` unwraps the SDK's `{ data }` envelope down to the payload.
+  // The generated `LocalDeviceInfoDto` is structurally equivalent to the
+  // hand-written `LocalDeviceInfo`, bridged here to keep the public return
+  // type stable for consumers.
+  const data = await daemonClient.callEnveloped(() => getLocalDeviceInfoSdk({ throwOnError: true }))
+  return data as unknown as LocalDeviceInfo
 }
 
 /**
@@ -79,11 +80,11 @@ export async function getLocalDeviceInfo(): Promise<LocalDeviceInfo> {
  * 获取已配对的设备列表。
  */
 export async function getPairedPeers(): Promise<SpaceMember[]> {
-  // Backed by the `listPairedDevices` SDK fn (GET /paired-devices). `callSdk`
-  // unwraps the SDK's `{ data }` to the `SpaceMemberListEnvelope`, then `.data`
-  // is the `SpaceMemberDto[]` payload, bridged to the hand-written `SpaceMember[]`.
-  const envelope = await daemonClient.callSdk(() => listPairedDevicesSdk({ throwOnError: true }))
-  return envelope.data as unknown as SpaceMember[]
+  // Backed by the `listPairedDevices` SDK fn (GET /paired-devices).
+  // `callEnveloped` unwraps the SDK's `{ data }` envelope down to the
+  // `SpaceMemberDto[]` payload, bridged to the hand-written `SpaceMember[]`.
+  const data = await daemonClient.callEnveloped(() => listPairedDevicesSdk({ throwOnError: true }))
+  return data as unknown as SpaceMember[]
 }
 
 /**

--- a/src/api/daemon/mobile-sync.ts
+++ b/src/api/daemon/mobile-sync.ts
@@ -11,9 +11,10 @@
  * - `PATCH  /mobile-sync/settings`                        → update settings
  * - `GET    /mobile-sync/lan-interfaces`                  → LAN interfaces
  *
- * Thin transport layer: each call goes through `daemonClient.callSdk`, which
- * normalizes a thrown error into a `DaemonApiError` whose `.details` carries
- * the `{ code, message, details? }` body. The semantic-error translation back
+ * Thin transport layer: each call goes through `daemonClient.callEnveloped`,
+ * which unwraps the daemon's canonical `{ data, ts }` envelope to the payload
+ * and normalizes a thrown error into a `DaemonApiError` whose `.details`
+ * carries the `{ code, message, details? }` body. The semantic-error translation back
  * into the `MobileSyncError` union lives in the public wrapper
  * (`src/api/tauri-command/mobile_sync.ts`). The two QR PNGs arrive base64 from
  * the daemon, ready for `<img src="data:image/png;base64,...">`.
@@ -45,16 +46,12 @@ import { daemonClient } from './client'
 export async function registerMobileDevice(
   body: RegisterMobileDeviceRequest
 ): Promise<RegisterMobileDeviceResultDto> {
-  const envelope = await daemonClient.callSdk(() =>
-    registerMobileDeviceSdk({ body, throwOnError: true })
-  )
-  return envelope.data
+  return daemonClient.callEnveloped(() => registerMobileDeviceSdk({ body, throwOnError: true }))
 }
 
 /** `GET /mobile-sync/devices` — registered devices, sorted by recent activity. */
 export async function listMobileDevices(): Promise<MobileDeviceViewDto[]> {
-  const envelope = await daemonClient.callSdk(() => listMobileDevicesSdk({ throwOnError: true }))
-  return envelope.data
+  return daemonClient.callEnveloped(() => listMobileDevicesSdk({ throwOnError: true }))
 }
 
 /** `DELETE /mobile-sync/devices/{id}` — revoke a device's credentials. */
@@ -69,34 +66,24 @@ export async function rotateMobilePassword(
   deviceId: string,
   body: RotateMobilePasswordRequest
 ): Promise<RotateMobilePasswordResultDto> {
-  const envelope = await daemonClient.callSdk(() =>
+  return daemonClient.callEnveloped(() =>
     rotateMobilePasswordSdk({ path: { device_id: deviceId }, body, throwOnError: true })
   )
-  return envelope.data
 }
 
 /** `GET /mobile-sync/settings` — settings + LAN URL parts + install methods. */
 export async function getMobileSyncSettings(): Promise<MobileSyncSettingsViewDto> {
-  const envelope = await daemonClient.callSdk(() =>
-    getMobileSyncSettingsSdk({ throwOnError: true })
-  )
-  return envelope.data
+  return daemonClient.callEnveloped(() => getMobileSyncSettingsSdk({ throwOnError: true }))
 }
 
 /** `PATCH /mobile-sync/settings` — three-state patch (see request DTO docs). */
 export async function updateMobileSyncSettings(
   body: UpdateMobileSyncSettingsRequest
 ): Promise<UpdateMobileSyncSettingsResultDto> {
-  const envelope = await daemonClient.callSdk(() =>
-    updateMobileSyncSettingsSdk({ body, throwOnError: true })
-  )
-  return envelope.data
+  return daemonClient.callEnveloped(() => updateMobileSyncSettingsSdk({ body, throwOnError: true }))
 }
 
 /** `GET /mobile-sync/lan-interfaces` — RFC1918 IPv4 candidates for the QR URL. */
 export async function listMobileLanInterfaces(): Promise<LanInterfaceViewDto[]> {
-  const envelope = await daemonClient.callSdk(() =>
-    listMobileLanInterfacesSdk({ throwOnError: true })
-  )
-  return envelope.data
+  return daemonClient.callEnveloped(() => listMobileLanInterfacesSdk({ throwOnError: true }))
 }

--- a/src/api/daemon/presence.ts
+++ b/src/api/daemon/presence.ts
@@ -28,14 +28,13 @@ export interface PresenceRefreshResult {
  *
  * # Transport / 传输 (ADR-008 P7)
  * Routes through the @hey-api generated SDK (`refreshPresence`) via
- * `daemonClient.callSdk`, which unwraps the SDK's `{ data }` to the
- * `PresenceRefreshEnvelope` and drives the daemon session lifecycle. The
- * probe counters live under `envelope.data`; the generated
+ * `daemonClient.callEnveloped`, which drives the daemon session lifecycle and
+ * unwraps down to the probe-counter payload. The generated
  * `PresenceRefreshResponse` is structurally equivalent to the hand-written
  * `PresenceRefreshResult`, bridged at the boundary to keep the public return
  * type stable for downstream consumers.
  */
 export async function refreshPresence(): Promise<PresenceRefreshResult> {
-  const envelope = await daemonClient.callSdk(() => refreshPresenceSdk({ throwOnError: true }))
-  return envelope.data as unknown as PresenceRefreshResult
+  const data = await daemonClient.callEnveloped(() => refreshPresenceSdk({ throwOnError: true }))
+  return data as unknown as PresenceRefreshResult
 }

--- a/src/api/daemon/settings.ts
+++ b/src/api/daemon/settings.ts
@@ -15,11 +15,12 @@
  * # Transport / 传输 (ADR-008 P6)
  * This module is the SDK exemplar: `getSettings` / `updateSettings` route through
  * the @hey-api generated SDK (`getSettingsSdk` / `updateSettingsSdk`) via
- * `daemonClient.callSdk`, which drives the daemon session lifecycle (pre-emptive
- * refresh + one-shot 401 retry). Both endpoints now return the canonical
- * `ApiEnvelope { data, ts }`; PUT folds `success` + `restartRequired` INTO `data`
- * (`SettingsUpdateResultDto`). The public wrapper signatures and the hand-written
- * `Settings` domain types below are preserved verbatim for downstream consumers.
+ * `daemonClient.callEnveloped`, which drives the daemon session lifecycle
+ * (pre-emptive refresh + one-shot 401 retry) and unwraps the canonical
+ * `ApiEnvelope { data, ts }` down to the payload. PUT folds `success` +
+ * `restartRequired` INTO that payload (`SettingsUpdateResultDto`). The public
+ * wrapper signatures and the hand-written `Settings` domain types below are
+ * preserved verbatim for downstream consumers.
  */
 
 import {
@@ -245,13 +246,12 @@ interface SettingsPatchRequest {
  * @throws {DaemonApiError} On HTTP or session errors.
  */
 export async function getSettings(): Promise<Settings> {
-  // Route through the generated SDK; `callSdk` unwraps the SDK's `{ data }` to
-  // the `SettingsEnvelope`, then we unwrap `.data` to the Settings payload. The
-  // generated `SettingsDto` is structurally equivalent to the hand-written
-  // `Settings` (camelCase wire fields), bridged here to keep the public return
-  // type stable for downstream consumers.
-  const envelope = await daemonClient.callSdk(() => getSettingsSdk({ throwOnError: true }))
-  return envelope.data as unknown as Settings
+  // Route through the generated SDK; `callEnveloped` unwraps down to the
+  // Settings payload. The generated `SettingsDto` is structurally equivalent
+  // to the hand-written `Settings` (camelCase wire fields), bridged here to
+  // keep the public return type stable for downstream consumers.
+  const data = await daemonClient.callEnveloped(() => getSettingsSdk({ throwOnError: true }))
+  return data as unknown as Settings
 }
 
 /**
@@ -270,9 +270,9 @@ export async function updateSettings(
 ): Promise<{ success: boolean; restartRequired: boolean }> {
   const patch = toSettingsPatchRequest(settings)
   // Route through the generated SDK. `success` + `restartRequired` are now folded
-  // INTO the envelope payload (`SettingsUpdateResultDto`) per ADR-008 §0.1, so we
-  // read them from `envelope.data` rather than top-level siblings.
-  const envelope = await daemonClient.callSdk(() =>
+  // INTO the envelope payload (`SettingsUpdateResultDto`) per ADR-008 §0.1;
+  // `callEnveloped` unwraps down to that payload.
+  const data = await daemonClient.callEnveloped(() =>
     updateSettingsSdk({
       // `toSettingsPatchRequest` returns a structurally-equivalent camelCase patch;
       // bridge to the generated `SettingsPatchDto` shape for the SDK body param.
@@ -280,7 +280,7 @@ export async function updateSettings(
       throwOnError: true,
     })
   )
-  return { success: envelope.data.success, restartRequired: envelope.data.restartRequired }
+  return { success: data.success, restartRequired: data.restartRequired }
 }
 
 /**

--- a/src/api/daemon/setupV2.ts
+++ b/src/api/daemon/setupV2.ts
@@ -98,10 +98,10 @@ export interface MigrationProgressResponse {
 // ── Transport (ADR-008 P7) ──────────────────────────────────────────────────
 //
 // Each /v2/setup/* call routes through the @hey-api generated SDK via
-// `daemonClient.callSdk`, which drives the daemon session lifecycle and unwraps
-// the SDK's outer `{ data }` to the canonical `ApiEnvelope<T> { data, ts }`;
-// the wrappers below read `envelope.data` for the payload. Error bodies are NOT
-// enveloped (still `ApiErrorResponse { code, message, details? }`); `callSdk`
+// `daemonClient.callEnveloped`, which drives the daemon session lifecycle and
+// unwraps the SDK's outer `{ data }` plus the canonical `ApiEnvelope<T>
+// { data, ts }` down to the payload `T`. Error bodies are NOT enveloped (still
+// `ApiErrorResponse { code, message, details? }`); the underlying `callSdk`
 // normalizes thrown SDK errors back into the `DaemonApiError` shape — preserving
 // the `"<status> on <path>"` message and the body on `.details` — so the
 // `classify*Error` matchers below remain unchanged.
@@ -365,10 +365,10 @@ export async function initializeSpace(
   body: InitializeSpaceRequest
 ): Promise<InitializeSpaceResponse> {
   try {
-    const envelope = await daemonClient.callSdk(() =>
+    const data = await daemonClient.callEnveloped(() =>
       setupV2Initialize({ body: body as unknown as InitializeSpaceRequestDto, throwOnError: true })
     )
-    return envelope.data as unknown as InitializeSpaceResponse
+    return data as unknown as InitializeSpaceResponse
   } catch (err) {
     throw classifyInitializeError(err)
   }
@@ -376,10 +376,10 @@ export async function initializeSpace(
 
 export async function issuePairingInvitation(): Promise<IssueInvitationResponse> {
   try {
-    const envelope = await daemonClient.callSdk(() =>
+    const data = await daemonClient.callEnveloped(() =>
       setupV2IssueInvitation({ throwOnError: true })
     )
-    return envelope.data as unknown as IssueInvitationResponse
+    return data as unknown as IssueInvitationResponse
   } catch (err) {
     throw classifyIssueError(err)
   }
@@ -400,13 +400,13 @@ function normalizeInvitationCode(raw: string): string {
 
 export async function redeemInvitation(body: RedeemRequest): Promise<RedeemResponse> {
   try {
-    const envelope = await daemonClient.callSdk(() =>
+    const data = await daemonClient.callEnveloped(() =>
       setupV2Redeem({
         body: { ...body, code: normalizeInvitationCode(body.code) } as unknown as RedeemRequestDto,
         throwOnError: true,
       })
     )
-    return envelope.data as unknown as RedeemResponse
+    return data as unknown as RedeemResponse
   } catch (err) {
     throw classifyRedeemError(err)
   }
@@ -430,8 +430,8 @@ export async function resetSetup(): Promise<void> {
 
 export async function getSetupState(): Promise<SetupStateResponse> {
   try {
-    const envelope = await daemonClient.callSdk(() => setupV2GetState({ throwOnError: true }))
-    return envelope.data as unknown as SetupStateResponse
+    const data = await daemonClient.callEnveloped(() => setupV2GetState({ throwOnError: true }))
+    return data as unknown as SetupStateResponse
   } catch (err) {
     throw classifyQueryError(err)
   }
@@ -453,7 +453,7 @@ export async function getSetupState(): Promise<SetupStateResponse> {
  */
 export async function switchSpace(body: SwitchSpaceRequest): Promise<SwitchSpaceResponse> {
   try {
-    const envelope = await daemonClient.callSdk(() =>
+    const data = await daemonClient.callEnveloped(() =>
       setupV2SwitchSpace({
         body: {
           ...body,
@@ -462,7 +462,7 @@ export async function switchSpace(body: SwitchSpaceRequest): Promise<SwitchSpace
         throwOnError: true,
       })
     )
-    return envelope.data as unknown as SwitchSpaceResponse
+    return data as unknown as SwitchSpaceResponse
   } catch (err) {
     throw classifySwitchSpaceError(err)
   }
@@ -476,10 +476,10 @@ export async function switchSpace(body: SwitchSpaceRequest): Promise<SwitchSpace
  */
 export async function queryMigrationProgress(): Promise<MigrationProgressResponse> {
   try {
-    const envelope = await daemonClient.callSdk(() =>
+    const data = await daemonClient.callEnveloped(() =>
       setupV2GetMigrationProgress({ throwOnError: true })
     )
-    return envelope.data as unknown as MigrationProgressResponse
+    return data as unknown as MigrationProgressResponse
   } catch (err) {
     throw classifyMigrationProgressError(err)
   }

--- a/src/api/daemon/storage.ts
+++ b/src/api/daemon/storage.ts
@@ -9,10 +9,12 @@
  *
  * # Transport / 传输 (ADR-008 P7)
  * `getStorageStats` / `clearCache` route through the @hey-api generated SDK
- * (`getStorageStatsSdk` / `clearStorageCacheSdk`) via `daemonClient.callSdk`,
- * which drives the daemon session lifecycle. The public wrapper signatures and
- * the hand-written `StorageStats` domain type below are preserved verbatim for
- * downstream consumers.
+ * (`getStorageStatsSdk` / `clearStorageCacheSdk`) through the daemon client,
+ * which drives the daemon session lifecycle: `getStorageStats` uses
+ * `daemonClient.callEnveloped` (unwraps down to the payload), `clearCache`
+ * stays on `daemonClient.callSdk` (its result is ignored). The public wrapper
+ * signatures and the hand-written `StorageStats` domain type below are
+ * preserved verbatim for downstream consumers.
  */
 
 import {
@@ -47,12 +49,12 @@ export interface StorageStats {
  * @throws {DaemonApiError} On HTTP or session errors.
  */
 export async function getStorageStats(): Promise<StorageStats> {
-  // Route through the generated SDK; `callSdk` unwraps the SDK's `{ data }` to the
-  // `StorageStatsEnvelope`, then we unwrap `.data` to the payload. The generated
-  // `StorageStatsDto` is structurally equivalent to the hand-written `StorageStats`,
-  // bridged here to keep the public return type stable for downstream consumers.
-  const envelope = await daemonClient.callSdk(() => getStorageStatsSdk({ throwOnError: true }))
-  return envelope.data as unknown as StorageStats
+  // Route through the generated SDK; `callEnveloped` unwraps down to the payload.
+  // The generated `StorageStatsDto` is structurally equivalent to the hand-written
+  // `StorageStats`, bridged here to keep the public return type stable for
+  // downstream consumers.
+  const data = await daemonClient.callEnveloped(() => getStorageStatsSdk({ throwOnError: true }))
+  return data as unknown as StorageStats
 }
 
 /**

--- a/src/api/daemon/upgrade.ts
+++ b/src/api/daemon/upgrade.ts
@@ -17,11 +17,11 @@
  *
  * # Transport / 传输 (ADR-008 P7)
  * Both endpoints route through the @hey-api generated SDK
- * (`getUpgradeStatus` / `acknowledgeUpgrade`) via `daemonClient.callSdk`, which
- * drives the daemon session lifecycle. `callSdk` unwraps the SDK's outer
- * `{ data }` to the canonical `ApiEnvelope { data, ts }`; the payload is then
- * read from `envelope.data`. The public wrapper signatures and the hand-written
- * `UpgradeStatus` domain type below are preserved verbatim for consumers.
+ * (`getUpgradeStatus` / `acknowledgeUpgrade`) via `daemonClient.callEnveloped`,
+ * which drives the daemon session lifecycle and unwraps the canonical
+ * `ApiEnvelope { data, ts }` down to the payload. The public wrapper signatures
+ * and the hand-written `UpgradeStatus` domain type below are preserved verbatim
+ * for consumers.
  */
 
 import {
@@ -51,13 +51,12 @@ export type UpgradeStatus =
  * @throws {DaemonApiError} On HTTP or session errors.
  */
 export async function getUpgradeStatus(): Promise<UpgradeStatus> {
-  // Route through the generated SDK; `callSdk` unwraps the SDK's `{ data }` to
-  // the `UpgradeStatusEnvelope`, then we unwrap `.data` to the payload. The
-  // generated `UpgradeStatusDto` is structurally equivalent to the hand-written
-  // `UpgradeStatus` discriminated union, bridged here to keep the public return
-  // type stable for consumers.
-  const envelope = await daemonClient.callSdk(() => getUpgradeStatusSdk({ throwOnError: true }))
-  return envelope.data as unknown as UpgradeStatus
+  // Route through the generated SDK; `callEnveloped` unwraps down to the
+  // payload. The generated `UpgradeStatusDto` is structurally equivalent to the
+  // hand-written `UpgradeStatus` discriminated union, bridged here to keep the
+  // public return type stable for consumers.
+  const data = await daemonClient.callEnveloped(() => getUpgradeStatusSdk({ throwOnError: true }))
+  return data as unknown as UpgradeStatus
 }
 
 /**
@@ -73,9 +72,8 @@ export async function getUpgradeStatus(): Promise<UpgradeStatus> {
  * @throws {DaemonApiError} On HTTP or session errors.
  */
 export async function acknowledgeUpgrade(): Promise<string> {
-  // Route through the generated SDK; `callSdk` unwraps the SDK's `{ data }` to
-  // the `AckUpgradeEnvelope`, then we read `.data.acknowledged` (the written
-  // version string).
-  const envelope = await daemonClient.callSdk(() => acknowledgeUpgradeSdk({ throwOnError: true }))
-  return envelope.data.acknowledged
+  // Route through the generated SDK; `callEnveloped` unwraps down to the
+  // payload, from which we read `acknowledged` (the written version string).
+  const data = await daemonClient.callEnveloped(() => acknowledgeUpgradeSdk({ throwOnError: true }))
+  return data.acknowledged
 }

--- a/src/api/tauri-command/clipboard_delivery.ts
+++ b/src/api/tauri-command/clipboard_delivery.ts
@@ -87,13 +87,13 @@ export async function getEntryDeliveryView(entryId: string): Promise<EntryDelive
   // is wire-identical (field names + discriminated-union tag literals) to the
   // hand-written `EntryDeliveryView` kept here as the stable API name for upper
   // layers (useEntryDelivery / EntryDeliveryBadge / tests); bridged at the
-  // `as unknown as` boundary. `callSdk` unwraps to the `EntryDeliveryViewEnvelope`,
-  // then `.data` is the payload. EntryNotFound surfaces as a `DaemonApiError`
-  // (404) which consumers already degrade-render.
-  const envelope = await daemonClient.callSdk(() =>
+  // `as unknown as` boundary. `callEnveloped` unwraps down to the payload.
+  // EntryNotFound surfaces as a `DaemonApiError` (404) which consumers already
+  // degrade-render.
+  const data = await daemonClient.callEnveloped(() =>
     getClipboardEntryDeliverySdk({ path: { id: entryId }, throwOnError: true })
   )
-  return envelope.data as unknown as EntryDeliveryView
+  return data as unknown as EntryDeliveryView
 }
 
 // ============================================================================
@@ -186,13 +186,13 @@ export async function resendEntry(args: ResendEntryArgs): Promise<ResendEntryRep
   // typed `ResendEntryCommandError` is rebuilt from the normalized error body so
   // the consumers' `error.code` switch + i18n placeholders are unchanged.
   try {
-    const envelope = await daemonClient.callSdk(() =>
+    const data = await daemonClient.callEnveloped(() =>
       resendClipboardEntrySdk({
         body: { entryId: args.entryId, peers: args.targetDeviceIds ?? null },
         throwOnError: true,
       })
     )
-    return envelope.data as unknown as ResendEntryReportDto
+    return data as unknown as ResendEntryReportDto
   } catch (error) {
     throw toResendEntryError(error)
   }

--- a/src/components/clipboard/__tests__/ClipboardItem.test.tsx
+++ b/src/components/clipboard/__tests__/ClipboardItem.test.tsx
@@ -8,6 +8,10 @@ vi.mock('@/api/daemon/client', () => ({
   daemonClient: {
     // Replay the happy path: callSdk unwraps the SDK's outer { data } to the envelope.
     callSdk: vi.fn((call: () => Promise<{ data: unknown }>) => call().then(r => r.data)),
+    // 复刻 callEnveloped 快乐路径：连拆 SDK { data } 与 { data, ts } 信封。
+    callEnveloped: vi.fn((call: () => Promise<{ data: { data: unknown } }>) =>
+      call().then(r => r.data.data)
+    ),
     blobUrl: vi.fn((path: string) => `http://127.0.0.1:12345${path}?auth=Session+test`),
   },
 }))

--- a/src/lib/__tests__/daemon-auth.test.ts
+++ b/src/lib/__tests__/daemon-auth.test.ts
@@ -31,6 +31,10 @@ vi.mock('@/api/daemon/client', () => ({
     initialize: (...args: unknown[]) => mockInitialize(...args),
     refreshSession: (...args: unknown[]) => mockRefreshSession(...args),
     callSdk: vi.fn((call: () => Promise<{ data: unknown }>) => call().then(r => r.data)),
+    // 复刻 callEnveloped 快乐路径：连拆 SDK { data } 与 { data, ts } 信封。
+    callEnveloped: vi.fn((call: () => Promise<{ data: { data: unknown } }>) =>
+      call().then(r => r.data.data)
+    ),
     destroy: (...args: unknown[]) => mockDestroy(...args),
     get initialized() {
       return true

--- a/src/lib/daemon-auth.ts
+++ b/src/lib/daemon-auth.ts
@@ -102,12 +102,12 @@ export async function verifyAuthState(): Promise<AuthStateResult> {
   }
 
   // Step 2: Encryption state (L2, requires session token). Route through
-  // `callSdk` so it drives the session lifecycle; `callSdk` unwraps the SDK's
-  // outer `{ data }` to the EncryptionStateEnvelope, whose `.data` is the payload.
+  // `callEnveloped` so it drives the session lifecycle and unwraps down to the
+  // `EncryptionStateResponse` payload.
   try {
-    const envelope = await daemonClient.callSdk(() => getEncryptionState({ throwOnError: true }))
-    result.encryptionInitialized = envelope.data.initialized
-    result.encryptionSessionReady = envelope.data.sessionReady
+    const data = await daemonClient.callEnveloped(() => getEncryptionState({ throwOnError: true }))
+    result.encryptionInitialized = data.initialized
+    result.encryptionSessionReady = data.sessionReady
   } catch (err) {
     // If encryption state check fails (e.g. 401), daemon is reachable but
     // encryption info is unavailable. daemonReady stays true.
@@ -132,9 +132,11 @@ export async function waitForEncryptionReady(timeoutMs = 30_000): Promise<boolea
 
   while (Date.now() < deadline) {
     try {
-      const envelope = await daemonClient.callSdk(() => getEncryptionState({ throwOnError: true }))
+      const data = await daemonClient.callEnveloped(() =>
+        getEncryptionState({ throwOnError: true })
+      )
 
-      if (envelope.data.sessionReady) {
+      if (data.sessionReady) {
         return true
       }
     } catch {


### PR DESCRIPTION
## Summary

- **Rust (ce07ce774)**: every `uc-daemon-client` feature module repeated the same per-endpoint ritual — connection check, authorized request build, send, ad-hoc status/error formatting, `ApiEnvelope<T>` decode + `.data` unwrap (21 sites across 9 http modules, three of which had grown private helpers with divergent error formats). New `http/enveloped.rs` owns the whole ritual: `enveloped_request<T>()` returns the payload, `send_checked()`/`empty_request()` cover binary-body and empty-success endpoints. Errors become typed `DaemonRequestError` with `Status { path, status, code, message }` parsed from the daemon's canonical error body, so callers branch on `.code()`/`.is_not_found()` instead of scraping strings — this replaces `DaemonSearchRequestError` and the dead `[NOT_FOUND]` message-prefix hack. uc-cli setup commands keep their concise user-facing error lines via `daemon_error_message()`.
- **Frontend (50da7d24d)**: `callSdk` only strips the hey-api transport wrapper; the `{ data, ts }` envelope was still hand-unwrapped at 36 sites across 13 files. New `daemonClient.callEnveloped<T>()` is the single envelope-aware entry point; all enveloped call sites migrated, wrappers now declare only the payload type. Test mocks of `@/api/daemon/client` gain a matching `callEnveloped` replay.
- Net effect: the envelope wire shape is now known to exactly one module per side. Evolving it (signing, versioning) touches two files instead of ~60 call sites. The `ts` field is dropped in both seams — nothing consumes it.

Deliberate exceptions that still hand-unwrap (documented in code): the frontend bootstrap health probe (`callSdk` would gate the unauthenticated check behind a session refresh), the desktop/CLI health probes (tolerant text-body parse), and the Bearer token-exchange handshake the seam's auth step depends on.

## Test plan

- [x] `cargo test -p uc-daemon-client --lib` (7/7) and `cargo test -p uc-cli` (69/69); `cargo check` on all dependent crates (uc-desktop, uc-tauri, uc-observability); clippy/fmt clean on changed files
- [x] Frontend: `tsc --noEmit` clean, `vitest run` full suite 618/618, prettier + eslint clean
- [x] Black-box CLI e2e suite (`src-tauri/tests/e2e`, fresh debug `uniclip`/`uniclipd`): 84/84 passed, including invite/join pairing handshake, get-entry 404 branches, and error_cases — i.e. the new seam exercised against a real daemon
- [ ] Reviewer: sanity-check the slightly changed CLI error wording on daemon failures (search/setup commands now render via `DaemonRequestError` Display / `daemon_error_message()`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified daemon API response handling with a unified envelope-unwrapping method applied across multiple API modules.

* **Bug Fixes**
  * CLI commands now display human-readable daemon error messages instead of raw error formatting in failure scenarios.

* **Tests**
  * Updated test mocks across multiple files to support the new response-handling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->