### PR TITLE
fix(ci): avoid setup-node token auth for npm trusted publish

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -99,12 +99,22 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: lts/*
-          registry-url: 'https://registry.npmjs.org'
 
       - name: Update npm for trusted publishing
         # OIDC trusted publishing requires npm >= 11.5.1; pin to latest to be
         # explicit rather than relying on whatever the runner image bundles.
         run: npm install -g npm@latest && npm --version
+
+      - name: Prepare npm trusted publishing config
+        run: |
+          NPM_CONFIG_USERCONFIG="${RUNNER_TEMP}/npm-trusted-publish.npmrc"
+          {
+            echo "registry=https://registry.npmjs.org/"
+          } > "$NPM_CONFIG_USERCONFIG"
+          echo "NPM_CONFIG_USERCONFIG=$NPM_CONFIG_USERCONFIG" >> "$GITHUB_ENV"
+          echo "NODE_AUTH_TOKEN=" >> "$GITHUB_ENV"
+          unset NODE_AUTH_TOKEN
+          npm config get registry
 
       - name: Download CLI release assets
         env:

--- a/scripts/__tests__/npm-publish-workflow.test.ts
+++ b/scripts/__tests__/npm-publish-workflow.test.ts
@@ -28,4 +28,16 @@ describe('npm publish workflow trigger', () => {
     )
     expect(npmWorkflow).toContain('"repository_dispatch"')
   })
+
+  it('removes setup-node token auth before trusted publishing', () => {
+    const npmWorkflow = readWorkflow('npm-publish.yml')
+
+    expect(npmWorkflow).toContain(
+      'NPM_CONFIG_USERCONFIG="${RUNNER_TEMP}/npm-trusted-publish.npmrc"'
+    )
+    expect(npmWorkflow).toContain('unset NODE_AUTH_TOKEN')
+    expect(npmWorkflow).not.toContain('registry-url:')
+    expect(npmWorkflow).not.toContain('_authToken')
+    expect(npmWorkflow).toContain('Publish to npm')
+  })
 })


### PR DESCRIPTION
## Summary
- remove setup-node's npm token config from the npm trusted publishing workflow
- add a regression check so the workflow keeps token auth out of the trusted publishing path

## Verification
- bunx vitest run scripts/__tests__
- bunx prettier --check .github/workflows/npm-publish.yml scripts/__tests__/npm-publish-workflow.test.ts
- node -e "const fs=require('fs'); const yaml=require('yaml'); for (const f of ['.github/workflows/npm-publish.yml','.github/workflows/release.yml']) { yaml.parse(fs.readFileSync(f,'utf8')); console.log('ok '+f) }"
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated npm publishing workflow configuration to use trusted publishing setup.
  * Added test coverage for npm publishing workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->