### PR TITLE
fix(clipboard): stop Linux/X11 image capture storm (#957)

### DIFF
--- a/apps/daemon/src/daemon/app.rs
+++ b/apps/daemon/src/daemon/app.rs
@@ -5,6 +5,7 @@
 
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
+use std::time::Duration;
 
 use tokio::sync::broadcast;
 use tokio::sync::RwLock;
@@ -133,6 +134,57 @@ async fn run_startup_file_cache_hygiene(history_facade: Arc<ClipboardHistoryFaca
         }
         Err(e) => {
             warn!(error = %e, "Startup file cache cleanup failed (non-fatal)");
+        }
+    }
+}
+
+/// Interval between periodic file-cache hygiene sweeps after the startup pass.
+///
+/// `cleanup_expired_files` enforces the `file_sync.file_cache_quota_per_device`
+/// cap, but originally ran only at startup — so a session that kept accumulating
+/// cache (e.g. issue #957's image capture storm) blew past the user's cap until
+/// the next restart. Re-running the sweep on this cadence bounds growth mid-
+/// session. This is an independent maintenance cadence, NOT coupled to the
+/// restart-handoff budgets in `uc_daemon_process::timing`, so it lives here as a
+/// single named constant rather than in that module.
+const FILE_CACHE_HYGIENE_INTERVAL: Duration = Duration::from_secs(300);
+
+/// Run the startup file-cache hygiene pass once, then re-run the cleanup +
+/// quota sweep every [`FILE_CACHE_HYGIENE_INTERVAL`] until `cancel` fires, so
+/// the cache quota is enforced throughout a long-running session and not only
+/// at startup. Detached + fire-and-forget like the startup pass; failures are
+/// logged and never abort the loop.
+async fn run_file_cache_hygiene(
+    history_facade: Arc<ClipboardHistoryFacade>,
+    cancel: CancellationToken,
+) {
+    run_startup_file_cache_hygiene(Arc::clone(&history_facade)).await;
+
+    let mut ticker = tokio::time::interval(FILE_CACHE_HYGIENE_INTERVAL);
+    // The first tick is immediate; consume it since the startup pass just ran.
+    ticker.tick().await;
+    loop {
+        tokio::select! {
+            _ = cancel.cancelled() => break,
+            _ = ticker.tick() => {
+                match history_facade.cleanup_expired_files().await {
+                    Ok(result) => {
+                        if result.files_removed > 0 || result.entries_deleted > 0 {
+                            info!(
+                                files_removed = result.files_removed,
+                                entries_deleted = result.entries_deleted,
+                                orphans_removed = result.orphans_removed,
+                                bytes_reclaimed = result.bytes_reclaimed,
+                                errors = result.errors,
+                                "Periodic file cache cleanup completed"
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        warn!(error = %e, "Periodic file cache cleanup failed (non-fatal)");
+                    }
+                }
+            }
         }
     }
 }
@@ -492,8 +544,11 @@ impl DaemonApp {
         // "service task exited unexpectedly" shutdown arm; this matches the
         // prior fire-and-forget GUI startup behavior.
         let history_facade_for_hygiene = Arc::clone(&self.app_facade.clipboard_history);
-        let _hygiene_handle =
-            tokio::spawn(run_startup_file_cache_hygiene(history_facade_for_hygiene));
+        let hygiene_cancel = self.cancel.child_token();
+        let _hygiene_handle = tokio::spawn(run_file_cache_hygiene(
+            history_facade_for_hygiene,
+            hygiene_cancel,
+        ));
 
         // mobile_sync LAN listener:经 controller 走"对齐到期望状态"的路径,
         // 不再一次性 tokio::spawn。同一个 controller 也注入了 MobileSyncFacade,

--- a/apps/daemon/src/daemon/app.rs
+++ b/apps/daemon/src/daemon/app.rs
@@ -161,6 +161,12 @@ async fn run_file_cache_hygiene(
     run_startup_file_cache_hygiene(Arc::clone(&history_facade)).await;
 
     let mut ticker = tokio::time::interval(FILE_CACHE_HYGIENE_INTERVAL);
+    // Drop missed ticks instead of bursting catch-up sweeps: after a stall
+    // (e.g. the host sleeps/suspends for hours), the default `Burst` would fire
+    // every skipped tick back-to-back, running redundant cleanups on resume.
+    // `Skip` collapses them into a single sweep at the next aligned slot, then
+    // resumes the normal cadence.
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     // The first tick is immediate; consume it since the startup pass just ran.
     ticker.tick().await;
     loop {

--- a/crates/uc-core/src/clipboard/system.rs
+++ b/crates/uc-core/src/clipboard/system.rs
@@ -478,6 +478,20 @@ impl SystemClipboardSnapshot {
             .map(|rep| rep.size_bytes())
     }
 
+    /// Inline bytes of the dominant image representation — the same one
+    /// [`Self::primary_image_size_bytes`] measures — or `None` when the
+    /// snapshot carries no image representation or that representation isn't
+    /// held inline (e.g. it was spooled to a file). Lets a caller fingerprint
+    /// the very bytes whose size it would otherwise compare, without exposing
+    /// the image-detection predicate. This stays a pure byte accessor: any
+    /// decoding/normalization is the caller's concern, not the domain's.
+    pub fn primary_image_inline_bytes(&self) -> Option<&[u8]> {
+        self.representations
+            .iter()
+            .find(|rep| is_image_representation(rep))
+            .and_then(|rep| rep.inline_bytes())
+    }
+
     /// 是否为空快照（没有任何 representation）
     pub fn is_empty(&self) -> bool {
         self.representations.is_empty()

--- a/crates/uc-platform/src/clipboard/platform/linux/x11/event_loop.rs
+++ b/crates/uc-platform/src/clipboard/platform/linux/x11/event_loop.rs
@@ -19,7 +19,7 @@ use rustix::event::{poll, PollFd, PollFlags};
 use tracing::{debug, info, warn};
 use x11rb::connection::Connection;
 use x11rb::protocol::xfixes::{self, SelectionEventMask};
-use x11rb::protocol::xproto::ConnectionExt as _;
+use x11rb::protocol::xproto::{AtomEnum, ConnectionExt as _};
 use x11rb::protocol::Event;
 
 use crate::clipboard::event_loop::{PlatformClipboardEventLoop, ShutdownRx};
@@ -93,18 +93,40 @@ impl PlatformClipboardEventLoop for X11EventLoop {
             Err(e) => warn!(error = %e, "x11 watcher: baseline read failed"),
         }
         let mut pending_change = baseline_ctx.take_selection_changed();
+        // Last CLIPBOARD owner we logged, to surface ownership churn without
+        // spamming: issue #957's storm is driven by an EXTERNAL client
+        // re-asserting ownership on a cadence, so logging the owner each time it
+        // changes names the culprit (when it carries WM_CLASS) and exposes a
+        // rapid A↔B ownership war directly in the daemon log.
+        let mut last_owner: Option<u32> = None;
 
         loop {
             // Drain anything currently buffered. We process every event so
             // we don't miss a change that arrived while we were reading —
             // including ones flagged mid-read by the previous iteration.
             let mut saw_change = std::mem::take(&mut pending_change);
+            let mut new_owner = None;
             while let Some(event) = conn
                 .poll_for_event()
                 .context("x11 watcher: poll_for_event failed")?
             {
-                if matches!(event, Event::XfixesSelectionNotify(_)) {
+                if let Event::XfixesSelectionNotify(notify) = event {
                     saw_change = true;
+                    new_owner = Some(notify.owner);
+                }
+            }
+
+            // Diagnostic only (DEBUG, throttled to ownership changes) — does not
+            // affect capture. Resolved after draining so the WM_CLASS query
+            // doesn't interleave with the event drain above.
+            if let Some(owner) = new_owner {
+                if last_owner != Some(owner) {
+                    last_owner = Some(owner);
+                    debug!(
+                        owner,
+                        owner_info = %describe_window(conn, owner),
+                        "x11 watcher: CLIPBOARD selection owner changed"
+                    );
                 }
             }
 
@@ -224,6 +246,33 @@ fn read_changed_selection(
          or offered no interesting mimes) — clipboard change lost"
     );
     ctx.take_selection_changed()
+}
+
+/// Best-effort, diagnostics-only human description of an X11 window: its
+/// `WM_CLASS` when set, otherwise just the hex id. Selection-owner windows are
+/// often unmanaged utility windows with no `WM_CLASS`, so an empty class is
+/// expected and simply yields the bare id. Never fails — any X error degrades
+/// to the id (or "none" for the cleared selection).
+fn describe_window<C: Connection>(conn: &C, window: u32) -> String {
+    if window == x11rb::NONE {
+        return "none (selection cleared)".to_string();
+    }
+    let class = conn
+        .get_property(false, window, AtomEnum::WM_CLASS, AtomEnum::STRING, 0, 256)
+        .ok()
+        .and_then(|cookie| cookie.reply().ok())
+        // WM_CLASS is "instance\0class\0"; render the NULs as spaces.
+        .map(|reply| {
+            String::from_utf8_lossy(&reply.value)
+                .replace('\0', " ")
+                .trim()
+                .to_string()
+        })
+        .filter(|s| !s.is_empty());
+    match class {
+        Some(c) => format!("0x{window:x} ({c})"),
+        None => format!("0x{window:x}"),
+    }
 }
 
 /// Current owner window of `CLIPBOARD`, or `x11rb::NONE` when unowned or

--- a/crates/uc-platform/src/clipboard/watcher.rs
+++ b/crates/uc-platform/src/clipboard/watcher.rs
@@ -1,5 +1,5 @@
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 use tracing::{debug, info, warn};
 
 // `clipboard_rs::ClipboardHandler` is only required by the macOS / Windows
@@ -27,36 +27,53 @@ pub type PlatformEventSender = tokio::sync::mpsc::Sender<PlatformEvent>;
 /// Time window to suppress rapid consecutive file clipboard events.
 /// macOS fires multiple events when copying files (e.g. APFS→resolved path transition)
 /// where content bytes may differ slightly.
-const FILE_DEDUP_WINDOW: std::time::Duration = std::time::Duration::from_millis(500);
+const FILE_DEDUP_WINDOW: Duration = Duration::from_millis(500);
 
-/// Time window to suppress a rapid burst of same-size image clipboard events.
+/// Longest gap between two consecutive reads that still counts as part of the
+/// *same* ongoing image burst (issue #957 storm guard).
 ///
-/// On X11 a clipboard owner (or a desktop clipboard manager such as Klipper /
-/// CopyQ / GPaste) can re-assert selection ownership several times per second,
-/// and some sources serialize the *same* image with non-deterministic padding /
-/// alpha bytes on every read. The content hash — and therefore
-/// `meaningful_origin_key` (`image:<hash>`) — then differs on every read, so
-/// the key-based dedup above never fires and each read becomes a brand-new
-/// entry + blob + outbound sync. Observed in the wild as a ~400 ms self-feeding
-/// storm (see issue #957) that filled disk with hundreds of identical-looking
-/// images.
+/// On X11 a clipboard owner — the source app, or a desktop clipboard manager
+/// such as Klipper / CopyQ / GPaste — can re-assert selection ownership on a
+/// cadence; the freedesktop ClipboardManager spec even mandates that owners
+/// reacquire the selection whenever their content or metadata changes, so an
+/// `XfixesSelectionNotify` is *not* proof of new content. Some sources also
+/// re-serialize the *same* image with non-deterministic padding / alpha bytes
+/// on every read, so the content hash — and therefore `meaningful_origin_key`
+/// (`image:<hash>`) — churns and the key-based dedup above never fires. Each
+/// read would otherwise become a brand-new entry + blob + outbound sync: the
+/// self-feeding storm of issue #957 that filled disk with thousands of
+/// identical-looking images.
 ///
 /// Byte size is a cheap, stable proxy for image identity here: the storm keeps
-/// identical dimensions while only the hash churns. A genuinely different image
-/// (different byte size) passes through immediately; only a same-size image
-/// arriving within this window of the previous image is suppressed. The window
-/// is refreshed on every suppressed event so a sustained burst stays muted as
-/// long as it keeps firing faster than the window.
-const IMAGE_DEDUP_WINDOW: std::time::Duration = std::time::Duration::from_millis(1500);
+/// identical dimensions while only the hash churns. The guard latches on the
+/// previous image's byte size and suppresses any same-size image arriving
+/// within this gap; the latch is refreshed on every suppressed read, so a
+/// sustained burst of *any* cadence below this gap stays muted indefinitely.
+/// The original #957 fix used a fixed 1500 ms window, which a slower ~1.83 s
+/// real-world storm slipped straight past — the gap between re-reads exceeded
+/// the window, so the suppression branch was never entered. This gap is sized
+/// well above plausible re-assert cadences; once a burst genuinely stops the
+/// latch lapses after this much idle time, so a deliberate later re-copy of a
+/// same-size image still emits, and any intervening non-image copy breaks it
+/// immediately.
+///
+/// Note this is a heuristic guard, not a content-equality check: two *different*
+/// images that serialize to the exact same byte length, copied back-to-back
+/// within this gap with nothing in between, would be wrongly collapsed. A
+/// content-stable image fingerprint (hashing decoded pixels rather than raw
+/// serialized bytes) is the deeper fix and would let the key-based dedup above
+/// handle that case without the size proxy.
+const IMAGE_STORM_MAX_GAP: Duration = Duration::from_secs(5);
 
 pub struct ClipboardWatcher {
     local_clipboard: Arc<dyn SystemClipboardPort>,
     sender: PlatformEventSender,
     last_meaningful_dedupe_key: Option<String>,
     last_file_emit_time: Option<Instant>,
-    /// `(observed_at, size_bytes)` of the most recent image-dominant snapshot,
-    /// updated on every image observation (emitted or suppressed). Drives the
-    /// [`IMAGE_DEDUP_WINDOW`] storm guard.
+    /// `(observed_at, size_bytes)` of the most recent image-dominant snapshot.
+    /// Updated on every image observation (emitted or suppressed) and cleared
+    /// when a non-image snapshot is emitted. Drives the [`IMAGE_STORM_MAX_GAP`]
+    /// storm guard.
     last_image_seen: Option<(Instant, i64)>,
 }
 
@@ -83,6 +100,34 @@ fn dedupe_key(snapshot: &SystemClipboardSnapshot) -> Option<String> {
 /// Returns true if any representation in the snapshot is a file representation.
 fn snapshot_has_files(snapshot: &SystemClipboardSnapshot) -> bool {
     snapshot.representations.iter().any(is_file_representation)
+}
+
+/// Largest serialized image we will decode to fingerprint. Above this the
+/// decode + pixel hash is too costly to run on the watcher path, so we skip it
+/// and fall back to the size-based storm latch.
+const MAX_FINGERPRINT_DECODE_BYTES: usize = 64 * 1024 * 1024;
+
+/// A decode-stable identity for a clipboard image: the blake3 hash of its
+/// canonical RGBA8 pixel buffer plus dimensions.
+///
+/// Two reads of the *same* image produce the same fingerprint even when the
+/// source re-serializes it with churning padding / alpha / metadata bytes (the
+/// issue #957 storm shape) — decoding normalizes the container away, so unlike
+/// the raw-byte content hash this does not churn. Returns `None` for images we
+/// can't decode (unknown/unsupported format such as `image/xpm`, or corrupt
+/// bytes) or that exceed [`MAX_FINGERPRINT_DECODE_BYTES`]; the caller then
+/// falls back to the raw-byte key plus the size-based storm latch.
+fn stable_image_fingerprint(bytes: &[u8]) -> Option<String> {
+    if bytes.is_empty() || bytes.len() > MAX_FINGERPRINT_DECODE_BYTES {
+        return None;
+    }
+    let image = image::load_from_memory(bytes).ok()?;
+    let rgba = image.to_rgba8();
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(&rgba.width().to_le_bytes());
+    hasher.update(&rgba.height().to_le_bytes());
+    hasher.update(rgba.as_raw());
+    Some(hasher.finalize().to_hex().to_string())
 }
 
 impl ClipboardWatcher {
@@ -120,7 +165,35 @@ impl ClipboardWatcher {
     }
 
     fn emit_with_dedup(&mut self, snapshot: SystemClipboardSnapshot) {
-        let current_dedupe_key = dedupe_key(&snapshot);
+        self.emit_with_dedup_at(snapshot, Instant::now());
+    }
+
+    /// Dedup core with an injected `now`, so the time-based guards are testable
+    /// without sleeping. Production callers go through [`Self::emit_with_dedup`].
+    fn emit_with_dedup_at(&mut self, snapshot: SystemClipboardSnapshot, now: Instant) {
+        let raw_key = dedupe_key(&snapshot);
+        let is_image = raw_key.as_deref().is_some_and(|k| k.starts_with("image:"));
+
+        // For an image-dominant snapshot, prefer a decode-stable fingerprint
+        // over the raw-byte content hash. The same image re-serialized with
+        // churning padding / alpha (issue #957) otherwise yields a fresh
+        // `image:<hash>` on every read and slips the key dedup below; the
+        // fingerprint stays constant, so re-reads collapse via that dedup
+        // regardless of cadence and without the size-proxy false-negative.
+        // `None` (undecodable format like image/xpm, or oversized) falls back to
+        // the raw key + the size-based storm latch.
+        let image_fingerprint = if is_image {
+            snapshot
+                .primary_image_inline_bytes()
+                .and_then(stable_image_fingerprint)
+        } else {
+            None
+        };
+        let current_dedupe_key = match (&raw_key, &image_fingerprint) {
+            (Some(k), Some(fp)) if k.starts_with("image:") => Some(format!("image:{fp}")),
+            _ => raw_key,
+        };
+
         if let Some(key) = current_dedupe_key.as_ref() {
             if self.last_meaningful_dedupe_key.as_deref() == Some(key.as_str()) {
                 // Info-level on purpose: this is the last silent spot where a
@@ -134,28 +207,32 @@ impl ClipboardWatcher {
             }
         }
 
-        // Image storm guard: an image-dominant snapshot whose image byte size
-        // matches the previous image within `IMAGE_DEDUP_WINDOW` is treated as a
-        // re-read of the same image (the hash churns under us; see
-        // `IMAGE_DEDUP_WINDOW`). Keyed off the image representation's own size
-        // (not the whole-snapshot total) so co-resident metadata reps can't make
-        // two genuinely different images look identically sized, nor mask the
-        // storm's stable image size. Computed before the value moves into
-        // `try_send`.
-        let image_size = current_dedupe_key
-            .as_ref()
-            .filter(|k| k.starts_with("image:"))
-            .and_then(|_| snapshot.primary_image_size_bytes());
+        // Image storm guard (fallback for images we could NOT fingerprint): an
+        // image-dominant snapshot whose image byte size matches the previous
+        // image within `IMAGE_STORM_MAX_GAP` is treated as a re-read of the same
+        // image (the raw hash churns under us; see `IMAGE_STORM_MAX_GAP`). Keyed
+        // off the image representation's own size (not the whole-snapshot total)
+        // so co-resident metadata reps can't make two genuinely different images
+        // look identically sized. Decodable images are already handled by the
+        // stable fingerprint key above, so the size latch is skipped for them —
+        // it can't tell two same-size images apart and would otherwise drop a
+        // genuinely different same-size image. Computed before the value moves
+        // into `try_send`.
+        let image_size = if is_image && image_fingerprint.is_none() {
+            snapshot.primary_image_size_bytes()
+        } else {
+            None
+        };
         if let Some(size) = image_size {
-            let now = Instant::now();
             if let Some((last, last_size)) = self.last_image_seen {
-                if last_size == size && now.duration_since(last) < IMAGE_DEDUP_WINDOW {
-                    // Refresh the window so a sustained burst stays suppressed.
+                if last_size == size && now.duration_since(last) < IMAGE_STORM_MAX_GAP {
+                    // Refresh the latch so a sustained burst — at any cadence
+                    // below IMAGE_STORM_MAX_GAP — stays suppressed.
                     self.last_image_seen = Some((now, size));
                     debug!(
                         size_bytes = size,
                         elapsed_ms = now.duration_since(last).as_millis(),
-                        "Suppressing rapid same-size image clipboard event (storm guard)"
+                        "Suppressing same-size image clipboard event (storm guard)"
                     );
                     return;
                 }
@@ -166,7 +243,6 @@ impl ClipboardWatcher {
         // multiple clipboard events when copying files (APFS→resolved
         // path transition) where content bytes may differ slightly.
         if snapshot_has_files(&snapshot) {
-            let now = Instant::now();
             if let Some(last) = self.last_file_emit_time {
                 if now.duration_since(last) < FILE_DEDUP_WINDOW {
                     debug!(
@@ -193,10 +269,15 @@ impl ClipboardWatcher {
                 .as_ref()
                 .is_some_and(|k| k.starts_with("files:"))
             {
-                self.last_file_emit_time = Some(Instant::now());
+                self.last_file_emit_time = Some(now);
             }
             if let Some(size) = image_size {
-                self.last_image_seen = Some((Instant::now(), size));
+                self.last_image_seen = Some((now, size));
+            } else {
+                // A genuinely-new non-image copy ends any ongoing image burst,
+                // so drop the latch: a later same-size image must not be muted
+                // as if the storm were still running.
+                self.last_image_seen = None;
             }
             if let Some(key) = current_dedupe_key {
                 self.last_meaningful_dedupe_key = Some(key);
@@ -288,6 +369,47 @@ mod tests {
         }
     }
 
+    /// Plain-text snapshot, so `meaningful_origin_key` keys on `text:` (not
+    /// `image:`) — used to exercise the latch-reset-on-non-image path.
+    fn text(s: &str) -> SystemClipboardSnapshot {
+        let rep = ObservedClipboardRepresentation::new(
+            RepresentationId::new(),
+            FormatId::from("text"),
+            Some(MimeType("text/plain".to_string())),
+            s.as_bytes().to_vec(),
+        );
+        SystemClipboardSnapshot {
+            ts_ms: 0,
+            representations: vec![rep],
+        }
+    }
+
+    /// Encode a solid-colour `w`×`h` RGB image in `format` — real, decodable
+    /// bytes so `stable_image_fingerprint` runs (unlike the `image()` helper's
+    /// raw fill bytes, which don't decode and exercise the size-latch fallback).
+    fn encode(format: image::ImageFormat, w: u32, h: u32, rgb: [u8; 3]) -> Vec<u8> {
+        let buf = image::RgbImage::from_pixel(w, h, image::Rgb(rgb));
+        let mut out = std::io::Cursor::new(Vec::new());
+        image::DynamicImage::ImageRgb8(buf)
+            .write_to(&mut out, format)
+            .expect("encode test image");
+        out.into_inner()
+    }
+
+    /// Image snapshot carrying real (decodable) `bytes`.
+    fn decodable_image(bytes: Vec<u8>) -> SystemClipboardSnapshot {
+        let rep = ObservedClipboardRepresentation::new(
+            RepresentationId::new(),
+            FormatId::from("image"),
+            Some(MimeType("image/png".to_string())),
+            bytes,
+        );
+        SystemClipboardSnapshot {
+            ts_ms: 0,
+            representations: vec![rep],
+        }
+    }
+
     fn drain(rx: &mut tokio::sync::mpsc::Receiver<PlatformEvent>) -> usize {
         let mut n = 0;
         while rx.try_recv().is_ok() {
@@ -363,6 +485,115 @@ mod tests {
             drain(&mut rx),
             1,
             "stable image size must storm-guard despite a churning secondary rep"
+        );
+    }
+
+    #[test]
+    fn slow_same_size_image_storm_collapses_regardless_of_cadence() {
+        // Regression for the #957 0.15 recurrence: the real storm re-read the
+        // same image every ~1.83 s, which exceeded the old fixed 1500 ms window
+        // so the guard never fired and every read became a new entry + blob.
+        // With a sustained-burst latch, a same-size churning-hash burst at a
+        // cadence ABOVE the old window still collapses to a single emit.
+        let (mut w, mut rx) = watcher();
+        let base = Instant::now();
+        for i in 0u8..16 {
+            let at = base + Duration::from_millis(1830 * i as u64);
+            w.emit_with_dedup_at(image(4096, i), at);
+        }
+        assert_eq!(
+            drain(&mut rx),
+            1,
+            "a slow (~1.83s) same-size image storm must still collapse to one emit"
+        );
+    }
+
+    #[test]
+    fn same_size_image_after_long_idle_emits_again() {
+        // Once a burst genuinely stops, the latch must lapse: a deliberate later
+        // re-copy of a same-size image (gap beyond IMAGE_STORM_MAX_GAP) emits,
+        // so the guard can't swallow real copies forever.
+        let (mut w, mut rx) = watcher();
+        let base = Instant::now();
+        w.emit_with_dedup_at(image(4096, 1), base);
+        w.emit_with_dedup_at(
+            image(4096, 2),
+            base + IMAGE_STORM_MAX_GAP + Duration::from_millis(1),
+        );
+        assert_eq!(
+            drain(&mut rx),
+            2,
+            "a same-size image after the latch lapses must emit"
+        );
+    }
+
+    #[test]
+    fn intervening_non_image_breaks_image_latch() {
+        // An intervening non-image copy (text) marks a genuinely-new sequence
+        // and must break the image latch, so a following same-size image within
+        // the gap is not wrongly muted.
+        let (mut w, mut rx) = watcher();
+        let base = Instant::now();
+        w.emit_with_dedup_at(image(4096, 1), base); // emit, latch = 4096
+        w.emit_with_dedup_at(text("hello"), base + Duration::from_millis(100)); // emit, clears latch
+        w.emit_with_dedup_at(image(4096, 2), base + Duration::from_millis(200)); // emit, latch was cleared
+        assert_eq!(
+            drain(&mut rx),
+            3,
+            "a non-image copy between same-size images must break the latch"
+        );
+    }
+
+    #[test]
+    fn churning_serialization_of_same_image_collapses_via_fingerprint() {
+        // The same image serialized two different ways (PNG vs BMP) yields
+        // different raw bytes, different byte sizes, and a different raw-byte
+        // hash — neither the raw key dedup nor the size latch could collapse
+        // them. The decode-stable fingerprint must, even at a cadence beyond
+        // IMAGE_STORM_MAX_GAP (so the size latch is irrelevant here).
+        let (mut w, mut rx) = watcher();
+        let base = Instant::now();
+        let png = encode(image::ImageFormat::Png, 8, 8, [10, 20, 30]);
+        let bmp = encode(image::ImageFormat::Bmp, 8, 8, [10, 20, 30]);
+        assert_ne!(
+            png.len(),
+            bmp.len(),
+            "the two serializations must differ in byte size"
+        );
+        w.emit_with_dedup_at(decodable_image(png), base);
+        w.emit_with_dedup_at(
+            decodable_image(bmp),
+            base + IMAGE_STORM_MAX_GAP + Duration::from_secs(1),
+        );
+        assert_eq!(
+            drain(&mut rx),
+            1,
+            "the same image in two serializations must collapse via the fingerprint"
+        );
+    }
+
+    #[test]
+    fn different_images_of_equal_byte_size_both_emit_via_fingerprint() {
+        // Two genuinely different images encoded as same-dimension BMPs have the
+        // SAME byte size (BMP size depends only on dimensions), so the size
+        // latch alone would wrongly drop the second. The fingerprint tells them
+        // apart by pixels, so both must emit — this is the size-proxy
+        // false-negative the fingerprint exists to remove.
+        let (mut w, mut rx) = watcher();
+        let base = Instant::now();
+        let a = encode(image::ImageFormat::Bmp, 8, 8, [10, 20, 30]);
+        let b = encode(image::ImageFormat::Bmp, 8, 8, [200, 100, 50]);
+        assert_eq!(
+            a.len(),
+            b.len(),
+            "same-dimension BMPs must have equal byte size for this test to bite"
+        );
+        w.emit_with_dedup_at(decodable_image(a), base);
+        w.emit_with_dedup_at(decodable_image(b), base + Duration::from_millis(100));
+        assert_eq!(
+            drain(&mut rx),
+            2,
+            "different images of equal byte size must both emit (no size false-negative)"
         );
     }
 }


### PR DESCRIPTION
## Summary

On Linux/X11, copying one image could trigger a self-sustaining capture storm (#957): an external clipboard owner re-asserts CLIPBOARD ownership on a cadence (~1.8s in the field log), and because the same image re-serializes with churning padding/alpha bytes, its raw-byte content hash changed on every read — so each re-read became a new entry + iroh blob + outbound sync, ballooning storage past the user's configured cap.

- **Decode-stable image fingerprint** (`66443546`): the image dedup key now derives from the canonical RGBA8 pixels (blake3 over pixels + dimensions) instead of the raw serialized bytes, so re-reads of the *same* image collapse via the existing key dedup — cadence-independent and without the size-proxy false-negative. The size-based storm guard is reframed as a sustained-burst latch (1500ms → 5s) and kept as the fallback for images that can't be decoded (e.g. `image/xpm`). Adds a time-injection seam (`emit_with_dedup_at(now)`) + regression tests.
- **Periodic cache-quota enforcement** (`6b61d23a`): `file_cache_quota_per_device` was enforced only at daemon startup, so a long session could exceed the cap until restart. It now re-runs every 300s until shutdown — the issue's second symptom ("容量上限未生效").
- **X11 owner diagnostic** (`329f664e`): on CLIPBOARD owner change, DEBUG-log the new owner window id + best-effort `WM_CLASS`, so a field report can name the external client driving the storm without the user running `xprop`/`clipnotify`. Diagnostics-only.

Refs #957. **Leaving the issue open intentionally** — pending field confirmation from the reporter (@zhubeilife) that the 0.15 storm is actually resolved on their machine; please do not auto-close on merge.

## Test plan

- [x] `cargo test -p uc-platform` — watcher 10/10 incl. new regression tests (slow >1500ms storm collapses; latch lapses after idle; non-image breaks latch; same-image/different-serialization collapses via fingerprint; different same-size images both emit)
- [x] `cargo test -p uc-core` (120/120); `cargo test -p uc-application` cleanup/quota (15/15, never-evict-newest guard intact)
- [x] `cargo clippy --all-targets` clean on changed crates; `cargo check --workspace` green
- [ ] Field confirmation from @zhubeilife that the storm no longer reproduces on 0.15+
- [ ] (reviewer) sanity-check periodic quota cadence on a live session

### Known follow-up (not in this PR)
The fingerprint decodes on the watcher thread bounded only by a 64MB *serialized* input cap; a huge / low-bytes-per-pixel image could still spike decoded RGBA memory. Bounding decoded dimensions + a few test-coverage gaps are tracked locally and will follow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Clipboard snapshots now expose direct access to inline image bytes for the primary image representation.

* **Improvements**
  * Clipboard watching on X11 is more resilient against rapid self-feeding image bursts via smarter deduplication and throttling.
  * Improved clipboard debug diagnostics by reporting the current owning window details more accurately.
  * Added periodic file cache hygiene in the daemon to repeatedly clean up expired cached files without requiring restarts.

* **Bug Fixes**
  * Reduced cases where clipboard change detection could churn unnecessarily during repeated image re-assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->