### PR TITLE
fix(hooks): format staged Rust via rustfmt, not broken cargo fmt invocation

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
       "prettier --write"
     ],
     "{apps,crates,src-tauri}/**/*.rs": [
-      "cargo fmt --manifest-path=Cargo.toml --"
+      "rustfmt --edition 2021"
     ]
   },
   "dependencies": {


### PR DESCRIPTION
## Problem
The lint-staged rule for Rust files runs
`cargo fmt --manifest-path=Cargo.toml --`. Since the cargo workspace root
moved to the repo root (#1041, 41e41d21a), the root Cargo.toml is a virtual
workspace manifest with no [package], so cargo fmt errors with "Failed to
find targets" and aborts the pre-commit hook for every commit touching a
Rust file under apps/ crates/ src-tauri/.

## Fix
Run `rustfmt --edition 2021` directly on staged files — idiomatic lint-staged
(per-file, fast). No rustfmt.toml in repo ⇒ byte-identical to cargo fmt.
Explicit --edition 2021 is required (bare rustfmt defaults to 2015 and
misformats async/dyn). CI still runs `cargo fmt --all` as the authority.

## Verification
Misformatted a .rs file → staged → bun lint-staged → rustfmt auto-fixed,
hook passed (no more "Failed to find targets").

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code formatting configuration for development tooling.

---

**Note:** This release contains no user-facing changes. The update addresses internal development processes only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->