### PR TITLE
fix(daemon): wait for predecessor instance-lock release on restart

### DIFF
--- a/src-tauri/crates/uc-cli/src/local_daemon.rs
+++ b/src-tauri/crates/uc-cli/src/local_daemon.rs
@@ -14,20 +14,25 @@ use uc_daemon_process::spawn::{spawn_detached_daemon, SpawnDaemonError};
 
 const HEALTH_PATH: &str = "/health";
 const PROBE_TIMEOUT: Duration = Duration::from_secs(2);
-const STARTUP_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Total budget to wait for a spawned daemon to become healthy. Derived in the
+/// cross-process timing contract: covers a replacement waiting out an exiting
+/// predecessor's instance-lock release AND THEN bootstrapping from scratch.
+const STARTUP_TIMEOUT: Duration = uc_daemon_process::timing::DAEMON_STARTUP_TIMEOUT;
+
 const POLL_INTERVAL: Duration = Duration::from_millis(200);
 
 /// ADR-008 P5-L L8d-2: how long to wait for a controlled-restart predecessor's
 /// endpoint to go absent before spawning the promoted replacement.
 ///
-/// Must exceed the daemon-side drain window: `POST /lifecycle/restart` returns
-/// immediately, but the predecessor keeps `/health` UP for the entire bounded
-/// drain (`uc-daemon`'s `CONTROLLED_RESTART_DRAIN_TIMEOUT`, 30s) and only then
-/// cancels — followed by two 5s shutdown joins and the iroh `endpoint.close()`
-/// teardown. So the endpoint can stay reachable for ~40s+; 60s leaves headroom
-/// so a legitimately slow drain does not hard-fail the promotion before the old
+/// Derived in the cross-process timing contract from the daemon-side drain
+/// window (`timing::CONTROLLED_RESTART_DRAIN_TIMEOUT`): `POST
+/// /lifecycle/restart` returns immediately, but the predecessor keeps
+/// `/health` UP for the entire bounded drain and only then cancels — followed
+/// by its normal teardown. The doubled window leaves headroom so a
+/// legitimately slow drain does not hard-fail the promotion before the old
 /// daemon exits.
-const PROMOTE_DRAIN_TIMEOUT: Duration = Duration::from_secs(60);
+const PROMOTE_DRAIN_TIMEOUT: Duration = uc_daemon_process::timing::PROMOTE_DRAIN_TIMEOUT;
 
 /// The package version this CLI build expects the daemon to report. Mirrors the
 /// GUI host, which passes its own shell `CARGO_PKG_VERSION` to the classifier

--- a/src-tauri/crates/uc-daemon-local/src/instance_lock.rs
+++ b/src-tauri/crates/uc-daemon-local/src/instance_lock.rs
@@ -11,6 +11,7 @@
 
 use std::fs::{self, File};
 use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
 
 use fs2::FileExt;
 
@@ -118,72 +119,99 @@ impl DaemonInstanceLock {
     pub fn path(&self) -> &Path {
         &self.path
     }
+
+    /// Blocking acquire — parks the calling thread in `flock(2)` until the
+    /// current holder releases. Only called from [`acquire_with_deadline`]'s
+    /// dedicated blocking thread; the `DISABLE_ENV` escape valve is handled
+    /// by the `try_acquire` fast path before this runs.
+    fn acquire_blocking(data_dir: &Path) -> Result<Self, InstanceLockError> {
+        let lock_path = data_dir.join(".uniclipd.lock");
+        let file = File::create(&lock_path).map_err(InstanceLockError::Io)?;
+
+        #[cfg(unix)]
+        repair_lock_permissions(&lock_path);
+
+        file.lock_exclusive().map_err(InstanceLockError::Io)?;
+        Ok(Self {
+            _file: Some(file),
+            path: lock_path,
+        })
+    }
 }
 
-/// Retry an instance-lock acquisition while it keeps returning
-/// [`InstanceLockError::AlreadyRunning`].
+/// Acquire the per-profile instance lock, blocking (event-driven) until an
+/// exiting holder releases it, bounded by `deadline`.
 ///
 /// Used by the daemon host on EVERY start to ride out the gap where an exiting
 /// predecessor still holds the lock during iroh teardown: the predecessor's
 /// `/health` endpoint goes absent (HTTP server cancelled) BEFORE the instance
 /// lock is released (iroh `endpoint.close()` then guard drop), so a freshly
-/// spawned daemon can briefly observe `AlreadyRunning` even though the
-/// predecessor is already exiting. This race is not specific to controlled
-/// restarts — any health-probing spawner (CLI/GUI) can hit it after a plain
-/// stop/start cycle (observed in production, 2026-06-12: spawner saw `/health`
-/// absent at T+2s, predecessor released the lock at T+5.4s, replacement exited
-/// `AlreadyRunning`). Only [`InstanceLockError::AlreadyRunning`] is
-/// retried; any other error (e.g. [`InstanceLockError::Io`]) is returned
-/// immediately. If `max_attempts` is exhausted while still `AlreadyRunning`, the
-/// last `AlreadyRunning` is returned.
+/// spawned daemon can observe the lock still held even though the predecessor
+/// is already exiting. This race is not specific to controlled restarts — any
+/// health-probing spawner (CLI/GUI) can hit it after a plain stop/start cycle
+/// (observed in production, 2026-06-12: spawner saw `/health` absent at T+2s,
+/// predecessor released the lock at T+5.4s, replacement exited
+/// `AlreadyRunning`).
 ///
-/// `max_attempts` caps attempts, not sleeps: the closure is always called at
-/// least once (even with `max_attempts == 0`), and a sleep happens only BETWEEN
-/// attempts, so `n` attempts incur at most `n - 1` sleeps.
+/// The wait is a blocking `flock(2)` on a dedicated DETACHED `std::thread`
+/// (NOT `spawn_blocking`: tokio joins its blocking pool on runtime drop, so a
+/// thread still parked in `flock` after a deadline expiry would deadlock the
+/// daemon's exit path): the kernel wakes the waiter the instant the holder
+/// releases — no polling, no budget tuned to the predecessor's internal
+/// teardown phases. `deadline` is therefore pure protection against a holder
+/// that never exits, not a timing estimate; expiring returns
+/// [`InstanceLockError::AlreadyRunning`].
 ///
-/// Generic over `T` so it is unit-testable with a fake closure (no real fs2
-/// lock needed).
-pub async fn retry_while_already_running<T, F>(
-    mut attempt: F,
-    max_attempts: usize,
-    interval: std::time::Duration,
-) -> Result<T, InstanceLockError>
-where
-    F: FnMut() -> Result<T, InstanceLockError>,
-{
-    let mut remaining = max_attempts;
-    let mut attempts_made: usize = 0;
-    loop {
-        attempts_made += 1;
-        match attempt() {
-            Ok(value) => {
-                if attempts_made > 1 {
-                    tracing::info!(
-                        retry_count = attempts_made - 1,
-                        "daemon instance lock acquired after waiting for predecessor release"
-                    );
-                }
-                return Ok(value);
-            }
-            Err(InstanceLockError::AlreadyRunning { lock_path }) => {
-                remaining = remaining.saturating_sub(1);
-                if remaining == 0 {
-                    return Err(InstanceLockError::AlreadyRunning { lock_path });
-                }
-                if attempts_made == 1 {
-                    tracing::warn!(
-                        lock_path = %lock_path.display(),
-                        max_attempts,
-                        interval_ms = interval.as_millis() as u64,
-                        "daemon instance lock busy — predecessor likely still \
-                         releasing; retrying"
-                    );
-                }
-                tokio::time::sleep(interval).await;
-            }
-            // Any non-AlreadyRunning error is terminal — do not retry.
-            Err(other) => return Err(other),
+/// Failure semantics: a fast-path I/O error is terminal immediately; a
+/// deadline expiry leaves the detached thread parked in `flock(2)` — if the
+/// holder later exits, the thread wins the lock, fails to send it (receiver
+/// dropped), and releases it immediately; process exit reclaims the thread
+/// and any held lock either way, so the orphan is harmless.
+pub async fn acquire_with_deadline(
+    data_dir: &Path,
+    deadline: Duration,
+) -> Result<DaemonInstanceLock, InstanceLockError> {
+    // Fast path — also covers the `DISABLE_ENV` escape valve and terminal
+    // I/O errors (bad permissions, disk full) without spawning a thread.
+    let lock_path = match DaemonInstanceLock::try_acquire(data_dir) {
+        Ok(lock) => return Ok(lock),
+        Err(InstanceLockError::AlreadyRunning { lock_path }) => lock_path,
+        Err(other) => return Err(other),
+    };
+
+    tracing::warn!(
+        lock_path = %lock_path.display(),
+        deadline_ms = deadline.as_millis() as u64,
+        "daemon instance lock busy — blocking until the holder releases it"
+    );
+
+    let started = Instant::now();
+    let dir = data_dir.to_path_buf();
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    std::thread::Builder::new()
+        .name("uniclipd-lock-wait".into())
+        .spawn(move || {
+            // If the receiver is gone (deadline expired), the sent lock is
+            // dropped right here, releasing it for the next contender.
+            let _ = tx.send(DaemonInstanceLock::acquire_blocking(&dir));
+        })
+        .map_err(InstanceLockError::Io)?;
+
+    match tokio::time::timeout(deadline, rx).await {
+        Ok(Ok(Ok(lock))) => {
+            tracing::info!(
+                elapsed_ms = started.elapsed().as_millis() as u64,
+                "daemon instance lock acquired after holder release"
+            );
+            Ok(lock)
         }
+        Ok(Ok(Err(error))) => Err(error),
+        // Sender dropped without sending — the wait thread panicked.
+        Ok(Err(_recv_error)) => Err(InstanceLockError::Io(std::io::Error::other(
+            "instance lock wait thread terminated unexpectedly",
+        ))),
+        // Deadline expired: the holder never released within the bound.
+        Err(_elapsed) => Err(InstanceLockError::AlreadyRunning { lock_path }),
     }
 }
 
@@ -287,83 +315,80 @@ mod tests {
             .expect("lock must be re-acquirable immediately after the prior guard drops");
     }
 
-    // ---------- retry_while_already_running ----------
+    // ---------- acquire_with_deadline ----------
+    //
+    // These tests use real `flock(2)` blocking and real time, so they build
+    // their own multi-thread runtime inside a sync `#[test]` body: the
+    // `ENV_LOCK` guard (a std MutexGuard, !Send) can then be held across the
+    // whole test without making the test future non-Send.
 
-    /// A fake lock path so `AlreadyRunning` can be constructed without touching
-    /// the filesystem — `retry_while_already_running` never inspects the path.
-    fn fake_lock_path() -> PathBuf {
-        PathBuf::from("/tmp/fake.uniclipd.lock")
+    fn blocking_test_runtime() -> tokio::runtime::Runtime {
+        tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(2)
+            .enable_time()
+            .build()
+            .unwrap()
     }
 
-    /// ADR-008 P5-L L8d-2: (a) N `AlreadyRunning` then `Ok` → succeeds after the
-    /// predecessor releases the lock, before exhausting the attempt budget.
-    #[tokio::test(start_paused = true)]
-    async fn retry_succeeds_after_some_already_running() {
-        let calls = std::cell::Cell::new(0usize);
-        let attempt = || {
-            let n = calls.get();
-            calls.set(n + 1);
-            if n < 3 {
-                Err(InstanceLockError::AlreadyRunning {
-                    lock_path: fake_lock_path(),
-                })
-            } else {
-                Ok::<u32, InstanceLockError>(42)
-            }
-        };
+    /// Free lock → the fast path acquires immediately, no blocking thread.
+    #[test]
+    fn acquire_with_deadline_succeeds_immediately_when_free() {
+        let _env = ENV_LOCK.lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
 
-        let value = retry_while_already_running(attempt, 10, std::time::Duration::from_millis(200))
-            .await
-            .expect("must succeed once the predecessor releases the lock");
-
-        assert_eq!(value, 42);
-        assert_eq!(calls.get(), 4, "3 AlreadyRunning + 1 Ok = 4 attempts total");
+        let lock = blocking_test_runtime()
+            .block_on(acquire_with_deadline(dir.path(), Duration::from_secs(1)))
+            .expect("free lock must be acquired on the fast path");
+        assert!(lock.path().exists());
     }
 
-    /// (b) Always `AlreadyRunning` → returns `AlreadyRunning` after exhausting
-    /// `max_attempts`; assert the attempt count is exactly the budget.
-    #[tokio::test(start_paused = true)]
-    async fn retry_exhausts_budget_then_returns_already_running() {
-        let calls = std::cell::Cell::new(0usize);
-        let attempt = || {
-            calls.set(calls.get() + 1);
-            Err::<u32, _>(InstanceLockError::AlreadyRunning {
-                lock_path: fake_lock_path(),
-            })
-        };
+    /// Held lock released mid-wait → the blocked waiter wakes and acquires
+    /// well before the deadline (event-driven, not deadline-driven).
+    #[test]
+    fn acquire_with_deadline_wakes_when_holder_releases() {
+        let _env = ENV_LOCK.lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
 
-        let err = retry_while_already_running(attempt, 5, std::time::Duration::from_millis(200))
-            .await
-            .expect_err("a predecessor that never releases must surface AlreadyRunning");
+        let holder = DaemonInstanceLock::try_acquire(dir.path()).unwrap();
+        let release_after = Duration::from_millis(300);
+        let releaser = std::thread::spawn(move || {
+            std::thread::sleep(release_after);
+            drop(holder);
+        });
 
+        let started = Instant::now();
+        let lock = blocking_test_runtime()
+            .block_on(acquire_with_deadline(dir.path(), Duration::from_secs(10)))
+            .expect("waiter must acquire once the holder releases");
+        let elapsed = started.elapsed();
+
+        assert!(lock.path().exists());
+        assert!(
+            elapsed >= Duration::from_millis(250),
+            "must actually have waited for the holder (elapsed {elapsed:?})"
+        );
+        assert!(
+            elapsed < Duration::from_secs(5),
+            "must wake on release, long before the deadline (elapsed {elapsed:?})"
+        );
+        releaser.join().unwrap();
+    }
+
+    /// Holder never releases → deadline expires with `AlreadyRunning`.
+    #[test]
+    fn acquire_with_deadline_times_out_when_holder_never_releases() {
+        let _env = ENV_LOCK.lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+
+        let _holder = DaemonInstanceLock::try_acquire(dir.path()).unwrap();
+
+        let err = blocking_test_runtime()
+            .block_on(acquire_with_deadline(
+                dir.path(),
+                Duration::from_millis(300),
+            ))
+            .expect_err("a holder that never releases must surface AlreadyRunning");
         assert!(matches!(err, InstanceLockError::AlreadyRunning { .. }));
-        assert_eq!(
-            calls.get(),
-            5,
-            "must attempt exactly max_attempts times before giving up"
-        );
-    }
-
-    /// (c) An `Io` error on the first call propagates immediately without retry —
-    /// only `AlreadyRunning` is transient.
-    #[tokio::test(start_paused = true)]
-    async fn retry_propagates_io_error_without_retry() {
-        let calls = std::cell::Cell::new(0usize);
-        let attempt = || {
-            calls.set(calls.get() + 1);
-            Err::<u32, _>(InstanceLockError::Io(std::io::Error::other("disk full")))
-        };
-
-        let err = retry_while_already_running(attempt, 10, std::time::Duration::from_millis(200))
-            .await
-            .expect_err("Io is terminal — must propagate");
-
-        assert!(matches!(err, InstanceLockError::Io(_)));
-        assert_eq!(
-            calls.get(),
-            1,
-            "non-AlreadyRunning errors must not be retried"
-        );
     }
 
     #[test]

--- a/src-tauri/crates/uc-daemon-local/src/instance_lock.rs
+++ b/src-tauri/crates/uc-daemon-local/src/instance_lock.rs
@@ -123,12 +123,16 @@ impl DaemonInstanceLock {
 /// Retry an instance-lock acquisition while it keeps returning
 /// [`InstanceLockError::AlreadyRunning`].
 ///
-/// Used by the daemon host to ride out the gap where a controlled-restart
+/// Used by the daemon host on EVERY start to ride out the gap where an exiting
 /// predecessor still holds the lock during iroh teardown: the predecessor's
 /// `/health` endpoint goes absent (HTTP server cancelled) BEFORE the instance
 /// lock is released (iroh `endpoint.close()` then guard drop), so a freshly
-/// spawned promotion daemon can briefly observe `AlreadyRunning` even though the
-/// predecessor is already exiting. Only [`InstanceLockError::AlreadyRunning`] is
+/// spawned daemon can briefly observe `AlreadyRunning` even though the
+/// predecessor is already exiting. This race is not specific to controlled
+/// restarts — any health-probing spawner (CLI/GUI) can hit it after a plain
+/// stop/start cycle (observed in production, 2026-06-12: spawner saw `/health`
+/// absent at T+2s, predecessor released the lock at T+5.4s, replacement exited
+/// `AlreadyRunning`). Only [`InstanceLockError::AlreadyRunning`] is
 /// retried; any other error (e.g. [`InstanceLockError::Io`]) is returned
 /// immediately. If `max_attempts` is exhausted while still `AlreadyRunning`, the
 /// last `AlreadyRunning` is returned.
@@ -148,13 +152,32 @@ where
     F: FnMut() -> Result<T, InstanceLockError>,
 {
     let mut remaining = max_attempts;
+    let mut attempts_made: usize = 0;
     loop {
+        attempts_made += 1;
         match attempt() {
-            Ok(value) => return Ok(value),
+            Ok(value) => {
+                if attempts_made > 1 {
+                    tracing::info!(
+                        retry_count = attempts_made - 1,
+                        "daemon instance lock acquired after waiting for predecessor release"
+                    );
+                }
+                return Ok(value);
+            }
             Err(InstanceLockError::AlreadyRunning { lock_path }) => {
                 remaining = remaining.saturating_sub(1);
                 if remaining == 0 {
                     return Err(InstanceLockError::AlreadyRunning { lock_path });
+                }
+                if attempts_made == 1 {
+                    tracing::warn!(
+                        lock_path = %lock_path.display(),
+                        max_attempts,
+                        interval_ms = interval.as_millis() as u64,
+                        "daemon instance lock busy — predecessor likely still \
+                         releasing; retrying"
+                    );
                 }
                 tokio::time::sleep(interval).await;
             }

--- a/src-tauri/crates/uc-daemon-local/src/lib.rs
+++ b/src-tauri/crates/uc-daemon-local/src/lib.rs
@@ -29,5 +29,5 @@ pub mod instance_lock;
 // contract types + health-wait helpers without the `uc-daemon-local →
 // uc-application → uc-infra` edge.
 pub use uc_daemon_process::{
-    contract, handover, health_wait, process_metadata, socket, spawn, spawn_contract,
+    contract, handover, health_wait, process_metadata, socket, spawn, spawn_contract, timing,
 };

--- a/src-tauri/crates/uc-daemon-process/src/lib.rs
+++ b/src-tauri/crates/uc-daemon-process/src/lib.rs
@@ -28,6 +28,8 @@
 //! - [`socket`]: loopback HTTP address + daemon token path resolution.
 //! - [`spawn`]: `uniclipd` detached spawn (`setsid` / `DETACHED_PROCESS`).
 //! - [`spawn_contract`]: CLI→daemon run-mode / unattended-unlock env contract.
+//! - [`timing`]: cross-process timing contract for the daemon stop → start
+//!   handoff (base durations + derived wait budgets in one place).
 
 pub mod contract;
 pub mod handover;
@@ -36,6 +38,7 @@ pub mod process_metadata;
 pub mod socket;
 pub mod spawn;
 pub mod spawn_contract;
+pub mod timing;
 #[cfg(windows)]
 pub(crate) mod win_console;
 #[cfg(windows)]

--- a/src-tauri/crates/uc-daemon-process/src/timing.rs
+++ b/src-tauri/crates/uc-daemon-process/src/timing.rs
@@ -1,0 +1,103 @@
+//! Cross-process timing contract for the daemon stop → start handoff.
+//!
+//! Three independently shipping actors participate in a daemon restart — the
+//! exiting daemon, its replacement, and the spawner (CLI/GUI shell) — and
+//! their wait budgets are coupled: each actor's budget must cover the phases
+//! of the actor it waits on. Those relations used to live only in comments
+//! spread across crates ("must exceed the daemon-side drain window",
+//! "comfortably covers the two 5s shutdown joins"), which meant changing one
+//! base duration silently invalidated budgets in files the editor never
+//! opened (this is exactly how the 2026-06-12 restart race shipped). This
+//! module makes the relations load-bearing: base durations are named once,
+//! every dependent budget is DERIVED, and changing a base moves the whole
+//! chain.
+//!
+//! Dependency chain (top feeds bottom):
+//!
+//! ```text
+//! exiting daemon teardown   = 2 × SHUTDOWN_JOIN_TIMEOUT + iroh close
+//! replacement's lock wait   = PREDECESSOR_RELEASE_BUDGET   (covers ↑)
+//! spawner's startup wait    = DAEMON_STARTUP_TIMEOUT       (covers ↑ + bootstrap)
+//! spawner's promote wait    = PROMOTE_DRAIN_TIMEOUT        (covers drain + teardown)
+//! ```
+
+use std::time::Duration;
+
+const fn sum(a: Duration, b: Duration) -> Duration {
+    Duration::from_millis(a.as_millis() as u64 + b.as_millis() as u64)
+}
+
+const fn double(d: Duration) -> Duration {
+    Duration::from_millis(2 * d.as_millis() as u64)
+}
+
+/// Exiting-daemon-side: bound on EACH of the two teardown joins in the daemon
+/// shutdown path (the service `JoinSet` drain, then the HTTP server task
+/// join) — see `DaemonApp::run` in `uc-daemon`.
+pub const SHUTDOWN_JOIN_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Exiting-daemon-side: slack for the iroh `endpoint.close()` teardown that
+/// runs AFTER the daemon main loop returns and BEFORE the instance lock is
+/// released. The bound is iroh-internal (not ours to derive from), hence a
+/// margin: the 2026-06-12 production log shows iroh's own abort firing ~400ms
+/// after the main loop stopped, so 5s is comfortable.
+pub const IROH_TEARDOWN_MARGIN: Duration = Duration::from_secs(5);
+
+/// Replacement-daemon-side: budget to wait for an exiting predecessor to
+/// release the per-profile instance lock.
+///
+/// The predecessor's `/health` goes absent BEFORE its lock release (HTTP
+/// server cancelled first, lock dropped only after iroh unbinds), so a
+/// health-probing spawner can launch the replacement while the lock is still
+/// held. The replacement must therefore ride out the predecessor's worst-case
+/// graceful teardown: two shutdown joins plus the iroh close margin.
+pub const PREDECESSOR_RELEASE_BUDGET: Duration =
+    sum(double(SHUTDOWN_JOIN_TIMEOUT), IROH_TEARDOWN_MARGIN);
+
+/// Spawner-side: how long a fresh daemon may take from process spawn to
+/// `/health` answering, EXCLUDING any wait on a predecessor's lock (DB
+/// migrations, secure storage, iroh bind, HTTP bind).
+pub const DAEMON_BOOTSTRAP_ALLOWANCE: Duration = Duration::from_secs(15);
+
+/// Spawner-side: total budget to wait for a spawned daemon to become healthy.
+///
+/// Must cover the replacement's worst case: waiting out a predecessor's lock
+/// release AND THEN bootstrapping from scratch.
+pub const DAEMON_STARTUP_TIMEOUT: Duration =
+    sum(PREDECESSOR_RELEASE_BUDGET, DAEMON_BOOTSTRAP_ALLOWANCE);
+
+/// Exiting-daemon-side: bounded wait for control leases to drain during a
+/// controlled restart (ADR-008 P5-L L8b). If leases do not drain within this
+/// window the supervisor ABORTS the restart (clears quiescing, keeps running)
+/// rather than force-killing in-flight work (R8-F3).
+pub const CONTROLLED_RESTART_DRAIN_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Spawner-side: how long to wait for a controlled-restart predecessor's
+/// endpoint to go absent before declaring the promotion failed (ADR-008 P5-L
+/// L8d-2).
+///
+/// `POST /lifecycle/restart` returns immediately, but the predecessor keeps
+/// `/health` UP for the entire bounded drain and only then cancels — followed
+/// by its normal teardown. Doubling the drain window leaves headroom for that
+/// teardown so a legitimately slow drain does not hard-fail the promotion
+/// before the old daemon exits.
+pub const PROMOTE_DRAIN_TIMEOUT: Duration = double(CONTROLLED_RESTART_DRAIN_TIMEOUT);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Pin the derived values so a change to a base constant shows up in a
+    /// test diff (reviewers see the whole chain move, not just one number).
+    #[test]
+    fn derived_budgets_cover_their_dependency() {
+        assert_eq!(PREDECESSOR_RELEASE_BUDGET, Duration::from_secs(15));
+        assert_eq!(DAEMON_STARTUP_TIMEOUT, Duration::from_secs(30));
+        assert_eq!(PROMOTE_DRAIN_TIMEOUT, Duration::from_secs(60));
+
+        // The relations themselves, independent of the concrete numbers.
+        assert!(PREDECESSOR_RELEASE_BUDGET >= double(SHUTDOWN_JOIN_TIMEOUT));
+        assert!(DAEMON_STARTUP_TIMEOUT > PREDECESSOR_RELEASE_BUDGET);
+        assert!(PROMOTE_DRAIN_TIMEOUT > CONTROLLED_RESTART_DRAIN_TIMEOUT);
+    }
+}

--- a/src-tauri/crates/uc-daemon-process/src/timing.rs
+++ b/src-tauri/crates/uc-daemon-process/src/timing.rs
@@ -15,10 +15,11 @@
 //! Dependency chain (top feeds bottom):
 //!
 //! ```text
-//! exiting daemon teardown   = 2 × SHUTDOWN_JOIN_TIMEOUT + iroh close
-//! replacement's lock wait   = PREDECESSOR_RELEASE_BUDGET   (covers ↑)
-//! spawner's startup wait    = DAEMON_STARTUP_TIMEOUT       (covers ↑ + bootstrap)
-//! spawner's promote wait    = PROMOTE_DRAIN_TIMEOUT        (covers drain + teardown)
+//! exiting daemon teardown    = 2 × SHUTDOWN_JOIN_TIMEOUT + iroh close
+//! worst graceful teardown    = PREDECESSOR_RELEASE_BUDGET  (covers ↑)
+//! replacement's lock wait    = LOCK_ACQUIRE_DEADLINE       (covers ↑, hang protection)
+//! spawner's startup wait     = DAEMON_STARTUP_TIMEOUT      (covers ↑ + bootstrap)
+//! spawner's promote wait     = PROMOTE_DRAIN_TIMEOUT       (covers drain + teardown)
 //! ```
 
 use std::time::Duration;
@@ -54,6 +55,17 @@ pub const IROH_TEARDOWN_MARGIN: Duration = Duration::from_secs(5);
 pub const PREDECESSOR_RELEASE_BUDGET: Duration =
     sum(double(SHUTDOWN_JOIN_TIMEOUT), IROH_TEARDOWN_MARGIN);
 
+/// Replacement-daemon-side: hard deadline for the event-driven (blocking
+/// `flock`) wait on a predecessor's lock release.
+///
+/// The kernel wakes the waiter the instant the holder releases, so unlike a
+/// polling budget this deadline is NOT a tuned estimate of the predecessor's
+/// teardown — it is pure protection against a hung predecessor that never
+/// exits. Floor: it must exceed [`PREDECESSOR_RELEASE_BUDGET`] (the
+/// worst-case GRACEFUL teardown); doubled for slack, since a longer deadline
+/// costs nothing when the holder behaves.
+pub const LOCK_ACQUIRE_DEADLINE: Duration = double(PREDECESSOR_RELEASE_BUDGET);
+
 /// Spawner-side: how long a fresh daemon may take from process spawn to
 /// `/health` answering, EXCLUDING any wait on a predecessor's lock (DB
 /// migrations, secure storage, iroh bind, HTTP bind).
@@ -62,9 +74,8 @@ pub const DAEMON_BOOTSTRAP_ALLOWANCE: Duration = Duration::from_secs(15);
 /// Spawner-side: total budget to wait for a spawned daemon to become healthy.
 ///
 /// Must cover the replacement's worst case: waiting out a predecessor's lock
-/// release AND THEN bootstrapping from scratch.
-pub const DAEMON_STARTUP_TIMEOUT: Duration =
-    sum(PREDECESSOR_RELEASE_BUDGET, DAEMON_BOOTSTRAP_ALLOWANCE);
+/// release (up to its full deadline) AND THEN bootstrapping from scratch.
+pub const DAEMON_STARTUP_TIMEOUT: Duration = sum(LOCK_ACQUIRE_DEADLINE, DAEMON_BOOTSTRAP_ALLOWANCE);
 
 /// Exiting-daemon-side: bounded wait for control leases to drain during a
 /// controlled restart (ADR-008 P5-L L8b). If leases do not drain within this
@@ -92,12 +103,14 @@ mod tests {
     #[test]
     fn derived_budgets_cover_their_dependency() {
         assert_eq!(PREDECESSOR_RELEASE_BUDGET, Duration::from_secs(15));
-        assert_eq!(DAEMON_STARTUP_TIMEOUT, Duration::from_secs(30));
+        assert_eq!(LOCK_ACQUIRE_DEADLINE, Duration::from_secs(30));
+        assert_eq!(DAEMON_STARTUP_TIMEOUT, Duration::from_secs(45));
         assert_eq!(PROMOTE_DRAIN_TIMEOUT, Duration::from_secs(60));
 
         // The relations themselves, independent of the concrete numbers.
         assert!(PREDECESSOR_RELEASE_BUDGET >= double(SHUTDOWN_JOIN_TIMEOUT));
-        assert!(DAEMON_STARTUP_TIMEOUT > PREDECESSOR_RELEASE_BUDGET);
+        assert!(LOCK_ACQUIRE_DEADLINE > PREDECESSOR_RELEASE_BUDGET);
+        assert!(DAEMON_STARTUP_TIMEOUT > LOCK_ACQUIRE_DEADLINE);
         assert!(PROMOTE_DRAIN_TIMEOUT > CONTROLLED_RESTART_DRAIN_TIMEOUT);
     }
 }

--- a/src-tauri/crates/uc-daemon/src/daemon/app.rs
+++ b/src-tauri/crates/uc-daemon/src/daemon/app.rs
@@ -5,7 +5,6 @@
 
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
-use std::time::Duration;
 
 use tokio::sync::broadcast;
 use tokio::sync::RwLock;
@@ -674,14 +673,17 @@ impl DaemonApp {
                 .await;
         }
 
-        tokio::time::timeout(Duration::from_secs(5), async {
+        // These two joins are the dominant terms of the replacement daemon's
+        // lock-wait budget (`timing::PREDECESSOR_RELEASE_BUDGET`); changing
+        // the shared constant moves that budget with it.
+        tokio::time::timeout(uc_daemon_local::timing::SHUTDOWN_JOIN_TIMEOUT, async {
             while service_tasks.join_next().await.is_some() {}
         })
         .await
         .ok();
 
         if !http_handle_consumed {
-            tokio::time::timeout(Duration::from_secs(5), http_handle)
+            tokio::time::timeout(uc_daemon_local::timing::SHUTDOWN_JOIN_TIMEOUT, http_handle)
                 .await
                 .ok();
         }

--- a/src-tauri/crates/uc-daemon/src/daemon/host.rs
+++ b/src-tauri/crates/uc-daemon/src/daemon/host.rs
@@ -40,17 +40,21 @@ use super::search_assembly::build_daemon_search_assembly;
 use super::service_assembly::build_daemon_service_plan;
 use super::tokio_runtime::build_daemon_tokio_runtime;
 
-/// Backoff between instance-lock acquisition retries during a controlled-restart
-/// promotion (ADR-008 P5-L L8d-2). Only engaged when a handover record is
-/// present (see [`run`]); production never writes one, so this is unused there.
-const HANDOVER_LOCK_RETRY_INTERVAL: Duration = Duration::from_millis(200);
+/// Backoff between instance-lock acquisition retries while an exiting
+/// predecessor is still releasing the lock (ADR-008 P5-L L8d-2). Engaged on
+/// every daemon start — see the acquisition comment in [`run`] for why the
+/// retry must not be gated on a handover record.
+const LOCK_RETRY_INTERVAL: Duration = Duration::from_millis(200);
 
-/// Max instance-lock acquisition attempts while a controlled-restart predecessor
-/// is still releasing the lock (ADR-008 P5-L L8d-2). The retry sleeps only
-/// BETWEEN attempts, so 75 attempts incur 74 × 200ms ≈ 14.8s of waiting — a ~15s
-/// budget that comfortably covers the predecessor's two 5s shutdown joins plus
-/// the iroh `endpoint.close()` teardown.
-const HANDOVER_LOCK_MAX_ATTEMPTS: usize = 75;
+/// Max instance-lock acquisition attempts while a predecessor is still
+/// releasing the lock (ADR-008 P5-L L8d-2). DERIVED from the cross-process
+/// timing contract: enough attempts at [`LOCK_RETRY_INTERVAL`] to sleep
+/// through [`uc_daemon_local::timing::PREDECESSOR_RELEASE_BUDGET`] (the predecessor's
+/// worst-case graceful teardown), plus the initial attempt. The retry sleeps
+/// only BETWEEN attempts, so `n` attempts incur `n - 1` interval sleeps.
+const LOCK_MAX_ATTEMPTS: usize = (uc_daemon_local::timing::PREDECESSOR_RELEASE_BUDGET.as_millis()
+    / LOCK_RETRY_INTERVAL.as_millis()) as usize
+    + 1;
 
 /// Process-level persistent resource handles passed to the daemon on each spawn.
 ///
@@ -94,36 +98,49 @@ pub fn run(run_mode: DaemonRunMode) -> anyhow::Result<()> {
         // released, otherwise the replacement races `AddrInUse`. Do NOT move
         // this guard's scope earlier (e.g. into a sub-block).
         //
-        // When a handover record is present (a controlled-restart promotion
-        // spawn, ADR-008 P5-L L8d-2), acquisition retries with a bounded backoff
-        // to ride out the window where the predecessor still holds the lock
-        // during iroh teardown (its `/health` goes absent before lock-release).
-        //
-        // Peek (do NOT clear) the handover record before acquiring: a present
-        // record means we are a controlled-restart promotion spawn, so we must
-        // tolerate the predecessor still releasing the lock. In production no
-        // writer exists → `handover_present` is always false → single-shot
-        // `try_acquire`, byte-identical to before. The `clear` below still
-        // consumes the record AFTER the lock is held (claim under lock — R8-F1).
-        let handover_present =
-            uc_daemon_local::handover::read(&storage_paths.app_data_root_dir).is_some();
-        let _instance_lock = if handover_present {
-            uc_daemon_local::instance_lock::retry_while_already_running(
-                || {
-                    uc_daemon_local::instance_lock::DaemonInstanceLock::try_acquire(
-                        &storage_paths.app_data_root_dir,
-                    )
-                },
-                HANDOVER_LOCK_MAX_ATTEMPTS,
-                HANDOVER_LOCK_RETRY_INTERVAL,
-            )
-            .await
-        } else {
-            uc_daemon_local::instance_lock::DaemonInstanceLock::try_acquire(
-                &storage_paths.app_data_root_dir,
-            )
-        }
-        .map_err(|e| anyhow::anyhow!("{e}"))?;
+        // Acquisition retries `AlreadyRunning` with a bounded backoff (the
+        // derived `timing::PREDECESSOR_RELEASE_BUDGET`, currently 15s) on
+        // EVERY start — not only controlled-restart promotions — to ride out
+        // the window where an exiting predecessor still holds the lock during
+        // iroh teardown (its `/health` goes absent before lock-release). Any
+        // health-probing spawner (CLI/GUI) can hit that window after a plain
+        // stop/start cycle: observed in production (2026-06-12), the spawner
+        // saw `/health` absent ~2s after the predecessor's shutdown signal and
+        // spawned a replacement that lost the single-shot `try_acquire` to a
+        // predecessor that needed ~5.4s to release. The cost of the retry when
+        // a HEALTHY daemon holds the lock is a ~15s delay before the same
+        // `AlreadyRunning` error — acceptable, since health-probing spawners
+        // never spawn against a healthy daemon (only a manual double-launch
+        // pays it). I/O errors are still terminal on the first attempt.
+        let _instance_lock = uc_daemon_local::instance_lock::retry_while_already_running(
+            || {
+                uc_daemon_local::instance_lock::DaemonInstanceLock::try_acquire(
+                    &storage_paths.app_data_root_dir,
+                )
+            },
+            LOCK_MAX_ATTEMPTS,
+            LOCK_RETRY_INTERVAL,
+        )
+        .await
+        .map_err(|e| {
+            // Surface the failure in the JSON log: this error otherwise only
+            // reaches stderr via anyhow's Termination in `main`, which is
+            // detached/nulled in production — the log would just stop dead
+            // after bootstrap with no trace of why the process exited.
+            let error_kind = match &e {
+                uc_daemon_local::instance_lock::InstanceLockError::AlreadyRunning { .. } => {
+                    "instance_lock_already_running"
+                }
+                uc_daemon_local::instance_lock::InstanceLockError::Io(_) => "instance_lock_io",
+            };
+            tracing::error!(
+                error_kind,
+                retryable = false,
+                error = %e,
+                "daemon instance lock acquisition failed — exiting"
+            );
+            anyhow::anyhow!("{e}")
+        })?;
 
         // ADR-008 P5-L L7: now that we hold the instance lock, consume any pending
         // cross-process handover by clearing it (claim under lock — R8-F1). A

--- a/src-tauri/crates/uc-daemon/src/daemon/host.rs
+++ b/src-tauri/crates/uc-daemon/src/daemon/host.rs
@@ -18,7 +18,6 @@
 //! Migrated from `uc-desktop/src/daemon/host.rs` (ADR-008 P2, Slice 2b).
 
 use std::sync::Arc;
-use std::time::Duration;
 
 use tokio_util::sync::CancellationToken;
 use uc_application::clipboard_write::ClipboardWriteCoordinator;
@@ -39,22 +38,6 @@ use super::runtime_controls::build_daemon_runtime_controls;
 use super::search_assembly::build_daemon_search_assembly;
 use super::service_assembly::build_daemon_service_plan;
 use super::tokio_runtime::build_daemon_tokio_runtime;
-
-/// Backoff between instance-lock acquisition retries while an exiting
-/// predecessor is still releasing the lock (ADR-008 P5-L L8d-2). Engaged on
-/// every daemon start — see the acquisition comment in [`run`] for why the
-/// retry must not be gated on a handover record.
-const LOCK_RETRY_INTERVAL: Duration = Duration::from_millis(200);
-
-/// Max instance-lock acquisition attempts while a predecessor is still
-/// releasing the lock (ADR-008 P5-L L8d-2). DERIVED from the cross-process
-/// timing contract: enough attempts at [`LOCK_RETRY_INTERVAL`] to sleep
-/// through [`uc_daemon_local::timing::PREDECESSOR_RELEASE_BUDGET`] (the predecessor's
-/// worst-case graceful teardown), plus the initial attempt. The retry sleeps
-/// only BETWEEN attempts, so `n` attempts incur `n - 1` interval sleeps.
-const LOCK_MAX_ATTEMPTS: usize = (uc_daemon_local::timing::PREDECESSOR_RELEASE_BUDGET.as_millis()
-    / LOCK_RETRY_INTERVAL.as_millis()) as usize
-    + 1;
 
 /// Process-level persistent resource handles passed to the daemon on each spawn.
 ///
@@ -98,28 +81,23 @@ pub fn run(run_mode: DaemonRunMode) -> anyhow::Result<()> {
         // released, otherwise the replacement races `AddrInUse`. Do NOT move
         // this guard's scope earlier (e.g. into a sub-block).
         //
-        // Acquisition retries `AlreadyRunning` with a bounded backoff (the
-        // derived `timing::PREDECESSOR_RELEASE_BUDGET`, currently 15s) on
-        // EVERY start — not only controlled-restart promotions — to ride out
-        // the window where an exiting predecessor still holds the lock during
-        // iroh teardown (its `/health` goes absent before lock-release). Any
+        // Acquisition waits for the lock EVENT-DRIVEN (blocking `flock` on a
+        // detached thread; the kernel wakes us the instant the holder
+        // releases) on EVERY start — not only controlled-restart promotions —
+        // because an exiting predecessor still holds the lock during iroh
+        // teardown (its `/health` goes absent before lock-release). Any
         // health-probing spawner (CLI/GUI) can hit that window after a plain
         // stop/start cycle: observed in production (2026-06-12), the spawner
         // saw `/health` absent ~2s after the predecessor's shutdown signal and
-        // spawned a replacement that lost the single-shot `try_acquire` to a
-        // predecessor that needed ~5.4s to release. The cost of the retry when
-        // a HEALTHY daemon holds the lock is a ~15s delay before the same
-        // `AlreadyRunning` error — acceptable, since health-probing spawners
-        // never spawn against a healthy daemon (only a manual double-launch
-        // pays it). I/O errors are still terminal on the first attempt.
-        let _instance_lock = uc_daemon_local::instance_lock::retry_while_already_running(
-            || {
-                uc_daemon_local::instance_lock::DaemonInstanceLock::try_acquire(
-                    &storage_paths.app_data_root_dir,
-                )
-            },
-            LOCK_MAX_ATTEMPTS,
-            LOCK_RETRY_INTERVAL,
+        // spawned a replacement that lost the then-single-shot `try_acquire`
+        // to a predecessor that needed ~5.4s to release. The deadline
+        // (`timing::LOCK_ACQUIRE_DEADLINE`) is pure hang protection, not a
+        // teardown estimate — a healthy holder costs the waiter nothing
+        // extra, since only a manual double-launch ever waits it out. I/O
+        // errors are still terminal on the first attempt.
+        let _instance_lock = uc_daemon_local::instance_lock::acquire_with_deadline(
+            &storage_paths.app_data_root_dir,
+            uc_daemon_local::timing::LOCK_ACQUIRE_DEADLINE,
         )
         .await
         .map_err(|e| {

--- a/src-tauri/crates/uc-daemon/src/daemon/oneshot.rs
+++ b/src-tauri/crates/uc-daemon/src/daemon/oneshot.rs
@@ -76,7 +76,12 @@ pub(crate) const LEASE_POLL_INTERVAL: Duration = Duration::from_millis(250);
 /// (ADR-008 P5-L L8b). If leases do not drain within this window the supervisor
 /// ABORTS the restart (clears quiescing, keeps running) rather than force-killing
 /// in-flight work (R8-F3). Tunable; L8d end-to-end will validate the value.
-pub(crate) const CONTROLLED_RESTART_DRAIN_TIMEOUT: Duration = Duration::from_secs(30);
+///
+/// Aliased from the cross-process timing contract: the CLI's promote wait
+/// (`timing::PROMOTE_DRAIN_TIMEOUT`) is derived from this value, so it must
+/// not drift in a local literal.
+pub(crate) const CONTROLLED_RESTART_DRAIN_TIMEOUT: Duration =
+    uc_daemon_local::timing::CONTROLLED_RESTART_DRAIN_TIMEOUT;
 
 /// Tunable timings for the Oneshot lifecycle supervisor (grace / drain / poll).
 /// Bundled so the supervisor signature stays small; production uses

--- a/src-tauri/crates/uc-desktop/src/daemon_probe.rs
+++ b/src-tauri/crates/uc-desktop/src/daemon_probe.rs
@@ -32,7 +32,15 @@ use uc_daemon_process::spawn::spawn_detached_daemon;
 use crate::daemon::DaemonOwnership;
 
 pub const HEALTH_PATH: &str = "/health";
-pub const HEALTH_CHECK_TIMEOUT: Duration = Duration::from_secs(8);
+
+/// Budget for a freshly spawned daemon to become healthy. Aliased from the
+/// cross-process timing contract: a replacement daemon may legitimately spend
+/// up to `timing::LOCK_ACQUIRE_DEADLINE` waiting for an exiting predecessor's
+/// instance lock BEFORE it even binds `/health`, so this must cover lock wait
+/// + bootstrap — same budget the CLI spawner uses (`STARTUP_TIMEOUT` in
+/// `uc-cli`). A local literal here (the old 8s) silently went stale when the
+/// lock-wait deadline was introduced.
+pub const HEALTH_CHECK_TIMEOUT: Duration = uc_daemon_process::timing::DAEMON_STARTUP_TIMEOUT;
 pub const HEALTH_POLL_INTERVAL: Duration = Duration::from_millis(200);
 pub const PROBE_TIMEOUT: Duration = Duration::from_secs(2);
 pub const INCOMPATIBLE_DAEMON_EXIT_TIMEOUT: Duration = Duration::from_millis(1500);

--- a/src-tauri/crates/uc-tauri/src/run.rs
+++ b/src-tauri/crates/uc-tauri/src/run.rs
@@ -53,11 +53,25 @@ pub(crate) const SHUTDOWN_FRONTEND_GRACE_MS: u64 = 100;
 /// workspace 共享版本号所以与 `uniclipboard` bin 一致。
 const EXPECTED_PACKAGE_VERSION: &str = env!("CARGO_PKG_VERSION");
 
+/// GUI-local slack on top of the daemon's own startup budget: covers the
+/// probe round-trip, the incompatible-daemon replacement wait
+/// (`INCOMPATIBLE_DAEMON_EXIT_TIMEOUT`), and `connection_state` population
+/// after the daemon turns healthy.
+const AUTO_UNLOCK_LOCAL_MARGIN: Duration = Duration::from_secs(15);
+
 /// auto-unlock 等待 daemon connection_state 被填充的总上限。
-/// `bootstrap_daemon_in_process` 内部 `wait_for_daemon_health` 默认上限 8s
-/// （`HEALTH_CHECK_TIMEOUT`）+ legacy daemon 替换路径再加 `INCOMPATIBLE_DAEMON_EXIT_TIMEOUT`，
-/// 给 30s 足够覆盖最坏路径。超时只是放弃 auto-unlock，用户改用手动解锁。
-const AUTO_UNLOCK_DAEMON_READY_TIMEOUT: Duration = Duration::from_secs(30);
+///
+/// Derived from the cross-process timing contract instead of a local literal:
+/// the dominant term is the daemon's own startup budget
+/// (`timing::DAEMON_STARTUP_TIMEOUT`, which already covers a replacement
+/// waiting out a predecessor's instance lock and then bootstrapping), plus
+/// the GUI-local margin above. The wait runs in a detached background task,
+/// so a longer bound costs nothing; expiry only skips auto-unlock and the
+/// user unlocks manually.
+const AUTO_UNLOCK_DAEMON_READY_TIMEOUT: Duration = Duration::from_millis(
+    uc_daemon_process::timing::DAEMON_STARTUP_TIMEOUT.as_millis() as u64
+        + AUTO_UNLOCK_LOCAL_MARGIN.as_millis() as u64,
+);
 /// 轮询 connection_state 的间隔。
 const AUTO_UNLOCK_DAEMON_READY_POLL: Duration = Duration::from_millis(200);
 


### PR DESCRIPTION
## Summary

- Fixes a restart race where a plain stop/start cycle could leave the daemon dead with no recorded reason: the exiting daemon's `/health` goes absent **before** its instance lock is released (the lock drops only after iroh teardown, seconds later), so a health-probing spawner launched the replacement into a still-held lock and it exited `AlreadyRunning`. The replacement now waits for the predecessor's lock release on every start (b488f6b8), and the failure is `tracing::error!`-ed before exit so it is visible in the JSON log.
- The lock wait is event-driven, not polled: a blocking `flock(2)` on a helper thread wakes the instant the holder releases, bounded by a deadline that is pure hang protection rather than a tuned estimate of teardown time (e6759afa).
- All cross-process restart timing now lives in one derived contract, `uc-daemon-process::timing`: base durations are named once, every dependent budget (lock deadline, spawner startup timeout, promote drain window) is computed from them, with a pin test so changing a base surfaces the whole chain in the diff (73552327). Previously these relations existed only as comment arithmetic spread across three crates — which is exactly how this race shipped.
- GUI/CLI spawner wait budgets are derived from the same contract instead of local literals (f028f4cf, 73552327).

## Test plan

- [x] `cargo test -p uc-daemon-local --lib` — 37 passed, including new `instance_lock` tests: waiter wakes on holder release well before the deadline, deadline expiry surfaces `AlreadyRunning`, free-lock fast path.
- [x] `cargo test -p uc-daemon-process --lib` — 39 passed, including the timing-contract pin test (`derived_budgets_cover_their_dependency`).
- [ ] Manual stop/start cycle on a real daemon (`uniclip stop && uniclip start`) during the predecessor's iroh-teardown window, confirming the replacement blocks on the lock instead of exiting `AlreadyRunning`.

Note: `uc-daemon-local` doctests in `auth.rs` fail on `main` as well — untouched by this branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Refactor**
- Established a centralized timing contract for daemon restart handoff operations, replacing previously scattered hardcoded timeouts across components
- Updated daemon instance lock acquisition to use deadline-bounded blocking mechanisms for improved reliability during daemon transitions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->