### PR TITLE
fix(clipboard): review follow-ups that missed the #1051 merge

### DIFF
--- a/src/components/clipboard/__tests__/FileContextMenu.test.tsx
+++ b/src/components/clipboard/__tests__/FileContextMenu.test.tsx
@@ -5,9 +5,10 @@ import FileContextMenu from '@/components/clipboard/FileContextMenu'
 import { __resetResendActionStoreForTests } from '@/hooks/useResendAction'
 import i18n from '@/i18n'
 
-// Redux store hooks 与 file transfer 选择器: FileContextMenu 在内部用 redux
-// 决定 copy 是否 disable;本测专注 Resend 菜单项的可达性 + 点击行为,
-// 因此 selector 全 stub 成"传输已完成"的稳定快照。
+// Redux store hooks and file transfer selectors: FileContextMenu uses redux
+// internally to decide whether copy is disabled; these tests focus on the
+// Resend item's reachability + click behavior, so every selector is stubbed
+// to a stable "transfer completed" snapshot.
 vi.mock('@/store/hooks', () => ({
   useAppSelector: (selector: (state: unknown) => unknown) => selector({}),
 }))

--- a/src/components/clipboard/preview-renderers/FilePreview.tsx
+++ b/src/components/clipboard/preview-renderers/FilePreview.tsx
@@ -246,7 +246,7 @@ const FilePreview: React.FC<FilePreviewProps> = ({
               </div>
               <div className="min-w-0 flex-1">
                 <div className="truncate text-sm font-semibold text-foreground/80">{name}</div>
-                {fileSizes[index] != null && (
+                {fileSizes[index] != null && fileSizes[index] >= 0 && (
                   <div className="mt-0.5 text-[11px] font-medium tabular-nums text-muted-foreground/60">
                     {formatFileSize(fileSizes[index])}
                   </div>

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -721,6 +721,7 @@
     },
     "contextMenu": {
       "copy": "Copy",
+      "fileDeleted": "File deleted",
       "openFileLocation": "Open File Location",
       "resend": "Resend",
       "resending": "Resending...",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -712,6 +712,7 @@
     },
     "contextMenu": {
       "copy": "复制",
+      "fileDeleted": "文件已删除",
       "openFileLocation": "打开文件位置",
       "resend": "重发",
       "resending": "正在重发...",

--- a/src/store/slices/__tests__/clipboardSlice.test.ts
+++ b/src/store/slices/__tests__/clipboardSlice.test.ts
@@ -120,7 +120,12 @@ describe('fetchClipboardItems hydration', () => {
       .filter(dto => dto.fileTransferStatus != null)
       .map(dto => ({
         entryId: dto.id,
-        status: dto.fileTransferStatus as 'pending' | 'transferring' | 'completed' | 'failed',
+        status: dto.fileTransferStatus as
+          | 'pending'
+          | 'transferring'
+          | 'completed'
+          | 'failed'
+          | 'cancelled',
         reason: dto.fileTransferReason ?? null,
       }))
   }

--- a/src/store/slices/clipboardSlice.ts
+++ b/src/store/slices/clipboardSlice.ts
@@ -95,7 +95,12 @@ export const fetchClipboardItems = createAsyncThunk<
         .filter(item => item.fileTransferStatus != null)
         .map(item => ({
           entryId: item.id,
-          status: item.fileTransferStatus as 'pending' | 'transferring' | 'completed' | 'failed',
+          status: item.fileTransferStatus as
+            | 'pending'
+            | 'transferring'
+            | 'completed'
+            | 'failed'
+            | 'cancelled',
           reason: item.fileTransferReason ?? null,
         }))
       if (statusEntries.length > 0) {


### PR DESCRIPTION
## Summary

- #1051 was merged a few minutes before its babysit round-1 review-fix commit was pushed, leaving these CodeRabbit findings unaddressed on `main`. This PR cherry-picks that commit (227a58abf, originally c8b2f706a on the merged branch).
- Adds the missing `clipboard.contextMenu.fileDeleted` locale key (en + zh) — the stale-file context-menu label previously fell back to the raw default string.
- `FilePreview` multi-file branch now treats `-1` sentinel sizes as "unknown" instead of rendering `formatFileSize(-1)`, matching the single-file path and `buildPendingFileContent`'s contract.
- Widens the transfer-status hydration cast to include `'cancelled'` (type-level only; runtime value was already passed through) and converts a modified test comment block to English per repo guidelines.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` on clipboardSlice + FileContextMenu suites — 15/15 pass
- [ ] Optional manual check: pending multi-file inbound placeholder no longer shows a bogus size label

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed file size rendering in clipboard preview. File sizes now only display when valid (non-null and non-negative values), preventing previously displayed invalid negative sizes.

* **New Features**
  * Added "file deleted" status message to the clipboard context menu, improving user visibility of deleted file states.
  * Included comprehensive localization support for the new status message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->