### PR TITLE
Refactor clipboard realtime event reducer

### DIFF
--- a/src/hooks/__tests__/clipboardEventReducer.test.ts
+++ b/src/hooks/__tests__/clipboardEventReducer.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  createInitialClipboardEventReducerState,
+  flushClipboardLocal,
+  flushClipboardRemote,
+  reduceClipboardRealtimeEvent,
+  type ClipboardEventReducerAction,
+  type ClipboardEventReducerResult,
+  type ClipboardEventReducerState,
+  type ClipboardRealtimeEvent,
+} from '../clipboardEventReducer'
+
+function actionTypes(actions: ClipboardEventReducerAction[]): string[] {
+  return actions.map(action => action.type)
+}
+
+describe('clipboardEventReducer', () => {
+  it('turns incoming pending events into placeholder and transfer-status actions', () => {
+    const now = vi.fn(() => 1234)
+    const state = createInitialClipboardEventReducerState()
+
+    const result = reduce(
+      state,
+      {
+        topic: 'clipboard',
+        eventType: 'clipboard.incoming_pending',
+        payload: {
+          entryId: 'entry-1',
+          fromDevice: 'peer-1',
+          totalBytes: 2048,
+          filenames: ['report.pdf'],
+        },
+      },
+      now()
+    )
+
+    expect(actionTypes(result.actions)).toEqual([
+      'clipboard/addPendingEntry',
+      'fileTransfer/setEntryTransferStatus',
+    ])
+    expect(result.actions[0]).toMatchObject({
+      payload: {
+        entryId: 'entry-1',
+        fromDevice: 'peer-1',
+        totalBytes: 2048,
+        filenames: ['report.pdf'],
+        createdAt: 1234,
+      },
+    })
+    expect(result.actions[1]).toMatchObject({
+      payload: {
+        entryId: 'entry-1',
+        status: 'transferring',
+        reason: null,
+      },
+    })
+    expect(result.effects).toEqual([])
+  })
+
+  it('routes local new content through remove-pending, cancel-write, and immediate local fetch', () => {
+    const state = createInitialClipboardEventReducerState()
+
+    const result = reduce(state, newContent('entry-1', 'local'), 1000)
+
+    expect(actionTypes(result.actions)).toEqual([
+      'clipboard/removePendingEntry',
+      'fileTransfer/cancelClipboardWrite',
+    ])
+    expect(result.effects).toEqual([{ type: 'flushLocalEntries', entryIds: ['entry-1'] }])
+  })
+
+  it('coalesces rapid local new-content events into one trailing fetch effect', () => {
+    let state = createInitialClipboardEventReducerState()
+
+    let result = reduce(state, newContent('e1', 'local'), 1000)
+    state = result.state
+    expect(result.effects).toEqual([{ type: 'flushLocalEntries', entryIds: ['e1'] }])
+
+    result = reduce(state, newContent('e2', 'local'), 1050)
+    state = result.state
+    expect(result.effects).toEqual([{ type: 'scheduleLocalFlush', delayMs: 250 }])
+
+    result = reduce(state, newContent('e3', 'local'), 1100)
+    state = result.state
+    expect(result.effects).toEqual([])
+    expect(state.pendingLocalEntryIds).toEqual(['e2', 'e3'])
+
+    expect(flushClipboardLocal(state, { nowMs: 1300 })).toMatchObject({
+      actions: [],
+      effects: [{ type: 'flushLocalEntries', entryIds: ['e2', 'e3'] }],
+    })
+  })
+
+  it('throttles remote invalidation with a trailing effect', () => {
+    let state = createInitialClipboardEventReducerState()
+
+    let result = reduce(state, newContent('remote-1', 'remote'), 1000)
+    state = result.state
+    expect(result.effects).toEqual([{ type: 'invalidateRemote' }])
+
+    result = reduce(state, newContent('remote-2', 'remote'), 1100)
+    state = result.state
+    expect(result.effects).toEqual([{ type: 'scheduleRemoteInvalidate', delayMs: 200 }])
+
+    result = reduce(state, newContent('remote-3', 'remote'), 1150)
+    state = result.state
+    expect(result.effects).toEqual([])
+    expect(state.remoteInvalidateScheduled).toBe(true)
+
+    expect(flushClipboardRemote(state, { nowMs: 1300 })).toMatchObject({
+      actions: [],
+      effects: [{ type: 'invalidateRemote' }],
+    })
+  })
+
+  it('turns file-transfer status and progress events into store actions', () => {
+    const state = createInitialClipboardEventReducerState()
+
+    expect(
+      reduce(
+        state,
+        {
+          topic: 'file-transfer',
+          eventType: 'file-transfer.status_changed',
+          ts: 42,
+          payload: {
+            transferId: 'tx-1',
+            entryId: 'entry-1',
+            status: 'cancelled',
+            reason: 'cancelled:remote_peer',
+          },
+        },
+        1000
+      ).actions
+    ).toMatchObject([
+      {
+        type: 'fileTransfer/linkTransferToEntry',
+        payload: { transferId: 'tx-1', entryId: 'entry-1' },
+      },
+      {
+        type: 'fileTransfer/setEntryTransferStatus',
+        payload: { entryId: 'entry-1', status: 'cancelled', reason: 'cancelled:remote_peer' },
+      },
+      { type: 'clipboard/removePendingEntry', payload: 'entry-1' },
+      {
+        type: 'fileTransfer/markTransferCancelled',
+        payload: { transferId: 'tx-1', reason: 'remote_peer' },
+      },
+    ])
+
+    expect(
+      reduce(
+        state,
+        {
+          topic: 'file-transfer',
+          eventType: 'file-transfer.progress',
+          ts: 99,
+          payload: {
+            transferId: 'tx-1',
+            entryId: 'entry-1',
+            peerId: 'peer-1',
+            direction: 'Receiving',
+            bytesTransferred: 512,
+            totalBytes: 1024,
+          },
+        },
+        1000
+      ).actions
+    ).toMatchObject([
+      {
+        type: 'fileTransfer/updateTransferProgress',
+        payload: {
+          transferId: 'tx-1',
+          entryId: 'entry-1',
+          peerId: 'peer-1',
+          direction: 'Receiving',
+          bytesTransferred: 512,
+          totalBytes: 1024,
+          eventTs: 99,
+        },
+      },
+      {
+        type: 'fileTransfer/linkTransferToEntry',
+        payload: { transferId: 'tx-1', entryId: 'entry-1' },
+      },
+    ])
+  })
+})
+
+function reduce(
+  state: ClipboardEventReducerState,
+  event: ClipboardRealtimeEvent,
+  nowMs: number
+): ClipboardEventReducerResult {
+  return reduceClipboardRealtimeEvent(event, state, { nowMs, throttleMs: 300 })
+}
+
+function newContent(entryId: string, origin: 'local' | 'remote'): ClipboardRealtimeEvent {
+  return {
+    topic: 'clipboard',
+    eventType: 'clipboard.new_content',
+    payload: { entryId, preview: entryId, origin },
+  }
+}

--- a/src/hooks/__tests__/useTransferProgress.test.tsx
+++ b/src/hooks/__tests__/useTransferProgress.test.tsx
@@ -61,7 +61,7 @@ describe('useTransferProgress', () => {
     vi.useRealTimers()
   })
 
-  it('subscribes to file-transfer and clipboard topics on mount', async () => {
+  it('subscribes to file-transfer topic on mount', async () => {
     const { daemonWs } = await import('@/lib/daemon-ws')
     const { Wrapper } = createWrapper()
     renderHook(() => useTransferProgress(), { wrapper: Wrapper })
@@ -70,10 +70,7 @@ describe('useTransferProgress', () => {
       expect(capturedHandler).not.toBeNull()
     })
 
-    expect(daemonWs.subscribe).toHaveBeenCalledWith(
-      ['file-transfer', 'clipboard'],
-      expect.any(Function)
-    )
+    expect(daemonWs.subscribe).toHaveBeenCalledWith(['file-transfer'], expect.any(Function))
   })
 
   describe('durable transfer status', () => {
@@ -200,26 +197,8 @@ describe('useTransferProgress', () => {
     })
   })
 
-  describe('clipboard write cancellation', () => {
-    it('cancels clipboard write on clipboard.new_content event', async () => {
-      const { Wrapper } = createWrapper()
-      renderHook(() => useTransferProgress(), { wrapper: Wrapper })
-
-      await waitFor(() => {
-        expect(capturedHandler).not.toBeNull()
-      })
-
-      // Should not throw on clipboard.new_content
-      act(() => {
-        emitWsEvent('clipboard.new_content', {
-          entryId: 'entry-new',
-          preview: 'new content',
-          origin: 'remote',
-        })
-      })
-    })
-
-    it('ignores non-new-content clipboard events without error', async () => {
+  describe('unhandled events', () => {
+    it('ignores unrelated events without error', async () => {
       const { Wrapper, store } = createWrapper()
       renderHook(() => useTransferProgress(), { wrapper: Wrapper })
 
@@ -228,9 +207,7 @@ describe('useTransferProgress', () => {
       })
 
       act(() => {
-        emitWsEvent('clipboard.deleted', {
-          entryId: 'entry-del',
-        })
+        emitWsEvent('file-transfer.unknown', { transferId: 'tx-unknown' })
       })
 
       expect(store.getState().fileTransfer).toBeDefined()

--- a/src/hooks/clipboardEventReducer.ts
+++ b/src/hooks/clipboardEventReducer.ts
@@ -1,0 +1,349 @@
+import type { UnknownAction } from '@reduxjs/toolkit'
+import {
+  addPendingEntry,
+  removePendingEntry,
+  type PendingClipboardEntry,
+} from '@/store/slices/clipboardSlice'
+import {
+  cancelClipboardWrite,
+  linkTransferToEntry,
+  markTransferCancelled,
+  markTransferCompleted,
+  markTransferFailed,
+  normalizeCancelReason,
+  setEntryTransferStatus,
+  updateTransferProgress,
+} from '@/store/slices/fileTransferSlice'
+
+export interface ClipboardRealtimeEvent {
+  topic: string
+  eventType: string
+  payload: unknown
+  ts?: number
+}
+
+export type ClipboardEventReducerAction = UnknownAction
+
+export type ClipboardEventReducerEffect =
+  | { type: 'flushLocalEntries'; entryIds: string[] }
+  | { type: 'scheduleLocalFlush'; delayMs: number }
+  | { type: 'invalidateRemote' }
+  | { type: 'scheduleRemoteInvalidate'; delayMs: number }
+
+export interface ClipboardEventReducerResult {
+  actions: ClipboardEventReducerAction[]
+  effects: ClipboardEventReducerEffect[]
+  state: ClipboardEventReducerState
+}
+
+export interface ClipboardEventReducerOptions {
+  now: () => number
+  throttleMs: number
+}
+
+export interface ClipboardEventReducerState {
+  lastLocalFetchMs: number | undefined
+  localFlushScheduled: boolean
+  pendingLocalEntryIds: string[]
+  lastRemoteInvalidateMs: number | undefined
+  remoteInvalidateScheduled: boolean
+}
+
+export interface ClipboardEventReducerInput {
+  nowMs: number
+  throttleMs: number
+}
+
+interface ClipboardNewContentPayload {
+  entryId: string
+  preview: string
+  origin: string
+}
+
+interface ClipboardIncomingPendingPayload {
+  entryId: string
+  fromDevice: string
+  totalBytes?: number | null
+  filenames?: string[]
+}
+
+interface FileTransferStatusEvent {
+  transferId: string
+  entryId: string
+  status: string
+  reason?: string | null
+}
+
+interface FileTransferProgressEvent {
+  transferId: string
+  entryId?: string | null
+  peerId: string
+  direction: 'Sending' | 'Receiving'
+  bytesTransferred: number
+  totalBytes?: number | null
+}
+
+const VALID_TRANSFER_STATUSES = [
+  'pending',
+  'transferring',
+  'completed',
+  'failed',
+  'cancelled',
+] as const
+
+type ValidTransferStatus = (typeof VALID_TRANSFER_STATUSES)[number]
+
+export function createInitialClipboardEventReducerState(): ClipboardEventReducerState {
+  return {
+    lastLocalFetchMs: undefined,
+    localFlushScheduled: false,
+    pendingLocalEntryIds: [],
+    lastRemoteInvalidateMs: undefined,
+    remoteInvalidateScheduled: false,
+  }
+}
+
+function result(
+  state: ClipboardEventReducerState,
+  actions: ClipboardEventReducerAction[] = [],
+  effects: ClipboardEventReducerEffect[] = []
+): ClipboardEventReducerResult {
+  return { actions, effects, state }
+}
+
+function isValidTransferStatus(status: string): status is ValidTransferStatus {
+  return VALID_TRANSFER_STATUSES.includes(status as ValidTransferStatus)
+}
+
+export function createClipboardEventReducer({ now, throttleMs }: ClipboardEventReducerOptions) {
+  let state = createInitialClipboardEventReducerState()
+
+  function reduce(event: ClipboardRealtimeEvent): ClipboardEventReducerResult {
+    const reduction = reduceClipboardRealtimeEvent(event, state, { nowMs: now(), throttleMs })
+    state = reduction.state
+    return reduction
+  }
+
+  function flushLocal(): ClipboardEventReducerResult {
+    const reduction = flushClipboardLocal(state, { nowMs: now() })
+    state = reduction.state
+    return reduction
+  }
+
+  function flushRemote(): ClipboardEventReducerResult {
+    const reduction = flushClipboardRemote(state, { nowMs: now() })
+    state = reduction.state
+    return reduction
+  }
+
+  return {
+    reduce,
+    flushLocal,
+    flushRemote,
+  }
+}
+
+export function reduceClipboardRealtimeEvent(
+  event: ClipboardRealtimeEvent,
+  state: ClipboardEventReducerState,
+  input: ClipboardEventReducerInput
+): ClipboardEventReducerResult {
+  if (event.eventType === 'clipboard.incoming_pending') {
+    const payload = event.payload as ClipboardIncomingPendingPayload
+    const pending: PendingClipboardEntry = {
+      entryId: payload.entryId,
+      fromDevice: payload.fromDevice,
+      totalBytes: payload.totalBytes ?? null,
+      filenames: payload.filenames ?? [],
+      createdAt: input.nowMs,
+    }
+    return result(state, [
+      addPendingEntry(pending),
+      setEntryTransferStatus({
+        entryId: payload.entryId,
+        status: 'transferring',
+        reason: null,
+      }),
+    ])
+  }
+
+  if (event.eventType === 'clipboard.new_content') {
+    const payload = event.payload as ClipboardNewContentPayload
+    const actions = [removePendingEntry(payload.entryId), cancelClipboardWrite()]
+    if (payload.origin === 'local') {
+      const local = reduceLocalNewContent(payload.entryId, state, input)
+      return result(local.state, actions, local.effects)
+    }
+    const remote = reduceRemoteNewContent(state, input)
+    return result(remote.state, actions, remote.effects)
+  }
+
+  if (event.eventType === 'file-transfer.status_changed') {
+    return result(state, reduceTransferStatus(event.payload as FileTransferStatusEvent))
+  }
+
+  if (event.eventType === 'file-transfer.progress') {
+    return result(
+      state,
+      reduceTransferProgress(event.payload as FileTransferProgressEvent, event.ts)
+    )
+  }
+
+  return result(state)
+}
+
+export function flushClipboardLocal(
+  state: ClipboardEventReducerState,
+  input: Pick<ClipboardEventReducerInput, 'nowMs'>
+): ClipboardEventReducerResult {
+  const nextState = {
+    ...state,
+    localFlushScheduled: false,
+    lastLocalFetchMs: state.pendingLocalEntryIds.length > 0 ? input.nowMs : state.lastLocalFetchMs,
+    pendingLocalEntryIds: [],
+  }
+  const effects =
+    state.pendingLocalEntryIds.length > 0
+      ? [{ type: 'flushLocalEntries' as const, entryIds: state.pendingLocalEntryIds }]
+      : []
+  return result(nextState, [], effects)
+}
+
+export function flushClipboardRemote(
+  state: ClipboardEventReducerState,
+  input: Pick<ClipboardEventReducerInput, 'nowMs'>
+): ClipboardEventReducerResult {
+  return result(
+    {
+      ...state,
+      remoteInvalidateScheduled: false,
+      lastRemoteInvalidateMs: input.nowMs,
+    },
+    [],
+    [{ type: 'invalidateRemote' }]
+  )
+}
+
+function reduceLocalNewContent(
+  entryId: string,
+  state: ClipboardEventReducerState,
+  input: ClipboardEventReducerInput
+): Pick<ClipboardEventReducerResult, 'state' | 'effects'> {
+  const pendingLocalEntryIds = state.pendingLocalEntryIds.includes(entryId)
+    ? state.pendingLocalEntryIds
+    : [...state.pendingLocalEntryIds, entryId]
+  const sinceLast =
+    state.lastLocalFetchMs === undefined
+      ? Number.POSITIVE_INFINITY
+      : input.nowMs - state.lastLocalFetchMs
+
+  if (sinceLast >= input.throttleMs) {
+    const flushResult = flushClipboardLocal(
+      { ...state, localFlushScheduled: false, pendingLocalEntryIds },
+      { nowMs: input.nowMs }
+    )
+    return { state: flushResult.state, effects: flushResult.effects }
+  }
+
+  if (!state.localFlushScheduled) {
+    return {
+      state: { ...state, localFlushScheduled: true, pendingLocalEntryIds },
+      effects: [{ type: 'scheduleLocalFlush', delayMs: input.throttleMs - sinceLast }],
+    }
+  }
+
+  return {
+    state: { ...state, pendingLocalEntryIds },
+    effects: [],
+  }
+}
+
+function reduceRemoteNewContent(
+  state: ClipboardEventReducerState,
+  input: ClipboardEventReducerInput
+): Pick<ClipboardEventReducerResult, 'state' | 'effects'> {
+  const sinceLast =
+    state.lastRemoteInvalidateMs === undefined
+      ? Number.POSITIVE_INFINITY
+      : input.nowMs - state.lastRemoteInvalidateMs
+
+  if (sinceLast >= input.throttleMs) {
+    return {
+      state: {
+        ...state,
+        remoteInvalidateScheduled: false,
+        lastRemoteInvalidateMs: input.nowMs,
+      },
+      effects: [{ type: 'invalidateRemote' }],
+    }
+  }
+
+  if (!state.remoteInvalidateScheduled) {
+    return {
+      state: { ...state, remoteInvalidateScheduled: true },
+      effects: [{ type: 'scheduleRemoteInvalidate', delayMs: input.throttleMs - sinceLast }],
+    }
+  }
+
+  return { state, effects: [] }
+}
+
+function reduceTransferStatus(payload: FileTransferStatusEvent): ClipboardEventReducerAction[] {
+  const actions: ClipboardEventReducerAction[] = [
+    linkTransferToEntry({ transferId: payload.transferId, entryId: payload.entryId }),
+  ]
+
+  if (isValidTransferStatus(payload.status)) {
+    actions.push(
+      setEntryTransferStatus({
+        entryId: payload.entryId,
+        status: payload.status,
+        reason: payload.reason ?? null,
+      })
+    )
+  }
+
+  if (payload.status === 'failed') {
+    actions.push(
+      markTransferFailed({
+        transferId: payload.transferId,
+        error: payload.reason ?? undefined,
+      })
+    )
+  } else if (payload.status === 'cancelled') {
+    actions.push(
+      removePendingEntry(payload.entryId),
+      markTransferCancelled({
+        transferId: payload.transferId,
+        reason: normalizeCancelReason(payload.reason),
+      })
+    )
+  } else if (payload.status === 'completed') {
+    actions.push(markTransferCompleted({ transferId: payload.transferId }))
+  }
+
+  return actions
+}
+
+function reduceTransferProgress(
+  payload: FileTransferProgressEvent,
+  eventTs: number | undefined
+): ClipboardEventReducerAction[] {
+  const actions: ClipboardEventReducerAction[] = [
+    updateTransferProgress({
+      transferId: payload.transferId,
+      entryId: payload.entryId ?? null,
+      peerId: payload.peerId,
+      direction: payload.direction,
+      bytesTransferred: payload.bytesTransferred,
+      totalBytes: payload.totalBytes ?? null,
+      eventTs,
+    }),
+  ]
+
+  if (payload.entryId) {
+    actions.push(linkTransferToEntry({ transferId: payload.transferId, entryId: payload.entryId }))
+  }
+
+  return actions
+}

--- a/src/hooks/useClipboardEventStream.ts
+++ b/src/hooks/useClipboardEventStream.ts
@@ -5,12 +5,8 @@ import { projectClipboardEntry } from '@/lib/clipboard-transform'
 import { daemonWs } from '@/lib/daemon-ws'
 import { createLogger } from '@/lib/logger'
 import { useAppDispatch } from '@/store/hooks'
-import {
-  addPendingEntry,
-  removePendingEntry,
-  type PendingClipboardEntry,
-} from '@/store/slices/clipboardSlice'
-import { setEntryTransferStatus } from '@/store/slices/fileTransferSlice'
+import { createClipboardEventReducer } from './clipboardEventReducer'
+import type { ClipboardEventReducerEffect, ClipboardRealtimeEvent } from './clipboardEventReducer'
 
 const log = createLogger('use-clipboard-event-stream')
 
@@ -22,32 +18,6 @@ export interface UseClipboardEventStreamOptions {
   onDeleted: (id: string) => void
 }
 
-/**
- * Payload for `clipboard.new_content` daemon WS events.
- * (Matches the Rust `ClipboardNewContentEvent` serde shape.)
- */
-interface ClipboardNewContentPayload {
-  entryId: string
-  preview: string
-  origin: string // "local" | "remote"
-}
-
-/**
- * Payload for `clipboard.incoming_pending` daemon WS events.
- *
- * Daemon emits this right after V3 envelope decode (before blob fetch),
- * carrying the receiver-side entry_id that the eventual `new_content`
- * event will reuse. The frontend uses this to render a placeholder card
- * with a live transfer progress bar before the real entry persists.
- */
-interface ClipboardIncomingPendingPayload {
-  entryId: string
-  fromDevice: string
-  totalBytes?: number | null
-  /** Filenames the daemon already knows (from V3 envelope). May be empty. */
-  filenames?: string[]
-}
-
 export function useClipboardEventStream({
   enabled = true,
   throttleMs = 300,
@@ -56,7 +26,6 @@ export function useClipboardEventStream({
   onDeleted,
 }: UseClipboardEventStreamOptions): void {
   const dispatch = useAppDispatch()
-  const lastReloadTimestampRef = useRef<number | undefined>(undefined)
   const onLocalItemRef = useRef(onLocalItem)
   const onRemoteInvalidateRef = useRef(onRemoteInvalidate)
   const onDeletedRef = useRef(onDeleted)
@@ -74,26 +43,11 @@ export function useClipboardEventStream({
     }
     log.info('subscribing to clipboard topic')
 
-    // throttle 用的 trailing-edge timeout —— 用 effect-local 变量持有，
-    // cleanup 直接闭包捕获最新值；这样 react-doctor 不会再误报
-    // "timeoutRef.current 会在 cleanup 跑时变化"，因为根本不是 ref。
-    // 后果上等价：每次 effect 重订阅都会建一个新 timeoutId 槽位，旧的
-    // 在前一个 cleanup 里已经清掉。
-    let pendingTimeoutId: number | null = null
-
-    // 本地 new_content 合并:快速连续复制时,每条事件原本各拉一次完整列表
-    // (getClipboardEntries(50,0)) —— 那是 daemon 限流的主要放大源。这里把窗口
-    // 内的多次拉取压成一次:窗口内累积的 entryId 进 set,trailing 一拍用同一次
-    // 列表请求一并取回(前 50 条已覆盖这段时间全部新增 entry),再逐个回调
-    // onLocalItem,不丢任何一条。
+    let remoteInvalidateTimer: number | null = null
     let localFlushTimer: number | null = null
-    let lastLocalFetch: number | undefined = undefined
-    const pendingLocalIds = new Set<string>()
+    const reducer = createClipboardEventReducer({ now: () => Date.now(), throttleMs })
 
-    const flushLocalFetch = () => {
-      lastLocalFetch = Date.now()
-      const ids = Array.from(pendingLocalIds)
-      pendingLocalIds.clear()
+    const flushLocalFetch = (ids: string[]) => {
       void getClipboardEntries(50, 0)
         .then(response => {
           log.info(
@@ -114,96 +68,50 @@ export function useClipboardEventStream({
         .catch(err => log.error({ err }, 'Failed to fetch local clipboard entries'))
     }
 
-    const handler = (event: { topic: string; eventType: string; payload: unknown }) => {
-      log.info({ eventType: event.eventType }, 'received event')
-      // 接收端 inbound 流程一开始就发的"占位事件":让列表立刻出现一行
-      // 灰色 placeholder + 进度条,而不是要等 fetch + capture 全流程结束。
-      if (event.eventType === 'clipboard.incoming_pending') {
-        const payload = event.payload as ClipboardIncomingPendingPayload
-        log.info(
-          {
-            entryId: payload.entryId,
-            fromDevice: payload.fromDevice,
-            totalBytes: payload.totalBytes ?? null,
-            filenameCount: payload.filenames?.length ?? 0,
-          },
-          'clipboard.incoming_pending payload'
-        )
-        const pending: PendingClipboardEntry = {
-          entryId: payload.entryId,
-          fromDevice: payload.fromDevice,
-          totalBytes: payload.totalBytes ?? null,
-          filenames: payload.filenames ?? [],
-          createdAt: Date.now(),
-        }
-        dispatch(addPendingEntry(pending))
-        // 让 ItemRow 立即走 transferring 视觉(spinner + ring),
-        // 后续 file-transfer.progress 事件会接着填充字节进度。
-        dispatch(
-          setEntryTransferStatus({
-            entryId: payload.entryId,
-            status: 'transferring',
-            reason: null,
-          })
-        )
-        return
-      }
-
-      // Route clipboard.new_content to onLocalItem / onRemoteInvalidate.
-      if (event.eventType === 'clipboard.new_content') {
-        const payload = event.payload as ClipboardNewContentPayload
-        log.info(
-          { entryId: payload.entryId, origin: payload.origin },
-          'clipboard.new_content payload'
-        )
-        // 真实 entry 已经持久化了,占位卡片可以下线 ——
-        // 列表 refresh 拿到的真实 ClipboardEntry 会接替它。
-        dispatch(removePendingEntry(payload.entryId))
-        if (payload.origin === 'local') {
-          // leading + trailing 合并:首条立即拉取(无可感延迟),窗口内后续 entryId
-          // 累积到 set,在 trailing 一拍用一次列表请求一并取回。
-          pendingLocalIds.add(payload.entryId)
-          const now = Date.now()
-          const sinceLast =
-            lastLocalFetch === undefined ? Number.POSITIVE_INFINITY : now - lastLocalFetch
-          if (sinceLast >= throttleMs) {
-            if (localFlushTimer !== null) {
-              clearTimeout(localFlushTimer)
-              localFlushTimer = null
-            }
-            flushLocalFetch()
-          } else if (localFlushTimer === null) {
-            localFlushTimer = window.setTimeout(() => {
-              localFlushTimer = null
-              flushLocalFetch()
-            }, throttleMs - sinceLast)
+    const applyEffects = (effects: ClipboardEventReducerEffect[]) => {
+      for (const effect of effects) {
+        if (effect.type === 'flushLocalEntries') {
+          if (localFlushTimer !== null) {
+            clearTimeout(localFlushTimer)
+            localFlushTimer = null
           }
-          return
+          flushLocalFetch(effect.entryIds)
+          continue
         }
 
-        // Remote: throttled full list reload.
-        const now = Date.now()
-        const lastReload = lastReloadTimestampRef.current
-        if (lastReload === undefined || now - lastReload >= throttleMs) {
-          lastReloadTimestampRef.current = now
-          if (pendingTimeoutId !== null) {
-            clearTimeout(pendingTimeoutId)
-            pendingTimeoutId = null
+        if (effect.type === 'scheduleLocalFlush') {
+          if (localFlushTimer !== null) continue
+          localFlushTimer = window.setTimeout(() => {
+            localFlushTimer = null
+            applyEffects(reducer.flushLocal().effects)
+          }, effect.delayMs)
+          continue
+        }
+
+        if (effect.type === 'invalidateRemote') {
+          if (remoteInvalidateTimer !== null) {
+            clearTimeout(remoteInvalidateTimer)
+            remoteInvalidateTimer = null
           }
           onRemoteInvalidateRef.current()
-          return
+          continue
         }
 
-        if (pendingTimeoutId === null) {
-          const delay = throttleMs - (now - lastReload)
-          pendingTimeoutId = window.setTimeout(() => {
-            lastReloadTimestampRef.current = Date.now()
-            onRemoteInvalidateRef.current()
-            pendingTimeoutId = null
-          }, delay)
+        if (effect.type === 'scheduleRemoteInvalidate') {
+          if (remoteInvalidateTimer !== null) continue
+          remoteInvalidateTimer = window.setTimeout(() => {
+            remoteInvalidateTimer = null
+            applyEffects(reducer.flushRemote().effects)
+          }, effect.delayMs)
         }
-        return
       }
+    }
+
+    const handler = (event: ClipboardRealtimeEvent) => {
+      log.info({ eventType: event.eventType }, 'received event')
+      const reduction = reducer.reduce(event)
+      for (const action of reduction.actions) dispatch(action)
+      applyEffects(reduction.effects)
 
       // Note: clipboard.deleted is never emitted by the daemon.
       // The onDeleted callback is retained for API symmetry but will never fire.
@@ -213,9 +121,9 @@ export function useClipboardEventStream({
     const unsubscribe = daemonWs.subscribe(['clipboard'], handler)
 
     return () => {
-      if (pendingTimeoutId !== null) {
-        clearTimeout(pendingTimeoutId)
-        pendingTimeoutId = null
+      if (remoteInvalidateTimer !== null) {
+        clearTimeout(remoteInvalidateTimer)
+        remoteInvalidateTimer = null
       }
       if (localFlushTimer !== null) {
         clearTimeout(localFlushTimer)

--- a/src/hooks/useTransferProgress.ts
+++ b/src/hooks/useTransferProgress.ts
@@ -2,49 +2,18 @@ import { useEffect } from 'react'
 import { daemonWs } from '@/lib/daemon-ws'
 import { createLogger } from '@/lib/logger'
 import { useAppDispatch } from '@/store/hooks'
-import { removePendingEntry } from '@/store/slices/clipboardSlice'
-import {
-  markTransferCancelled,
-  markTransferCompleted,
-  markTransferFailed,
-  cancelClipboardWrite,
-  linkTransferToEntry,
-  normalizeCancelReason,
-  setEntryTransferStatus,
-  updateTransferProgress,
-} from '@/store/slices/fileTransferSlice'
+import { createClipboardEventReducer } from './clipboardEventReducer'
+import type { ClipboardRealtimeEvent } from './clipboardEventReducer'
 
 const log = createLogger('use-transfer-progress')
 const transferProgressDebugEnabled = import.meta.env.DEV
 
-interface FileTransferStatusEvent {
-  transferId: string
-  entryId: string
-  status: string
-  reason?: string | null
-}
-
-interface FileTransferProgressEvent {
-  transferId: string
-  entryId?: string | null
-  peerId: string
-  direction: 'Sending' | 'Receiving'
-  bytesTransferred: number
-  totalBytes?: number | null
-}
-
-interface DaemonTransferEvent {
-  eventType: string
-  payload: unknown
-  ts: number
-}
-
 /**
- * Hook that listens to file-transfer and clipboard events from the daemon WS,
- * dispatching durable status changes to the Redux fileTransfer slice.
+ * Hook that listens to file-transfer events from the daemon WS and forwards
+ * their state actions to Redux.
  *
  * - `file-transfer.status_changed` events update entry transfer status.
- * - `clipboard.new_content` events cancel pending clipboard auto-writes.
+ * - `file-transfer.progress` events update live progress.
  *
  * Call once in a top-level component (e.g. ClipboardContent) to activate.
  */
@@ -53,76 +22,40 @@ export function useTransferProgress(): void {
 
   useEffect(() => {
     let cancelled = false
-    const warnedMissingEntryLinkage = new Set<string>()
+    const reducer = createClipboardEventReducer({ now: () => Date.now(), throttleMs: 300 })
 
-    const handler = (event: DaemonTransferEvent) => {
+    const handler = (event: ClipboardRealtimeEvent) => {
       if (cancelled) return
 
-      if (event.eventType === 'clipboard.new_content') {
-        dispatch(cancelClipboardWrite())
-        return
-      }
-
-      if (event.eventType === 'file-transfer.status_changed') {
-        const payload = event.payload as FileTransferStatusEvent
-        const { entryId, status, reason } = payload
+      if (transferProgressDebugEnabled && event.eventType === 'file-transfer.status_changed') {
+        const payload = event.payload as {
+          transferId: string
+          entryId: string
+          status: string
+          reason?: string | null
+        }
         if (transferProgressDebugEnabled) {
           log.debug(
             {
               transferId: payload.transferId,
-              entryId,
-              status,
-              reason: reason ?? null,
+              entryId: payload.entryId,
+              status: payload.status,
+              reason: payload.reason ?? null,
             },
             'file transfer status changed'
           )
         }
-        dispatch(linkTransferToEntry({ transferId: payload.transferId, entryId }))
-        const validStatuses = [
-          'pending',
-          'transferring',
-          'completed',
-          'failed',
-          'cancelled',
-        ] as const
-        if (validStatuses.includes(status as (typeof validStatuses)[number])) {
-          dispatch(
-            setEntryTransferStatus({
-              entryId,
-              status: status as (typeof validStatuses)[number],
-              reason: reason ?? null,
-            })
-          )
-        }
-
-        if (status === 'failed') {
-          dispatch(
-            markTransferFailed({
-              transferId: payload.transferId,
-              error: reason ?? undefined,
-            })
-          )
-        } else if (status === 'cancelled') {
-          // 兜底清 placeholder:apply_inbound 的 partial 路径正常会再发
-          // `clipboard.new_content` 触发 removePendingEntry,但 status_changed
-          // 帧通常先到(它是 cancel arm 在撕 connection 之前 await 推过来的,
-          // 而 NewContent 要等 capture 落库)。早一步清掉 pendingItems 能避
-          // 免"取消后 placeholder 仍然置顶几秒"的视觉残留。幂等:
-          // clipboard.new_content 到达时再 remove 一次没副作用。
-          dispatch(removePendingEntry(entryId))
-          dispatch(
-            markTransferCancelled({
-              transferId: payload.transferId,
-              reason: normalizeCancelReason(reason),
-            })
-          )
-        } else if (status === 'completed') {
-          dispatch(markTransferCompleted({ transferId: payload.transferId }))
-        }
       }
 
-      if (event.eventType === 'file-transfer.progress') {
-        const payload = event.payload as FileTransferProgressEvent
+      if (transferProgressDebugEnabled && event.eventType === 'file-transfer.progress') {
+        const payload = event.payload as {
+          transferId: string
+          entryId?: string | null
+          peerId: string
+          direction: 'Sending' | 'Receiving'
+          bytesTransferred: number
+          totalBytes?: number | null
+        }
         if (transferProgressDebugEnabled) {
           log.debug(
             {
@@ -136,48 +69,13 @@ export function useTransferProgress(): void {
             'file transfer progress'
           )
         }
-        dispatch(
-          updateTransferProgress({
-            transferId: payload.transferId,
-            entryId: payload.entryId ?? null,
-            peerId: payload.peerId,
-            direction: payload.direction,
-            bytesTransferred: payload.bytesTransferred,
-            totalBytes: payload.totalBytes ?? null,
-            eventTs: event.ts,
-          })
-        )
-
-        if (payload.entryId) {
-          if (transferProgressDebugEnabled) {
-            log.debug(
-              {
-                transferId: payload.transferId,
-                entryId: payload.entryId,
-              },
-              'linked transfer to entry from progress event'
-            )
-          }
-          dispatch(
-            linkTransferToEntry({ transferId: payload.transferId, entryId: payload.entryId })
-          )
-        } else {
-          if (!warnedMissingEntryLinkage.has(payload.transferId)) {
-            warnedMissingEntryLinkage.add(payload.transferId)
-            log.warn(
-              {
-                transferId: payload.transferId,
-                peerId: payload.peerId,
-                direction: payload.direction,
-              },
-              'progress event missing entry linkage'
-            )
-          }
-        }
       }
+
+      const reduction = reducer.reduce(event)
+      for (const action of reduction.actions) dispatch(action)
     }
 
-    const unsubscribe = daemonWs.subscribe(['file-transfer', 'clipboard'], handler)
+    const unsubscribe = daemonWs.subscribe(['file-transfer'], handler)
 
     return () => {
       cancelled = true


### PR DESCRIPTION
## Summary
- Extract clipboard realtime event handling into a pure reducer with explicit state and effects
- Keep React hooks as thin subscription/effect wrappers
- Move clipboard new-content side effects out of the transfer-progress hook and cover them in reducer tests

## Verification
- npx vitest run src/hooks/__tests__/clipboardEventReducer.test.ts src/hooks/__tests__/useClipboardEventStream.test.tsx src/hooks/__tests__/useTransferProgress.test.tsx
- bun run build

## Notes
- Full local Vitest was run before commit and passed: 90 files, 626 tests
- Targeted ESLint for modified files passed before commit; pre-commit also ran eslint --fix and prettier --write on staged TS/TSX files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for clipboard event processing and file transfer operations

* **Improvements**
  * Enhanced clipboard event handling with improved throttling and coalescing for local and remote operations
  * Improved file transfer status and progress tracking

<!-- end of auto-generated comment: release notes by coderabbit.ai -->