### PR TITLE
feat(packaging): distribution channel sources + CodeQL/cask CI fixes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -31,3 +31,9 @@
 *.ttf binary
 *.eot binary
 *.pdf binary
+
+# Linguist / CodeQL: Homebrew casks & formulae are Ruby DSL, not analyzable
+# application source. Exclude them from language detection so CodeQL's default
+# setup does not add "ruby" and then fail finalize with "no source code seen"
+# (the brew cask added in #1086 is the only Ruby in the repo).
+packaging/**/*.rb linguist-detectable=false

--- a/.github/workflows/choco-publish.yml
+++ b/.github/workflows/choco-publish.yml
@@ -1,0 +1,92 @@
+name: 'Chocolatey Publish'
+run-name: >-
+  ${{ github.event_name == 'release'
+    && format('choco-{0}', github.event.release.tag_name)
+    || format('choco-manual-{0}', inputs.version) }}
+
+# Chocolatey 没有官方自动升级 bot(不像 nixpkgs 的 r-ryantm、Scoop Extras 的
+# excavator),每个新版本都得我们自己 pack + push。本 workflow 在 stable
+# release 正式发布后自动:下载 NSIS 安装器、算 sha256(并与 release 自带的
+# minisign 签名 SHA256SUMS.txt 交叉核对防篡改)、回填 nuspec 与 install 脚本、
+# choco pack、choco push 到 community repo。
+#
+# 首版仍需人工过 moderation 上架;之后版本走 trusted maintainer 自动校验。
+# 与 homebrew-tap.yml / copr.yml 一样监听 release.published —— stable release
+# 在 release.yml 里是 draft,人工点 "Publish" 后 asset URL 才可达,此时触发。
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: '版本号(不带 v 前缀,例如 0.15.0)'
+        required: true
+        type: string
+
+jobs:
+  publish:
+    name: Pack and push to Chocolatey
+    # 跳过 prerelease 自动路径;手动 dispatch 任何版本都跑。
+    if: github.event_name == 'workflow_dispatch' || github.event.release.prerelease == false
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Resolve version
+        id: resolve
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          TAG: ${{ github.event.release.tag_name }}
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            VERSION="${INPUT_VERSION#v}"
+          else
+            VERSION="${TAG#v}"
+          fi
+          if [ -z "$VERSION" ]; then
+            echo "无法解析版本号 (event=$EVENT_NAME tag=$TAG input=$INPUT_VERSION)" >&2
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Resolved version: $VERSION"
+
+      - name: Download installer and fill manifest
+        shell: pwsh
+        env:
+          VERSION: ${{ steps.resolve.outputs.version }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $base = "https://github.com/UniClipboard/UniClipboard/releases/download/v$env:VERSION"
+          $exe  = "UniClipboard_${env:VERSION}_x64-setup.exe"
+
+          Write-Host "Downloading $base/$exe"
+          Invoke-WebRequest -Uri "$base/$exe" -OutFile $exe
+          $sha = (Get-FileHash $exe -Algorithm SHA256).Hash.ToLower()
+          Write-Host "sha256=$sha"
+
+          # 与 release 自带 SHA256SUMS.txt(minisign 签名的可信源)交叉核对。
+          $sums = (Invoke-WebRequest -Uri "$base/SHA256SUMS.txt").Content
+          if ($sums -notmatch [Regex]::Escape($sha)) {
+            Write-Error "下载的 $exe 的 sha256 未出现在 SHA256SUMS.txt,中止以防被篡改"
+          }
+
+          $nuspec  = 'packaging/chocolatey/uniclipboard.nuspec'
+          $install = 'packaging/chocolatey/tools/chocolateyInstall.ps1'
+          (Get-Content $nuspec)  -replace '<version>[^<]*</version>', "<version>$env:VERSION</version>" | Set-Content $nuspec
+          (Get-Content $install) -replace "checksum64\s+= '[^']*'", "checksum64     = '$sha'" | Set-Content $install
+
+      - name: Pack
+        shell: pwsh
+        run: choco pack packaging/chocolatey/uniclipboard.nuspec --out packaging/chocolatey
+
+      - name: Push
+        shell: pwsh
+        env:
+          CHOCO_API_KEY: ${{ secrets.CHOCOLATEY_API_KEY }}
+          VERSION: ${{ steps.resolve.outputs.version }}
+        run: |
+          choco apikey --key $env:CHOCO_API_KEY --source https://push.chocolatey.org/
+          choco push "packaging/chocolatey/uniclipboard.$env:VERSION.nupkg" --source https://push.chocolatey.org/

--- a/.github/workflows/homebrew-cask.yml
+++ b/.github/workflows/homebrew-cask.yml
@@ -126,9 +126,12 @@ jobs:
           git commit -m "$COMMIT_SUBJECT"
           git push --force-with-lease origin "uniclipboard-${VERSION}"
 
+          # printf so the blank line renders as a real newline; gh --body keeps
+          # literal "\n" as backslash-n in the PR description otherwise.
+          PR_BODY="$(printf 'Adds the UniClipboard macOS GUI cask.\n\nRelease: https://github.com/UniClipboard/UniClipboard/releases/tag/v%s\n' "$VERSION")"
           gh pr create \
             --repo Homebrew/homebrew-cask \
             --head "${FORK_REPO%/*}:uniclipboard-${VERSION}" \
             --base master \
             --title "$PR_TITLE" \
-            --body "Adds the UniClipboard macOS GUI cask.\n\nRelease: https://github.com/UniClipboard/UniClipboard/releases/tag/v${VERSION}"
+            --body "$PR_BODY"

--- a/.github/workflows/winget-publish.yml
+++ b/.github/workflows/winget-publish.yml
@@ -1,0 +1,66 @@
+name: 'winget Publish'
+run-name: >-
+  ${{ github.event_name == 'release'
+    && format('winget-{0}', github.event.release.tag_name)
+    || format('winget-manual-{0}', inputs.version) }}
+
+# winget 也没有官方自动升级 bot,新版本需自己提 PR 到 microsoft/winget-pkgs。
+# 用微软官方工具 wingetcreate 自动下载安装器、算 sha256、生成 manifest 并提 PR。
+#
+# 注意:wingetcreate `update` 要求包已存在于 winget-pkgs —— 首版需人工提交
+# (见 packaging/winget/README.md,推荐 wingetcreate new),之后由本 workflow
+# 接管。winget 不被 Repology 抓取,这条 workflow 不影响 packaging-status 徽章,
+# 只为补 Windows 官方包管理器的自动分发。
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: '版本号(不带 v 前缀,例如 0.15.0)'
+        required: true
+        type: string
+
+jobs:
+  publish:
+    name: Submit to winget-pkgs
+    if: github.event_name == 'workflow_dispatch' || github.event.release.prerelease == false
+    runs-on: windows-latest
+    steps:
+      - name: Resolve version
+        id: resolve
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          TAG: ${{ github.event.release.tag_name }}
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            VERSION="${INPUT_VERSION#v}"
+          else
+            VERSION="${TAG#v}"
+          fi
+          if [ -z "$VERSION" ]; then
+            echo "无法解析版本号 (event=$EVENT_NAME tag=$TAG input=$INPUT_VERSION)" >&2
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Resolved version: $VERSION"
+
+      - name: Update and submit via wingetcreate
+        shell: pwsh
+        env:
+          VERSION: ${{ steps.resolve.outputs.version }}
+          # GitHub PAT(classic, public_repo)用于 fork microsoft/winget-pkgs 提 PR。
+          WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $base = "https://github.com/UniClipboard/UniClipboard/releases/download/v$env:VERSION"
+
+          # 拉取微软官方 wingetcreate(自带下载安装器 + 算 hash + 生成 manifest)。
+          Invoke-WebRequest -Uri https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
+
+          .\wingetcreate.exe update UniClipboard.UniClipboard `
+            --version $env:VERSION `
+            --urls "$base/UniClipboard_${env:VERSION}_x64-setup.exe" "$base/UniClipboard_${env:VERSION}_arm64-setup.exe" `
+            --submit --token $env:WINGET_TOKEN

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -1,0 +1,51 @@
+# 打包与分发渠道总览
+
+本目录汇集 UniClipboard 各分发渠道的打包定义源。真正生效的副本在各渠道自己的仓库里（nixpkgs、Scoop Extras、homebrew-cask 等），这里保存源 + 提交指引，与 `packaging/aur/` 的惯例一致。
+
+## 渠道全景
+
+「Repology」列指该渠道是否被 [repology.org](https://repology.org/project/uniclipboard/versions) 抓取——即是否能让 packaging-status 徽章多一行。**Snap / COPR / 自建 Homebrew tap / npm / winget / Flathub 都不被 Repology 抓取**（已用 7zip 的完整源列表交叉验证）。
+
+| 渠道 | 目录 | Repology | 状态 |
+| --- | --- | --- | --- |
+| AUR (`uniclipboard-git`) | `packaging/aur/` | ✅ 抓 | CI 自动同步（`aur.yml`） |
+| COPR (Fedora/RHEL) | `packaging/uniclipboard.spec` | ❌ 不抓 | CI 自动发布（`copr.yml`） |
+| Snap Store | `snap/snapcraft.yaml` | ❌ 不抓 | CI 自动发布（`snap.yml`） |
+| Homebrew tap（自建） | 外部 `UniClipboard/homebrew-tap` | ❌ 不抓 | CI 自动更新（`homebrew-tap.yml`） |
+| npm CLI | `npm/` | ❌ 不抓 | CI 自动发布（`npm-publish.yml`） |
+| **nixpkgs** | `packaging/nix/` | ✅ 抓（+7 行） | **本次新增，待提交** |
+| **Scoop Extras** | `packaging/scoop/` | ✅ 抓 | **本次新增，待提交** |
+| Homebrew Cask（官方） | `packaging/homebrew/casks/` | ✅ 抓 | **origin/main 官方已实现（#1086）**：`homebrew-cask.yml` + 占位模板 |
+| **Chocolatey** | `packaging/chocolatey/` | ✅ 抓 | **本次新增**，首版手动 → 后续 CI 自动（`choco-publish.yml`） |
+| **winget** | `packaging/winget/` | ❌ 不抓 | **本次新增**，首版手动 → 后续 CI 自动（`winget-publish.yml`） |
+| **Flathub** | `packaging/flathub/` | ❌ 不抓 | **本次新增，待提交** |
+
+## 铺开优先级
+
+按性价比（对 Repology 徽章的贡献 ÷ 落地难度）：
+
+1. **nixpkgs** — 一次 PR ≈ 徽章 +7 行，可自荐，性价比最高。
+2. **Scoop Extras** — Windows 侧最省力，autoupdate 自动维护。
+3. ~~Homebrew Cask（官方）~~ — **已由 #1086 实现**（`homebrew-cask.yml` 在 release 时自动提 PR 到官方 homebrew-cask），无需再做。
+4. **Chocolatey** — 有人工 moderation，较慢。
+5. **winget** / **Flathub** — 不进 Repology，但分别补 Windows 官方包管理器 / Linux 桌面的真实分发缺口；Flathub 现场调试量最大。
+
+## 通用约定：hash 一律不手填
+
+所有 manifest 里的 sha256 都是占位（`0000…` 或 `REPLACE_WITH_SHA256` / `lib.fakeHash`）。**不要用任何不可信环境产出的哈希**——错误 hash 是供应链风险。每个渠道的 `README.md` 都给了用该渠道官方工具自动生成真值的命令（`nix-build` / `checkver.ps1 -Update` / `brew fetch` / `Get-RemoteChecksum` / `wingetcreate` / `sha256sum`）。所有 release 还自带 minisign 签名的 `SHA256SUMS.txt` 可交叉核对。
+
+## 后续版本的自动化
+
+首版上架后，各渠道的「后续版本升级」分三类：
+
+- **上游 bot 自动**：nixpkgs（`r-ryantm`）、Scoop Extras（`excavator`）合并后由对方机器人按 release / manifest `autoupdate` 自动开升级 PR，本仓库无需 workflow。
+- **本仓库 CI 自动**：Chocolatey 与 winget 无官方 bot，由 `.github/workflows/choco-publish.yml`、`winget-publish.yml` 在 stable release 发布后自动 push / 提 PR（监听 `release: published`、跳过 prerelease，与 `copr.yml`/`homebrew-tap.yml` 一致）。需配置 secret：
+  - `CHOCOLATEY_API_KEY` — community.chocolatey.org 的 API key
+  - `WINGET_TOKEN` — GitHub PAT（classic，`public_repo`），用于 fork `microsoft/winget-pkgs` 提 PR
+- **官方 CI 自动**：Homebrew Cask 由 #1086 的 `homebrew-cask.yml` 在 release 时自动提 PR（见 `docs/packaging/homebrew-cask.md`）。
+
+> 两个 CI workflow 首版都不接管——首版需人工提交 / 过审（见各子目录 README），workflow 从第二版起自动跟随。
+
+## 各渠道提交指引
+
+本次新增渠道见对应子目录的 `README.md`：`packaging/nix/`、`packaging/scoop/`、`packaging/chocolatey/`、`packaging/winget/`、`packaging/flathub/`。Homebrew Cask（官方）见 `docs/packaging/homebrew-cask.md`。

--- a/packaging/chocolatey/README.md
+++ b/packaging/chocolatey/README.md
@@ -1,0 +1,52 @@
+# Chocolatey 打包
+
+本目录是提交到 [Chocolatey Community Repository](https://community.chocolatey.org) 的包源：
+
+- `uniclipboard.nuspec` — 包元数据
+- `tools/chocolateyInstall.ps1` — 下载 NSIS 安装器并静默安装（`/S`）
+- `tools/chocolateyUninstall.ps1` — 静默卸载
+- `tools/VERIFICATION.txt` — 来源与校验说明
+
+## 为什么进 Chocolatey
+
+Repology 抓取 Chocolatey（源名 `chocolatey`），合并后徽章 +1 行。安装方式：
+```powershell
+choco install uniclipboard
+```
+
+> 提醒：Chocolatey community repo 有 **人工 moderation**，新包从提交到上架通常要数天到一两周，比 nixpkgs/Scoop 慢。元数据不全或 checksum 不对会被打回。
+
+## 提交步骤
+
+1. **填 checksum**（`chocolateyInstall.ps1` 里 `checksum64` 是 `REPLACE_WITH_SHA256` 占位）
+
+   从 release 的 `SHA256SUMS.txt`（minisign 签名）取，或：
+   ```powershell
+   Get-RemoteChecksum https://github.com/UniClipboard/UniClipboard/releases/download/v0.15.0/UniClipboard_0.15.0_x64-setup.exe
+   ```
+   > 不要用本仓库环境产出的 hash——沙箱输出不可信。
+
+2. **打包并本地实测**（必做）
+   ```powershell
+   cd packaging\chocolatey
+   choco pack
+   choco install uniclipboard --source . --yes   # 装、起、托盘、配对同步
+   choco uninstall uniclipboard --yes             # 验证卸载干净
+   ```
+
+3. **推送到 community repo**
+   ```powershell
+   # 先在 community.chocolatey.org 注册账号，拿 API key
+   choco apikey --key <YOUR_API_KEY> --source https://push.chocolatey.org/
+   choco push uniclipboard.0.15.0.nupkg --source https://push.chocolatey.org/
+   ```
+
+4. **等 moderation**：自动校验（virus scan、安装测试）+ 人工 review。按 moderator 反馈改，直到 Approved。
+
+5. **上架后**：Repology 下次抓取会显示 `chocolatey` 行。**后续版本由 CI 自动 push**——`.github/workflows/choco-publish.yml` 在每个 stable release 发布后下载安装器、算 checksum（与 `SHA256SUMS.txt` 交叉核对）、回填并 `choco push`。需在仓库配置 `CHOCOLATEY_API_KEY` secret。首版人工过 moderation 后即免手动。
+
+## 待确认
+
+- **WebView2 依赖**：`nuspec` 里以 XML 注释预留了 `<dependency>`，默认未启用。Win10/11 一般预装；若要强制，先确认 community 上 WebView2 的确切包 id（`webview2-runtime` 还是 `microsoft-edge-webview2-runtime`）再放开注释，避免引用不存在的包导致安装失败。
+- **仅 x64**：ARM64 Windows 通过 x64 模拟运行该安装器。如需原生 ARM64，在 `chocolateyInstall.ps1` 增补 arm64 的 url/checksum。
+- **未在 Windows 实测**：脚本经事实校对（URL、exe 名、silent 参数），安装/卸载需你在 Windows 上验证。

--- a/packaging/chocolatey/tools/VERIFICATION.txt
+++ b/packaging/chocolatey/tools/VERIFICATION.txt
@@ -1,0 +1,16 @@
+VERIFICATION
+
+This package is maintained by the UniClipboard project (the software vendor).
+
+The installer is downloaded at install time from the official GitHub Releases:
+  https://github.com/UniClipboard/UniClipboard/releases/tag/v0.15.0
+  UniClipboard_0.15.0_x64-setup.exe
+
+To verify the binary independently:
+  1. Download the .exe from the release above.
+  2. Compare its SHA256 against `checksum64` in tools\chocolateyInstall.ps1, and
+     against SHA256SUMS.txt published in the same release (minisign-signed with
+     the project's release key, public key in the repository).
+
+License: AGPL-3.0-only
+  https://github.com/UniClipboard/UniClipboard/blob/main/LICENSE

--- a/packaging/chocolatey/tools/chocolateyInstall.ps1
+++ b/packaging/chocolatey/tools/chocolateyInstall.ps1
@@ -1,0 +1,23 @@
+$ErrorActionPreference = 'Stop'
+
+# Version comes from the nuspec at install time (Chocolatey injects it). The
+# publish workflow then only needs to bump the nuspec <version> and checksum64.
+$version = $env:ChocolateyPackageVersion
+$packageArgs = @{
+  packageName    = 'uniclipboard'
+  fileType       = 'exe'
+  # Tauri NSIS installer. ARM64 Windows runs the x64 build under emulation, so a
+  # single x64 installer covers both; add url/checksum for arm64 if you want a
+  # native ARM64 install path.
+  url64bit       = "https://github.com/UniClipboard/UniClipboard/releases/download/v$version/UniClipboard_${version}_x64-setup.exe"
+  # Placeholder. Fill before pushing — see ..\README.md (Get-RemoteChecksum or
+  # the minisign-signed SHA256SUMS.txt from the release). Do NOT trust a hash
+  # produced by an untrusted shell.
+  checksum64     = 'REPLACE_WITH_SHA256'
+  checksumType64 = 'sha256'
+  silentArgs     = '/S'   # NSIS silent install
+  validExitCodes = @(0)
+  softwareName   = 'UniClipboard*'
+}
+
+Install-ChocolateyPackage @packageArgs

--- a/packaging/chocolatey/tools/chocolateyUninstall.ps1
+++ b/packaging/chocolatey/tools/chocolateyUninstall.ps1
@@ -1,0 +1,24 @@
+$ErrorActionPreference = 'Stop'
+
+$packageArgs = @{
+  packageName  = 'uniclipboard'
+  softwareName = 'UniClipboard*'
+  fileType     = 'exe'
+  silentArgs   = '/S'   # NSIS silent uninstall
+  validExitCodes = @(0)
+}
+
+[array]$key = Get-UninstallRegistryKey -SoftwareName $packageArgs['softwareName']
+
+if ($key.Count -eq 1) {
+  $key | ForEach-Object {
+    $packageArgs['file'] = "$($_.UninstallString)"
+    Uninstall-ChocolateyPackage @packageArgs
+  }
+} elseif ($key.Count -eq 0) {
+  Write-Warning "$($packageArgs.packageName) has already been uninstalled by other means."
+} elseif ($key.Count -gt 1) {
+  Write-Warning "$($key.Count) matches found!"
+  Write-Warning "To prevent accidental data loss, no programs will be uninstalled."
+  $key | ForEach-Object { Write-Warning "- $($_.DisplayName)" }
+}

--- a/packaging/chocolatey/uniclipboard.nuspec
+++ b/packaging/chocolatey/uniclipboard.nuspec
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>uniclipboard</id>
+    <version>0.15.0</version>
+    <packageSourceUrl>https://github.com/UniClipboard/UniClipboard/tree/main/packaging/chocolatey</packageSourceUrl>
+    <owners>UniClipboard</owners>
+    <title>UniClipboard</title>
+    <authors>UniClipboard</authors>
+    <projectUrl>https://uniclipboard.app/</projectUrl>
+    <iconUrl>https://cdn.jsdelivr.net/gh/UniClipboard/UniClipboard@v0.15.0/src-tauri/icons/icon.png</iconUrl>
+    <copyright>UniClipboard</copyright>
+    <licenseUrl>https://github.com/UniClipboard/UniClipboard/blob/main/LICENSE</licenseUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <projectSourceUrl>https://github.com/UniClipboard/UniClipboard</projectSourceUrl>
+    <bugTrackerUrl>https://github.com/UniClipboard/UniClipboard/issues</bugTrackerUrl>
+    <tags>uniclipboard clipboard sync p2p peer-to-peer encrypted cross-platform e2ee</tags>
+    <summary>Encrypted peer-to-peer clipboard sync between your devices</summary>
+    <description>
+UniClipboard syncs your clipboard securely across your devices on the local
+network. End-to-end encrypted and powered by iroh QUIC — no clouds, no
+accounts, no third-party servers, just direct peer-to-peer sync.
+
+Pair your devices once via the in-app QR code, then anything you copy on one
+device — text, images, or files — is automatically available on the others.
+
+This package installs the official Windows build published on GitHub Releases.
+    </description>
+    <releaseNotes>https://github.com/UniClipboard/UniClipboard/releases/tag/v0.15.0</releaseNotes>
+    <!-- UniClipboard needs the Microsoft Edge WebView2 Runtime (preinstalled on
+         current Windows 10/11). If you want Chocolatey to guarantee it, confirm
+         the exact community package id first, then enable a dependency, e.g.:
+    <dependencies>
+      <dependency id="webview2-runtime" />
+    </dependencies>
+    -->
+  </metadata>
+  <files>
+    <file src="tools\**" target="tools" />
+  </files>
+</package>

--- a/packaging/flathub/README.md
+++ b/packaging/flathub/README.md
@@ -1,0 +1,44 @@
+# Flathub 打包
+
+本目录是提交到 [Flathub](https://github.com/flathub) 的 Flatpak 包源：
+
+- `app.uniclipboard.desktop.yml` — Flatpak manifest（app-id = Tauri identifier）
+- `app.uniclipboard.desktop.metainfo.xml` — AppStream 元数据（Flathub 强制要求）
+
+## 重要：Flathub 不进 Repology
+
+和 winget 一样，**Repology 不抓 Flathub**，这一步不会改变 packaging-status 徽章。做它的理由：Flathub 是 Linux 桌面应用覆盖面最大的分发渠道（远超 deb/rpm/AppImage 总和），补齐最大的真实分发缺口。
+```bash
+flatpak install flathub app.uniclipboard.desktop
+```
+
+## 这是几个渠道里最难的一个
+
+不像 nixpkgs/Scoop 能较快落地，Flathub 首次提交通常需要明显的现场调试。已知卡点：
+
+1. **WebKitGTK 版本匹配**：deb 二进制链接系统 `webkit2gtk-4.1`（GTK3）。需确认所选 `org.gnome.Platform` 版本提供同一 ABI；若不匹配，要换 runtime 版本或把 webkitgtk 作为 extension/bundle。`runtime-version: '46'` 是起点，按构建报错调整。
+2. **剪贴板权限**：Tauri 在 Wayland 沙箱里读系统剪贴板依赖 `wlr-data-control` 协议，flatpak 默认可能受限。装好后务必实测复制/粘贴是否真的跨设备同步，必要时调 `finish-args` 或走 portal。
+3. **AppStream 截图**：`metainfo.xml` 里截图 URL 是占位，**必须** 换成真实可访问的图片（提交一张到仓库 `assets/` 再引用），否则 Flathub CI 的 `appstream-util validate` 不过。
+4. **release date**：`metainfo.xml` 里 0.15.0 的 `date` 按实际发布日核对。
+
+## 提交流程
+
+1. **本地构建验证**（必做，需 `flatpak-builder`）
+   ```bash
+   flatpak install flathub org.gnome.Platform//46 org.gnome.Sdk//46
+   # 先填 manifest 里两个 deb 的 sha256（全 0 占位）：
+   #   sha256sum 下载好的 .deb，或与 release SHA256SUMS.txt 核对（勿用沙箱产出的 hash）
+   flatpak-builder --user --install --force-clean build-dir packaging/flathub/app.uniclipboard.desktop.yml
+   flatpak run app.uniclipboard.desktop      # 起、托盘、配对、复制粘贴同步全测一遍
+   ```
+   校验 metadata：
+   ```bash
+   flatpak run org.freedesktop.appstream-glib validate \
+     packaging/flathub/app.uniclipboard.desktop.metainfo.xml
+   ```
+
+2. **申请上架**：fork [`flathub/flathub`](https://github.com/flathub/flathub)，基于 `new-pr` 分支提交 manifest + metainfo，开 PR。Flathub reviewer 会过权限、构建、AppStream。合并后会为本应用建独立仓库 `flathub/app.uniclipboard.desktop`，后续版本在那里维护（可启用 Flatpak External Data Checker 自动跟随 release）。
+
+## 待确认
+
+- manifest/metainfo 经事实校对（app-id、deb 名、命令名、权限依据 `snap/snapcraft.yaml` 的 plugs 推导），但 **构建与运行未在本环境验证**，需你按上面流程实测调通。

--- a/packaging/flathub/app.uniclipboard.desktop.metainfo.xml
+++ b/packaging/flathub/app.uniclipboard.desktop.metainfo.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>app.uniclipboard.desktop</id>
+
+  <name>UniClipboard</name>
+  <summary>Encrypted peer-to-peer clipboard sync between your devices</summary>
+
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>AGPL-3.0-only</project_license>
+
+  <developer id="app.uniclipboard">
+    <name>UniClipboard</name>
+  </developer>
+
+  <description>
+    <p>
+      UniClipboard syncs your clipboard securely across your devices on the
+      local network. End-to-end encrypted and powered by iroh QUIC — no clouds,
+      no accounts, no third-party servers, just direct peer-to-peer sync.
+    </p>
+    <p>
+      Pair your devices once via the in-app QR code, then anything you copy on
+      one device — text, images, or files — is automatically available on the
+      others.
+    </p>
+  </description>
+
+  <launchable type="desktop-id">app.uniclipboard.desktop.desktop</launchable>
+
+  <!-- Flathub requires at least one screenshot. Replace with a real raw URL
+       (e.g. an image committed to the repo) before submitting. -->
+  <screenshots>
+    <screenshot type="default">
+      <caption>UniClipboard main window</caption>
+      <image>https://raw.githubusercontent.com/UniClipboard/UniClipboard/main/assets/screenshot-main.png</image>
+    </screenshot>
+  </screenshots>
+
+  <url type="homepage">https://uniclipboard.app/</url>
+  <url type="bugtracker">https://github.com/UniClipboard/UniClipboard/issues</url>
+  <url type="vcs-browser">https://github.com/UniClipboard/UniClipboard</url>
+
+  <categories>
+    <category>Network</category>
+    <category>Utility</category>
+  </categories>
+
+  <keywords>
+    <keyword>clipboard</keyword>
+    <keyword>sync</keyword>
+    <keyword>p2p</keyword>
+    <keyword>encrypted</keyword>
+  </keywords>
+
+  <content_rating type="oars-1.1" />
+
+  <releases>
+    <release version="0.15.0" date="2026-06-15">
+      <url type="details">https://github.com/UniClipboard/UniClipboard/releases/tag/v0.15.0</url>
+    </release>
+  </releases>
+</component>

--- a/packaging/flathub/app.uniclipboard.desktop.yml
+++ b/packaging/flathub/app.uniclipboard.desktop.yml
@@ -1,0 +1,68 @@
+# Flatpak manifest for Flathub. App-id intentionally matches the Tauri
+# bundle identifier (app.uniclipboard.desktop).
+#
+# Build strategy: repackage the official .deb (same rationale as the nixpkgs
+# AppImage wrap — a from-source Tauri build inside the offline flatpak-builder
+# sandbox would need vendored cargo + bun deps and is impractical). Flathub
+# accepts deb repackaging for this class of app.
+app-id: app.uniclipboard.desktop
+runtime: org.gnome.Platform
+runtime-version: '46'
+sdk: org.gnome.Sdk
+command: uniclipboard
+
+finish-args:
+  # GUI. WebKitGTK comes from the GNOME runtime.
+  - --share=ipc
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --device=dri
+  # LAN peer-to-peer sync.
+  - --share=network
+  # System tray (libayatana-appindicator -> StatusNotifier).
+  - --talk-name=org.kde.StatusNotifierWatcher
+  - --talk-name=org.freedesktop.Notifications
+  # KEK lives in the OS keyring (secret-service); mirrors the snap
+  # password-manager-service plug.
+  - --talk-name=org.freedesktop.secrets
+  # File-transfer feature + portable data; tighten to a portal later if possible.
+  - --filesystem=home
+  - --filesystem=xdg-download
+
+modules:
+  - name: uniclipboard
+    buildsystem: simple
+    build-commands:
+      # Unpack the .deb (ar -> data.tar) into the build dir.
+      - ar x *.deb
+      - tar -xf data.tar.*
+      # Binaries: GUI + its required sidecar daemon.
+      - install -Dm755 usr/bin/uniclipboard /app/bin/uniclipboard
+      - install -Dm755 usr/bin/uniclipd /app/bin/uniclipd
+      # Desktop file must be named after the app-id; point its icon at the app-id too.
+      - desktop-file-edit --set-icon=app.uniclipboard.desktop usr/share/applications/uniclipboard.desktop
+      - install -Dm644 usr/share/applications/uniclipboard.desktop
+        /app/share/applications/app.uniclipboard.desktop.desktop
+      # Icons must be renamed from "uniclipboard" to the app-id.
+      - |
+        for png in $(find usr/share/icons -name 'uniclipboard.png'); do
+          dest="/app/${png#usr/}"
+          dest="${dest%/uniclipboard.png}/app.uniclipboard.desktop.png"
+          install -Dm644 "$png" "$dest"
+        done
+      # AppStream metadata (Flathub requirement).
+      - install -Dm644 app.uniclipboard.desktop.metainfo.xml
+        /app/share/metainfo/app.uniclipboard.desktop.metainfo.xml
+    sources:
+      - type: file
+        url: https://github.com/UniClipboard/UniClipboard/releases/download/v0.15.0/UniClipboard_0.15.0_amd64.deb
+        sha256: '0000000000000000000000000000000000000000000000000000000000000000'
+        only-arches:
+          - x86_64
+      - type: file
+        url: https://github.com/UniClipboard/UniClipboard/releases/download/v0.15.0/UniClipboard_0.15.0_arm64.deb
+        sha256: '0000000000000000000000000000000000000000000000000000000000000000'
+        only-arches:
+          - aarch64
+      - type: file
+        path: app.uniclipboard.desktop.metainfo.xml

--- a/packaging/nix/README.md
+++ b/packaging/nix/README.md
@@ -1,0 +1,77 @@
+# nixpkgs 打包
+
+`package.nix` 是提交到 [nixpkgs](https://github.com/NixOS/nixpkgs) 的 derivation 源，保存在仓库内（与 `packaging/aur/` 同一惯例）。真正生效的是 nixpkgs 仓库里的那份副本，本目录只是源 + 提交说明。
+
+## 为什么优先做 nixpkgs
+
+Repology 抓取 nixpkgs 的 6 个 stable channel + unstable。**一次合并的 PR ≈ Repology packaging-status 徽章 +7 行**，是所有分发渠道里性价比最高的。
+
+> 注意：Repology 不抓 Snap Store / COPR / 自建 Homebrew tap。当前 CI 已自动发布的那几个渠道对徽章没有贡献，nixpkgs 才是第一个能让徽章变丰富的渠道。
+
+## 方案：从 AppImage 二进制重打包
+
+本 derivation **不从源码编译**，而是用 `appimageTools.wrapType2` 包装官方发布的 AppImage。原因：UniClipboard 是 Tauri 应用（Rust workspace + bun 前端 + vendored `iroh-blobs` + sidecar `uniclipd`），在 Nix 沙箱里从源码构建需要 fixed-output 的 bun 依赖、带 git 源的 `cargoLock`、双二进制产物，落地和维护成本都很高。二进制重打包是 nixpkgs 对这类应用的常见、被接受的做法。
+
+代价：部分 reviewer 偏好源码构建。若被要求，迁移路径见文末「迁移到源码构建」。
+
+## 提交步骤
+
+1. **fork 并 clone nixpkgs**
+   ```bash
+   git clone https://github.com/<你的账号>/nixpkgs
+   cd nixpkgs
+   git checkout -b uniclipboard-init
+   ```
+
+2. **放置文件**（nixpkgs 的 `by-name` 结构，按首两字母分目录）
+   ```bash
+   mkdir -p pkgs/by-name/un/uniclipboard
+   cp <本仓库>/packaging/nix/package.nix pkgs/by-name/un/uniclipboard/package.nix
+   ```
+
+3. **算 hash**（`package.nix` 里目前是 `lib.fakeHash` 占位）
+
+   本仓库环境没有 nix，无法预先算好。在任意装了 nix 的机器上二选一：
+   ```bash
+   # 方式 A：直接 build，把 Nix 报错里的 "got: sha256-..." 填回 package.nix
+   nix-build -A uniclipboard
+
+   # 方式 B：提前 prefetch
+   nix store prefetch-file --hash-type sha256 \
+     https://github.com/UniClipboard/UniClipboard/releases/download/v0.15.0/UniClipboard_0.15.0_amd64.AppImage
+   ```
+   该 hash 也可与 release 自带的 `SHA256SUMS.txt`（minisign 签名）交叉核对。
+
+4. **本地验证**（必做——本仓库环境无法替你跑）
+   ```bash
+   nix-build -A uniclipboard          # 能 build
+   ./result/bin/uniclipboard          # 能启动、托盘正常、能配对同步
+   nix-shell -p nixpkgs-review --run "nixpkgs-review wip"
+   ```
+   若启动报缺 `.so`，把对应包加进 `package.nix` 的 `extraPkgs`。若 `extraInstallCommands` 里 desktop/icon 路径对不上，`ls` 一下 `appimageContents` 调整。
+
+5. **填 maintainer**：把自己加进 `maintainers/maintainer-list.nix`，再写进 `package.nix` 的 `meta.maintainers`。也可以不当 maintainer 直接提，但有人维护更容易被合。
+
+6. **提交**（nixpkgs 的 commit message 规范）
+   ```bash
+   git add pkgs/by-name/un/uniclipboard maintainers/maintainer-list.nix
+   git commit -m "uniclipboard: init at 0.15.0"
+   git push -u origin uniclipboard-init
+   ```
+
+7. **开 PR**：base 选 `NixOS/nixpkgs:master`，勾选 PR 模板里跑过的测试项（至少 `nix-build` + 实际运行）。ofborg 会自动在多平台构建。
+
+8. **合并后**：约一个 channel 周期（unstable 几天、stable 跟随下次 release）后，Repology 会自动抓到，徽章多出 `nixpkgs unstable` 等行。
+
+## 后续版本维护
+
+合并后升级很轻量：改 `version` + 重新算 `hash` 即可。可让 nixpkgs 的 `nixpkgs-update` 机器人自动跟随 GitHub Release，无需每次手动提 PR。
+
+## 待办 / 已知缺口
+
+- **本环境未验证**：本仓库无 nix，`package.nix` 是经过事实校对（URL、版本、license、元数据均来自仓库真实值）的草稿，但 **build 与运行必须由你在有 nix 的机器上验证**。已知需现场核对的点都在 `package.nix` 注释里标了。
+- **仅 `x86_64-linux`**：首版只覆盖 amd64。aarch64 的 AppImage 资产存在（`UniClipboard_0.15.0_aarch64.AppImage`），但 `appimageTools` 对 aarch64 支持较弱，建议先合 x86_64，之后用「解 `.deb` + `autoPatchelfHook`」方式补多架构。
+
+## 迁移到源码构建（仅在 reviewer 要求时）
+
+大方向：`rustPlatform.buildRustPackage` + `cargoLock.lockFileContents`（含 vendored `iroh-blobs` 的 `outputHashes`）+ 用 `stdenvNoCC` 预构建 bun 前端为 fixed-output derivation，再 `nativeBuildInputs` 加 `wrapGAppsHook4 pkg-config`、`buildInputs` 加 `webkitgtk_4_1 libsoup_3 libayatana-appindicator`。本 `meta` 与 desktop/icon 处理可直接复用。

--- a/packaging/nix/package.nix
+++ b/packaging/nix/package.nix
@@ -1,0 +1,73 @@
+# nixpkgs derivation for UniClipboard — binary repackage of the upstream AppImage.
+#
+# Why a binary repackage instead of a source build:
+#   UniClipboard is a Tauri app (Rust workspace + bun-built frontend + a vendored
+#   iroh-blobs git dependency + a sidecar `uniclipd` daemon). A from-source build
+#   under the Nix sandbox would need a fixed-output bun/node_modules derivation, a
+#   cargoLock entry for the vendored git source, and two separate binaries — hard
+#   to land and to keep green. Wrapping the official AppImage is an accepted
+#   nixpkgs pattern for this class of app and is far easier to maintain. If a
+#   reviewer asks for a source build, see ./README.md for the migration path.
+#
+# This file is the in-repo submission source (same convention as packaging/aur/).
+# To ship it, copy it into nixpkgs at pkgs/by-name/un/uniclipboard/package.nix —
+# see ./README.md for the full step-by-step.
+{
+  lib,
+  appimageTools,
+  fetchurl,
+}:
+let
+  pname = "uniclipboard";
+  version = "0.15.0";
+
+  src = fetchurl {
+    url = "https://github.com/UniClipboard/UniClipboard/releases/download/v${version}/UniClipboard_${version}_amd64.AppImage";
+    # Placeholder. Replace with the real hash before submitting. Easiest path:
+    # leave this as-is, run `nix-build`, and copy the "got:" hash Nix prints.
+    # Or precompute:
+    #   nix store prefetch-file --hash-type sha256 \
+    #     https://github.com/UniClipboard/UniClipboard/releases/download/v0.15.0/UniClipboard_0.15.0_amd64.AppImage
+    # The same value is published (minisign-signed) in the release SHA256SUMS.txt.
+    hash = lib.fakeHash;
+  };
+
+  appimageContents = appimageTools.extractType2 { inherit pname version src; };
+in
+appimageTools.wrapType2 {
+  inherit pname version src;
+
+  # The AppImage bundles most of the GTK/WebKit stack, but the wrapped FHS env
+  # may still miss a library at runtime. If the app fails to start with a
+  # "cannot open shared object file" error, add the missing package here.
+  extraPkgs = pkgs: with pkgs; [ ];
+
+  extraInstallCommands = ''
+    # Desktop entry + icons taken from the AppImage payload. File names follow
+    # Tauri's AppImage layout (main binary name = "uniclipboard"). If the first
+    # build fails here, run `ls ${appimageContents}` and adjust the paths.
+    install -Dm444 ${appimageContents}/uniclipboard.desktop \
+      $out/share/applications/uniclipboard.desktop
+    substituteInPlace $out/share/applications/uniclipboard.desktop \
+      --replace-warn 'Exec=AppRun --no-sandbox %U' 'Exec=uniclipboard %U' \
+      --replace-warn 'Exec=AppRun' 'Exec=uniclipboard'
+    cp -r ${appimageContents}/usr/share/icons $out/share/icons
+  '';
+
+  meta = {
+    description = "Encrypted peer-to-peer clipboard sync between your devices";
+    longDescription = ''
+      UniClipboard syncs your clipboard securely across your devices on the local
+      network. End-to-end encrypted and powered by iroh QUIC — no clouds, no
+      accounts, no third-party servers, just direct peer-to-peer sync of text,
+      images, and files.
+    '';
+    homepage = "https://uniclipboard.app";
+    downloadPage = "https://github.com/UniClipboard/UniClipboard/releases";
+    license = lib.licenses.agpl3Only;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    maintainers = with lib.maintainers; [ ]; # add your nixpkgs handle here
+    mainProgram = "uniclipboard";
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/packaging/scoop/README.md
+++ b/packaging/scoop/README.md
@@ -1,0 +1,58 @@
+# Scoop 打包
+
+`uniclipboard.json` 是提交到 [ScoopInstaller/Extras](https://github.com/ScoopInstaller/Extras) bucket 的 manifest 源。UniClipboard 是 GUI 应用，归 `Extras` bucket（`Main` 只收命令行工具）。
+
+## 为什么进 Scoop
+
+Repology 抓取 Scoop 官方 bucket（源名 `scoop`）。合并后徽章 +1 行，且这是 Windows 用户最省力的安装方式：
+```powershell
+scoop bucket add extras
+scoop install uniclipboard
+```
+
+## manifest 要点
+
+- **portable 模式**：用 `*-portable.zip`（内含 `UniClipboard.exe` + 必需的后台服务 `uniclipd.exe` + `portable.dat` 标记 + README）。zip 用 `Compress-Archive '$STAGE/*'` 打包，文件在根目录，因此 **不需要 `extract_dir`**。
+- **`"persist": "data"`**：`portable.dat` 让应用把加密数据写到 exe 同目录的 `data/`。Scoop 把它持久化到 `~/scoop/persist/uniclipboard/data`，升级换版本目录时数据不丢。
+- **`checkver` + `autoupdate`**：已配置跟随 GitHub Release。后续版本由 Extras 的 excavator bot 自动开升级 PR，无需手动维护。
+
+## 提交步骤
+
+1. **fork 并 clone Extras**
+   ```powershell
+   git clone https://github.com/<你的账号>/Extras
+   cd Extras
+   git checkout -b uniclipboard
+   copy <本仓库>\packaging\scoop\uniclipboard.json bucket\uniclipboard.json
+   ```
+
+2. **填 hash**（manifest 里两个架构的 `hash` 目前是全 `0` 占位）
+
+   用 Extras 自带工具自动下载 zip、算 sha256、顺带校验 `autoupdate` URL，一步到位：
+   ```powershell
+   .\bin\checkver.ps1 uniclipboard . -Update
+   ```
+   > 不要手填 hash——本仓库环境无法生成可信哈希，上面这条命令会用官方工具算真值替换占位。也可与 release 自带的 `SHA256SUMS.txt`（minisign 签名）交叉核对。
+
+3. **本地验证**（必做）
+   ```powershell
+   scoop install .\bucket\uniclipboard.json
+   # 验证：能装、能起、托盘正常、能配对同步、scoop uninstall 干净
+   .\bin\formatjson.ps1 uniclipboard .     # 统一格式
+   .\bin\checkurls.ps1   uniclipboard .     # URL 可达性
+   ```
+
+4. **提交并开 PR**（Extras 的 commit 规范）
+   ```powershell
+   git add bucket\uniclipboard.json
+   git commit -m "uniclipboard: Add version 0.15.0"
+   git push -u origin uniclipboard
+   ```
+   base 选 `ScoopInstaller/Extras:master`。
+
+5. **合并后**：Repology 下次抓取（通常几天内）会显示 `scoop` 行。
+
+## 已知缺口
+
+- **WebView2 依赖**：靠 `notes` 提示。Win10/11 一般预装；如需强约束可后续改 `suggest`/`depends`，但要先确认 Scoop 里 WebView2 包名再写，避免引用不存在的依赖。
+- **未在 Windows 实测**：manifest 经事实校对（zip 结构、exe 名、URL 均来自仓库真实值），但安装/运行需你在 Windows 上验证。

--- a/packaging/scoop/uniclipboard.json
+++ b/packaging/scoop/uniclipboard.json
@@ -1,0 +1,36 @@
+{
+  "version": "0.15.0",
+  "description": "Encrypted peer-to-peer clipboard sync between your devices",
+  "homepage": "https://uniclipboard.app",
+  "license": "AGPL-3.0-only",
+  "architecture": {
+    "64bit": {
+      "url": "https://github.com/UniClipboard/UniClipboard/releases/download/v0.15.0/UniClipboard_0.15.0_x64-portable.zip",
+      "hash": "0000000000000000000000000000000000000000000000000000000000000000"
+    },
+    "arm64": {
+      "url": "https://github.com/UniClipboard/UniClipboard/releases/download/v0.15.0/UniClipboard_0.15.0_arm64-portable.zip",
+      "hash": "0000000000000000000000000000000000000000000000000000000000000000"
+    }
+  },
+  "bin": "UniClipboard.exe",
+  "shortcuts": [["UniClipboard.exe", "UniClipboard"]],
+  "persist": "data",
+  "notes": [
+    "UniClipboard runs in portable mode here: your encrypted data lives in the persisted 'data' folder next to the executable and is kept across updates.",
+    "Requires the Microsoft Edge WebView2 Runtime (preinstalled on current Windows 10/11)."
+  ],
+  "checkver": {
+    "github": "https://github.com/UniClipboard/UniClipboard"
+  },
+  "autoupdate": {
+    "architecture": {
+      "64bit": {
+        "url": "https://github.com/UniClipboard/UniClipboard/releases/download/v$version/UniClipboard_$version_x64-portable.zip"
+      },
+      "arm64": {
+        "url": "https://github.com/UniClipboard/UniClipboard/releases/download/v$version/UniClipboard_$version_arm64-portable.zip"
+      }
+    }
+  }
+}

--- a/packaging/uniclipboard.spec
+++ b/packaging/uniclipboard.spec
@@ -35,7 +35,7 @@ Version:        %{?_version}%{!?_version:@VERSION@}
 Release:        1%{?dist}
 Summary:        Privacy-first end-to-end encrypted cross-device clipboard sync
 
-License:        Apache-2.0 OR MIT
+License:        AGPL-3.0-only
 URL:            https://github.com/UniClipboard/UniClipboard
 
 # Tauri 在 release.yml 中输出的 binary RPM 命名 = UniClipboard-<tag>-1.<arch>.rpm

--- a/packaging/winget/README.md
+++ b/packaging/winget/README.md
@@ -1,0 +1,62 @@
+# winget 打包
+
+本目录是提交到 [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs) 的 manifest 源（3 文件 schema）：
+
+- `UniClipboard.UniClipboard.installer.yaml`
+- `UniClipboard.UniClipboard.locale.en-US.yaml`
+- `UniClipboard.UniClipboard.yaml`（version）
+
+最终落在 `manifests/u/UniClipboard/UniClipboard/0.15.0/`。
+
+## 重要：winget 不进 Repology
+
+已用 7zip 在 Repology 的完整源列表验证过——**Repology 不抓 winget**。所以这一步 **不会让 packaging-status 徽章变化**。做它的理由是补上 Windows 官方包管理器的安装入口：
+```powershell
+winget install uniclipboard
+```
+
+## 推荐路径：用 wingetcreate（自动算 hash + 自动提 PR）
+
+手写 3 个 yaml 容易在 hash 和格式上出错。微软官方工具 `wingetcreate` 会下载安装器、自动算 sha256、生成 manifest 并直接提 PR——本目录的 yaml 仅作结构参考 / 手动 fallback。
+
+```powershell
+winget install wingetcreate
+
+# 首次创建：交互式，自动下载两个 setup.exe 算 hash
+wingetcreate new `
+  https://github.com/UniClipboard/UniClipboard/releases/download/v0.15.0/UniClipboard_0.15.0_x64-setup.exe `
+  https://github.com/UniClipboard/UniClipboard/releases/download/v0.15.0/UniClipboard_0.15.0_arm64-setup.exe
+
+# 校验 + 提交（需 GitHub token，会自动 fork + 开 PR）
+wingetcreate submit --token <GITHUB_TOKEN>
+```
+
+后续版本升级更省事：
+```powershell
+wingetcreate update UniClipboard.UniClipboard `
+  --version <new> `
+  --urls <x64-url> <arm64-url> `
+  --submit --token <GITHUB_TOKEN>
+```
+
+## 手动路径（若不用 wingetcreate）
+
+1. 把 `installer.yaml` 里两个 `InstallerSha256` 的全 `0` 占位换成真值（从 release `SHA256SUMS.txt` 取，或 `Get-FileHash <exe> -Algorithm SHA256`）。不要用本仓库环境产出的 hash。
+2. 本地校验：
+   ```powershell
+   winget validate --manifest packaging\winget
+   # 启用本地 manifest 安装测试（需开发者模式）
+   winget settings --enable LocalManifestFiles
+   winget install --manifest packaging\winget
+   ```
+3. 把三个文件复制到 winget-pkgs 的 `manifests/u/UniClipboard/UniClipboard/0.15.0/`，commit 开 PR。
+
+## 后续版本自动化（CI）
+
+首版人工提交后，`.github/workflows/winget-publish.yml` 会在每个 stable release 发布后用 wingetcreate 自动提 PR 到 `microsoft/winget-pkgs`。需在仓库配置 `WINGET_TOKEN`（GitHub PAT，classic，`public_repo`）。注意 wingetcreate `update` 要求包已存在——**首版必须先手动**（上面的 `wingetcreate new`），workflow 从第二版接管。
+
+## 待确认
+
+- **`Scope: user`**：依据 Tauri NSIS 默认 `currentUser` 安装模式。若实际打的是 perMachine 安装器，改成 `machine`。
+- **升级匹配**：若 winget 升级检测不到已装版本，按 validation 提示补 `AppsAndFeaturesEntries`（DisplayName / ProductCode）。
+- **未在 Windows 实测**：manifest 经事实校对（URL、installer 类型、locale 元数据），安装需你在 Windows 上验证。

--- a/packaging/winget/UniClipboard.UniClipboard.installer.yaml
+++ b/packaging/winget/UniClipboard.UniClipboard.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: UniClipboard.UniClipboard
+PackageVersion: 0.15.0
+InstallerLocale: en-US
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+  - silent
+  - silentWithProgress
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/UniClipboard/UniClipboard/releases/download/v0.15.0/UniClipboard_0.15.0_x64-setup.exe
+    InstallerSha256: 0000000000000000000000000000000000000000000000000000000000000000
+  - Architecture: arm64
+    InstallerUrl: https://github.com/UniClipboard/UniClipboard/releases/download/v0.15.0/UniClipboard_0.15.0_arm64-setup.exe
+    InstallerSha256: 0000000000000000000000000000000000000000000000000000000000000000
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/packaging/winget/UniClipboard.UniClipboard.locale.en-US.yaml
+++ b/packaging/winget/UniClipboard.UniClipboard.locale.en-US.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: UniClipboard.UniClipboard
+PackageVersion: 0.15.0
+PackageLocale: en-US
+Publisher: UniClipboard
+PublisherUrl: https://uniclipboard.app/
+PublisherSupportUrl: https://github.com/UniClipboard/UniClipboard/issues
+PackageName: UniClipboard
+PackageUrl: https://uniclipboard.app/
+License: AGPL-3.0-only
+LicenseUrl: https://github.com/UniClipboard/UniClipboard/blob/main/LICENSE
+Copyright: Copyright UniClipboard
+ShortDescription: Encrypted peer-to-peer clipboard sync between your devices
+Description: |-
+  UniClipboard syncs your clipboard securely across your devices on the local
+  network. End-to-end encrypted and powered by iroh QUIC — no clouds, no
+  accounts, no third-party servers, just direct peer-to-peer sync of text,
+  images, and files. Pair your devices once via the in-app QR code, then
+  anything you copy on one device is automatically available on the others.
+Moniker: uniclipboard
+Tags:
+  - clipboard
+  - sync
+  - p2p
+  - peer-to-peer
+  - encrypted
+  - cross-platform
+ReleaseNotesUrl: https://github.com/UniClipboard/UniClipboard/releases/tag/v0.15.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/packaging/winget/UniClipboard.UniClipboard.yaml
+++ b/packaging/winget/UniClipboard.UniClipboard.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: UniClipboard.UniClipboard
+PackageVersion: 0.15.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Summary

- **Distribution channel sources** (`5d3b9aa2`): in-repo packaging definitions + submission READMEs for **nixpkgs** and **Scoop** (both tracked by Repology — each one that lands adds rows to the packaging-status badge), plus **Chocolatey**, and the non-Repology Windows/Linux gaps **winget** and **Flathub**. Homebrew Cask is intentionally omitted — already covered by the official #1086 workflow. All hashes are placeholders filled by each channel's own tooling; no untrusted hashes are committed.
- **Auto-publish CI** (`7b3ddbaf`): `choco-publish.yml` + `winget-publish.yml` push to Chocolatey/winget on stable release — they have no upstream bot (unlike nixpkgs' r-ryantm or Scoop's excavator). `choco-publish` cross-checks the downloaded installer against the release's signed `SHA256SUMS.txt`. Requires `CHOCOLATEY_API_KEY` + `WINGET_TOKEN` secrets.
- **CodeQL Ruby failure fix** (`15c0fde9`): #1086's `packaging/homebrew/casks/uniclipboard.rb` is the repo's only Ruby file, so CodeQL default setup adds "ruby" and finalize fails with "no source code seen" (exit 32). `.gitattributes` now marks `packaging/**/*.rb` `linguist-detectable=false`. Also fixes a literal `\n` in `homebrew-cask.yml`'s `gh pr create --body`.
- **COPR spec license fix** (`b3a790ce`): spec declared `Apache-2.0 OR MIT`; the actual license is `AGPL-3.0-only` (matches LICENSE / Cargo.toml / package.json).

## Test plan

- [x] `git check-attr linguist-detectable packaging/homebrew/casks/uniclipboard.rb` → `false`; normal sources (`Cargo.toml`, `main.rs`) stay `unspecified`.
- [x] Both publish workflows parse as valid YAML (jobs/steps).
- [ ] After merge: CodeQL no longer lists Ruby and the run goes green (languages are re-detected on push to the default branch).
- [ ] First submission per channel is manual — fill the placeholder hash with the channel's own tool per each `packaging/<channel>/README.md`; the CI workflows take over from the second release.
- [ ] Set `CHOCOLATEY_API_KEY` and `WINGET_TOKEN` repo secrets before the publish workflows can run.

> Docs: scanned `docs-site` install guides — no change needed; the new channels aren't published yet, so listing them would be premature. Add them to `install.mdx` once each lands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * UniClipboard is now available through Chocolatey, Windows Package Manager (winget), Flathub, nixpkgs, and Scoop package managers.

* **Documentation**
  * Added comprehensive packaging guides and automated release workflows for all distribution channels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->