### PR TITLE
ci(npm-publish): auto-publish npm packages after alpha releases

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -14,15 +14,17 @@ run-name: >-
 # one main package (uniclipboard) whose JS launcher picks the matching one via
 # optionalDependencies. Assembly lives in scripts/build-npm-packages.mjs.
 #
-# Channel mapping: the auto path publishes stable releases only (same policy
-# as homebrew-tap.yml — alpha releases are frequent and npm versions are
-# permanent). Prereleases can still be published via workflow_dispatch; their
-# version suffix maps to the npm dist-tag (X.Y.Z-alpha.N → `alpha`), and only
-# stable gets `latest`.
+# Channel mapping (same pattern as snap.yml / copr.yml): alpha releases are
+# auto-published by release.yml with GITHUB_TOKEN, so their release.published
+# event never fires other workflows — release.yml dispatches this workflow
+# explicitly (dispatch-npm-alpha). beta / rc / stable are left as drafts and
+# published by a human; that release.published event lands here. The version
+# suffix maps to the npm dist-tag (X.Y.Z-alpha.N → `alpha`), and only stable
+# gets `latest`.
 #
-# `workflow_dispatch` is exposed for debugging / re-runs against an existing
-# published release. Already-published package versions are skipped, so the
-# whole job is idempotent.
+# `workflow_dispatch` doubles as the alpha auto-publish entry (dispatched by
+# release.yml) and the manual debugging / re-run path. Already-published
+# package versions are skipped, so the whole job is idempotent.
 on:
   release:
     types: [published]
@@ -38,9 +40,10 @@ permissions: {}
 jobs:
   publish:
     name: Publish npm packages
-    # Skip prereleases on the auto path; manual dispatch always runs so any
-    # published release (including prereleases) can be pushed deliberately.
-    if: github.event_name == 'workflow_dispatch' || github.event.release.prerelease == false
+    # The release.published path serves manually published releases
+    # (beta / rc / stable); alpha arrives via release.yml's explicit dispatch
+    # instead, so skip it here to avoid double-publishing on re-publish.
+    if: github.event_name == 'workflow_dispatch' || !contains(github.event.release.tag_name, '-alpha')
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -545,3 +545,32 @@ jobs:
             -f inputs[run_ids]=""
 
           echo "Dispatched copr.yml for v${VERSION} (uniclipboard-alpha)." >> "$GITHUB_STEP_SUMMARY"
+
+  dispatch-npm-alpha:
+    # alpha release 由本 workflow 用 GITHUB_TOKEN 自动发布,不会触发
+    # npm-publish.yml 的 release.published 入口,这里显式 dispatch
+    # (与 dispatch-snap / dispatch-copr-alpha 同一模式)。
+    #
+    # 版本后缀映射 npm dist-tag:X.Y.Z-alpha.N → `alpha`,不会动 `latest`。
+    # 已发布过的版本会被 npm-publish.yml 跳过,重复 dispatch 幂等。
+    # stable / beta / rc 仍由人工发布 GitHub Release 后触发 npm-publish.yml。
+    name: Dispatch npm publish for alpha
+    needs: [validate, create-release]
+    if: ${{ success() && needs.validate.outputs.channel == 'alpha' }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - name: Dispatch npm publish
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.validate.outputs.version }}
+        run: |
+          gh api \
+            --method POST \
+            "repos/${{ github.repository }}/actions/workflows/npm-publish.yml/dispatches" \
+            -f ref="v${VERSION}" \
+            -f inputs[version]="${VERSION}"
+
+          echo "Dispatched npm-publish.yml for v${VERSION} (dist-tag: alpha)." >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

- Alpha releases are auto-published by `release.yml` with `GITHUB_TOKEN`, so their `release.published` event never triggers other workflows — snap and COPR already work around this with explicit dispatch jobs, but npm had no equivalent, so alpha npm packages were never published. Adds a `dispatch-npm-alpha` job to `release.yml` that dispatches `npm-publish.yml` with the release tag after `create-release` succeeds, mirroring `dispatch-snap` / `dispatch-copr-alpha` (c9566add4).
- Aligns the `npm-publish.yml` auto-path policy with snap/copr: the `release.published` entry now skips only `-alpha` tags (previously all prereleases) since alphas arrive via the explicit dispatch; a manually published beta/rc release will now publish to npm under its matching dist-tag. Header comments rewritten to document the new channel mapping (c9566add4).

The existing version→dist-tag mapping in `npm-publish.yml` handles the rest: `X.Y.Z-alpha.N` publishes under the `alpha` dist-tag and never touches `latest`; already-published versions are skipped, so repeated dispatches are idempotent.

## Test plan

- [x] YAML parses cleanly; job graph verified (`dispatch-npm-alpha` needs `[validate, create-release]`, gated on `channel == 'alpha'`).
- [x] Scanned `docs-site/` — no docs reference npm installation yet, so no docs updates needed.
- [ ] Verify on the next alpha release that `npm-publish.yml` is dispatched and publishes all six packages under the `alpha` dist-tag (requires Trusted Publisher to be configured for every package on npmjs.com).
- [ ] Confirm `latest` dist-tag is untouched after the alpha publish (`npm dist-tag ls @uniclipboard/cli`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release automation workflow for alpha releases with improved dispatch logic
  * Updated workflow documentation to clarify publishing behavior and idempotency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->