### PR TITLE
fix(clipboard/linux/x11): poll owner lifetime, not fixed retry window

### DIFF
--- a/.planning/debug/issue-1029-x11-lazy-clipboard/README.md
+++ b/.planning/debug/issue-1029-x11-lazy-clipboard/README.md
@@ -1,0 +1,105 @@
+# #1029 — X11 剪贴板 lazy 供数竞态复现 harness
+
+手动复现 + 回归 harness，用于 issue #1029 的 **文本主线**:Linux 桌面 (GNOME/Wayland
+无 data-control,daemon 回落 XWayland 的 X11 reader) 下，复制 Chrome 地址栏 URL
+**间歇性** 同步失效。
+
+> 这是手动 dev 工具，**不是 CI 测试**:需要一个 X11/XWayland 显示和 `python3-xlib`。
+> 纯逻辑 (退避判定) 的可移植单测在
+> `crates/uc-platform/src/clipboard/platform/linux/x11/event_loop.rs` 的 `tests` 模块里。
+
+## 竞态根因 (一句话)
+
+X11/ICCCM 下，「同一个 owner 已持有 selection、之后 **追加** target」**不发任何事件**。
+Chrome(经 XWayland 桥) 复制后立刻 own CLIPBOARD(发一次 XFIXES),但那一瞬只
+advertise 私有 target(如 `chromium/x-source-url`),`text/plain` 晚几十~几百 ms
+才补上——**补的时候不重新 own，所以没有第二次 XFIXES**。晚到的 `text/plain` 再也
+不会触发读取 → 这次复制永久丢失。
+
+`#1054` 加的「固定 3×150ms 重试」(≈300ms 窗口) 只能救「窗口内补上」的;窗口外补上
+的救不了。本目录的 harness 就是把这个时序竞态做成可控、可回归的最小模型。
+
+## 修复 (本 PR)
+
+`event_loop.rs::read_changed_selection` 把固定 3×150ms 重试换成**绑 owner 生命周期的
+自适应退避轮询**:记录触发本轮的 owner，只要它仍持有 selection 就以指数退避
+(150→300→500ms，封顶) 持续重读，直到：
+
+1. 读到非空 → 成功;
+2. owner 变成别的 client → 放弃 (新 owner 会自己发 XFIXES 触发新一轮);
+3. owner 变 NONE(清空)→ 放弃 (合法清空);
+4. 撞到 3s 硬上限 (`CHANGE_POLL_DEADLINE`)→ 放弃 (owner 对这次 ownership 始终只给
+   私有/无法解码的格式)。
+
+诚实边界:3s 仍是上限，但语义从「赌 300ms 内补上」变成「陪等到 owner 放手或 3s」,
+鲁棒性高一个量级。供数延迟 > 3s 仍会丢——这是正确行为。
+
+## 文件
+
+| 文件 | 作用 |
+| --- | --- |
+| `lazy_owner.py` | python-xlib 写的「慢供数」X11 selection owner:own CLIPBOARD，先只 advertise 私有 `chromium/x-source-url`,`DELAY_MS` 后才补 `UTF8_STRING` + `text/plain;charset=utf-8`,**补时不重新 own**。Chrome lazy 供数的最小模型。 |
+| `repro.sh` | 编排：起 `uniclip probe watch` → 起 `lazy_owner.py <DELAY>` → 等待 → 收尾 → 判定捕获/丢失。无参跑默认矩阵，或传 `<DELAY_MS>:<WAIT_S>`。 |
+
+## 运行环境
+
+- 一个 X11/XWayland 显示 (`DISPLAY=:0`)。开发验证用的是 **niri(wlroots 系)+
+  `xwayland-satellite`** 提供的 `:0`(无需 X auth,`Gdk.Display.open(":0")` 直连)。
+  GNOME-on-Wayland 本身也是经 XWayland 桥跑同一条 `x11/reader.rs`,所以同样能复现。
+- `python3-xlib`(开发机为 0.33)。
+- debug 版 `uniclip`,带 `dev-tools` feature:
+
+  ```bash
+  cargo build -p uc-cli --features dev-tools
+  ```
+
+  `probe watch` 内部用的就是 daemon 同款 `build_event_loop()` + 本次修改的 watcher,
+  所以 **不用跑完整 daemon** 就能验证读取行为。
+
+> `repro.sh` 会强制 `unset WAYLAND_DISPLAY; export DISPLAY=:0`,把 daemon 逼上 X11
+> reader(#1029 的真实路径)。若保留 `WAYLAND_DISPLAY`,wlroots 桌面会走原生
+> Wayland data-control(`wayland/snapshot.rs`),那不是本竞态要测的路径。
+
+## 用法
+
+```bash
+# 默认矩阵:100 1000 2000 2500 3500 ms
+.planning/debug/issue-1029-x11-lazy-clipboard/repro.sh
+
+# 指定用例:<DELAY_MS>:<收尾前等待秒数>
+.planning/debug/issue-1029-x11-lazy-clipboard/repro.sh 1000:5 3500:6
+
+# repo 路径 / 二进制路径可覆盖
+UC_REPO=~/projects/UniClipboard UC_PROBE=/path/to/uniclip repro.sh
+```
+
+**判定信号**:`uniclip probe watch` 会为每次捕获的 snapshot 打印自己的 `event #N` 行;
+`lazy_owner.py` 供的就是固定 URL `http://example.com/lazy-chrome-url-AABBCC`,所以日志里
+**出现该 URL = 捕获成功，没出现 = 丢失**。注意 `probe` **不输出** `uc_platform` 的
+tracing 日志，所以 grep `clipboard change lost` / `recovered after retry` 是抓不到的，
+要看 URL 标记。
+
+## 实测 before/after(Fedora 44 aarch64,niri + xwayland-satellite,`:0`)
+
+同一台机、同一 harness，只换二进制：
+
+| 供数延迟 DELAY | BEFORE(`origin/main`,3×150ms 固定重试) | AFTER(本 PR,owner 生命周期退避 + 3s 上限) |
+| --- | --- | --- |
+| 100 ms  | ✅ 捕获 (落在 ~300ms 窗口内) | ✅ 捕获 |
+| 1000 ms | ❌ **丢失** | ✅ **捕获** |
+| 2000 ms | —(必丢) | ✅ 捕获 |
+| 2500 ms | ❌ **丢失** | ✅ 捕获 |
+| 3500 ms | —(必丢) | ❌ 丢失 (> 3s 上限，诚实边界) |
+
+结论：修复把可救回窗口从 ~300ms 拉到 ~3s(且全程盯同一 owner，不再赌 XFIXES),
+3500ms 仍丢恰好证明上限是真实边界而非无限轮询。
+
+## 已知限制 / 后续
+
+- 供数延迟 > `CHANGE_POLL_DEADLINE`(3s) 仍丢。真实 Chrome 的补数延迟远低于此;若现场
+  日志出现 3s+ 的极端 case，再考虑调大上限或做非阻塞重构。
+- **非阻塞重构**(把长轮询移出主 event-loop 阻塞路径) 本次 **未做**:阻塞期间 (≤3s)
+  新 owner-change 的 XFIXES 在 X 连接缓冲排队，读完即处理;「owner 变更提前退出」也能
+  缓解快速连续复制时的阻塞。如需进一步降低快速连复制的延迟，这是下一步。
+- 结构性根因 (GNOME 不给 data-control → 被迫走 XWayland) 不在本修复范围;这里是把
+  XWayland 这条既有路径加固到鲁棒。

--- a/.planning/debug/issue-1029-x11-lazy-clipboard/lazy_owner.py
+++ b/.planning/debug/issue-1029-x11-lazy-clipboard/lazy_owner.py
@@ -1,0 +1,59 @@
+# Simulates an XWayland-bridged Chrome that supplies clipboard data LAZILY:
+# owns CLIPBOARD immediately (one XFIXES notify), but only advertises a private
+# target at first; text/plain becomes available DELAY_MS later, WITHOUT
+# re-asserting ownership (so no new XFIXES). Reproduces the #1029 race.
+import sys, time, threading
+from Xlib import X, display, Xatom
+from Xlib.protocol import event as Xevent
+
+DELAY_MS = int(sys.argv[1]) if len(sys.argv) > 1 else 1000
+TEXT = b"http://example.com/lazy-chrome-url-AABBCC"
+
+d = display.Display()
+root = d.screen().root
+win = root.create_window(0, 0, 1, 1, 0, d.screen().root_depth,
+                         X.InputOutput, X.CopyFromParent,
+                         event_mask=X.PropertyChangeMask)
+
+def atom(n): return d.get_atom(n)
+CLIPBOARD = atom("CLIPBOARD"); TARGETS = atom("TARGETS"); TIMESTAMP = atom("TIMESTAMP")
+UTF8 = atom("UTF8_STRING"); TPLAIN = atom("text/plain;charset=utf-8")
+PRIVATE = atom("chromium/x-source-url")
+
+ready = [False]
+win.set_selection_owner(CLIPBOARD, X.CurrentTime)
+d.sync()
+print(f"owner set; own_ok={d.get_selection_owner(CLIPBOARD)==win}; text/plain in {DELAY_MS}ms", flush=True)
+
+def flip():
+    time.sleep(DELAY_MS/1000.0)
+    ready[0] = True
+    print(f"[t={DELAY_MS}ms] text/plain NOW available (no new XFIXES)", flush=True)
+threading.Thread(target=flip, daemon=True).start()
+
+while True:
+    e = d.next_event()
+    if e.type != X.SelectionRequest:
+        continue
+    target = e.target
+    prop = e.property if e.property != X.NONE else e.target
+    req = e.requestor
+    filled = False
+    name = d.get_atom_name(target)
+    if target == TARGETS:
+        lst = [TIMESTAMP, TARGETS, PRIVATE]
+        if ready[0]:
+            lst += [UTF8, TPLAIN]
+        req.change_property(prop, Xatom.ATOM, 32, lst)
+        filled = True
+    elif target in (UTF8, TPLAIN):
+        if ready[0]:
+            req.change_property(prop, target, 8, TEXT)
+            filled = True
+    elif target == TIMESTAMP:
+        req.change_property(prop, Xatom.INTEGER, 32, [0]); filled = True
+    print(f"  req target={name} ready={ready[0]} filled={filled}", flush=True)
+    n = Xevent.SelectionNotify(time=e.time, requestor=req, selection=e.selection,
+                               target=target, property=(prop if filled else X.NONE))
+    req.send_event(n, propagate=False)
+    d.flush()

--- a/.planning/debug/issue-1029-x11-lazy-clipboard/repro.sh
+++ b/.planning/debug/issue-1029-x11-lazy-clipboard/repro.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# Repro / regression harness for the #1029 X11 lazy-clipboard race.
+#
+# Drives `uniclip probe watch` (daemon-identical event loop) against
+# lazy_owner.py, which owns CLIPBOARD immediately but only serves text/plain
+# DELAY_MS later WITHOUT re-asserting ownership (no second XFIXES). The fixed
+# 3x150ms retry lost any delay beyond ~300ms; the owner-lifetime backoff poll
+# recovers anything within CHANGE_POLL_DEADLINE (3s).
+#
+# Verdict signal: `uniclip probe watch` prints its own "event #N" lines for
+# every captured snapshot. lazy_owner.py serves the literal URL below, so a
+# log line containing it == the copy was captured. Its absence == lost.
+# (probe does not emit uc_platform tracing logs, so grepping for
+# "clipboard change lost" / "recovered after retry" finds nothing — use the
+# URL marker.)
+#
+# Requirements (see README.md):
+#   - an XWayland / X11 display at :0 (e.g. niri + xwayland-satellite, or any
+#     real X server). GNOME-on-Wayland reproduces via its XWayland bridge too.
+#   - python3-xlib
+#   - a debug uniclip built with dev-tools:
+#       cargo build -p uc-cli --features dev-tools
+#
+# Usage:
+#   ./repro.sh                       # default matrix: 100 1000 2000 2500 3500
+#   ./repro.sh 1000:5 3500:6         # explicit <DELAY_MS>:<POST_OWNER_WAIT_S>
+set +e
+
+REPO="${UC_REPO:-$HOME/projects/UniClipboard}"
+PROBE="${UC_PROBE:-$REPO/target/debug/uniclip}"
+OWNER="$(dirname "$0")/lazy_owner.py"
+URL_MARKER="http://example.com/lazy-chrome-url-AABBCC"
+
+# Force the X11 reader even on a Wayland session (this is the #1029 path).
+export DISPLAY="${DISPLAY:-:0}"
+unset WAYLAND_DISPLAY
+
+run_case() {
+  local D=$1
+  local WAIT=$2
+  pkill -f lazy_owner.py 2>/dev/null; pkill -f "probe watch" 2>/dev/null; sleep 0.5
+  RUST_LOG=uc_platform=info "$PROBE" probe watch -v >"/tmp/watch_${D}.log" 2>&1 </dev/null &
+  local WPID=$!
+  sleep 2                       # let the watcher subscribe XFIXES first
+  python3 "$OWNER" "${D}" >"/tmp/owner_${D}.log" 2>&1 </dev/null &
+  local OPID=$!
+  sleep "${WAIT}"               # owner triggers; flips text/plain at D ms
+  kill "$OPID" "$WPID" 2>/dev/null
+  pkill -f lazy_owner.py 2>/dev/null; pkill -f "probe watch" 2>/dev/null; sleep 0.5
+  echo "########## DELAY = ${D} ms (post-owner wait ${WAIT}s) ##########"
+  if grep -aq "$URL_MARKER" "/tmp/watch_${D}.log"; then
+    echo "RESULT: CAPTURED"
+  else
+    echo "RESULT: LOST (no captured event carried the lazy URL)"
+  fi
+}
+
+cases=("$@")
+if [ ${#cases[@]} -eq 0 ]; then
+  cases=(100:5 1000:5 2000:5 2500:5 3500:6)
+fi
+for arg in "${cases[@]}"; do
+  D="${arg%%:*}"
+  W="${arg##*:}"
+  [ "$W" = "$arg" ] && W=5      # bare "1000" -> default 5s wait
+  run_case "$D" "$W"
+  echo
+done
+echo "===== DONE ====="

--- a/crates/uc-platform/src/clipboard/platform/linux/x11/event_loop.rs
+++ b/crates/uc-platform/src/clipboard/platform/linux/x11/event_loop.rs
@@ -12,7 +12,7 @@
 //! timeout + Condvar check.
 
 use std::os::fd::{AsFd, BorrowedFd};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result};
 use rustix::event::{poll, PollFd, PollFlags};
@@ -32,16 +32,25 @@ use super::reader::{read_snapshot, ReadContext};
 /// (extremely unusual). 250 ms keeps us reactive without burning CPU.
 const FALLBACK_POLL_TIMEOUT_MS: i32 = 250;
 
-/// Total read attempts after a selection-change notification when the read
-/// keeps coming back empty. Chromium (reached through the XWayland
-/// selection bridge) is known to refuse or serve empty payloads for a short
-/// window right after a copy; a couple of short retries absorbs that
-/// (issue #1029).
-const CHANGE_READ_ATTEMPTS: u32 = 3;
+/// Hard upper bound for polling a single selection ownership after a change
+/// notification. X11/ICCCM emits no event when an owner that already holds
+/// the selection later *adds* targets — Chromium reached through the
+/// XWayland bridge advertises a private target first and only fills in
+/// `text/plain` a beat later (issue #1029). So once an owner takes over we
+/// poll it ourselves until it serves readable content, releases the
+/// selection, or this budget elapses. The cap stops us polling forever when
+/// an owner only ever offers private / undecodable formats.
+const CHANGE_POLL_DEADLINE: Duration = Duration::from_secs(3);
 
-/// Pause between those attempts. Long enough for the owner to finish
-/// installing its offer, short enough to keep capture latency negligible.
-const CHANGE_READ_RETRY_DELAY: Duration = Duration::from_millis(150);
+/// First backoff between empty reads while the same owner keeps holding the
+/// selection. Short enough that the common case (data ready within a couple
+/// hundred ms) is captured with negligible latency.
+const CHANGE_POLL_INITIAL_DELAY: Duration = Duration::from_millis(150);
+
+/// Backoff cap. The interval doubles (150 → 300 → 500 …) up to this value so
+/// the tail of the poll window stays dense — a late `text/plain` is picked
+/// up within at most this long of becoming available.
+const CHANGE_POLL_MAX_DELAY: Duration = Duration::from_millis(500);
 
 pub(crate) struct X11EventLoop {
     server: X11Server,
@@ -187,8 +196,17 @@ impl PlatformClipboardEventLoop for X11EventLoop {
     }
 }
 
-/// Read the selection after a change notification, retrying a bounded
-/// number of times when the read comes back empty while an owner exists.
+/// Read the selection after a change notification, polling the triggering
+/// owner across its lifetime until it serves readable content, releases the
+/// selection, or [`CHANGE_POLL_DEADLINE`] elapses.
+///
+/// X11 fires no event when an owner that already holds the selection later
+/// adds targets, so a fixed short retry window misses an owner that supplies
+/// data lazily (issue #1029). Instead we record the owner this notification
+/// is about and re-read with exponential backoff for as long as that same
+/// owner keeps the selection. A *different* owner (or a clear) ends the
+/// round: its own `XfixesSelectionNotify` drives a fresh read, so chasing it
+/// here would be redundant.
 ///
 /// Returns true when a further selection change was observed (and
 /// necessarily consumed) during one of the reads — the caller must loop
@@ -199,7 +217,18 @@ fn read_changed_selection(
     shutdown_rx: &ShutdownRx,
 ) -> bool {
     let ctx = ReadContext::new(None);
-    for attempt in 1..=CHANGE_READ_ATTEMPTS {
+    // The owner this notification is about. A query failure reads as NONE,
+    // which the first empty read treats as a legitimate clear.
+    let initial_owner = current_selection_owner(server);
+    let deadline = Instant::now() + CHANGE_POLL_DEADLINE;
+    let mut delay = CHANGE_POLL_INITIAL_DELAY;
+    let mut attempt: u32 = 0;
+
+    loop {
+        if shutdown_rx.is_signaled() {
+            return ctx.take_selection_changed();
+        }
+        attempt += 1;
         match read_snapshot(server, &ctx) {
             Ok(snap) if !snap.representations.is_empty() => {
                 if attempt > 1 {
@@ -209,24 +238,34 @@ fn read_changed_selection(
                 return ctx.take_selection_changed();
             }
             Ok(_) => {
-                // Empty with no owner is a legitimate cleared clipboard —
-                // not worth retrying or warning about.
-                if current_selection_owner(server) == x11rb::NONE {
-                    info!("x11 watcher: selection has no owner (cleared); nothing to capture");
-                    return ctx.take_selection_changed();
+                let current_owner = current_selection_owner(server);
+                let now = Instant::now();
+                match poll_outcome(initial_owner, current_owner, now >= deadline) {
+                    PollOutcome::Cleared => {
+                        info!("x11 watcher: selection has no owner (cleared); nothing to capture");
+                        return ctx.take_selection_changed();
+                    }
+                    PollOutcome::OwnerChanged => {
+                        debug!(
+                            "x11 watcher: selection owner changed during poll; deferring to \
+                             the new owner's change notification"
+                        );
+                        return ctx.take_selection_changed();
+                    }
+                    PollOutcome::Expired => break,
+                    PollOutcome::KeepPolling => {
+                        // Never sleep past the deadline so the final read lands
+                        // right at the budget edge rather than beyond it.
+                        let nap = delay.min(deadline.saturating_duration_since(now));
+                        debug!(
+                            attempt,
+                            retry_delay_ms = nap.as_millis() as u64,
+                            "x11 watcher: empty snapshot; owner still holds selection, backing off"
+                        );
+                        std::thread::sleep(nap);
+                        delay = next_poll_delay(delay);
+                    }
                 }
-                if shutdown_rx.is_signaled() {
-                    return ctx.take_selection_changed();
-                }
-                if attempt == CHANGE_READ_ATTEMPTS {
-                    break;
-                }
-                debug!(
-                    attempt,
-                    retry_delay_ms = CHANGE_READ_RETRY_DELAY.as_millis() as u64,
-                    "x11 watcher: empty snapshot after selection change; retrying"
-                );
-                std::thread::sleep(CHANGE_READ_RETRY_DELAY);
             }
             Err(e) => {
                 warn!(
@@ -239,13 +278,57 @@ fn read_changed_selection(
             }
         }
     }
+
     warn!(
-        attempts = CHANGE_READ_ATTEMPTS,
+        attempts = attempt,
+        budget_ms = CHANGE_POLL_DEADLINE.as_millis() as u64,
         error_kind = "x11_selection_read_empty",
-        "x11 watcher: selection changed but no readable content (owner refused, timed out, \
-         or offered no interesting mimes) — clipboard change lost"
+        "x11 watcher: owner held the selection for the whole poll window but never served \
+         readable content (offered only private / undecodable mimes, refused, or timed out) \
+         — clipboard change lost"
     );
     ctx.take_selection_changed()
+}
+
+/// What to do after an empty read while polling a single ownership. See
+/// [`poll_outcome`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PollOutcome {
+    /// No owner holds the selection — a legitimate clear; nothing to capture.
+    Cleared,
+    /// A different client now owns the selection; its own change
+    /// notification will drive a fresh read, so this round stops.
+    OwnerChanged,
+    /// The triggering owner still holds the selection but hasn't served any
+    /// readable content yet — keep waiting.
+    KeepPolling,
+    /// The triggering owner held the selection for the whole budget without
+    /// ever serving readable content — give up (treated as a lost change).
+    Expired,
+}
+
+/// Decide what to do after an empty read while polling a single ownership.
+///
+/// `initial_owner` is the owner observed when the poll round began (the one
+/// the triggering notification is about); `current_owner` is the owner now.
+/// Clear and owner-change are reported ahead of budget expiry so the log
+/// names the real reason the round ended rather than a misleading timeout.
+fn poll_outcome(initial_owner: u32, current_owner: u32, budget_exhausted: bool) -> PollOutcome {
+    if current_owner == x11rb::NONE {
+        PollOutcome::Cleared
+    } else if current_owner != initial_owner {
+        PollOutcome::OwnerChanged
+    } else if budget_exhausted {
+        PollOutcome::Expired
+    } else {
+        PollOutcome::KeepPolling
+    }
+}
+
+/// Next backoff interval: double the current one, capped at
+/// [`CHANGE_POLL_MAX_DELAY`].
+fn next_poll_delay(current: Duration) -> Duration {
+    (current * 2).min(CHANGE_POLL_MAX_DELAY)
 }
 
 /// Best-effort, diagnostics-only human description of an X11 window: its
@@ -275,9 +358,9 @@ fn describe_window<C: Connection>(conn: &C, window: u32) -> String {
     }
 }
 
-/// Current owner window of `CLIPBOARD`, or `x11rb::NONE` when unowned or
-/// the query fails (treated as unowned — the caller only uses this to
-/// decide whether an empty read is worth retrying).
+/// Current owner window of `CLIPBOARD`, or `x11rb::NONE` when unowned or the
+/// query fails (treated as unowned). The poll loop uses this both to detect a
+/// legitimate clear and to tell whether the owner it is polling has changed.
 fn current_selection_owner(server: &X11Server) -> u32 {
     server
         .conn
@@ -286,4 +369,97 @@ fn current_selection_owner(server: &X11Server) -> u32 {
         .and_then(|cookie| cookie.reply().ok())
         .map(|reply| reply.owner)
         .unwrap_or(x11rb::NONE)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Distinct non-NONE owner window ids for the decision-function tests.
+    const OWNER_A: u32 = 0x0100_0001;
+    const OWNER_B: u32 = 0x0200_0002;
+
+    #[test]
+    fn poll_outcome_keeps_polling_same_owner_within_budget() {
+        // The lazy-supply case (#1029): same owner, still empty, budget left.
+        assert_eq!(
+            poll_outcome(OWNER_A, OWNER_A, false),
+            PollOutcome::KeepPolling
+        );
+    }
+
+    #[test]
+    fn poll_outcome_expires_when_same_owner_exhausts_budget() {
+        assert_eq!(poll_outcome(OWNER_A, OWNER_A, true), PollOutcome::Expired);
+    }
+
+    #[test]
+    fn poll_outcome_reports_clear_regardless_of_budget() {
+        assert_eq!(
+            poll_outcome(OWNER_A, x11rb::NONE, false),
+            PollOutcome::Cleared
+        );
+        assert_eq!(
+            poll_outcome(OWNER_A, x11rb::NONE, true),
+            PollOutcome::Cleared
+        );
+    }
+
+    #[test]
+    fn poll_outcome_defers_to_new_owner_regardless_of_budget() {
+        // A different live owner took over: stop polling the old ownership
+        // even with budget to spare — the new owner fires its own notify.
+        assert_eq!(
+            poll_outcome(OWNER_A, OWNER_B, false),
+            PollOutcome::OwnerChanged
+        );
+        assert_eq!(
+            poll_outcome(OWNER_A, OWNER_B, true),
+            PollOutcome::OwnerChanged
+        );
+    }
+
+    #[test]
+    fn poll_outcome_clear_takes_precedence_over_expiry() {
+        // Ordering guarantee: an owner that vanished right as the budget ran
+        // out is a clear (not a lost change), so the log isn't misleading.
+        assert_eq!(
+            poll_outcome(OWNER_A, x11rb::NONE, true),
+            PollOutcome::Cleared
+        );
+    }
+
+    #[test]
+    fn next_poll_delay_doubles_then_caps() {
+        let d0 = CHANGE_POLL_INITIAL_DELAY;
+        assert_eq!(d0, Duration::from_millis(150));
+        let d1 = next_poll_delay(d0);
+        assert_eq!(d1, Duration::from_millis(300));
+        // 600 ms would exceed the cap, so it clamps to CHANGE_POLL_MAX_DELAY…
+        let d2 = next_poll_delay(d1);
+        assert_eq!(d2, CHANGE_POLL_MAX_DELAY);
+        // …and stays there.
+        let d3 = next_poll_delay(d2);
+        assert_eq!(d3, CHANGE_POLL_MAX_DELAY);
+    }
+
+    #[test]
+    fn poll_schedule_fits_several_dense_reads_inside_budget() {
+        // Sanity-check the schedule the loop will follow: count the reads
+        // that start before the deadline. The capped tail must keep reads
+        // dense enough that late data is caught within CHANGE_POLL_MAX_DELAY.
+        let mut delay = CHANGE_POLL_INITIAL_DELAY;
+        let mut elapsed = Duration::ZERO;
+        let mut reads = 1; // the first read is immediate
+        while elapsed + delay <= CHANGE_POLL_DEADLINE {
+            elapsed += delay;
+            reads += 1;
+            delay = next_poll_delay(delay);
+        }
+        assert!(
+            reads >= 7,
+            "expected the 3s window to allow >=7 reads, got {reads}"
+        );
+        assert!(CHANGE_POLL_MAX_DELAY <= Duration::from_millis(500));
+    }
 }


### PR DESCRIPTION
> 🤖 此 PR 由 AI (Claude Code) 辅助创建。

## Summary

- **Root cause (#1029):** under GNOME/Wayland (no `data-control`) the daemon falls back to the XWayland X11 reader. X11/ICCCM fires **no event** when an owner that already holds `CLIPBOARD` later *adds* targets — Chromium advertises a private target first and fills in `text/plain` a beat later, so the `#1054` fixed `3×150ms` (~300ms) retry window missed any owner that supplied text after it elapsed: the late `text/plain` never triggered another read and the copy was lost.
- **Fix (47c0d95):** `read_changed_selection` now records the owner the notification is about and re-reads with exponential backoff (`150→300→500ms`, capped) for as long as **that same owner** keeps the selection, stopping early on clear / owner-change (the new owner fires its own notification) and giving up at a `3s` hard cap. The stop/continue decision is a pure `poll_outcome` fn, unit-tested without an X server. The old fixed-window retry is removed entirely — no parallel old/new path.
- **Harness (e71d880):** archives the manual repro out of `/tmp` into `.planning/debug/issue-1029-x11-lazy-clipboard/` (lazy-supply owner model + orchestrator + README with the before/after table).

Honest boundary: `3s` is still a cap, but the semantics shift from "bet text/plain lands within 300ms" to "wait until the owner releases the selection or 3s elapses" — robust by an order of magnitude. Supply delays beyond the cap still time out, which is correct. The structural root cause (GNOME not exposing `data-control`) is out of scope; this hardens the existing XWayland path.

Refs #1029 (mitigates the reported text loss; not auto-closing — leaving the structural GNOME `data-control` gap for the maintainer to judge).

## Test plan

- [x] `cargo test -p uc-platform --lib event_loop::tests` — 7 new `poll_outcome` / `next_poll_delay` / schedule unit tests pass (Fedora rustc 1.95.0).
- [x] Built `uniclip --features dev-tools` and ran the repro harness on a Fedora 44 XWayland `:0` reader (niri + xwayland-satellite — same `x11/reader.rs` path GNOME uses). Same machine, swapping only the binary:
  - BEFORE (`origin/main`, 3×150ms): supply delays **1000 / 2500ms lost**; 100ms captured.
  - AFTER (this PR): **1000 / 2000 / 2500ms all recover**; 100ms captured; only 3500ms (> 3s cap) dropped — proving the cap is a real boundary, not infinite polling.
- [ ] Field confirmation on the actual #1029 reporter env (Debian 13 + GNOME + Wayland): verify the intermittent Chrome address-bar URL loss is gone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Linux (X11) clipboard handling with enhanced selection change detection and more robust retry logic to ensure clipboard content arrives reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->