### PR TITLE
fix(ui): scroll overflowing dialog body with pinned header and footer

### DIFF
--- a/src/components/device/DeviceSettingsDialog.tsx
+++ b/src/components/device/DeviceSettingsDialog.tsx
@@ -45,6 +45,7 @@ import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
+  DialogBody,
   DialogContent,
   DialogFooter,
   DialogHeader,
@@ -192,7 +193,7 @@ const DeviceSettingsDialog: React.FC<DeviceSettingsDialogProps> = ({
           </div>
         </DialogHeader>
 
-        <div className="space-y-5">
+        <DialogBody className="space-y-5">
           {/* ── 连接信息 ──────────────────────────────────────── */}
           <DialogSection
             title={t('devices.settings.sections.connection', { defaultValue: '连接信息' })}
@@ -288,7 +289,7 @@ const DeviceSettingsDialog: React.FC<DeviceSettingsDialogProps> = ({
               </>
             )}
           </DialogSection>
-        </div>
+        </DialogBody>
 
         <DialogFooter className="!flex-row !justify-between">
           <Button variant="destructive" size="sm" onClick={() => onUnpair(deviceId)}>

--- a/src/components/device/MobileSyncSettingsDialog.tsx
+++ b/src/components/device/MobileSyncSettingsDialog.tsx
@@ -68,6 +68,7 @@ import {
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
+  DialogBody,
   DialogContent,
   DialogDescription,
   DialogFooter,
@@ -294,7 +295,7 @@ const MobileSyncSettingsDialog: React.FC<Props> = ({ open, onOpenChange, onSetti
             </div>
           </DialogHeader>
 
-          <div className="space-y-5">
+          <DialogBody className="space-y-5">
             {(settings?.lanListenerError || settingsError) && (
               <div className="space-y-2">
                 {settings?.lanListenerError && (
@@ -413,7 +414,7 @@ const MobileSyncSettingsDialog: React.FC<Props> = ({ open, onOpenChange, onSetti
                 unavailableLabel={t('devices.mobileSync.lanListener.currentUrl.unavailable')}
               />
             </DialogSection>
-          </div>
+          </DialogBody>
 
           <DialogFooter className="!flex-row !items-center !justify-between">
             <div

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -53,7 +53,7 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          'fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-background p-4 text-sm ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95',
+          'fixed top-1/2 left-1/2 z-50 flex max-h-[calc(100%-2rem)] w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 flex-col gap-4 overflow-y-auto rounded-xl bg-background p-4 text-sm ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95',
           className
         )}
         {...props}
@@ -74,7 +74,27 @@ function DialogContent({
 
 function DialogHeader({ className, ...props }: React.ComponentProps<'div'>) {
   return (
-    <div data-slot="dialog-header" className={cn('flex flex-col gap-2', className)} {...props} />
+    <div
+      data-slot="dialog-header"
+      className={cn('flex shrink-0 flex-col gap-2', className)}
+      {...props}
+    />
+  )
+}
+
+/**
+ * Scrollable body slot. Place between DialogHeader and DialogFooter so the
+ * header/footer stay pinned (shrink-0) while only this region scrolls when the
+ * dialog hits its max height. The `-mx-4 px-4` cancels the content padding so
+ * the scrollbar sits flush with the dialog edge while text keeps its inset.
+ */
+function DialogBody({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="dialog-body"
+      className={cn('-mx-4 min-h-0 flex-1 overflow-y-auto px-4', className)}
+      {...props}
+    />
   )
 }
 
@@ -90,7 +110,7 @@ function DialogFooter({
     <div
       data-slot="dialog-footer"
       className={cn(
-        '-mx-4 -mb-4 flex flex-col-reverse gap-2 rounded-b-xl border-t bg-muted/50 p-4 sm:flex-row sm:justify-end',
+        '-mx-4 -mb-4 flex shrink-0 flex-col-reverse gap-2 rounded-b-xl border-t bg-muted/50 p-4 sm:flex-row sm:justify-end',
         className
       )}
       {...props}
@@ -133,6 +153,7 @@ function DialogDescription({
 
 export {
   Dialog,
+  DialogBody,
   DialogClose,
   DialogContent,
   DialogDescription,


### PR DESCRIPTION
## Summary

- `DialogContent` was vertically centered (`top-1/2 -translate-y-1/2`) with **no max-height**, so tall content bled past the top/bottom of the viewport and was unreachable (no scroll). Most visible in the device-settings and mobile-sync-settings modals. (1ebae8578)
- Reworked the shared primitive `src/components/ui/dialog.tsx`: `DialogContent` is now a flex column capped at `max-h-[calc(100%-2rem)]`; `DialogHeader`/`DialogFooter` get `shrink-0` so they stay pinned; new `DialogBody` slot (`flex-1 min-h-0 overflow-y-auto`, with `-mx-4 px-4` so the scrollbar sits flush) scrolls on its own. (1ebae8578)
- `DialogContent` keeps `overflow-y-auto` as a fallback, so dialogs that don't opt into `DialogBody` degrade to whole-content scroll instead of clipping. (1ebae8578)
- Adopted `DialogBody` in `DeviceSettingsDialog` and `MobileSyncSettingsDialog`, the two known-tall modals. Side benefit: the corner `×` no longer scrolls away, since `DialogContent` itself no longer scrolls when `DialogBody` is used. (1ebae8578)

No `docs-site` changes: the modals are documented by their controls, not their scroll behavior, and no control/setting/flag/error string changed.

## Test plan

- [x] `tsc --noEmit` clean (0 errors)
- [x] `eslint` clean on the 3 changed files
- [x] `vitest run` green for `MobileSyncSettingsDialog` + `EnableMobileSyncDialog` (13 tests)
- [ ] Manual: open Device Settings / Mobile Sync Settings in a short window, confirm header + footer stay pinned while only the body scrolls, in both light and dark themes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved dialog component layout with enhanced scrolling support for long content.
  * Dialog headers and footers now remain fixed while body content scrolls independently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->