### PR TITLE
refactor(clipboard-sync): split dispatch use case into 5 collaborators

### DIFF
--- a/crates/AGENTS.md
+++ b/crates/AGENTS.md
@@ -1,6 +1,6 @@
 # PROJECT KNOWLEDGE BASE
 
-**Last refreshed:** 2026-06-14 (auto; 19 workspace crates)
+**Last refreshed:** 2026-06-15 (manual; WHERE TO LOOK + COMPLEXITY HOTSPOTS + libp2p→iroh/clipboard fixes)
 
 ## OVERVIEW
 
@@ -49,9 +49,9 @@ Rust monorepo workspace (root `Cargo.toml`) with strict hexagonal boundaries: li
 | Runtime/usecase accessors        | `src-tauri/crates/uc-tauri/src/bootstrap/runtime.rs` | `AppRuntime`, `usecases()` factory                            |
 | Tauri commands                   | `src-tauri/crates/uc-tauri/src/commands/`  | Commands call app-layer usecases (or daemon HTTP since ADR-008) |
 | Domain contracts (ports)         | `crates/uc-core/src/ports/`                | Add traits here first                                         |
-| App workflows                    | `crates/uc-application/src/`               | clipboard_capture / pairing_* / file_transfer / sync_planner  |
-| Infra implementations            | `crates/uc-infra/src/`                     | Diesel repos, encryption, fs, timers                          |
-| Platform adapters                | `crates/uc-platform/src/`                  | libp2p, clipboard, secure storage                             |
+| App workflows                    | `crates/uc-application/src/`               | top-level clipboard_capture / pairing_* / file_transfer / sync_planner; `usecases/` = clipboard_sync, mobile_sync, … |
+| Infra implementations            | `crates/uc-infra/src/`                     | Diesel repos, encryption, fs, timers, iroh transport (`network/iroh/`) |
+| Platform adapters                | `crates/uc-platform/src/`                  | clipboard (linux X11/Wayland, windows, macos), secure storage, app dirs |
 | Daemon API surface               | `crates/uc-webserver/src/api/`             | HTTP + WS endpoints; ApiEnvelope normalization                |
 | Legacy reference                 | Removed (2026-02-26)                       | Do not reintroduce legacy module tree                         |
 
@@ -93,10 +93,12 @@ Rust monorepo workspace (root `Cargo.toml`) with strict hexagonal boundaries: li
 
 ## COMPLEXITY HOTSPOTS
 
-- `crates/uc-bootstrap/src/assembly.rs`: global wiring; smallest safe edits only.
-- `crates/uc-application/src/`: setup/pairing orchestrators, high-state async transitions.
-- `crates/uc-core/src/network/`: protocol-critical state machines.
-- `crates/uc-infra/src/network/`: iroh transport internals; keep business rules out.
+- `crates/uc-bootstrap/src/assembly.rs`: global hex wiring (port→adapter); smallest safe edits only.
+- `crates/uc-infra/src/network/iroh/` (`node.rs` ~1.7k lines, `presence_adapter.rs` ~1.5k): iroh endpoint/event-loop internals; preserve non-blocking progress, keep business rules out.
+- `crates/uc-platform/src/clipboard/platform/linux/` (X11 + Wayland): most-churned area lately; MIME-alias / self-echo race fixes cluster here.
+- `crates/uc-application/src/usecases/mobile_sync/` (`apply_incoming.rs` ~2.1k lines): large, actively-evolving LAN mobile-sync flows.
+- `crates/uc-application/src/facade/space_setup/facade.rs` (~2k) + `pairing_inbound/orchestrator.rs` (~1.8k): high-state setup/pairing transitions.
+- `crates/uc-core/src/network/`: protocol-critical session / state machines.
 
 ## COMMANDS
 
@@ -121,7 +123,7 @@ bun run test:coverage
 
 - `src-legacy/` was removed on 2026-02-26; treat any references as historical context only.
 - Root `AGENTS.md` is the navigation index; this file is the Rust-workspace knowledge base covering `crates/`, `apps/`, and `src-tauri/`. Tauri packaging details live in `src-tauri/AGENTS.md`.
-- Any change touching `crates/uc-platform/src/adapters/libp2p_network.rs` must run `cargo test -p uc-platform` before merge.
+- Any change touching `crates/uc-platform/src/clipboard/` (esp. the linux X11/Wayland adapters) should run `cargo test -p uc-platform` before merge. (The network transport is no longer in uc-platform — it lives in `crates/uc-infra/src/network/iroh/`.)
 - Current desktop log files live under the app data root's `logs/` directory, using the current app dir name `app.uniclipboard.desktop` plus optional `UC_PROFILE` suffix.
 - macOS: `~/Library/Application Support/app.uniclipboard.desktop[-<profile>]/logs/`
 - Linux: `~/.local/share/app.uniclipboard.desktop[-<profile>]/logs/`

--- a/crates/uc-application/src/usecases/clipboard_sync/dispatch_entry/delivery.rs
+++ b/crates/uc-application/src/usecases/clipboard_sync/dispatch_entry/delivery.rs
@@ -1,0 +1,351 @@
+//! Per-peer result classification + delivery recording + the deferred
+//! (post-deadline) drain continuation.
+//!
+//! `DeliveryRecorder` holds the two ports that persist and surface
+//! delivery outcomes (`entry_delivery_repo` + the host-event bus).
+//! Write-then-emit ordering in [`DeliveryRecorder::flush`] is LOAD-BEARING:
+//! the host event is a payload-less "refetch ping", so the frontend's
+//! follow-up read must observe the DB write — reordering or batching
+//! emit-before-write surfaces a stale snapshot to the detail view.
+
+use std::sync::Arc;
+use std::time::Instant;
+
+use tokio::task::{JoinError, JoinSet};
+use tracing::{debug, info, warn, Instrument};
+
+use uc_core::clipboard::{DeliveryFailureReason, EntryDeliveryRecord, EntryDeliveryStatus};
+use uc_core::ids::EntryId;
+use uc_core::ports::{ClipboardDispatchError, ClockPort, DispatchAck, EntryDeliveryRepositoryPort};
+
+use crate::facade::blob_transfer::SharedHostEventEmitter;
+use crate::facade::host_event::{DeliveryHostEvent, HostEvent};
+
+use super::{DispatchPerTarget, PeerDispatchResult};
+
+/// Outcome bucket for [`classify_dispatch_result`]. `Panicked` rolls up
+/// into `Errored` at the call site because `DispatchOutcome` has no
+/// separate panic bucket and treating a panicked task as "errored" keeps
+/// `attempted = succeeded + failed + deferred` intact for telemetry.
+pub(crate) enum DispatchResultBucket {
+    Accepted,
+    Duplicate,
+    Offline,
+    Errored,
+    Panicked,
+}
+
+/// Folded view of one fanned-out peer's `JoinSet` result, ready to fold
+/// into `DispatchOutcome` (or the background continuation).
+pub(crate) struct ProcessedDispatchResult {
+    /// `None` iff the task panicked / was cancelled (no DeviceId recoverable).
+    pub per_target: Option<DispatchPerTarget>,
+    /// `None` iff `entry_id` was `None` OR the task panicked. Otherwise a
+    /// fully populated record ready for `record_attempt`.
+    pub delivery_record: Option<EntryDeliveryRecord>,
+    pub bucket: DispatchResultBucket,
+}
+
+/// Shared per-peer result-handling — used by both the foreground fold and
+/// the background continuation that drains the leftover `JoinSet` after the
+/// fan-out deadline. A free function (not a method) so the detached
+/// background task can call it without holding `&self`.
+///
+/// `now_ms` is sampled by the caller (each peer's `updated_at_ms` reflects
+/// the moment that peer's result was observed, not a shared snapshot).
+pub(crate) fn classify_dispatch_result(
+    joined: Result<PeerDispatchResult, JoinError>,
+    entry_id: Option<&EntryId>,
+    now_ms: i64,
+) -> ProcessedDispatchResult {
+    match joined {
+        Ok((device_id, Ok(DispatchAck::Accepted))) => {
+            debug!(device_id = %device_id.as_str(), "dispatch → Accepted");
+            let delivery_record = entry_id.map(|eid| EntryDeliveryRecord {
+                entry_id: eid.clone(),
+                target_device_id: device_id.clone(),
+                status: EntryDeliveryStatus::Delivered,
+                reason_detail: None,
+                updated_at_ms: now_ms,
+            });
+            ProcessedDispatchResult {
+                per_target: Some(DispatchPerTarget {
+                    device_id,
+                    outcome: Ok(DispatchAck::Accepted),
+                }),
+                delivery_record,
+                bucket: DispatchResultBucket::Accepted,
+            }
+        }
+        Ok((device_id, Ok(DispatchAck::DuplicateIgnored))) => {
+            debug!(device_id = %device_id.as_str(), "dispatch → DuplicateIgnored");
+            let delivery_record = entry_id.map(|eid| EntryDeliveryRecord {
+                entry_id: eid.clone(),
+                target_device_id: device_id.clone(),
+                status: EntryDeliveryStatus::Duplicate,
+                reason_detail: None,
+                updated_at_ms: now_ms,
+            });
+            ProcessedDispatchResult {
+                per_target: Some(DispatchPerTarget {
+                    device_id,
+                    outcome: Ok(DispatchAck::DuplicateIgnored),
+                }),
+                delivery_record,
+                bucket: DispatchResultBucket::Duplicate,
+            }
+        }
+        Ok((device_id, Err(ClipboardDispatchError::Offline))) => {
+            debug!(device_id = %device_id.as_str(), "dispatch → Offline");
+            let delivery_record = entry_id.map(|eid| EntryDeliveryRecord {
+                entry_id: eid.clone(),
+                target_device_id: device_id.clone(),
+                status: EntryDeliveryStatus::Failed {
+                    reason: DeliveryFailureReason::Offline,
+                },
+                reason_detail: None,
+                updated_at_ms: now_ms,
+            });
+            ProcessedDispatchResult {
+                per_target: Some(DispatchPerTarget {
+                    device_id,
+                    outcome: Err("offline".to_string()),
+                }),
+                delivery_record,
+                bucket: DispatchResultBucket::Offline,
+            }
+        }
+        Ok((device_id, Err(err))) => {
+            warn!(device_id = %device_id.as_str(), error = %err, "dispatch failed");
+            let (failure_reason, reason_detail) = match &err {
+                // Offline is handled in the previous arm; kept for exhaustiveness.
+                ClipboardDispatchError::Offline => (DeliveryFailureReason::Offline, None),
+                ClipboardDispatchError::LocalPolicyExceeded(s) => {
+                    (DeliveryFailureReason::LocalPolicy, Some(s.clone()))
+                }
+                ClipboardDispatchError::PeerRejected(s) => {
+                    (DeliveryFailureReason::PeerRejected, Some(s.clone()))
+                }
+                ClipboardDispatchError::Io(s) => (DeliveryFailureReason::Io, Some(s.clone())),
+                ClipboardDispatchError::Internal(s) => {
+                    (DeliveryFailureReason::Internal, Some(s.clone()))
+                }
+            };
+            let delivery_record = entry_id.map(|eid| EntryDeliveryRecord {
+                entry_id: eid.clone(),
+                target_device_id: device_id.clone(),
+                status: EntryDeliveryStatus::Failed {
+                    reason: failure_reason,
+                },
+                reason_detail,
+                updated_at_ms: now_ms,
+            });
+            ProcessedDispatchResult {
+                per_target: Some(DispatchPerTarget {
+                    device_id,
+                    outcome: Err(err.to_string()),
+                }),
+                delivery_record,
+                bucket: DispatchResultBucket::Errored,
+            }
+        }
+        Err(err) => {
+            warn!(error = %err, "dispatch task panicked or cancelled");
+            ProcessedDispatchResult {
+                per_target: None,
+                delivery_record: None,
+                bucket: DispatchResultBucket::Panicked,
+            }
+        }
+    }
+}
+
+/// Persists per-peer delivery outcomes and pings the frontend to refetch.
+pub(crate) struct DeliveryRecorder {
+    entry_delivery_repo: Arc<dyn EntryDeliveryRepositoryPort>,
+    host_event_bus: SharedHostEventEmitter,
+}
+
+impl DeliveryRecorder {
+    pub(crate) fn new(
+        entry_delivery_repo: Arc<dyn EntryDeliveryRepositoryPort>,
+        host_event_bus: SharedHostEventEmitter,
+    ) -> Self {
+        Self {
+            entry_delivery_repo,
+            host_event_bus,
+        }
+    }
+
+    /// Sequentially `record_attempt` each record then `emit_or_warn` the
+    /// matching refetch ping. Write-then-emit order is load-bearing — the
+    /// host event carries no payload, so the frontend's follow-up read must
+    /// observe the write. Errors only `warn!`; this is an observability
+    /// side-effect that must not mask dispatch's real success/failure.
+    pub(crate) async fn flush(&self, records: &[EntryDeliveryRecord]) {
+        for record in records {
+            if let Err(err) = self.entry_delivery_repo.record_attempt(record).await {
+                warn!(
+                    error = %err,
+                    entry_id = %record.entry_id,
+                    target_device_id = %record.target_device_id,
+                    "failed to record entry delivery"
+                );
+                continue;
+            }
+            self.host_event_bus.emit_or_warn(HostEvent::Delivery(
+                DeliveryHostEvent::StatusChanged {
+                    entry_id: record.entry_id.to_string(),
+                    target_device_id: record.target_device_id.as_str().to_string(),
+                },
+            ));
+        }
+    }
+}
+
+/// Drive the post-deadline leftover tasks to completion on a detached
+/// task: classify each settle, record it immediately (per-settle, NOT
+/// batched, so an early-settling peer's badge isn't held hostage by a
+/// staggered-retry long-tail), and log a per-bucket summary when drained.
+///
+/// Best-effort RECORD-ONLY (VISION locked decision #59): a peer that
+/// finally settles Offline / Errored after the deadline is recorded as
+/// such, never replayed — automatic redelivery is an absolute禁区.
+pub(crate) fn spawn_deferred_drain(
+    mut set: JoinSet<PeerDispatchResult>,
+    entry_id: Option<EntryId>,
+    clock: Arc<dyn ClockPort>,
+    recorder: Arc<DeliveryRecorder>,
+    content_hash: String,
+) {
+    let deferred_count = set.len();
+    tokio::spawn(
+        async move {
+            let started = Instant::now();
+            let mut accepted = 0usize;
+            let mut duplicate = 0usize;
+            let mut offline = 0usize;
+            let mut errored = 0usize;
+            while let Some(joined) = set.join_next().await {
+                let processed = classify_dispatch_result(joined, entry_id.as_ref(), clock.now_ms());
+                match processed.bucket {
+                    DispatchResultBucket::Accepted => accepted += 1,
+                    DispatchResultBucket::Duplicate => duplicate += 1,
+                    DispatchResultBucket::Offline => offline += 1,
+                    DispatchResultBucket::Errored | DispatchResultBucket::Panicked => errored += 1,
+                }
+                if let Some(rec) = processed.delivery_record {
+                    recorder.flush(std::slice::from_ref(&rec)).await;
+                }
+            }
+            info!(
+                content_hash = %content_hash,
+                deferred_count,
+                accepted,
+                duplicate,
+                offline,
+                errored,
+                bg_duration_ms = started.elapsed().as_millis() as u64,
+                "dispatch: deferred fan-out completed"
+            );
+        }
+        .in_current_span(),
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use uc_core::ids::DeviceId;
+
+    fn dev(id: &str) -> DeviceId {
+        DeviceId::new(id)
+    }
+
+    fn eid() -> EntryId {
+        EntryId::from("entry-1".to_string())
+    }
+
+    #[test]
+    fn accepted_maps_to_delivered_record_and_accepted_bucket() {
+        let joined = Ok((dev("peer-a"), Ok(DispatchAck::Accepted)));
+        let p = classify_dispatch_result(joined, Some(&eid()), 42);
+        assert!(matches!(p.bucket, DispatchResultBucket::Accepted));
+        let pt = p.per_target.expect("per_target present");
+        assert_eq!(pt.device_id, dev("peer-a"));
+        assert!(matches!(pt.outcome, Ok(DispatchAck::Accepted)));
+        let rec = p.delivery_record.expect("delivery record present");
+        assert!(matches!(rec.status, EntryDeliveryStatus::Delivered));
+        assert_eq!(rec.updated_at_ms, 42);
+        assert_eq!(rec.reason_detail, None);
+    }
+
+    #[test]
+    fn duplicate_maps_to_duplicate_record_and_bucket() {
+        let joined = Ok((dev("peer-a"), Ok(DispatchAck::DuplicateIgnored)));
+        let p = classify_dispatch_result(joined, Some(&eid()), 1);
+        assert!(matches!(p.bucket, DispatchResultBucket::Duplicate));
+        assert!(matches!(
+            p.per_target.unwrap().outcome,
+            Ok(DispatchAck::DuplicateIgnored)
+        ));
+        assert!(matches!(
+            p.delivery_record.unwrap().status,
+            EntryDeliveryStatus::Duplicate
+        ));
+    }
+
+    #[test]
+    fn offline_maps_to_failed_offline_and_offline_bucket() {
+        let joined = Ok((dev("peer-a"), Err(ClipboardDispatchError::Offline)));
+        let p = classify_dispatch_result(joined, Some(&eid()), 1);
+        assert!(matches!(p.bucket, DispatchResultBucket::Offline));
+        assert!(matches!(p.per_target.unwrap().outcome, Err(ref s) if s == "offline"));
+        assert!(matches!(
+            p.delivery_record.unwrap().status,
+            EntryDeliveryStatus::Failed {
+                reason: DeliveryFailureReason::Offline
+            }
+        ));
+    }
+
+    #[test]
+    fn non_offline_error_maps_to_errored_with_reason_detail() {
+        let joined = Ok((
+            dev("peer-a"),
+            Err(ClipboardDispatchError::PeerRejected("nope".to_string())),
+        ));
+        let p = classify_dispatch_result(joined, Some(&eid()), 1);
+        assert!(matches!(p.bucket, DispatchResultBucket::Errored));
+        let rec = p.delivery_record.unwrap();
+        assert!(matches!(
+            rec.status,
+            EntryDeliveryStatus::Failed {
+                reason: DeliveryFailureReason::PeerRejected
+            }
+        ));
+        assert_eq!(rec.reason_detail, Some("nope".to_string()));
+    }
+
+    #[test]
+    fn no_entry_id_yields_per_target_but_no_delivery_record() {
+        let joined = Ok((dev("peer-a"), Ok(DispatchAck::Accepted)));
+        let p = classify_dispatch_result(joined, None, 1);
+        assert!(p.per_target.is_some());
+        assert!(p.delivery_record.is_none());
+    }
+
+    #[tokio::test]
+    async fn panicked_task_maps_to_panicked_bucket_with_no_target_or_record() {
+        // A real JoinError is only obtainable from a JoinSet, so drive a
+        // panicking task through to settle, then classify its Err(JoinError).
+        let mut set: JoinSet<PeerDispatchResult> = JoinSet::new();
+        set.spawn(async { panic!("boom") });
+        let joined = set.join_next().await.expect("one task settled");
+        assert!(joined.is_err(), "panicked task must surface as JoinError");
+        let p = classify_dispatch_result(joined, Some(&eid()), 1);
+        assert!(matches!(p.bucket, DispatchResultBucket::Panicked));
+        assert!(p.per_target.is_none());
+        assert!(p.delivery_record.is_none());
+    }
+}

--- a/crates/uc-application/src/usecases/clipboard_sync/dispatch_entry/fanout.rs
+++ b/crates/uc-application/src/usecases/clipboard_sync/dispatch_entry/fanout.rs
@@ -1,0 +1,121 @@
+//! `DeadlineBoundedFanout` — generic, port-free mechanism that drains a
+//! [`JoinSet`] under a wall-clock deadline.
+//!
+//! It owns the single trickiest, most-churned (#785 / #886) and most
+//! reusable concurrency concern in the dispatch path: run N tasks, hand
+//! each settled result to a sink as it lands, and once the deadline
+//! elapses stop waiting and return whatever is still in flight so the
+//! caller can drive it to completion off the hot path.
+//!
+//! ## Contract red line — VISION locked decision #59 (clipboard transience)
+//!
+//! This is a *deadline + observe* mechanism, NOT a queue / retry /
+//! redelivery mechanism. Tasks run exactly once; the deadline only bounds
+//! how long the FOREGROUND waits for them. Tasks still in flight at the
+//! deadline are handed back so the caller can *finish and record* them —
+//! never replayed. Do not grow retry / backoff / persistence into this
+//! type: automatic redelivery is an absolute project禁区.
+
+use std::time::{Duration, Instant};
+
+use tokio::task::{JoinError, JoinSet};
+
+/// Drains a `JoinSet` for at most `deadline`, yielding still-running tasks
+/// back to the caller when the deadline elapses.
+pub(crate) struct DeadlineBoundedFanout {
+    deadline: Duration,
+}
+
+impl DeadlineBoundedFanout {
+    pub(crate) fn new(deadline: Duration) -> Self {
+        Self { deadline }
+    }
+
+    /// Drain `set` until the deadline elapses or every task settles,
+    /// handing each foreground settle (including the `Err(JoinError)` of a
+    /// panicked / cancelled task) to `on_settled` as it lands — so a sink
+    /// that timestamps results observes each task's individual completion.
+    ///
+    /// Returns the still-running `JoinSet` (possibly empty) for the caller
+    /// to drive in the background. If the deadline has already elapsed when
+    /// called, no task is awaited and the whole set is returned untouched.
+    pub(crate) async fn drain_foreground<R>(
+        &self,
+        mut set: JoinSet<R>,
+        mut on_settled: impl FnMut(Result<R, JoinError>),
+    ) -> JoinSet<R>
+    where
+        R: Send + 'static,
+    {
+        let started = Instant::now();
+        loop {
+            let remaining = self.deadline.saturating_sub(started.elapsed());
+            if remaining.is_zero() {
+                break;
+            }
+            match tokio::time::timeout(remaining, set.join_next()).await {
+                Ok(Some(joined)) => on_settled(joined),
+                Ok(None) => break, // set drained — all tasks settled within deadline
+                Err(_) => break,   // deadline elapsed — defer the remainder
+            }
+        }
+        set
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+    use tokio::time::sleep;
+
+    #[tokio::test]
+    async fn returns_empty_set_when_all_tasks_settle_within_deadline() {
+        let fanout = DeadlineBoundedFanout::new(Duration::from_secs(5));
+        let mut set: JoinSet<u32> = JoinSet::new();
+        for i in 0..3 {
+            set.spawn(async move { i });
+        }
+        let mut settled = Vec::new();
+        let leftover = fanout
+            .drain_foreground(set, |r| settled.push(r.unwrap()))
+            .await;
+        settled.sort_unstable();
+        assert_eq!(settled, vec![0, 1, 2]);
+        assert_eq!(leftover.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn hands_back_in_flight_tasks_when_deadline_elapses() {
+        let fanout = DeadlineBoundedFanout::new(Duration::from_millis(50));
+        let mut set: JoinSet<u32> = JoinSet::new();
+        set.spawn(async { 1 }); // settles fast
+        set.spawn(async {
+            sleep(Duration::from_secs(10)).await;
+            2
+        }); // outlives the deadline
+        let mut settled = Vec::new();
+        let leftover = fanout
+            .drain_foreground(set, |r| settled.push(r.unwrap()))
+            .await;
+        assert_eq!(settled, vec![1]);
+        assert_eq!(leftover.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn surfaces_join_error_for_panicked_task() {
+        let fanout = DeadlineBoundedFanout::new(Duration::from_secs(5));
+        let mut set: JoinSet<u32> = JoinSet::new();
+        set.spawn(async { panic!("boom") });
+        let mut errors = 0usize;
+        let leftover = fanout
+            .drain_foreground(set, |r| {
+                if r.is_err() {
+                    errors += 1;
+                }
+            })
+            .await;
+        assert_eq!(errors, 1);
+        assert_eq!(leftover.len(), 0);
+    }
+}

--- a/crates/uc-application/src/usecases/clipboard_sync/dispatch_entry/header.rs
+++ b/crates/uc-application/src/usecases/clipboard_sync/dispatch_entry/header.rs
@@ -1,0 +1,198 @@
+//! `OutboundHeaderFactory` — builds the [`ClipboardHeader`] stamped on
+//! every fanned-out frame: protocol version, content hash, capture time,
+//! origin device id / name, payload version, and the cross-device
+//! `flow_id` that lets the inbound peer join the same Sentry trace.
+
+use std::sync::Arc;
+
+use tracing::warn;
+use uc_core::ids::DeviceId;
+use uc_core::ports::{ClipboardHeader, ClockPort, LocalIdentityPort, SettingsPort};
+use uc_observability::FlowId;
+
+use super::DispatchClipboardEntryInput;
+
+pub(crate) struct OutboundHeaderFactory {
+    settings: Arc<dyn SettingsPort>,
+    local_identity: Arc<dyn LocalIdentityPort>,
+    clock: Arc<dyn ClockPort>,
+}
+
+impl OutboundHeaderFactory {
+    pub(crate) fn new(
+        settings: Arc<dyn SettingsPort>,
+        local_identity: Arc<dyn LocalIdentityPort>,
+        clock: Arc<dyn ClockPort>,
+    ) -> Self {
+        Self {
+            settings,
+            local_identity,
+            clock,
+        }
+    }
+
+    /// Build the outbound header once per dispatch; cloned per target on
+    /// the wire. `local_device` is resolved once by the caller.
+    pub(crate) async fn build(
+        &self,
+        input: &DispatchClipboardEntryInput,
+        flow_id: &FlowId,
+        local_device: &DeviceId,
+    ) -> ClipboardHeader {
+        let origin_device_name = self.load_origin_device_name().await;
+        ClipboardHeader {
+            version: ClipboardHeader::CURRENT_VERSION,
+            content_hash: input.content_hash.clone(),
+            captured_at_ms: self.clock.now_ms(),
+            origin_device_id: local_device.as_str().to_string(),
+            origin_device_name,
+            payload_version: input.payload_version,
+            flow_id: Some(flow_id.to_string()),
+        }
+    }
+
+    /// Load the device's own display name to embed in the outbound header
+    /// so the peer can show "from <Alice's Laptop>". Falls back to the
+    /// fingerprint if settings are unreadable or empty.
+    async fn load_origin_device_name(&self) -> String {
+        match self.settings.load().await {
+            Ok(settings) => {
+                if let Some(name) = settings.general.device_name {
+                    if !name.is_empty() {
+                        return name;
+                    }
+                }
+            }
+            Err(err) => {
+                warn!(error = %err, "dispatch: settings load failed; using fingerprint fallback");
+            }
+        }
+        match self.local_identity.get_current_fingerprint().await {
+            Ok(Some(fp)) => fp.as_display().to_string(),
+            _ => "unknown-device".to_string(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::test_support::*;
+    use super::*;
+
+    fn factory(
+        settings: MockSettings_,
+        local_identity: MockLocalIdentity,
+    ) -> OutboundHeaderFactory {
+        OutboundHeaderFactory::new(
+            Arc::new(settings),
+            Arc::new(local_identity),
+            Arc::new(FixedClock(1_700_000_000_000)),
+        )
+    }
+
+    /// Stamps protocol version, content hash, payload version, clock-sourced
+    /// capture time, origin id, and the flow id — and prefers the settings
+    /// device name when it is present and non-empty.
+    #[tokio::test]
+    async fn build_stamps_header_and_uses_settings_device_name() {
+        let mut settings = MockSettings_::new();
+        settings
+            .expect_load()
+            .returning(|| Ok(settings_with_device_name("Alice Laptop")));
+        // Fingerprint is the fallback; it must not be consulted here.
+        let local_identity = MockLocalIdentity::new();
+
+        let factory = factory(settings, local_identity);
+        let input = dispatch_input();
+        let flow = FlowId::generate();
+        let header = factory.build(&input, &flow, &dev("self-device")).await;
+
+        assert_eq!(header.version, ClipboardHeader::CURRENT_VERSION);
+        assert_eq!(header.content_hash, input.content_hash);
+        assert_eq!(header.payload_version, input.payload_version);
+        assert_eq!(header.captured_at_ms, 1_700_000_000_000);
+        assert_eq!(header.origin_device_id, "self-device");
+        assert_eq!(header.origin_device_name, "Alice Laptop");
+        assert_eq!(header.flow_id, Some(flow.to_string()));
+    }
+
+    /// No usable settings name (absent) ⇒ fall back to the fingerprint
+    /// display.
+    #[tokio::test]
+    async fn build_falls_back_to_fingerprint_when_settings_name_absent() {
+        let mut settings = MockSettings_::new();
+        settings.expect_load().returning(|| Ok(default_settings()));
+        let mut local_identity = MockLocalIdentity::new();
+        local_identity
+            .expect_get_current_fingerprint()
+            .returning(|| Ok(Some(fp(7))));
+
+        let factory = factory(settings, local_identity);
+        let header = factory
+            .build(&dispatch_input(), &FlowId::generate(), &dev("self-device"))
+            .await;
+
+        assert_eq!(header.origin_device_name, fp(7).as_display().to_string());
+    }
+
+    /// An empty settings name is treated as "absent" — the fingerprint
+    /// fallback still kicks in.
+    #[tokio::test]
+    async fn build_falls_back_to_fingerprint_when_settings_name_empty() {
+        let mut settings = MockSettings_::new();
+        settings
+            .expect_load()
+            .returning(|| Ok(settings_with_device_name("")));
+        let mut local_identity = MockLocalIdentity::new();
+        local_identity
+            .expect_get_current_fingerprint()
+            .returning(|| Ok(Some(fp(7))));
+
+        let factory = factory(settings, local_identity);
+        let header = factory
+            .build(&dispatch_input(), &FlowId::generate(), &dev("self-device"))
+            .await;
+
+        assert_eq!(header.origin_device_name, fp(7).as_display().to_string());
+    }
+
+    /// Settings load failure also degrades to the fingerprint fallback
+    /// (best-effort header naming must never abort the dispatch).
+    #[tokio::test]
+    async fn build_falls_back_to_fingerprint_when_settings_load_errors() {
+        let mut settings = MockSettings_::new();
+        settings
+            .expect_load()
+            .returning(|| Err(anyhow::anyhow!("settings unavailable")));
+        let mut local_identity = MockLocalIdentity::new();
+        local_identity
+            .expect_get_current_fingerprint()
+            .returning(|| Ok(Some(fp(3))));
+
+        let factory = factory(settings, local_identity);
+        let header = factory
+            .build(&dispatch_input(), &FlowId::generate(), &dev("self-device"))
+            .await;
+
+        assert_eq!(header.origin_device_name, fp(3).as_display().to_string());
+    }
+
+    /// No settings name AND no fingerprint ⇒ the `"unknown-device"`
+    /// last-resort literal.
+    #[tokio::test]
+    async fn build_uses_unknown_device_when_no_name_and_no_fingerprint() {
+        let mut settings = MockSettings_::new();
+        settings.expect_load().returning(|| Ok(default_settings()));
+        let mut local_identity = MockLocalIdentity::new();
+        local_identity
+            .expect_get_current_fingerprint()
+            .returning(|| Ok(None));
+
+        let factory = factory(settings, local_identity);
+        let header = factory
+            .build(&dispatch_input(), &FlowId::generate(), &dev("self-device"))
+            .await;
+
+        assert_eq!(header.origin_device_name, "unknown-device");
+    }
+}

--- a/crates/uc-application/src/usecases/clipboard_sync/dispatch_entry/mod.rs
+++ b/crates/uc-application/src/usecases/clipboard_sync/dispatch_entry/mod.rs
@@ -53,11 +53,11 @@
 //! `ingest_inbound.rs::tests` and Phase 1 `roster/facade.rs::FakePresence`).
 
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use bytes::Bytes;
-use tokio::task::{JoinError, JoinSet};
-use tracing::{debug, info, info_span, instrument, warn, Instrument};
+use tokio::task::JoinSet;
+use tracing::{info, info_span, instrument, Instrument};
 use uc_observability::FlowId;
 
 /// 主流程等 fan-out join 的硬上限。超过此时长后,剩余仍在跑的 peer task 会被
@@ -80,24 +80,41 @@ use uc_observability::FlowId;
 /// 长尾缩到 ~0,但主流程本身的截断契约不变。详见 #785。
 const FAN_OUT_DEADLINE: Duration = Duration::from_secs(5);
 
+mod delivery;
+mod fanout;
+mod header;
+mod per_peer;
+mod target_selector;
+
+#[cfg(test)]
+mod test_support;
+
+use delivery::{
+    classify_dispatch_result, spawn_deferred_drain, DeliveryRecorder, DispatchResultBucket,
+};
+use fanout::DeadlineBoundedFanout;
+use header::OutboundHeaderFactory;
+use per_peer::PerPeerDispatcher;
+use target_selector::TargetSelector;
+
 use crate::facade::blob_transfer::SharedHostEventEmitter;
-use crate::facade::host_event::{DeliveryHostEvent, HostEvent};
 use uc_core::clipboard::{
-    ClipboardContentCategory, ClipboardContentCategorySet, DeliveryFailureReason,
-    EntryDeliveryRecord, EntryDeliveryStatus,
+    ClipboardContentCategory, ClipboardContentCategorySet, EntryDeliveryRecord,
 };
 use uc_core::ids::{DeviceId, EntryId};
 use uc_core::ports::security::TransferCipherPort;
 use uc_core::ports::{
-    ClipboardDispatchError, ClipboardDispatchPort, ClipboardHeader, ClockPort, DeviceIdentityPort,
-    DispatchAck, EntryDeliveryRepositoryPort, FirstSyncStatePort, LocalIdentityPort,
-    PeerAddressRepositoryPort, PresencePort, ReachabilityState, SettingsPort, SyncPayload,
+    ClipboardDispatchError, ClipboardDispatchPort, ClockPort, DeviceIdentityPort, DispatchAck,
+    EntryDeliveryRepositoryPort, FirstSyncStatePort, LocalIdentityPort, PeerAddressRepositoryPort,
+    PresencePort, SettingsPort, SyncPayload,
 };
 use uc_core::MemberRepositoryPort;
 use uc_observability::analytics::{
-    AnalyticsPort, Direction, Event, FailureReason, PayloadSizeBucket, PayloadType,
-    SyncDeferReason, SyncDeferredProps, SyncEventProps, SyncFailureStage, TransportType,
+    AnalyticsPort, FailureReason, PayloadSizeBucket, PayloadType, SyncFailureStage,
 };
+
+/// One fanned-out peer's settled result: the device plus the wire outcome.
+pub(crate) type PeerDispatchResult = (DeviceId, Result<DispatchAck, ClipboardDispatchError>);
 
 /// Slice 8c-1 · classify the dispatched payload by category priority
 /// (File > Image > Text). Empty / unknown sets fall back to Text rather
@@ -147,37 +164,6 @@ fn dispatch_failure_stage(err: &ClipboardDispatchError) -> SyncFailureStage {
         ClipboardDispatchError::Offline
         | ClipboardDispatchError::PeerRejected(_)
         | ClipboardDispatchError::Io(_) => SyncFailureStage::ImmediateSend,
-    }
-}
-
-async fn capture_sync_attempted(
-    analytics: &Arc<dyn AnalyticsPort>,
-    first_sync_state: &Arc<dyn FirstSyncStatePort>,
-    payload_type: PayloadType,
-    payload_size_bucket: PayloadSizeBucket,
-) {
-    analytics.capture(Event::SyncAttempted(SyncEventProps {
-        direction: Direction::Outbound,
-        payload_type,
-        payload_size_bucket,
-        transport_type: TransportType::P2pDirect,
-        peer_os: None,
-        sync_latency_ms: None,
-        failure_reason: None,
-        failure_stage: None,
-    }));
-    // Slice 8c-2 · funnel: first attempt fires regardless of outcome — keeps
-    // the "started but failed" 漏点信号。deferred 路径也会调用本函数，确保
-    // attempted 时序一致；dashboard 端用 `attempted - deferred` 推导用户感知尝试。
-    match first_sync_state.mark_first_sync_attempted().await {
-        Ok(true) => analytics.capture(Event::FirstClipboardSyncAttempted {
-            direction: Direction::Outbound,
-        }),
-        Ok(false) => {}
-        Err(err) => warn!(
-            error = %err,
-            "first_sync_state.mark_first_sync_attempted failed; skipping fire",
-        ),
     }
 }
 
@@ -267,7 +253,7 @@ pub(crate) enum DispatchSyncError {
 ///
 /// Sole consumer is `ResendEntryUseCase`, whose unit tests assert dispatch
 /// input shape (`target_filter` / `entry_id` / `content_hash`) without
-/// constructing the full 14-port dispatch use case. Production wiring
+/// constructing the full 13-port dispatch use case. Production wiring
 /// satisfies the trait through the blanket impl below. Not exposed beyond
 /// the crate.
 #[async_trait::async_trait]
@@ -288,40 +274,34 @@ impl DispatchEntryRunner for DispatchClipboardEntryUseCase {
     }
 }
 
+/// Fans one clipboard payload out to every eligible peer and records each
+/// per-peer outcome. The use case is thin orchestration over five
+/// concern-scoped collaborators:
+///
+/// - [`TargetSelector`] — who is eligible (roster ∩ !self ∩ filter ∩ gate);
+/// - [`OutboundHeaderFactory`] — the wire header stamped on every frame;
+/// - [`PerPeerDispatcher`] — dispatch one peer + emit its 1:1 telemetry;
+/// - [`DeadlineBoundedFanout`] — run the per-peer tasks under a deadline;
+/// - [`DeliveryRecorder`] — persist outcomes + ping the frontend.
+///
+/// `device_identity` and `clock` stay here as shared context resolved once
+/// per pass: identity stamps both the self-filter and the header origin;
+/// the clock stamps the aggregate outcome and each peer's delivery record.
 pub(crate) struct DispatchClipboardEntryUseCase {
-    peer_addr_repo: Arc<dyn PeerAddressRepositoryPort>,
-    member_repo: Arc<dyn MemberRepositoryPort>,
-    presence: Arc<dyn PresencePort>,
-    transfer_cipher: Arc<dyn TransferCipherPort>,
-    clipboard_dispatch: Arc<dyn ClipboardDispatchPort>,
+    cipher: Arc<dyn TransferCipherPort>,
     device_identity: Arc<dyn DeviceIdentityPort>,
-    local_identity: Arc<dyn LocalIdentityPort>,
-    settings: Arc<dyn SettingsPort>,
     clock: Arc<dyn ClockPort>,
-    /// fan-out 完成后,按每个 target 的成功/失败落盘 delivery 记录。
-    /// 仅在 `DispatchClipboardEntryInput.entry_id` 为 `Some` 时调用。
-    entry_delivery_repo: Arc<dyn EntryDeliveryRepositoryPort>,
-    /// Slice 8c-1 · per-peer telemetry. One `sync_attempted` /
-    /// `sync_succeeded` / `sync_failed` event fires per fan-out target so
-    /// PostHog reliability dashboards stay per-peer (peer_os, latency,
-    /// failure_reason are all 1:1 with a single peer outcome).
-    analytics: Arc<dyn AnalyticsPort>,
-    /// Slice 8c-2 · first-sync funnel dedup. spawn 内每次 `mark_*` 返回 `Ok(true)`
-    /// 即"我是首次"，同时额外 fire `first_clipboard_sync_attempted` /
-    /// `first_clipboard_sync_succeeded` / `first_file_sync_succeeded`。
-    /// race 防护由 port impl 内部 `tokio::sync::Mutex` 守护，调用方零感知。
-    first_sync_state: Arc<dyn FirstSyncStatePort>,
-    /// 共享 host-event bus。每条 delivery 记录写盘成功后追发一条
-    /// [`HostEvent::Delivery`],让前端 detail badge 在 dispatch 完成后自动
-    /// 刷新而无需手动切 entry。Issue #747 Phase 5。
-    ///
-    /// emit 走 [`HostEventBus::emit_or_warn`] —— 失败仅 warn,不阻塞
-    /// dispatch 主路径;事件丢失 / 乱序由前端 refetch 幂等吸收。CLI / 单元
-    /// 测试装配传一根空 bus 即可(无下游 = noop)。
-    host_event_bus: SharedHostEventEmitter,
+    selector: TargetSelector,
+    header_factory: OutboundHeaderFactory,
+    dispatcher: Arc<PerPeerDispatcher>,
+    fanout: DeadlineBoundedFanout,
+    recorder: Arc<DeliveryRecorder>,
 }
 
 impl DispatchClipboardEntryUseCase {
+    /// The 13-port positional signature is intentionally preserved so
+    /// bootstrap and tests keep wiring unchanged; the ports are reassembled
+    /// into the five concern-scoped collaborators here.
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         peer_addr_repo: Arc<dyn PeerAddressRepositoryPort>,
@@ -338,20 +318,21 @@ impl DispatchClipboardEntryUseCase {
         entry_delivery_repo: Arc<dyn EntryDeliveryRepositoryPort>,
         host_event_bus: SharedHostEventEmitter,
     ) -> Self {
+        let header_clock = Arc::clone(&clock);
         Self {
-            peer_addr_repo,
-            member_repo,
-            presence,
-            transfer_cipher,
-            clipboard_dispatch,
+            cipher: transfer_cipher,
             device_identity,
-            local_identity,
-            settings,
             clock,
-            analytics,
-            first_sync_state,
-            entry_delivery_repo,
-            host_event_bus,
+            selector: TargetSelector::new(peer_addr_repo, member_repo),
+            header_factory: OutboundHeaderFactory::new(settings, local_identity, header_clock),
+            dispatcher: Arc::new(PerPeerDispatcher::new(
+                clipboard_dispatch,
+                presence,
+                analytics,
+                first_sync_state,
+            )),
+            fanout: DeadlineBoundedFanout::new(FAN_OUT_DEADLINE),
+            recorder: Arc::new(DeliveryRecorder::new(entry_delivery_repo, host_event_bus)),
         }
     }
 
@@ -379,9 +360,9 @@ impl DispatchClipboardEntryUseCase {
     ) -> Result<DispatchOutcome, DispatchSyncError> {
         let flow_id = FlowId::generate();
         tracing::Span::current().record("flow.id", tracing::field::display(&flow_id));
-        // 1. Encrypt. A locked session surfaces here — let it short-circuit
-        //    so we don't spam the dispatch wire with encrypt-retries.
-        let ciphertext = match self.transfer_cipher.encrypt(&input.plaintext).await {
+        // 1. Encrypt once. A locked session surfaces here — let it
+        //    short-circuit so we don't spam the dispatch wire with retries.
+        let ciphertext = match self.cipher.encrypt(&input.plaintext).await {
             Ok(bytes) => Bytes::from(bytes),
             Err(err) => {
                 return Err(match err {
@@ -393,58 +374,17 @@ impl DispatchClipboardEntryUseCase {
             }
         };
 
-        // 2. Enumerate targets. `peer_addr_repo.list()` is the iteration
-        //    source (see module doc); self is the only filter. Presence
-        //    state is intentionally NOT consulted — see module doc for
-        //    rationale. The dispatch port reports `Offline` per-target
-        //    for unreachable peers, which we fold into the outcome below.
-        let records =
-            self.peer_addr_repo.list().await.map_err(|err| {
-                DispatchSyncError::Repository(format!("peer_addr_repo.list: {err}"))
-            })?;
-
+        // 2. Resolve identity once (it stamps both the self-filter and the
+        //    header origin), then enumerate eligible targets and build the
+        //    wire header. Presence is intentionally NOT consulted at
+        //    enumeration time — the per-target preflight happens in the
+        //    fan-out (see `PerPeerDispatcher`).
         let local_device = self.device_identity.current_device_id();
-        let mut candidates: Vec<DeviceId> = Vec::with_capacity(records.len());
-        for record in records {
-            if record.device_id == local_device {
-                continue;
-            }
-            // ADR-005 §2.5 resend:`target_filter` 收紧 fan-out 目标白名单。
-            // `None` 维持现状(全 fan-out);`Some(list)` 只保留交集。
-            // 注意:此处不把"空 list"视作特殊 passthrough —— `ResendEntryUseCase`
-            // 在差集为空(或显式空列表)时直接返回 `NoEligibleTargets`,根本
-            // 不会调进 dispatch。若 dispatch 仍收到空 list,只能是其它调用
-            // 方,按"交集为空"自然落到下面的"no paired peers"分支返回零
-            // fan-out。
-            if let Some(filter) = &input.target_filter {
-                if !filter.iter().any(|d| d == &record.device_id) {
-                    continue;
-                }
-            }
-            if !self
-                .is_send_allowed(&record.device_id, &input.categories)
-                .await
-            {
-                continue;
-            }
-            candidates.push(record.device_id);
-        }
-
-        // 3. Build the header once and clone per target.
-        //
-        // PR3:`flow_id` 写进 header,跨设备传到 inbound 端。inbound 收到后
-        // 会用同一个 id 落到自己的 root span,Sentry 上"A 端 dispatch →
-        // B 端 ingest"两条 trace 在 `flow.id` 维度自动 join。
-        let origin_device_name = self.load_origin_device_name().await;
-        let header = ClipboardHeader {
-            version: ClipboardHeader::CURRENT_VERSION,
-            content_hash: input.content_hash.clone(),
-            captured_at_ms: self.clock.now_ms(),
-            origin_device_id: local_device.as_str().to_string(),
-            origin_device_name,
-            payload_version: input.payload_version,
-            flow_id: Some(flow_id.to_string()),
-        };
+        let candidates = self.selector.select(&input, &local_device).await?;
+        let header = self
+            .header_factory
+            .build(&input, &flow_id, &local_device)
+            .await;
 
         if candidates.is_empty() {
             info!("dispatch: no paired peers; skipping fan-out");
@@ -462,34 +402,21 @@ impl DispatchClipboardEntryUseCase {
 
         tracing::Span::current().record("fanout.candidates", candidates.len());
 
-        // 4. Fan-out. One JoinSet task per target; results merged at the end.
-        //
-        // 每个 peer 走自己的 `peer.dispatch` child span，带上 `peer.device_id`
-        // + `flow.id`。这样 Sentry 上扇出 N 个目标时能看到 N 条平行 child span，
-        // 单点失败一目了然，而不是被 root 的"末次写入"覆盖。`flow.id` 在
-        // child 上也写一份是冗余 —— 但 root span 不一定总在同一个 trace，
-        // 在 worker 任务里显式 carry 更稳。
-        //
-        // Slice 8c-1 · each spawned task fires per-peer telemetry. `sync_attempted`
-        // 始终在 dispatch 前发一次，保证时序一致；`sync_succeeded` / `sync_failed`
-        // / `sync_deferred` 与 attempted 形成 1:1 配对。known-offline peer 仍尝试
-        // 发送（presence 可能 stale）；若 dispatch 仍判为 Offline，结果事件用
-        // `sync_deferred` 而不是 `sync_failed`，因为那是预期不可用，不该计入
-        // 用户感知失败口径（dashboard 以 `attempted - deferred` 推导用户感知尝试）。
+        // 4. Fan out: one task per target, each driving `dispatch_one`
+        //    (presence preflight + dispatch + per-peer telemetry) inside its
+        //    own `peer.dispatch` child span carrying `flow.id`, so Sentry
+        //    can join the outbound dispatch with the inbound ingest.
         let payload_type = payload_type_from_categories(&input.categories);
         let payload_size_bucket = PayloadSizeBucket::from_bytes(input.plaintext.len() as u64);
-        let mut set: JoinSet<(DeviceId, Result<DispatchAck, ClipboardDispatchError>)> =
-            JoinSet::new();
+        let header = Arc::new(header);
+        let mut set: JoinSet<PeerDispatchResult> = JoinSet::new();
         for device_id in &candidates {
-            let dispatch = Arc::clone(&self.clipboard_dispatch);
-            let presence = Arc::clone(&self.presence);
-            let analytics = Arc::clone(&self.analytics);
-            let first_sync_state = Arc::clone(&self.first_sync_state);
-            let header = header.clone();
-            let device_id = device_id.clone();
+            let dispatcher = Arc::clone(&self.dispatcher);
+            let header = Arc::clone(&header);
             let payload = SyncPayload {
                 ciphertext: ciphertext.clone(),
             };
+            let device_id = device_id.clone();
             let child_span = info_span!(
                 "peer.dispatch",
                 peer.device_id = %device_id.as_str(),
@@ -498,259 +425,71 @@ impl DispatchClipboardEntryUseCase {
             );
             set.spawn(
                 async move {
-                    // attempted 始终在 dispatch 前发，时序与口径保持单一：
-                    //   attempted = succeeded + failed + deferred
-                    //   用户感知尝试 = attempted - deferred
-                    // 详见 docs/architecture/telemetry-events.md §7.3b。
-                    let preflight_state = presence.current_state(&device_id).await;
-                    let known_offline = matches!(preflight_state, ReachabilityState::Offline);
-                    capture_sync_attempted(
-                        &analytics,
-                        &first_sync_state,
-                        payload_type,
-                        payload_size_bucket,
-                    )
-                    .await;
-
-                    // Skip the dial entirely when presence already reports
-                    // Offline. A dial against a silently-dead peer can run
-                    // up to STAGGERED_DELAYS[2] (1.5s) + ATTEMPT_TIMEOUT (3s)
-                    // = 4.5s before failing — short of the main loop's
-                    // FAN_OUT_DEADLINE (5s) on its own, but with multiple
-                    // peers piling on the same offline target it still
-                    // stalls every clipboard copy on the deadline. Since
-                    // the dispatch adapter writes presence Offline on its
-                    // own dial failures (PresencePort::mark_offline) and
-                    // the presence fast-path enforces a TTL re-dial, by the
-                    // time `known_offline` is true we have first-hand
-                    // evidence the peer is unreachable — re-dialing here
-                    // would burn the deadline to learn nothing new.
-                    //
-                    // Telemetry preserves attempted+deferred parity: we
-                    // already fired `sync_attempted` above, and now fire
-                    // `sync_deferred` with `peer_known_offline` as the
-                    // reason, matching the post-dial deferred path's
-                    // semantics. Background recovery is unchanged — the
-                    // next clipboard event will retry, and an inbound
-                    // presence connection from the peer flips state back
-                    // to Online and reopens the dial path.
-                    if known_offline {
-                        analytics.capture(Event::SyncDeferred(SyncDeferredProps {
-                            direction: Direction::Outbound,
+                    dispatcher
+                        .dispatch_one(
+                            device_id,
+                            header,
+                            payload,
                             payload_type,
                             payload_size_bucket,
-                            peer_os: None,
-                            defer_reason: SyncDeferReason::PeerKnownOffline,
-                        }));
-                        return (device_id, Err(ClipboardDispatchError::Offline));
-                    }
-
-                    let started_at = Instant::now();
-                    let result = dispatch.dispatch(&device_id, &header, payload).await;
-                    let duration_ms =
-                        started_at.elapsed().as_millis().min(u32::MAX as u128) as u32;
-
-                    // Pre-#886 the use case stamped a local negative
-                    // cache here on `Offline` / `Io` failures. The
-                    // dispatch adapter now calls
-                    // `PresencePort::mark_offline` itself when the dial
-                    // path fully fails, which arms a sticky window in
-                    // the presence adapter — the next dispatch's
-                    // preflight reads `Offline` from `current_state` and
-                    // short-circuits without us maintaining a parallel
-                    // cache here.
-
-                    let event = match &result {
-                        Ok(_) => Event::SyncSucceeded(SyncEventProps {
-                            direction: Direction::Outbound,
-                            payload_type,
-                            payload_size_bucket,
-                            transport_type: TransportType::P2pDirect,
-                            peer_os: None,
-                            sync_latency_ms: Some(duration_ms),
-                            failure_reason: None,
-                            failure_stage: None,
-                        }),
-                        Err(err) => Event::SyncFailed(SyncEventProps {
-                            direction: Direction::Outbound,
-                            payload_type,
-                            payload_size_bucket,
-                            transport_type: TransportType::P2pDirect,
-                            peer_os: None,
-                            sync_latency_ms: None,
-                            failure_reason: Some(map_dispatch_error_to_failure_reason(err)),
-                            failure_stage: Some(dispatch_failure_stage(err)),
-                        }),
-                    };
-                    let is_ok = result.is_ok();
-                    analytics.capture(event);
-
-                    // Slice 8c-2 · funnel: first success path fires both the
-                    // generic clipboard event and (if payload_type=File) the
-                    // file-specific event. Both flags独立 dedup。
-                    if is_ok {
-                        match first_sync_state.mark_first_sync_succeeded().await {
-                            Ok(true) => analytics.capture(Event::FirstClipboardSyncSucceeded {
-                                direction: Direction::Outbound,
-                                peer_os: None,
-                                transport_type: TransportType::P2pDirect,
-                                duration_ms,
-                            }),
-                            Ok(false) => {}
-                            Err(err) => warn!(
-                                error = %err,
-                                "first_sync_state.mark_first_sync_succeeded failed; skipping fire",
-                            ),
-                        }
-                        if matches!(payload_type, PayloadType::File) {
-                            match first_sync_state.mark_first_file_sync_succeeded().await {
-                                Ok(true) => analytics.capture(Event::FirstFileSyncSucceeded {
-                                    peer_os: None,
-                                    transport_type: TransportType::P2pDirect,
-                                    payload_size_bucket,
-                                }),
-                                Ok(false) => {}
-                                Err(err) => warn!(
-                                    error = %err,
-                                    "first_sync_state.mark_first_file_sync_succeeded failed; skipping fire",
-                                ),
-                            }
-                        }
-                    }
-
-                    (device_id, result)
+                        )
+                        .await
                 }
                 .instrument(child_span),
             );
         }
 
+        // 5. Drain within the fan-out deadline; classify + fold each
+        //    foreground settle as it lands. Each peer samples its own
+        //    `now_ms` (inside the closure), so a delivery record reflects
+        //    that peer's actual completion time. Tasks still in flight at
+        //    the deadline are handed back for the background drain below.
+        let entry_id = input.entry_id.clone();
         let mut per_target = Vec::with_capacity(candidates.len());
         let mut total_accepted = 0;
         let mut total_duplicate = 0;
         let mut total_offline = 0;
         let mut total_errored = 0;
-
-        // fan-out 完成后,如果调用方提供了 entry_id,就把"每个对端的结果"
-        // 落盘到 entry_delivery 表。先在 join loop 内收集本地待写记录,
-        // 循环结束再串行 await,避免在 hot path 上多次 await 让出调度器。
-        // updated_at_ms 在每个 arm 内独立采样,反映该对端的实际完成时刻
-        // (不同 peer 的 fan-out 延迟分布很广,共用单点时间会丢失排障信息)。
-        let entry_id_for_delivery = input.entry_id.clone();
         let mut delivery_records: Vec<EntryDeliveryRecord> = Vec::new();
 
-        // 主流程 fan-out join 受 `FAN_OUT_DEADLINE` 截断。在 deadline 内 settle
-        // 的 peer 走原路径(计数 + per_target + delivery)。deadline 到时仍在跑
-        // 的 task 会被整体 move 给后台 spawn 继续 join,主流程立即返回
-        // `total_pending = set.len()`。详见常量 doc 与 #785。
-        let fanout_started = Instant::now();
-        loop {
-            let remaining = FAN_OUT_DEADLINE.saturating_sub(fanout_started.elapsed());
-            if remaining.is_zero() {
-                break;
-            }
-            match tokio::time::timeout(remaining, set.join_next()).await {
-                Ok(Some(joined)) => {
-                    let processed = classify_dispatch_result(
-                        joined,
-                        entry_id_for_delivery.as_ref(),
-                        self.clock.now_ms(),
-                    );
-                    match processed.bucket {
-                        DispatchResultBucket::Accepted => total_accepted += 1,
-                        DispatchResultBucket::Duplicate => total_duplicate += 1,
-                        DispatchResultBucket::Offline => total_offline += 1,
-                        DispatchResultBucket::Errored | DispatchResultBucket::Panicked => {
-                            total_errored += 1
-                        }
-                    }
-                    if let Some(pt) = processed.per_target {
-                        per_target.push(pt);
-                    }
-                    if let Some(rec) = processed.delivery_record {
-                        delivery_records.push(rec);
+        let leftover = self
+            .fanout
+            .drain_foreground(set, |joined| {
+                let processed =
+                    classify_dispatch_result(joined, entry_id.as_ref(), self.clock.now_ms());
+                match processed.bucket {
+                    DispatchResultBucket::Accepted => total_accepted += 1,
+                    DispatchResultBucket::Duplicate => total_duplicate += 1,
+                    DispatchResultBucket::Offline => total_offline += 1,
+                    DispatchResultBucket::Errored | DispatchResultBucket::Panicked => {
+                        total_errored += 1
                     }
                 }
-                Ok(None) => break, // set drained — all peers settled within deadline
-                Err(_) => break,   // deadline elapsed — defer remaining to background
-            }
-        }
+                if let Some(pt) = processed.per_target {
+                    per_target.push(pt);
+                }
+                if let Some(rec) = processed.delivery_record {
+                    delivery_records.push(rec);
+                }
+            })
+            .await;
 
-        // 串行落盘 delivery 记录。失败仅 log,不阻塞主流程的返回,这是
-        // 一个可观测性副作用,不该影响 dispatch 自身的成败语义。
-        //
-        // Issue #747 Phase 5:成功写入一条 record 后,立即追发一条
-        // `HostEvent::Delivery::StatusChanged`,让 GUI detail 视图实时
-        // 刷新。先 record → 后 emit 的顺序很关键 —— 前端拿到事件后会
-        // refetch view,view 必须能读到最新写入,否则前端会得到一份与
-        // 事件不一致的旧快照(看似"再切一次 entry 才刷新"的旧问题原貌)。
-        // 事件 payload 不携带 status —— 前端按 entry_id 匹配后 refetch
-        // 拿真相,事件只是"该不该 refetch"的指针,见 `DeliveryHostEvent`
-        // 的注释。
-        flush_delivery_records(
-            &delivery_records,
-            self.entry_delivery_repo.as_ref(),
-            &self.host_event_bus,
-        )
-        .await;
+        // 6. Record the foreground deliveries (write-then-emit is
+        //    load-bearing — see `DeliveryRecorder::flush`).
+        self.recorder.flush(&delivery_records).await;
 
-        // 把剩余 in-flight 的 peer task 移交后台继续 join。helper 自带
-        // delivery 写盘 + emit,语义与主流程内一致;只是发生在 dispatch_capture
-        // 已经返回之后,前端 delivery badge 会按 peer 真实完成时刻陆续刷新,
-        // 而不是被 staggered retry 长尾整体卡住。
-        let total_pending = set.len();
+        // 7. Hand still-in-flight peers to a detached background drain that
+        //    records each as it finally settles — so an early-acking peer's
+        //    badge isn't held hostage by a staggered-retry long tail. This
+        //    is best-effort RECORD-ONLY, never a resend (VISION #59).
+        let total_pending = leftover.len();
         if total_pending > 0 {
-            let entry_id_bg = entry_id_for_delivery.clone();
-            let clock_bg = Arc::clone(&self.clock);
-            let entry_delivery_repo_bg = Arc::clone(&self.entry_delivery_repo);
-            let host_event_bus_bg = Arc::clone(&self.host_event_bus);
-            let content_hash_bg = input.content_hash.clone();
-            tokio::spawn(
-                async move {
-                    let bg_started = Instant::now();
-                    let mut bg_accepted = 0usize;
-                    let mut bg_duplicate = 0usize;
-                    let mut bg_offline = 0usize;
-                    let mut bg_errored = 0usize;
-                    // 每个 peer task join 完就立刻把它那条 delivery record
-                    // 写盘 + emit,不再累成一笔等所有 deferred peer 跑完再
-                    // flush。否则一个 staggered retry 拖尾的离线 peer 会
-                    // 把前面早就 ack 的 peer 的 badge 刷新也一起卡 15s,
-                    // 与注释里"按 peer 真实完成时刻陆续刷新"的承诺相违背。
-                    while let Some(joined) = set.join_next().await {
-                        let processed = classify_dispatch_result(
-                            joined,
-                            entry_id_bg.as_ref(),
-                            clock_bg.now_ms(),
-                        );
-                        match processed.bucket {
-                            DispatchResultBucket::Accepted => bg_accepted += 1,
-                            DispatchResultBucket::Duplicate => bg_duplicate += 1,
-                            DispatchResultBucket::Offline => bg_offline += 1,
-                            DispatchResultBucket::Errored | DispatchResultBucket::Panicked => {
-                                bg_errored += 1
-                            }
-                        }
-                        if let Some(rec) = processed.delivery_record {
-                            flush_delivery_records(
-                                std::slice::from_ref(&rec),
-                                entry_delivery_repo_bg.as_ref(),
-                                &host_event_bus_bg,
-                            )
-                            .await;
-                        }
-                    }
-                    info!(
-                        content_hash = %content_hash_bg,
-                        deferred_count = total_pending,
-                        accepted = bg_accepted,
-                        duplicate = bg_duplicate,
-                        offline = bg_offline,
-                        errored = bg_errored,
-                        bg_duration_ms = bg_started.elapsed().as_millis() as u64,
-                        "dispatch: deferred fan-out completed"
-                    );
-                }
-                .in_current_span(),
+            spawn_deferred_drain(
+                leftover,
+                entry_id,
+                Arc::clone(&self.clock),
+                Arc::clone(&self.recorder),
+                input.content_hash.clone(),
             );
         }
 
@@ -764,255 +503,6 @@ impl DispatchClipboardEntryUseCase {
             total_pending,
             at_ms: self.clock.now_ms(),
         })
-    }
-
-    /// Per-device sync gate: returns `true` when the local device should
-    /// fan a clipboard frame out to `device_id`. Two stages:
-    ///
-    /// 1. Device-level kill switch (`send_enabled`).
-    /// 2. Content-type filter (`send_content_types`, AND-of-allowed across
-    ///    the snapshot's category set — see `uc-core` `category.rs` module doc).
-    ///    Empty set (raw-bytes / unrecognised payload) passes (fail open)
-    ///    so we don't stall sync silently.
-    ///
-    /// Member-record miss / repo error → fail open with a WARN, mirroring
-    /// the device-level gate's posture: a transient glitch should not
-    /// silently kill sync.
-    async fn is_send_allowed(
-        &self,
-        device_id: &DeviceId,
-        categories: &ClipboardContentCategorySet,
-    ) -> bool {
-        match self.member_repo.get(device_id).await {
-            Ok(Some(member)) => {
-                if !member.sync_preferences.send_enabled {
-                    info!(
-                        device_id = %device_id.as_str(),
-                        reason = "send_disabled_by_user",
-                        "dispatch: skipping peer per per-device sync preferences"
-                    );
-                    return false;
-                }
-                if !categories.allowed_by(&member.sync_preferences.send_content_types) {
-                    info!(
-                        device_id = %device_id.as_str(),
-                        categories = %categories.labels(),
-                        denied = %categories
-                            .denied_labels(&member.sync_preferences.send_content_types),
-                        reason = "content_type_disabled_by_user",
-                        "dispatch: skipping peer per per-device content_types filter"
-                    );
-                    return false;
-                }
-                true
-            }
-            Ok(None) => {
-                warn!(
-                    device_id = %device_id.as_str(),
-                    "dispatch: peer in addr repo but missing from member repo; failing open"
-                );
-                true
-            }
-            Err(err) => {
-                warn!(
-                    device_id = %device_id.as_str(),
-                    error = %err,
-                    "dispatch: member repo lookup failed; failing open"
-                );
-                true
-            }
-        }
-    }
-
-    /// Load the device's own display name to embed in the outbound header
-    /// so the peer can show "from <Alice's Laptop>". Falls back to the
-    /// fingerprint if settings are unreadable or empty.
-    async fn load_origin_device_name(&self) -> String {
-        match self.settings.load().await {
-            Ok(settings) => {
-                if let Some(name) = settings.general.device_name {
-                    if !name.is_empty() {
-                        return name;
-                    }
-                }
-            }
-            Err(err) => {
-                warn!(error = %err, "dispatch: settings load failed; using fingerprint fallback");
-            }
-        }
-        match self.local_identity.get_current_fingerprint().await {
-            Ok(Some(fp)) => fp.as_display().to_string(),
-            _ => "unknown-device".to_string(),
-        }
-    }
-}
-
-/// Outcome bucket for `classify_dispatch_result`. Caller uses this to bump the
-/// matching counter on the aggregated `DispatchOutcome` (or the background
-/// continuation's own counters). `Panicked` rolls up into `Errored` because
-/// the existing `DispatchOutcome` API surface has no separate panic bucket
-/// and treating a panicked task as "errored" keeps `attempted = succeeded +
-/// failed + deferred` semantics intact for telemetry.
-enum DispatchResultBucket {
-    Accepted,
-    Duplicate,
-    Offline,
-    Errored,
-    Panicked,
-}
-
-/// Folded view of one fanned-out peer's `JoinSet` result, ready for the
-/// caller to fold into `DispatchOutcome` (or the background continuation).
-struct ProcessedDispatchResult {
-    /// `None` iff the task panicked / was cancelled (no DeviceId recoverable).
-    per_target: Option<DispatchPerTarget>,
-    /// `None` iff `entry_id` was `None` OR the task panicked. Otherwise a
-    /// fully populated record ready for `EntryDeliveryRepositoryPort::record_attempt`.
-    delivery_record: Option<EntryDeliveryRecord>,
-    bucket: DispatchResultBucket,
-}
-
-/// Shared per-peer result-handling — used by both the main flow and the
-/// background continuation that drains `set` after the fan-out deadline.
-/// Kept as a free function (not a method) so the background `tokio::spawn`
-/// task can call it without holding `&self`.
-///
-/// `now_ms` is sampled by the caller (each peer's `updated_at_ms` reflects
-/// the moment that peer's result was observed, not a shared snapshot of
-/// dispatch completion).
-fn classify_dispatch_result(
-    joined: Result<(DeviceId, Result<DispatchAck, ClipboardDispatchError>), JoinError>,
-    entry_id: Option<&EntryId>,
-    now_ms: i64,
-) -> ProcessedDispatchResult {
-    match joined {
-        Ok((device_id, Ok(DispatchAck::Accepted))) => {
-            debug!(device_id = %device_id.as_str(), "dispatch → Accepted");
-            let delivery_record = entry_id.map(|eid| EntryDeliveryRecord {
-                entry_id: eid.clone(),
-                target_device_id: device_id.clone(),
-                status: EntryDeliveryStatus::Delivered,
-                reason_detail: None,
-                updated_at_ms: now_ms,
-            });
-            ProcessedDispatchResult {
-                per_target: Some(DispatchPerTarget {
-                    device_id,
-                    outcome: Ok(DispatchAck::Accepted),
-                }),
-                delivery_record,
-                bucket: DispatchResultBucket::Accepted,
-            }
-        }
-        Ok((device_id, Ok(DispatchAck::DuplicateIgnored))) => {
-            debug!(device_id = %device_id.as_str(), "dispatch → DuplicateIgnored");
-            let delivery_record = entry_id.map(|eid| EntryDeliveryRecord {
-                entry_id: eid.clone(),
-                target_device_id: device_id.clone(),
-                status: EntryDeliveryStatus::Duplicate,
-                reason_detail: None,
-                updated_at_ms: now_ms,
-            });
-            ProcessedDispatchResult {
-                per_target: Some(DispatchPerTarget {
-                    device_id,
-                    outcome: Ok(DispatchAck::DuplicateIgnored),
-                }),
-                delivery_record,
-                bucket: DispatchResultBucket::Duplicate,
-            }
-        }
-        Ok((device_id, Err(ClipboardDispatchError::Offline))) => {
-            debug!(device_id = %device_id.as_str(), "dispatch → Offline");
-            let delivery_record = entry_id.map(|eid| EntryDeliveryRecord {
-                entry_id: eid.clone(),
-                target_device_id: device_id.clone(),
-                status: EntryDeliveryStatus::Failed {
-                    reason: DeliveryFailureReason::Offline,
-                },
-                reason_detail: None,
-                updated_at_ms: now_ms,
-            });
-            ProcessedDispatchResult {
-                per_target: Some(DispatchPerTarget {
-                    device_id,
-                    outcome: Err("offline".to_string()),
-                }),
-                delivery_record,
-                bucket: DispatchResultBucket::Offline,
-            }
-        }
-        Ok((device_id, Err(err))) => {
-            warn!(device_id = %device_id.as_str(), error = %err, "dispatch failed");
-            let (failure_reason, reason_detail) = match &err {
-                // Offline 在上一个 arm 已处理,这里不会进。保留以满足穷尽性。
-                ClipboardDispatchError::Offline => (DeliveryFailureReason::Offline, None),
-                ClipboardDispatchError::LocalPolicyExceeded(s) => {
-                    (DeliveryFailureReason::LocalPolicy, Some(s.clone()))
-                }
-                ClipboardDispatchError::PeerRejected(s) => {
-                    (DeliveryFailureReason::PeerRejected, Some(s.clone()))
-                }
-                ClipboardDispatchError::Io(s) => (DeliveryFailureReason::Io, Some(s.clone())),
-                ClipboardDispatchError::Internal(s) => {
-                    (DeliveryFailureReason::Internal, Some(s.clone()))
-                }
-            };
-            let delivery_record = entry_id.map(|eid| EntryDeliveryRecord {
-                entry_id: eid.clone(),
-                target_device_id: device_id.clone(),
-                status: EntryDeliveryStatus::Failed {
-                    reason: failure_reason,
-                },
-                reason_detail,
-                updated_at_ms: now_ms,
-            });
-            ProcessedDispatchResult {
-                per_target: Some(DispatchPerTarget {
-                    device_id,
-                    outcome: Err(err.to_string()),
-                }),
-                delivery_record,
-                bucket: DispatchResultBucket::Errored,
-            }
-        }
-        Err(err) => {
-            warn!(error = %err, "dispatch task panicked or cancelled");
-            ProcessedDispatchResult {
-                per_target: None,
-                delivery_record: None,
-                bucket: DispatchResultBucket::Panicked,
-            }
-        }
-    }
-}
-
-/// Sequentially `record_attempt` each entry-delivery record then `emit_or_warn`
-/// the matching `DeliveryHostEvent`. Write-then-emit order is load-bearing —
-/// the host event is a "refetch ping" with no payload, so the frontend's
-/// follow-up read must observe the write. See `DeliveryHostEvent` docs.
-///
-/// Errors only `warn!`; this is an observability side-effect that must not
-/// mask `dispatch_capture`'s real success/failure semantics.
-async fn flush_delivery_records(
-    records: &[EntryDeliveryRecord],
-    repo: &dyn EntryDeliveryRepositoryPort,
-    bus: &SharedHostEventEmitter,
-) {
-    for record in records {
-        if let Err(err) = repo.record_attempt(record).await {
-            warn!(
-                error = %err,
-                entry_id = %record.entry_id,
-                target_device_id = %record.target_device_id,
-                "failed to record entry delivery"
-            );
-            continue;
-        }
-        bus.emit_or_warn(HostEvent::Delivery(DeliveryHostEvent::StatusChanged {
-            entry_id: record.entry_id.to_string(),
-            target_device_id: record.target_device_id.as_str().to_string(),
-        }));
     }
 }
 
@@ -1047,15 +537,17 @@ mod tests {
     use mockall::predicate::*;
     use tokio::sync::broadcast;
 
+    use uc_core::clipboard::{DeliveryFailureReason, EntryDeliveryStatus};
     use uc_core::ports::security::{TransferCipherError, TransferCipherPort};
     use uc_core::ports::{
-        ClockPort, DeviceIdentityPort, FirstSyncStateError, LocalIdentityError, LocalIdentityPort,
-        PeerAddressError, PeerAddressRecord, PeerAddressRepositoryPort, PresenceError,
-        PresenceEvent, PresencePort, ReachabilityState, SettingsPort,
+        ClipboardHeader, ClockPort, DeviceIdentityPort, FirstSyncStateError, LocalIdentityError,
+        LocalIdentityPort, PeerAddressError, PeerAddressRecord, PeerAddressRepositoryPort,
+        PresenceError, PresenceEvent, PresencePort, ReachabilityState, SettingsPort,
     };
     use uc_core::security::IdentityFingerprint;
     use uc_core::settings::model::Settings;
     use uc_core::{MemberRepositoryPort, MemberSyncPreferences, MembershipError, SpaceMember};
+    use uc_observability::analytics::{Direction, Event, SyncDeferReason, TransportType};
 
     // ── mockall: PeerAddressRepositoryPort ──────────────────────────────
 

--- a/crates/uc-application/src/usecases/clipboard_sync/dispatch_entry/per_peer.rs
+++ b/crates/uc-application/src/usecases/clipboard_sync/dispatch_entry/per_peer.rs
@@ -1,0 +1,393 @@
+//! `PerPeerDispatcher` — the per-target dispatch body fanned out by the
+//! use case. Owns the four ports the JoinSet task touches 1:1 per peer
+//! (wire dispatch + presence preflight + the two telemetry funnels) so the
+//! "send to one peer and emit its per-peer analytics" concern has a single
+//! home and an independent test surface.
+//!
+//! ## Load-bearing invariants (Slice 8c funnel)
+//!
+//! - `sync_attempted` fires BEFORE any dial — on every path, including the
+//!   known-offline deferral — so `attempted = succeeded + failed +
+//!   deferred` holds and the dashboard can derive user-perceived attempts
+//!   as `attempted - deferred`.
+//! - A presence preflight of `Offline` short-circuits to
+//!   `SyncDeferred(PeerKnownOffline)` + `Err(Offline)` WITHOUT dialing —
+//!   redialing a peer the dispatch adapter already concluded unreachable
+//!   would only burn the fan-out deadline (see the use-case module doc).
+//! - `sync_latency_ms` is recorded only on success; a failure has no
+//!   end-to-end timing.
+//! - `mark_*` errors are warn-only and never abort the dial.
+
+use std::sync::Arc;
+use std::time::Instant;
+
+use tracing::warn;
+use uc_core::ids::DeviceId;
+use uc_core::ports::{
+    ClipboardDispatchError, ClipboardDispatchPort, ClipboardHeader, FirstSyncStatePort,
+    PresencePort, ReachabilityState, SyncPayload,
+};
+use uc_observability::analytics::{
+    AnalyticsPort, Direction, Event, PayloadSizeBucket, PayloadType, SyncDeferReason,
+    SyncDeferredProps, SyncEventProps, TransportType,
+};
+
+use super::{dispatch_failure_stage, map_dispatch_error_to_failure_reason, PeerDispatchResult};
+
+pub(crate) struct PerPeerDispatcher {
+    clipboard_dispatch: Arc<dyn ClipboardDispatchPort>,
+    presence: Arc<dyn PresencePort>,
+    analytics: Arc<dyn AnalyticsPort>,
+    first_sync_state: Arc<dyn FirstSyncStatePort>,
+}
+
+impl PerPeerDispatcher {
+    pub(crate) fn new(
+        clipboard_dispatch: Arc<dyn ClipboardDispatchPort>,
+        presence: Arc<dyn PresencePort>,
+        analytics: Arc<dyn AnalyticsPort>,
+        first_sync_state: Arc<dyn FirstSyncStatePort>,
+    ) -> Self {
+        Self {
+            clipboard_dispatch,
+            presence,
+            analytics,
+            first_sync_state,
+        }
+    }
+
+    /// Fire `sync_attempted` (+ first-attempt funnel). ALWAYS called before
+    /// any dial so funnel parity holds on every path; the deferred path
+    /// calls it too. `mark_*` failure is warn-only.
+    async fn capture_attempted(
+        &self,
+        payload_type: PayloadType,
+        payload_size_bucket: PayloadSizeBucket,
+    ) {
+        self.analytics.capture(Event::SyncAttempted(SyncEventProps {
+            direction: Direction::Outbound,
+            payload_type,
+            payload_size_bucket,
+            transport_type: TransportType::P2pDirect,
+            peer_os: None,
+            sync_latency_ms: None,
+            failure_reason: None,
+            failure_stage: None,
+        }));
+        match self.first_sync_state.mark_first_sync_attempted().await {
+            Ok(true) => self.analytics.capture(Event::FirstClipboardSyncAttempted {
+                direction: Direction::Outbound,
+            }),
+            Ok(false) => {}
+            Err(err) => warn!(
+                error = %err,
+                "first_sync_state.mark_first_sync_attempted failed; skipping fire",
+            ),
+        }
+    }
+
+    /// Dispatch one encrypted payload to one peer, emitting that peer's
+    /// per-peer telemetry, and return the device + wire outcome for the
+    /// fan-out to fold.
+    pub(crate) async fn dispatch_one(
+        &self,
+        device_id: DeviceId,
+        header: Arc<ClipboardHeader>,
+        payload: SyncPayload,
+        payload_type: PayloadType,
+        payload_size_bucket: PayloadSizeBucket,
+    ) -> PeerDispatchResult {
+        // Preflight presence, then fire attempted (ordering: attempted must
+        // precede the dial / deferral so funnel parity holds).
+        let preflight_state = self.presence.current_state(&device_id).await;
+        let known_offline = matches!(preflight_state, ReachabilityState::Offline);
+        self.capture_attempted(payload_type, payload_size_bucket)
+            .await;
+
+        // Skip the dial entirely when presence already reports Offline. The
+        // dispatch adapter writes presence Offline on its own dial failures
+        // and enforces a TTL re-dial, so by the time `known_offline` is true
+        // we have first-hand evidence the peer is unreachable. Telemetry
+        // fires `sync_deferred` (not `sync_failed`) to preserve
+        // attempted+deferred parity. Background recovery is unchanged — the
+        // next clipboard event retries and an inbound presence connection
+        // flips the peer back to Online.
+        if known_offline {
+            self.analytics
+                .capture(Event::SyncDeferred(SyncDeferredProps {
+                    direction: Direction::Outbound,
+                    payload_type,
+                    payload_size_bucket,
+                    peer_os: None,
+                    defer_reason: SyncDeferReason::PeerKnownOffline,
+                }));
+            return (device_id, Err(ClipboardDispatchError::Offline));
+        }
+
+        let started_at = Instant::now();
+        let result = self
+            .clipboard_dispatch
+            .dispatch(&device_id, &header, payload)
+            .await;
+        let duration_ms = started_at.elapsed().as_millis().min(u32::MAX as u128) as u32;
+
+        let event = match &result {
+            Ok(_) => Event::SyncSucceeded(SyncEventProps {
+                direction: Direction::Outbound,
+                payload_type,
+                payload_size_bucket,
+                transport_type: TransportType::P2pDirect,
+                peer_os: None,
+                sync_latency_ms: Some(duration_ms),
+                failure_reason: None,
+                failure_stage: None,
+            }),
+            Err(err) => Event::SyncFailed(SyncEventProps {
+                direction: Direction::Outbound,
+                payload_type,
+                payload_size_bucket,
+                transport_type: TransportType::P2pDirect,
+                peer_os: None,
+                sync_latency_ms: None,
+                failure_reason: Some(map_dispatch_error_to_failure_reason(err)),
+                failure_stage: Some(dispatch_failure_stage(err)),
+            }),
+        };
+        let is_ok = result.is_ok();
+        self.analytics.capture(event);
+
+        // First-success funnel: fires the generic clipboard event and (if
+        // File) the file-specific event. Both flags dedup independently.
+        if is_ok {
+            match self.first_sync_state.mark_first_sync_succeeded().await {
+                Ok(true) => self.analytics.capture(Event::FirstClipboardSyncSucceeded {
+                    direction: Direction::Outbound,
+                    peer_os: None,
+                    transport_type: TransportType::P2pDirect,
+                    duration_ms,
+                }),
+                Ok(false) => {}
+                Err(err) => warn!(
+                    error = %err,
+                    "first_sync_state.mark_first_sync_succeeded failed; skipping fire",
+                ),
+            }
+            if matches!(payload_type, PayloadType::File) {
+                match self.first_sync_state.mark_first_file_sync_succeeded().await {
+                    Ok(true) => self.analytics.capture(Event::FirstFileSyncSucceeded {
+                        peer_os: None,
+                        transport_type: TransportType::P2pDirect,
+                        payload_size_bucket,
+                    }),
+                    Ok(false) => {}
+                    Err(err) => warn!(
+                        error = %err,
+                        "first_sync_state.mark_first_file_sync_succeeded failed; skipping fire",
+                    ),
+                }
+            }
+        }
+
+        (device_id, result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::test_support::*;
+    use super::*;
+
+    use uc_core::ports::DispatchAck;
+    use uc_observability::analytics::{FailureReason, SyncFailureStage};
+
+    fn header() -> Arc<ClipboardHeader> {
+        Arc::new(test_header())
+    }
+
+    fn bucket() -> PayloadSizeBucket {
+        PayloadSizeBucket::from_bytes(11)
+    }
+
+    /// Online (Unknown) peer + accepting dispatch: `sync_attempted` fires
+    /// before the dial, then `sync_succeeded` carries latency. Result is the
+    /// peer's `Ok(ack)`.
+    #[tokio::test]
+    async fn dispatch_one_success_fires_attempted_then_succeeded_with_latency() {
+        let mut dispatch = MockDispatch::new();
+        dispatch
+            .expect_dispatch()
+            .times(1)
+            .returning(|_, _, _| Ok(DispatchAck::Accepted));
+
+        let analytics = Arc::new(CapturingAnalyticsSink::default());
+        let dispatcher = PerPeerDispatcher::new(
+            Arc::new(dispatch),
+            Arc::new(StaticPresence(ReachabilityState::Unknown)),
+            analytics.clone(),
+            Arc::new(AllMarkedFirstSyncState),
+        );
+
+        let (device, outcome) = dispatcher
+            .dispatch_one(
+                dev("peer-a"),
+                header(),
+                sync_payload(),
+                PayloadType::Text,
+                bucket(),
+            )
+            .await;
+
+        assert_eq!(device.as_str(), "peer-a");
+        assert!(matches!(outcome, Ok(DispatchAck::Accepted)));
+
+        let events = analytics.events();
+        assert_eq!(events.len(), 2, "got {events:?}");
+        assert!(matches!(events[0], Event::SyncAttempted(_)));
+        match &events[1] {
+            Event::SyncSucceeded(p) => {
+                assert_eq!(p.direction, Direction::Outbound);
+                assert_eq!(p.transport_type, TransportType::P2pDirect);
+                assert!(p.sync_latency_ms.is_some());
+                assert!(p.failure_reason.is_none());
+                assert!(p.failure_stage.is_none());
+            }
+            other => panic!("expected SyncSucceeded, got {other:?}"),
+        }
+    }
+
+    /// Presence `Offline` short-circuits: the dispatch port is NEVER touched,
+    /// `sync_attempted` still fires (funnel parity), and the deferral is
+    /// reported via `sync_deferred(PeerKnownOffline)` + `Err(Offline)`.
+    #[tokio::test]
+    async fn dispatch_one_known_offline_skips_dial_and_fires_deferred() {
+        let mut dispatch = MockDispatch::new();
+        dispatch.expect_dispatch().times(0);
+
+        let analytics = Arc::new(CapturingAnalyticsSink::default());
+        let dispatcher = PerPeerDispatcher::new(
+            Arc::new(dispatch),
+            Arc::new(StaticPresence(ReachabilityState::Offline)),
+            analytics.clone(),
+            Arc::new(AllMarkedFirstSyncState),
+        );
+
+        let (device, outcome) = dispatcher
+            .dispatch_one(
+                dev("peer-off"),
+                header(),
+                sync_payload(),
+                PayloadType::Text,
+                bucket(),
+            )
+            .await;
+
+        assert_eq!(device.as_str(), "peer-off");
+        assert!(matches!(outcome, Err(ClipboardDispatchError::Offline)));
+
+        let events = analytics.events();
+        assert_eq!(events.len(), 2, "got {events:?}");
+        assert!(matches!(events[0], Event::SyncAttempted(_)));
+        match &events[1] {
+            Event::SyncDeferred(p) => {
+                assert_eq!(p.defer_reason, SyncDeferReason::PeerKnownOffline);
+                assert_eq!(p.direction, Direction::Outbound);
+            }
+            other => panic!("expected SyncDeferred, got {other:?}"),
+        }
+    }
+
+    /// A failing dispatch fires `sync_failed` with a mapped reason/stage and
+    /// NO latency (a failure has no end-to-end timing).
+    #[tokio::test]
+    async fn dispatch_one_failure_fires_failed_without_latency() {
+        let mut dispatch = MockDispatch::new();
+        dispatch
+            .expect_dispatch()
+            .times(1)
+            .returning(|_, _, _| Err(ClipboardDispatchError::PeerRejected("nope".to_string())));
+
+        let analytics = Arc::new(CapturingAnalyticsSink::default());
+        let dispatcher = PerPeerDispatcher::new(
+            Arc::new(dispatch),
+            Arc::new(StaticPresence(ReachabilityState::Unknown)),
+            analytics.clone(),
+            Arc::new(AllMarkedFirstSyncState),
+        );
+
+        let (device, outcome) = dispatcher
+            .dispatch_one(
+                dev("peer-rej"),
+                header(),
+                sync_payload(),
+                PayloadType::Text,
+                bucket(),
+            )
+            .await;
+
+        assert_eq!(device.as_str(), "peer-rej");
+        assert!(matches!(
+            outcome,
+            Err(ClipboardDispatchError::PeerRejected(_))
+        ));
+
+        let events = analytics.events();
+        assert_eq!(events.len(), 2, "got {events:?}");
+        assert!(matches!(events[0], Event::SyncAttempted(_)));
+        match &events[1] {
+            Event::SyncFailed(p) => {
+                assert!(p.sync_latency_ms.is_none());
+                assert_eq!(p.failure_reason, Some(FailureReason::NetworkError));
+                assert_eq!(p.failure_stage, Some(SyncFailureStage::ImmediateSend));
+            }
+            other => panic!("expected SyncFailed, got {other:?}"),
+        }
+    }
+
+    /// First-success funnel: a fresh `first_sync_state` + a `File` payload
+    /// fires each `first_*` event exactly once (generic clipboard + file).
+    #[tokio::test]
+    async fn dispatch_one_first_file_success_fires_each_first_event_once() {
+        let mut dispatch = MockDispatch::new();
+        dispatch
+            .expect_dispatch()
+            .times(1)
+            .returning(|_, _, _| Ok(DispatchAck::Accepted));
+
+        let analytics = Arc::new(CapturingAnalyticsSink::default());
+        let dispatcher = PerPeerDispatcher::new(
+            Arc::new(dispatch),
+            Arc::new(StaticPresence(ReachabilityState::Unknown)),
+            analytics.clone(),
+            Arc::new(InMemoryFirstSyncState::default()),
+        );
+
+        let _ = dispatcher
+            .dispatch_one(
+                dev("peer-a"),
+                header(),
+                sync_payload(),
+                PayloadType::File,
+                bucket(),
+            )
+            .await;
+
+        let events = analytics.events();
+        let first_attempted = events
+            .iter()
+            .filter(|e| matches!(e, Event::FirstClipboardSyncAttempted { .. }))
+            .count();
+        let first_succeeded = events
+            .iter()
+            .filter(|e| matches!(e, Event::FirstClipboardSyncSucceeded { .. }))
+            .count();
+        let first_file = events
+            .iter()
+            .filter(|e| matches!(e, Event::FirstFileSyncSucceeded { .. }))
+            .count();
+        assert_eq!(
+            (first_attempted, first_succeeded, first_file),
+            (1, 1, 1),
+            "got {events:?}"
+        );
+    }
+}

--- a/crates/uc-application/src/usecases/clipboard_sync/dispatch_entry/target_selector.rs
+++ b/crates/uc-application/src/usecases/clipboard_sync/dispatch_entry/target_selector.rs
@@ -1,0 +1,355 @@
+//! `TargetSelector` — resolves the eligible fan-out roster for one
+//! dispatch pass: the peers we hold an address for, minus self, narrowed
+//! by the optional resend `target_filter`, gated by each peer's per-device
+//! send preferences.
+//!
+//! ## Invariants preserved from the inlined logic
+//!
+//! - Iteration source is `peer_addr_repo.list()` (members we have an
+//!   address blob for), NOT `member_repo` — avoids iterating ghost
+//!   half-paired rows.
+//! - Presence is intentionally NOT consulted here; the per-target preflight
+//!   happens later in `PerPeerDispatcher`.
+//! - `Some(vec![])` `target_filter` ⇒ empty intersection ⇒ zero targets
+//!   (NOT a passthrough); `ResendEntryUseCase` already short-circuits the
+//!   empty-difference case before it ever reaches dispatch.
+//! - The send gate fails OPEN on a member-repo miss / error — a transient
+//!   glitch must not silently kill sync.
+
+use std::sync::Arc;
+
+use tracing::{info, warn};
+use uc_core::clipboard::ClipboardContentCategorySet;
+use uc_core::ids::DeviceId;
+use uc_core::ports::PeerAddressRepositoryPort;
+use uc_core::MemberRepositoryPort;
+
+use super::{DispatchClipboardEntryInput, DispatchSyncError};
+
+pub(crate) struct TargetSelector {
+    peer_addr_repo: Arc<dyn PeerAddressRepositoryPort>,
+    member_repo: Arc<dyn MemberRepositoryPort>,
+}
+
+impl TargetSelector {
+    pub(crate) fn new(
+        peer_addr_repo: Arc<dyn PeerAddressRepositoryPort>,
+        member_repo: Arc<dyn MemberRepositoryPort>,
+    ) -> Self {
+        Self {
+            peer_addr_repo,
+            member_repo,
+        }
+    }
+
+    /// Enumerate eligible fan-out targets for this pass. `local_device` is
+    /// resolved once by the caller (it also stamps the wire header origin)
+    /// and passed in so device identity is read a single time per dispatch.
+    pub(crate) async fn select(
+        &self,
+        input: &DispatchClipboardEntryInput,
+        local_device: &DeviceId,
+    ) -> Result<Vec<DeviceId>, DispatchSyncError> {
+        let records =
+            self.peer_addr_repo.list().await.map_err(|err| {
+                DispatchSyncError::Repository(format!("peer_addr_repo.list: {err}"))
+            })?;
+
+        let mut candidates: Vec<DeviceId> = Vec::with_capacity(records.len());
+        for record in records {
+            if record.device_id == *local_device {
+                continue;
+            }
+            // ADR-005 §2.5 resend: `target_filter` narrows the fan-out
+            // allowlist. `None` keeps the status quo (full fan-out);
+            // `Some(list)` keeps only the intersection.
+            if let Some(filter) = &input.target_filter {
+                if !filter.iter().any(|d| d == &record.device_id) {
+                    continue;
+                }
+            }
+            if !self
+                .is_send_allowed(&record.device_id, &input.categories)
+                .await
+            {
+                continue;
+            }
+            candidates.push(record.device_id);
+        }
+        Ok(candidates)
+    }
+
+    /// Per-device sync gate: returns `true` when the local device should
+    /// fan a clipboard frame out to `device_id`. Two stages:
+    ///
+    /// 1. Device-level kill switch (`send_enabled`).
+    /// 2. Content-type filter (`send_content_types`, AND-of-allowed across
+    ///    the snapshot's category set — see `uc-core` `category.rs` module doc).
+    ///    Empty set (raw-bytes / unrecognised payload) passes (fail open)
+    ///    so we don't stall sync silently.
+    ///
+    /// Member-record miss / repo error → fail open with a WARN, mirroring
+    /// the device-level gate's posture: a transient glitch should not
+    /// silently kill sync.
+    async fn is_send_allowed(
+        &self,
+        device_id: &DeviceId,
+        categories: &ClipboardContentCategorySet,
+    ) -> bool {
+        match self.member_repo.get(device_id).await {
+            Ok(Some(member)) => {
+                if !member.sync_preferences.send_enabled {
+                    info!(
+                        device_id = %device_id.as_str(),
+                        reason = "send_disabled_by_user",
+                        "dispatch: skipping peer per per-device sync preferences"
+                    );
+                    return false;
+                }
+                if !categories.allowed_by(&member.sync_preferences.send_content_types) {
+                    info!(
+                        device_id = %device_id.as_str(),
+                        categories = %categories.labels(),
+                        denied = %categories
+                            .denied_labels(&member.sync_preferences.send_content_types),
+                        reason = "content_type_disabled_by_user",
+                        "dispatch: skipping peer per per-device content_types filter"
+                    );
+                    return false;
+                }
+                true
+            }
+            Ok(None) => {
+                warn!(
+                    device_id = %device_id.as_str(),
+                    "dispatch: peer in addr repo but missing from member repo; failing open"
+                );
+                true
+            }
+            Err(err) => {
+                warn!(
+                    device_id = %device_id.as_str(),
+                    error = %err,
+                    "dispatch: member repo lookup failed; failing open"
+                );
+                true
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::test_support::*;
+    use super::*;
+
+    use uc_core::clipboard::ClipboardContentCategory;
+    use uc_core::settings::model::ContentTypes;
+    use uc_core::{MemberSyncPreferences, MembershipError};
+
+    fn selector(peer_addr_repo: MockPeerAddrRepo, member_repo: MockMemberRepo) -> TargetSelector {
+        TargetSelector::new(Arc::new(peer_addr_repo), Arc::new(member_repo))
+    }
+
+    /// `member_repo` returning the default (all-enabled) preferences for any
+    /// queried device — the send gate is a no-op, so `select` reflects pure
+    /// roster ∩ !self ∩ filter narrowing.
+    fn member_repo_all_enabled() -> MockMemberRepo {
+        let mut m = MockMemberRepo::new();
+        m.expect_get()
+            .returning(|did| Ok(Some(member(did, MemberSyncPreferences::default()))));
+        m
+    }
+
+    fn ids(devices: &[DeviceId]) -> Vec<String> {
+        devices.iter().map(|d| d.as_str().to_string()).collect()
+    }
+
+    /// `None` filter ⇒ every roster peer except the local device, in roster
+    /// order. The send gate is open, so nothing else is dropped.
+    #[tokio::test]
+    async fn select_returns_all_non_self_peers_when_no_filter() {
+        let mut repo = MockPeerAddrRepo::new();
+        repo.expect_list().times(1).returning(|| {
+            Ok(vec![
+                record("peer-a"),
+                record("self-device"),
+                record("peer-b"),
+            ])
+        });
+
+        let selector = selector(repo, member_repo_all_enabled());
+        let targets = selector
+            .select(&dispatch_input(), &dev("self-device"))
+            .await
+            .expect("select ok");
+
+        assert_eq!(ids(&targets), vec!["peer-a", "peer-b"]);
+    }
+
+    /// `Some(list)` keeps only the intersection of roster and filter.
+    #[tokio::test]
+    async fn select_keeps_only_target_filter_intersection() {
+        let mut repo = MockPeerAddrRepo::new();
+        repo.expect_list()
+            .times(1)
+            .returning(|| Ok(vec![record("peer-a"), record("peer-b"), record("peer-c")]));
+
+        let selector = selector(repo, member_repo_all_enabled());
+        let mut input = dispatch_input();
+        input.target_filter = Some(vec![dev("peer-b")]);
+        let targets = selector
+            .select(&input, &dev("self-device"))
+            .await
+            .expect("select ok");
+
+        assert_eq!(ids(&targets), vec!["peer-b"]);
+    }
+
+    /// `Some(vec![])` is the legal "no targets" filter — an empty
+    /// intersection, NOT a passthrough.
+    #[tokio::test]
+    async fn select_with_empty_target_filter_yields_no_targets() {
+        let mut repo = MockPeerAddrRepo::new();
+        repo.expect_list()
+            .times(1)
+            .returning(|| Ok(vec![record("peer-a"), record("peer-b")]));
+
+        let selector = selector(repo, member_repo_all_enabled());
+        let mut input = dispatch_input();
+        input.target_filter = Some(vec![]);
+        let targets = selector
+            .select(&input, &dev("self-device"))
+            .await
+            .expect("select ok");
+
+        assert!(targets.is_empty(), "got {:?}", ids(&targets));
+    }
+
+    /// A peer with `send_enabled = false` is dropped by the device-level
+    /// kill switch; the other peer survives.
+    #[tokio::test]
+    async fn select_excludes_send_disabled_peer() {
+        let mut repo = MockPeerAddrRepo::new();
+        repo.expect_list()
+            .times(1)
+            .returning(|| Ok(vec![record("peer-on"), record("peer-mute")]));
+
+        let mut member_repo = MockMemberRepo::new();
+        member_repo
+            .expect_get()
+            .returning(|did| match did.as_str() {
+                "peer-mute" => {
+                    let mut prefs = MemberSyncPreferences::default();
+                    prefs.send_enabled = false;
+                    Ok(Some(member(did, prefs)))
+                }
+                _ => Ok(Some(member(did, MemberSyncPreferences::default()))),
+            });
+
+        let selector = selector(repo, member_repo);
+        let targets = selector
+            .select(&dispatch_input(), &dev("self-device"))
+            .await
+            .expect("select ok");
+
+        assert_eq!(ids(&targets), vec!["peer-on"]);
+    }
+
+    /// A `Text` snapshot is withheld from a peer whose `send_content_types`
+    /// has text disabled; the default-allowed peer still receives it.
+    #[tokio::test]
+    async fn select_excludes_peer_denying_content_type() {
+        let mut repo = MockPeerAddrRepo::new();
+        repo.expect_list()
+            .times(1)
+            .returning(|| Ok(vec![record("peer-on"), record("peer-no-text")]));
+
+        let mut member_repo = MockMemberRepo::new();
+        member_repo
+            .expect_get()
+            .returning(|did| match did.as_str() {
+                "peer-no-text" => {
+                    let mut prefs = MemberSyncPreferences::default();
+                    let mut ct = ContentTypes::default();
+                    ct.text = false;
+                    prefs.send_content_types = ct;
+                    Ok(Some(member(did, prefs)))
+                }
+                _ => Ok(Some(member(did, MemberSyncPreferences::default()))),
+            });
+
+        let selector = selector(repo, member_repo);
+        let mut input = dispatch_input();
+        input.categories = ClipboardContentCategorySet::empty();
+        input.categories.insert(ClipboardContentCategory::Text);
+        let targets = selector
+            .select(&input, &dev("self-device"))
+            .await
+            .expect("select ok");
+
+        assert_eq!(ids(&targets), vec!["peer-on"]);
+    }
+
+    /// Member-repo miss (`Ok(None)`) fails OPEN — a roster/member drift must
+    /// not silently kill sync.
+    #[tokio::test]
+    async fn select_fails_open_on_member_lookup_miss() {
+        let mut repo = MockPeerAddrRepo::new();
+        repo.expect_list()
+            .times(1)
+            .returning(|| Ok(vec![record("peer-orphan")]));
+
+        let mut member_repo = MockMemberRepo::new();
+        member_repo.expect_get().returning(|_| Ok(None));
+
+        let selector = selector(repo, member_repo);
+        let targets = selector
+            .select(&dispatch_input(), &dev("self-device"))
+            .await
+            .expect("select ok");
+
+        assert_eq!(ids(&targets), vec!["peer-orphan"]);
+    }
+
+    /// Member-repo error also fails OPEN — a transient glitch is not a
+    /// reason to drop a paired peer.
+    #[tokio::test]
+    async fn select_fails_open_on_member_lookup_error() {
+        let mut repo = MockPeerAddrRepo::new();
+        repo.expect_list()
+            .times(1)
+            .returning(|| Ok(vec![record("peer-glitch")]));
+
+        let mut member_repo = MockMemberRepo::new();
+        member_repo
+            .expect_get()
+            .returning(|_| Err(MembershipError::Repository("db down".to_string())));
+
+        let selector = selector(repo, member_repo);
+        let targets = selector
+            .select(&dispatch_input(), &dev("self-device"))
+            .await
+            .expect("select ok");
+
+        assert_eq!(ids(&targets), vec!["peer-glitch"]);
+    }
+
+    /// `peer_addr_repo.list` failure is a fatal pass error, surfaced as
+    /// `DispatchSyncError::Repository` (not swallowed into an empty roster).
+    #[tokio::test]
+    async fn select_surfaces_peer_addr_repo_error() {
+        let mut repo = MockPeerAddrRepo::new();
+        repo.expect_list()
+            .times(1)
+            .returning(|| Err(uc_core::ports::PeerAddressError::Internal("io".to_string())));
+
+        let selector = selector(repo, member_repo_all_enabled());
+        let err = selector
+            .select(&dispatch_input(), &dev("self-device"))
+            .await
+            .expect_err("list failure must surface");
+
+        assert!(matches!(err, DispatchSyncError::Repository(_)));
+    }
+}

--- a/crates/uc-application/src/usecases/clipboard_sync/dispatch_entry/test_support.rs
+++ b/crates/uc-application/src/usecases/clipboard_sync/dispatch_entry/test_support.rs
@@ -1,0 +1,271 @@
+//! Shared test doubles + fixtures for the `dispatch_entry` collaborator unit
+//! tests (`target_selector`, `per_peer`, `header`).
+//!
+//! The use-case integration tests in `mod.rs` keep their own inline mocks
+//! verbatim (they were verified port-for-port against the pre-split file and
+//! must not move). This module exists so the sibling collaborators can each
+//! assert against the same ports from their own focused test module without
+//! re-deriving a mock per file. Names intentionally mirror the `mod.rs`
+//! inline doubles; the two live in different modules, so there is no clash.
+
+use std::sync::Mutex as StdMutex;
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use chrono::Utc;
+use tokio::sync::broadcast;
+
+use uc_core::clipboard::ClipboardContentCategorySet;
+use uc_core::ids::DeviceId;
+use uc_core::ports::{
+    ClipboardDispatchError, ClipboardDispatchPort, ClipboardHeader, ClockPort, DispatchAck,
+    FirstSyncStateError, FirstSyncStatePort, LocalIdentityError, LocalIdentityPort,
+    PeerAddressError, PeerAddressRecord, PeerAddressRepositoryPort, PresenceError, PresenceEvent,
+    PresencePort, ReachabilityState, SettingsPort, SyncPayload,
+};
+use uc_core::security::IdentityFingerprint;
+use uc_core::settings::model::Settings;
+use uc_core::{MemberRepositoryPort, MemberSyncPreferences, MembershipError, SpaceMember};
+use uc_observability::analytics::{AnalyticsPort, Event};
+
+use super::DispatchClipboardEntryInput;
+
+// ── mockall ports ───────────────────────────────────────────────────────
+
+mockall::mock! {
+    pub PeerAddrRepo {}
+
+    #[async_trait]
+    impl PeerAddressRepositoryPort for PeerAddrRepo {
+        async fn get(
+            &self,
+            device: &DeviceId,
+        ) -> Result<Option<PeerAddressRecord>, PeerAddressError>;
+        async fn upsert(&self, record: &PeerAddressRecord) -> Result<(), PeerAddressError>;
+        async fn list(&self) -> Result<Vec<PeerAddressRecord>, PeerAddressError>;
+        async fn remove(&self, device: &DeviceId) -> Result<(), PeerAddressError>;
+    }
+}
+
+mockall::mock! {
+    pub MemberRepo {}
+
+    #[async_trait]
+    impl MemberRepositoryPort for MemberRepo {
+        async fn get(&self, device_id: &DeviceId) -> Result<Option<SpaceMember>, MembershipError>;
+        async fn list(&self) -> Result<Vec<SpaceMember>, MembershipError>;
+        async fn save(&self, member: &SpaceMember) -> Result<(), MembershipError>;
+        async fn remove(&self, device_id: &DeviceId) -> Result<bool, MembershipError>;
+    }
+}
+
+mockall::mock! {
+    pub Dispatch {}
+
+    #[async_trait]
+    impl ClipboardDispatchPort for Dispatch {
+        async fn dispatch(
+            &self,
+            target: &DeviceId,
+            header: &ClipboardHeader,
+            payload: SyncPayload,
+        ) -> Result<DispatchAck, ClipboardDispatchError>;
+    }
+}
+
+mockall::mock! {
+    pub LocalIdentity {}
+
+    #[async_trait]
+    impl LocalIdentityPort for LocalIdentity {
+        async fn create(&self) -> Result<IdentityFingerprint, LocalIdentityError>;
+        async fn ensure(&self) -> Result<IdentityFingerprint, LocalIdentityError>;
+        async fn get_current_fingerprint(
+            &self,
+        ) -> Result<Option<IdentityFingerprint>, LocalIdentityError>;
+    }
+}
+
+mockall::mock! {
+    pub Settings_ {}
+
+    #[async_trait]
+    impl SettingsPort for Settings_ {
+        async fn load(&self) -> anyhow::Result<Settings>;
+        async fn save(&self, s: &Settings) -> anyhow::Result<()>;
+    }
+}
+
+// ── hand-written fakes ──────────────────────────────────────────────────
+
+/// Sync, 1-line `ClockPort`; mockall's adapter would be strictly more code.
+pub(crate) struct FixedClock(pub(crate) i64);
+impl ClockPort for FixedClock {
+    fn now_ms(&self) -> i64 {
+        self.0
+    }
+}
+
+/// Presence stub that always reports the same `ReachabilityState`. The
+/// collaborators only read `current_state`; `ensure_reachable` / `subscribe`
+/// are present to satisfy the trait.
+pub(crate) struct StaticPresence(pub(crate) ReachabilityState);
+#[async_trait]
+impl PresencePort for StaticPresence {
+    async fn ensure_reachable(
+        &self,
+        _device: &DeviceId,
+    ) -> Result<ReachabilityState, PresenceError> {
+        Ok(self.0)
+    }
+
+    async fn current_state(&self, _device: &DeviceId) -> ReachabilityState {
+        self.0
+    }
+
+    fn subscribe(&self) -> broadcast::Receiver<PresenceEvent> {
+        let (_tx, rx) = broadcast::channel(1);
+        rx
+    }
+}
+
+/// Records every captured analytics `Event` so tests can assert the per-peer
+/// funnel ordering and field values.
+#[derive(Default)]
+pub(crate) struct CapturingAnalyticsSink {
+    captured: StdMutex<Vec<Event>>,
+}
+impl CapturingAnalyticsSink {
+    pub(crate) fn events(&self) -> Vec<Event> {
+        self.captured.lock().unwrap().clone()
+    }
+}
+impl AnalyticsPort for CapturingAnalyticsSink {
+    fn capture(&self, event: Event) {
+        self.captured.lock().unwrap().push(event);
+    }
+}
+
+/// `first_sync_state` whose every flag is already marked: every `mark_*`
+/// returns `Ok(false)`, so the dispatcher never fires a `first_*` event.
+pub(crate) struct AllMarkedFirstSyncState;
+#[async_trait]
+impl FirstSyncStatePort for AllMarkedFirstSyncState {
+    async fn mark_first_sync_attempted(&self) -> Result<bool, FirstSyncStateError> {
+        Ok(false)
+    }
+    async fn mark_first_sync_succeeded(&self) -> Result<bool, FirstSyncStateError> {
+        Ok(false)
+    }
+    async fn mark_first_file_sync_succeeded(&self) -> Result<bool, FirstSyncStateError> {
+        Ok(false)
+    }
+}
+
+/// In-memory `first_sync_state` mirroring production: the first `mark_*`
+/// returns `Ok(true)`, subsequent calls `Ok(false)`; each flag independent.
+#[derive(Default)]
+pub(crate) struct InMemoryFirstSyncState {
+    attempted: tokio::sync::Mutex<bool>,
+    succeeded: tokio::sync::Mutex<bool>,
+    file_succeeded: tokio::sync::Mutex<bool>,
+}
+#[async_trait]
+impl FirstSyncStatePort for InMemoryFirstSyncState {
+    async fn mark_first_sync_attempted(&self) -> Result<bool, FirstSyncStateError> {
+        Ok(flip_once(&self.attempted).await)
+    }
+    async fn mark_first_sync_succeeded(&self) -> Result<bool, FirstSyncStateError> {
+        Ok(flip_once(&self.succeeded).await)
+    }
+    async fn mark_first_file_sync_succeeded(&self) -> Result<bool, FirstSyncStateError> {
+        Ok(flip_once(&self.file_succeeded).await)
+    }
+}
+
+async fn flip_once(flag: &tokio::sync::Mutex<bool>) -> bool {
+    let mut guard = flag.lock().await;
+    if *guard {
+        false
+    } else {
+        *guard = true;
+        true
+    }
+}
+
+// ── fixtures ────────────────────────────────────────────────────────────
+
+pub(crate) fn dev(id: &str) -> DeviceId {
+    DeviceId::new(id)
+}
+
+pub(crate) fn fp(seed: u8) -> IdentityFingerprint {
+    IdentityFingerprint::from_raw_string(
+        (0..16)
+            .map(|i| char::from(b'A' + ((seed as usize + i) % 26) as u8))
+            .collect::<String>(),
+    )
+    .expect("valid fingerprint")
+}
+
+pub(crate) fn record(device: &str) -> PeerAddressRecord {
+    PeerAddressRecord {
+        device_id: DeviceId::new(device),
+        addr_blob: vec![0xAA; 32],
+        observed_at: Utc::now(),
+    }
+}
+
+/// Build a `SpaceMember` for `device` carrying the given sync preferences.
+pub(crate) fn member(device: &DeviceId, prefs: MemberSyncPreferences) -> SpaceMember {
+    SpaceMember {
+        device_id: device.clone(),
+        device_name: format!("Test {}", device.as_str()),
+        identity_fingerprint: fp(0),
+        joined_at: Utc::now(),
+        sync_preferences: prefs,
+    }
+}
+
+pub(crate) fn settings_with_device_name(name: &str) -> Settings {
+    let mut s = Settings::default();
+    s.general.device_name = Some(name.to_string());
+    s
+}
+
+pub(crate) fn default_settings() -> Settings {
+    Settings::default()
+}
+
+/// Default dispatch input (empty category set, no resend filter). Tests
+/// mutate the `pub` fields they care about.
+pub(crate) fn dispatch_input() -> DispatchClipboardEntryInput {
+    DispatchClipboardEntryInput {
+        plaintext: Bytes::from_static(b"hello world"),
+        content_hash: "9".repeat(64),
+        payload_version: 3,
+        categories: ClipboardContentCategorySet::empty(),
+        entry_id: None,
+        target_filter: None,
+    }
+}
+
+/// A minimal wire header for the per-peer dispatch tests, which only care
+/// that the header is forwarded unchanged to the dispatch port.
+pub(crate) fn test_header() -> ClipboardHeader {
+    ClipboardHeader {
+        version: ClipboardHeader::CURRENT_VERSION,
+        content_hash: "0".repeat(64),
+        captured_at_ms: 0,
+        origin_device_id: "self-device".to_string(),
+        origin_device_name: "Self".to_string(),
+        payload_version: 3,
+        flow_id: None,
+    }
+}
+
+pub(crate) fn sync_payload() -> SyncPayload {
+    SyncPayload {
+        ciphertext: Bytes::from_static(b"ciphertext"),
+    }
+}

--- a/tests/e2e/tests/clipboard_sync.rs
+++ b/tests/e2e/tests/clipboard_sync.rs
@@ -603,3 +603,169 @@ async fn paired_send_stdin_pipe() {
         );
     }
 }
+
+// ---------------------------------------------------------------------------
+// Per-device send gate (TargetSelector)
+// ---------------------------------------------------------------------------
+//
+// Unlike the cross-node delivery tests above, the send gate is decided
+// entirely on the SENDER. `TargetSelector` consults each peer's
+// `send_enabled` before the peer ever enters the fan-out, so the effect is
+// observable in the sender's own `send --json` `DispatchOutcomeResponse`
+// without any rendezvous relay or successful p2p delivery — which makes this
+// the one dispatch-selection behaviour we can assert *hard* in headless E2E.
+
+/// Device id of the unique remote (non-local) member in `cli`'s roster.
+/// Dispatch `perTarget` rows are keyed by this same id.
+fn remote_member_id(cli: &TestCli) -> String {
+    let out = cli.run_capture(&["--json", "members"]);
+    assert!(out.success(), "members failed: {}", out.stderr);
+    let members: Value = serde_json::from_str(out.stdout.trim())
+        .unwrap_or_else(|e| panic!("members not valid JSON: {e}\nstdout: {}", out.stdout));
+    let remote: Vec<&Value> = members
+        .as_array()
+        .unwrap_or_else(|| panic!("members not a JSON array: {}", out.stdout))
+        .iter()
+        .filter(|m| !m.get("is_local").and_then(|v| v.as_bool()).unwrap_or(false))
+        .collect();
+    assert_eq!(
+        remote.len(),
+        1,
+        "expected exactly one remote member, got {remote:?}"
+    );
+    remote[0]
+        .get("device_id")
+        .and_then(|v| v.as_str())
+        .unwrap_or_else(|| panic!("remote member missing device_id: {:?}", remote[0]))
+        .to_string()
+}
+
+/// Flip a peer's `send_enabled` gate on `daemon` (the sender side) via
+/// `PATCH /member/:id/sync-preferences`. Asserts the endpoint answers 200.
+async fn set_peer_send_enabled(daemon: &TestDaemon, peer_id: &str, enabled: bool) {
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .unwrap();
+    let token = get_session_token(daemon, &client).await;
+    let resp = client
+        .patch(format!(
+            "{}/member/{peer_id}/sync-preferences",
+            daemon.base_url()
+        ))
+        .header("Authorization", format!("Session {token}"))
+        .json(&serde_json::json!({ "sendEnabled": enabled }))
+        .send()
+        .await
+        .expect("patch sync-preferences request");
+    assert_eq!(
+        resp.status().as_u16(),
+        200,
+        "patch sync-preferences should answer 200, got {}",
+        resp.status()
+    );
+}
+
+/// Run `send --json` and parse the `DispatchOutcomeResponse` body.
+fn send_json(cli: &TestCli, payload: &str) -> Value {
+    let out = cli.run_capture(&["--json", "send", payload]);
+    // `send` exits 1 when nothing was accepted; both 0 and 1 are non-crash.
+    assert!(
+        out.exit_code == 0 || out.exit_code == 1,
+        "send crashed (exit={}): {}",
+        out.exit_code,
+        out.stderr
+    );
+    serde_json::from_str(out.stdout.trim())
+        .unwrap_or_else(|e| panic!("send --json not valid JSON: {e}\nstdout: {}", out.stdout))
+}
+
+/// `deviceId`s present in a dispatch outcome's `perTarget` (camelCase key —
+/// note `members` output uses snake_case `device_id`, but the dispatch
+/// response DTO is camelCase).
+fn per_target_ids(outcome: &Value) -> Vec<String> {
+    outcome
+        .get("perTarget")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|t| {
+                    t.get("deviceId")
+                        .and_then(|v| v.as_str())
+                        .map(str::to_string)
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// A muted peer (`send_enabled = false`) is dropped by `TargetSelector`
+/// BEFORE the fan-out, so the sender's dispatch outcome carries no row for it
+/// at all — not even an offline/errored one (the dial was never attempted).
+/// Un-muting restores it as a candidate, which proves the *gate* — not a
+/// missing roster/address row — is what excluded it.
+///
+/// This is delivery-independent: every assertion reads only the sender's
+/// `send --json` outcome, so it holds with or without a working p2p route.
+#[tokio::test]
+#[ignore]
+async fn paired_send_gate_excludes_muted_peer() {
+    let (alice_daemon, alice_cli, bob_daemon, bob_cli) = pair_two_nodes("send-gate").await;
+
+    // Let pairing finish populating Alice's peer-address + member rows.
+    tokio::time::sleep(Duration::from_secs(2)).await;
+    let bob_id = remote_member_id(&alice_cli);
+
+    // Mute Bob on Alice's side, then dispatch. Bob is Alice's only peer, so
+    // excluding him collapses the fan-out to the empty "no eligible targets"
+    // shape: zero per-target rows and zero counts, but a real content hash
+    // (the encrypt+enumerate pipeline still ran — it just found no targets).
+    set_peer_send_enabled(&alice_daemon, &bob_id, false).await;
+    let muted = send_json(
+        &alice_cli,
+        &format!("send-gate-muted-{}", std::process::id()),
+    );
+    assert!(
+        per_target_ids(&muted).is_empty(),
+        "muted peer must be excluded from per_target: {muted}"
+    );
+    for key in [
+        "totalAccepted",
+        "totalDuplicate",
+        "totalOffline",
+        "totalErrored",
+    ] {
+        assert_eq!(
+            muted.get(key).and_then(|v| v.as_u64()).unwrap_or(u64::MAX),
+            0,
+            "{key} must be 0 once the only peer is muted (no dial attempted): {muted}"
+        );
+    }
+    assert!(
+        muted
+            .get("contentHash")
+            .and_then(|v| v.as_str())
+            .map(|h| !h.is_empty())
+            .unwrap_or(false),
+        "muted send still encrypts + reports a contentHash: {muted}"
+    );
+
+    // Un-mute and dispatch again: Bob re-enters the fan-out and settles into
+    // per_target (accepted on a live loopback route, otherwise offline/errored
+    // within FAN_OUT_DEADLINE — never left pending). His reappearance is the
+    // differential that pins the exclusion above on the send gate.
+    set_peer_send_enabled(&alice_daemon, &bob_id, true).await;
+    let restored = send_json(
+        &alice_cli,
+        &format!("send-gate-restored-{}", std::process::id()),
+    );
+    assert!(
+        per_target_ids(&restored).iter().any(|id| id == &bob_id),
+        "un-muted peer must re-enter the fan-out per_target: {restored}"
+    );
+
+    drop(alice_cli);
+    drop(bob_cli);
+    drop(alice_daemon);
+    drop(bob_daemon);
+}


### PR DESCRIPTION
## Summary

- Split the ~1k-line `DispatchClipboardEntryUseCase` into a `dispatch_entry/` module of 5 concern-scoped collaborators — target selection, outbound header building, per-peer dispatch+telemetry, deadline-bounded fan-out, and delivery recording. The public `::new(13-port)` signature and runtime behaviour are unchanged: the existing use-case integration tests were preserved verbatim and stay green (730b74a).
- Gave each collaborator a focused unit-test surface (selector send-gate / fail-open, per-peer attempted-before-dial + known-offline deferral + latency, header name fallbacks, fan-out deadline, classify/delivery mapping). Shared test doubles live in `dispatch_entry/test_support.rs`, `cfg(test)` only — the `mod.rs` integration tests keep their own inline mocks (730b74a).
- Added a delivery-independent CLI e2e (`paired_send_gate_excludes_muted_peer`) that pins the extracted `TargetSelector`: muting a peer (`send_enabled=false`) drops it from the sender's dispatch `perTarget` with no dial attempted; un-muting restores it. Every assertion reads only the sender's outcome, so it holds in headless E2E with no rendezvous relay (ff74a3d).
- Refreshed `crates/AGENTS.md` fact sections (WHERE TO LOOK, COMPLEXITY HOTSPOTS) and retargeted a stale `uc-platform/.../libp2p_network.rs` reference to the current iroh transport / clipboard adapters (40fc6eb).

This is a behaviour-equivalent refactor: no CLI flags, settings, defaults, or error messages changed, so `docs-site/` needs no update.

## Test plan

- [x] `cargo test -p uc-application` -> 643 + 10 pass, 0 warnings
- [x] `cargo fmt --check` clean (uc-application + tests/e2e)
- [x] `cargo check -p uc-bootstrap -p uc-webserver -p uc-daemon -p uc-tauri`
- [x] e2e `--ignored`: `paired_send_gate_excludes_muted_peer` -> 1 passed
- [ ] Reviewer: spot-check behaviour-equivalence by diffing the `#[cfg(test)] mod tests` block in `git show 730b74a:crates/uc-application/src/usecases/clipboard_sync/dispatch_entry/mod.rs` against the pre-split `dispatch_entry.rs` (should be verbatim aside from the relocation).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ability to control which peers receive clipboard syncs via per-peer send gates (mute functionality)

* **Refactor**
  * Reorganized clipboard sync dispatch system into modular, maintainable components with improved delivery tracking

* **Tests**
  * Added E2E test for peer send gate exclusion behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->