### PR TITLE
feat(logging): platform-conventional log dir + 7-day retention

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,12 +96,19 @@ Then selectively read:
 - `src-tauri/AGENTS.md` for Tauri packaging specifics
 - `apps/cli/AGENTS.md` for `uniclip` CLI-local rules
 
-Log file locations for the current desktop app naming:
-- macOS: `~/Library/Application Support/app.uniclipboard.desktop[-<profile>]/logs/`
-- Linux: `~/.local/share/app.uniclipboard.desktop[-<profile>]/logs/`
+Log file locations (platform-conventional, separate from the data root; single
+source of truth is `uc_app_paths::app_log_dir()`):
+- macOS: `~/Library/Logs/app.uniclipboard.desktop[-<profile>]/`
+- Linux: `~/.local/state/app.uniclipboard.desktop[-<profile>]/logs/`
 - Windows: `%LOCALAPPDATA%\\app.uniclipboard.desktop[-<profile>]\\logs\\`
 
-Do not assume the older `uniclipboard` root is current. Current code resolves data/logs under `app.uniclipboard.desktop`, with an optional `UC_PROFILE` suffix such as `-dev`.
+Per-role files (`uniclipboard-{gui,daemon,cli}.json.<date>`), daily rotation,
+7-day retention (older files pruned on start). Portable builds keep logs under
+`<exe>/data/logs/`.
+
+Do not assume the older `uniclipboard` root is current, and note logs are no
+longer under the data root's `logs/` subdir on macOS/Linux. The app dir name is
+`app.uniclipboard.desktop`, with an optional `UC_PROFILE` suffix such as `-dev`.
 
 Use when:
 - entering an unfamiliar subsystem

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9913,6 +9913,7 @@ dependencies = [
  "toml 0.8.2",
  "tracing",
  "tracing-subscriber",
+ "uc-app-paths",
  "uc-application",
  "uc-core",
  "uc-infra",

--- a/crates/AGENTS.md
+++ b/crates/AGENTS.md
@@ -124,8 +124,9 @@ bun run test:coverage
 - `src-legacy/` was removed on 2026-02-26; treat any references as historical context only.
 - Root `AGENTS.md` is the navigation index; this file is the Rust-workspace knowledge base covering `crates/`, `apps/`, and `src-tauri/`. Tauri packaging details live in `src-tauri/AGENTS.md`.
 - Any change touching `crates/uc-platform/src/clipboard/` (esp. the linux X11/Wayland adapters) should run `cargo test -p uc-platform` before merge. (The network transport is no longer in uc-platform — it lives in `crates/uc-infra/src/network/iroh/`.)
-- Current desktop log files live under the app data root's `logs/` directory, using the current app dir name `app.uniclipboard.desktop` plus optional `UC_PROFILE` suffix.
-- macOS: `~/Library/Application Support/app.uniclipboard.desktop[-<profile>]/logs/`
-- Linux: `~/.local/share/app.uniclipboard.desktop[-<profile>]/logs/`
+- Log files live in the platform-conventional log location (separate from the data root since the logs split). Single source of truth: `uc_app_paths::app_log_dir()`. Per-role files `uniclipboard-{gui,daemon,cli}.json.<date>`, daily rotation, 7-day retention (older pruned on start).
+- macOS: `~/Library/Logs/app.uniclipboard.desktop[-<profile>]/`
+- Linux: `~/.local/state/app.uniclipboard.desktop[-<profile>]/logs/`
 - Windows: `%LOCALAPPDATA%\app.uniclipboard.desktop[-<profile>]\logs\`
+- Portable ("green") builds keep logs under `<exe>/data/logs/`.
 - Older legacy app-data roots may still exist from previous builds, but they are not the current default.

--- a/crates/uc-app-paths/src/lib.rs
+++ b/crates/uc-app-paths/src/lib.rs
@@ -179,6 +179,72 @@ pub fn app_cache_root() -> Option<PathBuf> {
     Some(base_cache_dir()?.join(resolved_app_dir_name(None)))
 }
 
+/// Resolve the platform-conventional **log directory** (the final leaf, not a
+/// root). Logs follow each OS's logging convention instead of living under the
+/// data root, while still honoring the portable redirect and the `UC_PROFILE`
+/// suffix.
+///
+/// This is the single source of truth for *where logs live*: every consumer
+/// (the daemon, the CLI, and the GUI host's pre-wiring tracing init) resolves
+/// the log directory through this function. No other code should join `"logs"`
+/// onto a base path.
+///
+/// - macOS:            `~/Library/Logs/<app>`
+/// - Linux:            `<XDG_STATE_HOME>/<app>/logs` (falls back to the
+///                     data-local root when the state dir is unavailable)
+/// - Windows / other:  `<data-local>/<app>/logs`
+/// - portable:         `<portable-root>/logs`
+///
+/// Returns `None` only when the underlying base directory is unavailable.
+pub fn app_log_dir() -> Option<PathBuf> {
+    // Portable ("green") builds keep logs next to the executable, alongside the
+    // rest of the data, so the app leaves no trace in the system log location.
+    if let Some(portable_root) = portable_data_root() {
+        return Some(portable_root.join("logs"));
+    }
+    platform_log_dir(&resolved_app_dir_name(None))
+}
+
+#[cfg(target_os = "macos")]
+fn platform_log_dir(app_dir_name: &str) -> Option<PathBuf> {
+    // Apple convention: per-user logs live under `~/Library/Logs/<app>`.
+    Some(
+        dirs::home_dir()?
+            .join("Library")
+            .join("Logs")
+            .join(app_dir_name),
+    )
+}
+
+#[cfg(target_os = "linux")]
+fn platform_log_dir(app_dir_name: &str) -> Option<PathBuf> {
+    // XDG convention groups logs under the state dir; fall back to the
+    // data-local root when the state dir is unavailable.
+    let base = dirs::state_dir().or_else(dirs::data_local_dir)?;
+    Some(base.join(app_dir_name).join("logs"))
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+fn platform_log_dir(app_dir_name: &str) -> Option<PathBuf> {
+    // Windows (and any other platform) has no dedicated OS log directory, so
+    // logs stay under the data-local app root, matching the historical layout.
+    Some(dirs::data_local_dir()?.join(app_dir_name).join("logs"))
+}
+
+/// The pre-split log location `<app_data_root>/logs`, exposed only so callers
+/// can clean up the old directory after logs moved to [`app_log_dir`].
+///
+/// Returns `None` when the data root is unavailable, or when the old and new
+/// locations coincide (Windows / portable) — in that case there is nothing to
+/// clean up.
+pub fn legacy_logs_dir() -> Option<PathBuf> {
+    let legacy = app_data_root()?.join("logs");
+    match app_log_dir() {
+        Some(current) if current == legacy => None,
+        _ => Some(legacy),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -264,6 +330,33 @@ mod tests {
         match prev {
             Some(v) => std::env::set_var("UC_PROFILE", v),
             None => std::env::remove_var("UC_PROFILE"),
+        }
+    }
+
+    #[test]
+    fn app_log_dir_is_absolute_and_carries_app_name() {
+        // Resolution can return None in a bare CI sandbox without a home dir;
+        // assert the contract only when a directory is available.
+        if let Some(dir) = app_log_dir() {
+            assert!(dir.is_absolute(), "log dir must be absolute: {dir:?}");
+            assert!(
+                dir.to_string_lossy().contains(APP_DIR_NAME),
+                "log dir must include the app directory name: {dir:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn legacy_logs_dir_is_none_when_it_equals_current() {
+        // On any platform where `app_log_dir()` resolves to the old
+        // `<app_data_root>/logs` location (Windows / portable), there is
+        // nothing to clean up, so `legacy_logs_dir()` must report `None`.
+        if let (Some(current), Some(data_root)) = (app_log_dir(), app_data_root()) {
+            if current == data_root.join("logs") {
+                assert_eq!(legacy_logs_dir(), None);
+            } else {
+                assert_eq!(legacy_logs_dir(), Some(data_root.join("logs")));
+            }
         }
     }
 }

--- a/crates/uc-app-paths/src/lib.rs
+++ b/crates/uc-app-paths/src/lib.rs
@@ -339,10 +339,15 @@ mod tests {
         // assert the contract only when a directory is available.
         if let Some(dir) = app_log_dir() {
             assert!(dir.is_absolute(), "log dir must be absolute: {dir:?}");
-            assert!(
-                dir.to_string_lossy().contains(APP_DIR_NAME),
-                "log dir must include the app directory name: {dir:?}"
-            );
+            // Portable builds keep logs under `<portable-root>/logs`, which does
+            // not carry the app directory name, so only assert it off the
+            // platform-conventional path.
+            if portable_data_root().is_none() {
+                assert!(
+                    dir.to_string_lossy().contains(APP_DIR_NAME),
+                    "log dir must include the app directory name: {dir:?}"
+                );
+            }
         }
     }
 

--- a/crates/uc-bootstrap/Cargo.toml
+++ b/crates/uc-bootstrap/Cargo.toml
@@ -11,6 +11,10 @@ uc-application = { path = "../uc-application" }
 uc-infra = { path = "../uc-infra" }
 uc-platform = { path = "../uc-platform" }
 uc-observability = { path = "../uc-observability" }
+# Directory-layout authority: used to locate the superseded `<data>/logs`
+# directory for one-time cleanup after logs moved to the platform-conventional
+# location.
+uc-app-paths = { path = "../uc-app-paths" }
 
 tokio = { version = "1", features = ["full"] }
 tokio-util = "0.7"

--- a/crates/uc-bootstrap/src/tracing.rs
+++ b/crates/uc-bootstrap/src/tracing.rs
@@ -176,6 +176,13 @@ pub fn init_tracing_subscriber() -> anyhow::Result<()> {
     let paths = AppPaths::from_app_dirs(&app_dirs);
     std::fs::create_dir_all(&paths.logs_dir)?;
 
+    // Step 1a: One-time migration. Logs moved to the platform-conventional
+    // location; best-effort removal of the old `<data>/logs` directory. No-op
+    // when old and new coincide (Windows / portable) or when it is already gone.
+    if let Some(legacy_logs) = uc_app_paths::legacy_logs_dir() {
+        let _ = std::fs::remove_dir_all(&legacy_logs);
+    }
+
     // Step 1b: Resolve device_id for process-wide logging correlation
     let device_id = std::fs::read_to_string(&paths.device_id_path()).ok();
 

--- a/crates/uc-core/src/app_dirs/mod.rs
+++ b/crates/uc-core/src/app_dirs/mod.rs
@@ -4,6 +4,13 @@ use std::path::PathBuf;
 pub struct AppDirs {
     pub app_data_root: PathBuf,
     pub app_cache_root: PathBuf,
+    /// Fully-resolved log directory (the final leaf, not a root).
+    ///
+    /// Logs follow each platform's logging convention rather than living under
+    /// `app_data_root`, so this is carried as an already-resolved value from the
+    /// directory-layout authority. `uc-core` stays platform-agnostic — it only
+    /// holds the path, it does not compute it.
+    pub app_log_dir: PathBuf,
 }
 
 /// Derived filesystem paths for all application subsystems.
@@ -63,7 +70,9 @@ impl AppPaths {
             db_path: dirs.app_data_root.join("uniclipboard.db"),
             vault_dir: dirs.app_data_root.join("vault"),
             settings_path: dirs.app_data_root.join("settings.json"),
-            logs_dir: dirs.app_data_root.join("logs"),
+            // Logs no longer derive from the data root: the directory-layout
+            // authority resolves the platform-conventional location upstream.
+            logs_dir: dirs.app_log_dir.clone(),
             cache_dir: cache_root.clone(),
             file_cache_dir: dirs.app_data_root.join("file-cache"),
             spool_dir: cache_root.join("spool"),
@@ -79,6 +88,9 @@ impl AppPaths {
         let dirs = AppDirs {
             app_data_root: base.clone(),
             app_cache_root: cache_base,
+            // Test/fallback layout: keep logs under the provided base. The
+            // platform-conventional location is resolved upstream in production.
+            app_log_dir: base.join("logs"),
         };
         Self::from_app_dirs(&dirs)
     }
@@ -102,6 +114,7 @@ mod tests {
         let dirs = AppDirs {
             app_data_root: root.clone(),
             app_cache_root: root.clone(),
+            app_log_dir: root.join("logs"),
         };
         let paths = AppPaths::from_app_dirs(&dirs);
 
@@ -122,6 +135,7 @@ mod tests {
         let dirs = AppDirs {
             app_data_root: data.clone(),
             app_cache_root: cache.clone(),
+            app_log_dir: data.join("logs"),
         };
         let paths = AppPaths::from_app_dirs(&dirs);
 

--- a/crates/uc-desktop/src/gui_wiring.rs
+++ b/crates/uc-desktop/src/gui_wiring.rs
@@ -82,10 +82,13 @@ pub fn build_gui_client_context() -> anyhow::Result<GuiClientDeps> {
         .ok_or_else(|| anyhow::anyhow!("unable to resolve app data root directory"))?;
     let app_cache_root = uc_app_paths::app_cache_root()
         .ok_or_else(|| anyhow::anyhow!("unable to resolve app cache root directory"))?;
+    let app_log_dir = uc_app_paths::app_log_dir()
+        .ok_or_else(|| anyhow::anyhow!("unable to resolve app log directory"))?;
 
     let dirs = AppDirs {
         app_data_root,
         app_cache_root,
+        app_log_dir,
     };
     let paths = AppPaths::from_app_dirs(&dirs);
 

--- a/crates/uc-observability/src/init.rs
+++ b/crates/uc-observability/src/init.rs
@@ -27,6 +27,11 @@ use tracing_subscriber::{fmt, registry};
 use crate::format::FlatJsonFormat;
 use crate::profile::LogProfile;
 
+/// Number of daily rolling log files to keep per role. Older files are pruned
+/// automatically on initialization, so the log directory cannot grow without
+/// bound.
+const LOG_RETENTION_DAYS: usize = 7;
+
 /// Build the console (pretty) layer with per-layer filtering.
 ///
 /// Returns a layer suitable for composing with other layers on a subscriber.
@@ -83,9 +88,17 @@ where
     let json_filter = profile.json_filter();
 
     // ADR-008 D20 (P4-0): per-role file name so the GUI host and the detached
-    // `uniclipd` never append to the same rolling log file.
-    let file_name = format!("{}.json", crate::scope::role_log_file_stem());
-    let daily_appender = tracing_appender::rolling::daily(logs_dir, file_name);
+    // `uniclipd` never append to the same rolling log file. The `.json` is part
+    // of the *prefix* (no suffix is set), so the rolled files keep the
+    // `uniclipboard-<role>.json.<date>` shape — the Builder appends `.<date>`.
+    // `max_files` prunes everything older than the last `LOG_RETENTION_DAYS`.
+    let filename_prefix = format!("{}.json", crate::scope::role_log_file_stem());
+    let daily_appender = tracing_appender::rolling::RollingFileAppender::builder()
+        .rotation(tracing_appender::rolling::Rotation::DAILY)
+        .filename_prefix(filename_prefix)
+        .max_log_files(LOG_RETENTION_DAYS)
+        .build(logs_dir)
+        .map_err(|err| anyhow::anyhow!("failed to build rolling log appender: {err}"))?;
     let (non_blocking, guard) = tracing_appender::non_blocking(daily_appender);
 
     let json_layer = fmt::layer()

--- a/crates/uc-platform/src/app_dirs.rs
+++ b/crates/uc-platform/src/app_dirs.rs
@@ -117,9 +117,18 @@ impl AppDirsPort for DirsAppDirsAdapter {
         let base_cache = self
             .base_cache_dir()
             .ok_or(AppDirsError::CacheDirUnavailable)?;
+        // "Where logs live" has a single source of truth in `uc-app-paths`.
+        // The test override redirects every directory under one base, so logs
+        // follow it there (keeping tests off the real system log location);
+        // production resolves the platform-conventional location upstream.
+        let app_log_dir = match &self.base_data_local_dir_override {
+            Some(base) => base.join(&self.cached_app_dir_name).join("logs"),
+            None => uc_app_paths::app_log_dir().ok_or(AppDirsError::DataLocalDirUnavailable)?,
+        };
         Ok(AppDirs {
             app_data_root: base_data.join(&self.cached_app_dir_name),
             app_cache_root: base_cache.join(&self.cached_app_dir_name),
+            app_log_dir,
         })
     }
 }

--- a/docs-site/content/docs/en/help/troubleshooting.mdx
+++ b/docs-site/content/docs/en/help/troubleshooting.mdx
@@ -402,17 +402,19 @@ If a problem is hard to reproduce, enable verbose logging first
 (Settings → General → **Debug mode**, or `uniclip debug on`), reproduce,
 then export. Turn it back off and restart afterwards.
 
-If you'd rather grab the files by hand, logs live in a `logs/`
-subdirectory next to the encrypted history:
+If you'd rather grab the files by hand, logs live in each platform's
+conventional log location (separate from the encrypted history). Only the
+last 7 days are kept per process; older files are removed automatically:
 
-| Platform | Path                                                           |
-| -------- | -------------------------------------------------------------- |
-| macOS    | `~/Library/Application Support/app.uniclipboard.desktop/logs/` |
-| Linux    | `~/.local/share/app.uniclipboard.desktop/logs/`                |
-| Windows  | `%LOCALAPPDATA%\app.uniclipboard.desktop\logs\`                |
+| Platform | Path                                                  |
+| -------- | ----------------------------------------------------- |
+| macOS    | `~/Library/Logs/app.uniclipboard.desktop/`            |
+| Linux    | `~/.local/state/app.uniclipboard.desktop/logs/`       |
+| Windows  | `%LOCALAPPDATA%\app.uniclipboard.desktop\logs\`       |
 
-With `UC_PROFILE` set, the directory carries a suffix
-(`app.uniclipboard.desktop-dev`). See
+Each process writes its own file: `uniclipboard-gui`,
+`uniclipboard-daemon`, or `uniclipboard-cli`. With `UC_PROFILE` set, the
+directory carries a suffix (`app.uniclipboard.desktop-dev`). See
 [Install — Where data lives](../getting-started/install#where-data-lives).
 
 Reproduce while capturing — much better than digging through old logs:

--- a/docs-site/content/docs/en/help/troubleshooting.mdx
+++ b/docs-site/content/docs/en/help/troubleshooting.mdx
@@ -406,11 +406,11 @@ If you'd rather grab the files by hand, logs live in each platform's
 conventional log location (separate from the encrypted history). Only the
 last 7 days are kept per process; older files are removed automatically:
 
-| Platform | Path                                                  |
-| -------- | ----------------------------------------------------- |
-| macOS    | `~/Library/Logs/app.uniclipboard.desktop/`            |
-| Linux    | `~/.local/state/app.uniclipboard.desktop/logs/`       |
-| Windows  | `%LOCALAPPDATA%\app.uniclipboard.desktop\logs\`       |
+| Platform | Path                                            |
+| -------- | ----------------------------------------------- |
+| macOS    | `~/Library/Logs/app.uniclipboard.desktop/`      |
+| Linux    | `~/.local/state/app.uniclipboard.desktop/logs/` |
+| Windows  | `%LOCALAPPDATA%\app.uniclipboard.desktop\logs\` |
 
 Each process writes its own file: `uniclipboard-gui`,
 `uniclipboard-daemon`, or `uniclipboard-cli`. With `UC_PROFILE` set, the

--- a/docs-site/content/docs/en/help/troubleshooting.mdx
+++ b/docs-site/content/docs/en/help/troubleshooting.mdx
@@ -412,6 +412,9 @@ last 7 days are kept per process; older files are removed automatically:
 | Linux    | `~/.local/state/app.uniclipboard.desktop/logs/` |
 | Windows  | `%LOCALAPPDATA%\app.uniclipboard.desktop\logs\` |
 
+On Linux, if the state directory is unavailable, logs fall back to the
+data-local root instead: `~/.local/share/app.uniclipboard.desktop/logs/`.
+
 Each process writes its own file: `uniclipboard-gui`,
 `uniclipboard-daemon`, or `uniclipboard-cli`. With `UC_PROFILE` set, the
 directory carries a suffix (`app.uniclipboard.desktop-dev`). See

--- a/docs-site/content/docs/zh/help/troubleshooting.mdx
+++ b/docs-site/content/docs/zh/help/troubleshooting.mdx
@@ -282,11 +282,11 @@ GUI、daemon、CLI 日志打成一个 zip 放到下载目录。
 
 如果你更想手动拿文件，日志写在各平台约定的日志目录下（已和加密历史分开存放）。每种进程只保留最近 7 天，更早的会在启动时自动清理：
 
-| 平台    | 路径                                              |
-| ------- | ------------------------------------------------- |
-| macOS   | `~/Library/Logs/app.uniclipboard.desktop/`        |
-| Linux   | `~/.local/state/app.uniclipboard.desktop/logs/`   |
-| Windows | `%LOCALAPPDATA%\app.uniclipboard.desktop\logs\`   |
+| 平台    | 路径                                            |
+| ------- | ----------------------------------------------- |
+| macOS   | `~/Library/Logs/app.uniclipboard.desktop/`      |
+| Linux   | `~/.local/state/app.uniclipboard.desktop/logs/` |
+| Windows | `%LOCALAPPDATA%\app.uniclipboard.desktop\logs\` |
 
 每种进程各写各的文件：`uniclipboard-gui`、`uniclipboard-daemon`、`uniclipboard-cli`。带 `UC_PROFILE` 时目录后会有后缀（如 `app.uniclipboard.desktop-dev`）。详见 [安装 — 数据存储位置](../getting-started/install#数据存储位置)。
 

--- a/docs-site/content/docs/zh/help/troubleshooting.mdx
+++ b/docs-site/content/docs/zh/help/troubleshooting.mdx
@@ -280,15 +280,15 @@ GUI、daemon、CLI 日志打成一个 zip 放到下载目录。
 如果问题很难复现，先开启更详细的日志（设置 → 常规 → **调试模式**，或
 `uniclip debug on`），复现后再导出。事后记得关掉并重启。
 
-如果你更想手动拿文件，日志写在和加密历史同级的 `logs/` 子目录下：
+如果你更想手动拿文件，日志写在各平台约定的日志目录下（已和加密历史分开存放）。每种进程只保留最近 7 天，更早的会在启动时自动清理：
 
-| 平台    | 路径                                                           |
-| ------- | -------------------------------------------------------------- |
-| macOS   | `~/Library/Application Support/app.uniclipboard.desktop/logs/` |
-| Linux   | `~/.local/share/app.uniclipboard.desktop/logs/`                |
-| Windows | `%LOCALAPPDATA%\app.uniclipboard.desktop\logs\`                |
+| 平台    | 路径                                              |
+| ------- | ------------------------------------------------- |
+| macOS   | `~/Library/Logs/app.uniclipboard.desktop/`        |
+| Linux   | `~/.local/state/app.uniclipboard.desktop/logs/`   |
+| Windows | `%LOCALAPPDATA%\app.uniclipboard.desktop\logs\`   |
 
-带 `UC_PROFILE` 时目录后会有后缀（如 `app.uniclipboard.desktop-dev`）。详见 [安装 — 数据存储位置](../getting-started/install#数据存储位置)。
+每种进程各写各的文件：`uniclipboard-gui`、`uniclipboard-daemon`、`uniclipboard-cli`。带 `UC_PROFILE` 时目录后会有后缀（如 `app.uniclipboard.desktop-dev`）。详见 [安装 — 数据存储位置](../getting-started/install#数据存储位置)。
 
 复现一次问题再抓日志，效果远好于事后翻：
 

--- a/docs/architecture/logging-architecture.md
+++ b/docs/architecture/logging-architecture.md
@@ -5,7 +5,7 @@
 UniClipboard uses **`tracing`** crate as the primary logging framework with structured logging and span-based context tracking. The system produces **dual output** from a single tracing pipeline:
 
 - **Console output**: Pretty human-readable format with ANSI colors (stdout)
-- **JSON file output**: Structured flat JSON with daily-rotating files for tooling and analysis
+- **JSON file output**: Structured flat JSON with daily-rotating files (7-day retention) for tooling and analysis
 
 A **dual-track** coexistence is maintained during the transition from legacy `log` crate to `tracing`:
 
@@ -251,11 +251,23 @@ The tracing subscriber produces two simultaneous outputs from the same pipeline:
 
 ### JSON File Locations
 
-- **macOS**: `~/Library/Application Support/app.uniclipboard.desktop[-<profile>]/logs/uniclipboard.json.YYYY-MM-DD`
-- **Linux**: `~/.local/share/app.uniclipboard.desktop[-<profile>]/logs/uniclipboard.json.YYYY-MM-DD`
-- **Windows**: `%LOCALAPPDATA%\app.uniclipboard.desktop[-<profile>]\logs\uniclipboard.json.YYYY-MM-DD`
+Each process role writes its own daily-rotating file — `uniclipboard-gui`,
+`uniclipboard-daemon`, or `uniclipboard-cli` (e.g.
+`uniclipboard-daemon.json.YYYY-MM-DD`) — so co-resident processes never share a
+file. Logs follow each platform's logging convention and live **outside** the
+data directory:
+
+- **macOS**: `~/Library/Logs/app.uniclipboard.desktop[-<profile>]/`
+- **Linux**: `~/.local/state/app.uniclipboard.desktop[-<profile>]/logs/` (XDG state dir)
+- **Windows**: `%LOCALAPPDATA%\app.uniclipboard.desktop[-<profile>]\logs\`
 
 `[-<profile>]` means the directory gains a suffix such as `-dev` when `UC_PROFILE` is set.
+
+**Retention**: the last 7 daily files per role are kept; older files are pruned
+automatically on each start, so the log directory cannot grow without bound.
+Portable ("green") builds keep logs next to the executable under
+`<exe>/data/logs/`. The single source of truth for the location is
+`uc_app_paths::app_log_dir()`.
 
 ## Configuration
 
@@ -577,30 +589,32 @@ bun run tauri:dev
 
 **JSON log file**:
 
+Replace `gui` with `daemon` or `cli` to inspect another role's file.
+
 ```bash
 # macOS - view latest JSON log
-cat ~/Library/Application\ Support/app.uniclipboard.desktop/logs/uniclipboard.json.$(date +%Y-%m-%d) | jq .
+cat ~/Library/Logs/app.uniclipboard.desktop/uniclipboard-gui.json.$(date +%Y-%m-%d) | jq .
 
 # macOS - follow live
-tail -f ~/Library/Application\ Support/app.uniclipboard.desktop/logs/uniclipboard.json.$(date +%Y-%m-%d)
+tail -f ~/Library/Logs/app.uniclipboard.desktop/uniclipboard-gui.json.$(date +%Y-%m-%d)
 
 # Linux
-tail -f ~/.local/share/app.uniclipboard.desktop/logs/uniclipboard.json.$(date +%Y-%m-%d)
+tail -f ~/.local/state/app.uniclipboard.desktop/logs/uniclipboard-gui.json.$(date +%Y-%m-%d)
 
 # Windows (PowerShell)
-Get-Content "$env:LOCALAPPDATA\app.uniclipboard.desktop\logs\uniclipboard.json.$(Get-Date -Format yyyy-MM-dd)" -Wait
+Get-Content "$env:LOCALAPPDATA\app.uniclipboard.desktop\logs\uniclipboard-gui.json.$(Get-Date -Format yyyy-MM-dd)" -Wait
 ```
 
 **Filter JSON logs for errors**:
 
 ```bash
-cat ~/Library/Application\ Support/app.uniclipboard.desktop/logs/uniclipboard.json.$(date +%Y-%m-%d) | jq 'select(.level == "ERROR")'
+cat ~/Library/Logs/app.uniclipboard.desktop/uniclipboard-gui.json.$(date +%Y-%m-%d) | jq 'select(.level == "ERROR")'
 ```
 
 **View last 100 lines**:
 
 ```bash
-tail -n 100 ~/Library/Application\ Support/app.uniclipboard.desktop/logs/uniclipboard.json.$(date +%Y-%m-%d)
+tail -n 100 ~/Library/Logs/app.uniclipboard.desktop/uniclipboard-gui.json.$(date +%Y-%m-%d)
 ```
 
 ## Testing
@@ -652,7 +666,7 @@ cd src-tauri && cargo test --package uc-tauri -- bootstrap::tracing
 ### JSON log file not created
 
 1. Check app has write permissions to the log directory
-2. Verify the directory exists: `ls ~/Library/Application\ Support/app.uniclipboard.desktop/logs/` (macOS)
+2. Verify the directory exists: `ls ~/Library/Logs/app.uniclipboard.desktop/` (macOS)
 3. Check `init_tracing_subscriber()` completed without error (look for "Tracing initialized" in console)
 4. Ensure `UC_LOG_PROFILE` is a valid value (or unset for default)
 

--- a/docs/architecture/logging-architecture.md
+++ b/docs/architecture/logging-architecture.md
@@ -218,7 +218,7 @@ The tracing subscriber produces two simultaneous outputs from the same pipeline:
 
 - **Format**: Flat NDJSON (one JSON object per line)
 - **Destination**: Daily-rotating file in platform log directory
-- **File naming**: `uniclipboard.json.YYYY-MM-DD`
+- **File naming**: `uniclipboard-{gui,daemon,cli}.json.YYYY-MM-DD` (role prefix; see [JSON File Locations](#json-file-locations))
 - **Rotation**: New file each day (UTC date boundary)
 
 **JSON field layout**:

--- a/src-tauri/crates/uc-tauri/src/run.rs
+++ b/src-tauri/crates/uc-tauri/src/run.rs
@@ -936,8 +936,18 @@ pub fn run(tauri_ctx: tauri::Context<tauri::Wry>) -> anyhow::Result<()> {
 /// failure) is lost. `None` when the app-data root is unavailable or a
 /// subscriber was already registered.
 fn init_gui_tracing() -> Option<uc_observability::WorkerGuard> {
-    let app_data_root = uc_app_paths::app_data_root()?;
-    let logs_dir = app_data_root.join("logs");
+    // Single source of truth for the log location (platform-conventional,
+    // portable-aware) lives in uc-app-paths; this pre-wiring init reads it
+    // rather than deriving its own `<data>/logs` path.
+    let logs_dir = uc_app_paths::app_log_dir()?;
+
+    // One-time migration: best-effort removal of the old `<data>/logs`
+    // directory now that logs moved to the platform-conventional location.
+    // No-op when old and new coincide (Windows / portable) or already gone.
+    if let Some(legacy_logs) = uc_app_paths::legacy_logs_dir() {
+        let _ = std::fs::remove_dir_all(&legacy_logs);
+    }
+
     let profile = uc_observability::LogProfile::from_env();
     uc_observability::init_tracing_subscriber(&logs_dir, profile).ok()
 }


### PR DESCRIPTION
## Summary

- **Relocate logs to each OS's conventional log directory**, out of the data root where they were mixed with the db/vault/cache (`f8757805b`). macOS → `~/Library/Logs/<app>/`, Linux → `<XDG_STATE_HOME>/<app>/logs/`, Windows unchanged, portable unchanged. The location has a **single source of truth** in `uc_app_paths::app_log_dir()`; every consumer (daemon, CLI, GUI pre-wiring init) reads it instead of joining `"logs"` onto a base path. `AppDirs` carries the resolved dir so `uc-core` stays platform-agnostic. A best-effort one-time cleanup removes the superseded `<data>/logs` dir on first launch (no-op on Windows/portable).
- **Cap log retention at 7 daily files per role** (`cc6c5e9b0`). The rolling appender never pruned, so the dir grew unbounded; switched to the builder API with `max_log_files(7)`. The `.json` stays in the filename *prefix* so rolled files remain `uniclipboard-<role>.json.<date>` — **log export matching is unaffected**.
- **Docs** updated in lockstep (`02bc5a11b`): architecture doc, agent indexes, and user-facing troubleshooting (en + zh).

User-facing features verified unaffected: GUI "open logs directory" and log export both read `AppPaths.logs_dir` (= new location) automatically; `debug_mode` only controls verbosity profile, never the path.

## Test plan

- [x] `cargo check` — uc-app-paths, uc-core, uc-platform, uc-desktop, uc-observability, uc-bootstrap, uc-tauri, uc-daemon, uc-cli
- [x] Unit tests — uc-app-paths (incl. new `app_log_dir` / `legacy_logs_dir` tests), uc-core `app_dirs`, uc-observability (142), diagnostics log-export (2)
- [x] `cargo clippy` on changed crates — no new warnings introduced
- [x] Verified filename format unchanged → diagnostics export `is_supported_log_file` / `rolling_name_is_in_window` still match
- [ ] Manual smoke on macOS/Windows: confirm logs land in the new dir, GUI "open logs directory" opens it, and one-click export zips gui+daemon+cli files (developed/verified on Linux/WSL only)

Refactor: #822

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes
* **Documentation**
  * Updated troubleshooting and logging architecture guides with platform-specific log locations, per-process filenames, `UC_PROFILE`-based directory suffixing, and portable build paths.
* **Improvements**
  * Moved JSON logs to platform-conventional directories (logs are stored outside the app data root’s `logs/` subdirectory).
  * Daily rolling logs are retained for 7 days and pruned automatically on startup.
  * One-time best-effort cleanup now removes legacy `<data>/logs` on first run where applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->