### PR TITLE
docs(install): add brew trust step for Homebrew 6.0+ tap trust

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,11 @@ On macOS, install via the official tap [`UniClipboard/homebrew-tap`](https://git
 ```bash
 brew tap UniClipboard/tap
 
+# Homebrew 6.0+ requires you to trust third-party taps before it will load
+# their formulae/casks. Skip this and you'll hit
+# "Refusing to load ... from untrusted tap". It only needs to run once.
+brew trust UniClipboard/tap
+
 # Desktop app (.app bundle)
 brew install --cask uniclipboard
 
@@ -182,11 +187,12 @@ brew install --cask uniclipboard
 brew install uniclipboard
 ```
 
-Or install in a single command without tapping first:
+Or install in a single command without tapping first (still trust the tap once):
 
 ```bash
-brew install --cask UniClipboard/tap/uniclipboard   # GUI
-brew install UniClipboard/tap/uniclipboard          # CLI
+brew trust UniClipboard/tap                          # Homebrew 6.0+, one-time
+brew install --cask UniClipboard/tap/uniclipboard    # GUI
+brew install UniClipboard/tap/uniclipboard           # CLI
 ```
 
 The cask and the formula can coexist — install both if you want the GUI plus the `uniclip` command.

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -175,6 +175,10 @@ macOS 用户可以通过官方 tap [`UniClipboard/homebrew-tap`](https://github.
 ```bash
 brew tap UniClipboard/tap
 
+# Homebrew 6.0+ 默认要求先信任第三方 tap 才会加载其 formula/cask，
+# 否则会报 “Refusing to load ... from untrusted tap”。该步骤只需执行一次。
+brew trust UniClipboard/tap
+
 # 桌面应用（.app）
 brew install --cask uniclipboard
 
@@ -182,11 +186,12 @@ brew install --cask uniclipboard
 brew install uniclipboard
 ```
 
-也可以省去 `brew tap`，一行直装：
+也可以省去 `brew tap`，一行直装（仍需先信任一次该 tap）：
 
 ```bash
-brew install --cask UniClipboard/tap/uniclipboard   # GUI
-brew install UniClipboard/tap/uniclipboard          # CLI
+brew trust UniClipboard/tap                          # Homebrew 6.0+，一次性
+brew install --cask UniClipboard/tap/uniclipboard    # GUI
+brew install UniClipboard/tap/uniclipboard           # CLI
 ```
 
 GUI 和 CLI 互不冲突，需要的话两个都装即可。

--- a/docs-site/content/docs/en/getting-started/install.mdx
+++ b/docs-site/content/docs/en/getting-started/install.mdx
@@ -61,6 +61,11 @@ The easiest path on macOS is the official Homebrew tap.
 ```bash
 brew tap UniClipboard/tap
 
+# Homebrew 6.0+ requires trusting third-party taps before it loads their
+# formulae/casks — otherwise you'll see "Refusing to load ... from
+# untrusted tap". This only needs to run once.
+brew trust UniClipboard/tap
+
 # Desktop app (the .app bundle)
 brew install --cask uniclipboard
 
@@ -68,11 +73,12 @@ brew install --cask uniclipboard
 brew install uniclipboard
 ```
 
-Or install in a single command without tapping first:
+Or install in a single command without tapping first (still trust the tap once):
 
 ```bash
-brew install --cask UniClipboard/tap/uniclipboard   # GUI
-brew install UniClipboard/tap/uniclipboard          # CLI
+brew trust UniClipboard/tap                          # Homebrew 6.0+, one-time
+brew install --cask UniClipboard/tap/uniclipboard    # GUI
+brew install UniClipboard/tap/uniclipboard           # CLI
 ```
 
 The cask and the formula can coexist — install both if you want the GUI

--- a/docs-site/content/docs/zh/getting-started/install.mdx
+++ b/docs-site/content/docs/zh/getting-started/install.mdx
@@ -59,6 +59,10 @@ macOS 推荐使用官方 Homebrew tap。
 ```bash
 brew tap UniClipboard/tap
 
+# Homebrew 6.0+ 默认要求先信任第三方 tap 才会加载其 formula/cask，
+# 否则会报 “Refusing to load ... from untrusted tap”。该步骤只需执行一次。
+brew trust UniClipboard/tap
+
 # 桌面应用（.app）
 brew install --cask uniclipboard
 
@@ -66,11 +70,12 @@ brew install --cask uniclipboard
 brew install uniclipboard
 ```
 
-也可以省去 `brew tap`，一行直装：
+也可以省去 `brew tap`，一行直装（仍需先信任一次该 tap）：
 
 ```bash
-brew install --cask UniClipboard/tap/uniclipboard   # GUI
-brew install UniClipboard/tap/uniclipboard          # CLI
+brew trust UniClipboard/tap                          # Homebrew 6.0+，一次性
+brew install --cask UniClipboard/tap/uniclipboard    # GUI
+brew install UniClipboard/tap/uniclipboard           # CLI
 ```
 
 cask 与 formula 互不冲突，需要的话两个都装即可（GUI + 终端 `uniclip`）。


### PR DESCRIPTION
## Summary

- Homebrew 6.0 enables `HOMEBREW_REQUIRE_TAP_TRUST` by default, so loading the third-party `UniClipboard/tap` now fails with `Refusing to load ... from untrusted tap` until the tap is trusted. The existing install docs never mention this, so a fresh `brew tap` + `brew install` breaks on any up-to-date Homebrew. (96be6b6e5)
- Document a one-time `brew trust UniClipboard/tap` in both the tap-first and one-line install flows, across `README.md`, `README_ZH.md`, and the docs-site install pages (`en`/`zh`), kept in lockstep.

## Test plan

- [x] Confirmed the requirement is on by default on Homebrew 6.0.1: `brew config` reports `HOMEBREW_REQUIRE_TAP_TRUST: set` even with the shell env var unset.
- [x] Verified `brew trust <tap>` syntax and behavior via `brew trust --help` (records the tap in `trust.json`; a sibling `deskflow/tap` entry was added the same way).
- [ ] Reviewer: render the docs-site macOS tab (en + zh) and confirm the new `brew trust` line and note read cleanly.

_No linked issue — surfaced from a real `Refusing to load ... from untrusted tap` failure during local install._

🤖 Drafted with AI assistance (Claude Code).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated macOS Homebrew installation instructions to include a required `brew trust UniClipboard/tap` command for Homebrew 6.0+ before installing the application.
  * Revised installation guides in both English and Chinese with updated command examples reflecting the new trust requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->