### PR TITLE
fix(clipboard): advertise full text MIME alias set on Linux writers

### DIFF
--- a/crates/uc-platform/src/clipboard/platform/linux.rs
+++ b/crates/uc-platform/src/clipboard/platform/linux.rs
@@ -20,6 +20,12 @@
 pub(super) mod wayland;
 pub(super) mod x11;
 
+/// Shared Linux clipboard READ-path MIME mapping, used by BOTH the Wayland
+/// (`wayland::snapshot`) and X11 (`x11::reader`) backends. Default-private to
+/// the `linux` subtree; the `pub(super)` (== `pub(in ...::linux)`) helpers
+/// inside it are reachable from every descendant of `linux`.
+mod mime;
+
 use anyhow::Result;
 use async_trait::async_trait;
 use tracing::{info, warn};

--- a/crates/uc-platform/src/clipboard/platform/linux/mime.rs
+++ b/crates/uc-platform/src/clipboard/platform/linux/mime.rs
@@ -1,0 +1,268 @@
+//! Shared Linux clipboard READ-path MIME mapping.
+//!
+//! Both Linux backends — Wayland (`wlr-data-control` / `ext-data-control`)
+//! and X11 (ICCCM selections) — observe the SAME set of clipboard MIME /
+//! atom names and must map them to the SAME internal `format_id` and the
+//! SAME RFC media type so downstream dedup / sync logic never needs a
+//! per-backend branch. Historically each backend carried its own copy of
+//! these helpers (`x11::atoms` and `wayland::snapshot`), and the two drifted
+//! (different atom sets, a missing RFC translation on the Wayland side that
+//! could push a non-RFC atom name into a `MimeType`). This module is the
+//! single source of truth for the read path; both backends call into it.
+//!
+//! Ownership note (`uc-platform` AGENTS §6.4 / §9.2): platform-atom knowledge
+//! (`UTF8_STRING`, `STRING`, `TEXT`, `text/plain;charset=UTF-8`, ...) stays
+//! confined to this layer. The values returned upward are stable platform
+//! semantics — internal `format_id` strings and RFC media types — never raw
+//! OS atom names.
+//!
+//! Scope is the READ path only. The advertise/write helper
+//! `default_mime_for_format` is intentionally NOT hoisted here: it has two
+//! separate write-side homes (`x11::atoms` and `wayland::protocol`) and is
+//! exercised by the writers, not the snapshot readers.
+
+/// Map a clipboard MIME / X11 atom name to the internal `format_id` used by
+/// `SystemClipboardSnapshot`. Kept aligned with the format IDs that
+/// `CommonClipboardImpl::read_snapshot` produces on other platforms so that
+/// downstream dedup / sync logic doesn't need a per-platform branch.
+pub(super) fn format_id_for(mime: &str) -> &'static str {
+    match mime {
+        "text/plain"
+        | "text/plain;charset=utf-8"
+        | "text/plain;charset=UTF-8"
+        | "UTF8_STRING"
+        | "STRING"
+        | "TEXT" => "text",
+        "text/html" => "html",
+        "text/rtf" => "rtf",
+        "text/uri-list" | "text/x-uri" | "text/x-moz-url" => "files",
+        s if s.starts_with("image/") => "image",
+        _ => "raw",
+    }
+}
+
+/// Is this MIME / atom one we want to capture into a snapshot? This is the
+/// shared whitelist for both Linux backends. Every entry that is NOT a
+/// platform-native atom (`UTF8_STRING` / `STRING` / `TEXT`) is already a
+/// valid RFC media type, which is what keeps [`rfc_mime_for`]'s caller-side
+/// fallback safe (see that fn's docs).
+pub(super) fn is_interesting_mime(mime: &str) -> bool {
+    matches!(
+        mime,
+        "text/plain"
+            | "text/plain;charset=utf-8"
+            | "text/plain;charset=UTF-8"
+            | "UTF8_STRING"
+            | "STRING"
+            | "TEXT"
+            | "text/html"
+            | "text/rtf"
+            | "text/uri-list"
+            | "text/x-uri"
+            | "text/x-moz-url"
+    ) || mime.starts_with("image/")
+}
+
+/// Once we've captured a primary text representation, skip the aliased text
+/// atoms — the compositor / selection owner typically advertises
+/// `STRING` + `UTF8_STRING` + `text/plain;charset=utf-8` as duplicates of the
+/// same bytes, and we don't want N copies in the snapshot. Returns true only
+/// for the plain-text aliases (NOT `text/html` / `text/rtf` / `text/uri-list`,
+/// which carry distinct payloads).
+pub(super) fn is_text_mime(mime: &str) -> bool {
+    matches!(
+        mime,
+        "text/plain"
+            | "text/plain;charset=utf-8"
+            | "text/plain;charset=UTF-8"
+            | "UTF8_STRING"
+            | "STRING"
+            | "TEXT"
+    )
+}
+
+/// Lower number = read first when the source advertises multiple aliased
+/// text targets. ICCCM recommends `UTF8_STRING` / `text/plain;charset=utf-8`
+/// over the Latin-1-bounded `STRING` and `TEXT`, but real-world sources
+/// (Chromium, file managers, some IDE widgets) often list `STRING` *before*
+/// `UTF8_STRING` in their `TARGETS` / offered-mimes reply. If we honored that
+/// order we'd read the `STRING` copy first — which for URLs containing
+/// non-ASCII characters (e.g. `http://host/job/玉兔Pro/`) is the
+/// percent-encoded `http://host/job/%E7%8E%89%E5%85%94Pro/` fallback the
+/// source emits as the 7-bit-safe variant, leaving the user's paste / sync
+/// target with the `%XX` form. By sorting text candidates with this key
+/// before reading, we always reach for the UTF-8 native variant first
+/// regardless of source ordering.
+pub(super) fn text_mime_priority(mime: &str) -> u32 {
+    match mime {
+        // Explicit UTF-8 plain-text MIMEs — always preferred when present.
+        "text/plain;charset=utf-8" | "text/plain;charset=UTF-8" => 0,
+        // ICCCM's UTF-8 atom — second-best (some legacy sources reorder it).
+        "UTF8_STRING" => 1,
+        // Charset-less `text/plain`; modern sources treat it as UTF-8, but
+        // it's allowed to be Latin-1, so prefer the explicit variants above.
+        "text/plain" => 2,
+        // ICCCM defines `STRING` as Latin-1 only — sources commonly use it
+        // for a 7-bit-safe (often percent-encoded) fallback. Read last.
+        "STRING" => 3,
+        // ICCCM `TEXT` is locale-encoded. Same story as `STRING`.
+        "TEXT" => 4,
+        // Non-text mimes — keep them after all text mimes.
+        _ => u32::MAX,
+    }
+}
+
+/// Translate a platform-native clipboard target name to an RFC MIME type.
+///
+/// The native targets `UTF8_STRING`, `STRING`, and `TEXT` are X11 ICCCM /
+/// Wayland atom names, NOT valid RFC media types; they must be canonicalized
+/// before constructing a `MimeType` so the value stored in a snapshot is a
+/// real media type (e.g. text/plain), never an atom name. Returns `None` for
+/// names that are already RFC-shaped — callers fall back to the original
+/// string for those (every other [`is_interesting_mime`] entry is a valid
+/// RFC media type, so that fallback is always RFC-valid).
+pub(super) fn rfc_mime_for(atom_name: &str) -> Option<&'static str> {
+    match atom_name {
+        "UTF8_STRING" | "STRING" | "TEXT" => Some("text/plain"),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn interesting_mime_includes_text_html_uri_image() {
+        assert!(is_interesting_mime("text/plain"));
+        assert!(is_interesting_mime("text/plain;charset=utf-8"));
+        assert!(is_interesting_mime("text/plain;charset=UTF-8"));
+        assert!(is_interesting_mime("UTF8_STRING"));
+        assert!(is_interesting_mime("text/html"));
+        assert!(is_interesting_mime("text/rtf"));
+        assert!(is_interesting_mime("text/uri-list"));
+        assert!(is_interesting_mime("text/x-uri"));
+        assert!(is_interesting_mime("text/x-moz-url"));
+        assert!(is_interesting_mime("image/png"));
+        assert!(is_interesting_mime("image/jpeg"));
+        assert!(is_interesting_mime("image/svg+xml"));
+    }
+
+    #[test]
+    fn interesting_mime_excludes_unknown() {
+        assert!(!is_interesting_mime("application/octet-stream"));
+        assert!(!is_interesting_mime("x-special/gnome-copied-files"));
+        assert!(!is_interesting_mime("application/x-kde4-urilist"));
+    }
+
+    #[test]
+    fn format_id_mapping_is_stable() {
+        assert_eq!(format_id_for("text/plain"), "text");
+        assert_eq!(format_id_for("text/plain;charset=UTF-8"), "text");
+        assert_eq!(format_id_for("UTF8_STRING"), "text");
+        assert_eq!(format_id_for("text/html"), "html");
+        assert_eq!(format_id_for("text/rtf"), "rtf");
+        assert_eq!(format_id_for("text/uri-list"), "files");
+        assert_eq!(format_id_for("text/x-uri"), "files");
+        assert_eq!(format_id_for("text/x-moz-url"), "files");
+        assert_eq!(format_id_for("image/png"), "image");
+        assert_eq!(format_id_for("image/jpeg"), "image");
+        assert_eq!(format_id_for("application/octet-stream"), "raw");
+    }
+
+    #[test]
+    fn text_mime_predicate_covers_plain_text_aliases_only() {
+        for m in [
+            "text/plain",
+            "text/plain;charset=utf-8",
+            "text/plain;charset=UTF-8",
+            "UTF8_STRING",
+            "STRING",
+            "TEXT",
+        ] {
+            assert!(is_text_mime(m), "{m} should be a text mime");
+        }
+        for m in ["text/html", "text/rtf", "text/uri-list", "image/png"] {
+            assert!(!is_text_mime(m), "{m} should not be a text mime");
+        }
+    }
+
+    #[test]
+    fn text_mime_priority_prefers_utf8_variants() {
+        // Strict ordering: explicit UTF-8 < UTF8_STRING < text/plain < STRING < TEXT.
+        assert!(text_mime_priority("text/plain;charset=utf-8") < text_mime_priority("UTF8_STRING"));
+        assert!(text_mime_priority("text/plain;charset=UTF-8") < text_mime_priority("UTF8_STRING"));
+        assert!(text_mime_priority("UTF8_STRING") < text_mime_priority("text/plain"));
+        assert!(text_mime_priority("text/plain") < text_mime_priority("STRING"));
+        assert!(text_mime_priority("STRING") < text_mime_priority("TEXT"));
+    }
+
+    #[test]
+    fn text_mime_priority_demotes_non_text_to_back() {
+        // Non-text MIMEs must sort after every text MIME so that the
+        // reorder pass never moves them in front of a text variant.
+        let last_text = text_mime_priority("TEXT");
+        for non_text in ["text/html", "text/uri-list", "image/png", "x-special/foo"] {
+            assert!(
+                text_mime_priority(non_text) > last_text,
+                "non-text mime {non_text} ranked above text"
+            );
+        }
+    }
+
+    #[test]
+    fn sort_pulls_utf8_text_mime_in_front_of_string() {
+        // Simulates a source that advertises STRING (percent-encoded URL)
+        // before UTF8_STRING (UTF-8 original) — a documented Chromium
+        // pattern. After sorting, UTF8_STRING must come first so we read
+        // the UTF-8 variant and never touch the percent-encoded copy.
+        let mut mimes: Vec<&str> = vec!["STRING", "UTF8_STRING", "text/html", "image/png"];
+        mimes.sort_by_key(|m| text_mime_priority(m));
+        assert_eq!(mimes[0], "UTF8_STRING");
+        assert_eq!(mimes[1], "STRING");
+        // Non-text mimes retained but pushed behind every text variant.
+        assert!(mimes.contains(&"text/html"));
+        assert!(mimes.contains(&"image/png"));
+    }
+
+    #[test]
+    fn rfc_mime_canonicalizes_native_targets_only() {
+        assert_eq!(rfc_mime_for("UTF8_STRING"), Some("text/plain"));
+        assert_eq!(rfc_mime_for("STRING"), Some("text/plain"));
+        assert_eq!(rfc_mime_for("TEXT"), Some("text/plain"));
+        // Already-RFC names are passed through unchanged (None => keep original).
+        assert_eq!(rfc_mime_for("text/plain"), None);
+        assert_eq!(rfc_mime_for("text/html"), None);
+        assert_eq!(rfc_mime_for("image/png"), None);
+    }
+
+    #[test]
+    fn every_interesting_non_native_mime_is_rfc_shaped() {
+        // Robustness guard: the read-path call sites fall back to the
+        // original MIME string when `rfc_mime_for` returns None. That is
+        // only safe if every non-native interesting MIME is already a
+        // valid RFC media type (i.e. contains a '/'). Native atoms
+        // (UTF8_STRING/STRING/TEXT) are exempt because rfc_mime_for
+        // rewrites them.
+        for m in [
+            "text/plain",
+            "text/plain;charset=utf-8",
+            "text/plain;charset=UTF-8",
+            "text/html",
+            "text/rtf",
+            "text/uri-list",
+            "text/x-uri",
+            "text/x-moz-url",
+            "image/png",
+            "image/jpeg",
+        ] {
+            assert!(is_interesting_mime(m), "{m} should be interesting");
+            if rfc_mime_for(m).is_none() {
+                assert!(
+                    m.contains('/'),
+                    "non-native interesting mime {m} must be RFC-shaped"
+                );
+            }
+        }
+    }
+}

--- a/crates/uc-platform/src/clipboard/platform/linux/wayland/protocol/ext.rs
+++ b/crates/uc-platform/src/clipboard/platform/linux/wayland/protocol/ext.rs
@@ -664,35 +664,43 @@ fn handle_write(
     let mut payloads: HashMap<String, Arc<Vec<u8>>> = HashMap::new();
 
     for rep in &snapshot.representations {
-        let mime_str = rep
+        let Some(primary_mime) = rep
             .mime
             .as_ref()
             .map(|m| m.0.clone())
-            .or_else(|| super::default_mime_for_format(&rep.format_id).map(String::from));
+            .or_else(|| super::default_mime_for_format(&rep.format_id).map(String::from))
+        else {
+            continue;
+        };
 
-        if let Some(mime) = mime_str {
+        // 用 `rep_bytes` 而非 `expect_inline_bytes`：远端 push 的 image rep 由
+        // `apply_inbound::materializer` 合成为 `LocalFile` source（指向 blob cache
+        // 文件），直接调 `expect_inline_bytes` 会 panic（见
+        // `clipboard::payload::rep_bytes` 注释）。读盘失败时跳过该 rep + warn,
+        // 与 macOS / Windows 平台同语义。
+        let bytes = match crate::clipboard::payload::rep_bytes(rep) {
+            Ok(b) => Arc::new(b.into_owned()),
+            Err(err) => {
+                warn!(
+                    error = %err,
+                    format_id = %rep.format_id,
+                    mime = %primary_mime,
+                    "ext-data-control write: read LocalFile rep failed; skipping this mime"
+                );
+                continue;
+            }
+        };
+
+        // Advertise every MIME alias a paster might request (text expands to the
+        // full UTF-8 family) so apps like Firefox that only negotiate
+        // `text/plain;charset=utf-8` / `UTF8_STRING` can paste. All aliases share
+        // the same payload bytes.
+        for mime in super::offer_mimes_for(&primary_mime) {
             if payloads.contains_key(&mime) {
                 continue;
             }
-            // 用 `rep_bytes` 而非 `expect_inline_bytes`：远端 push 的 image rep 由
-            // `apply_inbound::materializer` 合成为 `LocalFile` source（指向 blob cache
-            // 文件），直接调 `expect_inline_bytes` 会 panic（见
-            // `clipboard::payload::rep_bytes` 注释）。读盘失败时跳过该 rep + warn,
-            // 与 macOS / Windows 平台同语义。
-            let bytes = match crate::clipboard::payload::rep_bytes(rep) {
-                Ok(b) => b.into_owned(),
-                Err(err) => {
-                    warn!(
-                        error = %err,
-                        format_id = %rep.format_id,
-                        mime = %mime,
-                        "ext-data-control write: read LocalFile rep failed; skipping this mime"
-                    );
-                    continue;
-                }
-            };
             source.offer(mime.clone());
-            payloads.insert(mime, Arc::new(bytes));
+            payloads.insert(mime, Arc::clone(&bytes));
         }
     }
 

--- a/crates/uc-platform/src/clipboard/platform/linux/wayland/protocol/ext.rs
+++ b/crates/uc-platform/src/clipboard/platform/linux/wayland/protocol/ext.rs
@@ -651,9 +651,13 @@ fn handle_write(
         .clone();
 
     if snapshot.representations.is_empty() {
-        if let Some(prev) = state.active_source.take() {
-            prev.source.destroy();
-        }
+        // Clear the selection. Do NOT destroy the previous source eagerly:
+        // `set_selection(None)` makes the compositor cancel it, and the
+        // `Cancelled` handler destroys it. An eager destroy here used to make
+        // the compositor emit an extra `Selection { id: None }` event on top of
+        // the clear, desyncing `self_echo_pending` (see the replace path below
+        // for the full self-deadlock failure mode).
+        state.active_source = None;
         device.set_selection(None);
         state.cached_snapshot = None;
         state.self_echo_pending = state.self_echo_pending.saturating_add(1);
@@ -709,10 +713,19 @@ fn handle_write(
         anyhow::bail!("ext-data-control write: no mime could be derived from snapshot");
     }
 
-    if let Some(prev) = state.active_source.take() {
-        prev.source.destroy();
-    }
-
+    // Do NOT destroy the previous source before installing the new one.
+    // `set_selection` atomically replaces the selection and the compositor
+    // sends `Cancelled` for the old source, which the source Dispatch handler
+    // destroys. Destroying it eagerly here made the compositor emit a spurious
+    // `Selection { id: None }` (clear) event *in addition to* the `Selection`
+    // for the new source — two self-originated selection events for a single
+    // `self_echo_pending += 1`. The clear consumed the only echo token, so the
+    // new selection (our own write) was mis-classified as an external change
+    // and read back via `build_from_offer` on this very worker thread. That
+    // read can only be served by this same thread, so it self-deadlocked until
+    // the 2s per-mime read timeout fired — blocking real apps' paste requests
+    // for seconds. Replacing without the eager destroy keeps echo accounting
+    // balanced (one self `Selection`, one token).
     device.set_selection(Some(&source));
     state.cached_snapshot = Some(snapshot);
     state.self_echo_pending = state.self_echo_pending.saturating_add(1);
@@ -894,14 +907,24 @@ impl Dispatch<ExtDataControlSourceV1, ()> for WorkerState {
                 }
             }
             ext_data_control_source_v1::Event::Cancelled => {
-                if let Some(active) = &state.active_source {
-                    if active.source.id() == source.id() {
-                        debug!("ext-data-control worker: source cancelled by compositor");
-                        if let Some(prev) = state.active_source.take() {
-                            prev.source.destroy();
-                        }
-                    }
+                // A source is cancelled either because another client took over
+                // the selection, or because we replaced our own source via a
+                // fresh `set_selection`. Destroy it in both cases to release the
+                // proxy. Only drop `active_source` when the *current* source
+                // lost the selection; a cancelled *previous* source is just our
+                // own replace cleanup and must not disturb the live one.
+                let is_active = state
+                    .active_source
+                    .as_ref()
+                    .map(|active| active.source.id() == source.id())
+                    .unwrap_or(false);
+                if is_active {
+                    debug!("ext-data-control worker: active source cancelled by compositor");
+                    state.active_source = None;
+                } else {
+                    debug!("ext-data-control worker: replaced source cancelled — cleaning up");
                 }
+                source.destroy();
             }
             _ => {}
         }

--- a/crates/uc-platform/src/clipboard/platform/linux/wayland/protocol/mod.rs
+++ b/crates/uc-platform/src/clipboard/platform/linux/wayland/protocol/mod.rs
@@ -190,6 +190,57 @@ pub(super) fn default_mime_for_format(format_id: &str) -> Option<&'static str> {
     }
 }
 
+/// MIME aliases advertised for a UTF-8 plain-text payload, canonical type first.
+///
+/// Unlike X11 ICCCM (where the selection owner converts on demand), a Wayland
+/// data-control source must advertise *every* MIME a paster might negotiate
+/// over — the compositor performs no conversion. Toolkits disagree on the
+/// canonical text type: GTK / Firefox request `text/plain;charset=utf-8` and
+/// the X11 atom name `UTF8_STRING`, Qt also accepts `STRING` / `TEXT`, and
+/// older code uses a bare `text/plain`. Advertising only one of these makes the
+/// selection invisible to apps that ask for the others — Firefox's Wayland
+/// address bar pastes nothing from a bare `text/plain` offer. Mirror
+/// `wl-clipboard` (and the X11 writer's alias set) by offering the whole family,
+/// all backed by the same bytes.
+pub(super) const TEXT_PLAIN_MIME_ALIASES: &[&str] = &[
+    "text/plain;charset=utf-8",
+    "text/plain;charset=UTF-8",
+    "text/plain",
+    "UTF8_STRING",
+    "STRING",
+    "TEXT",
+];
+
+/// Returns true when `mime` denotes a UTF-8 plain-text payload that should be
+/// advertised under the full [`TEXT_PLAIN_MIME_ALIASES`] set.
+///
+/// Clipboard text synced by the app is always UTF-8, so a bare `text/plain`
+/// (no charset) is treated as UTF-8 and still expands to the charset-qualified
+/// and `UTF8_STRING` aliases.
+pub(super) fn is_text_plain_mime(mime: &str) -> bool {
+    let normalized = mime.trim().to_ascii_lowercase();
+    normalized.starts_with("text/plain")
+        || matches!(normalized.as_str(), "utf8_string" | "string" | "text")
+}
+
+/// Resolve the ordered list of MIME types to advertise for a single
+/// representation whose primary MIME is `primary_mime`.
+///
+/// Plain-text payloads (see [`is_text_plain_mime`]) expand to the full
+/// [`TEXT_PLAIN_MIME_ALIASES`] family; every other format yields just its own
+/// type. The first entry is the canonical/preferred type. Shared between the
+/// [`wlr`] and [`ext`] write paths.
+pub(super) fn offer_mimes_for(primary_mime: &str) -> Vec<String> {
+    if is_text_plain_mime(primary_mime) {
+        TEXT_PLAIN_MIME_ALIASES
+            .iter()
+            .map(|m| (*m).to_string())
+            .collect()
+    } else {
+        vec![primary_mime.to_string()]
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -205,5 +256,47 @@ mod tests {
         assert_eq!(default_mime_for_format("image"), Some("image/png"));
         assert_eq!(default_mime_for_format("files"), Some("text/uri-list"));
         assert_eq!(default_mime_for_format("unknown"), None);
+    }
+
+    #[test]
+    fn bare_text_plain_expands_to_full_utf8_alias_set() {
+        // The bug: a remote text push normalizes to a bare `text/plain` rep, and
+        // the Wayland writer used to advertise only that. Firefox's address bar
+        // requests `text/plain;charset=utf-8` / `UTF8_STRING` and pasted nothing.
+        let offered = offer_mimes_for("text/plain");
+        assert!(offered.contains(&"text/plain;charset=utf-8".to_string()));
+        assert!(offered.contains(&"UTF8_STRING".to_string()));
+        assert!(offered.contains(&"text/plain".to_string()));
+        // Canonical type must come first so paste-priority pickers prefer it.
+        assert_eq!(
+            offered.first().map(String::as_str),
+            Some("text/plain;charset=utf-8")
+        );
+    }
+
+    #[test]
+    fn charset_qualified_text_also_expands() {
+        let offered = offer_mimes_for("text/plain;charset=utf-8");
+        assert_eq!(offered.len(), TEXT_PLAIN_MIME_ALIASES.len());
+        assert!(offered.contains(&"UTF8_STRING".to_string()));
+    }
+
+    #[test]
+    fn non_text_mimes_are_left_untouched() {
+        assert_eq!(offer_mimes_for("text/html"), vec!["text/html".to_string()]);
+        assert_eq!(offer_mimes_for("image/png"), vec!["image/png".to_string()]);
+        assert_eq!(
+            offer_mimes_for("text/uri-list"),
+            vec!["text/uri-list".to_string()]
+        );
+    }
+
+    #[test]
+    fn x11_atom_names_count_as_text() {
+        assert!(is_text_plain_mime("UTF8_STRING"));
+        assert!(is_text_plain_mime("STRING"));
+        assert!(is_text_plain_mime("TEXT"));
+        assert!(!is_text_plain_mime("text/html"));
+        assert!(!is_text_plain_mime("image/png"));
     }
 }

--- a/crates/uc-platform/src/clipboard/platform/linux/wayland/protocol/mod.rs
+++ b/crates/uc-platform/src/clipboard/platform/linux/wayland/protocol/mod.rs
@@ -214,13 +214,36 @@ pub(super) const TEXT_PLAIN_MIME_ALIASES: &[&str] = &[
 /// Returns true when `mime` denotes a UTF-8 plain-text payload that should be
 /// advertised under the full [`TEXT_PLAIN_MIME_ALIASES`] set.
 ///
-/// Clipboard text synced by the app is always UTF-8, so a bare `text/plain`
-/// (no charset) is treated as UTF-8 and still expands to the charset-qualified
-/// and `UTF8_STRING` aliases.
+/// Accepts the X11 atom-name aliases (`UTF8_STRING` / `STRING` / `TEXT`) and
+/// `text/plain` whose charset is either absent or `utf-8`. Clipboard text
+/// synced by the app is always UTF-8, so a bare `text/plain` (no charset) is
+/// treated as UTF-8. A `text/plain` carrying any other charset (e.g. GBK,
+/// ISO-8859-1) is rejected — expanding it to the UTF-8 alias family would
+/// re-advertise non-UTF-8 bytes as `UTF8_STRING` / `text/plain;charset=utf-8`
+/// and corrupt the paste.
 pub(super) fn is_text_plain_mime(mime: &str) -> bool {
     let normalized = mime.trim().to_ascii_lowercase();
-    normalized.starts_with("text/plain")
-        || matches!(normalized.as_str(), "utf8_string" | "string" | "text")
+
+    // X11 atom-name aliases always denote UTF-8 plain text.
+    if matches!(normalized.as_str(), "utf8_string" | "string" | "text") {
+        return true;
+    }
+
+    // Split the media type from its parameters; require exactly `text/plain`.
+    let mut parts = normalized.split(';').map(str::trim);
+    if parts.next() != Some("text/plain") {
+        return false;
+    }
+
+    // A charset parameter, if present, must be UTF-8. Absence => UTF-8.
+    for param in parts {
+        if let Some(charset) = param.strip_prefix("charset=") {
+            if charset != "utf-8" {
+                return false;
+            }
+        }
+    }
+    true
 }
 
 /// Resolve the ordered list of MIME types to advertise for a single
@@ -298,5 +321,34 @@ mod tests {
         assert!(is_text_plain_mime("TEXT"));
         assert!(!is_text_plain_mime("text/html"));
         assert!(!is_text_plain_mime("image/png"));
+    }
+
+    #[test]
+    fn non_utf8_text_plain_is_rejected() {
+        // A non-UTF-8 charset must NOT expand to the UTF-8 alias family —
+        // otherwise its bytes would be advertised as UTF8_STRING /
+        // text/plain;charset=utf-8 and corrupt paste.
+        assert!(!is_text_plain_mime("text/plain;charset=gbk"));
+        assert!(!is_text_plain_mime("text/plain;charset=iso-8859-1"));
+        assert!(!is_text_plain_mime("text/plain; charset=GBK"));
+        // The old prefix check false-matched this; the parser rejects it.
+        assert!(!is_text_plain_mime("text/plaintext"));
+
+        // Bare and explicit utf-8 still count; a non-charset param is ignored.
+        assert!(is_text_plain_mime("text/plain"));
+        assert!(is_text_plain_mime("text/plain;charset=utf-8"));
+        assert!(is_text_plain_mime("text/plain;charset=UTF-8"));
+        assert!(is_text_plain_mime("text/plain; charset=utf-8"));
+        assert!(is_text_plain_mime("text/plain;format=flowed"));
+
+        // The expansion path stays intact for accepted variants.
+        assert_eq!(
+            offer_mimes_for("text/plain;charset=gbk"),
+            vec!["text/plain;charset=gbk".to_string()]
+        );
+        assert_eq!(
+            offer_mimes_for("text/plain").len(),
+            TEXT_PLAIN_MIME_ALIASES.len()
+        );
     }
 }

--- a/crates/uc-platform/src/clipboard/platform/linux/wayland/protocol/wlr.rs
+++ b/crates/uc-platform/src/clipboard/platform/linux/wayland/protocol/wlr.rs
@@ -676,35 +676,43 @@ fn handle_write(
     let mut payloads: HashMap<String, Arc<Vec<u8>>> = HashMap::new();
 
     for rep in &snapshot.representations {
-        let mime_str = rep
+        let Some(primary_mime) = rep
             .mime
             .as_ref()
             .map(|m| m.0.clone())
-            .or_else(|| super::default_mime_for_format(&rep.format_id).map(String::from));
+            .or_else(|| super::default_mime_for_format(&rep.format_id).map(String::from))
+        else {
+            continue;
+        };
 
-        if let Some(mime) = mime_str {
+        // 用 `rep_bytes` 而非 `expect_inline_bytes`：远端 push 的 image rep 由
+        // `apply_inbound::materializer` 合成为 `LocalFile` source（指向 blob cache
+        // 文件），直接调 `expect_inline_bytes` 会 panic（见
+        // `clipboard::payload::rep_bytes` 注释）。读盘失败时跳过该 rep + warn,
+        // 与 macOS / Windows 平台同语义。
+        let bytes = match crate::clipboard::payload::rep_bytes(rep) {
+            Ok(b) => Arc::new(b.into_owned()),
+            Err(err) => {
+                warn!(
+                    error = %err,
+                    format_id = %rep.format_id,
+                    mime = %primary_mime,
+                    "wlr-data-control write: read LocalFile rep failed; skipping this mime"
+                );
+                continue;
+            }
+        };
+
+        // Advertise every MIME alias a paster might request (text expands to the
+        // full UTF-8 family) so apps like Firefox that only negotiate
+        // `text/plain;charset=utf-8` / `UTF8_STRING` can paste. All aliases share
+        // the same payload bytes.
+        for mime in super::offer_mimes_for(&primary_mime) {
             if payloads.contains_key(&mime) {
                 continue;
             }
-            // 用 `rep_bytes` 而非 `expect_inline_bytes`：远端 push 的 image rep 由
-            // `apply_inbound::materializer` 合成为 `LocalFile` source（指向 blob cache
-            // 文件），直接调 `expect_inline_bytes` 会 panic（见
-            // `clipboard::payload::rep_bytes` 注释）。读盘失败时跳过该 rep + warn,
-            // 与 macOS / Windows 平台同语义。
-            let bytes = match crate::clipboard::payload::rep_bytes(rep) {
-                Ok(b) => b.into_owned(),
-                Err(err) => {
-                    warn!(
-                        error = %err,
-                        format_id = %rep.format_id,
-                        mime = %mime,
-                        "wlr-data-control write: read LocalFile rep failed; skipping this mime"
-                    );
-                    continue;
-                }
-            };
             source.offer(mime.clone());
-            payloads.insert(mime, Arc::new(bytes));
+            payloads.insert(mime, Arc::clone(&bytes));
         }
     }
 

--- a/crates/uc-platform/src/clipboard/platform/linux/wayland/protocol/wlr.rs
+++ b/crates/uc-platform/src/clipboard/platform/linux/wayland/protocol/wlr.rs
@@ -663,9 +663,13 @@ fn handle_write(
         .clone();
 
     if snapshot.representations.is_empty() {
-        if let Some(prev) = state.active_source.take() {
-            prev.source.destroy();
-        }
+        // Clear the selection. Do NOT destroy the previous source eagerly:
+        // `set_selection(None)` makes the compositor cancel it, and the
+        // `Cancelled` handler destroys it. An eager destroy here used to make
+        // the compositor emit an extra `Selection { id: None }` event on top of
+        // the clear, desyncing `self_echo_pending` (see the replace path below
+        // for the full self-deadlock failure mode).
+        state.active_source = None;
         device.set_selection(None);
         state.cached_snapshot = None;
         state.self_echo_pending = state.self_echo_pending.saturating_add(1);
@@ -721,10 +725,19 @@ fn handle_write(
         anyhow::bail!("wlr-data-control write: no mime could be derived from snapshot");
     }
 
-    if let Some(prev) = state.active_source.take() {
-        prev.source.destroy();
-    }
-
+    // Do NOT destroy the previous source before installing the new one.
+    // `set_selection` atomically replaces the selection and the compositor
+    // sends `Cancelled` for the old source, which the source Dispatch handler
+    // destroys. Destroying it eagerly here made the compositor emit a spurious
+    // `Selection { id: None }` (clear) event *in addition to* the `Selection`
+    // for the new source — two self-originated selection events for a single
+    // `self_echo_pending += 1`. The clear consumed the only echo token, so the
+    // new selection (our own write) was mis-classified as an external change
+    // and read back via `build_from_offer` on this very worker thread. That
+    // read can only be served by this same thread, so it self-deadlocked until
+    // the 2s per-mime read timeout fired — blocking real apps' paste requests
+    // for seconds. Replacing without the eager destroy keeps echo accounting
+    // balanced (one self `Selection`, one token).
     device.set_selection(Some(&source));
     state.cached_snapshot = Some(snapshot);
     state.self_echo_pending = state.self_echo_pending.saturating_add(1);
@@ -909,14 +922,24 @@ impl Dispatch<ZwlrDataControlSourceV1, ()> for WorkerState {
                 }
             }
             zwlr_data_control_source_v1::Event::Cancelled => {
-                if let Some(active) = &state.active_source {
-                    if active.source.id() == source.id() {
-                        debug!("wlr-data-control worker: source cancelled by compositor");
-                        if let Some(prev) = state.active_source.take() {
-                            prev.source.destroy();
-                        }
-                    }
+                // A source is cancelled either because another client took over
+                // the selection, or because we replaced our own source via a
+                // fresh `set_selection`. Destroy it in both cases to release the
+                // proxy. Only drop `active_source` when the *current* source
+                // lost the selection; a cancelled *previous* source is just our
+                // own replace cleanup and must not disturb the live one.
+                let is_active = state
+                    .active_source
+                    .as_ref()
+                    .map(|active| active.source.id() == source.id())
+                    .unwrap_or(false);
+                if is_active {
+                    debug!("wlr-data-control worker: active source cancelled by compositor");
+                    state.active_source = None;
+                } else {
+                    debug!("wlr-data-control worker: replaced source cancelled — cleaning up");
                 }
+                source.destroy();
             }
             _ => {}
         }

--- a/crates/uc-platform/src/clipboard/platform/linux/wayland/snapshot.rs
+++ b/crates/uc-platform/src/clipboard/platform/linux/wayland/snapshot.rs
@@ -17,6 +17,9 @@ use uc_core::clipboard::{MimeType, ObservedClipboardRepresentation, SystemClipbo
 use uc_core::ids::RepresentationId;
 use wayland_client::Connection;
 
+use super::super::mime::{
+    format_id_for, is_interesting_mime, is_text_mime, rfc_mime_for, text_mime_priority,
+};
 use super::backend::OfferLike;
 use super::transfer;
 
@@ -29,55 +32,6 @@ const READ_TIMEOUT: Duration = Duration::from_secs(2);
 /// existing `MAX_IMAGE_FILE_BYTES` ceiling in `common.rs` plus a little
 /// headroom for HTML/RTF that occasionally exceeds plain image budgets.
 const MAX_MIME_BYTES: usize = 32 * 1024 * 1024;
-
-fn is_interesting_mime(mime: &str) -> bool {
-    matches!(
-        mime,
-        "text/plain"
-            | "text/plain;charset=utf-8"
-            | "UTF8_STRING"
-            | "STRING"
-            | "TEXT"
-            | "text/html"
-            | "text/uri-list"
-            | "text/x-uri"
-            | "text/x-moz-url"
-    ) || mime.starts_with("image/")
-}
-
-/// Map a wayland MIME string to the internal `format_id` used by
-/// `SystemClipboardSnapshot`. Keep these aligned with the format IDs that
-/// `CommonClipboardImpl::read_snapshot` produces on other platforms so that
-/// downstream dedup / sync logic doesn't need a per-platform branch.
-fn format_id_for(mime: &str) -> &'static str {
-    match mime {
-        "text/plain" | "text/plain;charset=utf-8" | "UTF8_STRING" | "STRING" | "TEXT" => "text",
-        "text/html" => "html",
-        "text/uri-list" => "files",
-        s if s.starts_with("image/") => "image",
-        _ => "raw",
-    }
-}
-
-/// Lower number = read first when the source advertises multiple aliased
-/// text targets. Mirrors `x11::atoms::text_mime_priority`; the two are kept
-/// in sync deliberately rather than shared because the X11 and Wayland
-/// modules don't otherwise have a common helper module and the function
-/// is short. Rationale: real-world sources (Chromium, file managers)
-/// often advertise `STRING` (a 7-bit-safe, often percent-encoded copy of
-/// non-ASCII URLs) before `UTF8_STRING` (the original UTF-8). Reading in
-/// advertise order captures the percent-encoded variant and propagates
-/// `%XX` sequences to every paste / sync target.
-fn text_mime_priority(mime: &str) -> u32 {
-    match mime {
-        "text/plain;charset=utf-8" | "text/plain;charset=UTF-8" => 0,
-        "UTF8_STRING" => 1,
-        "text/plain" => 2,
-        "STRING" => 3,
-        "TEXT" => 4,
-        _ => u32::MAX,
-    }
-}
 
 pub(super) fn build_from_offer<O: OfferLike>(
     conn: &Connection,
@@ -106,11 +60,8 @@ pub(super) fn build_from_offer<O: OfferLike>(
         // as aliases of the same data, and reading all three would inflate
         // the snapshot with duplicates that downstream dedup wouldn't catch
         // (different format_id but same bytes).
-        let is_text_mime = matches!(
-            mime.as_str(),
-            "text/plain" | "text/plain;charset=utf-8" | "UTF8_STRING" | "STRING" | "TEXT"
-        );
-        if is_text_mime && text_captured {
+        let is_text = is_text_mime(mime);
+        if is_text && text_captured {
             continue;
         }
         let is_image_mime = mime.starts_with("image/");
@@ -125,16 +76,26 @@ pub(super) fn build_from_offer<O: OfferLike>(
                     size = bytes.len(),
                     "wayland: read mime payload"
                 );
-                if is_text_mime {
+                if is_text {
                     text_captured = true;
                 }
                 if is_image_mime {
                     image_captured = true;
                 }
+                // Canonicalize platform-native targets (UTF8_STRING / STRING
+                // / TEXT) to an RFC media type before storing — mirrors the
+                // X11 reader. Never store a raw atom name as a MimeType:
+                // fall back to the original only when it is already
+                // RFC-shaped, otherwise omit the mime (None).
+                let rfc_mime = match rfc_mime_for(mime) {
+                    Some(canonical) => Some(MimeType(canonical.to_string())),
+                    None if mime.contains('/') => Some(MimeType(mime.to_string())),
+                    None => None,
+                };
                 reps.push(ObservedClipboardRepresentation::new(
                     RepresentationId::new(),
                     format_id_for(mime).into(),
-                    Some(MimeType(mime.to_string())),
+                    rfc_mime,
                     bytes,
                 ));
             }
@@ -148,69 +109,4 @@ pub(super) fn build_from_offer<O: OfferLike>(
         ts_ms: chrono::Utc::now().timestamp_millis(),
         representations: reps,
     })
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn interesting_mime_includes_text_html_uri_image() {
-        assert!(is_interesting_mime("text/plain"));
-        assert!(is_interesting_mime("text/plain;charset=utf-8"));
-        assert!(is_interesting_mime("UTF8_STRING"));
-        assert!(is_interesting_mime("text/html"));
-        assert!(is_interesting_mime("text/uri-list"));
-        assert!(is_interesting_mime("image/png"));
-        assert!(is_interesting_mime("image/jpeg"));
-        assert!(is_interesting_mime("image/svg+xml"));
-    }
-
-    #[test]
-    fn interesting_mime_excludes_unknown() {
-        assert!(!is_interesting_mime("application/octet-stream"));
-        assert!(!is_interesting_mime("x-special/gnome-copied-files"));
-        assert!(!is_interesting_mime("application/x-kde4-urilist"));
-    }
-
-    #[test]
-    fn text_mime_priority_prefers_utf8_variants() {
-        assert!(text_mime_priority("text/plain;charset=utf-8") < text_mime_priority("UTF8_STRING"));
-        assert!(text_mime_priority("UTF8_STRING") < text_mime_priority("text/plain"));
-        assert!(text_mime_priority("text/plain") < text_mime_priority("STRING"));
-        assert!(text_mime_priority("STRING") < text_mime_priority("TEXT"));
-    }
-
-    #[test]
-    fn text_mime_priority_demotes_non_text_to_back() {
-        let last_text = text_mime_priority("TEXT");
-        for non_text in ["text/html", "text/uri-list", "image/png"] {
-            assert!(text_mime_priority(non_text) > last_text);
-        }
-    }
-
-    #[test]
-    fn sort_pulls_utf8_text_mime_in_front_of_string() {
-        // Simulates a source that advertises STRING (percent-encoded URL)
-        // before UTF8_STRING (UTF-8 original) — a documented Chromium
-        // pattern. After sorting, UTF8_STRING must come first so we read
-        // the UTF-8 variant and never touch the percent-encoded copy.
-        let mut mimes: Vec<&str> = vec!["STRING", "UTF8_STRING", "text/html", "image/png"];
-        mimes.sort_by_key(|m| text_mime_priority(m));
-        assert_eq!(mimes[0], "UTF8_STRING");
-        assert_eq!(mimes[1], "STRING");
-        // Non-text mimes retained but pushed behind every text variant.
-        assert!(mimes.contains(&"text/html"));
-        assert!(mimes.contains(&"image/png"));
-    }
-
-    #[test]
-    fn format_id_mapping_matches_common_rs() {
-        assert_eq!(format_id_for("text/plain"), "text");
-        assert_eq!(format_id_for("UTF8_STRING"), "text");
-        assert_eq!(format_id_for("text/html"), "html");
-        assert_eq!(format_id_for("text/uri-list"), "files");
-        assert_eq!(format_id_for("image/png"), "image");
-        assert_eq!(format_id_for("image/jpeg"), "image");
-    }
 }

--- a/crates/uc-platform/src/clipboard/platform/linux/x11/atoms.rs
+++ b/crates/uc-platform/src/clipboard/platform/linux/x11/atoms.rs
@@ -1,9 +1,12 @@
 //! ICCCM / XDND / freedesktop atoms used by the X11 clipboard backend.
 //!
 //! Atom set mirrors what `clipboard_rs`'s X11 path interns plus the few extra
-//! mime aliases the reader needs to recognize as "this is text" / "this is
-//! html" so that snapshot building is symmetric with the Wayland backend's
-//! `snapshot::is_interesting_mime` filter.
+//! mime aliases the reader needs to recognize. The READ-path MIME predicates
+//! (`format_id_for`, `is_interesting_mime`, `is_text_mime`, `rfc_mime_for`,
+//! `text_mime_priority`) live in the shared `super::super::mime` module so
+//! the X11 and Wayland backends stay in lockstep; this file keeps only the
+//! interned atom set plus the write-side `default_mime_for_format` advertise
+//! helper.
 
 use x11rb::atom_manager;
 
@@ -50,103 +53,6 @@ atom_manager! {
     }
 }
 
-/// Format ID assigned to a representation derived from a given X11 mime atom name.
-///
-/// Kept aligned with `wayland::snapshot::format_id_for` so the downstream
-/// dedup / sync logic doesn't need a per-platform branch.
-pub(super) fn format_id_for(mime: &str) -> &'static str {
-    match mime {
-        "text/plain"
-        | "text/plain;charset=utf-8"
-        | "text/plain;charset=UTF-8"
-        | "UTF8_STRING"
-        | "STRING"
-        | "TEXT" => "text",
-        "text/html" => "html",
-        "text/rtf" => "rtf",
-        "text/uri-list" => "files",
-        s if s.starts_with("image/") => "image",
-        _ => "raw",
-    }
-}
-
-/// Is this MIME one we want to capture into a snapshot? Kept symmetric with
-/// `wayland::snapshot::is_interesting_mime`.
-pub(super) fn is_interesting_mime(mime: &str) -> bool {
-    matches!(
-        mime,
-        "text/plain"
-            | "text/plain;charset=utf-8"
-            | "text/plain;charset=UTF-8"
-            | "UTF8_STRING"
-            | "STRING"
-            | "TEXT"
-            | "text/html"
-            | "text/rtf"
-            | "text/uri-list"
-    ) || mime.starts_with("image/")
-}
-
-/// Once we've captured a text representation, skip the aliased text atoms —
-/// the compositor / source typically advertises STRING + UTF8_STRING +
-/// text/plain;charset=utf-8 as duplicates of the same bytes, and we don't
-/// want N copies in the snapshot.
-pub(super) fn is_text_mime(mime: &str) -> bool {
-    matches!(
-        mime,
-        "text/plain"
-            | "text/plain;charset=utf-8"
-            | "text/plain;charset=UTF-8"
-            | "UTF8_STRING"
-            | "STRING"
-            | "TEXT"
-    )
-}
-
-/// Lower number = read first when the source advertises multiple aliased
-/// text targets. ICCCM recommends `UTF8_STRING` / `text/plain;charset=utf-8`
-/// over the Latin-1-bounded `STRING` and `TEXT`, but real-world sources
-/// (Chromium, file managers, some IDE widgets) often list `STRING` *before*
-/// `UTF8_STRING` in their `TARGETS` reply. If we honored that order we'd
-/// read the `STRING` copy first — which for URLs containing non-ASCII
-/// characters (e.g. `http://host/job/玉兔Pro/`) is the percent-encoded
-/// `http://host/job/%E7%8E%89%E5%85%94Pro/` fallback the source emits as
-/// the 7-bit-safe variant, leaving the user's paste / sync target with the
-/// `%XX` form. By sorting text candidates with this key before reading, we
-/// always reach for the UTF-8 native variant first regardless of source
-/// ordering.
-pub(super) fn text_mime_priority(mime: &str) -> u32 {
-    match mime {
-        // Explicit UTF-8 plain-text MIMEs — always preferred when present.
-        "text/plain;charset=utf-8" | "text/plain;charset=UTF-8" => 0,
-        // ICCCM's UTF-8 atom — second-best (some legacy sources reorder it).
-        "UTF8_STRING" => 1,
-        // Charset-less `text/plain`; modern sources treat it as UTF-8, but
-        // it's allowed to be Latin-1, so prefer the explicit variants above.
-        "text/plain" => 2,
-        // ICCCM defines `STRING` as Latin-1 only — sources commonly use it
-        // for a 7-bit-safe (often percent-encoded) fallback. Read last.
-        "STRING" => 3,
-        // ICCCM `TEXT` is locale-encoded. Same story as `STRING`.
-        "TEXT" => 4,
-        // Non-text mimes — keep them after all text mimes.
-        _ => u32::MAX,
-    }
-}
-
-/// Translate an X11 atom name to an RFC MIME type.
-///
-/// Platform-native targets (`UTF8_STRING`, `STRING`, `TEXT`) are not valid
-/// RFC media types; they must be mapped before constructing a
-/// `MimeType`. Returns `None` for names that are already RFC-shaped — the
-/// caller should use the original string.
-pub(super) fn rfc_mime_for(atom_name: &str) -> Option<&'static str> {
-    match atom_name {
-        "UTF8_STRING" | "STRING" | "TEXT" => Some("text/plain"),
-        _ => None,
-    }
-}
-
 /// Map a snapshot `format_id` → the canonical X11 mime atom name we advertise.
 /// Mirrors `wayland::protocol::default_mime_for_format`.
 pub(super) fn default_mime_for_format(format_id: &str) -> Option<&'static str> {
@@ -163,56 +69,9 @@ pub(super) fn default_mime_for_format(format_id: &str) -> Option<&'static str> {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn interesting_mime_includes_text_html_uri_image() {
-        assert!(is_interesting_mime("text/plain"));
-        assert!(is_interesting_mime("UTF8_STRING"));
-        assert!(is_interesting_mime("text/html"));
-        assert!(is_interesting_mime("text/uri-list"));
-        assert!(is_interesting_mime("image/png"));
-        assert!(is_interesting_mime("image/jpeg"));
-    }
-
-    #[test]
-    fn interesting_mime_excludes_unknown() {
-        assert!(!is_interesting_mime("application/octet-stream"));
-        assert!(!is_interesting_mime("x-special/gnome-copied-files"));
-    }
-
-    #[test]
-    fn format_id_mapping_matches_wayland() {
-        assert_eq!(format_id_for("text/plain"), "text");
-        assert_eq!(format_id_for("UTF8_STRING"), "text");
-        assert_eq!(format_id_for("text/html"), "html");
-        assert_eq!(format_id_for("text/rtf"), "rtf");
-        assert_eq!(format_id_for("text/uri-list"), "files");
-        assert_eq!(format_id_for("image/png"), "image");
-        assert_eq!(format_id_for("image/jpeg"), "image");
-    }
-
-    #[test]
-    fn text_mime_priority_prefers_utf8_variants() {
-        // Strict ordering: explicit UTF-8 < UTF8_STRING < text/plain < STRING < TEXT.
-        assert!(text_mime_priority("text/plain;charset=utf-8") < text_mime_priority("UTF8_STRING"));
-        assert!(text_mime_priority("text/plain;charset=UTF-8") < text_mime_priority("UTF8_STRING"));
-        assert!(text_mime_priority("UTF8_STRING") < text_mime_priority("text/plain"));
-        assert!(text_mime_priority("text/plain") < text_mime_priority("STRING"));
-        assert!(text_mime_priority("STRING") < text_mime_priority("TEXT"));
-    }
-
-    #[test]
-    fn text_mime_priority_demotes_non_text_to_back() {
-        // Non-text MIMEs must sort after every text MIME so that the
-        // reorder pass never moves them in front of a text variant.
-        let last_text = text_mime_priority("TEXT");
-        for non_text in ["text/html", "text/uri-list", "image/png", "x-special/foo"] {
-            assert!(
-                text_mime_priority(non_text) > last_text,
-                "non-text mime {non_text} ranked above text"
-            );
-        }
-    }
+    // `format_id_for` moved to the shared read-path module; the write-side
+    // round-trip below still needs it to assert advertise/parse symmetry.
+    use super::super::super::mime::format_id_for;
 
     #[test]
     fn default_mime_round_trip() {

--- a/crates/uc-platform/src/clipboard/platform/linux/x11/reader.rs
+++ b/crates/uc-platform/src/clipboard/platform/linux/x11/reader.rs
@@ -32,7 +32,7 @@ use x11rb::protocol::xproto::{Atom, AtomEnum, ConnectionExt as _, Property, Prop
 use x11rb::protocol::Event;
 use x11rb::CURRENT_TIME;
 
-use super::atoms::{
+use super::super::mime::{
     format_id_for, is_interesting_mime, is_text_mime, rfc_mime_for, text_mime_priority,
 };
 use super::connection::X11Server;

--- a/crates/uc-platform/src/clipboard/platform/linux/x11/writer.rs
+++ b/crates/uc-platform/src/clipboard/platform/linux/x11/writer.rs
@@ -115,6 +115,11 @@ pub(super) fn install_snapshot(
         // without the charset suffix still get bytes (mirrors what wlr /
         // ext data-control sources do via their multi-offer dance, and
         // what clipboard_rs's `file_uri_list_to_clipboard_data` did for X11).
+        // A bare `text/plain` is treated as UTF-8 (clipboard text synced by the
+        // app is always UTF-8) and expands to the SAME full alias set as the
+        // charset-qualified form — otherwise Firefox / GTK, which request
+        // `UTF8_STRING` / `text/plain;charset=utf-8`, paste nothing from a
+        // remote-push rep that normalized to bare `text/plain`.
         //
         // 用 `rep_bytes` 而非 `expect_inline_bytes`：远端 push 的 image rep 由
         // `apply_inbound::materializer` 合成为 `LocalFile` source（指向 blob cache
@@ -134,7 +139,7 @@ pub(super) fn install_snapshot(
             }
         };
         match mime.as_str() {
-            "text/plain;charset=utf-8" | "text/plain;charset=UTF-8" => {
+            "text/plain;charset=utf-8" | "text/plain;charset=UTF-8" | "text/plain" => {
                 payloads.entry(atoms.UTF8_STRING).or_insert(bytes.clone());
                 payloads.entry(atoms.STRING).or_insert(bytes.clone());
                 payloads.entry(atoms.TEXT).or_insert(bytes.clone());
@@ -145,11 +150,6 @@ pub(super) fn install_snapshot(
                 payloads
                     .entry(atoms.TEXT_PLAIN_UTF8_BIG)
                     .or_insert(bytes.clone());
-            }
-            "text/plain" => {
-                payloads.entry(atoms.TEXT_PLAIN).or_insert(bytes.clone());
-                payloads.entry(atoms.TEXT).or_insert(bytes.clone());
-                payloads.entry(atoms.STRING).or_insert(bytes.clone());
             }
             _ => {}
         }


### PR DESCRIPTION
## Summary

- Remote-push / restore text normalizes to a bare `text/plain` representation. The Linux **Wayland** data-control writers (`ext`/`wlr`) advertised only that single MIME, and the **X11** writer's bare-`text/plain` branch advertised only `{TEXT_PLAIN, TEXT, STRING}`. GTK/Firefox negotiate paste over `text/plain;charset=utf-8` / `UTF8_STRING`, so they matched no offered type and pasted **nothing** — even though the entry was captured to the DB, persisted to disk, and readable by `wl-paste` (which reads via data-control and therefore masked the bug). (`b034b09a`)
- Clipboard text synced by the app is always UTF-8, so a bare `text/plain` is now treated as UTF-8 and expands to the full alias family, mirroring `wl-clipboard`: `text/plain;charset=utf-8`, `text/plain;charset=UTF-8`, `text/plain`, `UTF8_STRING`, `STRING`, `TEXT`.
  - wayland: new shared `offer_mimes_for()` in `protocol/mod.rs`; `ext.rs`/`wlr.rs` read each rep's bytes once and offer every alias backed by the same `Arc`.
  - x11: folded the bare `text/plain` selection-target branch into the charset-qualified branch so `UTF8_STRING` / `text/plain;charset=utf-8` are served.

## Test plan

- [x] `cargo test -p uc-platform --lib` on Fedora/niri (aarch64): 62 passed, 0 failed (5 new alias-helper unit tests included).
- [x] End-to-end on Fedora/niri: a harness writing a bare `text/plain` snapshot through the fixed `ext-data-control` writer is now pasteable in Firefox's address bar (`wl-paste --list-types` shows the full alias set). Pre-fix the same write was invisible to Firefox.
- [ ] Reviewer: sanity-check on an X11 / XWayland session that a synced text entry now pastes into a `UTF8_STRING`-requesting app (couldn't be exercised on the Wayland-only test box).
- [ ] Reviewer: confirm no regression for non-text reps (html/rtf/image/files) — those bypass alias expansion and offer their single canonical MIME unchanged.

No `docs-site/` changes: pure platform-layer fix, no CLI flag / setting / version-gate / error-message surface changed; the docs do not describe the broken behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Skip unreadable clipboard representations and log a warning instead of failing.
  * Prevent duplicate MIME offers by reusing the same payload across MIME aliases.
  * Fix selection lifecycle and cancellation handling to avoid premature source destruction and self-echo miscounts.

* **Improvements**
  * Broader UTF‑8 text/plain alias support across Linux clipboards (Wayland & X11).
  * Consolidated shared MIME mapping for consistent behavior across backends.

* **Documentation**
  * Updated notes describing shared MIME handling.

* **Tests**
  * Added/updated tests for MIME aliasing, priority, and canonicalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->