### PR TITLE
fix(platform): X11 watcher drops clipboard changes on race/slow owner

### DIFF
--- a/crates/uc-platform/src/clipboard/platform/linux.rs
+++ b/crates/uc-platform/src/clipboard/platform/linux.rs
@@ -22,7 +22,7 @@ pub(super) mod x11;
 
 use anyhow::Result;
 use async_trait::async_trait;
-use tracing::{debug, info, warn};
+use tracing::{info, warn};
 use uc_core::clipboard::SystemClipboardSnapshot;
 use uc_core::ports::SystemClipboardPort;
 
@@ -47,7 +47,7 @@ impl LinuxClipboard {
                     return Ok(Self::Wayland(wl));
                 }
                 Ok(None) => {
-                    debug!(
+                    info!(
                         "Linux clipboard: Wayland session but no data-control protocol; \
                          falling through to native x11rb"
                     );
@@ -63,7 +63,10 @@ impl LinuxClipboard {
 
         match x11::try_new_clipboard() {
             Ok(Some(x)) => {
-                info!("Linux clipboard: native X11 (x11rb)");
+                info!(
+                    wayland_session = is_wayland_session(),
+                    "Linux clipboard: native X11 (x11rb)"
+                );
                 Ok(Self::X11(x))
             }
             Ok(None) => Err(anyhow::anyhow!(
@@ -128,7 +131,7 @@ pub(super) fn build_event_loop() -> Result<Box<dyn PlatformClipboardEventLoop>> 
                 return Ok(Box::new(wl));
             }
             Ok(None) => {
-                debug!(
+                info!(
                     "Linux clipboard event loop: Wayland session but no data-control \
                      protocol; falling through to native x11rb"
                 );
@@ -141,7 +144,10 @@ pub(super) fn build_event_loop() -> Result<Box<dyn PlatformClipboardEventLoop>> 
 
     match x11::try_new_event_loop() {
         Ok(Some(loop_)) => {
-            info!("Linux clipboard event loop: native X11 (x11rb + XFIXES)");
+            info!(
+                wayland_session = is_wayland_session(),
+                "Linux clipboard event loop: native X11 (x11rb + XFIXES)"
+            );
             Ok(Box::new(loop_))
         }
         Ok(None) => Err(anyhow::anyhow!(

--- a/crates/uc-platform/src/clipboard/platform/linux/wayland/protocol/mod.rs
+++ b/crates/uc-platform/src/clipboard/platform/linux/wayland/protocol/mod.rs
@@ -69,7 +69,7 @@ fn select(conn: &Connection) -> Result<Option<Protocol>> {
     let ext_available = ext::probe(conn).context("ext-data-control probe failed")?;
     let wlr_available = wlr::probe(conn).context("wlr-data-control probe failed")?;
 
-    debug!(
+    info!(
         ext = ext_available,
         wlr = wlr_available,
         force = ?force,
@@ -108,7 +108,7 @@ pub(crate) fn try_new_event_loop() -> Result<Option<WaylandEventLoop>> {
     let conn = match Connection::connect_to_env() {
         Ok(c) => c,
         Err(e) => {
-            debug!(error = %e, "wayland: cannot connect; skipping wayland event loop");
+            warn!(error = %e, "wayland: cannot connect; skipping wayland event loop");
             return Ok(None);
         }
     };
@@ -143,7 +143,7 @@ pub(crate) fn try_new_clipboard() -> Result<Option<WaylandClipboard>> {
     let conn = match Connection::connect_to_env() {
         Ok(c) => c,
         Err(e) => {
-            debug!(error = %e, "wayland: cannot connect; skipping wayland clipboard");
+            warn!(error = %e, "wayland: cannot connect; skipping wayland clipboard");
             return Ok(None);
         }
     };

--- a/crates/uc-platform/src/clipboard/platform/linux/x11/clipboard.rs
+++ b/crates/uc-platform/src/clipboard/platform/linux/x11/clipboard.rs
@@ -29,7 +29,7 @@ use x11rb::connection::Connection;
 use x11rb::protocol::Event;
 
 use super::connection::X11Server;
-use super::reader::read_snapshot;
+use super::reader::{read_snapshot, ReadContext};
 use super::writer::{install_snapshot, service_selection_request, WriterState};
 
 /// Upper bound on how long the caller waits for the worker to ack a
@@ -175,7 +175,7 @@ fn worker_main(request_rx: Receiver<Request>, wakeup_fd: OwnedFd) -> Result<()> 
                         // race our own SelectionRequest servicing.
                         Ok(snap)
                     } else {
-                        read_snapshot(&server, Some(&state))
+                        read_snapshot(&server, &ReadContext::new(Some(&state)))
                     };
                     let _ = reply.send(res);
                 }

--- a/crates/uc-platform/src/clipboard/platform/linux/x11/event_loop.rs
+++ b/crates/uc-platform/src/clipboard/platform/linux/x11/event_loop.rs
@@ -12,23 +12,36 @@
 //! timeout + Condvar check.
 
 use std::os::fd::{AsFd, BorrowedFd};
+use std::time::Duration;
 
 use anyhow::{Context, Result};
 use rustix::event::{poll, PollFd, PollFlags};
 use tracing::{debug, info, warn};
 use x11rb::connection::Connection;
 use x11rb::protocol::xfixes::{self, SelectionEventMask};
+use x11rb::protocol::xproto::ConnectionExt as _;
 use x11rb::protocol::Event;
 
 use crate::clipboard::event_loop::{PlatformClipboardEventLoop, ShutdownRx};
 use crate::clipboard::watcher::ClipboardWatcher;
 
 use super::connection::X11Server;
-use super::reader::read_snapshot;
+use super::reader::{read_snapshot, ReadContext};
 
 /// Used when the shutdown channel didn't manage to allocate an eventfd
 /// (extremely unusual). 250 ms keeps us reactive without burning CPU.
 const FALLBACK_POLL_TIMEOUT_MS: i32 = 250;
+
+/// Total read attempts after a selection-change notification when the read
+/// keeps coming back empty. Chromium (reached through the XWayland
+/// selection bridge) is known to refuse or serve empty payloads for a short
+/// window right after a copy; a couple of short retries absorbs that
+/// (issue #1029).
+const CHANGE_READ_ATTEMPTS: u32 = 3;
+
+/// Pause between those attempts. Long enough for the owner to finish
+/// installing its offer, short enough to keep capture latency negligible.
+const CHANGE_READ_RETRY_DELAY: Duration = Duration::from_millis(150);
 
 pub(crate) struct X11EventLoop {
     server: X11Server,
@@ -68,19 +81,24 @@ impl PlatformClipboardEventLoop for X11EventLoop {
 
         // Emit a baseline snapshot so consumers see the current clipboard
         // state without waiting for the next change — matches what the
-        // wayland watcher does after the device-bind roundtrip.
-        match read_snapshot(&server, None) {
+        // wayland watcher does after the device-bind roundtrip. A change
+        // landing during this read is flagged and serviced by the first
+        // loop iteration instead of being dropped.
+        let baseline_ctx = ReadContext::new(None);
+        match read_snapshot(&server, &baseline_ctx) {
             Ok(snap) if !snap.representations.is_empty() => {
                 handler.notify_with_snapshot(snap);
             }
             Ok(_) => debug!("x11 watcher: baseline read returned empty snapshot"),
             Err(e) => warn!(error = %e, "x11 watcher: baseline read failed"),
         }
+        let mut pending_change = baseline_ctx.take_selection_changed();
 
         loop {
             // Drain anything currently buffered. We process every event so
-            // we don't miss a change that arrived while we were reading.
-            let mut saw_change = false;
+            // we don't miss a change that arrived while we were reading —
+            // including ones flagged mid-read by the previous iteration.
+            let mut saw_change = std::mem::take(&mut pending_change);
             while let Some(event) = conn
                 .poll_for_event()
                 .context("x11 watcher: poll_for_event failed")?
@@ -91,18 +109,20 @@ impl PlatformClipboardEventLoop for X11EventLoop {
             }
 
             if saw_change {
-                match read_snapshot(&server, None) {
-                    Ok(snap) if !snap.representations.is_empty() => {
-                        handler.notify_with_snapshot(snap);
-                    }
-                    Ok(_) => debug!("x11 watcher: selection-notify produced empty snapshot"),
-                    Err(e) => warn!(error = %e, "x11 watcher: read_snapshot failed"),
-                }
+                pending_change = read_changed_selection(&server, &mut handler, &shutdown_rx);
             }
 
             if shutdown_rx.is_signaled() {
                 debug!("x11 watcher: shutdown observed before poll");
                 break;
+            }
+
+            if pending_change {
+                // A change was flagged while we were reading; service it now
+                // instead of blocking in poll (its event was already consumed,
+                // so the fd would stay quiet).
+                debug!("x11 watcher: selection changed during read; re-reading");
+                continue;
             }
 
             // Wait for either the X11 fd to become readable or the shutdown
@@ -143,4 +163,78 @@ impl PlatformClipboardEventLoop for X11EventLoop {
         info!("x11 event loop: stopped");
         Ok(())
     }
+}
+
+/// Read the selection after a change notification, retrying a bounded
+/// number of times when the read comes back empty while an owner exists.
+///
+/// Returns true when a further selection change was observed (and
+/// necessarily consumed) during one of the reads — the caller must loop
+/// around and read again rather than block in poll.
+fn read_changed_selection(
+    server: &X11Server,
+    handler: &mut ClipboardWatcher,
+    shutdown_rx: &ShutdownRx,
+) -> bool {
+    let ctx = ReadContext::new(None);
+    for attempt in 1..=CHANGE_READ_ATTEMPTS {
+        match read_snapshot(server, &ctx) {
+            Ok(snap) if !snap.representations.is_empty() => {
+                if attempt > 1 {
+                    info!(attempt, "x11 watcher: selection read recovered after retry");
+                }
+                handler.notify_with_snapshot(snap);
+                return ctx.take_selection_changed();
+            }
+            Ok(_) => {
+                // Empty with no owner is a legitimate cleared clipboard —
+                // not worth retrying or warning about.
+                if current_selection_owner(server) == x11rb::NONE {
+                    info!("x11 watcher: selection has no owner (cleared); nothing to capture");
+                    return ctx.take_selection_changed();
+                }
+                if shutdown_rx.is_signaled() {
+                    return ctx.take_selection_changed();
+                }
+                if attempt == CHANGE_READ_ATTEMPTS {
+                    break;
+                }
+                debug!(
+                    attempt,
+                    retry_delay_ms = CHANGE_READ_RETRY_DELAY.as_millis() as u64,
+                    "x11 watcher: empty snapshot after selection change; retrying"
+                );
+                std::thread::sleep(CHANGE_READ_RETRY_DELAY);
+            }
+            Err(e) => {
+                warn!(
+                    error = %e,
+                    error_kind = "x11_selection_read_failed",
+                    retryable = true,
+                    "x11 watcher: read_snapshot failed after selection change"
+                );
+                return ctx.take_selection_changed();
+            }
+        }
+    }
+    warn!(
+        attempts = CHANGE_READ_ATTEMPTS,
+        error_kind = "x11_selection_read_empty",
+        "x11 watcher: selection changed but no readable content (owner refused, timed out, \
+         or offered no interesting mimes) — clipboard change lost"
+    );
+    ctx.take_selection_changed()
+}
+
+/// Current owner window of `CLIPBOARD`, or `x11rb::NONE` when unowned or
+/// the query fails (treated as unowned — the caller only uses this to
+/// decide whether an empty read is worth retrying).
+fn current_selection_owner(server: &X11Server) -> u32 {
+    server
+        .conn
+        .get_selection_owner(server.atoms.CLIPBOARD)
+        .ok()
+        .and_then(|cookie| cookie.reply().ok())
+        .map(|reply| reply.owner)
+        .unwrap_or(x11rb::NONE)
 }

--- a/crates/uc-platform/src/clipboard/platform/linux/x11/reader.rs
+++ b/crates/uc-platform/src/clipboard/platform/linux/x11/reader.rs
@@ -18,12 +18,13 @@
 //! [`super::writer::service_selection_request`] from within the wait loop
 //! so an external paster doesn't time out while we're reading.
 
+use std::cell::Cell;
 use std::os::fd::AsFd;
 use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result};
 use rustix::event::{poll, PollFd, PollFlags};
-use tracing::{debug, warn};
+use tracing::{debug, info, warn};
 use uc_core::clipboard::{MimeType, ObservedClipboardRepresentation, SystemClipboardSnapshot};
 use uc_core::ids::RepresentationId;
 use x11rb::connection::Connection;
@@ -52,6 +53,34 @@ const MAX_MIME_BYTES: usize = 32 * 1024 * 1024;
 /// pull at most this much per `PropertyNotify`.
 const PROPERTY_CHUNK_LONGS: u32 = 16 * 1024 * 1024 / 4;
 
+/// Shared context for one snapshot read.
+///
+/// Bundles the optional writer state (so inbound `SelectionRequest`s can be
+/// serviced inline) with a flag recording whether an
+/// `XfixesSelectionNotify` was consumed — and would otherwise be lost —
+/// while a read round-trip was in flight. The watcher event loop re-reads
+/// when the flag is set; without it a clipboard change landing mid-read is
+/// dropped permanently (issue #1029).
+pub(super) struct ReadContext<'a> {
+    writer_state: Option<&'a WriterState>,
+    selection_changed: Cell<bool>,
+}
+
+impl<'a> ReadContext<'a> {
+    pub(super) fn new(writer_state: Option<&'a WriterState>) -> Self {
+        Self {
+            writer_state,
+            selection_changed: Cell::new(false),
+        }
+    }
+
+    /// True when a selection-change notification was swallowed during the
+    /// read. Reading resets the flag.
+    pub(super) fn take_selection_changed(&self) -> bool {
+        self.selection_changed.replace(false)
+    }
+}
+
 /// Read the current `CLIPBOARD` contents into a snapshot.
 ///
 /// Returns an empty snapshot (no representations) if there is no current
@@ -59,17 +88,17 @@ const PROPERTY_CHUNK_LONGS: u32 = 16 * 1024 * 1024 / 4;
 /// are logged at warn and skipped — one broken mime should not lose the
 /// others.
 ///
-/// `writer_state` (if any) is consulted only for the corner case where a
-/// `SelectionRequest` from an external paster arrives while we're waiting:
-/// we service it inline so the paster doesn't time out.
+/// `ctx.writer_state` (if any) is consulted only for the corner case where
+/// a `SelectionRequest` from an external paster arrives while we're
+/// waiting: we service it inline so the paster doesn't time out.
 pub(super) fn read_snapshot(
     server: &X11Server,
-    writer_state: Option<&WriterState>,
+    ctx: &ReadContext<'_>,
 ) -> Result<SystemClipboardSnapshot> {
-    let targets = match convert_selection_bytes(server, server.atoms.TARGETS, writer_state)? {
+    let targets = match convert_selection_bytes(server, server.atoms.TARGETS, ctx)? {
         Some(b) => b,
         None => {
-            debug!("x11 read: no selection owner — empty snapshot");
+            info!("x11 read: no TARGETS reply (no owner, owner refused, or timed out) — empty snapshot");
             return Ok(empty_snapshot());
         }
     };
@@ -80,12 +109,21 @@ pub(super) fn read_snapshot(
     // Resolve atom→name in one batch (one round-trip per atom is fine; the
     // count is typically <16). Build the (atom, mime_name) pairs first so we
     // can run the dedup/filter pass on string names symmetric with wayland.
+    let mut all_names: Vec<String> = Vec::with_capacity(target_atoms.len());
     let mut candidates: Vec<(Atom, String)> = Vec::with_capacity(target_atoms.len());
     for a in target_atoms {
         let name = server.atom_name(a);
         if is_interesting_mime(&name) {
-            candidates.push((a, name));
+            candidates.push((a, name.clone()));
         }
+        all_names.push(name);
+    }
+    if candidates.is_empty() && !all_names.is_empty() {
+        // Names are mime identifiers / atom names, never payload content.
+        info!(
+            targets = %all_names.join(", "),
+            "x11 read: owner advertised no interesting mimes — empty snapshot"
+        );
     }
     // Reorder so we read UTF-8-friendly text mimes (e.g. `UTF8_STRING`,
     // `text/plain;charset=utf-8`) before the Latin-1-bounded fallbacks
@@ -111,10 +149,10 @@ pub(super) fn read_snapshot(
             continue;
         }
 
-        let bytes = match convert_selection_bytes(server, atom, writer_state) {
+        let bytes = match convert_selection_bytes(server, atom, ctx) {
             Ok(Some(b)) => b,
             Ok(None) => {
-                debug!(mime = %mime, "x11 read: owner refused mime");
+                info!(mime = %mime, "x11 read: owner refused mime (or reply timed out)");
                 continue;
             }
             Err(e) => {
@@ -123,6 +161,7 @@ pub(super) fn read_snapshot(
             }
         };
         if bytes.is_empty() {
+            info!(mime = %mime, "x11 read: owner returned empty payload for mime");
             continue;
         }
 
@@ -164,7 +203,7 @@ fn empty_snapshot() -> SystemClipboardSnapshot {
 fn convert_selection_bytes(
     server: &X11Server,
     target: Atom,
-    writer_state: Option<&WriterState>,
+    ctx: &ReadContext<'_>,
 ) -> Result<Option<Vec<u8>>> {
     let conn = &server.conn;
     let atoms = server.atoms;
@@ -190,7 +229,7 @@ fn convert_selection_bytes(
     // Wait for SelectionNotify addressed to our requestor window for this
     // selection. Service inbound SelectionRequest events that arrive in
     // the meantime so external pasters don't stall.
-    let notify = wait_for_selection_notify(server, atoms.CLIPBOARD, target, writer_state)?;
+    let notify = wait_for_selection_notify(server, atoms.CLIPBOARD, target, ctx)?;
     let Some(notify) = notify else {
         return Ok(None);
     };
@@ -199,7 +238,7 @@ fn convert_selection_bytes(
         return Ok(None);
     }
 
-    read_property_value(server, target, writer_state)
+    read_property_value(server, target, ctx)
 }
 
 /// Read the bytes currently stored at our `UC_CLIPBOARD_PROP`. Handles the
@@ -209,7 +248,7 @@ fn convert_selection_bytes(
 fn read_property_value(
     server: &X11Server,
     target: Atom,
-    writer_state: Option<&WriterState>,
+    ctx: &ReadContext<'_>,
 ) -> Result<Option<Vec<u8>>> {
     let conn = &server.conn;
     let atoms = server.atoms;
@@ -250,7 +289,7 @@ fn read_property_value(
                 buf.reserve(hint);
             }
         }
-        read_incr_into(server, target, &mut buf, writer_state)?;
+        read_incr_into(server, target, &mut buf, ctx)?;
         return Ok(Some(buf));
     }
 
@@ -272,7 +311,7 @@ fn read_incr_into(
     server: &X11Server,
     target: Atom,
     buf: &mut Vec<u8>,
-    writer_state: Option<&WriterState>,
+    ctx: &ReadContext<'_>,
 ) -> Result<()> {
     let conn = &server.conn;
     let atoms = server.atoms;
@@ -291,7 +330,7 @@ fn read_incr_into(
             server,
             deadline,
             |e| matches!(e, Event::PropertyNotify(_)),
-            writer_state,
+            ctx,
         )?;
         let Event::PropertyNotify(PropertyNotifyEvent {
             window,
@@ -338,7 +377,7 @@ fn wait_for_selection_notify(
     server: &X11Server,
     selection: Atom,
     target: Atom,
-    writer_state: Option<&WriterState>,
+    ctx: &ReadContext<'_>,
 ) -> Result<Option<x11rb::protocol::xproto::SelectionNotifyEvent>> {
     let deadline = Instant::now() + READ_TIMEOUT;
     let event = wait_for_event_filtered(
@@ -350,13 +389,22 @@ fn wait_for_selection_notify(
             }
             _ => false,
         },
-        writer_state,
+        ctx,
     );
     match event {
         Ok(Event::SelectionNotify(n)) => Ok(Some(n)),
         Ok(_) => Ok(None),
         Err(e) if e.to_string().contains("x11 wait: deadline expired") => {
-            debug!(target = %target, "x11 read: selection_notify deadline expired");
+            // A misbehaving / slow owner (Chromium via the XWayland bridge
+            // is the known offender) — visible at warn so field logs can
+            // tell "owner never answered" apart from "no event at all".
+            warn!(
+                target = %server.atom_name(target),
+                timeout_ms = READ_TIMEOUT.as_millis() as u64,
+                error_kind = "x11_selection_reply_timeout",
+                retryable = true,
+                "x11 read: selection owner did not reply before deadline"
+            );
             Ok(None)
         }
         Err(e) => Err(e),
@@ -371,7 +419,7 @@ fn wait_for_event_filtered(
     server: &X11Server,
     deadline: Instant,
     pred: impl Fn(&Event) -> bool,
-    writer_state: Option<&WriterState>,
+    ctx: &ReadContext<'_>,
 ) -> Result<Event> {
     let conn = &server.conn;
     loop {
@@ -383,7 +431,7 @@ fn wait_for_event_filtered(
             if pred(&event) {
                 return Ok(event);
             }
-            route_unrelated_event(server, &event, writer_state);
+            route_unrelated_event(server, &event, ctx);
         }
 
         let now = Instant::now();
@@ -410,17 +458,25 @@ fn wait_for_event_filtered(
 
 /// Hand a non-target event off to the right place. SelectionRequest goes to
 /// the writer (if we have one) so external pasters don't stall while we're
-/// reading. Other events are dropped — they'd be SelectionClear (lose
-/// ownership) or unrelated XFIXES traffic, neither of which the reader
-/// needs to act on; the next handle_write / event loop iteration picks up
-/// the consequences.
-fn route_unrelated_event(server: &X11Server, event: &Event, writer_state: Option<&WriterState>) {
-    if let Event::SelectionRequest(req) = event {
-        if let Some(ws) = writer_state {
-            if let Err(e) = super::writer::service_selection_request(server, ws, req.clone()) {
-                warn!(error = %e, "x11 read: inline service_selection_request failed");
+/// reading. `XfixesSelectionNotify` is recorded on the context — the
+/// watcher's change subscription delivers on this same connection, and
+/// consuming one here without flagging it would lose that clipboard change
+/// for good (issue #1029). Everything else is dropped — SelectionClear and
+/// the like are picked up by the next handle_write / event loop iteration.
+fn route_unrelated_event(server: &X11Server, event: &Event, ctx: &ReadContext<'_>) {
+    match event {
+        Event::SelectionRequest(req) => {
+            if let Some(ws) = ctx.writer_state {
+                if let Err(e) = super::writer::service_selection_request(server, ws, req.clone()) {
+                    warn!(error = %e, "x11 read: inline service_selection_request failed");
+                }
             }
         }
+        Event::XfixesSelectionNotify(_) => {
+            ctx.selection_changed.set(true);
+            debug!("x11 read: selection changed mid-read; flagged for re-read");
+        }
+        _ => {}
     }
 }
 
@@ -458,5 +514,16 @@ mod tests {
     #[test]
     fn parse_atom_list_empty() {
         assert_eq!(parse_atom_list(&[]), Vec::<Atom>::new());
+    }
+
+    #[test]
+    fn read_context_take_selection_changed_resets() {
+        let ctx = ReadContext::new(None);
+        assert!(!ctx.take_selection_changed());
+
+        ctx.selection_changed.set(true);
+        assert!(ctx.take_selection_changed());
+        // Taking the flag must reset it.
+        assert!(!ctx.take_selection_changed());
     }
 }

--- a/crates/uc-platform/src/clipboard/watcher.rs
+++ b/crates/uc-platform/src/clipboard/watcher.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 use std::time::Instant;
-use tracing::{debug, warn};
+use tracing::{debug, info, warn};
 
 // `clipboard_rs::ClipboardHandler` is only required by the macOS / Windows
 // adapter that wraps `ClipboardWatcherContext`. The native Wayland and X11
@@ -123,7 +123,10 @@ impl ClipboardWatcher {
         let current_dedupe_key = dedupe_key(&snapshot);
         if let Some(key) = current_dedupe_key.as_ref() {
             if self.last_meaningful_dedupe_key.as_deref() == Some(key.as_str()) {
-                debug!(
+                // Info-level on purpose: this is the last silent spot where a
+                // user-visible "copy did nothing" can hide (key is kind:hash,
+                // never payload content).
+                info!(
                     dedupe_key = %key,
                     "Skipping duplicated meaningful clipboard snapshot"
                 );

--- a/crates/uc-platform/tests/x11_watcher.rs
+++ b/crates/uc-platform/tests/x11_watcher.rs
@@ -1,0 +1,321 @@
+//! X11 剪贴板 watcher 集成测试(issue #1029 回归)。
+//!
+//! 这些测试需要一个可用的 X display,因此全部 `#[ignore]`。运行方式:
+//!
+//! ```bash
+//! xvfb-run -a cargo test -p uc-platform --test x11_watcher -- --ignored --test-threads=1
+//! ```
+//!
+//! 必须 `--test-threads=1`:所有用例共享同一个 X server 的 `CLIPBOARD`
+//! selection,并发运行会互相抢所有权。
+//!
+//! 测试通过一个"可编程假 owner"(直接用 x11rb 实现的 selection owner,
+//! 可配置响应延迟 / 拒绝窗口)模拟 Chromium 经 XWayland 桥时的两种坏行为:
+//!
+//! 1. watcher 读取期间 selection 再次易主 —— 修复前该变更事件会在
+//!    `route_unrelated_event` 中被吞掉,内容永久丢失;
+//! 2. owner 在拿到所有权后的短窗口内拒绝供数 —— 修复前单次空读即静默放弃。
+
+#![cfg(target_os = "linux")]
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::thread::JoinHandle;
+use std::time::{Duration, Instant};
+
+use uc_platform::clipboard::watcher::{ClipboardWatcher, PlatformEvent};
+use uc_platform::clipboard::{build_event_loop, shutdown_channel, NoopSystemClipboard, ShutdownTx};
+use x11rb::connection::Connection;
+use x11rb::protocol::xproto::{
+    Atom, AtomEnum, ConnectionExt as _, CreateWindowAux, EventMask, PropMode, SelectionNotifyEvent,
+    WindowClass, SELECTION_NOTIFY_EVENT,
+};
+use x11rb::protocol::Event;
+use x11rb::rust_connection::RustConnection;
+use x11rb::wrapper::ConnectionExt as _;
+
+/// 单个事件的最长等待时间。涵盖最坏情况:2s TARGETS 超时 + 3 次重试。
+const EVENT_DEADLINE: Duration = Duration::from_secs(8);
+
+// ---------------------------------------------------------------------------
+// 可编程假 selection owner
+// ---------------------------------------------------------------------------
+
+/// 假 owner 的行为脚本。
+#[derive(Clone, Copy)]
+struct OwnerSpec {
+    /// 对 `UTF8_STRING` 请求返回的内容。
+    text: &'static [u8],
+    /// 响应 `UTF8_STRING` 数据请求前的人为延迟 —— 把 watcher 钉在读取中,
+    /// 制造"读取期间 selection 易主"的竞态窗口。注意延迟必须放在数据
+    /// 响应而不是 TARGETS 上:`convert_selection` 永远发给当前 owner,
+    /// 若 TARGETS 之后才易主,同一次读取会顺带从新 owner 拿到数据,
+    /// 旧代码也能侥幸通过。
+    data_delay: Duration,
+    /// 拿到所有权后这段时间内拒绝一切请求(回 property=NONE),
+    /// 模拟 Chromium 复制后短暂无法供数的窗口。
+    refuse_for: Duration,
+}
+
+impl OwnerSpec {
+    fn well_behaved(text: &'static [u8]) -> Self {
+        Self {
+            text,
+            data_delay: Duration::ZERO,
+            refuse_for: Duration::ZERO,
+        }
+    }
+}
+
+struct FakeOwner {
+    stop: Arc<AtomicBool>,
+    join: Option<JoinHandle<()>>,
+}
+
+impl FakeOwner {
+    /// 启动假 owner 并阻塞到它确实拿到 `CLIPBOARD` 所有权后返回。
+    fn spawn(spec: OwnerSpec) -> Self {
+        let stop = Arc::new(AtomicBool::new(false));
+        let thread_stop = Arc::clone(&stop);
+        let (ready_tx, ready_rx) = std::sync::mpsc::channel();
+        let join = std::thread::spawn(move || owner_main(spec, thread_stop, ready_tx));
+        ready_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("fake owner failed to acquire CLIPBOARD ownership");
+        Self {
+            stop,
+            join: Some(join),
+        }
+    }
+}
+
+impl Drop for FakeOwner {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+        if let Some(join) = self.join.take() {
+            let _ = join.join();
+        }
+    }
+}
+
+fn intern(conn: &RustConnection, name: &[u8]) -> Atom {
+    conn.intern_atom(false, name)
+        .expect("intern_atom request")
+        .reply()
+        .expect("intern_atom reply")
+        .atom
+}
+
+fn owner_main(spec: OwnerSpec, stop: Arc<AtomicBool>, ready_tx: std::sync::mpsc::Sender<()>) {
+    let (conn, screen_num) = x11rb::connect(None).expect("fake owner: X connect");
+    let screen = &conn.setup().roots[screen_num];
+    let win = conn.generate_id().expect("fake owner: generate_id");
+    conn.create_window(
+        x11rb::COPY_DEPTH_FROM_PARENT,
+        win,
+        screen.root,
+        0,
+        0,
+        1,
+        1,
+        0,
+        WindowClass::INPUT_OUTPUT,
+        screen.root_visual,
+        &CreateWindowAux::new(),
+    )
+    .expect("fake owner: create_window request")
+    .check()
+    .expect("fake owner: create_window");
+
+    let clipboard = intern(&conn, b"CLIPBOARD");
+    let targets = intern(&conn, b"TARGETS");
+    let utf8_string = intern(&conn, b"UTF8_STRING");
+
+    conn.set_selection_owner(win, clipboard, x11rb::CURRENT_TIME)
+        .expect("fake owner: set_selection_owner request")
+        .check()
+        .expect("fake owner: set_selection_owner");
+    conn.flush().expect("fake owner: flush");
+    let owned_at = Instant::now();
+    let _ = ready_tx.send(());
+
+    while !stop.load(Ordering::Relaxed) {
+        let event = conn.poll_for_event().expect("fake owner: poll_for_event");
+        let Some(event) = event else {
+            std::thread::sleep(Duration::from_millis(5));
+            continue;
+        };
+        let Event::SelectionRequest(req) = event else {
+            // SelectionClear(所有权被抢走)等事件:继续服务已收到的
+            // 请求即可,与真实的慢 owner 行为一致。
+            continue;
+        };
+
+        let mut reply_property = req.property;
+        if owned_at.elapsed() < spec.refuse_for {
+            reply_property = x11rb::NONE;
+        } else if req.target == targets {
+            conn.change_property32(
+                PropMode::REPLACE,
+                req.requestor,
+                req.property,
+                AtomEnum::ATOM,
+                &[targets, utf8_string],
+            )
+            .expect("fake owner: change_property (TARGETS)")
+            .check()
+            .expect("fake owner: change_property check (TARGETS)");
+        } else if req.target == utf8_string {
+            std::thread::sleep(spec.data_delay);
+            conn.change_property8(
+                PropMode::REPLACE,
+                req.requestor,
+                req.property,
+                utf8_string,
+                spec.text,
+            )
+            .expect("fake owner: change_property (UTF8_STRING)")
+            .check()
+            .expect("fake owner: change_property check (UTF8_STRING)");
+        } else {
+            reply_property = x11rb::NONE;
+        }
+
+        let notify = SelectionNotifyEvent {
+            response_type: SELECTION_NOTIFY_EVENT,
+            sequence: 0,
+            time: req.time,
+            requestor: req.requestor,
+            selection: req.selection,
+            target: req.target,
+            property: reply_property,
+        };
+        conn.send_event(false, req.requestor, EventMask::NO_EVENT, notify)
+            .expect("fake owner: send_event request")
+            .check()
+            .expect("fake owner: send_event");
+        conn.flush().expect("fake owner: flush after reply");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// watcher 测试夹具
+// ---------------------------------------------------------------------------
+
+struct WatcherHarness {
+    rx: tokio::sync::mpsc::Receiver<PlatformEvent>,
+    shutdown: ShutdownTx,
+    join: Option<JoinHandle<anyhow::Result<()>>>,
+}
+
+impl WatcherHarness {
+    fn start() -> Self {
+        // 强制选择 X11 后端:开发机的 Wayland 会话里 WAYLAND_DISPLAY 会让
+        // build_event_loop 优先选 wayland。进程级 env 修改没问题 ——
+        // 本文件要求 --test-threads=1 串行执行。
+        std::env::remove_var("WAYLAND_DISPLAY");
+
+        let (tx, rx) = tokio::sync::mpsc::channel(16);
+        let watcher = ClipboardWatcher::new(Arc::new(NoopSystemClipboard), tx);
+        let event_loop = build_event_loop().expect("X display required (run under xvfb-run)");
+        let (shutdown, shutdown_rx) = shutdown_channel();
+        let join = std::thread::spawn(move || event_loop.run(watcher, shutdown_rx));
+        Self {
+            rx,
+            shutdown,
+            join: Some(join),
+        }
+    }
+
+    /// 在 deadline 内等待一条文本内容恰为 `expected` 的剪贴板事件。
+    /// 其间允许出现其他事件(例如竞态用例里第一个 owner 的内容)。
+    async fn expect_text_event(&mut self, expected: &[u8]) {
+        let deadline = Instant::now() + EVENT_DEADLINE;
+        loop {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            assert!(
+                !remaining.is_zero(),
+                "timed out waiting for clipboard event with text {:?}",
+                String::from_utf8_lossy(expected)
+            );
+            let event = tokio::time::timeout(remaining, self.rx.recv())
+                .await
+                .unwrap_or_else(|_| {
+                    panic!(
+                        "timed out waiting for clipboard event with text {:?}",
+                        String::from_utf8_lossy(expected)
+                    )
+                })
+                .expect("watcher channel closed unexpectedly");
+            let PlatformEvent::ClipboardChanged { snapshot } = event;
+            let matched = snapshot
+                .representations
+                .iter()
+                .filter_map(|rep| rep.inline_bytes())
+                .any(|bytes| bytes == expected);
+            if matched {
+                return;
+            }
+        }
+    }
+}
+
+impl Drop for WatcherHarness {
+    fn drop(&mut self) {
+        self.shutdown.signal();
+        if let Some(join) = self.join.take() {
+            let _ = join.join();
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 用例
+// ---------------------------------------------------------------------------
+
+/// 基线:行为良好的 owner,一次复制一次捕获。
+#[tokio::test]
+#[ignore = "requires an X display (xvfb-run)"]
+async fn captures_basic_copy() {
+    let mut harness = WatcherHarness::start();
+    let _owner = FakeOwner::spawn(OwnerSpec::well_behaved(b"x11-watcher-basic"));
+    harness.expect_text_event(b"x11-watcher-basic").await;
+}
+
+/// 竞态回归(issue #1029):owner A 故意拖慢数据响应,把 watcher 钉在
+/// 读取中;此时 owner B 抢走 selection。B 的 XfixesSelectionNotify 会在
+/// 读取期间被消费 —— 修复前直接被丢弃,第一次读取以 A 的旧内容收尾,
+/// B 的内容永久丢失;修复后通过 pending 标志补读,最终必须捕获到 B 的内容。
+#[tokio::test]
+#[ignore = "requires an X display (xvfb-run)"]
+async fn change_during_read_is_not_lost() {
+    let mut harness = WatcherHarness::start();
+
+    let _owner_a = FakeOwner::spawn(OwnerSpec {
+        text: b"x11-watcher-race-old",
+        data_delay: Duration::from_millis(400),
+        refuse_for: Duration::ZERO,
+    });
+    // 给 watcher 时间收到 A 的变更通知并进入(被拖慢的)读取。
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    let _owner_b = FakeOwner::spawn(OwnerSpec::well_behaved(b"x11-watcher-race-new"));
+
+    harness.expect_text_event(b"x11-watcher-race-new").await;
+}
+
+/// 重试回归(issue #1029):owner 在拿到所有权后的前 180ms 拒绝一切请求
+/// (Chromium 经 XWayland 桥的典型坏窗口)。修复前首次空读即静默放弃;
+/// 修复后 150ms 间隔的重试应拿到内容。
+#[tokio::test]
+#[ignore = "requires an X display (xvfb-run)"]
+async fn retry_recovers_initially_refusing_owner() {
+    let mut harness = WatcherHarness::start();
+
+    let _owner = FakeOwner::spawn(OwnerSpec {
+        text: b"x11-watcher-retry",
+        data_delay: Duration::ZERO,
+        refuse_for: Duration::from_millis(180),
+    });
+
+    harness.expect_text_event(b"x11-watcher-retry").await;
+}

--- a/docs-site/content/docs/en/help/troubleshooting.mdx
+++ b/docs-site/content/docs/en/help/troubleshooting.mdx
@@ -261,11 +261,13 @@ Windows usually needs no extra grants. If `uniclip watch` is silent:
 
 The desktop session matters more than the distro:
 
-- **Wayland**: requires the `wlr-data-control` protocol. GNOME has long
-  refused to ship it — use a `wl-clipboard`-style bridge or switch to
-  Plasma / Sway / another supported compositor.
-- **X11**: works out of the box but needs at least one clipboard
-  manager in session (`xclip` / `xsel`).
+- **Wayland**: `ext-data-control-v1` (GNOME / mutter ≥ 47, Plasma 6) and
+  `wlr-data-control` (Sway / Hyprland and other wlroots compositors) are
+  supported natively — no bridge tooling required. When neither protocol
+  is available, capture falls back to XWayland (the X11 path)
+  automatically.
+- **X11**: works out of the box with the built-in native clipboard
+  listener; no external clipboard tools (`xclip` / `xsel`) are needed.
 - **Headless servers**: with no X / Wayland, only the CLI's `send` /
   `watch` features work; GUI clipboard capture isn't available.
 

--- a/docs-site/content/docs/zh/help/troubleshooting.mdx
+++ b/docs-site/content/docs/zh/help/troubleshooting.mdx
@@ -176,8 +176,8 @@ Windows 通常不需要额外授权。如果 `uniclip watch` 没事件：
 
 桌面会话差异最大：
 
-- **Wayland**：要求合成器实现 `wlr-data-control` 协议。GNOME 在很长时间内都不实现该协议，需要装 `wl-clipboard` 之类的桥接工具或切到 Plasma / Sway 等支持的合成器。
-- **X11**：开箱即用，但要求会话里至少有一个剪贴板管理器（`xclip` / `xsel` 任一）。
+- **Wayland**：原生支持 `ext-data-control-v1`（GNOME / mutter ≥ 47、Plasma 6）与 `wlr-data-control`（Sway / Hyprland 等 wlroots 系合成器），无需安装桥接工具。两个协议都不可用时会自动回落到 XWayland（X11 路径）。
+- **X11**：开箱即用，内置原生剪贴板监听，不依赖 `xclip` / `xsel` 等外部剪贴板工具。
 - **无头服务器**：没有 X / Wayland 时只剩 CLI 的 `send` / `watch` 工作；GUI 的剪贴板捕获不可用。
 
 </Tab>


### PR DESCRIPTION
## Summary

- **Fix two silent loss paths in the X11 clipboard watcher** (35b7eba): an `XfixesSelectionNotify` consumed while a snapshot read was in flight was dropped for good (the copy it announced was never read), and a read that came back empty right after a change notification gave up after one attempt. Reads now flag mid-read selection changes and re-read, and empty reads retry up to 3×/150 ms while an owner exists. Chromium reached through the XWayland selection bridge is the known trigger for both.
- **Make every failure on the change path observable** (35b7eba): no-TARGETS-reply, per-mime refusal/timeout/empty payload, no-interesting-mimes (with the offered target list), retries-exhausted, and the shared watcher's dedupe skip now log at INFO/WARN; backend selection logs the data-control probe results (`ext=`/`wlr=`) and `wayland_session` flag at startup. The #1029 log file was completely silent at the failure instant — the next field report will pinpoint the failing stage.
- **Regression tests with a programmable fake selection owner** (ce0a54b): x11rb-based owner scripts the two misbehaviors. Verified bidirectionally under Xvfb — both regression cases fail on pre-fix code and pass with the fix.
- **Refresh stale Linux clipboard troubleshooting docs** (836395c): GNOME no longer needs a wl-clipboard bridge (native `ext-data-control-v1`, automatic XWayland fallback) and X11 needs no `xclip`/`xsel`. en/zh updated in lockstep.

Refs #1029 (not auto-closing: the fixes target the suspected loss paths, but the reporter's machine still needs to confirm after the next alpha; the new startup logging also has to answer why a Debian 13 GNOME Wayland session fell back to the X11 backend at all).

## Test plan

- [x] `xvfb-run -a cargo test -p uc-platform --test x11_watcher -- --ignored --test-threads=1` (Docker rust:1.95-bookworm): 3/3 pass on this branch; `change_during_read_is_not_lost` + `retry_recovers_initially_refusing_owner` verified to FAIL on pre-fix code.
- [x] `cargo test -p uc-platform --lib` on Linux (54 pass) and `cargo check -p uc-platform` on Linux + macOS.
- [x] `cargo clippy -p uc-platform`: no new warnings (pre-existing ones untouched).
- [ ] Field confirmation on #1029 after the next alpha: either the copies are captured, or the new INFO/WARN lines identify the failing stage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced X11 clipboard read reliability with improved selection-change handling and retry logic during reads.

* **Documentation**
  * Updated Linux clipboard support documentation; Wayland and X11 are now natively supported without requiring external clipboard tools.

* **Tests**
  * Added X11 clipboard watcher integration tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->