### PR TITLE
fix(snap): install binaries from workspace-root target/

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -170,10 +170,14 @@ parts:
 
       # 3) 安装到 snap install 目录。strict snap 启动时 mount 这个目录
       # 到 /usr,所以路径必须以 usr/ 开头。
-      install -Dm755 src-tauri/target/release/uniclipboard \
+      # NOTE: artifacts land in the workspace-root target/ (#1041 moved the
+      # cargo workspace root to the repo root; `cd src-tauri` no longer creates
+      # a nested target/). After the `cd ..` above we are at the repo root, so
+      # the release binaries are at target/release/, NOT src-tauri/target/.
+      install -Dm755 target/release/uniclipboard \
         "${CRAFT_PART_INSTALL}/usr/bin/uniclipboard"
       # ADR-008 D13: ship the daemon next to the GUI so it spawns as a sibling.
-      install -Dm755 src-tauri/target/release/uniclipd \
+      install -Dm755 target/release/uniclipd \
         "${CRAFT_PART_INSTALL}/usr/bin/uniclipd"
       install -Dm644 snap/local/uniclipboard.desktop \
         "${CRAFT_PART_INSTALL}/usr/share/applications/uniclipboard.desktop"


### PR DESCRIPTION
🤖 This PR was prepared with AI assistance (Claude Code).

## Summary

- `#1041` moved the cargo workspace root to the repo root, so `cd src-tauri && cargo build` now drops release artifacts in the **repo-root** `target/`, not `src-tauri/target/` (`.cargo/config.toml` also dropped its `target-dir` override). The snap `override-build` still installed from `src-tauri/target/release/`, so the build succeeded (`Finished release profile ...`) but the next step failed with `install: cannot stat 'src-tauri/target/release/uniclipboard'` → `override-build failed with code 1`. Fixed by installing from `target/release/` — we are back at the repo root after the `cd ..` above (158829031).
- This was a **silent regression**: `cargo build` exited 0, only the hard-coded install path surfaced it. It broke the snap build since `v0.15.0-alpha.4` (first tag after #1041) — `v0.15.0` stable, alpha.4 and alpha.5 all failed; `v0.15.0-alpha.3` (pre-#1041) was the last green snap.
- `src-tauri/icons/*.png` install paths are source files and are left unchanged.

## Test plan

- [x] Dispatched the Snap workflow on this branch (run `27536623897`, `stable` channel): both **amd64** and **arm64** jobs green; published rev **371** (amd64) / rev **370** (arm64) to the snap store `stable` channel. The `cannot stat` failure is gone.
- [ ] Merge before the next tag-based release: `release.published` builds the snap from the **tag**, so cutting a tag without this fix on `main` will fail again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Snap packaging configuration to ensure proper installation of application binaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->