### PR TITLE
fix(mobile-sync): LAN picker excludes container virtual interfaces

### DIFF
--- a/src-tauri/crates/uc-application/src/usecases/mobile_sync/list_lan_interfaces.rs
+++ b/src-tauri/crates/uc-application/src/usecases/mobile_sync/list_lan_interfaces.rs
@@ -70,7 +70,7 @@ impl ListLanInterfacesUseCase {
         // 对外只保留字符串形式。保留原始 `Ipv4Addr` 作为排序 key，排完再丢。
         let mut filtered: Vec<(LanInterfaceOption, std::net::Ipv4Addr)> = raw
             .into_iter()
-            .filter(is_lan_candidate)
+            .filter(may_advertise_interface)
             .map(|iface| {
                 let raw_ipv4 = iface.ipv4;
                 (
@@ -99,7 +99,7 @@ impl ListLanInterfacesUseCase {
 
 // ─── helpers ────────────────────────────────────────────────────────────
 
-/// "算 LAN 候选"判定。
+/// "算 LAN 候选"判定 —— **只**看地址段口径（RFC1918 + Tailscale CGNAT）。
 ///
 /// 接受 IPv4 RFC1918 私有地址（10/8 / 172.16/12 / 192.168/16）与 CGNAT 段
 /// 100.64.0.0/10（Tailscale 默认 IPv4 范围）。
@@ -107,9 +107,12 @@ impl ListLanInterfacesUseCase {
 /// 链路本地 169.254/16、Clash fake-ip 198.18/15 等始终排除：它们要么本身
 /// 就是"看似可达实际不通"的常见陷阱来源，要么与本机 LAN 同步场景不相
 /// 关。
-/// `register_device.rs` 的多候选地址收集（`collect_advertise_urls`）复用本
-/// 判定 —— 下拉展示与进码候选共用同一口径，避免"列表里看得到、码里却
-/// 没有"的不一致。
+///
+/// 注意：本判定不剔除容器虚拟网卡（docker0 / veth* / br-*）—— 它们的地址
+/// 可能落在合格段内但手机永远连不上。"能否进码给手机用"的完整口径是
+/// [`may_advertise_interface`]，下拉展示（本 use case）与进码候选
+/// （`register_device::collect_advertise_urls`）都走它，避免"列表里看得到、
+/// 码里却没有"的不一致。
 pub(crate) fn is_lan_candidate(iface: &LanInterface) -> bool {
     if iface.is_loopback {
         return false;
@@ -124,6 +127,35 @@ pub(crate) fn is_lan_candidate(iface: &LanInterface) -> bool {
         [100, b, _, _] if (b & 0xc0) == 0x40 => true,
         _ => false,
     }
+}
+
+/// 容器虚拟网卡剔除（规格 §5.2，风险收敛见规格 §10）。
+///
+/// Docker 默认网桥落在 RFC1918 的 172.17/16 段内，仅按 IP 段过滤会被误纳
+/// 入候选 —— 手机永远连不上容器网桥地址。按接口名判定：
+/// - `docker0`（默认网桥）、`veth*`（容器对端）—— 名字即可断定，直接剔除；
+/// - `br-*` 既可能是 Docker 自定义网桥也可能是真实 LAN 网桥（如用户自建
+///   桥接），仅当其地址同时落在 Docker 默认地址池所在的 172.16/12 段时才
+///   剔除，避免误伤 `br-` 命名的真实网桥。
+pub(crate) fn is_virtual_container_iface(iface: &LanInterface) -> bool {
+    if iface.name == "docker0" || iface.name.starts_with("veth") {
+        return true;
+    }
+    if iface.name.starts_with("br-") {
+        let octets = iface.ipv4.octets();
+        return matches!(octets, [172, 16..=31, _, _]);
+    }
+    false
+}
+
+/// "可进码给手机用"的完整口径 —— 单一真相来源。
+///
+/// = [`is_lan_candidate`]（地址段合格）且**非**容器虚拟网卡
+/// （[`is_virtual_container_iface`]）。下拉展示（本 use case）与 QR 候选收集
+/// （`register_device::collect_advertise_urls`）共用本判定，避免两处口径漂移
+/// 导致"列表里挑得到、扫码端却拿不到"的不一致。
+pub(crate) fn may_advertise_interface(iface: &LanInterface) -> bool {
+    is_lan_candidate(iface) && !is_virtual_container_iface(iface)
 }
 
 /// 排序桶：10.x = 0，172.16.x = 1，192.168.x = 2，100.64–127.x = 3，
@@ -205,6 +237,28 @@ mod tests {
         ])));
         let out = uc.execute().await.expect("ok");
         assert!(out.is_empty(), "non-candidate must be filtered: {out:?}");
+    }
+
+    #[tokio::test]
+    async fn drops_container_virtual_interfaces() {
+        // 回归:下拉口径必须与进码口径一致 —— docker0 / veth* / br-(172.16/12)
+        // 容器虚拟网卡即便落在合格地址段也不能出现在选择列表里,否则用户会
+        // 挑到一个手机永远连不上的地址。`register_device::collect_advertise_urls`
+        // 已剔除它们,二者共用 `may_advertise_interface`,本测试守住下拉这一侧。
+        let uc = ListLanInterfacesUseCase::new(Arc::new(FixedProbe(vec![
+            make("docker0", [172, 17, 0, 1], false),   // Docker 默认网桥
+            make("vethXYZ", [10, 99, 0, 1], false),    // 容器对端
+            make("br-ABC123", [172, 18, 0, 1], false), // Docker 自定义网桥(172.16/12)
+            make("en0", [192, 168, 1, 5], false),      // 真实 LAN —— 必须保留
+            make("br-lan", [192, 168, 2, 1], false),   // br- 命名的真实网桥(非 172)—— 保留
+        ])));
+        let out = uc.execute().await.expect("ok");
+        let ips: Vec<&str> = out.iter().map(|o| o.ipv4.as_str()).collect();
+        assert_eq!(
+            ips,
+            vec!["192.168.1.5", "192.168.2.1"],
+            "docker0/veth*/br-(172.16/12) must never be offered as QR targets: {out:?}"
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/crates/uc-application/src/usecases/mobile_sync/register_device.rs
+++ b/src-tauri/crates/uc-application/src/usecases/mobile_sync/register_device.rs
@@ -35,7 +35,7 @@ use uc_core::settings::model::MobileSyncSettings;
 use uc_observability::analytics::{AnalyticsPort, Event};
 
 use super::connect_uri::{build_mobile_sync_connect_uri, ConnectUriError, ConnectUriOther};
-use super::list_lan_interfaces::is_lan_candidate;
+use super::list_lan_interfaces::may_advertise_interface;
 
 // ─── public-shaped (input / output / error) ─────────────────────────────
 
@@ -245,10 +245,11 @@ impl RegisterMobileShortcutDeviceUseCase {
     /// 1. 公网入口 `lan_advertise_base_url`（Some 时，原样，恒排首位）；
     /// 2. 用户钉死的 `lan_advertise_ip`（Some 时）—— 无公网入口时它就是
     ///    `urls[0]`，与 v1 的 `url` 取值保持一致；
-    /// 3. 全部合格网卡 IP：[`is_lan_candidate`] 宽口径（RFC1918 + Tailscale
-    ///    CGNAT 100.64/10），剔除容器虚拟网卡
-    ///    （[`is_virtual_container_iface`]），按 10/8 → 172.16/12 →
-    ///    192.168/16 → 100.64/10 桶序、段内 IPv4 数值序。
+    /// 3. 全部合格网卡 IP：[`may_advertise_interface`] 口径（RFC1918 +
+    ///    Tailscale CGNAT 100.64/10 的宽地址段，且剔除 docker0 / veth* /
+    ///    br-* 容器虚拟网卡），按 10/8 → 172.16/12 → 192.168/16 →
+    ///    100.64/10 桶序、段内 IPv4 数值序。下拉展示（`list_lan_interfaces`）
+    ///    与此处共用同一判定，保证两处口径不漂移。
     ///
     /// 网卡探测失败时：若 1/2 已有候选则降级继续（v1 在这两条路径下根本
     /// 不探测网卡，不能让探测失败反过来弄死老路径），否则照旧报
@@ -270,10 +271,8 @@ impl RegisterMobileShortcutDeviceUseCase {
 
         match self.lan_interface_probe.list_interfaces().await {
             Ok(raw) => {
-                let mut nics: Vec<LanInterface> = raw
-                    .into_iter()
-                    .filter(|iface| is_lan_candidate(iface) && !is_virtual_container_iface(iface))
-                    .collect();
+                let mut nics: Vec<LanInterface> =
+                    raw.into_iter().filter(may_advertise_interface).collect();
                 nics.sort_by(|a, b| {
                     advertise_bucket(&a.ipv4.octets())
                         .cmp(&advertise_bucket(&b.ipv4.octets()))
@@ -543,27 +542,8 @@ fn validate_password_length(password: &str) -> Result<(), RegisterMobileShortcut
     Ok(())
 }
 
-/// 容器虚拟网卡剔除（规格 §5.2，风险收敛见规格 §10）。
-///
-/// Docker 默认网桥落在 RFC1918 的 172.17/16 段内，仅按 IP 段过滤会被误纳
-/// 入进码 —— 手机永远连不上容器网桥地址。按接口名判定：
-/// - `docker0`（默认网桥）、`veth*`（容器对端）—— 名字即可断定，直接剔除；
-/// - `br-*` 既可能是 Docker 自定义网桥也可能是真实 LAN 网桥（如用户自建
-///   桥接），仅当其地址同时落在 Docker 默认地址池所在的 172.16/12 段时才
-///   剔除，避免误伤 `br-` 命名的真实网桥。
-fn is_virtual_container_iface(iface: &LanInterface) -> bool {
-    if iface.name == "docker0" || iface.name.starts_with("veth") {
-        return true;
-    }
-    if iface.name.starts_with("br-") {
-        let octets = iface.ipv4.octets();
-        return matches!(octets, [172, 16..=31, _, _]);
-    }
-    false
-}
-
 /// 排序桶（规格 §5.3）:10/8 = 0,172.16/12 = 1,192.168/16 = 2,
-/// 100.64/10（Tailscale CGNAT）= 3,其它 = 4(经 `is_lan_candidate`
+/// 100.64/10（Tailscale CGNAT）= 3,其它 = 4(经 `may_advertise_interface`
 /// 过滤后理论上不存在)。与 `list_lan_interfaces` 的下拉排序口径一致。
 fn advertise_bucket(octets: &[u8; 4]) -> u8 {
     match octets {


### PR DESCRIPTION
## Problem

The LAN interface picker (`list_lan_interfaces::execute`) filtered candidates with `is_lan_candidate` only, while QR candidate collection (`register_device::collect_advertise_urls`) additionally excluded container virtual interfaces (`docker0` / `veth*` / `br-*`) via `is_virtual_container_iface`.

As a result the dropdown could offer a container bridge address (e.g. `docker0` at `172.17.0.1`) that the phone can never reach — directly contradicting the doc comment which claimed the dropdown and the QR candidates shared one filter ("共用同一口径").

## Fix

- Extract `may_advertise_interface` = `is_lan_candidate && !is_virtual_container_iface` as the **single source of truth**, living in `list_lan_interfaces.rs` next to `is_lan_candidate`.
- Route both the picker and `collect_advertise_urls` through it, so the two paths can no longer drift.
- Correct the stale doc comment on `is_lan_candidate`.
- Leave the user-pinned `lan_advertise_ip` path untouched — it is an explicit, settings-validated override that is deliberately trusted as-is.

## Testing

- New picker-side regression test `drops_container_virtual_interfaces` (docker0 / veth* / br-(172.16/12) dropped; real LAN and br-(non-172) kept).
- `cargo test -p uc-application mobile_sync::list_lan_interfaces` — 8 passed.
- `cargo test -p uc-application mobile_sync::register_device` — 33 passed (incl. existing `urls_exclude_docker_virtual_interfaces`).
- `cargo clippy -p uc-application --tests` — no new warnings on the touched lines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved local network interface discovery by implementing refined filtering to exclude virtual container network interfaces and bridge adapters, ensuring more reliable device detection and mobile synchronization capabilities.

* **Tests**
  * Added regression tests to verify virtual container network interfaces are correctly excluded from available LAN interfaces and advertised in device sync operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->