### PR TITLE
fix(daemon): end post-update hang via instance-lock eviction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10080,6 +10080,7 @@ version = "0.15.0-alpha.4"
 dependencies = [
  "anyhow",
  "libc",
+ "semver",
  "serde",
  "serde_json",
  "tempfile",

--- a/apps/cli/src/commands/stop.rs
+++ b/apps/cli/src/commands/stop.rs
@@ -202,6 +202,7 @@ mod tests {
             mode,
             started_at_ms: 0,
             spawned_by: uc_daemon_process::process_metadata::DaemonSpawnOrigin::Unknown,
+            package_version: String::new(),
         }
     }
 

--- a/crates/AGENTS.md
+++ b/crates/AGENTS.md
@@ -1,6 +1,6 @@
 # PROJECT KNOWLEDGE BASE
 
-**Last refreshed:** 2026-06-12 (auto; 19 workspace crates)
+**Last refreshed:** 2026-06-13 (auto; 19 workspace crates)
 
 ## OVERVIEW
 

--- a/crates/uc-daemon-local/src/instance_lock.rs
+++ b/crates/uc-daemon-local/src/instance_lock.rs
@@ -179,6 +179,18 @@ pub async fn acquire_with_deadline(
         Err(other) => return Err(other),
     };
 
+    // Single-instance arbitration (the "evicted after update" fix): before
+    // patiently waiting out the holder, decide whether THIS daemon out-ranks it
+    // (`should_evict_holder`). A strictly-older or stuck/orphaned holder is
+    // SIGTERM'd — escalating to SIGKILL — so the newcomer takes over
+    // deterministically, instead of waiting out `deadline` and exiting
+    // `AlreadyRunning` (the symptom users hit after an update: had to kill the
+    // leftover uniclipd by hand). An equal-or-newer holder is left untouched
+    // (downgrade protection) and we fall through to the cooperative wait below.
+    if let Some(lock) = try_evict_outranked_holder(data_dir).await? {
+        return Ok(lock);
+    }
+
     tracing::warn!(
         lock_path = %lock_path.display(),
         deadline_ms = deadline.as_millis() as u64,
@@ -186,33 +198,164 @@ pub async fn acquire_with_deadline(
     );
 
     let started = Instant::now();
-    let dir = data_dir.to_path_buf();
-    let (tx, rx) = tokio::sync::oneshot::channel();
-    std::thread::Builder::new()
-        .name("uniclipd-lock-wait".into())
-        .spawn(move || {
-            // If the receiver is gone (deadline expired), the sent lock is
-            // dropped right here, releasing it for the next contender.
-            let _ = tx.send(DaemonInstanceLock::acquire_blocking(&dir));
-        })
-        .map_err(InstanceLockError::Io)?;
-
-    match tokio::time::timeout(deadline, rx).await {
-        Ok(Ok(Ok(lock))) => {
+    match block_acquire_within(data_dir, deadline).await? {
+        Some(lock) => {
             tracing::info!(
                 elapsed_ms = started.elapsed().as_millis() as u64,
                 "daemon instance lock acquired after holder release"
             );
             Ok(lock)
         }
+        // Deadline expired: the holder never released within the bound.
+        None => Err(InstanceLockError::AlreadyRunning { lock_path }),
+    }
+}
+
+/// Park a detached thread in blocking `flock(2)`; resolve to `Ok(Some(lock))` if
+/// acquired within `budget`, `Ok(None)` if the budget expired with the holder
+/// still in place, `Err` on I/O / wait-thread failure.
+///
+/// A DETACHED `std::thread` (NOT `spawn_blocking`: tokio joins its blocking pool
+/// on runtime drop, so a thread still parked in `flock` after a budget expiry
+/// would deadlock the daemon's exit path). On expiry the thread is harmless: if
+/// the holder later exits, the thread wins the lock, fails to send it (receiver
+/// dropped), and releases it immediately; process exit reclaims it regardless.
+async fn block_acquire_within(
+    data_dir: &Path,
+    budget: Duration,
+) -> Result<Option<DaemonInstanceLock>, InstanceLockError> {
+    let dir = data_dir.to_path_buf();
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    std::thread::Builder::new()
+        .name("uniclipd-lock-wait".into())
+        .spawn(move || {
+            let _ = tx.send(DaemonInstanceLock::acquire_blocking(&dir));
+        })
+        .map_err(InstanceLockError::Io)?;
+
+    match tokio::time::timeout(budget, rx).await {
+        Ok(Ok(Ok(lock))) => Ok(Some(lock)),
         Ok(Ok(Err(error))) => Err(error),
         // Sender dropped without sending — the wait thread panicked.
         Ok(Err(_recv_error)) => Err(InstanceLockError::Io(std::io::Error::other(
             "instance lock wait thread terminated unexpectedly",
         ))),
-        // Deadline expired: the holder never released within the bound.
-        Err(_elapsed) => Err(InstanceLockError::AlreadyRunning { lock_path }),
+        // Budget expired: the holder never released within the bound.
+        Err(_elapsed) => Ok(None),
     }
+}
+
+/// Evict the current lock holder iff THIS daemon strictly out-ranks it, then try
+/// to take the freed lock. Returns `Ok(Some(lock))` if eviction won the lock,
+/// `Ok(None)` if no eviction was warranted or it did not free the lock in time
+/// (caller falls through to the cooperative deadline wait), `Err` on terminal
+/// I/O.
+///
+/// Best-effort and conservative: an unreadable/absent holder PID file, a
+/// stale/foreign PID (D22 — not a live `uniclipd`), or an equal-or-newer holder
+/// all yield `Ok(None)` WITHOUT signaling anyone.
+async fn try_evict_outranked_holder(
+    data_dir: &Path,
+) -> Result<Option<DaemonInstanceLock>, InstanceLockError> {
+    use uc_daemon_process::contract::{
+        force_terminate_local_daemon_pid, terminate_local_daemon_pid,
+    };
+    use uc_daemon_process::process_metadata::{
+        read_pid_metadata_in, should_evict_holder, verify_pid_identity, PidVerification,
+        SELF_PACKAGE_VERSION,
+    };
+    use uc_daemon_process::timing::{EVICT_SIGKILL_GRACE, EVICT_SIGTERM_GRACE};
+
+    // Best-effort read of the holder's PID metadata; on any problem fall back to
+    // the plain cooperative wait.
+    let holder = match read_pid_metadata_in(data_dir) {
+        Ok(Some(metadata)) => metadata,
+        Ok(None) => return Ok(None),
+        Err(error) => {
+            tracing::warn!(%error, "could not read lock holder PID metadata — skipping eviction");
+            return Ok(None);
+        }
+    };
+
+    let self_pid = std::process::id();
+
+    // Never signal our own PID. If a stale PID file's recorded pid was recycled
+    // to THIS very process, `verify_pid_identity` would see it "alive" (it is us)
+    // and we would SIGTERM ourselves — the real lock holder is someone else, so
+    // fall back to the cooperative wait instead.
+    if holder.pid == self_pid {
+        return Ok(None);
+    }
+
+    // D22: never signal a PID that is not a live `uniclipd`. A stale PID means
+    // the real holder already exited (the lock will free on its own); a foreign
+    // PID is someone else's process. Either way, do not signal.
+    if !matches!(verify_pid_identity(&holder), PidVerification::Active) {
+        return Ok(None);
+    }
+
+    let self_started_at_ms = now_ms();
+    if !should_evict_holder(SELF_PACKAGE_VERSION, self_started_at_ms, self_pid, &holder) {
+        tracing::info!(
+            holder_pid = holder.pid,
+            holder_version = %holder.package_version,
+            self_version = SELF_PACKAGE_VERSION,
+            "instance lock held by an equal-or-newer daemon — not evicting (downgrade protection)"
+        );
+        return Ok(None);
+    }
+
+    tracing::warn!(
+        holder_pid = holder.pid,
+        holder_version = %holder.package_version,
+        self_version = SELF_PACKAGE_VERSION,
+        "instance lock held by an out-ranked daemon — evicting it (SIGTERM, then SIGKILL)"
+    );
+
+    if let Err(error) = terminate_local_daemon_pid(holder.pid) {
+        tracing::warn!(holder_pid = holder.pid, %error, "SIGTERM to lock holder failed");
+    }
+    if let Some(lock) = block_acquire_within(data_dir, EVICT_SIGTERM_GRACE).await? {
+        tracing::info!(
+            holder_pid = holder.pid,
+            "instance lock acquired after holder SIGTERM"
+        );
+        return Ok(Some(lock));
+    }
+
+    // Holder did not release within the graceful window. Re-verify identity (a
+    // recycled PID must not be SIGKILL'd) and escalate.
+    if matches!(verify_pid_identity(&holder), PidVerification::Active) {
+        tracing::warn!(
+            holder_pid = holder.pid,
+            "lock holder still alive after SIGTERM grace — escalating to SIGKILL"
+        );
+        if let Err(error) = force_terminate_local_daemon_pid(holder.pid) {
+            tracing::warn!(holder_pid = holder.pid, %error, "SIGKILL to lock holder failed");
+        }
+        if let Some(lock) = block_acquire_within(data_dir, EVICT_SIGKILL_GRACE).await? {
+            tracing::info!(
+                holder_pid = holder.pid,
+                "instance lock acquired after holder SIGKILL"
+            );
+            return Ok(Some(lock));
+        }
+    }
+
+    // Even SIGKILL did not free it in time (D-state, or a PID that went stale
+    // between checks). Fall through to the cooperative deadline wait.
+    Ok(None)
+}
+
+/// Unix-epoch milliseconds for "now" — this process's start instant for
+/// single-instance ranking (`should_evict_holder`). Matches how
+/// `DaemonPidMetadata::now` stamps `started_at_ms`, so the value compared here
+/// is on the same clock as a holder's persisted timestamp.
+fn now_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
 }
 
 fn is_would_block(error: &std::io::Error) -> bool {

--- a/crates/uc-daemon-local/src/instance_lock.rs
+++ b/crates/uc-daemon-local/src/instance_lock.rs
@@ -187,18 +187,27 @@ pub async fn acquire_with_deadline(
     // `AlreadyRunning` (the symptom users hit after an update: had to kill the
     // leftover uniclipd by hand). An equal-or-newer holder is left untouched
     // (downgrade protection) and we fall through to the cooperative wait below.
+    // Eviction (below) may itself spend up to EVICT_SIGTERM_GRACE +
+    // EVICT_SIGKILL_GRACE before falling through to the cooperative wait. Start
+    // the clock BEFORE it and charge that time against `deadline`, so the total
+    // wait still honors the caller's budget — the spawner-side
+    // DAEMON_STARTUP_TIMEOUT is derived assuming this lock wait stays ≤ deadline
+    // (the coupling `timing` exists to keep load-bearing).
+    let started = Instant::now();
+
     if let Some(lock) = try_evict_outranked_holder(data_dir).await? {
         return Ok(lock);
     }
 
+    let remaining = deadline.saturating_sub(started.elapsed());
+
     tracing::warn!(
         lock_path = %lock_path.display(),
-        deadline_ms = deadline.as_millis() as u64,
+        deadline_ms = remaining.as_millis() as u64,
         "daemon instance lock busy — blocking until the holder releases it"
     );
 
-    let started = Instant::now();
-    match block_acquire_within(data_dir, deadline).await? {
+    match block_acquire_within(data_dir, remaining).await? {
         Some(lock) => {
             tracing::info!(
                 elapsed_ms = started.elapsed().as_millis() as u64,

--- a/crates/uc-daemon-process/Cargo.toml
+++ b/crates/uc-daemon-process/Cargo.toml
@@ -33,6 +33,10 @@ tokio = { version = "1", features = ["time"] }
 uc-app-paths = { path = "../uc-app-paths" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+# Single-instance arbitration compares daemon package versions read from peer
+# PID files (`should_evict_holder`). `semver` is a pure-parse leaf — it pulls
+# nothing heavy, preserving this crate's iroh/diesel-free thin invariant.
+semver = "1"
 # Best-effort warn-level logging in the handover store (corrupt/unclearable
 # record). `tracing` is a leaf facade — it pulls nothing heavy, so the
 # iroh/diesel-free invariant of this thin crate is preserved.

--- a/crates/uc-daemon-process/src/contract.rs
+++ b/crates/uc-daemon-process/src/contract.rs
@@ -86,6 +86,39 @@ pub fn terminate_local_daemon_pid(pid: u32) -> Result<(), TerminateDaemonError> 
     }
 }
 
+/// Force-kill `pid`: Unix `SIGKILL` (uncatchable, immediate), Windows
+/// `TerminateProcess` (already forceful). Used by single-instance eviction as
+/// the escalation when a `SIGTERM`'d holder does not release the instance lock
+/// within the grace window. The flock is reclaimed by the kernel the moment the
+/// process dies, so a contender parked in `flock(2)` wakes immediately after.
+pub fn force_terminate_local_daemon_pid(pid: u32) -> Result<(), TerminateDaemonError> {
+    // Same pid-0 guard as `terminate_local_daemon_pid`: a corrupted PID file
+    // reading as 0 would broadcast to the caller's whole process group.
+    if pid == 0 {
+        return Err(TerminateDaemonError(
+            "refusing to force-terminate pid 0".to_string(),
+        ));
+    }
+
+    #[cfg(unix)]
+    {
+        send_sigkill(pid)
+            .map_err(|e| TerminateDaemonError(format!("failed to force-terminate pid {pid}: {e}")))
+    }
+
+    #[cfg(windows)]
+    {
+        crate::win_process::terminate_pid(pid).map_err(TerminateDaemonError)
+    }
+
+    #[cfg(not(any(unix, windows)))]
+    {
+        Err(TerminateDaemonError(format!(
+            "process termination unsupported on this platform (pid {pid})"
+        )))
+    }
+}
+
 /// Send SIGTERM to `pid` via the raw `kill(2)` syscall. `Err` carries the OS
 /// error (`ESRCH` = no such process, `EPERM` = exists but unsignalable).
 #[cfg(unix)]
@@ -97,6 +130,23 @@ fn send_sigterm(pid: u32) -> Result<(), std::io::Error> {
         .map_err(|_| std::io::Error::new(std::io::ErrorKind::InvalidInput, "pid exceeds pid_t"))?;
     // SAFETY: kill(2) has no preconditions; callers guard pid != 0.
     if unsafe { libc::kill(pid, libc::SIGTERM) } == 0 {
+        Ok(())
+    } else {
+        Err(std::io::Error::last_os_error())
+    }
+}
+
+/// Send SIGKILL to `pid` via the raw `kill(2)` syscall. `Err` carries the OS
+/// error (`ESRCH` = no such process, `EPERM` = exists but unsignalable).
+#[cfg(unix)]
+fn send_sigkill(pid: u32) -> Result<(), std::io::Error> {
+    // A pid above pid_t::MAX can only come from a corrupted PID file; the `as`
+    // cast would wrap it negative, and kill(2) on a negative pid signals the
+    // process *group* |pid| — reject before the cast.
+    let pid = libc::pid_t::try_from(pid)
+        .map_err(|_| std::io::Error::new(std::io::ErrorKind::InvalidInput, "pid exceeds pid_t"))?;
+    // SAFETY: kill(2) has no preconditions; callers guard pid != 0.
+    if unsafe { libc::kill(pid, libc::SIGKILL) } == 0 {
         Ok(())
     } else {
         Err(std::io::Error::last_os_error())

--- a/crates/uc-daemon-process/src/process_metadata.rs
+++ b/crates/uc-daemon-process/src/process_metadata.rs
@@ -93,10 +93,27 @@ pub struct DaemonPidMetadata {
     /// conservatively not GUI-owned.
     #[serde(default)]
     pub spawned_by: DaemonSpawnOrigin,
+    /// This daemon's package version (e.g. `"0.15.0-alpha.4"`), used by
+    /// single-instance arbitration ([`should_evict_holder`]) so a newcomer can
+    /// refuse to downgrade a strictly-newer incumbent. `#[serde(default)]` so a
+    /// PID file predating this field deserializes to an empty string, which
+    /// [`should_evict_holder`] ranks BELOW any parseable version — a pre-upgrade
+    /// daemon is therefore always out-ranked by a versioned successor.
+    #[serde(default)]
+    pub package_version: String,
 }
 
+/// This process's package version, baked in at compile time.
+///
+/// The whole workspace shares a single `version` (root `Cargo.toml`; every crate
+/// uses `version.workspace = true`), so this equals the daemon binary's version
+/// reported in the health handshake. A PID file's `package_version` is therefore
+/// a faithful stand-in for "what version is this daemon" without an HTTP probe.
+pub const SELF_PACKAGE_VERSION: &str = env!("CARGO_PKG_VERSION");
+
 impl DaemonPidMetadata {
-    /// 构造一份"现在"的元数据：`pid` + `mode` + `spawned_by` + 当前时间戳。
+    /// 构造一份"现在"的元数据：`pid` + `mode` + `spawned_by` + 当前时间戳 +
+    /// 本进程版本（[`SELF_PACKAGE_VERSION`]）。
     pub fn now(pid: u32, mode: DaemonProcessMode, spawned_by: DaemonSpawnOrigin) -> Self {
         let started_at_ms = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -107,6 +124,7 @@ impl DaemonPidMetadata {
             mode,
             started_at_ms,
             spawned_by,
+            package_version: SELF_PACKAGE_VERSION.to_string(),
         }
     }
 
@@ -123,6 +141,17 @@ impl DaemonPidMetadata {
 /// Leaf filename of the daemon PID file, kept byte-identical to
 /// `AppPaths::daemon_pid_path()` (`<app_data_root>/.daemon-pid`).
 const DAEMON_PID_FILE_NAME: &str = ".daemon-pid";
+
+/// Read the daemon PID metadata for a SPECIFIC profile `data_dir`
+/// (`<data_dir>/.daemon-pid`) rather than the process-wide default root.
+///
+/// Used by single-instance arbitration in `instance_lock`, which already knows
+/// the exact profile directory it is locking and must read the holder's PID
+/// file beside that lock. Same semantics as
+/// [`DaemonPidManager::read_pid_metadata`]: `Ok(None)` if absent/empty/corrupt.
+pub fn read_pid_metadata_in(data_dir: &Path) -> Result<Option<DaemonPidMetadata>> {
+    DaemonPidManager::new(data_dir.join(DAEMON_PID_FILE_NAME)).read_pid_metadata()
+}
 
 /// Provides the process-wide singleton `DaemonPidManager` used by standalone helpers.
 fn default_manager() -> Result<&'static DaemonPidManager> {
@@ -251,6 +280,9 @@ impl DaemonPidManager {
             mode: DaemonProcessMode::Standalone,
             started_at_ms: 0,
             spawned_by: DaemonSpawnOrigin::Unknown,
+            // A bare-u32 PID file predates the version field; empty string ranks
+            // below any parseable version in `should_evict_holder`.
+            package_version: String::new(),
         }))
     }
 
@@ -346,6 +378,66 @@ pub fn verify_pid_identity(metadata: &DaemonPidMetadata) -> PidVerification {
     // treat it as active — the liveness check already passed.
 
     PidVerification::Active
+}
+
+/// Total order over daemon process "identity" for single-instance arbitration.
+///
+/// Returns `true` iff a daemon described by (`self_version`,
+/// `self_started_at_ms`, `self_pid`) strictly out-ranks the current lock
+/// `holder` and should therefore EVICT it.
+///
+/// Ranking is lexicographic, highest wins:
+/// 1. semver `package_version` — an empty/unparseable version ranks BELOW any
+///    parseable one;
+/// 2. `started_at_ms` — later wins;
+/// 3. `pid` — higher wins, a deterministic final tie-break.
+///
+/// ## Why this is a safe single-instance rule, not a mutual-kill
+///
+/// - It is a STRICT TOTAL ORDER (antisymmetric): for any two distinct processes
+///   exactly one out-ranks the other, so `should_evict_holder(A, B)` and
+///   `should_evict_holder(B, A)` are never both `true`.
+/// - Only the contender that FAILED to take the flock ever calls this; the
+///   holder is busy serving and never arbitrates, so there is no simultaneous
+///   bidirectional decision.
+/// - A freshly launched contender always has a later `started_at_ms` than an
+///   incumbent, so **same version ⇒ contender evicts incumbent**. In practice
+///   this only fires against a stuck/orphaned holder: GUI bootstrap REUSES a
+///   healthy same-version daemon (probe → Compatible) instead of spawning a
+///   second one, so a second same-version daemon exists only when the incumbent
+///   is unreachable yet still holds the lock.
+/// - A strictly-newer incumbent always out-ranks the contender, giving free
+///   downgrade protection (mirrors the GUI's `RefusedNewerDaemon`).
+pub fn should_evict_holder(
+    self_version: &str,
+    self_started_at_ms: u64,
+    self_pid: u32,
+    holder: &DaemonPidMetadata,
+) -> bool {
+    use std::cmp::Ordering;
+
+    fn parse(v: &str) -> Option<semver::Version> {
+        semver::Version::parse(v.trim()).ok()
+    }
+
+    // None (empty/unparseable) ranks below any parseable version.
+    fn cmp_version(a: &Option<semver::Version>, b: &Option<semver::Version>) -> Ordering {
+        match (a, b) {
+            (Some(x), Some(y)) => x.cmp(y),
+            (Some(_), None) => Ordering::Greater,
+            (None, Some(_)) => Ordering::Less,
+            (None, None) => Ordering::Equal,
+        }
+    }
+
+    let self_v = parse(self_version);
+    let holder_v = parse(&holder.package_version);
+
+    let ordering = cmp_version(&self_v, &holder_v)
+        .then(self_started_at_ms.cmp(&holder.started_at_ms))
+        .then(self_pid.cmp(&holder.pid));
+
+    ordering == Ordering::Greater
 }
 
 const DAEMON_BINARY_NAME: &str = "uniclipd";
@@ -603,6 +695,105 @@ mod tests {
             !parsed.is_gui_spawned(),
             "legacy daemons must never be treated as GUI-owned"
         );
+    }
+
+    #[test]
+    fn json_without_package_version_defaults_to_empty() {
+        // PID files predating the version field must parse, with the empty
+        // version that `should_evict_holder` ranks as oldest.
+        let legacy = r#"{"pid":7,"mode":"standalone","startedAtMs":123,"spawnedBy":"gui"}"#;
+        let parsed: DaemonPidMetadata = serde_json::from_str(legacy).unwrap();
+        assert_eq!(parsed.package_version, "");
+    }
+
+    fn holder_meta(version: &str, started_at_ms: u64, pid: u32) -> DaemonPidMetadata {
+        DaemonPidMetadata {
+            pid,
+            mode: DaemonProcessMode::Standalone,
+            started_at_ms,
+            spawned_by: DaemonSpawnOrigin::Unknown,
+            package_version: version.to_string(),
+        }
+    }
+
+    #[test]
+    fn evicts_strictly_older_holder() {
+        // The update scenario: a newer daemon evicts a leftover older one.
+        let h = holder_meta("0.15.0-alpha.4", 1_000, 100);
+        assert!(should_evict_holder("0.15.0-alpha.5", 2_000, 200, &h));
+    }
+
+    #[test]
+    fn refuses_to_evict_strictly_newer_holder() {
+        // Downgrade protection: an older daemon never evicts a newer one, even
+        // though it started later.
+        let h = holder_meta("0.15.0-alpha.5", 1_000, 100);
+        assert!(!should_evict_holder("0.15.0-alpha.4", 9_999, 200, &h));
+    }
+
+    #[test]
+    fn same_version_later_started_evicts_incumbent() {
+        // A fresh contender always has a later started_at, so a same-version
+        // stuck/orphaned holder is evicted ("later wins").
+        let h = holder_meta("0.15.0-alpha.4", 1_000, 100);
+        assert!(should_evict_holder("0.15.0-alpha.4", 2_000, 200, &h));
+    }
+
+    #[test]
+    fn same_version_earlier_started_does_not_evict() {
+        // The incumbent out-ranks a contender claiming an earlier start.
+        let h = holder_meta("0.15.0-alpha.4", 2_000, 100);
+        assert!(!should_evict_holder("0.15.0-alpha.4", 1_000, 200, &h));
+    }
+
+    #[test]
+    fn missing_holder_version_ranks_as_oldest() {
+        // A pre-version-field PID file (empty version) is always out-ranked by a
+        // versioned successor, regardless of timestamps.
+        let h = holder_meta("", 9_999, 100);
+        assert!(should_evict_holder("0.15.0-alpha.4", 1, 200, &h));
+    }
+
+    #[test]
+    fn self_missing_version_never_evicts_versioned_holder() {
+        // Defensive: an unparseable own version must not evict a versioned
+        // holder (treat ourselves as oldest).
+        let h = holder_meta("0.15.0-alpha.4", 1, 100);
+        assert!(!should_evict_holder("", 9_999, 200, &h));
+    }
+
+    #[test]
+    fn eviction_order_is_antisymmetric_no_mutual_kill() {
+        // The crux of "same-version also evicts" being safe: for any two
+        // distinct processes exactly one out-ranks the other — never A>B && B>A,
+        // and never a stalemate. A strict total order over (version, started_at,
+        // pid) guarantees both.
+        let cases = [
+            ("0.15.0", 1_000u64, 100u32),
+            ("0.15.0", 2_000, 200),
+            ("0.16.0", 1_000, 50),
+            ("", 5_000, 300),
+            ("0.15.0", 1_000, 101), // same version+time, tie-broken by pid
+        ];
+        for (av, at, ap) in cases {
+            for (bv, bt, bp) in cases {
+                if (av, at, ap) == (bv, bt, bp) {
+                    continue;
+                }
+                let a = holder_meta(av, at, ap);
+                let b = holder_meta(bv, bt, bp);
+                let a_evicts_b = should_evict_holder(av, at, ap, &b);
+                let b_evicts_a = should_evict_holder(bv, bt, bp, &a);
+                assert!(
+                    !(a_evicts_b && b_evicts_a),
+                    "mutual eviction between {av}/{at}/{ap} and {bv}/{bt}/{bp}"
+                );
+                assert!(
+                    a_evicts_b || b_evicts_a,
+                    "no decisive winner between {av}/{at}/{ap} and {bv}/{bt}/{bp}"
+                );
+            }
+        }
     }
 
     #[test]

--- a/crates/uc-daemon-process/src/timing.rs
+++ b/crates/uc-daemon-process/src/timing.rs
@@ -66,6 +66,23 @@ pub const PREDECESSOR_RELEASE_BUDGET: Duration =
 /// costs nothing when the holder behaves.
 pub const LOCK_ACQUIRE_DEADLINE: Duration = double(PREDECESSOR_RELEASE_BUDGET);
 
+/// Replacement-daemon-side: grace for an EVICTED holder to release the instance
+/// lock after `SIGTERM`, before escalating to `SIGKILL` (single-instance
+/// arbitration — `instance_lock::acquire_with_deadline`).
+///
+/// Reuses [`PREDECESSOR_RELEASE_BUDGET`]: a holder evicted while cooperatively
+/// shutting down needs the same worst-case graceful teardown window as one that
+/// exits on its own, so a merely-slow (not stuck) daemon is never `SIGKILL`'d
+/// mid-teardown. A genuinely stuck holder ignores `SIGTERM` and is reclaimed by
+/// the `SIGKILL` escalation after this window.
+pub const EVICT_SIGTERM_GRACE: Duration = PREDECESSOR_RELEASE_BUDGET;
+
+/// Replacement-daemon-side: grace for the kernel to reclaim the flock after a
+/// `SIGKILL`. `SIGKILL` is uncatchable and the advisory lock is released on
+/// process death, so this covers only scheduler/teardown latency, not any
+/// in-daemon shutdown work.
+pub const EVICT_SIGKILL_GRACE: Duration = Duration::from_secs(2);
+
 /// Spawner-side: how long a fresh daemon may take from process spawn to
 /// `/health` answering, EXCLUDING any wait on a predecessor's lock (DB
 /// migrations, secure storage, iroh bind, HTTP bind).

--- a/crates/uc-desktop/src/daemon_probe.rs
+++ b/crates/uc-desktop/src/daemon_probe.rs
@@ -332,6 +332,9 @@ fn terminate_incompatible_daemon_by_port() -> Result<(), DaemonBootstrapError> {
         mode: DaemonProcessMode::Standalone,
         started_at_ms: 0,
         spawned_by: DaemonSpawnOrigin::Unknown,
+        // Unused by `verify_pid_identity` (liveness + exe name only); the real
+        // version is not knowable from a port lookup with no PID file.
+        package_version: String::new(),
     };
 
     if let PidVerification::Stale(reason) = verify_pid_identity(&synthetic) {
@@ -851,6 +854,7 @@ mod tests {
             mode,
             started_at_ms: 0,
             spawned_by: DaemonSpawnOrigin::Unknown,
+            package_version: String::new(),
         }
     }
 
@@ -936,6 +940,7 @@ mod tests {
             mode: DaemonProcessMode::Standalone,
             started_at_ms: 0,
             spawned_by: origin,
+            package_version: String::new(),
         }
     }
 

--- a/crates/uc-desktop/src/daemon_probe.rs
+++ b/crates/uc-desktop/src/daemon_probe.rs
@@ -541,60 +541,68 @@ pub async fn restart_local_daemon(
             )
         })?;
 
-    // ── 1. 读 PID 文件，校验身份 ──────────────────────────────────
-    let metadata = read_pid_metadata()
-        .map_err(|e| DaemonBootstrapError::Probe(e.context("failed to read daemon PID metadata")))?
-        .ok_or_else(|| {
-            DaemonBootstrapError::Probe(anyhow::anyhow!(
-                "daemon PID file not found — daemon may not be running"
-            ))
-        })?;
+    // ── 1. 读 PID 文件（可能不存在）──────────────────────────────
+    // Retry-from-bootstrap-failure may run with NO daemon at all (the spawn
+    // never succeeded, or the daemon crashed and cleared its PID file). A
+    // missing PID file is therefore NOT an error here — there is simply nothing
+    // to stop, so we skip straight to spawning a fresh daemon ("restart"
+    // degrades to "start"). The network-settings caller always has a running
+    // daemon, so it keeps the stop→spawn path.
+    let metadata = read_pid_metadata().map_err(|e| {
+        DaemonBootstrapError::Probe(e.context("failed to read daemon PID metadata"))
+    })?;
 
-    if matches!(metadata.mode, DaemonProcessMode::InProcess) {
-        return Err(DaemonBootstrapError::IncompatibleDaemon {
-            details: format!(
-                "cannot restart in-process daemon (pid {}); quit the hosting GUI first",
-                metadata.pid
-            ),
-        });
-    }
-
-    let need_terminate = matches!(verify_pid_identity(&metadata), PidVerification::Active);
-
-    if need_terminate {
-        // ── 2. SIGTERM 旧 daemon ──────────────────────────────────
-        tracing::info!(pid = metadata.pid, "restart_local_daemon: sending SIGTERM");
-        if let Err(e) = terminate_local_daemon_pid(metadata.pid) {
-            tracing::warn!(pid = metadata.pid, error = %e, "SIGTERM failed, proceeding to spawn");
+    if let Some(metadata) = &metadata {
+        if matches!(metadata.mode, DaemonProcessMode::InProcess) {
+            return Err(DaemonBootstrapError::IncompatibleDaemon {
+                details: format!(
+                    "cannot restart in-process daemon (pid {}); quit the hosting GUI first",
+                    metadata.pid
+                ),
+            });
         }
 
-        // ── 3. 等待旧 daemon 进程真正退出 ────────────────────────
-        // HTTP 端点消失 ≠ 进程退出。daemon graceful shutdown 先停
-        // HTTP server，再关 iroh/释放 instance lock。必须等进程死
-        // 透，否则新 daemon 拿不到锁或端口。
-        let exit_timeout = Duration::from_secs(10);
-        let deadline = tokio::time::Instant::now() + exit_timeout;
-        loop {
-            if !uc_daemon_process::process_metadata::is_pid_alive(metadata.pid) {
-                tracing::info!(
-                    pid = metadata.pid,
-                    "restart_local_daemon: old daemon process exited"
-                );
-                break;
+        if matches!(verify_pid_identity(metadata), PidVerification::Active) {
+            // ── 2. SIGTERM 旧 daemon ──────────────────────────────
+            tracing::info!(pid = metadata.pid, "restart_local_daemon: sending SIGTERM");
+            if let Err(e) = terminate_local_daemon_pid(metadata.pid) {
+                tracing::warn!(pid = metadata.pid, error = %e, "SIGTERM failed, proceeding to spawn");
             }
-            if tokio::time::Instant::now() >= deadline {
-                tracing::warn!(
-                    pid = metadata.pid,
-                    "restart_local_daemon: old daemon did not exit within timeout; spawning anyway"
-                );
-                break;
+
+            // ── 3. 等待旧 daemon 进程真正退出 ────────────────────
+            // HTTP 端点消失 ≠ 进程退出。daemon graceful shutdown 先停
+            // HTTP server，再关 iroh/释放 instance lock。必须等进程死
+            // 透，否则新 daemon 拿不到锁或端口。若它卡死没在超时内退出，
+            // 新 daemon 的 instance-lock eviction 会把它 SIGKILL 驱逐。
+            let exit_timeout = Duration::from_secs(10);
+            let deadline = tokio::time::Instant::now() + exit_timeout;
+            loop {
+                if !uc_daemon_process::process_metadata::is_pid_alive(metadata.pid) {
+                    tracing::info!(
+                        pid = metadata.pid,
+                        "restart_local_daemon: old daemon process exited"
+                    );
+                    break;
+                }
+                if tokio::time::Instant::now() >= deadline {
+                    tracing::warn!(
+                        pid = metadata.pid,
+                        "restart_local_daemon: old daemon did not exit within timeout; \
+                         spawning anyway (new daemon will evict it via the instance lock)"
+                    );
+                    break;
+                }
+                tokio::time::sleep(HEALTH_POLL_INTERVAL).await;
             }
-            tokio::time::sleep(HEALTH_POLL_INTERVAL).await;
+        } else {
+            tracing::info!(
+                pid = metadata.pid,
+                "restart_local_daemon: PID is stale, spawning fresh daemon"
+            );
         }
     } else {
         tracing::info!(
-            pid = metadata.pid,
-            "restart_local_daemon: PID is stale, spawning fresh daemon"
+            "restart_local_daemon: no PID file — nothing to stop, spawning fresh daemon"
         );
     }
 

--- a/crates/uc-desktop/src/daemon_probe.rs
+++ b/crates/uc-desktop/src/daemon_probe.rs
@@ -553,16 +553,22 @@ pub async fn restart_local_daemon(
     })?;
 
     if let Some(metadata) = &metadata {
-        if matches!(metadata.mode, DaemonProcessMode::InProcess) {
-            return Err(DaemonBootstrapError::IncompatibleDaemon {
-                details: format!(
-                    "cannot restart in-process daemon (pid {}); quit the hosting GUI first",
-                    metadata.pid
-                ),
-            });
-        }
-
         if matches!(verify_pid_identity(metadata), PidVerification::Active) {
+            // A LIVE in-process daemon is a legacy GUI shell hosting the daemon
+            // inside its own process — SIGTERM would tear that GUI down, so
+            // refuse. Gate this on the PID being actually Active: stale
+            // InProcess metadata left behind by a since-exited legacy GUI must
+            // NOT block a fresh spawn, otherwise restart strands on "quit the
+            // hosting GUI first" when there is no GUI left to quit.
+            if matches!(metadata.mode, DaemonProcessMode::InProcess) {
+                return Err(DaemonBootstrapError::IncompatibleDaemon {
+                    details: format!(
+                        "cannot restart in-process daemon (pid {}); quit the hosting GUI first",
+                        metadata.pid
+                    ),
+                });
+            }
+
             // ── 2. SIGTERM 旧 daemon ──────────────────────────────
             tracing::info!(pid = metadata.pid, "restart_local_daemon: sending SIGTERM");
             if let Err(e) = terminate_local_daemon_pid(metadata.pid) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -211,16 +211,21 @@ const AppContent = ({
 
   const resolvedEncryptionStatus = encryptionStatus ?? encryptionData ?? null
 
-  // Retry without restarting the app: re-run the WS bootstrap (idempotent —
-  // resolves immediately if already connected), force a fresh session token,
-  // then re-pull the encryption status. This recovers the common #995 case
-  // where only the session token had gone stale.
+  // Retry RESTARTS the daemon, then reconnects. A plain WS reconnect can never
+  // recover from a daemon that is wedged or left over from a previous version
+  // (the post-update "had to kill uniclipd by hand" case): restart_daemon stops
+  // THIS profile's pid-file daemon, waits for it to exit, and spawns a fresh one
+  // — whose instance-lock eviction reclaims the lock from any stuck holder. A
+  // missing pid file is fine (nothing to stop → just start). We then re-run the
+  // WS bootstrap, force a fresh session token, and re-pull encryption status.
   const handleBootstrapRetry = useCallback(() => {
     bootstrapRetryingRef.current = true
     setLoadingTimedOut(false)
     setBootEncryptionError(null)
     setBootstrapFailure(null)
-    connectDaemonWs()
+    commands
+      .restartDaemon()
+      .then(() => connectDaemonWs())
       .then(() => {
         setDaemonBootstrapReady(true)
         return daemonClient.refreshSession()


### PR DESCRIPTION
## Summary

After an update (or a plain stop/start), users had to manually kill leftover `uniclipd` processes before the app would open. The updater SIGTERMs the old daemon but does **not** wait for it to exit on Unix, so the freshly spawned daemon found the predecessor still holding `.uniclipd.lock`, waited out `LOCK_ACQUIRE_DEADLINE`, exited `AlreadyRunning`, and the GUI hung.

- **Single-instance acquire-or-evict** (00ea6ea, 7d6cb44, 5be6df9): on lock contention the new daemon reads the holder's PID metadata and, if it strictly out-ranks it — newer version, or same version started later (the stuck/orphan case) — evicts it via SIGTERM → grace → SIGKILL, reclaiming the flock the instant the holder dies. A strict total order over `(version, started_at, pid)` guarantees no mutual eviction; an equal-or-newer holder is left untouched (downgrade protection). Requires a new `package_version` field in PID metadata, a SIGKILL primitive, and named grace budgets in the timing chain.
- **Retry restarts the daemon** (d9376a7): the bootstrap-failure "Retry" button only re-ran the WS reconnect, which can't recover from a wedged/leftover daemon. It now invokes `restart_daemon` (stop this profile's pid-file daemon, wait for exit, spawn fresh — the new daemon evicts any stuck holder), then reconnects. `restart_local_daemon` now treats a missing PID file as "spawn fresh" instead of erroring. Per-profile; the version-mismatch path still shows "Open updater" so Retry never downgrades a newer daemon.

This also makes the updater's "SIGTERM without wait" race self-healing: the new, higher-version daemon evicts the lingering old one.

## Test plan

- [x] `cargo check` across uc-daemon-process / uc-daemon-local / uc-desktop / uc-cli / uc-daemon
- [x] `cargo test`: uc-daemon-process (47, incl. arbitration antisymmetry / no-mutual-kill), uc-daemon-local `instance_lock` (8), uc-desktop `daemon_probe` (14), uc-cli `stop` (5)
- [x] frontend `tsc --noEmit` clean; `eslint src/App.tsx` no new errors
- [ ] Real device: reproduce the post-update hang (leftover stuck `uniclipd` holding the lock) and confirm the new daemon evicts it and the GUI opens with no manual kill
- [ ] Real device: click "Retry" on the "Couldn't reach the background service" screen and confirm it restarts the daemon and reconnects

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add a public way to forcefully terminate a local daemon process.

* **Bug Fixes**
  * Restart flow now restarts the daemon before reconnecting to improve bootstrap reliability.
  * Missing PID metadata during restart is no longer treated as a hard error.

* **Refactor**
  * Improved single-instance arbitration and lock/eviction behavior to make daemon handover and startup more robust.

* **Documentation**
  * Auto-generated timestamp updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->