### PR TITLE
feat(skills): add local-log-debug and realign dual-side-debug

### DIFF
--- a/.claude/skills/dual-side-debug/SKILL.md
+++ b/.claude/skills/dual-side-debug/SKILL.md
@@ -14,9 +14,12 @@ The helper script lives at `.claude/skills/dual-side-debug/dual-logs.sh`. It is 
 
 ## Log layout you must remember
 
-* **macOS logs**: `~/Library/Application Support/app.uniclipboard.desktop[-<UC_PROFILE>]/logs/uniclipboard.json.YYYY-MM-DD`
-* **Windows logs (mounted)**: `/tmp/win-local/app.uniclipboard.desktop[-<WIN_PROFILE>]/logs/uniclipboard.json.YYYY-MM-DD`
-* Format: **JSON Lines**. Each line has at least `timestamp` (UTC, ISO-8601 with `Z`), `level`, `target`, `message`, `span`, `device_id`, plus structured fields.
+* **macOS logs**: `~/Library/Logs/app.uniclipboard.desktop[-<UC_PROFILE>]/uniclipboard-{gui,daemon,cli}.json.YYYY-MM-DD`
+  — Apple convention (`~/Library/Logs/<app>`); the profile dir **is** the log dir, there is **no `logs/` subdir** on macOS.
+* **Windows logs (mounted)**: `/tmp/win-local/app.uniclipboard.desktop[-<WIN_PROFILE>]/logs/uniclipboard-{gui,daemon,cli}.json.YYYY-MM-DD`
+  — Windows keeps the `logs/` subdir under the data-local app root.
+* **Per-role files** (since the platform-log-dir split): each process writes its own family — `gui` (Tauri host), `daemon` (`uniclipd`), `cli` (`uniclip`) — daily rotation, 7-day retention. `dual-logs.sh` picks the **newest by mtime** per side, i.e. the busiest process (usually the daemon for sync/pairing/transfer). The legacy single-file name `uniclipboard.json.YYYY-MM-DD` is still matched for old logs. For per-role single-host digging, use the **`local-log-debug`** skill instead.
+* Format: **JSON Lines**. Each line has at least `timestamp` (UTC, ISO-8601 with `Z`, always the first field), `level`, `target`, `message`, `span`, `device_id`, plus structured fields.
 * The date in the filename is **UTC**, not local time. A file named `...2026-04-25` can be the live file while it is still 2026-04-24 in PDT.
 
 ## Mount setup (do this once per Mac reboot)

--- a/.claude/skills/dual-side-debug/dual-logs.sh
+++ b/.claude/skills/dual-side-debug/dual-logs.sh
@@ -1,12 +1,20 @@
 #!/usr/bin/env bash
 # dual-logs.sh — Helper for inspecting macOS + Windows uniclipboard logs side-by-side.
 #
-# Logs are JSONL (one JSON object per line). File names use UTC dates
-# (uniclipboard.json.YYYY-MM-DD), so "today" here means UTC today.
+# Logs are JSONL (one JSON object per line). Since the platform-log-dir split,
+# files are written per role: uniclipboard-{gui,daemon,cli}.json.YYYY-MM-DD
+# (daily rotation, UTC dates), so "today" here means UTC today. The legacy
+# single-file name (uniclipboard.json.YYYY-MM-DD) is still matched for old logs.
+# "Latest" = newest by mtime across roles, which in practice is the busiest
+# process (usually the daemon). For per-role single-host digging, use the
+# `local-log-debug` skill instead.
 #
-# macOS path:    $MAC_BASE/app.uniclipboard.desktop[-<UC_PROFILE>]/logs/
+# macOS path:    $MAC_BASE/app.uniclipboard.desktop[-<UC_PROFILE>]/
+#                (Apple convention: ~/Library/Logs/<app>; the app dir IS the log
+#                dir — there is NO `logs/` subdir on macOS anymore)
 # Windows path:  $WIN_BASE/app.uniclipboard.desktop[-<WIN_PROFILE>]/logs/
-#                (SMB share of //<host>/Users/<user>/AppData/Local mounted at $WIN_BASE)
+#                (SMB share of //<host>/Users/<user>/AppData/Local mounted at
+#                $WIN_BASE; Windows keeps the `logs/` subdir under the data root)
 #
 # Win profile resolution priority:
 #   1. --win-profile <name> on the command line
@@ -15,7 +23,7 @@
 
 set -euo pipefail
 
-MAC_BASE="${MAC_BASE:-$HOME/Library/Application Support}"
+MAC_BASE="${MAC_BASE:-$HOME/Library/Logs}"
 WIN_BASE="${WIN_BASE:-/tmp/win-local}"
 WIN_LOGS_OVERRIDE="${WIN_LOGS:-}"
 DEFAULT_PROFILE="${UC_PROFILE_DEFAULT:-dev}"
@@ -74,22 +82,31 @@ profile_dir() {
 mac_profile_dir() { profile_dir "$MAC_BASE" "${1:-}"; }
 win_profile_dir() { profile_dir "$WIN_BASE" "${1:-}"; }
 
-# list_profile_dirs_in <base>
-#   Print one line per existing profile dir that has a logs/ subdir.
-#   Format: <profile>\t<dir>\t<latest_log>\t<latest_mtime_iso>\t<latest_mtime_epoch>
+# Resolve the actual logs directory per platform. macOS logs live directly under
+# ~/Library/Logs/<app> (no subdir); Windows keeps a `logs/` subdir under the
+# data-local app root. These are the asymmetry the rest of the script relies on.
+mac_logs_dir() { mac_profile_dir "${1:-}"; }
+win_logs_dir() { printf '%s/logs' "$(win_profile_dir "${1:-}")"; }
+
+# list_profile_dirs_in <base> [logs_subdir]
+#   Print one line per existing profile dir that has logs. `logs_subdir` is the
+#   relative dir holding the log files: "logs" for Windows (default, keeps the
+#   data-root subdir), "" for macOS (the profile dir itself is the log dir).
+#   Format: <profile>\t<logdir>\t<latest_log>\t<latest_mtime_iso>\t<latest_mtime_epoch>
 list_profile_dirs_in() {
-  local base="$1"
+  local base="$1" logs_subdir="${2-logs}"
   shopt -s nullglob
-  local d name profile latest mtime epoch
+  local d name profile logdir latest mtime epoch
   for d in "$base"/app.uniclipboard.desktop "$base"/app.uniclipboard.desktop-*; do
-    [[ -d "$d/logs" ]] || continue
+    if [[ -n "$logs_subdir" ]]; then logdir="$d/$logs_subdir"; else logdir="$d"; fi
+    [[ -d "$logdir" ]] || continue
     name="$(basename "$d")"
     if [[ "$name" == "app.uniclipboard.desktop" ]]; then
       profile="default"
     else
       profile="${name#app.uniclipboard.desktop-}"
     fi
-    latest="$(latest_log_in "$d/logs" || true)"
+    latest="$(latest_log_in "$logdir" || true)"
     if [[ -n "$latest" ]]; then
       mtime="$(stat -f '%Sm' -t '%Y-%m-%dT%H:%M:%S' "$latest" 2>/dev/null || echo '')"
       epoch="$(stat -f '%m' "$latest" 2>/dev/null || echo '0')"
@@ -97,7 +114,7 @@ list_profile_dirs_in() {
       mtime=""
       epoch="0"
     fi
-    printf '%s\t%s\t%s\t%s\t%s\n' "$profile" "$d/logs" "${latest:-<empty>}" "${mtime:-<no-logs>}" "$epoch"
+    printf '%s\t%s\t%s\t%s\t%s\n' "$profile" "$logdir" "${latest:-<empty>}" "${mtime:-<no-logs>}" "$epoch"
   done
 }
 
@@ -111,11 +128,17 @@ auto_detect_profile() {
 latest_log_in() {
   local dir="$1"
   [[ -d "$dir" ]] || return 1
-  # Pick the most recently modified uniclipboard.json.* file.
-  # ls -t orders by mtime descending.
+  # Pick the most recently modified log file across all roles. The glob
+  # `uniclipboard*.json.*` matches the per-role names
+  # (uniclipboard-{gui,daemon,cli}.json.<date>) AND the legacy single-file name
+  # (uniclipboard.json.<date>). ls -t orders by mtime descending, so the busiest
+  # role's file wins — usually the daemon for sync/pairing/transfer debugging.
   local f
-  f="$(ls -t "$dir"/uniclipboard.json.* 2>/dev/null | head -n1 || true)"
-  [[ -n "$f" ]] || return 1
+  f="$(ls -t "$dir"/uniclipboard*.json.* 2>/dev/null | head -n1 || true)"
+  # Guard against nullglob (list_profile_dirs_in enables it): with no match the
+  # glob vanishes and bare `ls -t` would list the cwd. Only accept a path that
+  # actually lives inside $dir.
+  [[ -n "$f" && "$f" == "$dir/"* ]] || return 1
   printf '%s' "$f"
 }
 
@@ -156,7 +179,7 @@ resolve_win_logs() {
   # Priority 1: explicit --win-profile flag
   if [[ -n "$win_profile" ]]; then
     WIN_PROFILE_RESOLVED="$win_profile"
-    WIN_LOGS_RESOLVED="$(win_profile_dir "$win_profile")/logs"
+    WIN_LOGS_RESOLVED="$(win_logs_dir "$win_profile")"
     return
   fi
 
@@ -172,7 +195,7 @@ resolve_win_logs() {
   detected="$(auto_detect_profile "$WIN_BASE")"
   if [[ -n "$detected" ]]; then
     WIN_PROFILE_RESOLVED="$detected (auto)"
-    WIN_LOGS_RESOLVED="$(win_profile_dir "$detected")/logs"
+    WIN_LOGS_RESOLVED="$(win_logs_dir "$detected")"
   else
     WIN_PROFILE_RESOLVED="<none>"
     WIN_LOGS_RESOLVED=""
@@ -191,7 +214,7 @@ cmd_status() {
     esac
   done
   local mac_dir mac_log win_log
-  mac_dir="$(mac_profile_dir "$profile")/logs"
+  mac_dir="$(mac_logs_dir "$profile")"
 
   echo "=== uniclipboard dual-log status ==="
   echo "now (local):   $(date '+%Y-%m-%d %H:%M:%S %Z')"
@@ -212,7 +235,7 @@ cmd_status() {
   else
     echo "  (profile dir does not exist — likely wrong UC_PROFILE)"
     echo "  available profiles:"
-    list_profile_dirs_in "$MAC_BASE" \
+    list_profile_dirs_in "$MAC_BASE" "" \
       | awk -F'\t' '{printf "    - %s  (latest=%s, mtime=%s)\n", $1, $3, $4}'
   fi
   echo
@@ -255,7 +278,7 @@ cmd_list_profiles() {
   if [[ "$side" == "mac" || "$side" == "both" ]]; then
     echo "===== mac profiles (base: $MAC_BASE) ====="
     printf '%s\t%s\t%s\t%s\n' "PROFILE" "DIR" "LATEST" "MTIME"
-    list_profile_dirs_in "$MAC_BASE" | cut -f1-4
+    list_profile_dirs_in "$MAC_BASE" "" | cut -f1-4
   fi
   if [[ "$side" == "win" || "$side" == "both" ]]; then
     [[ "$side" == "both" ]] && echo
@@ -279,7 +302,7 @@ cmd_paths() {
     esac
   done
   local mac_dir mac_log win_log
-  mac_dir="$(mac_profile_dir "$profile")/logs"
+  mac_dir="$(mac_logs_dir "$profile")"
   mac_log="$(latest_log_in "$mac_dir" 2>/dev/null || true)"
   resolve_win_logs "$win_profile"
   win_log="$(latest_log_in "$WIN_LOGS_RESOLVED" 2>/dev/null || true)"
@@ -291,7 +314,7 @@ resolve_pair() {
   # Sets globals MAC_LOG and WIN_LOG. Empties them if missing.
   local profile="$1" win_profile="${2:-}"
   local mac_dir
-  mac_dir="$(mac_profile_dir "$profile")/logs"
+  mac_dir="$(mac_logs_dir "$profile")"
   MAC_LOG="$(latest_log_in "$mac_dir" 2>/dev/null || true)"
   resolve_win_logs "$win_profile"
   WIN_LOG="$(latest_log_in "$WIN_LOGS_RESOLVED" 2>/dev/null || true)"

--- a/.claude/skills/local-log-debug/SKILL.md
+++ b/.claude/skills/local-log-debug/SKILL.md
@@ -1,0 +1,205 @@
+---
+name: local-log-debug
+description: Inspect and analyze uniclipboard's local JSONL logs on a SINGLE machine — query, filter, and time-merge the per-role (gui/daemon/cli) log files to answer "what just happened" or trace a symptom (pairing, sync, transfer, clipboard capture, daemon lifecycle) back through the logs. Use when the user asks to "check the logs", "why did X fail", "what did the daemon do", or describes a bug to diagnose from logs on this one host. NOT for cross-device peer debugging (use dual-side-debug) and NOT for writing/reviewing tracing code (use tracing-best-practices).
+user-invocable: true
+---
+
+# local-log-debug
+
+Read and reason over uniclipboard's local logs on **one** machine, across the
+three process roles (gui / daemon / cli), using the current platform-conventional
+log layout.
+
+The helper script `.claude/skills/local-log-debug/uc-logs.sh` is the **only**
+thing you should need to invoke for log work — it resolves the per-platform log
+directory, picks the latest file per role, and handles tail / grep / structured
+query / time-merge. Don't hand-roll `ls`/`tail`/`jq` pipelines unless the script
+genuinely can't express what you need.
+
+## When this skill applies (and when it does NOT)
+
+| Situation | Use |
+| --- | --- |
+| "Check the logs on this machine", trace a symptom from local logs | **this skill** |
+| Cross-device: "Windows didn't receive…", "Mac sent but peer…" | `dual-side-debug` (two hosts, SMB-mounted peer) |
+| Writing / reviewing `#[instrument]`, `tracing::*`, subscriber setup | `tracing-best-practices` |
+| Bundling recent logs to hand off / attach to an issue | `uniclip debug export-logs` (CLI) — see below |
+| Build / cargo / typecheck failures | not these JSONL logs at all |
+| Daemon HTTP API behavior or sqlite state | logs are observability, not state |
+
+## Log layout you must remember (current, post-split)
+
+Single source of truth for *where logs live* is `uc_app_paths::app_log_dir()`.
+Logs are **separate from the data root** (since the platform-log-dir split) and
+are written **per role** so co-resident processes never share a file.
+
+* Directory (`<app>` = `app.uniclipboard.desktop[-<UC_PROFILE>]`):
+  * **macOS**: `~/Library/Logs/<app>/`
+  * **Linux**: `$XDG_STATE_HOME/<app>/logs/` (default `~/.local/state/...`; falls back to the data-local root)
+  * **Windows**: `%LOCALAPPDATA%\<app>\logs\`
+  * **portable build**: `<exe>/data/logs/`
+* Per-role files, daily rotation, **7-day retention** (older pruned on start):
+  * `uniclipboard-gui.json.<UTC-date>` — the Tauri GUI host (`uniclipboard`)
+  * `uniclipboard-daemon.json.<UTC-date>` — the detached `uniclipd` daemon
+  * `uniclipboard-cli.json.<UTC-date>` — the `uniclip` CLI
+* Format: **JSON Lines**. Every line has `timestamp` (UTC ISO-8601, ends `Z`, and
+  is always the **first** field), `level`, `target`, `message`, usually `span`
+  and `device_id`, plus flattened span/event fields.
+* The date in the filename is **UTC**, not local time. A `...2026-06-17` file can
+  be the live one while it's still 2026-06-16 in your local evening.
+
+> ⚠️ Do not trust the older layout. The `dual-side-debug` skill and some legacy
+> data roots still reference `~/Library/Application Support/.../logs/uniclipboard.json`
+> (single file, no role). That is the **pre-split** layout — wrong for this skill.
+
+### Profile resolution
+
+The app dir gets a `-<profile>` suffix from `UC_PROFILE`. The local dev default
+is **`dev`** (`package.json`'s `tauri:dev` sets `UC_PROFILE=dev`), so the script
+assumes `dev`. Override with `--profile <name>`, or `--profile default` for the
+no-suffix `app.uniclipboard.desktop` dir.
+
+### Escape hatch: `UC_LOG_DIR`
+
+If the script's platform/profile resolution ever disagrees with reality
+(portable build, WSL reading a Windows app's logs under `/mnt/c/...`, an
+unusual mount), set `UC_LOG_DIR=/abs/path/to/logs` and the script uses it
+verbatim. This is also the fallback for a pure-PowerShell host where bash can't
+run: resolve the dir per the table above and read the JSONL with your own tools.
+
+## Always run `status` first
+
+Before answering anything that depends on log content:
+
+```bash
+.claude/skills/local-log-debug/uc-logs.sh status
+```
+
+Then judge:
+
+1. Does the resolved log dir exist? If not, you're probably on the wrong
+   profile — try `--profile default`, or check sibling dirs in the parent.
+2. For each role, is the latest file `live (<2m)` / `recent (<10m)`? Anything
+   `stale` / `old` / `cold` means that process likely isn't running right now —
+   you may be reading a frozen session.
+
+If the user is actively reproducing but the relevant role is `cold`/`(no file)`,
+**stop and confirm the profile** before drawing conclusions. Don't silently
+analyze stale logs.
+
+## Commands
+
+Always invoke via the script, from the repo root:
+
+```bash
+.claude/skills/local-log-debug/uc-logs.sh <command> [args] [flags]
+```
+
+| Command | When to use |
+| --- | --- |
+| `status` | First call of any session. Profile + resolved dir + per-role freshness. |
+| `paths`  | Just need the resolved dir and latest file per role (to feed another tool). |
+| `tail`   | Quick "what just happened" — last 50 lines per selected role. |
+| `grep <pattern>` | Plain string match (a device id, an error fragment, a request id). Cheap first probe. |
+| `query --filter '<jq>'` | Structured jq filter over the JSONL. Best for level / target / span filters. |
+| `merge`  | Time-interleave the selected roles into one chronological stream, injecting `.role`. Use whenever the question is *"what happened across gui ↔ daemon around time X"*. |
+
+### Flags
+
+* `--role gui\|daemon\|cli\|all` — restrict to a role (default `all`).
+* `--profile <name>` — profile override (default `dev`; `default` = no suffix).
+* `--lines N` — output cap for tail/grep/query (default 50); per-file scan depth for merge (default 2000).
+* `--since <ISO8601>` — merge only: drop lines older than this UTC timestamp.
+
+## Recommended workflow
+
+1. **Ground yourself.** Run `status`. Confirm the right profile and that the
+   relevant role is live. Resolve any profile mismatch with the user first.
+2. **Narrow the time window.** Ask when the issue reproduced (or read it from the
+   conversation), convert to UTC, and pass it to `merge --since`.
+3. **Start broad, then narrow.**
+   * Broad cross-role story: `merge --since <UTC> --lines 800`.
+   * Narrow by signal: `query --filter '.level=="ERROR" or .level=="WARN"'`, or
+     by `target` / `span` for the suspect subsystem.
+4. **Correlate by id, don't assume.** When the symptom spans roles ("GUI asked,
+   daemon never acted"), grep the **same id** (`request_id`, `transfer_id`,
+   `entry_id`, `device_id`, `session_token_jti`) across roles — the merged view
+   beats two parallel monologues.
+5. **Quote sparingly.** Logs are noisy. In your reply, quote the 3–10 lines that
+   carry signal, with role + timestamp. Never dump raw JSONL walls.
+
+## jq cookbook
+
+Plug these straight into `query --filter '<jq>'`:
+
+```jq
+# Errors and warnings only
+.level == "ERROR" or .level == "WARN"
+
+# One subsystem (substring match on target)
+.target | test("pairing|file_transfer|clipboard_sync")
+
+# A specific span chain
+.span | test("daemon.ws.connection")
+
+# Around a particular id (works for any flattened field)
+.request_id == "b6c8588aa8a8699c"
+.device_id == "acf2b4da-a6f9-4b77-9074-e13b0ffc9496"
+```
+
+Compact projection for human reading (pipe `query`/`merge` output through this):
+
+```bash
+... | jq -c '{ts:.timestamp, role:.role, lvl:.level, tgt:.target, span:.span, msg:.message}'
+```
+
+### Subsystem target / span cheat-sheet
+
+Real strings seen in these logs, to seed your `target`/`span` filters:
+
+| Subsystem | Representative `target` / `span` |
+| --- | --- |
+| Daemon HTTP/WS API | `uc_webserver::api::server`, `uc_webserver::api::ws`, span `daemon.ws.connection`, `uc_webserver::api::control_lease` |
+| Daemon lifecycle / workers | `uc_daemon::daemon::app`, `uc_daemon::daemon::workers::*` (clipboard_watcher, peer_keepalive, file_sync_orchestrator, inbound_clipboard_sync) |
+| Clipboard capture (Linux) | `uc_platform::clipboard::platform::linux::x11::event_loop` (Wayland under the sibling `wayland` path) |
+| Sync / transfer (app layer) | `uc_application::usecases::clipboard_sync`, `uc_application::usecases::file_transfer`, `uc_application::usecases::mobile_sync`, span `peer.dispatch` |
+| Pairing / setup | `uc_application::facade::space_setup`, `uc_application::usecases::pairing_*` |
+| Search | `uc_application::facade::search::coordinator`, span `search.run_manual_rebuild_now` |
+| iroh networking (noisy) | `iroh::net_report`, `iroh::magicsock`, `iroh_relay::ping_tracker`, `iroh_blobs::store::*` |
+
+Note: a lot of `iroh*` / relay traffic is infra noise. The log profiles already
+mute the worst of it; when scanning, prefer filtering to `uc_*` targets first.
+
+## Verbosity is controlled elsewhere
+
+Local log **level** comes from `RUST_LOG` > `UC_LOG_PROFILE` > build type
+(debug→`Dev`, release→`Prod`). If a subsystem's lines are missing entirely, the
+profile may be filtering them — that's a *capture* problem, not a *reading*
+problem, and belongs to how the app was launched (e.g. `uniclip debug on`,
+`UC_LOG_PROFILE=debug_clipboard`), not to this skill.
+
+## Relationship to `uniclip debug export-logs`
+
+The CLI can bundle recent logs for handoff:
+
+```bash
+uniclip debug export-logs [--since-hours N]   # default 24h; writes a dir + manifest
+```
+
+Use that when the goal is to **package** logs (attach to an issue, send to the
+user). Use **this skill** when the goal is to **read and reason** about them in
+place. Related: `uniclip debug status|on|off` shows/toggles the effective log
+profile.
+
+## Things to avoid
+
+* Don't `cat` whole log files — daemon files get large.
+* Don't conclude "the daemon is broken" without checking its log **freshness**
+  in `status` first; a `cold` file just means the daemon isn't running.
+* Don't convert UTC ↔ local time silently. If you convert, say so.
+* Don't edit log paths in this doc if the layout changes — fix `uc-logs.sh`
+  first (and confirm against `uc_app_paths::app_log_dir()`), then this doc.
+* Don't confuse this with `dual-side-debug`: that skill reads a *second host's*
+  logs over a mount and still uses the *old* single-file layout.
+```
+

--- a/.claude/skills/local-log-debug/uc-logs.sh
+++ b/.claude/skills/local-log-debug/uc-logs.sh
@@ -1,0 +1,244 @@
+#!/usr/bin/env bash
+# uc-logs.sh — single-machine, cross-platform reader for uniclipboard's
+# per-role JSONL logs. Companion to the `local-log-debug` skill.
+#
+# Mirrors `uc_app_paths::app_log_dir()` (the single source of truth for where
+# logs live) so it resolves the same directory the running app writes to. If the
+# heuristics ever disagree with the app, override with UC_LOG_DIR and the script
+# uses that path verbatim.
+#
+# Roles map to file stems exactly as `uc_observability::scope::role_log_file_stem()`:
+#   gui    -> uniclipboard-gui.json.<UTC-date>
+#   daemon -> uniclipboard-daemon.json.<UTC-date>
+#   cli    -> uniclipboard-cli.json.<UTC-date>
+#
+# Usage:
+#   uc-logs.sh status                         # profile, resolved dir, per-role freshness
+#   uc-logs.sh paths                          # resolved dir + latest file per role
+#   uc-logs.sh tail   [--role R] [--lines N]
+#   uc-logs.sh grep   <pattern> [--role R] [--lines N]
+#   uc-logs.sh query  --filter '<jq>' [--role R] [--lines N]
+#   uc-logs.sh merge  [--since <ISO8601>] [--lines N]   # time-interleave roles, inject .role
+#
+# Flags:
+#   --role gui|daemon|cli|all   (default: all)
+#   --profile <name>            (default: dev; use `default` for the no-suffix dir)
+#   --lines N                   (default: 50 for tail/grep/query, 2000 per-file scan for merge)
+#   --since <ISO8601>           (merge only; drop lines with timestamp < this, UTC lexical compare)
+#
+# Env overrides:
+#   UC_LOG_DIR     full path to the logs dir; bypasses all platform/profile resolution
+#   UC_PROFILE     fallback profile when --profile is omitted (matches the app's env)
+set -euo pipefail
+
+APP_DIR_NAME="app.uniclipboard.desktop"
+
+die() { echo "uc-logs: $*" >&2; exit 1; }
+need() { command -v "$1" >/dev/null 2>&1 || die "missing required tool: $1"; }
+
+# ---- argument parsing -------------------------------------------------------
+CMD="${1:-}"; shift || true
+ROLE="all"
+PROFILE="${UC_PROFILE:-dev}"
+LINES=""
+SINCE=""
+FILTER=""
+PATTERN=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --role)    ROLE="${2:?--role needs a value}"; shift 2 ;;
+    --profile) PROFILE="${2:?--profile needs a value}"; shift 2 ;;
+    --lines)   LINES="${2:?--lines needs a value}"; shift 2 ;;
+    --since)   SINCE="${2:?--since needs a value}"; shift 2 ;;
+    --filter)  FILTER="${2:?--filter needs a value}"; shift 2 ;;
+    --*)       die "unknown flag: $1" ;;
+    *)         PATTERN="$1"; shift ;;
+  esac
+done
+
+case "$ROLE" in gui|daemon|cli|all) ;; *) die "--role must be gui|daemon|cli|all (got: $ROLE)";; esac
+
+# ---- platform / path resolution --------------------------------------------
+app_dir() {
+  if [ "$PROFILE" = "default" ] || [ -z "$PROFILE" ]; then
+    printf '%s' "$APP_DIR_NAME"
+  else
+    printf '%s-%s' "$APP_DIR_NAME" "$PROFILE"
+  fi
+}
+
+# Resolve the logs directory, matching uc_app_paths::app_log_dir().
+log_dir() {
+  if [ -n "${UC_LOG_DIR:-}" ]; then
+    printf '%s' "$UC_LOG_DIR"
+    return
+  fi
+  local app; app="$(app_dir)"
+  case "$(uname -s)" in
+    Darwin)
+      printf '%s/Library/Logs/%s' "$HOME" "$app" ;;
+    Linux)
+      # XDG state dir, fall back to data-local — same order as the Rust side.
+      local base="${XDG_STATE_HOME:-$HOME/.local/state}"
+      if [ ! -d "$base" ]; then base="${XDG_DATA_HOME:-$HOME/.local/share}"; fi
+      printf '%s/%s/logs' "$base" "$app" ;;
+    *)
+      # Windows via git-bash/MSYS; LOCALAPPDATA is set in that environment.
+      if [ -n "${LOCALAPPDATA:-}" ]; then
+        printf '%s/%s/logs' "$LOCALAPPDATA" "$app"
+      else
+        die "cannot resolve LOCALAPPDATA on this platform; set UC_LOG_DIR explicitly"
+      fi ;;
+  esac
+}
+
+role_stem() {
+  case "$1" in
+    gui)    printf 'uniclipboard-gui' ;;
+    daemon) printf 'uniclipboard-daemon' ;;
+    cli)    printf 'uniclipboard-cli' ;;
+  esac
+}
+
+roles() {
+  if [ "$ROLE" = "all" ]; then printf 'gui daemon cli'; else printf '%s' "$ROLE"; fi
+}
+
+# Latest file for a role = highest UTC date in the filename (lexical sort).
+# `|| true` keeps a no-match (ls fails under pipefail) from tripping `set -e`
+# at the `f="$(latest_file ...)"` call sites — a missing role is normal.
+latest_file() {
+  local dir="$1" role="$2" stem; stem="$(role_stem "$role")"
+  { ls -1 "$dir/$stem.json."* 2>/dev/null | sort | tail -1; } || true
+}
+
+mtime_epoch() {
+  case "$(uname -s)" in
+    Darwin) stat -f %m "$1" 2>/dev/null ;;
+    *)      stat -c %Y "$1" 2>/dev/null ;;
+  esac
+}
+
+freshness() {
+  local f="$1" now age m
+  m="$(mtime_epoch "$f")" || { echo "unknown"; return; }
+  [ -n "$m" ] || { echo "unknown"; return; }
+  now="$(date +%s)"; age=$(( now - m ))
+  if   [ "$age" -lt 120 ];  then echo "live (<2m)"
+  elif [ "$age" -lt 600 ];  then echo "recent (<10m)"
+  elif [ "$age" -lt 3600 ]; then echo "stale (<1h)"
+  elif [ "$age" -lt 86400 ]; then echo "old (<1d)"
+  else echo "cold (>1d)"; fi
+}
+
+# ---- commands ---------------------------------------------------------------
+cmd_paths() {
+  local dir; dir="$(log_dir)"
+  echo "profile : $PROFILE"
+  echo "log dir : $dir"
+  [ -d "$dir" ] || { echo "(directory does not exist)"; return; }
+  local r f
+  for r in $(roles); do
+    f="$(latest_file "$dir" "$r")"
+    if [ -n "$f" ]; then echo "$r : $f"; else echo "$r : (no file)"; fi
+  done
+}
+
+cmd_status() {
+  local dir; dir="$(log_dir)"
+  echo "profile : $PROFILE"
+  echo "log dir : $dir"
+  if [ ! -d "$dir" ]; then
+    echo "(directory does not exist — wrong profile, or that role/app never ran here)"
+    echo "hint: try --profile default, or list \$([ -d \"$(dirname "$dir")\" ] && echo siblings)"
+    return
+  fi
+  local r f
+  for r in gui daemon cli; do
+    f="$(latest_file "$dir" "$r")"
+    if [ -n "$f" ]; then
+      printf '%-7s %-14s %s\n' "$r" "$(freshness "$f")" "$(basename "$f")"
+    else
+      printf '%-7s %-14s %s\n' "$r" "-" "(no file)"
+    fi
+  done
+}
+
+# Collect "latest file per selected role" into an array; warn on missing.
+collect_files() {
+  local dir; dir="$(log_dir)"
+  [ -d "$dir" ] || die "log dir does not exist: $dir (run \`status\`; check --profile)"
+  local r f any=0
+  FILES=()
+  for r in $(roles); do
+    f="$(latest_file "$dir" "$r")"
+    if [ -n "$f" ]; then FILES+=("$f"); any=1
+    else echo "uc-logs: no file for role '$r' in $dir" >&2; fi
+  done
+  [ "$any" = 1 ] || die "no log files found for role(s): $(roles)"
+}
+
+cmd_tail() {
+  collect_files
+  local n="${LINES:-50}" f
+  for f in "${FILES[@]}"; do
+    echo "==> $(basename "$f") <=="
+    tail -n "$n" "$f"
+  done
+}
+
+cmd_grep() {
+  [ -n "$PATTERN" ] || die "grep needs a pattern: uc-logs.sh grep <pattern>"
+  collect_files
+  local n="${LINES:-50}" f
+  for f in "${FILES[@]}"; do
+    # Cheap string match first; cap output per file. `|| true`: no-match (grep
+    # exit 1) is a normal result, not a failure that should abort under set -e.
+    { grep -F -- "$PATTERN" "$f" 2>/dev/null | tail -n "$n" || true; } | while IFS= read -r line; do
+      printf '%s\t%s\n' "$(basename "$f")" "$line"
+    done
+  done
+}
+
+cmd_query() {
+  need jq
+  [ -n "$FILTER" ] || die "query needs --filter '<jq>'"
+  collect_files
+  local n="${LINES:-50}" f
+  for f in "${FILES[@]}"; do
+    # `?` swallows per-line errors inside jq; `|| true` covers a non-zero jq
+    # exit (e.g. a malformed line) so set -e doesn't abort the whole run.
+    { tail -n 5000 "$f" | jq -c "select($FILTER)?" 2>/dev/null | tail -n "$n" || true; }
+  done
+}
+
+cmd_merge() {
+  need jq
+  collect_files
+  local per="${LINES:-2000}" f role
+  # Per-file tail bounds the work; inject .role line-by-line (so one malformed
+  # line is skipped, not fatal); then `sort` the whole stream. `timestamp` is
+  # always the first field of every line (FlatJsonFormat), so a plain lexical
+  # sort of UTC ISO-8601 lines is chronological. Finally drop pre-since lines.
+  {
+    for f in "${FILES[@]}"; do
+      role="$(basename "$f" | sed -E 's/^uniclipboard-([a-z]+)\.json\..*/\1/')"
+      tail -n "$per" "$f" | jq -c --arg role "$role" '. + {role: $role}' 2>/dev/null || true
+    done
+  } | sort \
+    | { if [ -n "$SINCE" ]; then jq -c --arg s "$SINCE" 'select(.timestamp >= $s)' 2>/dev/null; else cat; fi; }
+}
+
+case "$CMD" in
+  status) cmd_status ;;
+  paths)  cmd_paths ;;
+  tail)   cmd_tail ;;
+  grep)   cmd_grep ;;
+  query)  cmd_query ;;
+  merge)  cmd_merge ;;
+  ""|-h|--help|help)
+    sed -n '2,40p' "$0" | sed 's/^# \{0,1\}//'
+    ;;
+  *) die "unknown command: $CMD (try: status paths tail grep query merge)" ;;
+esac


### PR DESCRIPTION
## Summary

- **New `local-log-debug` skill** (8460f96): a SKILL.md + `uc-logs.sh` bash helper for reading uniclipboard's per-role JSONL logs on a single machine. Path resolution mirrors `uc_app_paths::app_log_dir()` and file naming mirrors `uc_observability::scope::role_log_file_stem()`, so it reads the exact files the app writes (gui/daemon/cli). Provides `status/paths/tail/grep/query/merge` with a `UC_LOG_DIR` escape hatch. Scoped to single-host analysis — complements `dual-side-debug` (cross-host) and `tracing-best-practices` (writing tracing code).
- **Realign `dual-side-debug` to the post-split layout** (22bbbb9): macOS logs moved to `~/Library/Logs/<app>` with no `logs/` subdir, and files became per-role (`uniclipboard-{gui,daemon,cli}.json.<date>`). Updated `dual-logs.sh` path resolution (the new mac/win `logs/`-subdir asymmetry, a per-role glob that still matches the legacy single-file name) and the SKILL.md layout docs. Also fixed a pre-existing nullglob bug where an empty profile dir made `latest_log_in` list the cwd instead of returning empty.

These are dev-only agent skills under `.claude/skills/` — **no `docs-site/` user-facing surface changes** (scanned; clean).

> Note: the macOS layout that `dual-side-debug` now describes depends on the platform-log-dir migration (PR #1093). These skills are standalone tooling and can merge independently; on a host where #1093 isn't yet present, the legacy single-file name is still matched.

## Test plan

- [x] `bash -n` syntax check on both scripts.
- [x] `uc-logs.sh` verified against this host's real `dev`-profile logs: `status` (3 roles), `merge` (chronological, role-tagged), `query`, `grep`.
- [x] `dual-logs.sh` verified with fixtures simulating the new layout (mac no-`logs`-subdir + win `logs`-subdir, per-role files): `status`, `paths`, `list-profiles`, `tail`, `merge`, `grep`; nullglob fix confirmed (empty profile shows `<empty>`).
- [ ] Run `dual-logs.sh status` on a real macOS host with the SMB-mounted Windows peer — this Linux box can't exercise the BSD `stat` path (verified via a stat shim only).