### PR TITLE
Add official Homebrew Cask integration for GUI

### DIFF
--- a/.github/workflows/homebrew-cask.yml
+++ b/.github/workflows/homebrew-cask.yml
@@ -1,0 +1,134 @@
+name: 'Homebrew Official Cask'
+run-name: >-
+  ${{ github.event_name == 'release'
+    && format('homebrew-cask-{0}', github.event.release.tag_name)
+    || format('homebrew-cask-manual-{0}', inputs.version) }}
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Stable version without v prefix, e.g. 0.16.0'
+        required: true
+        type: string
+      fork_repo:
+        description: 'Pushable fork used to open the PR'
+        required: true
+        default: 'UniClipboard/homebrew-cask'
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  submit:
+    name: Submit official cask PR
+    if: github.event_name == 'workflow_dispatch' || github.event.release.prerelease == false
+    runs-on: macos-latest
+    env:
+      CASK_TOKEN: ${{ secrets.HOMEBREW_CASK_TOKEN }}
+      FORK_REPO: ${{ inputs.fork_repo || 'UniClipboard/homebrew-cask' }}
+    steps:
+      - name: Checkout UniClipboard
+        uses: actions/checkout@v4
+
+      - name: Resolve release metadata
+        id: release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            VERSION="${INPUT_VERSION#v}"
+          else
+            VERSION="${RELEASE_TAG#v}"
+          fi
+
+          if [ -z "$VERSION" ]; then
+            echo "Could not derive version" >&2
+            exit 1
+          fi
+
+          ASSETS_JSON="$(gh release view "v${VERSION}" --repo "${GITHUB_REPOSITORY}" --json assets)"
+          ARM_DIGEST="$(jq -r --arg version "$VERSION" '.assets[] | select(.name == "UniClipboard_" + $version + "_aarch64.dmg") | .digest // empty' <<<"$ASSETS_JSON")"
+          INTEL_DIGEST="$(jq -r --arg version "$VERSION" '.assets[] | select(.name == "UniClipboard_" + $version + "_x64.dmg") | .digest // empty' <<<"$ASSETS_JSON")"
+
+          ARM_SHA="${ARM_DIGEST#sha256:}"
+          INTEL_SHA="${INTEL_DIGEST#sha256:}"
+          if [ -z "$ARM_SHA" ] || [ -z "$INTEL_SHA" ]; then
+            echo "Missing GitHub release asset digests for UniClipboard_${VERSION}_{aarch64,x64}.dmg" >&2
+            exit 1
+          fi
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "arm_sha=$ARM_SHA" >> "$GITHUB_OUTPUT"
+          echo "intel_sha=$INTEL_SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Render cask
+        run: |
+          set -euo pipefail
+          mkdir -p rendered
+          sed \
+            -e 's/__VERSION__/${{ steps.release.outputs.version }}/g' \
+            -e 's/__SHA256_ARM__/${{ steps.release.outputs.arm_sha }}/g' \
+            -e 's/__SHA256_INTEL__/${{ steps.release.outputs.intel_sha }}/g' \
+            packaging/homebrew/casks/uniclipboard.rb > rendered/uniclipboard.rb
+          cat rendered/uniclipboard.rb
+
+      - name: Checkout Homebrew cask fork
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.FORK_REPO }}
+          token: ${{ secrets.HOMEBREW_CASK_TOKEN }}
+          path: homebrew-cask
+
+      - name: Update cask and open PR
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_CASK_TOKEN }}
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          set -euo pipefail
+          if [ -z "${CASK_TOKEN:-}" ]; then
+            echo "HOMEBREW_CASK_TOKEN is required" >&2
+            exit 1
+          fi
+
+          cd homebrew-cask
+          git config user.name "UniClipboard Release Bot"
+          git config user.email "release@uniclipboard.app"
+          git remote add upstream https://github.com/Homebrew/homebrew-cask.git || true
+          git fetch upstream master
+          git checkout -B "uniclipboard-${VERSION}" upstream/master
+
+          mkdir -p Casks/u
+          IS_NEW=0
+          if [ ! -f Casks/u/uniclipboard.rb ]; then
+            IS_NEW=1
+          fi
+          cp ../rendered/uniclipboard.rb Casks/u/uniclipboard.rb
+
+          if [ "$IS_NEW" -eq 1 ]; then
+            brew audit --cask --new Casks/u/uniclipboard.rb
+            COMMIT_SUBJECT="Add uniclipboard ${VERSION}"
+            PR_TITLE="Add uniclipboard ${VERSION}"
+          else
+            brew audit --cask Casks/u/uniclipboard.rb
+            COMMIT_SUBJECT="Update uniclipboard to ${VERSION}"
+            PR_TITLE="Update uniclipboard to ${VERSION}"
+          fi
+
+          git add Casks/u/uniclipboard.rb
+          git commit -m "$COMMIT_SUBJECT"
+          git push --force-with-lease origin "uniclipboard-${VERSION}"
+
+          gh pr create \
+            --repo Homebrew/homebrew-cask \
+            --head "${FORK_REPO%/*}:uniclipboard-${VERSION}" \
+            --base master \
+            --title "$PR_TITLE" \
+            --body "Adds the UniClipboard macOS GUI cask.\n\nRelease: https://github.com/UniClipboard/UniClipboard/releases/tag/v${VERSION}"

--- a/docs/packaging/homebrew-cask.md
+++ b/docs/packaging/homebrew-cask.md
@@ -1,0 +1,42 @@
+# Homebrew 官方 Cask 接入
+
+本文记录 UniClipboard GUI 进入 `Homebrew/homebrew-cask` 的维护流程。CLI 仍由 `UniClipboard/homebrew-tap` 维护；GUI 的目标是让用户直接运行：
+
+```bash
+brew install --cask uniclipboard
+```
+
+## 范围
+
+- 官方 Cask 只发布 macOS GUI：`UniClipboard.app`。
+- Cask 下载 GitHub Release 中的 DMG：
+  - Apple Silicon：`UniClipboard_<version>_aarch64.dmg`
+  - Intel：`UniClipboard_<version>_x64.dmg`
+- 版本只跟随 stable release；alpha、beta、rc 不提交到官方 Cask。
+- 私有 tap 可继续保留 CLI formula，避免 GUI 和 CLI 的所有权混在一起。
+
+## 文件
+
+- `packaging/homebrew/casks/uniclipboard.rb` 是提交到 `Homebrew/homebrew-cask` 的 Cask 模板。
+- `.github/workflows/homebrew-cask.yml` 会把模板中的版本和 SHA256 占位符替换成 release 资产的真实值，然后向官方仓库打开 PR。
+
+## 首次接入步骤
+
+1. 在 GitHub 创建或准备一个可推送分支的 fork，例如 `UniClipboard/homebrew-cask`。
+2. 配置仓库 secret：`HOMEBREW_CASK_TOKEN`。该 token 需要能向 fork push，并能向 `Homebrew/homebrew-cask` 打开 PR。
+3. 手动运行 `Homebrew Official Cask` workflow，填写 stable 版本号和 fork 仓库。
+4. 等待 workflow 生成 PR 后，按 Homebrew 维护者反馈调整 `packaging/homebrew/casks/uniclipboard.rb`，保持模板为单一事实来源。
+
+## 发布后维护
+
+`release.published` 事件只会对非 prerelease 触发官方 Cask 提交流程。若 Homebrew 侧已有自动 bump 或维护者要求手动更新，可临时禁用 `.github/workflows/homebrew-cask.yml` 的 release 触发，只保留 `workflow_dispatch`。
+
+## 本地校验
+
+在 macOS 上可先渲染模板，再运行：
+
+```bash
+brew audit --cask --new Casks/u/uniclipboard.rb
+brew install --cask ./Casks/u/uniclipboard.rb
+brew uninstall --cask uniclipboard
+```

--- a/packaging/homebrew/casks/uniclipboard.rb
+++ b/packaging/homebrew/casks/uniclipboard.rb
@@ -1,0 +1,28 @@
+cask "uniclipboard" do
+  arch arm: "aarch64", intel: "x64"
+
+  version "__VERSION__"
+  sha256 arm: "__SHA256_ARM__",
+         intel: "__SHA256_INTEL__"
+
+  url "https://github.com/UniClipboard/UniClipboard/releases/download/v#{version}/UniClipboard_#{version}_#{arch}.dmg",
+      verified: "github.com/UniClipboard/UniClipboard/"
+  name "UniClipboard"
+  desc "Privacy-first cross-device clipboard sync"
+  homepage "https://www.uniclipboard.app/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on macos: ">= :monterey"
+
+  app "UniClipboard.app"
+
+  zap trash: [
+    "~/Library/Application Support/app.uniclipboard.desktop",
+    "~/Library/Caches/app.uniclipboard.desktop",
+    "~/Library/Logs/app.uniclipboard.desktop",
+  ]
+end


### PR DESCRIPTION
### Motivation

- Provide an official Homebrew/homebrew-cask entry for the UniClipboard macOS GUI so users can install the app via `brew install --cask uniclipboard`.
- Automate creating/updating the upstream Cask on stable release publish and via manual dispatch to avoid manual maintenance work.
- Keep CLI packaging ownership with the existing `UniClipboard/homebrew-tap` and avoid mixing GUI/CLI ownership.

### Description

- Add a new GitHub Actions workflow `.github/workflows/homebrew-cask.yml` that fetches DMG asset digests from the GitHub release, renders a Cask from a local template, runs `brew audit`, pushes to a configured fork using `HOMEBREW_CASK_TOKEN`, and opens a PR against `Homebrew/homebrew-cask`.
- Add the Cask template `packaging/homebrew/casks/uniclipboard.rb` with Apple Silicon and Intel `sha256` placeholders, `livecheck`, macOS requirement, `app` install and `zap` cleanup paths.
- Add documentation `docs/packaging/homebrew-cask.md` describing scope, first-time setup (fork + `HOMEBREW_CASK_TOKEN`), workflow usage, and local validation commands.
- Workflow implements stable-only auto-run (skips prereleases), supports `workflow_dispatch` for manual runs, and differentiates new-add vs update commits for appropriate `brew audit` usage.

### Testing

- Rendered the Cask template substitution and ran Ruby syntax check with `ruby -c <(sed -e 's/__VERSION__/0.16.0/g' -e 's/__SHA256_ARM__/.../g' -e 's/__SHA256_INTEL__/.../g' packaging/homebrew/casks/uniclipboard.rb)`, which returned `Syntax OK`.
- Verified workflow YAML parses with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/homebrew-cask.yml"); puts "yaml ok"'`, which printed `yaml ok`.
- Validated `sed` rendering step and local `brew audit` target paths in the documentation examples (manual/local steps documented under `## 本地校验`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a311089537c83318924f6cd08a51324)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * UniClipboard is now available via Homebrew Cask for macOS (Monterey or later), supporting both Apple Silicon and Intel architectures.

* **Documentation**
  * Added documentation describing Homebrew Cask integration and installation instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->