### PR TITLE
feat(tooling): local update test harness for the self-update flow

### DIFF
--- a/docs/development/local-update-loop.md
+++ b/docs/development/local-update-loop.md
@@ -1,0 +1,99 @@
+# 本地自更新测试 (local update loop)
+
+这个工具让你在自己的电脑上完整跑一遍 **"检测到新版本 → 下载 → 安装 → 重启"** 的自更新流程，**不需要真的发布两个版本** 到线上更新渠道。
+
+## 为什么需要它
+
+桌面端的自更新链路（`src-tauri/crates/uc-tauri/src/commands/updater.rs`）只有在 updater 真正被触发时才会执行：下载新构件、校验签名、替换 app、重启。像 #1063 那个"更新重启后 daemon 实例锁竞态导致卡死"的修复，**只有走一遍真实的更新重启** 才能验证。
+
+以前要验证它，必须先往真实更新渠道发两个版本（旧 + 新）。这个工具把成本降到：**本地构建两次 + 一个 localhost 静态服务**。
+
+## 它怎么工作
+
+两个只在 **debug 构建** 里存在的环境变量（release 构建会被 `#[cfg(debug_assertions)]` 整段编译掉，线上二进制没有这条路径，无法被劫持）：
+
+- `UC_UPDATE_ENDPOINT`：把 updater 指向一个 localhost 的清单（manifest）地址，而不是线上发布服务器。
+- `UC_UPDATE_PUBKEY`：用一把一次性的开发签名公钥来校验，而不是内置的线上公钥。
+
+注意：**签名校验始终是开启的**，只是换成了一把开发用的临时密钥。所以这条路径和线上完全一致——真实地下载、校验、安装、重启。
+
+对应的后端实现见 `do_check_for_update` 与 `apply_dev_updater_override`（`commands/updater.rs`）。
+
+## 前置条件
+
+- macOS（当前只支持 macOS；Windows/Linux 的构件格式与安装路径不同）。
+- 仓库能正常构建桌面端：`bun install` 已跑过，Rust 工具链可用。
+- 脚本会自动把 `uniclipd` daemon 作为 sidecar 暂存（已存在则跳过，`--rebuild-sidecar` 可强制重建）。
+
+## 一次性准备：生成开发密钥
+
+```bash
+node scripts/dev-update-loop.mjs keygen
+```
+
+会在 `~/.uniclip-dev-updater/` 下生成一把一次性 minisign 密钥（私钥默认无密码）。这把钥匙只用于本地测试，**不要** 用线上密钥，也不会被提交进仓库。
+
+## 完整流程
+
+下面四步按顺序执行。`serve` 和 `run` 是常驻进程，请各开一个终端窗口。
+
+```bash
+# 1. 构建"旧"版 app（当前提交里的版本号），暂存到 target/dev-update/run/
+node scripts/dev-update-loop.mjs build-base
+
+# 2. 构建"新"版更新构件 + 清单（版本号自动 +1），暂存到 target/dev-update/serve/
+node scripts/dev-update-loop.mjs build-update
+```
+
+> `build-update` 阶段 tauri 会打印一条警告：签名私钥与 `tauri.conf.json` 里内置的（线上）公钥不匹配。**这是预期的**——我们正是用开发密钥签名、再在运行时用 `UC_UPDATE_PUBKEY` 换成开发公钥来校验。忽略它即可。
+
+```bash
+# 3. 终端 A：把清单和构件挂到 http://localhost:8723/
+node scripts/dev-update-loop.mjs serve
+
+# 4. 终端 B：带 override 启动"旧"版 app
+node scripts/dev-update-loop.mjs run
+```
+
+app 启动后，在界面里触发一次"检查更新"（设置页 / 关于页 / 托盘菜单均可）。然后观察它：发现新版本 → 下载 → 校验 → 安装 → 重启。重启后新 daemon 会接管，旧 daemon 被驱逐——这正是 #1063 要验证的行为。
+
+`run` 用的数据目录通过 `UC_PROFILE=updtest` 隔离（数据落在 `app.uniclipboard.desktop-updtest`），不会动到你日常使用的安装实例。`app.restart()` 会带着同样的环境变量重新拉起进程，所以 override 在重启后依然有效。
+
+## 验证 #1063（更新重启不卡死）
+
+在 `run` 终端里关注这些日志信号：
+
+- `pre-update: daemon stop complete` —— 安装前旧 daemon 已停止。
+- `update installed, restarting app` —— 安装完成，准备重启。
+
+`app.restart()` 之后，新进程会脱离当前终端，**终端不再有日志输出**。重启后的行为改看日志文件：
+
+```text
+~/Library/Application Support/app.uniclipboard.desktop-updtest/logs/
+```
+
+在那里确认：新 daemon 正常起来（出现实例锁驱逐相关日志），主窗口能正常进入，而不是卡在 loading。如果主窗口卡死、或必须手动 kill `uniclipd` 才能恢复，说明竞态仍在。
+
+## 重复测试
+
+不必每次都重新构建"旧"版。已有"旧"版后，只要再跑一次 `build-update`，版本号会在上次基础上继续 +1（状态记在 `target/dev-update/state.json`），然后重启 `serve` 即可再触发一轮。也可以用 `--update-version` 显式指定：
+
+```bash
+node scripts/dev-update-loop.mjs build-update --update-version 0.15.0-alpha.9
+```
+
+想从头开始（把"旧"版重置回当前提交版本），重新跑 `build-base`。
+
+## 常用选项与排错
+
+- `node scripts/dev-update-loop.mjs info` —— 打印解析出的路径、版本、override 环境变量。
+- `--port <n>` —— 自定义端口；`build-update`（写进清单 URL）、`serve`、`run` 三者必须一致。
+- 端口提醒：移动同步固定端口 `42720` 不随 profile 变化，测试时别同时开着日常实例的 daemon，否则会冲突。
+- 构建产物在 `target/debug/bundle/macos/`；构件清理只需删 `target/dev-update/`（在 `target/` 下，已被 git 忽略）。
+- 自定义路径/口令的环境变量：`UC_DEV_UPDATER_KEY_DIR`、`UC_DEV_UPDATER_KEY_PASSWORD`、`UC_DEV_UPDATER_PROFILE`、`UC_DEV_UPDATER_PORT`。
+- `install from cached bytes failed error=Cross-device link (os error 18)`：macOS 更新器把新 app 解压到 `$TMPDIR` 后用 `rename` 覆盖旧 app，跨卷 `rename` 会报 `EXDEV`。当仓库（以及 run 的 app）在非启动卷（如外置 SSD）、而 `$TMPDIR` 默认在启动卷时就会触发。`run` 已自动把 `$TMPDIR` 指到 `target/dev-update/tmp`（与 run app 同卷）规避；正式环境里 app 在 `/Applications`、与 `$TMPDIR` 同在启动卷，不会有这个问题。
+  - 顺带提醒：这也意味着 **真实用户若把 app 装在非启动卷上，自更新同样会失败**（tauri-plugin-updater 用 `rename` 而非带 copy 兜底的移动）。属上游已知限制，与本工具无关。
+
+## 与线上发布的关系
+
+本地清单的格式与线上完全一致，对齐 `scripts/assemble-update-manifest.js` 生成的结构（`version` / `notes` / `pub_date` / `platforms`）。`signature` 字段是 `.sig` 文件的原始内容（本身已是 base64）。这样本地验证的就是线上同一套格式，避免"本地能过、线上挂"。

--- a/scripts/dev-update-loop.mjs
+++ b/scripts/dev-update-loop.mjs
@@ -1,0 +1,449 @@
+#!/usr/bin/env node
+// Local updater test harness — exercise the full update -> restart flow on the
+// dev machine without publishing two real releases.
+//
+// Why this exists: bugs in the self-update path (e.g. the post-update daemon
+// instance-lock eviction in #1063) can only be verified by actually driving the
+// updater: download a "newer" artifact, verify its signature, install it, and
+// restart. Normally that needs two published releases on a real update channel.
+// This harness reduces it to two *local* debug builds plus a localhost server.
+//
+// How it works:
+//   - A throwaway minisign keypair signs the local artifact (`keygen`). The
+//     running app verifies against it via the debug-only `UC_UPDATE_PUBKEY`
+//     override; signature verification stays ON, so this drives the real path.
+//   - The running app is redirected to a localhost manifest via the debug-only
+//     `UC_UPDATE_ENDPOINT` override (see `do_check_for_update` /
+//     `apply_dev_updater_override` in `commands/updater.rs`). Both overrides are
+//     compiled out of release builds, so they cannot ship.
+//
+// Typical loop (each command in the order below; `serve` and `run` are
+// long-running, so keep them in separate terminals):
+//   node scripts/dev-update-loop.mjs keygen          # one-time
+//   node scripts/dev-update-loop.mjs build-base      # build + stage the "old" app
+//   node scripts/dev-update-loop.mjs build-update    # build the "newer" artifact + manifest
+//   node scripts/dev-update-loop.mjs serve           # terminal A: serve manifest + artifact
+//   node scripts/dev-update-loop.mjs run             # terminal B: launch the old app w/ overrides
+// Then trigger an update check in the app and watch it download -> install ->
+// restart, with the new daemon evicting the old one.
+//
+// macOS only for now (the dev machine is darwin); the artifact format and
+// install path differ on Windows/Linux. See docs/development/local-update-loop.md.
+
+import { spawnSync } from 'node:child_process'
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs'
+import { createServer } from 'node:http'
+import { homedir } from 'node:os'
+import { basename, dirname, extname, join, resolve } from 'node:path'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const srcTauri = join(repoRoot, 'src-tauri')
+const tauriConf = join(srcTauri, 'tauri.conf.json')
+
+// All generated state lives under the gitignored target dir.
+const workDir = join(repoRoot, 'target', 'dev-update')
+const runDir = join(workDir, 'run') // holds the running ("old") .app bundle
+const serveDir = join(workDir, 'serve') // holds the manifest + update artifact
+const stateFile = join(workDir, 'state.json')
+
+// Keys live outside target/ so `cargo clean` does not wipe them.
+const keyDir = process.env.UC_DEV_UPDATER_KEY_DIR || join(homedir(), '.uniclip-dev-updater')
+const privKeyFile = join(keyDir, 'dev.key')
+const pubKeyFile = join(keyDir, 'dev.key.pub')
+const passwordFile = join(keyDir, 'password.txt')
+
+// Isolated identity so the test build never touches the real install's data.
+const IDENTIFIER = 'app.uniclipboard.desktop.dev'
+const PRODUCT_NAME = 'UniClipboard Dev'
+const RUN_PROFILE = process.env.UC_DEV_UPDATER_PROFILE || 'updtest'
+const MANIFEST_NAME = 'update.json'
+const DEFAULT_PORT = Number(process.env.UC_DEV_UPDATER_PORT || 8723)
+
+// Native debug bundle output (no --target → not under a triple subdir).
+const bundleMacosDir = join(repoRoot, 'target', 'debug', 'bundle', 'macos')
+
+function die(msg) {
+  process.stderr.write(`error: ${msg}\n`)
+  process.exit(1)
+}
+
+function log(msg) {
+  process.stderr.write(`${msg}\n`)
+}
+
+function ensureDarwin() {
+  if (process.platform !== 'darwin') {
+    die(`this harness currently supports macOS only (got ${process.platform})`)
+  }
+}
+
+function readJson(path, fallback) {
+  try {
+    return JSON.parse(readFileSync(path, 'utf8'))
+  } catch {
+    return fallback
+  }
+}
+
+function readState() {
+  return readJson(stateFile, {})
+}
+
+function writeState(next) {
+  mkdirSync(workDir, { recursive: true })
+  writeFileSync(stateFile, JSON.stringify(next, null, 2) + '\n', 'utf8')
+}
+
+function currentVersion() {
+  const conf = readJson(tauriConf, null)
+  if (!conf?.version) die(`could not read version from ${tauriConf}`)
+  return conf.version
+}
+
+// Strictly-increasing bump. Increments a numeric prerelease suffix
+// (`-alpha.4` → `-alpha.5`) when present, otherwise bumps the patch.
+function bumpVersion(version) {
+  const pre = version.match(/^(.*-(?:alpha|beta|rc)\.)(\d+)$/)
+  if (pre) return `${pre[1]}${Number(pre[2]) + 1}`
+  const core = version.match(/^(\d+)\.(\d+)\.(\d+)/)
+  if (!core) die(`cannot bump unrecognized version: ${version}`)
+  return `${core[1]}.${core[2]}.${Number(core[3]) + 1}`
+}
+
+function run(cmd, args, opts = {}) {
+  log(`$ ${cmd} ${args.join(' ')}`)
+  const res = spawnSync(cmd, args, { stdio: 'inherit', cwd: repoRoot, ...opts })
+  if (res.status !== 0) {
+    die(`${cmd} exited with ${res.status ?? res.signal}`)
+  }
+}
+
+function parseFlags(argv) {
+  const flags = {}
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]
+    if (a.startsWith('--')) {
+      const eq = a.indexOf('=')
+      if (eq !== -1) {
+        flags[a.slice(2, eq)] = a.slice(eq + 1)
+      } else if (argv[i + 1] && !argv[i + 1].startsWith('--')) {
+        flags[a.slice(2)] = argv[++i]
+      } else {
+        flags[a.slice(2)] = true
+      }
+    }
+  }
+  return flags
+}
+
+// Stage the `uniclipd` daemon sidecar (debug) unless already present.
+function ensureSidecar(flags) {
+  const triple = spawnSync('rustc', ['--print', 'host-tuple'], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  }).stdout?.trim()
+  const staged = triple && existsSync(join(srcTauri, 'binaries', `uniclipd-${triple}`))
+  if (staged && !flags['rebuild-sidecar']) {
+    log(`sidecar already staged for ${triple} (pass --rebuild-sidecar to force)`)
+    return
+  }
+  run('node', [join(repoRoot, 'scripts', 'prepare-daemon-sidecar.mjs'), '--debug'])
+}
+
+// Write a minimal `-c` override config merged onto tauri.conf.json: isolated
+// identity + the requested version. Returns the temp config path.
+function writeOverrideConfig(version) {
+  mkdirSync(workDir, { recursive: true })
+  const path = join(workDir, 'tauri.override.conf.json')
+  const override = {
+    productName: PRODUCT_NAME,
+    identifier: IDENTIFIER,
+    version,
+  }
+  writeFileSync(path, JSON.stringify(override, null, 2) + '\n', 'utf8')
+  return path
+}
+
+function signingEnv() {
+  if (!existsSync(privKeyFile)) {
+    die(
+      `dev signing key not found at ${privKeyFile} — run: node scripts/dev-update-loop.mjs keygen`
+    )
+  }
+  return {
+    ...process.env,
+    TAURI_SIGNING_PRIVATE_KEY: readFileSync(privKeyFile, 'utf8').trim(),
+    TAURI_SIGNING_PRIVATE_KEY_PASSWORD: existsSync(passwordFile)
+      ? readFileSync(passwordFile, 'utf8')
+      : '',
+  }
+}
+
+function tauriBuild(version, env) {
+  const overrideConf = writeOverrideConfig(version)
+  // `bun x tauri` forwards all args verbatim to the local tauri CLI.
+  // --bundles app keeps it to the .app + updater artifact (skips the slow dmg).
+  run('bun', ['x', 'tauri', 'build', '--debug', '--bundles', 'app', '-c', overrideConf], { env })
+}
+
+function findNewest(dir, predicate) {
+  if (!existsSync(dir)) return null
+  const matches = readdirSync(dir)
+    .filter(predicate)
+    .map(name => ({ name, mtime: statSync(join(dir, name)).mtimeMs }))
+    .sort((a, b) => b.mtime - a.mtime)
+  return matches[0] ? join(dir, matches[0].name) : null
+}
+
+// ── commands ────────────────────────────────────────────────────────────────
+
+function cmdKeygen(flags) {
+  if (existsSync(privKeyFile) && !flags.force) {
+    log(`dev key already exists at ${privKeyFile} (pass --force to regenerate)`)
+    return
+  }
+  mkdirSync(keyDir, { recursive: true })
+  const password = process.env.UC_DEV_UPDATER_KEY_PASSWORD ?? ''
+  writeFileSync(passwordFile, password, 'utf8')
+  run('bun', ['x', 'tauri', 'signer', 'generate', '-w', privKeyFile, '-p', password, '-f', '--ci'])
+  log(`\ndev keypair written to ${keyDir}`)
+  log(`public key (for reference): ${pubKeyFile}`)
+}
+
+function cmdBuildBase(flags) {
+  ensureDarwin()
+  ensureSidecar(flags)
+  const version = currentVersion()
+  log(`building base ("old") app at version ${version}`)
+  tauriBuild(version, signingEnv())
+
+  const appBundle = findNewest(bundleMacosDir, n => n.endsWith('.app'))
+  if (!appBundle) die(`no .app bundle found in ${bundleMacosDir}`)
+
+  rmSync(runDir, { recursive: true, force: true })
+  mkdirSync(runDir, { recursive: true })
+  const dest = join(runDir, basename(appBundle))
+  cpSync(appBundle, dest, { recursive: true })
+
+  // Reset the version cursor so the next build-update bumps from the base.
+  writeState({ ...readState(), runningVersion: version, lastUpdateVersion: version })
+  log(`\nbase app staged at: ${dest}`)
+  log(`next: build-update, then serve + run`)
+}
+
+function cmdBuildUpdate(flags) {
+  ensureDarwin()
+  ensureSidecar(flags)
+  const state = readState()
+  const base = state.lastUpdateVersion || currentVersion()
+  const version = flags['update-version'] || bumpVersion(base)
+  log(`building update ("new") artifact at version ${version}`)
+  tauriBuild(version, signingEnv())
+
+  const artifact = findNewest(bundleMacosDir, n => n.endsWith('.app.tar.gz'))
+  if (!artifact) {
+    die(
+      `no .app.tar.gz updater artifact found in ${bundleMacosDir} (is createUpdaterArtifacts on?)`
+    )
+  }
+  const sig = `${artifact}.sig`
+  if (!existsSync(sig)) die(`missing signature next to artifact: ${sig}`)
+
+  // Clean, space-free filename for the served URL (bytes unchanged → sig valid).
+  const arch = process.arch === 'arm64' ? 'aarch64' : 'x86_64'
+  const artifactName = `UniClipboardDev_${version}_${arch}.app.tar.gz`
+
+  rmSync(serveDir, { recursive: true, force: true })
+  mkdirSync(serveDir, { recursive: true })
+  cpSync(artifact, join(serveDir, artifactName))
+
+  const port = Number(flags.port || DEFAULT_PORT)
+  // Manifest shape mirrors scripts/assemble-update-manifest.js (the canonical
+  // release manifest). `signature` is the raw .sig content (already base64).
+  const manifest = {
+    version,
+    notes: 'Local dev update test build.',
+    pub_date: new Date().toISOString().replace(/\.\d{3}Z$/, 'Z'),
+    platforms: {
+      [`darwin-${arch}`]: {
+        signature: readFileSync(sig, 'utf8').trim(),
+        url: `http://localhost:${port}/${artifactName}`,
+      },
+    },
+  }
+  writeFileSync(join(serveDir, MANIFEST_NAME), JSON.stringify(manifest, null, 2) + '\n', 'utf8')
+
+  writeState({ ...state, lastUpdateVersion: version })
+  log(`\nupdate artifact + manifest staged in: ${serveDir}`)
+  log(`manifest version ${version} → served at http://localhost:${port}/${MANIFEST_NAME}`)
+  log(`next: serve (terminal A) + run (terminal B)`)
+}
+
+function cmdServe(flags) {
+  if (!existsSync(join(serveDir, MANIFEST_NAME))) {
+    die(`no manifest in ${serveDir} — run build-update first`)
+  }
+  const port = Number(flags.port || DEFAULT_PORT)
+  const server = createServer((req, res) => {
+    const name =
+      decodeURIComponent((req.url || '/').split('?')[0].replace(/^\//, '')) || MANIFEST_NAME
+    const filePath = join(serveDir, name)
+    // Refuse path traversal; only serve files that live directly in serveDir.
+    if (dirname(filePath) !== serveDir || !existsSync(filePath)) {
+      res.writeHead(404)
+      res.end('not found')
+      log(`404 ${req.method} ${req.url}`)
+      return
+    }
+    const isJson = extname(filePath) === '.json'
+    res.writeHead(200, {
+      'content-type': isJson ? 'application/json' : 'application/octet-stream',
+      'content-length': statSync(filePath).size,
+    })
+    res.end(readFileSync(filePath))
+    log(`200 ${req.method} ${req.url}`)
+  })
+  server.listen(port, '127.0.0.1', () => {
+    log(`serving ${serveDir} at http://localhost:${port}/`)
+    log(`manifest: http://localhost:${port}/${MANIFEST_NAME}`)
+    log(`(Ctrl+C to stop)`)
+  })
+}
+
+function pubkeyOverride() {
+  if (!existsSync(pubKeyFile)) die(`public key not found at ${pubKeyFile} — run keygen`)
+  // The .pub file content is ALREADY the base64 blob the plugin expects: it
+  // base64-decodes config.pubkey once (verify_signature in
+  // tauri-plugin-updater) to recover the minisign "untrusted comment…" text.
+  // This is the exact same string format as tauri.conf.json's pubkey, so pass
+  // the file content verbatim — do NOT re-encode it.
+  return readFileSync(pubKeyFile, 'utf8').trim()
+}
+
+function runEnv(port) {
+  return {
+    UC_UPDATE_ENDPOINT: `http://localhost:${port}/${MANIFEST_NAME}`,
+    UC_UPDATE_PUBKEY: pubkeyOverride(),
+    UC_PROFILE: RUN_PROFILE,
+  }
+}
+
+function cmdRun(flags) {
+  ensureDarwin()
+  const appBundle = findNewest(runDir, n => n.endsWith('.app'))
+  if (!appBundle) die(`no base app in ${runDir} — run build-base first`)
+  const macosDir = join(appBundle, 'Contents', 'MacOS')
+  // Contents/MacOS holds BOTH the GUI binary and the bundled `uniclipd`
+  // sidecar, so pick the GUI binary via the bundle's CFBundleExecutable
+  // rather than guessing by directory order (`defaults` reads XML + binary
+  // plists). Fall back to the only non-sidecar binary if that lookup fails.
+  const fromPlist = spawnSync(
+    'defaults',
+    ['read', join(appBundle, 'Contents', 'Info'), 'CFBundleExecutable'],
+    { encoding: 'utf8' }
+  ).stdout?.trim()
+  const exeName =
+    fromPlist || readdirSync(macosDir).find(n => !n.startsWith('.') && n !== 'uniclipd')
+  if (!exeName) die(`could not resolve the GUI binary in ${macosDir}`)
+  const exe = join(macosDir, exeName)
+  const port = Number(flags.port || DEFAULT_PORT)
+  // The macOS updater extracts into a tempfile dir (env::temp_dir → $TMPDIR)
+  // and `rename`s it over the app bundle. rename across volumes fails with
+  // EXDEV, which happens when the repo (hence the run app) lives on a
+  // non-boot volume while $TMPDIR defaults to /var/folders on the boot
+  // volume. Co-locate $TMPDIR with the run app so the rename stays
+  // intra-volume — mirroring production, where /Applications and $TMPDIR
+  // share the boot volume.
+  const tmpDir = join(workDir, 'tmp')
+  mkdirSync(tmpDir, { recursive: true })
+  const env = { ...process.env, ...runEnv(port), TMPDIR: tmpDir }
+  log(`launching ${exe}`)
+  log(`  UC_UPDATE_ENDPOINT=${env.UC_UPDATE_ENDPOINT}`)
+  log(`  UC_PROFILE=${env.UC_PROFILE}`)
+  log(`  TMPDIR=${env.TMPDIR}`)
+  // Launch the inner binary (not `open`) so override env vars apply and logs
+  // stream to this terminal. app.restart() after install re-execs this binary
+  // with the same env, so the override survives the restart.
+  run(exe, [], { env })
+}
+
+function cmdInfo() {
+  const state = readState()
+  const port = DEFAULT_PORT
+  log(`repo:            ${repoRoot}`)
+  log(`current version: ${currentVersion()}`)
+  log(`last update ver: ${state.lastUpdateVersion || '(none)'}`)
+  log(
+    `key dir:         ${keyDir} (${existsSync(privKeyFile) ? 'present' : 'MISSING — run keygen'})`
+  )
+  log(`run dir:         ${runDir}`)
+  log(`serve dir:       ${serveDir}`)
+  log(`profile:         ${RUN_PROFILE}`)
+  log(`default port:    ${port}`)
+  if (existsSync(pubKeyFile)) {
+    log(`\nrun-time overrides:`)
+    log(`  UC_UPDATE_ENDPOINT=http://localhost:${port}/${MANIFEST_NAME}`)
+    log(`  UC_UPDATE_PUBKEY=${pubkeyOverride().slice(0, 24)}…`)
+  }
+}
+
+function cmdHelp() {
+  process.stdout.write(`Local updater test harness (macOS)
+
+Usage: node scripts/dev-update-loop.mjs <command> [options]
+
+Commands:
+  keygen          Generate the throwaway dev minisign keypair (one-time).
+                    --force                regenerate even if it exists
+  build-base      Build the "old" .app at the committed version, stage it to run.
+  build-update    Build the "new" updater artifact + manifest at a bumped version.
+                    --update-version <v>   explicit version (default: auto-bump)
+                    --port <n>             port baked into the manifest URL
+  serve           Serve the manifest + artifact over http://localhost:<port>.
+                    --port <n>             default ${DEFAULT_PORT}
+  run             Launch the staged "old" app with the dev updater overrides.
+                    --port <n>             must match the serve port
+  info            Print resolved paths, versions, and the override env vars.
+
+Shared options:
+  --rebuild-sidecar   force-rebuild the uniclipd daemon sidecar before a build
+
+Env overrides:
+  UC_DEV_UPDATER_KEY_DIR        key location (default ~/.uniclip-dev-updater)
+  UC_DEV_UPDATER_KEY_PASSWORD   key password (default empty)
+  UC_DEV_UPDATER_PROFILE        UC_PROFILE for the run (default ${RUN_PROFILE})
+  UC_DEV_UPDATER_PORT           default port (default ${DEFAULT_PORT})
+
+See docs/development/local-update-loop.md for the full runbook.
+`)
+}
+
+const commands = {
+  keygen: cmdKeygen,
+  'build-base': cmdBuildBase,
+  'build-update': cmdBuildUpdate,
+  serve: cmdServe,
+  run: cmdRun,
+  info: cmdInfo,
+  help: cmdHelp,
+}
+
+const [command, ...rest] = process.argv.slice(2)
+const handler = commands[command]
+if (!handler) {
+  if (command) process.stderr.write(`unknown command: ${command}\n\n`)
+  cmdHelp()
+  process.exit(command ? 1 : 0)
+}
+handler(parseFlags(rest))

--- a/src-tauri/crates/uc-tauri/src/commands/updater.rs
+++ b/src-tauri/crates/uc-tauri/src/commands/updater.rs
@@ -203,6 +203,61 @@ fn parse_channel(s: &str) -> UpdateChannel {
     }
 }
 
+/// Build the production updater endpoint list for a channel.
+///
+/// The primary host is the CDN-fronted release server; the GitHub Pages
+/// mirror is the fallback the plugin tries if the primary fails.
+fn default_updater_endpoints(channel_str: &str) -> Result<Vec<url::Url>, String> {
+    let primary: url::Url = format!("https://release.uniclipboard.app/{channel_str}.json")
+        .parse()
+        .map_err(|e| format!("Invalid primary updater URL: {e}"))?;
+    let fallback: url::Url =
+        format!("https://uniclipboard.github.io/UniClipboard/{channel_str}.json")
+            .parse()
+            .map_err(|e| format!("Invalid fallback updater URL: {e}"))?;
+    Ok(vec![primary, fallback])
+}
+
+/// Debug-only: let the local update test harness redirect the updater to a
+/// localhost manifest and verify against a throwaway dev key.
+///
+/// When `UC_UPDATE_ENDPOINT` is set, the updater points at that single
+/// manifest URL instead of the production release servers; when
+/// `UC_UPDATE_PUBKEY` is also set, signatures are verified against that
+/// minisign public key instead of the embedded production key. This drives
+/// the real download -> verify -> install -> restart path against a local
+/// server without publishing two releases — see
+/// `docs/development/local-update-loop.md`.
+///
+/// Compiled out of release builds entirely (`#[cfg(debug_assertions)]`), so
+/// shipped binaries have no env-var path to be steered at an
+/// attacker-controlled endpoint or key.
+#[cfg(debug_assertions)]
+fn apply_dev_updater_override(
+    builder: tauri_plugin_updater::UpdaterBuilder,
+    channel_str: &str,
+) -> Result<tauri_plugin_updater::UpdaterBuilder, String> {
+    let Some(endpoint) = std::env::var_os("UC_UPDATE_ENDPOINT") else {
+        return builder
+            .endpoints(default_updater_endpoints(channel_str)?)
+            .map_err(|e| e.to_string());
+    };
+    let endpoint = endpoint.to_string_lossy().into_owned();
+    let url: url::Url = endpoint
+        .parse()
+        .map_err(|e| format!("invalid UC_UPDATE_ENDPOINT {endpoint:?}: {e}"))?;
+    warn!(
+        target: "updater",
+        endpoint = %url,
+        "local-dev updater override active (UC_UPDATE_ENDPOINT)"
+    );
+    let mut builder = builder.endpoints(vec![url]).map_err(|e| e.to_string())?;
+    if let Some(pubkey) = std::env::var_os("UC_UPDATE_PUBKEY") {
+        builder = builder.pubkey(pubkey.to_string_lossy().into_owned());
+    }
+    Ok(builder)
+}
+
 /// Check for an available update on the specified (or auto-detected) channel.
 ///
 /// Crate-internal entry shared by the `check_for_update` Tauri command and
@@ -239,22 +294,16 @@ pub(crate) async fn do_check_for_update(
 
     info!(channel = %channel_str, "checking for update");
 
-    let primary_url: url::Url = format!("https://release.uniclipboard.app/{}.json", channel_str)
-        .parse()
-        .map_err(|e| format!("Invalid primary updater URL: {}", e))?;
-    let fallback_url: url::Url = format!(
-        "https://uniclipboard.github.io/UniClipboard/{}.json",
-        channel_str
-    )
-    .parse()
-    .map_err(|e| format!("Invalid fallback updater URL: {}", e))?;
-
-    let updater = app
-        .updater_builder()
-        .endpoints(vec![primary_url, fallback_url])
-        .map_err(|e| e.to_string())?
-        .build()
-        .map_err(|e| e.to_string())?;
+    let updater = {
+        let builder = app.updater_builder();
+        #[cfg(debug_assertions)]
+        let builder = apply_dev_updater_override(builder, channel_str)?;
+        #[cfg(not(debug_assertions))]
+        let builder = builder
+            .endpoints(default_updater_endpoints(channel_str)?)
+            .map_err(|e| e.to_string())?;
+        builder.build().map_err(|e| e.to_string())?
+    };
 
     let update = updater.check().await.map_err(|e| e.to_string())?;
 
@@ -1262,6 +1311,22 @@ mod tests {
         assert!(matches!(parse_channel("stable"), UpdateChannel::Stable));
         assert!(matches!(parse_channel("unknown"), UpdateChannel::Stable));
         assert!(matches!(parse_channel(""), UpdateChannel::Stable));
+    }
+
+    #[test]
+    fn default_updater_endpoints_match_release_hosts() {
+        // Locks the production endpoint format preserved across the refactor
+        // that introduced the debug-only `UC_UPDATE_ENDPOINT` override.
+        let eps = default_updater_endpoints("alpha").unwrap();
+        assert_eq!(eps.len(), 2);
+        assert_eq!(
+            eps[0].as_str(),
+            "https://release.uniclipboard.app/alpha.json"
+        );
+        assert_eq!(
+            eps[1].as_str(),
+            "https://uniclipboard.github.io/UniClipboard/alpha.json"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Add a way to exercise the desktop self-update flow (update → download → verify → install → restart) on a dev machine **without publishing two real releases** — the only practical way to E2E-verify update-restart fixes like the daemon instance-lock eviction (#1063).

- **Debug-only runtime updater override** (9e0a60cfd): `do_check_for_update` now honors `UC_UPDATE_ENDPOINT` / `UC_UPDATE_PUBKEY` under `#[cfg(debug_assertions)]`, redirecting the updater to a localhost manifest and verifying against a throwaway dev key. Compiled out of release builds entirely, so shipped binaries cannot be steered at an attacker-controlled endpoint/key. Production endpoint construction is factored into `default_updater_endpoints`, with a test locking its format.
- **Harness script** (0d3f009da): `scripts/dev-update-loop.mjs` — generates a throwaway minisign keypair, builds an "old" and a bumped "new" debug bundle (signed with the dev key), assembles a release-format manifest (mirrors `scripts/assemble-update-manifest.js`) pointing at localhost, serves it, and launches the old app with the overrides. macOS only for now.
- **Runbook** (67c84fd4c): `docs/development/local-update-loop.md`.

Signature verification stays ON throughout (just keyed to the dev key), so this drives the same download → verify → install path as production.

### Incidental finding (not fixed here)
The macOS install path in tauri-plugin-updater (`install_inner`) uses `std::fs::rename` with no cross-volume copy fallback, so updates fail with `EXDEV` when the app lives on a non-boot volume (it surfaced because this repo is on an external SSD). The harness works around it for testing by co-locating `$TMPDIR`, but it implies **real users who install to a non-boot volume cannot self-update**. Worth a follow-up (upstream limitation).

## Test plan

- [x] `cargo check -p uc-tauri` + updater unit tests (11/11, incl. new endpoint-format lock)
- [x] rustfmt / eslint / prettier clean on changed files
- [x] Manual end-to-end on macOS (arm64): keygen → build-base → build-update → serve → run → check-for-update → download → verify → install → restart; confirmed the new daemon evicts the old one and the main window is not stuck (i.e. #1063 holds)
- [ ] Windows support — planned follow-up (NSIS install path differs; the override itself is already cross-platform)
- [ ] Reviewer: confirm the override is absent from a release build (gated by `#[cfg(debug_assertions)]`)

🤖 AI-assisted (Claude Code).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added development documentation for local update testing workflows.

* **Chores**
  * Enhanced development tooling and infrastructure to support testing the complete update verification cycle locally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->