### PR TITLE
fix(ci): pass telemetry env to daemon sidecar build

### DIFF
--- a/.github/workflows/alpha-build.yml
+++ b/.github/workflows/alpha-build.yml
@@ -137,6 +137,10 @@ jobs:
         # forwarding the same `${{ matrix.args }}` the GUI build uses so the
         # name matches what tauri-cli looks up. See build.yml for the full note.
         shell: bash
+        env:
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+          POSTHOG_PROJECT_KEY: ${{ secrets.POSTHOG_PROJECT_KEY }}
+          APP_ENV: alpha
         run: node scripts/prepare-daemon-sidecar.mjs ${{ matrix.args }}
 
       - name: build alpha release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -239,6 +239,10 @@ jobs:
         # exactly what tauri-cli looks up. The daemon shares the GUI's
         # dependency graph, so any target the GUI cross-builds here, it builds.
         shell: bash
+        env:
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+          POSTHOG_PROJECT_KEY: ${{ secrets.POSTHOG_PROJECT_KEY }}
+          APP_ENV: ${{ steps.resolve-env.outputs.app_env }}
         run: node scripts/prepare-daemon-sidecar.mjs ${{ matrix.args }}
 
       - name: build Tauri app (macOS signed)


### PR DESCRIPTION
## Summary
- pass backend telemetry secrets into the uniclipd sidecar build step
- keep daemon APP_ENV aligned with the GUI release build

## Verification
- workflow env check for alpha-build.yml and build.yml
- YAML parse check for both workflows
- git diff --check
- local release build with test telemetry env: `cargo build -p uc-daemon --bin uniclipd --release`
- confirmed the test SENTRY_DSN, POSTHOG_PROJECT_KEY, and APP_ENV were baked into `target/release/uniclipd`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build workflows to apply consistent environment variables and telemetry configuration during the sidecar preparation phase in both alpha and production builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->