### PR TITLE
chore(agents): reliably load agent rules and machine-enforce them

### DIFF
--- a/.claude/hooks/bash-command-hint.sh
+++ b/.claude/hooks/bash-command-hint.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+# PostToolUse hook (Bash): inspect the executed command text from stdin JSON
+# and emit hints. Replaces the old inline hooks that relied on a non-existent
+# $TOOL_INPUT env var (the documented interface is stdin JSON).
+
+input=$(cat)
+
+if command -v jq >/dev/null 2>&1; then
+  cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // empty')
+else
+  # Best-effort fallback; does not handle escaped quotes inside the command.
+  cmd=$(printf '%s' "$input" | sed -n 's/.*"command"[[:space:]]*:[[:space:]]*"\(.*\)".*/\1/p' | head -n1)
+fi
+
+[ -n "$cmd" ] || exit 0
+
+if printf '%s' "$cmd" | grep -qE '(git mv|mv|rename).*src-tauri/crates/'; then
+  echo '[hook] Crate file moved — consider running /refresh-agents to update WHERE TO LOOK'
+fi
+
+if [ ! -f /tmp/claude-babysit-pr.lock ] && printf '%s' "$cmd" | grep -qE 'git push|gh pr create'; then
+  branch=$(git -C "${CLAUDE_PROJECT_DIR:-.}" rev-parse --abbrev-ref HEAD 2>/dev/null)
+  if [ -n "$branch" ] && [ "$branch" != "main" ] && [ "$branch" != "master" ]; then
+    echo "[babysit-pr:auto] Push/PR-create detected on branch ${branch}. Auto-starting CI & review monitor (max 3 rounds). Invoke /babysit-pr now."
+  fi
+fi

--- a/.claude/hooks/guide-hint.sh
+++ b/.claude/hooks/guide-hint.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+# PostToolUse hook (Edit|Write): on the first edit of a Rust / frontend file in a
+# session, remind the agent to read the matching docs/agent/*.md rules file.
+# Reminds at most once per session per area, via a flag file keyed by session_id.
+
+input=$(cat)
+
+if command -v jq >/dev/null 2>&1; then
+  file_path=$(printf '%s' "$input" | jq -r '.tool_input.file_path // empty')
+  session_id=$(printf '%s' "$input" | jq -r '.session_id // empty')
+else
+  file_path=$(printf '%s' "$input" | sed -n 's/.*"file_path"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n1)
+  session_id=$(printf '%s' "$input" | sed -n 's/.*"session_id"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n1)
+fi
+
+[ -n "$file_path" ] || exit 0
+[ -n "$session_id" ] || session_id="nosession"
+
+project_dir=${CLAUDE_PROJECT_DIR:-$(pwd)}
+rel=${file_path#"$project_dir"/}
+
+# Note: in `case`, * also matches `/`, so these cover nested paths.
+case "$rel" in
+  src-tauri/*.rs)
+    kind=rust
+    msg='[hook] First Rust edit this session — read docs/agent/rust-tauri-rules.md if you have not (plus docs/agent/architecture-rules.md when crate boundaries, ports, or DTO conversions are involved).'
+    ;;
+  src/*.ts | src/*.tsx | src/*.css)
+    kind=frontend
+    msg='[hook] First frontend edit this session — read docs/agent/frontend-ui-rules.md if you have not.'
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+
+flag="${TMPDIR:-/tmp}/claude-guide-hint-${session_id}-${kind}"
+[ -f "$flag" ] && exit 0
+touch "$flag" 2>/dev/null
+echo "$msg"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,6 +9,15 @@
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/bash-command-hint.sh"
           }
         ]
+      },
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/guide-hint.sh"
+          }
+        ]
       }
     ]
   }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,11 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "if echo \"$TOOL_INPUT\" | grep -qE '(git mv|mv|rename).*src-tauri/crates/'; then echo '[hook] Crate file moved — consider running /refresh-agents to update WHERE TO LOOK'; fi"
-          },
-          {
-            "type": "command",
-            "command": "if [ ! -f /tmp/claude-babysit-pr.lock ] && echo \"$TOOL_INPUT\" | grep -qE 'git push|gh pr create'; then branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null); if [ \"$branch\" != 'main' ] && [ \"$branch\" != 'master' ] && [ -n \"$branch\" ]; then echo '[babysit-pr:auto] Push/PR-create detected on branch '\"$branch\"'. Auto-starting CI & review monitor (max 3 rounds). Invoke /babysit-pr now.'; fi; fi"
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/bash-command-hint.sh"
           }
         ]
       }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,10 @@
 
 This file is a compatibility entrypoint for Claude Code.
 
+The root instruction source is imported below so the navigation index is always in context:
+
+@AGENTS.md
+
 ## 加载顺序
 
 1. **产品方向与底线** → [`VISION.md`](./VISION.md)

--- a/src-tauri/CLAUDE.md
+++ b/src-tauri/CLAUDE.md
@@ -1,0 +1,5 @@
+# CLAUDE.md
+
+Compatibility entrypoint. Local navigation for the Rust workspace is imported below:
+
+@AGENTS.md

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -154,6 +154,18 @@ resolver = "2"
 version = "0.15.0-alpha.3"
 license = "AGPL-3.0-only"
 
+# Machine-checked subset of docs/agent/rust-tauri-rules.md ("no unwrap/expect
+# in production", "use tracing, not println/eprintln"). Tests are exempted via
+# clippy.toml (allow-*-in-tests). Member crates opt in with [lints] workspace
+# = true; p2p-bench (throwaway diagnostics) stays out, uc-cli allows print at
+# crate level because stdout is its user-facing output.
+[workspace.lints.clippy]
+unwrap_used = "warn"
+expect_used = "warn"
+print_stdout = "warn"
+print_stderr = "warn"
+dbg_macro = "warn"
+
 # Dependencies for workspace crates, mainly for tauri plugins
 [workspace.dependencies]
 # tauri 2.11 是 specta rc.25 兼容的最低版本 —— 2.10.x 及之前在
@@ -170,3 +182,6 @@ tauri-plugin-autostart = "2"
 # vendor/iroh-blobs/src/store/fs/bao_file.rs::persist_regression 单元测试。
 [patch.crates-io]
 iroh-blobs = { path = "vendor/iroh-blobs" }
+
+[lints]
+workspace = true

--- a/src-tauri/clippy.toml
+++ b/src-tauri/clippy.toml
@@ -1,0 +1,6 @@
+# Companion to [workspace.lints.clippy] in Cargo.toml.
+# docs/agent/rust-tauri-rules.md: "Tests are the only exception" for unwrap/expect.
+allow-unwrap-in-tests = true
+allow-expect-in-tests = true
+allow-dbg-in-tests = true
+allow-print-in-tests = true

--- a/src-tauri/crates/uc-app-paths/Cargo.toml
+++ b/src-tauri/crates/uc-app-paths/Cargo.toml
@@ -13,3 +13,6 @@ path = "src/lib.rs"
 # Cross-platform base data/cache directory resolution. Same version uc-platform
 # and uc-daemon-process previously pinned, so resolved paths stay byte-identical.
 dirs = "6.0"
+
+[lints]
+workspace = true

--- a/src-tauri/crates/uc-application/Cargo.toml
+++ b/src-tauri/crates/uc-application/Cargo.toml
@@ -71,3 +71,6 @@ mockall = "0.13"
 tempfile = "3"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 image = "0.25"
+
+[lints]
+workspace = true

--- a/src-tauri/crates/uc-bootstrap/Cargo.toml
+++ b/src-tauri/crates/uc-bootstrap/Cargo.toml
@@ -66,3 +66,6 @@ bytes = "1.7"
 # elide BIND_LOCK 守护（production build 不启用此 feature，结构性防御依然
 # 生效）。见 uc-infra/src/network/iroh/node.rs BIND_LOCK doc comment。
 uc-infra = { path = "../uc-infra", features = ["test-util"] }
+
+[lints]
+workspace = true

--- a/src-tauri/crates/uc-cli-macros/Cargo.toml
+++ b/src-tauri/crates/uc-cli-macros/Cargo.toml
@@ -12,3 +12,6 @@ proc-macro = true
 syn = { version = "2", features = ["full", "visit-mut"] }
 quote = "1"
 proc-macro2 = "1"
+
+[lints]
+workspace = true

--- a/src-tauri/crates/uc-cli/Cargo.toml
+++ b/src-tauri/crates/uc-cli/Cargo.toml
@@ -73,3 +73,6 @@ axum = { version = "0.7", features = ["ws", "tokio", "http1", "http2"] }
 tower = { version = "0.5", features = ["util"] }
 tempfile = "3"
 tokio = { version = "1", features = ["test-util"] }
+
+[lints]
+workspace = true

--- a/src-tauri/crates/uc-cli/src/main.rs
+++ b/src-tauri/crates/uc-cli/src/main.rs
@@ -1,3 +1,8 @@
+// stdout/stderr ARE this crate's user-facing output channel (data/JSON to
+// stdout, human-readable lines via src/ui.rs per local AGENTS.md), so the
+// workspace-wide print lints do not apply here.
+#![allow(clippy::print_stdout, clippy::print_stderr)]
+
 mod commands;
 mod exit_codes;
 mod local_daemon;

--- a/src-tauri/crates/uc-core/Cargo.toml
+++ b/src-tauri/crates/uc-core/Cargo.toml
@@ -67,3 +67,6 @@ specta-derive = ["dep:specta", "dep:specta-typescript"]
 # Enables the `task_registry` module (adds tokio rt+time + tokio-util).
 # Consumers that need TaskRegistry opt in; keeps the default dep footprint slim.
 task-registry = ["dep:tokio-util", "tokio/rt", "tokio/time", "tokio/macros"]
+
+[lints]
+workspace = true

--- a/src-tauri/crates/uc-daemon-client/Cargo.toml
+++ b/src-tauri/crates/uc-daemon-client/Cargo.toml
@@ -43,3 +43,6 @@ tracing = "0.1"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }
+
+[lints]
+workspace = true

--- a/src-tauri/crates/uc-daemon-contract/Cargo.toml
+++ b/src-tauri/crates/uc-daemon-contract/Cargo.toml
@@ -20,3 +20,5 @@ utoipa = { version = "4", features = ["uuid", "chrono", "url"] }
 # downgrade guard (ADR-008 P5-L L2). semver is a leaf pure-Rust dep — it does
 # NOT pull iroh/diesel, so it keeps this contract crate client-safe.
 semver = "1"
+[lints]
+workspace = true

--- a/src-tauri/crates/uc-daemon-local/Cargo.toml
+++ b/src-tauri/crates/uc-daemon-local/Cargo.toml
@@ -42,3 +42,6 @@ libc = "0.2"
 [dev-dependencies]
 tempfile = "3"
 tokio = { version = "1", features = ["test-util"] }
+
+[lints]
+workspace = true

--- a/src-tauri/crates/uc-daemon-process/Cargo.toml
+++ b/src-tauri/crates/uc-daemon-process/Cargo.toml
@@ -56,3 +56,6 @@ windows-sys = { version = "0.59", features = ["Win32_Foundation", "Win32_System_
 [dev-dependencies]
 tempfile = "3"
 tokio = { version = "1", features = ["macros", "rt", "test-util"] }
+
+[lints]
+workspace = true

--- a/src-tauri/crates/uc-daemon/Cargo.toml
+++ b/src-tauri/crates/uc-daemon/Cargo.toml
@@ -45,3 +45,6 @@ uc-daemon-local = { path = "../uc-daemon-local", features = ["test-helpers"] }
 tempfile = "3"
 chrono = { version = "0.4", default-features = true }
 mockall = "0.13"
+
+[lints]
+workspace = true

--- a/src-tauri/crates/uc-desktop/Cargo.toml
+++ b/src-tauri/crates/uc-desktop/Cargo.toml
@@ -39,3 +39,6 @@ chrono = { version = "0.4", default-features = true }
 diesel = { version = "2.3.5", features = ["sqlite"] }
 mockall = "0.13"
 wiremock = "0.6"
+
+[lints]
+workspace = true

--- a/src-tauri/crates/uc-infra/Cargo.toml
+++ b/src-tauri/crates/uc-infra/Cargo.toml
@@ -139,3 +139,6 @@ tokio = { version = "1", features = ["full", "test-util"] }
 tempfile = "3"
 mockall = "0.13"
 wiremock = "0.6"
+
+[lints]
+workspace = true

--- a/src-tauri/crates/uc-observability/Cargo.toml
+++ b/src-tauri/crates/uc-observability/Cargo.toml
@@ -32,3 +32,6 @@ tempfile = "3"
 # Slice 7b-2: wiremock 烟测 PosthogSink HTTP 形态；tokio macros + rt-multi-thread 给 #[tokio::test] 用
 wiremock = "0.6"
 tokio = { version = "1", default-features = false, features = ["rt", "rt-multi-thread", "macros", "time"] }
+
+[lints]
+workspace = true

--- a/src-tauri/crates/uc-platform/Cargo.toml
+++ b/src-tauri/crates/uc-platform/Cargo.toml
@@ -178,3 +178,6 @@ clipboard-win = { version = "5.4" }
 objc2 = "0.6"
 objc2-app-kit = { version = "0.3", features = ["NSPasteboard", "NSPasteboardItem"] }
 objc2-foundation = { version = "0.3", features = ["NSArray", "NSData", "NSString"] }
+
+[lints]
+workspace = true

--- a/src-tauri/crates/uc-tauri/Cargo.toml
+++ b/src-tauri/crates/uc-tauri/Cargo.toml
@@ -112,3 +112,6 @@ tempfile = "3"
 mockall = "0.13"
 async-trait = "0.1"
 tokio = { version = "1", features = ["full", "test-util"] }
+
+[lints]
+workspace = true

--- a/src-tauri/crates/uc-webserver/Cargo.toml
+++ b/src-tauri/crates/uc-webserver/Cargo.toml
@@ -36,3 +36,6 @@ uuid = { version = "1.10.0", features = ["v4"] }
 [dev-dependencies]
 async-trait = "0.1"
 tower = { version = "0.5", features = ["util"] }
+
+[lints]
+workspace = true

--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -1,0 +1,5 @@
+# CLAUDE.md
+
+Compatibility entrypoint. Local navigation for the frontend is imported below:
+
+@AGENTS.md


### PR DESCRIPTION
## Summary

- Import `AGENTS.md` into `CLAUDE.md` via `@imports` at the repo root, `src-tauri/`, and `src/`, so the navigation index is always in context instead of depending on the agent following links (a0321e780).
- Fix the PostToolUse Bash hooks: they previously read a non-existent `$TOOL_INPUT` env var and never fired; they now parse the documented stdin JSON, extracted into `.claude/hooks/bash-command-hint.sh` (b9ddd233f).
- Add an `Edit|Write` hook (`.claude/hooks/guide-hint.sh`) that reminds the agent — once per session per area — to read the matching `docs/agent/*.md` rules file on the first Rust or frontend edit (e024ffd8e).
- Machine-check the "no unwrap/expect in production, use tracing not println" rules from `docs/agent/rust-tauri-rules.md` via `[workspace.lints.clippy]` warns; tests are exempted through `clippy.toml`, and `uc-cli` allows print lints at crate level since stdout is its user-facing output (d14fee799).

Docs left as-is — no user-facing surface changed (developer/agent tooling only).

## Test plan

- [x] `sh -n` syntax check passes on both new hook scripts.
- [ ] Verify the hooks fire in a fresh Claude Code session (guide hint on first Rust/frontend edit; bash hint on `git mv` of a crate file).
- [ ] `cargo clippy --workspace` in `src-tauri/` surfaces the new warns on existing unwrap/print sites without erroring the build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added compatibility documentation entrypoints with navigation references for improved code context and accessibility.

* **Chores**
  * Established workspace-wide code quality linting standards across all project crates to maintain consistency and catch issues early.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->