### PR TITLE
fix(cli): append trailing newline to `get` text output on a TTY

### DIFF
--- a/apps/cli/src/commands/get.rs
+++ b/apps/cli/src/commands/get.rs
@@ -12,7 +12,9 @@
 //!
 //! ## Output contract (agent-friendly)
 //!
-//! * **text / link** → content is printed to **stdout** (pipe-friendly).
+//! * **text / link** → content is printed to **stdout** (pipe-friendly). A
+//!   trailing newline is appended only when stdout is an interactive terminal,
+//!   so piped/redirected output keeps the exact bytes.
 //!   `--out` does not apply; redirect with `>` to capture to a file.
 //! * **image / file** → bytes are written to the `--out` directory (default
 //!   cache dir) and the **absolute path** is printed to stdout. `--out -`
@@ -28,7 +30,7 @@
 //! * `EXIT_CONTENT_UNAVAILABLE` — entry exists but its payload is `Lost` /
 //!   not materialized; the remedy is to re-send it from the source device.
 
-use std::io::Write;
+use std::io::{IsTerminal, Write};
 use std::path::PathBuf;
 
 use base64::engine::general_purpose::STANDARD;
@@ -225,8 +227,14 @@ async fn emit_text(
             outcome: "exported",
         });
     } else {
-        // Raw content to stdout (pipe-friendly); no trailing newline injected.
+        // Raw content to stdout. When stdout is an interactive terminal, append
+        // a trailing newline (if absent) so the shell prompt starts on its own
+        // line. When piped/redirected, keep the bytes verbatim so callers like
+        // `uniclip get | xclip` or `$(uniclip get)` capture the exact content.
         print!("{}", detail.content);
+        if std::io::stdout().is_terminal() && !detail.content.ends_with('\n') {
+            println!();
+        }
         let _ = std::io::stdout().flush();
     }
     exit_codes::EXIT_SUCCESS

--- a/docs-site/content/docs/en/cli/reference.mdx
+++ b/docs-site/content/docs/en/cli/reference.mdx
@@ -84,7 +84,9 @@ uniclip get --list -n 20
 ```
 
 Output contract: **text / link** content is printed to stdout
-(pipe-friendly); **image / file** bytes are written to `--out` (a
+(pipe-friendly). A trailing newline is appended only when stdout is an
+interactive terminal, so piped or redirected output stays byte-exact;
+**image / file** bytes are written to `--out` (a
 directory, defaulting to a per-user cache dir) and the absolute path is
 printed to stdout, or streamed to stdout with `--out -`. Status lines go
 to stderr, so stdout stays clean. Unlike `recv`, `get` never blocks.

--- a/docs-site/content/docs/zh/cli/reference.mdx
+++ b/docs-site/content/docs/zh/cli/reference.mdx
@@ -74,7 +74,7 @@ uniclip get --id <ENTRY_ID> --out ./inbox
 uniclip get --list -n 20
 ```
 
-输出约定：**文本 / 链接**内容打到 stdout（可管道）；**图片 / 文件**字节写入
+输出约定：**文本 / 链接**内容打到 stdout（可管道）；仅当 stdout 是交互式终端时才补一个尾换行，因此管道或重定向输出保持字节精确；**图片 / 文件**字节写入
 `--out`（目录，默认 per-user 缓存目录）并把绝对路径打到 stdout，或用 `--out -`
 直接写到 stdout。状态行走 stderr，stdout 保持干净。与 `recv` 不同，`get` 不阻塞。
 


### PR DESCRIPTION
## Summary

- `uniclip get` printed text/link content with `print!` and no trailing newline, so in an interactive terminal the shell prompt rendered glued to the last line of output (see #1080). Now append a newline only when stdout is a TTY and the content does not already end with one (cedfce107).
- Piped/redirected output stays byte-exact, preserving the pipe-friendly contract for callers like `uniclip get | xclip` and `$(uniclip get)`. TTY detection uses `std::io::IsTerminal`.
- Updated the `get` output contract in `docs-site` CLI reference (en + zh, in lockstep) to document the TTY-aware newline (24fe17b42).

Closes #1080.

## Test plan

- [x] `cargo test -p uc-cli` — 69 passed.
- [x] `cargo clippy -p uc-cli` — no new warnings in `get.rs`.
- [ ] Manual: run `uniclip get` in an interactive terminal and confirm the prompt starts on its own line; then `uniclip get | xxd | tail` (or `uniclip get > /tmp/x`) and confirm no extra `0x0a` byte was appended.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated `uniclip get` text output behavior to append trailing newline only when outputting to an interactive terminal, improving compatibility with pipes and redirects.

* **Documentation**
  * Updated English and Chinese documentation to reflect the revised output contract.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->