### PR TITLE
fix(ci): keep npm alpha publish trusted entrypoint

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -2,6 +2,8 @@ name: 'npm Publish'
 run-name: >-
   ${{ github.event_name == 'release'
     && format('npm-publish-{0}', github.event.release.tag_name)
+    || github.event_name == 'repository_dispatch'
+    && format('npm-publish-{0}', github.event.client_payload.version)
     || format('npm-publish-manual-{0}', inputs.version) }}
 
 # Publish the CLI to npm only after a release transitions to `published`,
@@ -16,18 +18,20 @@ run-name: >-
 #
 # Channel mapping (same pattern as snap.yml / copr.yml): alpha releases are
 # auto-published by release.yml with GITHUB_TOKEN, so their release.published
-# event never fires other workflows — release.yml dispatches this workflow
-# explicitly (dispatch-npm-alpha). beta / rc / stable are left as drafts and
-# published by a human; that release.published event lands here. The version
-# suffix maps to the npm dist-tag (X.Y.Z-alpha.N → `alpha`), and only stable
-# gets `latest`.
+# event never fires other workflows — release.yml sends repository_dispatch and
+# this workflow remains the top-level run that npm trusted publishing validates.
+# beta / rc / stable are left as drafts and published by a human; that
+# release.published event lands here. The version suffix maps to the npm
+# dist-tag (X.Y.Z-alpha.N → `alpha`), and only stable gets `latest`.
 #
-# `workflow_dispatch` doubles as the alpha auto-publish entry (dispatched by
-# release.yml) and the manual debugging / re-run path. Already-published
-# package versions are skipped, so the whole job is idempotent.
+# `workflow_dispatch` is the manual debugging / re-run path.
+# Already-published package versions are skipped, so the whole job is
+# idempotent.
 on:
   release:
     types: [published]
+  repository_dispatch:
+    types: [npm-publish]
   workflow_dispatch:
     inputs:
       version:
@@ -41,9 +45,10 @@ jobs:
   publish:
     name: Publish npm packages
     # The release.published path serves manually published releases
-    # (beta / rc / stable); alpha arrives via release.yml's explicit dispatch
-    # instead, so skip it here to avoid double-publishing on re-publish.
-    if: github.event_name == 'workflow_dispatch' || !contains(github.event.release.tag_name, '-alpha')
+    # (beta / rc / stable); alpha arrives via release.yml's repository_dispatch
+    # instead, so skip alpha release events to avoid double-publishing on
+    # re-publish.
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch' || !contains(github.event.release.tag_name, '-alpha')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -55,10 +60,13 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           TAG: ${{ github.event.release.tag_name }}
+          CLIENT_PAYLOAD_VERSION: ${{ github.event.client_payload.version }}
           INPUT_VERSION: ${{ inputs.version }}
         run: |
           if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             VERSION="${INPUT_VERSION#v}"
+          elif [ "$EVENT_NAME" = "repository_dispatch" ]; then
+            VERSION="${CLIENT_PAYLOAD_VERSION#v}"
           else
             VERSION="${TAG#v}"
           fi
@@ -82,11 +90,10 @@ jobs:
         uses: actions/checkout@v6
         with:
           # Release path: pin to the release tag so the launcher / assembly
-          # script match the binaries being published. Dispatch path: use the
-          # ref the workflow was dispatched on — older tags predate
-          # scripts/build-npm-packages.mjs and npm/, so checking out the tag
-          # would break exactly the debugging runs dispatch exists for.
-          ref: ${{ github.event_name == 'release' && format('v{0}', steps.resolve.outputs.version) || github.ref }}
+          # script match the binaries being published. Manual dispatch path:
+          # use the selected ref so older debugging runs can choose a branch
+          # that contains the npm assembly script.
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.ref || format('v{0}', steps.resolve.outputs.version) }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -548,8 +548,9 @@ jobs:
 
   dispatch-npm-alpha:
     # alpha release 由本 workflow 用 GITHUB_TOKEN 自动发布,不会触发
-    # npm-publish.yml 的 release.published 入口,这里显式 dispatch
-    # (与 dispatch-snap / dispatch-copr-alpha 同一模式)。
+    # npm-publish.yml 的 release.published 入口。这里发送 repository_dispatch,
+    # 让 npm-publish.yml 成为顶层 workflow run；npm trusted publishing 校验
+    # 顶层入口,不能用 actions/workflows/.../dispatches 间接触发。
     #
     # 版本后缀映射 npm dist-tag:X.Y.Z-alpha.N → `alpha`,不会动 `latest`。
     # 已发布过的版本会被 npm-publish.yml 跳过,重复 dispatch 幂等。
@@ -560,7 +561,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       actions: write
-      contents: read
+      contents: write
     steps:
       - name: Dispatch npm publish
         env:
@@ -569,8 +570,8 @@ jobs:
         run: |
           gh api \
             --method POST \
-            "repos/${{ github.repository }}/actions/workflows/npm-publish.yml/dispatches" \
-            -f ref="v${VERSION}" \
-            -f inputs[version]="${VERSION}"
+            "repos/${{ github.repository }}/dispatches" \
+            -f event_type="npm-publish" \
+            -f client_payload[version]="${VERSION}"
 
           echo "Dispatched npm-publish.yml for v${VERSION} (dist-tag: alpha)." >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/__tests__/npm-publish-workflow.test.ts
+++ b/scripts/__tests__/npm-publish-workflow.test.ts
@@ -1,0 +1,31 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+function readWorkflow(name: string) {
+  return fs.readFileSync(path.resolve(__dirname, '../../.github/workflows', name), 'utf8')
+}
+
+describe('npm publish workflow trigger', () => {
+  it('uses repository_dispatch for alpha npm publish handoff', () => {
+    const releaseWorkflow = readWorkflow('release.yml')
+    const npmDispatchJob = releaseWorkflow.slice(releaseWorkflow.indexOf('  dispatch-npm-alpha:'))
+
+    expect(npmDispatchJob).toContain('"repos/${{ github.repository }}/dispatches"')
+    expect(npmDispatchJob).toContain('event_type="npm-publish"')
+    expect(npmDispatchJob).toContain('client_payload[version]="${VERSION}"')
+    expect(npmDispatchJob).toContain('contents: write')
+    expect(releaseWorkflow).not.toContain('actions/workflows/npm-publish.yml/dispatches')
+  })
+
+  it('accepts repository_dispatch payloads in npm-publish.yml', () => {
+    const npmWorkflow = readWorkflow('npm-publish.yml')
+
+    expect(npmWorkflow).toContain('repository_dispatch:')
+    expect(npmWorkflow).toContain('types: [npm-publish]')
+    expect(npmWorkflow).toContain(
+      'CLIENT_PAYLOAD_VERSION: ${{ github.event.client_payload.version }}'
+    )
+    expect(npmWorkflow).toContain('"repository_dispatch"')
+  })
+})


### PR DESCRIPTION
## Summary
- route alpha npm publish handoff through repository_dispatch so npm-publish.yml stays the trusted publishing entrypoint
- teach npm-publish.yml to resolve versions from repository_dispatch payloads and checkout the release tag
- add a workflow regression test for the alpha npm publish handoff

## Verification
- bunx vitest run scripts/__tests__
- bunx prettier --check .github/workflows/npm-publish.yml .github/workflows/release.yml scripts/__tests__/npm-publish-workflow.test.ts
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/npm-publish.yml'); YAML.load_file('.github/workflows/release.yml'); puts 'yaml ok'"\n- git diff --check\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved release publishing workflow configuration to better manage different release types.
  * Enhanced workflow reliability with additional automated tests for the publishing process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->