### PR TITLE
refactor(cli): rename mobile-sync to mobile, simplify setup to multi-address

### DIFF
--- a/apps/cli/src/commands/mobile_sync/debug.rs
+++ b/apps/cli/src/commands/mobile_sync/debug.rs
@@ -1,4 +1,4 @@
-//! `uniclip mobile-sync debug ...` —— SyncClipboard 协议链路的本地回归命令。
+//! `uniclip mobile debug ...` —— SyncClipboard 协议链路的本地回归命令。
 //!
 //! P5a.9 引入,便于无 iPhone 时手动验证整条 SyncClipboard 协议链路。
 //! 全部 4 个子命令 **绕过 HTTP** 直接调 [`MobileSyncFacade`],模拟 iPhone

--- a/apps/cli/src/commands/mobile_sync/disable.rs
+++ b/apps/cli/src/commands/mobile_sync/disable.rs
@@ -18,7 +18,7 @@ struct DisableResult {
 }
 
 pub async fn run(json: bool, verbose: bool) -> i32 {
-    let ctx = match shared::enter("Mobile-sync disable", json, verbose).await {
+    let ctx = match shared::enter("Mobile disable", json, verbose).await {
         Ok(c) => c,
         Err(code) => return code,
     };

--- a/apps/cli/src/commands/mobile_sync/disable.rs
+++ b/apps/cli/src/commands/mobile_sync/disable.rs
@@ -1,4 +1,4 @@
-//! `uniclip mobile-sync disable` — one-shot disable: master switch off + LAN off.
+//! `uniclip mobile disable` — one-shot disable: master switch off + LAN off.
 //!
 //! Routes through daemon HTTP endpoints (P5-2b ADR).
 
@@ -46,7 +46,7 @@ pub async fn run(json: bool, verbose: bool) -> i32 {
                 ui::info(
                     "note",
                     "Paired devices remain registered. Revoke individually with \
-                     `uniclip mobile-sync revoke`.",
+                     `uniclip mobile revoke`.",
                 );
                 if out.restart_required {
                     ui::warn(shared::restart_hint());

--- a/apps/cli/src/commands/mobile_sync/mod.rs
+++ b/apps/cli/src/commands/mobile_sync/mod.rs
@@ -1,4 +1,5 @@
-//! `uniclip mobile-sync` —— 移动端同步管理命令组。
+//! `uniclip mobile` —— 移动端同步管理命令组(旧名 `mobile-sync` 仍作为隐藏
+//! 弃用别名保留,调用时打印迁移提示,见 `main.rs` 的 dispatcher)。
 //!
 //! 任务导向的命令拓扑 —— 顶层只暴露用户高频动作,网络细节收进 `network`:
 //!

--- a/apps/cli/src/commands/mobile_sync/network.rs
+++ b/apps/cli/src/commands/mobile_sync/network.rs
@@ -129,7 +129,7 @@ async fn set(
     verbose: bool,
 ) -> i32 {
     if !json {
-        ui::header("Mobile-sync network set");
+        ui::header("Mobile network set");
     }
 
     // Translate the advertise choice into the two persisted fields.
@@ -226,7 +226,7 @@ struct DisableResult {
 }
 
 async fn off(json: bool, verbose: bool) -> i32 {
-    let ctx = match shared::enter("Mobile-sync network off", json, verbose).await {
+    let ctx = match shared::enter("Mobile network off", json, verbose).await {
         Ok(c) => c,
         Err(code) => return code,
     };

--- a/apps/cli/src/commands/mobile_sync/network.rs
+++ b/apps/cli/src/commands/mobile_sync/network.rs
@@ -1,4 +1,4 @@
-//! `uniclip mobile-sync network ...` — LAN listener advanced configuration.
+//! `uniclip mobile network ...` — LAN listener advanced configuration.
 //!
 //! Routes through daemon HTTP endpoints (P5-2b ADR).
 

--- a/apps/cli/src/commands/mobile_sync/setup.rs
+++ b/apps/cli/src/commands/mobile_sync/setup.rs
@@ -14,11 +14,6 @@ use crate::commands::mobile_sync::shared;
 use crate::exit_codes;
 use crate::ui;
 
-/// SPEC §3.2 default LAN port. `setup` provisions this explicitly so the
-/// persisted port is inspectable, rather than relying on the daemon's silent
-/// fallback for an unset value.
-const DEFAULT_LAN_PORT: u16 = 42720;
-
 #[derive(Args, Debug)]
 pub struct SetupArgs {
     /// Human-readable device label, e.g. "My iPhone 15". Required in
@@ -81,7 +76,7 @@ struct SetupResult {
 
 pub async fn run(args: SetupArgs, json: bool, verbose: bool) -> i32 {
     if !json {
-        ui::header("Mobile-sync setup");
+        ui::header("Mobile setup");
     }
 
     // JSON mode is implicitly non-interactive — no terminal prompt is safe
@@ -185,19 +180,20 @@ pub async fn run(args: SetupArgs, json: bool, verbose: bool) -> i32 {
 
     // 8. Apply settings: enable feature + LAN listener. Mirrors the GUI's
     // one-click enable — we flip the switches and let the QR carry every
-    // detected interface. `--ip` is an optional advanced pin: patched only
-    // when given (`None` ⇒ leave unchanged), otherwise the QR auto-collects
-    // all interfaces. The port is provisioned explicitly (default 42720) so
-    // the persisted setting is inspectable. `lan_advertise_base_url` is left
-    // untouched — multi-address QRs happily carry a reverse-proxy entry
-    // alongside the LAN IPs, so there is no longer anything to clear.
+    // detected interface. `--ip` / `--port` are optional advanced pins:
+    // patched only when given (`None` ⇒ leave unchanged), so re-running
+    // `setup` never resets a previously configured port. An unset port falls
+    // back to the SPEC default (42720) at advertise time.
+    // `lan_advertise_base_url` is left untouched — multi-address QRs happily
+    // carry a reverse-proxy entry alongside the LAN IPs, so there is no longer
+    // anything to clear.
     let upd = match ctx
         .client
         .update_settings(&UpdateMobileSyncSettingsRequest {
             enabled: Some(true),
             lan_listen_enabled: Some(true),
             lan_advertise_ip: args.ip.clone().map(Some),
-            lan_port: Some(Some(args.port.unwrap_or(DEFAULT_LAN_PORT))),
+            lan_port: args.port.map(Some),
             lan_advertise_base_url: None,
         })
         .await

--- a/apps/cli/src/commands/mobile_sync/setup.rs
+++ b/apps/cli/src/commands/mobile_sync/setup.rs
@@ -1,4 +1,4 @@
-//! `uniclip mobile-sync setup` — one-shot setup wizard.
+//! `uniclip mobile setup` — one-shot setup wizard.
 //!
 //! Routes through daemon HTTP endpoints (P5-2b ADR) instead of in-process
 //! facade calls.
@@ -7,14 +7,16 @@ use clap::Args;
 use serde::Serialize;
 
 use uc_daemon_contract::api::dto::mobile_sync::{
-    LanInterfaceViewDto, RegisterMobileDeviceRequest, UpdateMobileSyncSettingsRequest,
+    RegisterMobileDeviceRequest, UpdateMobileSyncSettingsRequest,
 };
 
 use crate::commands::mobile_sync::shared;
 use crate::exit_codes;
 use crate::ui;
 
-/// SPEC §3.2 default LAN port.
+/// SPEC §3.2 default LAN port. `setup` provisions this explicitly so the
+/// persisted port is inspectable, rather than relying on the daemon's silent
+/// fallback for an unset value.
 const DEFAULT_LAN_PORT: u16 = 42720;
 
 #[derive(Args, Debug)]
@@ -24,13 +26,15 @@ pub struct SetupArgs {
     #[arg(long)]
     pub label: Option<String>,
 
-    /// LAN IPv4 to embed in the install URL (e.g. `192.168.1.5`).
-    /// Required in `--non-interactive` / `--json` mode; otherwise picked
-    /// interactively from the RFC1918 candidate list.
+    /// Optional advanced override: pin one LAN IPv4 (e.g. `192.168.1.5`) to
+    /// the front of the QR's address list. Leave unset and the QR carries
+    /// every detected LAN interface automatically — the scanning client
+    /// probes each in turn, so there is normally nothing to pick.
     #[arg(long, value_name = "IP")]
     pub ip: Option<String>,
 
-    /// Custom port for the LAN listener; defaults to 42720.
+    /// Optional advanced override: custom LAN listener port. Leave unset to
+    /// keep the existing / default port (42720).
     #[arg(long, value_name = "PORT")]
     pub port: Option<u16>,
 
@@ -51,9 +55,9 @@ pub struct SetupArgs {
     #[arg(long)]
     pub accept_network_risk: bool,
 
-    /// Skip all interactive prompts. `--label`, `--ip`,
-    /// `--accept-network-risk` must all be given. `--username` /
-    /// `--password-stdin` remain optional (default to auto-mint).
+    /// Skip all interactive prompts. `--label` and `--accept-network-risk`
+    /// must be given. `--ip` / `--port` / `--username` / `--password-stdin`
+    /// remain optional (IP/port keep defaults, credentials auto-mint).
     #[arg(long)]
     pub non_interactive: bool,
 }
@@ -67,8 +71,11 @@ struct SetupResult {
     password: String,
     install_url: String,
     qr_code_ascii: String,
-    advertise_ip: String,
-    port: u16,
+    /// Pinned advertise IP, if `--ip` was given; `null` when the QR relies on
+    /// auto-detected interfaces (the common case).
+    advertise_ip: Option<String>,
+    /// Resulting LAN listener port (resolved by the daemon; `null` ⇒ default).
+    port: Option<u16>,
     restart_required: bool,
 }
 
@@ -113,16 +120,12 @@ pub async fn run(args: SetupArgs, json: bool, verbose: bool) -> i32 {
     };
 
     // 3. Validate non-interactive required flags up front (before we touch
-    // the daemon, so misuse fails cheaply).
-    if non_interactive {
-        if args.label.is_none() {
-            ui::error("--label is required in --non-interactive / --json mode.");
-            return exit_codes::EXIT_ERROR;
-        }
-        if args.ip.is_none() {
-            ui::error("--ip is required in --non-interactive / --json mode.");
-            return exit_codes::EXIT_ERROR;
-        }
+    // the daemon, so misuse fails cheaply). Only --label is required now:
+    // the QR auto-carries every detected interface, so the user no longer
+    // has to pick an address (mirrors the GUI's one-click enable).
+    if non_interactive && args.label.is_none() {
+        ui::error("--label is required in --non-interactive / --json mode.");
+        return exit_codes::EXIT_ERROR;
     }
 
     // 4. Connect to daemon, hold lease.
@@ -132,22 +135,7 @@ pub async fn run(args: SetupArgs, json: bool, verbose: bool) -> i32 {
         Err(code) => return code,
     };
 
-    // 5. Resolve advertise IP. --ip wins; otherwise interactive pick.
-    let advertise_ip = match args.ip {
-        Some(ip) => ip,
-        None => {
-            // non_interactive case is already rejected above.
-            match resolve_advertise_interactively(&ctx).await {
-                Ok(ip) => ip,
-                Err(code) => return shared::finish_daemon(ctx, code).await,
-            }
-        }
-    };
-
-    // 6. Resolve port (no prompt; default 42720 silent).
-    let port = args.port.unwrap_or(DEFAULT_LAN_PORT);
-
-    // 7. Resolve label.
+    // 5. Resolve label.
     let label = match args.label {
         Some(l) => l,
         None => {
@@ -162,7 +150,7 @@ pub async fn run(args: SetupArgs, json: bool, verbose: bool) -> i32 {
         }
     };
 
-    // 8. Resolve username (optional). --username wins; else interactive
+    // 6. Resolve username (optional). --username wins; else interactive
     // [Enter for auto]; non_interactive without flag → auto.
     let custom_username = match args.username {
         Some(u) => Some(u),
@@ -180,7 +168,7 @@ pub async fn run(args: SetupArgs, json: bool, verbose: bool) -> i32 {
         },
     };
 
-    // 9. Resolve password. cli_password (from stdin) wins; else interactive
+    // 7. Resolve password. cli_password (from stdin) wins; else interactive
     // hidden prompt [Enter for auto]; non_interactive without flag → auto.
     let custom_password = match cli_password {
         Some(p) => Some(p),
@@ -195,18 +183,22 @@ pub async fn run(args: SetupArgs, json: bool, verbose: bool) -> i32 {
         },
     };
 
-    // 10. Apply settings: enable feature + LAN listener + advertise + port.
+    // 8. Apply settings: enable feature + LAN listener. Mirrors the GUI's
+    // one-click enable — we flip the switches and let the QR carry every
+    // detected interface. `--ip` is an optional advanced pin: patched only
+    // when given (`None` ⇒ leave unchanged), otherwise the QR auto-collects
+    // all interfaces. The port is provisioned explicitly (default 42720) so
+    // the persisted setting is inspectable. `lan_advertise_base_url` is left
+    // untouched — multi-address QRs happily carry a reverse-proxy entry
+    // alongside the LAN IPs, so there is no longer anything to clear.
     let upd = match ctx
         .client
         .update_settings(&UpdateMobileSyncSettingsRequest {
             enabled: Some(true),
             lan_listen_enabled: Some(true),
-            lan_advertise_ip: Some(Some(advertise_ip.clone())),
-            lan_port: Some(Some(port)),
-            // `setup` provisions the LAN ip:port form; clear any prior full
-            // base-URL override so the two never coexist (the reverse-proxy
-            // path is `network set --url`, see that command).
-            lan_advertise_base_url: Some(None),
+            lan_advertise_ip: args.ip.clone().map(Some),
+            lan_port: Some(Some(args.port.unwrap_or(DEFAULT_LAN_PORT))),
+            lan_advertise_base_url: None,
         })
         .await
     {
@@ -217,7 +209,18 @@ pub async fn run(args: SetupArgs, json: bool, verbose: bool) -> i32 {
         }
     };
 
-    // 11. Register the device.
+    // 8a. Abort before minting credentials if the listener failed to bind —
+    // otherwise we'd hand the user a QR for a socket that never came up
+    // (port in use / permission / unassignable IP). Mirrors the GUI guard.
+    if let Some(reason) = upd.lan_listener_bind_error.as_deref() {
+        ui::error(&format!(
+            "LAN listener failed to bind: {reason}. Free the port (or pick \
+             another with `--port`) and re-run setup."
+        ));
+        return shared::finish_daemon(ctx, exit_codes::EXIT_ERROR).await;
+    }
+
+    // 9. Register the device.
     let reg = match ctx
         .client
         .register_device(&RegisterMobileDeviceRequest {
@@ -234,7 +237,7 @@ pub async fn run(args: SetupArgs, json: bool, verbose: bool) -> i32 {
         }
     };
 
-    // 12. Render.
+    // 10. Render.
     if json {
         let dto = SetupResult {
             device_id: reg.device_id.clone(),
@@ -244,8 +247,8 @@ pub async fn run(args: SetupArgs, json: bool, verbose: bool) -> i32 {
             password: reg.password.clone(),
             install_url: reg.install_url.clone(),
             qr_code_ascii: reg.qr_code_ascii.clone(),
-            advertise_ip,
-            port,
+            advertise_ip: upd.lan_advertise_ip.clone(),
+            port: upd.lan_port,
             restart_required: upd.restart_required,
         };
         shared::finish_daemon_json(ctx, &dto).await
@@ -265,11 +268,14 @@ pub async fn run(args: SetupArgs, json: bool, verbose: bool) -> i32 {
             "Scan the QR with iPhone Camera, install the SyncClipboard \
              shortcut, then edit url / username / password fields.",
         );
+        ui::info(
+            "note",
+            "The QR carries every detected network address — the phone tries \
+             each until one connects, so no address picking is needed.",
+        );
         ui::warn("The password above will NOT be shown again. Copy it now.");
         if upd.restart_required {
             ui::warn(shared::restart_hint());
-        } else {
-            ui::info("note", "Daemon restart not needed (settings unchanged).");
         }
         shared::finish_daemon(ctx, exit_codes::EXIT_SUCCESS).await
     }
@@ -288,58 +294,4 @@ fn print_network_risk_banner() {
     );
     ui::info("•", "Strongly discouraged on public WiFi.");
     ui::info("•", "Anyone on the same LAN can sniff your data.");
-}
-
-/// Interactive picker for the LAN advertise IP. Single-IP case auto-picks
-/// silently. Empty list returns an error code — `setup` cannot proceed.
-async fn resolve_advertise_interactively(ctx: &shared::MobileSyncDaemonCtx) -> Result<String, i32> {
-    let opts = match ctx.client.list_lan_interfaces().await {
-        Ok(opts) => opts,
-        Err(err) => {
-            ui::error(&err.to_string());
-            return Err(exit_codes::EXIT_ERROR);
-        }
-    };
-    if opts.is_empty() {
-        ui::error("No RFC1918 LAN interface detected. Connect to a private network and retry.");
-        return Err(exit_codes::EXIT_ERROR);
-    }
-    if opts.len() == 1 {
-        let only = &opts[0];
-        ui::info("interface", &format!("{} ({})", only.name, only.ipv4));
-        return Ok(only.ipv4.clone());
-    }
-    pick_from_list(&opts).map_err(|code| {
-        ui::warn("Aborted by user.");
-        code
-    })
-}
-
-fn pick_from_list(opts: &[LanInterfaceViewDto]) -> Result<String, i32> {
-    ui::info("LAN interfaces", "");
-    for (i, o) in opts.iter().enumerate() {
-        ui::info(
-            &format!("    {}", i + 1),
-            &format!("{} ({})", o.name, o.ipv4),
-        );
-    }
-    loop {
-        let s = match ui::input(&format!("Pick interface [1-{}]", opts.len()), true) {
-            Ok(s) => s,
-            Err(_) => return Err(exit_codes::EXIT_ERROR),
-        };
-        let trimmed = s.trim();
-        let idx_one_based: usize = if trimmed.is_empty() {
-            1
-        } else {
-            match trimmed.parse::<usize>() {
-                Ok(n) if (1..=opts.len()).contains(&n) => n,
-                _ => {
-                    ui::warn(&format!("Invalid choice; expected 1..{}", opts.len()));
-                    continue;
-                }
-            }
-        };
-        return Ok(opts[idx_one_based - 1].ipv4.clone());
-    }
 }

--- a/apps/cli/src/commands/mobile_sync/status.rs
+++ b/apps/cli/src/commands/mobile_sync/status.rs
@@ -88,7 +88,7 @@ impl From<&MobileSyncSettingsViewDto> for StatusDto {
 }
 
 pub async fn run(json: bool, verbose: bool) -> i32 {
-    let ctx = match shared::enter("Mobile-sync status", json, verbose).await {
+    let ctx = match shared::enter("Mobile status", json, verbose).await {
         Ok(c) => c,
         Err(code) => return code,
     };

--- a/apps/cli/src/commands/mobile_sync/status.rs
+++ b/apps/cli/src/commands/mobile_sync/status.rs
@@ -1,4 +1,4 @@
-//! `uniclip mobile-sync status` — combined settings + devices view.
+//! `uniclip mobile status` — combined settings + devices view.
 //!
 //! Routes through daemon HTTP endpoints (P5-2b ADR).
 
@@ -143,7 +143,7 @@ pub async fn run(json: bool, verbose: bool) -> i32 {
         if devices.is_empty() {
             ui::info(
                 "devices",
-                "0 — run `uniclip mobile-sync setup` or `devices add` to register one.",
+                "0 — run `uniclip mobile setup` or `uniclip mobile add` to register one.",
             );
         } else {
             ui::info("devices", &format!("{} paired", devices.len()));

--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -313,8 +313,16 @@ enum Commands {
         #[command(subcommand)]
         subcommand: commands::dev::DevCommands,
     },
-    /// Manage mobile-sync (iPhone over LAN, SyncClipboard-compatible).
-    #[command(name = "mobile-sync")]
+    /// Manage mobile clipboard sync (iPhone over LAN, SyncClipboard-compatible).
+    #[command(name = "mobile")]
+    Mobile {
+        #[command(subcommand)]
+        subcommand: commands::mobile_sync::MobileSyncCommands,
+    },
+    /// Deprecated alias for `mobile`. Hidden from `--help`; still runs but
+    /// prints a deprecation notice. Kept so already-published scripts keep
+    /// working; will be removed in a future release.
+    #[command(name = "mobile-sync", hide = true)]
     MobileSync {
         #[command(subcommand)]
         subcommand: commands::mobile_sync::MobileSyncCommands,
@@ -459,7 +467,17 @@ fn main() -> anyhow::Result<()> {
             Commands::Dev { subcommand } => {
                 commands::dev::run(subcommand, cli.json, cli.verbose).await
             }
+            Commands::Mobile { subcommand } => {
+                commands::mobile_sync::run(subcommand, cli.json, cli.verbose).await
+            }
             Commands::MobileSync { subcommand } => {
+                // Deprecation notice goes to stderr (via ui::warn), so it never
+                // corrupts `--json` stdout. The old alias otherwise behaves
+                // identically to `mobile`.
+                ui::warn(
+                    "`mobile-sync` is deprecated; use `mobile` instead. \
+                     This alias will be removed in a future release.",
+                );
                 commands::mobile_sync::run(subcommand, cli.json, cli.verbose).await
             }
         }
@@ -637,12 +655,21 @@ mod tests {
     }
 
     #[test]
-    fn mobile_sync_kebab_case_is_accepted() {
-        // 子命令名是 kebab-case `mobile-sync` 而非默认的 `mobile_sync` /
-        // `mobilesync`。锁住这个外部契约 —— 改名会让所有发布的脚本失效。
-        // (Step 4 起 `enable` 已删, 用 `status` 这个稳定读命令探针。)
-        let result = Cli::try_parse_from(["uniclip", "mobile-sync", "status"]);
-        assert!(result.is_ok(), "expected `mobile-sync status` to parse");
+    fn mobile_is_the_primary_command_name() {
+        // `mobile` 是新的主命令名(显示在 --help 里)。锁住外部契约。
+        let cli = Cli::try_parse_from(["uniclip", "mobile", "status"])
+            .expect("expected `mobile status` to parse");
+        assert!(matches!(cli.command, Some(Commands::Mobile { .. })));
+    }
+
+    #[test]
+    fn mobile_sync_is_a_hidden_deprecated_alias() {
+        // `mobile-sync` 保留为隐藏的弃用别名 —— 仍能解析(已发布脚本不
+        // 失效),但映射到独立的 `MobileSync` 变体,runtime 会打印弃用提示
+        // 再走与 `mobile` 相同的逻辑。(用 `status` 这个稳定读命令做探针。)
+        let cli = Cli::try_parse_from(["uniclip", "mobile-sync", "status"])
+            .expect("expected `mobile-sync status` to still parse");
+        assert!(matches!(cli.command, Some(Commands::MobileSync { .. })));
     }
 
     #[test]
@@ -814,8 +841,9 @@ mod tests {
     #[test]
     fn mobile_sync_setup_parses_with_no_args() {
         // `setup` 不强制任何 flag —— 默认全交互式。runtime 才会按
-        // `--non-interactive` / `--json` 决定是否要求 --label / --ip /
-        // --accept-network-risk;clap 解析层不下结论。
+        // `--non-interactive` / `--json` 决定是否要求 --label /
+        // --accept-network-risk(--ip 已降级为可选高级覆盖);clap 解析层
+        // 不下结论。
         let r = Cli::try_parse_from(["uniclip", "mobile-sync", "setup"]);
         assert!(r.is_ok(), "expected `setup` to parse with no args");
     }

--- a/crates/uc-bootstrap/src/non_gui_runtime.rs
+++ b/crates/uc-bootstrap/src/non_gui_runtime.rs
@@ -182,7 +182,7 @@ pub struct ClipboardRestoreAssembly {
 ///
 /// - **capture**:真 `CaptureClipboardUseCase`。写 entry_repo + event_repo +
 ///   spool_queue,与 daemon 装配的 capture 完全等价。让 P5a.9 引入的
-///   `uniclip mobile-sync debug put-*` 子命令真能把数据落库,后续
+///   `uniclip mobile debug put-*` 子命令真能把数据落库,后续
 ///   `debug get-doc` / `debug get-file` 直接读得到 ——"完整链路" 验证不再
 ///   是空壳。
 /// - **write**:`NoopInboundWrite`。CLI 进程主动设置

--- a/deploy/vps/Caddyfile
+++ b/deploy/vps/Caddyfile
@@ -4,7 +4,7 @@
 # (ACME HTTP-01 / TLS-ALPN), then proxies every request to the app container's
 # mobile_lan listener over the internal Docker network. The plaintext mobile_lan
 # port is never published to the host — only Caddy's 80/443 are. The phone's
-# install URL must point at https://$UC_DOMAIN (set via `mobile-sync network set
+# install URL must point at https://$UC_DOMAIN (set via `mobile network set
 # --url`).
 #
 # mobile_lan is plain HTTP + Basic Auth with no websockets, so a default

--- a/deploy/vps/README.md
+++ b/deploy/vps/README.md
@@ -115,7 +115,7 @@ makes the phone's install URL/QR point at Caddy instead of a LAN IP:
 
 ```bash
 docker compose run --rm app \
-  uniclip mobile-sync network set \
+  uniclip mobile network set \
   --url https://${UC_DOMAIN:-clip.example.com} \
   --accept-network-risk
 ```
@@ -123,7 +123,7 @@ docker compose run --rm app \
 **c. Register your phone.** Mints credentials and prints the install QR/URL:
 
 ```bash
-docker compose run --rm app uniclip mobile-sync add --label "My iPhone"
+docker compose run --rm app uniclip mobile add --label "My iPhone"
 ```
 
 Scan the QR (or open the printed `https://<domain>` URL) in the SyncClipboard /
@@ -205,7 +205,7 @@ swaps the binary. To move to a pinned release, bump `UC_IMAGE` in `.env` before
 
 To change the advertised domain or add devices later, **stop the daemon first**
 (`docker compose down`), rerun the relevant `docker compose run --rm app
-uniclip mobile-sync …` command, then `docker compose up -d` — the write commands
+uniclip mobile …` command, then `docker compose up -d` — the write commands
 still refuse to run while the daemon is up.
 
 ## Security notes

--- a/deploy/vps/README.md
+++ b/deploy/vps/README.md
@@ -87,7 +87,7 @@ cp .env.example .env
 
 ## 2. Provision (one-time, interactive — BEFORE the daemon)
 
-`join` and the `mobile-sync` write commands refuse to run while a daemon is up,
+`join` and the `mobile` write commands refuse to run while a daemon is up,
 so all provisioning happens in one-off containers first. They share the same
 `uniclip-state` volume, so what they write is exactly what the long-running
 daemon reads in step 3.

--- a/docs-site/content/docs/en/cli/reference.mdx
+++ b/docs-site/content/docs/en/cli/reference.mdx
@@ -172,8 +172,9 @@ Behavioural notes:
   `setup`, `add`, `network set`, etc. The read command (`status`) is
   tolerant of a running daemon.
 - **`--json` implies non-interactive.** No prompts will be shown.
-  `setup` in non-interactive / JSON mode requires `--label`,
-  `--ip`, and `--accept-network-risk`. `--username` /
+  `setup` in non-interactive / JSON mode requires `--label` and
+  `--accept-network-risk`. `--ip` / `--port` are optional advanced pins
+  (omit them and the QR carries every detected interface). `--username` /
   `--password-stdin` remain optional and default to auto-mint.
 - **`--password-stdin`** reads exactly one line from stdin. Use it to
   pipe a password from a manager / CI without leaving it in shell
@@ -188,7 +189,7 @@ Behavioural notes:
   so the install URL / QR points at a TLS reverse proxy (Caddy, nginx,
   …) while the listener itself stays plain HTTP on the internal
   network. The two are mutually exclusive and setting one clears the
-  other; `mobile-sync status` reflects whichever is active.
+  other; `mobile status` reflects whichever is active.
 - A **debug** subcommand group exists (`uniclip mobile debug`)
   but is hidden from `--help` — it is reserved for development and
   E2E scripts (it bypasses HTTP and pokes the facade directly), and

--- a/docs-site/content/docs/en/cli/reference.mdx
+++ b/docs-site/content/docs/en/cli/reference.mdx
@@ -132,37 +132,37 @@ reach blob storage.
 
 ## Mobile sync
 
-`uniclip mobile-sync ...` is the CLI surface for the mobile companion
+`uniclip mobile ...` is the CLI surface for the mobile companion
 feature. It mirrors the **Devices → Mobile sync** panel in the GUI and
 the protocol is documented in the [Mobile LAN API](../reference/mobile-api).
 
 ```bash
 # One-shot wizard: turn the feature on, configure the LAN listener,
 # register one iPhone, print the install QR + a one-time password.
-uniclip mobile-sync setup
+uniclip mobile setup
 
 # Read-only view (allowed while the daemon is running)
-uniclip mobile-sync status            # combined: feature + LAN + paired devices
+uniclip mobile status            # combined: feature + LAN + paired devices
 
 # Paired device management
-uniclip mobile-sync add --label "My iPhone" \
+uniclip mobile add --label "My iPhone" \
     [--username my_user] [--password-stdin]
-uniclip mobile-sync revoke <device-id>
+uniclip mobile revoke <device-id>
 
 # Advanced listener configuration (write commands — daemon must be stopped).
 # `setup` already covers the common case; reach for these to re-point the
 # address or front the listener with a reverse proxy.
-uniclip mobile-sync network interfaces
+uniclip mobile network interfaces
 # LAN form: advertise an internal IPv4 → install URL is http://<IP>:<port>
-uniclip mobile-sync network set --ip <LAN_IPV4> [--port 42720] --accept-network-risk
+uniclip mobile network set --ip <LAN_IPV4> [--port 42720] --accept-network-risk
 # Reverse-proxy form: advertise a full base URL → install URL/QR points at
 # the HTTPS front-end (e.g. Caddy), while the listener stays plain HTTP.
-uniclip mobile-sync network set --url https://clip.example.com --accept-network-risk
-uniclip mobile-sync network off       # stop just the LAN listener
+uniclip mobile network set --url https://clip.example.com --accept-network-risk
+uniclip mobile network off       # stop just the LAN listener
 
 # Disable the feature entirely (master switch + listener off; paired
 # device records stay until you `revoke` them).
-uniclip mobile-sync disable
+uniclip mobile disable
 ```
 
 Behavioural notes:
@@ -189,7 +189,7 @@ Behavioural notes:
   …) while the listener itself stays plain HTTP on the internal
   network. The two are mutually exclusive and setting one clears the
   other; `mobile-sync status` reflects whichever is active.
-- A **debug** subcommand group exists (`uniclip mobile-sync debug`)
+- A **debug** subcommand group exists (`uniclip mobile debug`)
   but is hidden from `--help` — it is reserved for development and
   E2E scripts (it bypasses HTTP and pokes the facade directly), and
   may change without notice.

--- a/docs-site/content/docs/en/core-features/devices.mdx
+++ b/docs-site/content/docs/en/core-features/devices.mdx
@@ -261,7 +261,7 @@ back to force a refresh; if it's still off, head to
 | Copy Peer ID                    | `uniclip status --json` → `network.endpoint`                                                                          |
 | Unpair                          | **GUI only today**; a CLI subcommand is on the roadmap                                                                |
 | Per-peer content-type allowlist | **GUI only today**; CLI configuration subcommand is on the roadmap                                                    |
-| Mobile sync — status            | `uniclip mobile-sync status`                                                                                          |
-| Mobile sync — list paired       | `uniclip mobile-sync status`                                                                                          |
-| Mobile sync — register a device | `uniclip mobile-sync setup` (wizard) or `uniclip mobile-sync add --label …`                                           |
-| Mobile sync — revoke a device   | `uniclip mobile-sync revoke <device-id>`                                                                              |
+| Mobile sync — status            | `uniclip mobile status`                                                                                          |
+| Mobile sync — list paired       | `uniclip mobile status`                                                                                          |
+| Mobile sync — register a device | `uniclip mobile setup` (wizard) or `uniclip mobile add --label …`                                           |
+| Mobile sync — revoke a device   | `uniclip mobile revoke <device-id>`                                                                              |

--- a/docs-site/content/docs/en/core-features/devices.mdx
+++ b/docs-site/content/docs/en/core-features/devices.mdx
@@ -261,7 +261,7 @@ back to force a refresh; if it's still off, head to
 | Copy Peer ID                    | `uniclip status --json` → `network.endpoint`                                                                          |
 | Unpair                          | **GUI only today**; a CLI subcommand is on the roadmap                                                                |
 | Per-peer content-type allowlist | **GUI only today**; CLI configuration subcommand is on the roadmap                                                    |
-| Mobile sync — status            | `uniclip mobile status`                                                                                          |
-| Mobile sync — list paired       | `uniclip mobile status`                                                                                          |
-| Mobile sync — register a device | `uniclip mobile setup` (wizard) or `uniclip mobile add --label …`                                           |
-| Mobile sync — revoke a device   | `uniclip mobile revoke <device-id>`                                                                              |
+| Mobile sync — status            | `uniclip mobile status`                                                                                               |
+| Mobile sync — list paired       | `uniclip mobile status`                                                                                               |
+| Mobile sync — register a device | `uniclip mobile setup` (wizard) or `uniclip mobile add --label …`                                                     |
+| Mobile sync — revoke a device   | `uniclip mobile revoke <device-id>`                                                                                   |

--- a/docs-site/content/docs/en/core-features/mobile-sync.mdx
+++ b/docs-site/content/docs/en/core-features/mobile-sync.mdx
@@ -475,12 +475,12 @@ the Tailscale "Machines" list and confirm a **direct** connection
 
 | Action               | GUI                                                                        | CLI                                                    |
 | -------------------- | -------------------------------------------------------------------------- | ------------------------------------------------------ |
-| List paired devices  | Devices page → Mobile sync panel                                           | `uniclip mobile status`                           |
-| Add another device   | Mobile sync panel → **Add device**                                         | `uniclip mobile add --label "…"`                  |
+| List paired devices  | Devices page → Mobile sync panel                                           | `uniclip mobile status`                                |
+| Add another device   | Mobile sync panel → **Add device**                                         | `uniclip mobile add --label "…"`                       |
 | Edit a device        | Click device card → dialog → **Edit device** (label / username / password) | _GUI only today_; mint a new one and re-pair the phone |
-| Revoke a device      | Click device card → dialog → **Revoke**                                    | `uniclip mobile revoke <device-id>`               |
-| Disable feature      | Configure dialog → switch off                                              | `uniclip mobile disable`                          |
-| Inspect listener URL | Mobile sync panel header                                                   | `uniclip mobile status`                           |
+| Revoke a device      | Click device card → dialog → **Revoke**                                    | `uniclip mobile revoke <device-id>`                    |
+| Disable feature      | Configure dialog → switch off                                              | `uniclip mobile disable`                               |
+| Inspect listener URL | Mobile sync panel header                                                   | `uniclip mobile status`                                |
 
 **Editing** lets you change the label, username, and/or password from
 the **Edit device** view. Setting or regenerating the password mints a

--- a/docs-site/content/docs/en/core-features/mobile-sync.mdx
+++ b/docs-site/content/docs/en/core-features/mobile-sync.mdx
@@ -148,23 +148,23 @@ an Argon2id hash after the modal closes.
 # One-shot: enable feature + LAN listener, register one device,
 # print install QR + a one-time password.
 uniclip stop                                 # required: writes refuse a running daemon
-uniclip mobile-sync setup                    # interactive (recommended)
+uniclip mobile setup                    # interactive (recommended)
 
 # Or non-interactive (e.g. CI / scripts)
-uniclip mobile-sync setup \
+uniclip mobile setup \
     --label "My iPhone 15" \
-    --ip 192.168.1.5 \
     --accept-network-risk \
     --non-interactive
-# → prints baseUrl, username, password (one-time), installUrl,
-#   QR ASCII, and a "restart daemon" hint
+# → prints baseUrl, username, password (one-time), installUrl, and a
+#   multi-address QR (ASCII) that the phone probes address-by-address
 
 uniclip start                                # bring the daemon back up
 ```
 
-For non-interactive runs, `--label`, `--ip`, and
-`--accept-network-risk` are required. `--username` / `--password-stdin`
-are optional and default to auto-mint.
+For non-interactive runs, `--label` and `--accept-network-risk` are
+required. `--ip` / `--port` are optional advanced pins — omit them and the
+QR carries every detected interface, so there is normally nothing to pick.
+`--username` / `--password-stdin` are optional and default to auto-mint.
 
 </Tab>
 
@@ -174,7 +174,7 @@ are optional and default to auto-mint.
   The plaintext password is shown **once**. If the user loses it,
   click the device card on the **Mobile sync** grid, press
   **Edit device** inside the dialog and set or regenerate the password
-  (or `uniclip mobile-sync revoke <id>` + `add`) — there
+  (or `uniclip mobile revoke <id>` + `add`) — there
   is no way to retrieve the original.
 </Callout>
 
@@ -314,7 +314,7 @@ Either way, the connection settings are the same:
   IP:
 
 ```bash
-uniclip mobile-sync network set \
+uniclip mobile network set \
     --url https://clip.example.com \
     --accept-network-risk
 ```
@@ -475,12 +475,12 @@ the Tailscale "Machines" list and confirm a **direct** connection
 
 | Action               | GUI                                                                        | CLI                                                    |
 | -------------------- | -------------------------------------------------------------------------- | ------------------------------------------------------ |
-| List paired devices  | Devices page → Mobile sync panel                                           | `uniclip mobile-sync status`                           |
-| Add another device   | Mobile sync panel → **Add device**                                         | `uniclip mobile-sync add --label "…"`                  |
+| List paired devices  | Devices page → Mobile sync panel                                           | `uniclip mobile status`                           |
+| Add another device   | Mobile sync panel → **Add device**                                         | `uniclip mobile add --label "…"`                  |
 | Edit a device        | Click device card → dialog → **Edit device** (label / username / password) | _GUI only today_; mint a new one and re-pair the phone |
-| Revoke a device      | Click device card → dialog → **Revoke**                                    | `uniclip mobile-sync revoke <device-id>`               |
-| Disable feature      | Configure dialog → switch off                                              | `uniclip mobile-sync disable`                          |
-| Inspect listener URL | Mobile sync panel header                                                   | `uniclip mobile-sync status`                           |
+| Revoke a device      | Click device card → dialog → **Revoke**                                    | `uniclip mobile revoke <device-id>`               |
+| Disable feature      | Configure dialog → switch off                                              | `uniclip mobile disable`                          |
+| Inspect listener URL | Mobile sync panel header                                                   | `uniclip mobile status`                           |
 
 **Editing** lets you change the label, username, and/or password from
 the **Edit device** view. Setting or regenerating the password mints a
@@ -541,7 +541,7 @@ images, what to do after changing the LAN IP), see
   a new SyncClipboard-compatible client or shortcut that consumes
   the **Scan to add** QR.
 - [CLI reference — Mobile sync](../cli/reference#mobile-sync) — every
-  `uniclip mobile-sync ...` subcommand and flag.
+  `uniclip mobile ...` subcommand and flag.
 - [Self-hosting a headless server node](../guides/self-host-server-node)
   — run the gateway on a public VPS so the phone reaches it over HTTPS
   from any network.

--- a/docs-site/content/docs/en/guides/self-host-server-node.mdx
+++ b/docs-site/content/docs/en/guides/self-host-server-node.mdx
@@ -154,7 +154,7 @@ socket so peers can dial it directly.
 
 ## Provision (one-time, before the daemon)
 
-`join` and the `mobile-sync` write commands **refuse to run while a
+`join` and the `mobile` write commands **refuse to run while a
 daemon is up**, so all provisioning happens in one-off containers first.
 They share the same state volume the long-running daemon will read.
 
@@ -287,7 +287,7 @@ docker compose up -d --build                     # update (Option B: build from 
 Updates keep the state volume, so a new image just swaps the binary — no
 re-pairing. To change the advertised domain or add devices later, **stop
 the daemon first** (`docker compose down`), rerun the relevant
-`mobile-sync` command, then `docker compose up -d` — the write commands
+`mobile` command, then `docker compose up -d` — the write commands
 still refuse to run while the daemon is up.
 
 ## Verifying
@@ -312,6 +312,6 @@ the phone and confirm it appears on your desktops.
 | ------------------------------------- | ---------------------------------------------------------------------------------------------------- |
 | `setup not complete` on `up -d`       | Provisioning (`join`) didn't persist. Confirm the `docker compose run` commands hit the same volume. |
 | Caddy never gets a certificate        | DNS for `UC_DOMAIN` must resolve to this VPS and `80`/`443` must be open **before** `up -d`.         |
-| Phone gets the wrong URL              | Re-run `mobile-sync network set --url https://<domain>` (daemon stopped), then `up -d`.              |
+| Phone gets the wrong URL              | Re-run `mobile network set --url https://<domain>` (daemon stopped), then `up -d`.              |
 | Desktop on another network won't sync | Open `UC_IROH_BIND_PORT/udp` in the firewall and check `UC_PUBLIC_IP` is the real public IP.         |
 | `401` through your reverse proxy      | That means the gateway is up and asking for Basic Auth — use the credentials from `add`.             |

--- a/docs-site/content/docs/en/guides/self-host-server-node.mdx
+++ b/docs-site/content/docs/en/guides/self-host-server-node.mdx
@@ -174,7 +174,7 @@ makes the phone's install URL/QR point at your HTTPS endpoint:
 
 ```bash
 docker compose run --rm app \
-  uniclip mobile-sync network set \
+  uniclip mobile network set \
   --url https://clip.example.com \
   --accept-network-risk
 ```
@@ -182,7 +182,7 @@ docker compose run --rm app \
 **3. Register your phone.** Mints credentials and renders the install QR:
 
 ```bash
-docker compose run --rm app uniclip mobile-sync add --label "My iPhone"
+docker compose run --rm app uniclip mobile add --label "My iPhone"
 ```
 
 Copy the one-time password it prints — it is not shown again.

--- a/docs-site/content/docs/en/guides/self-host-server-node.mdx
+++ b/docs-site/content/docs/en/guides/self-host-server-node.mdx
@@ -312,6 +312,6 @@ the phone and confirm it appears on your desktops.
 | ------------------------------------- | ---------------------------------------------------------------------------------------------------- |
 | `setup not complete` on `up -d`       | Provisioning (`join`) didn't persist. Confirm the `docker compose run` commands hit the same volume. |
 | Caddy never gets a certificate        | DNS for `UC_DOMAIN` must resolve to this VPS and `80`/`443` must be open **before** `up -d`.         |
-| Phone gets the wrong URL              | Re-run `mobile network set --url https://<domain>` (daemon stopped), then `up -d`.              |
+| Phone gets the wrong URL              | Re-run `mobile network set --url https://<domain>` (daemon stopped), then `up -d`.                   |
 | Desktop on another network won't sync | Open `UC_IROH_BIND_PORT/udp` in the firewall and check `UC_PUBLIC_IP` is the real public IP.         |
 | `401` through your reverse proxy      | That means the gateway is up and asking for Basic Auth — use the credentials from `add`.             |

--- a/docs-site/content/docs/en/help/troubleshooting.mdx
+++ b/docs-site/content/docs/en/help/troubleshooting.mdx
@@ -337,8 +337,8 @@ without ever showing a 401 / 4xx response.
    candidate — copy the one the phone is on; with a specific
    interface picked, the row shows that single fixed URL. From the
    CLI, pass `--ip <LAN_IPV4>` to
-   `uniclip mobile-sync network set`.
-3. **Check listener state.** `uniclip mobile-sync status` reports
+   `uniclip mobile network set`.
+3. **Check listener state.** `uniclip mobile status` reports
    `lan_listener_error` if the daemon tried to bind and failed (port
    in use, permission denied). Resolve the underlying error or pick
    a different port.
@@ -354,7 +354,7 @@ The username or password is wrong. Reasons:
 
 - The plaintext password is shown **once** at registration. If you
   lost it, click **Rotate password** on the device row (or
-  `uniclip mobile-sync revoke <id>` + `add`) — there
+  `uniclip mobile revoke <id>` + `add`) — there
   is no way to recover the original.
 - The Shortcut on the phone may still hold an old credential after
   rotation. Re-edit the `url` / `username` / `password` fields.
@@ -374,7 +374,7 @@ Don't run the LAN listener on coffee shop / airport / conference
 Wi-Fi. The v1 wire format is plain HTTP with Basic Auth — anyone on
 the same SSID can sniff your clipboard. If you need to use it on an
 untrusted network, set the listener to disabled first
-(`uniclip mobile-sync network off`) and re-enable on a trusted
+(`uniclip mobile network off`) and re-enable on a trusted
 network.
 
 ### Changed the LAN IP / port?
@@ -385,7 +385,7 @@ Two things have to happen for the new value to be live:
 2. Update the Shortcut's `url` field on the phone to match the new
    advertised URL.
 
-`uniclip mobile-sync status` is a fast way to confirm what
+`uniclip mobile status` is a fast way to confirm what
 the daemon is currently advertising.
 
 ## Collecting logs

--- a/docs-site/content/docs/zh/cli/reference.mdx
+++ b/docs-site/content/docs/zh/cli/reference.mdx
@@ -114,36 +114,36 @@ uniclip blob fetch <TICKET> --entry-id <ENTRY_ID> --out ./restored.bin
 
 ## 移动端同步
 
-`uniclip mobile-sync ...` 是移动端同步功能的命令行入口，覆盖
+`uniclip mobile ...` 是移动端同步功能的命令行入口，覆盖
 **设备 → 移动端同步** 面板的所有动作。协议层文档见
 [移动端 LAN API](../reference/mobile-api)。
 
 ```bash
 # 一键向导：开启功能、配置 LAN 监听器、注册一台 iPhone，打印
 # 安装 QR 码与一次性密码。
-uniclip mobile-sync setup
+uniclip mobile setup
 
 # 只读命令（daemon 在跑时也可以调）
-uniclip mobile-sync status            # 综合视图：功能 + LAN + 已配对设备
+uniclip mobile status            # 综合视图：功能 + LAN + 已配对设备
 
 # 已配对设备管理
-uniclip mobile-sync add --label "My iPhone" \
+uniclip mobile add --label "My iPhone" \
     [--username my_user] [--password-stdin]
-uniclip mobile-sync revoke <device-id>
+uniclip mobile revoke <device-id>
 
 # 进阶监听器配置（写命令 —— 必须先停 daemon）。`setup` 已覆盖常用场景，
 # 需要手动改地址或反代前置时才用这一组。
-uniclip mobile-sync network interfaces
+uniclip mobile network interfaces
 # LAN 形态：宣告内网 IPv4 → 安装 URL 为 http://<IP>:<port>
-uniclip mobile-sync network set --ip <LAN_IPV4> [--port 42720] --accept-network-risk
+uniclip mobile network set --ip <LAN_IPV4> [--port 42720] --accept-network-risk
 # 反代形态：宣告完整 base URL → 安装 URL/二维码指向 HTTPS 前端（如 Caddy），
 # 监听器本身仍是内网明文 HTTP
-uniclip mobile-sync network set --url https://clip.example.com --accept-network-risk
-uniclip mobile-sync network off       # 只关 LAN 监听器
+uniclip mobile network set --url https://clip.example.com --accept-network-risk
+uniclip mobile network off       # 只关 LAN 监听器
 
 # 把整个功能彻底关掉（总开关 + 监听器都关；已配对设备记录保留，
 # 想清掉用 `revoke`）
-uniclip mobile-sync disable
+uniclip mobile disable
 ```
 
 行为约定：
@@ -165,7 +165,7 @@ uniclip mobile-sync disable
   host + 可选 port，如 `https://clip.example.com`），让安装 URL / 二维码
   指向 TLS 反向代理（Caddy、nginx 等），而监听器本身仍是内网明文 HTTP。
   两者互斥，设一个会清掉另一个；`mobile-sync status` 会反映当前生效的那个。
-- 还有一组 **debug** 子命令（`uniclip mobile-sync debug`），从 `--help`
+- 还有一组 **debug** 子命令（`uniclip mobile debug`），从 `--help`
   里隐藏 —— 仅供开发与 E2E 脚本使用（绕过 HTTP，直接打 facade），可能
   在不发版本说明的情况下变化。
 

--- a/docs-site/content/docs/zh/cli/reference.mdx
+++ b/docs-site/content/docs/zh/cli/reference.mdx
@@ -152,9 +152,9 @@ uniclip mobile disable
   `network set` 等之前先 `uniclip stop` / 退掉 GUI。读命令（`status`）在
   daemon 跑着时也可以。
 - **`--json` 隐含 non-interactive。** 不会出任何交互提示。`setup` 在
-  non-interactive / JSON 模式下必须显式给 `--label`、`--ip`、
-  `--accept-network-risk`；`--username` / `--password-stdin` 仍可选，
-  缺省走自动生成。
+  non-interactive / JSON 模式下必须显式给 `--label`、`--accept-network-risk`；
+  `--ip` / `--port` 是可选的高级覆盖项（不给则二维码自动携带所有检测到的
+  网卡）；`--username` / `--password-stdin` 仍可选，缺省走自动生成。
 - **`--password-stdin`** 从 stdin 读取一行作为密码。用它从密码管理器
   或 CI 里管道喂密码，避免泄漏到 shell history。
 - **默认端口 `42720`**（SPEC §3.2）。daemon socket 永远 bind 在
@@ -164,7 +164,7 @@ uniclip mobile disable
   `http://<IP>:<port>`；`--url` 写入完整 base URL（scheme +
   host + 可选 port，如 `https://clip.example.com`），让安装 URL / 二维码
   指向 TLS 反向代理（Caddy、nginx 等），而监听器本身仍是内网明文 HTTP。
-  两者互斥，设一个会清掉另一个；`mobile-sync status` 会反映当前生效的那个。
+  两者互斥，设一个会清掉另一个；`mobile status` 会反映当前生效的那个。
 - 还有一组 **debug** 子命令（`uniclip mobile debug`），从 `--help`
   里隐藏 —— 仅供开发与 E2E 脚本使用（绕过 HTTP，直接打 facade），可能
   在不发版本说明的情况下变化。

--- a/docs-site/content/docs/zh/core-features/devices.mdx
+++ b/docs-site/content/docs/zh/core-features/devices.mdx
@@ -208,7 +208,7 @@ Alert 区域展示，不再有专门的状态条。
 | 复制 Peer ID            | `uniclip status --json` 中的 `network.endpoint`                                                     |
 | 解除配对                | 当前 **仅 GUI** 提供专用命令；CLI 等价子命令在路线图上                                              |
 | 按对端的内容类型白名单  | 当前 **仅 GUI** 提供；CLI 等价配置子命令在路线图上                                                  |
-| 移动端同步 — 状态       | `uniclip mobile status`                                                                        |
-| 移动端同步 — 列出已配对 | `uniclip mobile status`                                                                        |
-| 移动端同步 — 注册设备   | `uniclip mobile setup`（向导） 或 `uniclip mobile add --label …`                          |
-| 移动端同步 — 吊销设备   | `uniclip mobile revoke <device-id>`                                                            |
+| 移动端同步 — 状态       | `uniclip mobile status`                                                                             |
+| 移动端同步 — 列出已配对 | `uniclip mobile status`                                                                             |
+| 移动端同步 — 注册设备   | `uniclip mobile setup`（向导） 或 `uniclip mobile add --label …`                                    |
+| 移动端同步 — 吊销设备   | `uniclip mobile revoke <device-id>`                                                                 |

--- a/docs-site/content/docs/zh/core-features/devices.mdx
+++ b/docs-site/content/docs/zh/core-features/devices.mdx
@@ -208,7 +208,7 @@ Alert 区域展示，不再有专门的状态条。
 | 复制 Peer ID            | `uniclip status --json` 中的 `network.endpoint`                                                     |
 | 解除配对                | 当前 **仅 GUI** 提供专用命令；CLI 等价子命令在路线图上                                              |
 | 按对端的内容类型白名单  | 当前 **仅 GUI** 提供；CLI 等价配置子命令在路线图上                                                  |
-| 移动端同步 — 状态       | `uniclip mobile-sync status`                                                                        |
-| 移动端同步 — 列出已配对 | `uniclip mobile-sync status`                                                                        |
-| 移动端同步 — 注册设备   | `uniclip mobile-sync setup`（向导） 或 `uniclip mobile-sync add --label …`                          |
-| 移动端同步 — 吊销设备   | `uniclip mobile-sync revoke <device-id>`                                                            |
+| 移动端同步 — 状态       | `uniclip mobile status`                                                                        |
+| 移动端同步 — 列出已配对 | `uniclip mobile status`                                                                        |
+| 移动端同步 — 注册设备   | `uniclip mobile setup`（向导） 或 `uniclip mobile add --label …`                          |
+| 移动端同步 — 吊销设备   | `uniclip mobile revoke <device-id>`                                                            |

--- a/docs-site/content/docs/zh/core-features/mobile-sync.mdx
+++ b/docs-site/content/docs/zh/core-features/mobile-sync.mdx
@@ -418,14 +418,14 @@ tailnet 地址。
 
 ## 管理已配对设备
 
-| 操作           | GUI                                                            | CLI                                      |
-| -------------- | -------------------------------------------------------------- | ---------------------------------------- |
-| 列出已配对     | 设备页 → 移动端同步面板                                        | `uniclip mobile status`             |
-| 再加一台       | 移动端同步面板 → **Add device**                                | `uniclip mobile add --label "…"`    |
-| 编辑设备       | 点设备卡片 → dialog → **Edit device**（label / 用户名 / 密码） | _目前只 GUI_；签新的并重新配对手机端     |
-| 吊销一台设备   | 点设备卡片 → dialog → **Revoke**                               | `uniclip mobile revoke <device-id>` |
-| 关闭整个功能   | 配置 modal → 关闭总开关                                        | `uniclip mobile disable`            |
-| 查当前监听 URL | 移动端同步面板状态条                                           | `uniclip mobile status`             |
+| 操作           | GUI                                                            | CLI                                  |
+| -------------- | -------------------------------------------------------------- | ------------------------------------ |
+| 列出已配对     | 设备页 → 移动端同步面板                                        | `uniclip mobile status`              |
+| 再加一台       | 移动端同步面板 → **Add device**                                | `uniclip mobile add --label "…"`     |
+| 编辑设备       | 点设备卡片 → dialog → **Edit device**（label / 用户名 / 密码） | _目前只 GUI_；签新的并重新配对手机端 |
+| 吊销一台设备   | 点设备卡片 → dialog → **Revoke**                               | `uniclip mobile revoke <device-id>`  |
+| 关闭整个功能   | 配置 modal → 关闭总开关                                        | `uniclip mobile disable`             |
+| 查当前监听 URL | 移动端同步面板状态条                                           | `uniclip mobile status`              |
 
 **编辑设备** 可以在 **Edit device** 视图里修改 label、用户名和/或密码。
 设置或重新生成密码会签发一个新的一次性密码，并原子失效旧的 Argon2id

--- a/docs-site/content/docs/zh/core-features/mobile-sync.mdx
+++ b/docs-site/content/docs/zh/core-features/mobile-sync.mdx
@@ -130,22 +130,22 @@ modal 顶部会出现红色 Alert，列出具体原因；监听不起来时 tab 
 ```bash
 # 一键：启用功能 + LAN 监听器，注册一台设备，打印安装 QR + 一次性密码。
 uniclip stop                                 # 必须：写命令拒绝同 profile daemon 在跑
-uniclip mobile-sync setup                    # 推荐：交互式
+uniclip mobile setup                    # 推荐：交互式
 
 # 或非交互（如 CI / 脚本）
-uniclip mobile-sync setup \
+uniclip mobile setup \
     --label "My iPhone 15" \
-    --ip 192.168.1.5 \
     --accept-network-risk \
     --non-interactive
-# → 输出 baseUrl、username、password (one-time)、installUrl、
-#   QR ASCII，以及"重启 daemon"提示
+# → 输出 baseUrl、username、password (one-time)、installUrl，
+#   以及一个多地址 QR (ASCII)，手机会逐个地址探活连通
 
 uniclip start                                # 把 daemon 拉回来
 ```
 
-非交互模式下 `--label`、`--ip`、`--accept-network-risk`
-必填；`--username` / `--password-stdin` 可选，缺省走自动生成。
+非交互模式下 `--label`、`--accept-network-risk` 必填；`--ip` / `--port`
+是可选的高级覆盖项 —— 不给就让 QR 自动携带所有检测到的网卡，通常无需选择。
+`--username` / `--password-stdin` 可选，缺省走自动生成。
 
 </Tab>
 
@@ -154,7 +154,7 @@ uniclip start                                # 把 daemon 拉回来
 <Callout type="info">
   明文密码 **只显示一次**。丢了就在 **移动端同步** 设备列表里点对应
   设备卡片，在弹出的 dialog 里点 **Edit device** 设置或重新生成密码，
-  或 `uniclip mobile-sync revoke <id>` + `add` 重新
+  或 `uniclip mobile revoke <id>` + `add` 重新
   签发 —— 没法把原始密码再拿回来。
 </Callout>
 
@@ -278,7 +278,7 @@ SyncClipboard 协议兼容客户端也能接入。推荐顺序：
   并宣告它的地址而不是内网 IP：
 
 ```bash
-uniclip mobile-sync network set \
+uniclip mobile network set \
     --url https://clip.example.com \
     --accept-network-risk
 ```
@@ -420,12 +420,12 @@ tailnet 地址。
 
 | 操作           | GUI                                                            | CLI                                      |
 | -------------- | -------------------------------------------------------------- | ---------------------------------------- |
-| 列出已配对     | 设备页 → 移动端同步面板                                        | `uniclip mobile-sync status`             |
-| 再加一台       | 移动端同步面板 → **Add device**                                | `uniclip mobile-sync add --label "…"`    |
+| 列出已配对     | 设备页 → 移动端同步面板                                        | `uniclip mobile status`             |
+| 再加一台       | 移动端同步面板 → **Add device**                                | `uniclip mobile add --label "…"`    |
 | 编辑设备       | 点设备卡片 → dialog → **Edit device**（label / 用户名 / 密码） | _目前只 GUI_；签新的并重新配对手机端     |
-| 吊销一台设备   | 点设备卡片 → dialog → **Revoke**                               | `uniclip mobile-sync revoke <device-id>` |
-| 关闭整个功能   | 配置 modal → 关闭总开关                                        | `uniclip mobile-sync disable`            |
-| 查当前监听 URL | 移动端同步面板状态条                                           | `uniclip mobile-sync status`             |
+| 吊销一台设备   | 点设备卡片 → dialog → **Revoke**                               | `uniclip mobile revoke <device-id>` |
+| 关闭整个功能   | 配置 modal → 关闭总开关                                        | `uniclip mobile disable`            |
+| 查当前监听 URL | 移动端同步面板状态条                                           | `uniclip mobile status`             |
 
 **编辑设备** 可以在 **Edit device** 视图里修改 label、用户名和/或密码。
 设置或重新生成密码会签发一个新的一次性密码，并原子失效旧的 Argon2id
@@ -475,7 +475,7 @@ tailnet 地址。
   SyncClipboard 客户端或快捷指令，需要消费弹窗里的「扫码接入」二维码，
   看这一页。
 - [CLI 参考 — 移动端同步](../cli/reference#移动端同步) —— 所有
-  `uniclip mobile-sync ...` 子命令与参数。
+  `uniclip mobile ...` 子命令与参数。
 - [自建无头 server 节点](../guides/self-host-server-node) —— 把网关跑在
   公网 VPS 上，让手机从任意网络都能经 HTTPS 访问。
 - [配对与同步 — 移动端伴侣](../guides/pairing#移动端伴侣) —— 移动端

--- a/docs-site/content/docs/zh/guides/self-host-server-node.mdx
+++ b/docs-site/content/docs/zh/guides/self-host-server-node.mdx
@@ -136,7 +136,7 @@ UC_IROH_BIND_PORT=42999         # iroh 直连用的固定 UDP 端口
 
 ## 置备（一次性，先于守护进程）
 
-`join` 和 `mobile-sync` 这些写命令**在 daemon 运行时会拒绝执行**，所以置备
+`join` 和 `mobile` 这些写命令**在 daemon 运行时会拒绝执行**，所以置备
 全部用一次性容器先做完。它们和常驻守护进程共用同一个状态卷。
 
 **1. 加入你的空间。** 在一台已在空间里的桌面端跑 `uniclip invite` 拿邀请码,
@@ -255,7 +255,7 @@ docker compose up -d --build                     # 升级（方案 B：源码构
 ```
 
 升级保留状态卷，新镜像只是换二进制 —— 不用重新配对。之后要改广告域名或加
-设备，**先停守护进程**（`docker compose down`），重跑对应的 `mobile-sync`
+设备，**先停守护进程**（`docker compose down`），重跑对应的 `mobile`
 命令，再 `docker compose up -d` —— 写命令在 daemon 运行时仍然会拒绝。
 
 ## 验证
@@ -279,6 +279,6 @@ curl -i http://clip.example.com:42720/SyncClipboard.json
 | ------------------------------- | -------------------------------------------------------------------------------- |
 | `up -d` 报 `setup not complete` | 置备（`join`）没落盘。确认 `docker compose run` 命令打的是同一个卷。             |
 | Caddy 一直签不出证书            | `UC_DOMAIN` 的 DNS 必须解析到这台 VPS，且 `80`/`443` 在 `up -d` **之前**已放开。 |
-| 手机拿到的 URL 不对             | 停掉守护进程重跑 `mobile-sync network set --url https://<域名>`，再 `up -d`。    |
+| 手机拿到的 URL 不对             | 停掉守护进程重跑 `mobile network set --url https://<域名>`，再 `up -d`。    |
 | 另一网络的桌面端同步不上        | 防火墙放开 `UC_IROH_BIND_PORT/udp`，并确认 `UC_PUBLIC_IP` 是真实公网 IP。        |
 | 经你的反代返回 `401`            | 说明网关在、并在要 Basic Auth —— 用 `add` 给出的凭据。                           |

--- a/docs-site/content/docs/zh/guides/self-host-server-node.mdx
+++ b/docs-site/content/docs/zh/guides/self-host-server-node.mdx
@@ -279,6 +279,6 @@ curl -i http://clip.example.com:42720/SyncClipboard.json
 | ------------------------------- | -------------------------------------------------------------------------------- |
 | `up -d` 报 `setup not complete` | 置备（`join`）没落盘。确认 `docker compose run` 命令打的是同一个卷。             |
 | Caddy 一直签不出证书            | `UC_DOMAIN` 的 DNS 必须解析到这台 VPS，且 `80`/`443` 在 `up -d` **之前**已放开。 |
-| 手机拿到的 URL 不对             | 停掉守护进程重跑 `mobile network set --url https://<域名>`，再 `up -d`。    |
+| 手机拿到的 URL 不对             | 停掉守护进程重跑 `mobile network set --url https://<域名>`，再 `up -d`。         |
 | 另一网络的桌面端同步不上        | 防火墙放开 `UC_IROH_BIND_PORT/udp`，并确认 `UC_PUBLIC_IP` 是真实公网 IP。        |
 | 经你的反代返回 `401`            | 说明网关在、并在要 Basic Auth —— 用 `add` 给出的凭据。                           |

--- a/docs-site/content/docs/zh/guides/self-host-server-node.mdx
+++ b/docs-site/content/docs/zh/guides/self-host-server-node.mdx
@@ -154,7 +154,7 @@ docker compose run --rm app uniclip join
 
 ```bash
 docker compose run --rm app \
-  uniclip mobile-sync network set \
+  uniclip mobile network set \
   --url https://clip.example.com \
   --accept-network-risk
 ```
@@ -162,7 +162,7 @@ docker compose run --rm app \
 **3. 注册你的手机。** 铸设备凭据并渲染安装 QR：
 
 ```bash
-docker compose run --rm app uniclip mobile-sync add --label "我的 iPhone"
+docker compose run --rm app uniclip mobile add --label "我的 iPhone"
 ```
 
 把它打印的一次性密码记下来 —— 不会再显示第二次。

--- a/docs-site/content/docs/zh/help/troubleshooting.mdx
+++ b/docs-site/content/docs/zh/help/troubleshooting.mdx
@@ -226,8 +226,8 @@ uniclip search rebuild     # 同步重建（会阻塞直至完成）
    IPv4。Configure dialog 已经替你兜住这一点：监听 IP 为 `Auto` 时，
    「当前监听地址」行会内联展开列出全部 RFC1918 候选 —— 挑手机所在
    那个直接复制；选了具体网卡时，行内就是固定的那条 URL。CLI 走
-   `uniclip mobile-sync network set --ip <LAN_IPV4>`。
-3. **看监听器状态。** `uniclip mobile-sync status` 在 daemon 试图 bind 但
+   `uniclip mobile network set --ip <LAN_IPV4>`。
+3. **看监听器状态。** `uniclip mobile status` 在 daemon 试图 bind 但
    失败时会上抛 `lan_listener_error`（端口被占、权限不足等），先解决
    底层错误或换一个端口。
 4. **桌面操作系统的防火墙。** 确认 `42720`（或你自定义的端口）允许 LAN
@@ -240,7 +240,7 @@ uniclip search rebuild     # 同步重建（会阻塞直至完成）
 用户名或密码错了。原因有两类：
 
 - 明文密码在注册时 **只显示一次**。丢了只能在设备行点 **轮换密码**
-  （或 `uniclip mobile-sync revoke <id>` + `add`）—— 没办法
+  （或 `uniclip mobile revoke <id>` + `add`）—— 没办法
   把原始密码再拿回来。
 - 轮换之后，手机上的快捷指令里可能还存着旧凭据。把
   `url` / `username` / `password` 字段都更新一次。
@@ -257,7 +257,7 @@ uniclip search rebuild     # 同步重建（会阻塞直至完成）
 **不要** 在咖啡馆 / 机场 / 会场的公共 Wi-Fi 下开启 LAN 监听器。v1
 线上格式是明文 HTTP + Basic Auth —— 同一 SSID 上的人就能嗅到你的剪贴
 内容。临时需要在不可信网络上工作时，先
-`uniclip mobile-sync network off` 关掉监听器，回到可信网络再开。
+`uniclip mobile network off` 关掉监听器，回到可信网络再开。
 
 ### 改了 LAN IP 或端口之后？
 
@@ -266,7 +266,7 @@ uniclip search rebuild     # 同步重建（会阻塞直至完成）
 1. 重启 daemon，让监听器重新 bind。
 2. 把手机端快捷指令里的 `url` 字段改成新的对外宣告 URL。
 
-`uniclip mobile-sync status` 可以快速确认 daemon 当前宣告的是哪个。
+`uniclip mobile status` 可以快速确认 daemon 当前宣告的是哪个。
 
 ## 收集日志
 

--- a/scripts/test_mobile_sync_debug_e2e.sh
+++ b/scripts/test_mobile_sync_debug_e2e.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# P5a.9: SyncClipboard 协议本地端到端 e2e（基于 `uniclip mobile-sync debug`
+# P5a.9: SyncClipboard 协议本地端到端 e2e（基于 `uniclip mobile debug`
 # 4 子命令，无 iPhone / 无 LAN / 无 daemon）。
 #
 # 验证范围:
@@ -140,7 +140,7 @@ ok "init succeeded"
 TEXT_A="hello P5a.9 e2e $(date +%s)"  # 唯一文本，避免与历史 entries 冲突
 
 step "Step 1.1 — put-text first time (expect: applied + entry_id)"
-OUT="$("$CLI" "${COMMON[@]}" --json mobile-sync debug put-text "$TEXT_A")"
+OUT="$("$CLI" "${COMMON[@]}" --json mobile debug put-text "$TEXT_A")"
 assert_contains "put-text outcome" '"outcome": "applied"' "$OUT"
 ENTRY_ID_A="$(extract_entry_id "$OUT")"
 if [[ -n "$ENTRY_ID_A" ]]; then
@@ -151,7 +151,7 @@ else
 fi
 
 step "Step 1.2 — get-doc reflects TEXT_A"
-OUT="$("$CLI" "${COMMON[@]}" mobile-sync debug get-doc 2>&1)"
+OUT="$("$CLI" "${COMMON[@]}" mobile debug get-doc 2>&1)"
 assert_contains "get-doc type" "type: Text" "$OUT"
 assert_contains "get-doc text" "$TEXT_A" "$OUT"
 assert_contains "get-doc has_data" "hasData: false" "$OUT"
@@ -160,7 +160,7 @@ assert_contains "get-doc hash" "hash:" "$OUT"
 # ── Step 2: dedup (content_hash 命中) ────────────────────────────────────
 
 step "Step 2 — put-text same TEXT_A (expect: duplicate_skipped + existing == entry_id_a)"
-OUT="$("$CLI" "${COMMON[@]}" --json mobile-sync debug put-text "$TEXT_A")"
+OUT="$("$CLI" "${COMMON[@]}" --json mobile debug put-text "$TEXT_A")"
 assert_contains "second put-text outcome" '"outcome": "duplicate_skipped"' "$OUT"
 EXISTING_ID="$(extract_existing_entry_id "$OUT")"
 if [[ "$EXISTING_ID" == "$ENTRY_ID_A" ]]; then
@@ -174,7 +174,7 @@ fi
 TEXT_B="different content $(date +%s%N)"
 
 step "Step 3.1 — put-text TEXT_B (expect: applied + new entry_id)"
-OUT="$("$CLI" "${COMMON[@]}" --json mobile-sync debug put-text "$TEXT_B")"
+OUT="$("$CLI" "${COMMON[@]}" --json mobile debug put-text "$TEXT_B")"
 assert_contains "TEXT_B outcome" '"outcome": "applied"' "$OUT"
 ENTRY_ID_B="$(extract_entry_id "$OUT")"
 if [[ -n "$ENTRY_ID_B" && "$ENTRY_ID_B" != "$ENTRY_ID_A" ]]; then
@@ -184,7 +184,7 @@ else
 fi
 
 step "Step 3.2 — get-doc reflects TEXT_B (latest wins)"
-OUT="$("$CLI" "${COMMON[@]}" mobile-sync debug get-doc 2>&1)"
+OUT="$("$CLI" "${COMMON[@]}" mobile debug get-doc 2>&1)"
 assert_contains "get-doc shows TEXT_B" "$TEXT_B" "$OUT"
 assert_not_contains "get-doc no longer shows TEXT_A" "$TEXT_A" "$OUT"
 
@@ -196,13 +196,13 @@ printf 'fake png bytes for P5a.9 e2e %s' "$(date +%s%N)" > "$PNG_PATH"
 PNG_SIZE=$(wc -c < "$PNG_PATH" | tr -d ' ')
 
 step "Step 4.1 — put-file $PNG_PATH (expect: step1 buffered + step2 applied)"
-OUT="$("$CLI" "${COMMON[@]}" --json mobile-sync debug put-file "$PNG_PATH")"
+OUT="$("$CLI" "${COMMON[@]}" --json mobile debug put-file "$PNG_PATH")"
 # 两步 outcome 在嵌套 JSON 里:{"file":{"outcome":"buffered",...},"doc":{"outcome":"applied",...}}
 assert_contains "step1 outcome" '"outcome": "buffered"' "$OUT"
 assert_contains "step2 outcome" '"outcome": "applied"' "$OUT"
 
 step "Step 4.2 — get-doc reflects Image meta + has_data=true + size=$PNG_SIZE"
-OUT="$("$CLI" "${COMMON[@]}" mobile-sync debug get-doc 2>&1)"
+OUT="$("$CLI" "${COMMON[@]}" mobile debug get-doc 2>&1)"
 assert_contains "type Image" "type: Image" "$OUT"
 assert_contains "has_data true" "hasData: true" "$OUT"
 assert_contains "size matches PNG_SIZE" "size: $PNG_SIZE" "$OUT"
@@ -218,7 +218,7 @@ fi
 
 step "Step 4.3 — get-file --output → diff bytes identical"
 OUT_PATH="$TMPDIR_RUN/p5a9-roundtrip.png"
-"$CLI" "${COMMON[@]}" mobile-sync debug get-file "$DATANAME" --output "$OUT_PATH" >/dev/null
+"$CLI" "${COMMON[@]}" mobile debug get-file "$DATANAME" --output "$OUT_PATH" >/dev/null
 if [[ -f "$OUT_PATH" ]]; then
     if diff -q "$PNG_PATH" "$OUT_PATH" >/dev/null; then
         ok "round-tripped bytes byte-identical ($PNG_SIZE bytes)"
@@ -235,20 +235,20 @@ WEBP_PATH="$TMPDIR_RUN/p5a9.txt"  # 故意用 .txt ext 但 override 成 image/we
 printf 'fake webp via override %s' "$(date +%s%N)" > "$WEBP_PATH"
 
 step "Step 5 — put-file with --mime image/webp on .txt extension (override wins)"
-OUT="$("$CLI" "${COMMON[@]}" --json mobile-sync debug put-file "$WEBP_PATH" --mime image/webp)"
+OUT="$("$CLI" "${COMMON[@]}" --json mobile debug put-file "$WEBP_PATH" --mime image/webp)"
 # 顶层 JSON 结构没有 mime 字段,但 step1 / step2 都应该 buffered + applied
 assert_contains "override step1 outcome" '"outcome": "buffered"' "$OUT"
 assert_contains "override step2 outcome" '"outcome": "applied"' "$OUT"
 
 step "Step 5.1 — get-doc 显示 type=Image 而不是 File"
-OUT="$("$CLI" "${COMMON[@]}" mobile-sync debug get-doc 2>&1)"
+OUT="$("$CLI" "${COMMON[@]}" mobile debug get-doc 2>&1)"
 assert_contains "override resulted in Image type" "type: Image" "$OUT"
 
 # ── Step 6: NotFound — get-file 不存在的 dataName ────────────────────────
 
 step "Step 6 — get-file <unknown> exits non-zero with NotFound message"
 set +e
-OUT="$("$CLI" "${COMMON[@]}" mobile-sync debug get-file "no-such-file-xyzzy.bin" 2>&1)"
+OUT="$("$CLI" "${COMMON[@]}" mobile debug get-file "no-such-file-xyzzy.bin" 2>&1)"
 CODE=$?
 set -e
 assert_exit_nonzero "get-file unknown" "$CODE"
@@ -260,7 +260,7 @@ step "Step 7 — start daemon then debug command must refuse"
 "$CLI" "${COMMON[@]}" start >/dev/null 2>&1
 sleep 2
 set +e
-OUT="$("$CLI" "${COMMON[@]}" mobile-sync debug put-text "should be refused" 2>&1)"
+OUT="$("$CLI" "${COMMON[@]}" mobile debug put-text "should be refused" 2>&1)"
 CODE=$?
 set -e
 assert_exit_nonzero "debug put-text while daemon running" "$CODE"
@@ -275,12 +275,12 @@ DOC_BYTES="fake binary file $(date +%s%N)"  # 唯一字节避开 dedup
 printf '%s' "$DOC_BYTES" > "$DOC_PATH"
 
 step "Step 8 — put-file .bin (item_type=File) → 两步均 applied,file-list rep 落库"
-OUT="$("$CLI" "${COMMON[@]}" --json mobile-sync debug put-file "$DOC_PATH")"
+OUT="$("$CLI" "${COMMON[@]}" --json mobile debug put-file "$DOC_PATH")"
 assert_contains "step1 buffered"        '"outcome": "buffered"' "$OUT"
 assert_contains "step2 applied"         '"outcome": "applied"'  "$OUT"
 
 # get-doc 应看到 type=File + dataName 指向 staging 文件
-DOC="$("$CLI" "${COMMON[@]}" mobile-sync debug get-doc 2>&1)"
+DOC="$("$CLI" "${COMMON[@]}" mobile debug get-doc 2>&1)"
 assert_contains "get-doc reports File" "type: File" "$DOC"
 DATANAME_FILE="$(extract_data_name "$DOC")"
 if [[ -n "$DATANAME_FILE" ]]; then
@@ -292,7 +292,7 @@ fi
 
 # P5a.3.5 后:get-file 经 staging.read_by_uri 直接返真文件字节(不是 URI list)
 OUT_FILE="$TMPDIR_RUN/p5a9-file-out.bin"
-"$CLI" "${COMMON[@]}" mobile-sync debug get-file "$DATANAME_FILE" --output "$OUT_FILE" >/dev/null 2>&1 \
+"$CLI" "${COMMON[@]}" mobile debug get-file "$DATANAME_FILE" --output "$OUT_FILE" >/dev/null 2>&1 \
     || fail "get-file for File-type dataName failed"
 if [[ -f "$OUT_FILE" ]]; then
     ok "get-file --output wrote real bytes"
@@ -314,24 +314,24 @@ TEXT_J="json-mode-check $(date +%s%N)"
 PNG_J_PATH="$TMPDIR_RUN/p5a9-json.png"
 printf 'json-mode unique png %s' "$(date +%s%N)" > "$PNG_J_PATH"
 
-OUT="$("$CLI" "${COMMON[@]}" --json mobile-sync debug put-text "$TEXT_J")"
+OUT="$("$CLI" "${COMMON[@]}" --json mobile debug put-text "$TEXT_J")"
 assert_contains "put-text JSON has outcome" '"outcome":' "$OUT"
 
-OUT="$("$CLI" "${COMMON[@]}" --json mobile-sync debug get-doc)"
+OUT="$("$CLI" "${COMMON[@]}" --json mobile debug get-doc)"
 assert_contains "get-doc JSON has item_type" '"item_type":' "$OUT"
 assert_contains "get-doc JSON has hash"      '"hash":'      "$OUT"
 
 # 这次 put-file 用一个**新**字节的 PNG，保证 latest 必是 Image（不是 Text/duplicate）
-OUT="$("$CLI" "${COMMON[@]}" --json mobile-sync debug put-file "$PNG_J_PATH")"
+OUT="$("$CLI" "${COMMON[@]}" --json mobile debug put-file "$PNG_J_PATH")"
 assert_contains "put-file JSON has file"     '"file":'                 "$OUT"
 assert_contains "put-file JSON has doc"      '"doc":'                  "$OUT"
 assert_contains "put-file step2 applied"     '"outcome": "applied"'    "$OUT"
 
 # get-file 需要一个真存在的 dataName —— 复用上一步 put-file 后的 latest
-LATEST="$("$CLI" "${COMMON[@]}" mobile-sync debug get-doc 2>&1)"
+LATEST="$("$CLI" "${COMMON[@]}" mobile debug get-doc 2>&1)"
 DATANAME_J="$(extract_data_name "$LATEST")"
 if [[ -n "$DATANAME_J" ]]; then
-    OUT="$("$CLI" "${COMMON[@]}" --json mobile-sync debug get-file "$DATANAME_J" \
+    OUT="$("$CLI" "${COMMON[@]}" --json mobile debug get-file "$DATANAME_J" \
         --output "$TMPDIR_RUN/json-out.bin")"
     assert_contains "get-file JSON has data_name" '"data_name":'   "$OUT"
     assert_contains "get-file JSON has mime"      '"mime":'        "$OUT"

--- a/scripts/test_mobile_sync_setup_e2e.sh
+++ b/scripts/test_mobile_sync_setup_e2e.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 #
-# mobile-sync setup / add / revoke / status 命令拓扑 + 自定义凭据校验的
+# mobile setup / add / revoke / status 命令拓扑 + 自定义凭据校验的
 # 本地端到端 e2e。
 #
 # 验证范围:
 #   * `setup` 一键向导 (--non-interactive --json) → register_device 出
 #     install_url + 一次性 password
-#   * `setup` 缺 flag 拒绝 (--label / --ip / --accept-network-risk)
+#   * `setup` 缺 flag 拒绝 (--label / --accept-network-risk;--ip 现为可选)
 #   * `status` / `disable` 综合行为(设备列表由 status 呈现)
 #   * `add` 自动凭据 + 自定义 username + --password-stdin pipe
 #   * username/password 校验 5 种拒绝形态:
@@ -146,7 +146,7 @@ ok "init succeeded"
 # ── Step 1: setup --non-interactive --json happy path ────────────────────
 
 step "Step 1 — setup --non-interactive --json happy path"
-run_capture "$CLI" "${COMMON[@]}" --json mobile-sync setup \
+run_capture "$CLI" "${COMMON[@]}" --json mobile setup \
     --non-interactive \
     --label "iPhone-A" \
     --ip "127.0.0.1" \
@@ -166,23 +166,22 @@ note "iPhone-A device_id: $DEVICE_A_ID"
 # ── Step 2: setup 缺 flag 拒绝 ───────────────────────────────────────────
 
 step "Step 2.1 — setup --non-interactive without --label rejected"
-run_capture "$CLI" "${COMMON[@]}" --json mobile-sync setup \
+run_capture "$CLI" "${COMMON[@]}" --json mobile setup \
     --non-interactive \
     --ip "127.0.0.1" \
     --accept-network-risk
 assert_exit_nonzero "missing --label" "$LAST_RC"
 assert_contains "error mentions --label" "--label is required" "$LAST_OUT"
 
-step "Step 2.2 — setup --non-interactive without --ip rejected"
-run_capture "$CLI" "${COMMON[@]}" --json mobile-sync setup \
-    --non-interactive \
-    --label "X" \
-    --accept-network-risk
-assert_exit_nonzero "missing --ip" "$LAST_RC"
-assert_contains "error mentions --ip" "--ip is required" "$LAST_OUT"
+# NOTE: there is intentionally no "setup without --ip rejected" case anymore.
+# --ip is now an optional advanced pin (the QR auto-carries every detected
+# interface), so omitting it is valid — and a *successful* setup would register
+# an extra device, which would break the device_count assertions below. The
+# "--ip optional" contract is covered by `mobile setup --help` wording and the
+# happy path in Step 1 (which still accepts an explicit --ip pin).
 
-step "Step 2.3 — setup --json without --accept-network-risk rejected"
-run_capture "$CLI" "${COMMON[@]}" --json mobile-sync setup \
+step "Step 2.2 — setup --json without --accept-network-risk rejected"
+run_capture "$CLI" "${COMMON[@]}" --json mobile setup \
     --label "X" \
     --ip "127.0.0.1"
 assert_exit_nonzero "missing --accept-network-risk" "$LAST_RC"
@@ -191,7 +190,7 @@ assert_contains "error mentions risk" "--accept-network-risk is required" "$LAST
 # ── Step 3: status comprehensive view ────────────────────────────────────
 
 step "Step 3 — status --json reflects 1 device + LAN enabled"
-run_capture "$CLI" "${COMMON[@]}" --json mobile-sync status
+run_capture "$CLI" "${COMMON[@]}" --json mobile status
 assert_exit_zero "status" "$LAST_RC"
 assert_contains "status enabled=true" '"enabled": true' "$LAST_OUT"
 assert_contains "status lan_listen_enabled=true" '"lan_listen_enabled": true' "$LAST_OUT"
@@ -201,7 +200,7 @@ assert_contains "status devices array contains iPhone-A" '"label": "iPhone-A"' "
 # ── Step 4: add (auto credentials) ───────────────────────────────────────
 
 step "Step 4 — add --label B (auto credentials)"
-run_capture "$CLI" "${COMMON[@]}" --json mobile-sync add --label "iPhone-B"
+run_capture "$CLI" "${COMMON[@]}" --json mobile add --label "iPhone-B"
 assert_exit_zero "add auto" "$LAST_RC"
 DEVICE_B_USERNAME="$(extract_username "$LAST_OUT")"
 note "iPhone-B auto username: $DEVICE_B_USERNAME"
@@ -217,7 +216,7 @@ fi
 step "Step 5 — add --label C --username alice_001 --password-stdin"
 CUSTOM_PW="MyStrongPassword123"
 run_capture_stdin "$CUSTOM_PW" \
-    "$CLI" "${COMMON[@]}" --json mobile-sync add \
+    "$CLI" "${COMMON[@]}" --json mobile add \
     --label "iPhone-C" \
     --username "alice_001" \
     --password-stdin
@@ -228,28 +227,28 @@ assert_contains "custom password echoed" "\"password\": \"$CUSTOM_PW\"" "$LAST_O
 # ── Step 6: 5 种校验拒绝 ─────────────────────────────────────────────────
 
 step "Step 6.1 — add --username alice_001 rejected (taken)"
-run_capture "$CLI" "${COMMON[@]}" --json mobile-sync add \
+run_capture "$CLI" "${COMMON[@]}" --json mobile add \
     --label "iPhone-Dup" \
     --username "alice_001"
 assert_exit_nonzero "duplicate username" "$LAST_RC"
 assert_contains "error mentions taken" "already taken" "$LAST_OUT"
 
 step "Step 6.2 — add --username ali rejected (too short)"
-run_capture "$CLI" "${COMMON[@]}" --json mobile-sync add \
+run_capture "$CLI" "${COMMON[@]}" --json mobile add \
     --label "iPhone-Short" \
     --username "ali"
 assert_exit_nonzero "username too short" "$LAST_RC"
 assert_contains "error mentions too short" "Username is too short" "$LAST_OUT"
 
 step "Step 6.3 — add --username 1abc12 rejected (digit-leading)"
-run_capture "$CLI" "${COMMON[@]}" --json mobile-sync add \
+run_capture "$CLI" "${COMMON[@]}" --json mobile add \
     --label "iPhone-DigitHead" \
     --username "1abc12"
 assert_exit_nonzero "username digit-leading" "$LAST_RC"
 assert_contains "error mentions letter-leading" "must start with an ASCII letter" "$LAST_OUT"
 
 step "Step 6.4 — add --username has-hyphen rejected (invalid char)"
-run_capture "$CLI" "${COMMON[@]}" --json mobile-sync add \
+run_capture "$CLI" "${COMMON[@]}" --json mobile add \
     --label "iPhone-Hyphen" \
     --username "alice-002"
 assert_exit_nonzero "username with hyphen" "$LAST_RC"
@@ -257,7 +256,7 @@ assert_contains "error mentions forbidden chars" "forbidden characters" "$LAST_O
 
 step "Step 6.5 — add --password-stdin too short (<8) rejected"
 run_capture_stdin "abc" \
-    "$CLI" "${COMMON[@]}" --json mobile-sync add \
+    "$CLI" "${COMMON[@]}" --json mobile add \
     --label "iPhone-WeakPw" \
     --password-stdin
 assert_exit_nonzero "password too short" "$LAST_RC"
@@ -266,14 +265,14 @@ assert_contains "error mentions password length" "Password is too short" "$LAST_
 # ── Step 7: status now shows 3 devices (A, B, C) ────────────────────────
 
 step "Step 7 — status --json now shows 3 devices"
-run_capture "$CLI" "${COMMON[@]}" --json mobile-sync status
+run_capture "$CLI" "${COMMON[@]}" --json mobile status
 assert_exit_zero "status after adds" "$LAST_RC"
 assert_contains "device_count=3" '"device_count": 3' "$LAST_OUT"
 
 # ── Step 8: revoke <id> 显式 ─────────────────────────────────────
 
 step "Step 8 — revoke <id> (iPhone-A explicit id)"
-run_capture "$CLI" "${COMMON[@]}" --json mobile-sync revoke "$DEVICE_A_ID"
+run_capture "$CLI" "${COMMON[@]}" --json mobile revoke "$DEVICE_A_ID"
 assert_exit_zero "revoke explicit" "$LAST_RC"
 assert_contains "revoked=true" '"revoked": true' "$LAST_OUT"
 assert_contains "revoke echoes device_id" "\"device_id\": \"$DEVICE_A_ID\"" "$LAST_OUT"
@@ -281,27 +280,27 @@ assert_contains "revoke echoes device_id" "\"device_id\": \"$DEVICE_A_ID\"" "$LA
 # ── Step 9: revoke (no id) --json 拒绝 ─────────────────────────
 
 step "Step 9 — revoke (no id) --json rejected"
-run_capture "$CLI" "${COMMON[@]}" --json mobile-sync revoke
+run_capture "$CLI" "${COMMON[@]}" --json mobile revoke
 assert_exit_nonzero "revoke no id JSON" "$LAST_RC"
 assert_contains "error mentions device-id required" "device-id" "$LAST_OUT"
 
 # ── Step 10: status now 2 devices ───────────────────────────────────────
 
 step "Step 10 — status --json now shows 2 devices"
-run_capture "$CLI" "${COMMON[@]}" --json mobile-sync status
+run_capture "$CLI" "${COMMON[@]}" --json mobile status
 assert_exit_zero "status after revoke" "$LAST_RC"
 assert_contains "device_count=2 after revoke" '"device_count": 2' "$LAST_OUT"
 
 # ── Step 11: disable -> both flags off ──────────────────────────────────
 
 step "Step 11 — disable --json (master + LAN both off)"
-run_capture "$CLI" "${COMMON[@]}" --json mobile-sync disable
+run_capture "$CLI" "${COMMON[@]}" --json mobile disable
 assert_exit_zero "disable" "$LAST_RC"
 assert_contains "disable enabled=false" '"enabled": false' "$LAST_OUT"
 assert_contains "disable lan_listen_enabled=false" '"lan_listen_enabled": false' "$LAST_OUT"
 
 step "Step 11.1 — status reflects disabled state, devices retained"
-run_capture "$CLI" "${COMMON[@]}" --json mobile-sync status
+run_capture "$CLI" "${COMMON[@]}" --json mobile status
 assert_exit_zero "status after disable" "$LAST_RC"
 assert_contains "status enabled=false" '"enabled": false' "$LAST_OUT"
 assert_contains "status lan_listen_enabled=false" '"lan_listen_enabled": false' "$LAST_OUT"
@@ -312,6 +311,6 @@ assert_contains "status devices retained" '"device_count": 2' "$LAST_OUT"
 echo
 echo "============================================="
 echo "PASS: all $PASS_COUNT assertions OK"
-echo "  mobile-sync — setup wizard / add / revoke / 校验 / status"
+echo "  mobile — setup wizard / add / revoke / 校验 / status"
 echo "  全部命令拓扑 + 自定义凭据规则 + 综合视图本地 e2e 验证通过"
 echo "============================================="

--- a/tests/e2e/tests/mobile_sync.rs
+++ b/tests/e2e/tests/mobile_sync.rs
@@ -107,8 +107,9 @@ async fn mobile_sync_setup_non_interactive_json() {
 async fn mobile_sync_setup_missing_flags_non_interactive() {
     let (_daemon, cli) = setup_initialized_node("ms-setup-missing").await;
 
-    // Run setup --non-interactive --json WITHOUT required --label, --ip,
-    // --accept-network-risk. The CLI should reject early.
+    // Run setup --non-interactive --json WITHOUT required --label /
+    // --accept-network-risk (--ip is now optional). The CLI should reject
+    // early on the still-required flags.
     let output = cli.run_capture(&["--json", "mobile-sync", "setup", "--non-interactive"]);
 
     assert!(
@@ -123,7 +124,6 @@ async fn mobile_sync_setup_missing_flags_non_interactive() {
     assert!(
         combined.contains("required")
             || combined.contains("--label")
-            || combined.contains("--ip")
             || combined.contains("--accept-network-risk")
             || combined.contains("error"),
         "error output should mention missing required flags: {combined}"

--- a/tests/e2e/tests/mobile_sync.rs
+++ b/tests/e2e/tests/mobile_sync.rs
@@ -42,7 +42,7 @@ async fn setup_initialized_node(name: &str) -> (TestDaemon, TestCli) {
 fn run_setup_non_interactive(cli: &TestCli, label: &str, ip: &str, extra_args: &[&str]) -> Value {
     let mut args: Vec<&str> = vec![
         "--json",
-        "mobile-sync",
+        "mobile",
         "setup",
         "--non-interactive",
         "--label",
@@ -72,7 +72,12 @@ fn run_setup_non_interactive(cli: &TestCli, label: &str, ip: &str, extra_args: &
 async fn mobile_sync_setup_non_interactive_json() {
     let (_daemon, cli) = setup_initialized_node("ms-setup-json").await;
 
-    let json = run_setup_non_interactive(&cli, "TestPhone", "192.168.1.100", &[]);
+    // Use a unique, uncommon LAN port. The well-known default (42720) is
+    // often occupied by a real UniClipboard instance on the same host (on
+    // WSL2 even a Windows-side instance, via localhost forwarding), and setup
+    // now aborts on a bind failure — so an e2e test must not depend on 42720
+    // being free. The 42720 default itself is the DEFAULT_LAN_PORT constant.
+    let json = run_setup_non_interactive(&cli, "TestPhone", "192.168.1.100", &["--port", "42725"]);
 
     // Verify all expected fields are present.
     assert!(
@@ -97,8 +102,8 @@ async fn mobile_sync_setup_non_interactive_json() {
     );
     assert_eq!(
         json.get("port").and_then(|v| v.as_u64()),
-        Some(42720),
-        "port should default to 42720: {json}"
+        Some(42725),
+        "setup response should reflect the configured port: {json}"
     );
 }
 
@@ -110,7 +115,7 @@ async fn mobile_sync_setup_missing_flags_non_interactive() {
     // Run setup --non-interactive --json WITHOUT required --label /
     // --accept-network-risk (--ip is now optional). The CLI should reject
     // early on the still-required flags.
-    let output = cli.run_capture(&["--json", "mobile-sync", "setup", "--non-interactive"]);
+    let output = cli.run_capture(&["--json", "mobile", "setup", "--non-interactive"]);
 
     assert!(
         !output.success(),
@@ -135,7 +140,7 @@ async fn mobile_sync_setup_missing_flags_non_interactive() {
 async fn mobile_sync_status_before_setup() {
     let (_daemon, cli) = setup_initialized_node("ms-status-before").await;
 
-    let output = cli.run_capture(&["--json", "mobile-sync", "status"]);
+    let output = cli.run_capture(&["--json", "mobile", "status"]);
     assert!(
         output.success(),
         "status before setup failed (exit={}): {}",
@@ -169,11 +174,13 @@ async fn mobile_sync_status_before_setup() {
 async fn mobile_sync_status_after_setup() {
     let (_daemon, cli) = setup_initialized_node("ms-status-after").await;
 
-    // Run setup first.
-    run_setup_non_interactive(&cli, "MyPhone", "192.168.1.50", &[]);
+    // Run setup first. A unique LAN port avoids colliding with the other
+    // setup-running tests on the default 42720 (they bind 0.0.0.0:port in
+    // parallel; setup now aborts on a bind failure).
+    run_setup_non_interactive(&cli, "MyPhone", "192.168.1.50", &["--port", "42721"]);
 
     // Now check status.
-    let output = cli.run_capture(&["--json", "mobile-sync", "status"]);
+    let output = cli.run_capture(&["--json", "mobile", "status"]);
     assert!(
         output.success(),
         "status after setup failed (exit={}): {}",
@@ -221,11 +228,11 @@ async fn mobile_sync_status_after_setup() {
 async fn mobile_sync_add_device() {
     let (_daemon, cli) = setup_initialized_node("ms-add-device").await;
 
-    // Initial setup.
-    run_setup_non_interactive(&cli, "FirstPhone", "192.168.1.10", &[]);
+    // Initial setup. Unique LAN port — see status_after_setup for why.
+    run_setup_non_interactive(&cli, "FirstPhone", "192.168.1.10", &["--port", "42722"]);
 
     // Add a second device.
-    let add_output = cli.run_capture(&["--json", "mobile-sync", "add", "--label", "SecondPhone"]);
+    let add_output = cli.run_capture(&["--json", "mobile", "add", "--label", "SecondPhone"]);
     assert!(
         add_output.success(),
         "add device failed (exit={}): stdout={}, stderr={}",
@@ -248,7 +255,7 @@ async fn mobile_sync_add_device() {
     );
 
     // Verify status shows 2 devices.
-    let status_output = cli.run_capture(&["--json", "mobile-sync", "status"]);
+    let status_output = cli.run_capture(&["--json", "mobile", "status"]);
     assert!(
         status_output.success(),
         "status failed: {}",
@@ -269,8 +276,10 @@ async fn mobile_sync_add_device() {
 async fn mobile_sync_revoke_device() {
     let (_daemon, cli) = setup_initialized_node("ms-revoke").await;
 
-    // Setup to register the first device.
-    let setup_json = run_setup_non_interactive(&cli, "PhoneToRevoke", "192.168.1.20", &[]);
+    // Setup to register the first device. Unique LAN port — see
+    // status_after_setup for why.
+    let setup_json =
+        run_setup_non_interactive(&cli, "PhoneToRevoke", "192.168.1.20", &["--port", "42723"]);
 
     let device_id = setup_json
         .get("device_id")
@@ -279,11 +288,11 @@ async fn mobile_sync_revoke_device() {
         .to_string();
 
     // Add a second device so we can verify count changes.
-    let add_out = cli.run_capture(&["--json", "mobile-sync", "add", "--label", "KeepMe"]);
+    let add_out = cli.run_capture(&["--json", "mobile", "add", "--label", "KeepMe"]);
     assert!(add_out.success(), "add failed: {}", add_out.stderr);
 
     // Verify 2 devices before revoke.
-    let pre_status = cli.run_capture(&["--json", "mobile-sync", "status"]);
+    let pre_status = cli.run_capture(&["--json", "mobile", "status"]);
     let pre_json: Value = serde_json::from_str(pre_status.stdout.trim()).expect("pre JSON");
     assert_eq!(
         pre_json.get("device_count").and_then(|v| v.as_u64()),
@@ -292,7 +301,7 @@ async fn mobile_sync_revoke_device() {
     );
 
     // Revoke the first device.
-    let revoke_output = cli.run_capture(&["--json", "mobile-sync", "revoke", &device_id]);
+    let revoke_output = cli.run_capture(&["--json", "mobile", "revoke", &device_id]);
     assert!(
         revoke_output.success(),
         "revoke failed (exit={}): stdout={}, stderr={}",
@@ -310,7 +319,7 @@ async fn mobile_sync_revoke_device() {
     );
 
     // Verify device_count decreased.
-    let post_status = cli.run_capture(&["--json", "mobile-sync", "status"]);
+    let post_status = cli.run_capture(&["--json", "mobile", "status"]);
     let post_json: Value = serde_json::from_str(post_status.stdout.trim()).expect("post JSON");
     assert_eq!(
         post_json.get("device_count").and_then(|v| v.as_u64()),
@@ -324,11 +333,11 @@ async fn mobile_sync_revoke_device() {
 async fn mobile_sync_disable() {
     let (_daemon, cli) = setup_initialized_node("ms-disable").await;
 
-    // Setup first.
-    run_setup_non_interactive(&cli, "DisablePhone", "192.168.1.30", &[]);
+    // Setup first. Unique LAN port — see status_after_setup for why.
+    run_setup_non_interactive(&cli, "DisablePhone", "192.168.1.30", &["--port", "42724"]);
 
     // Disable mobile-sync.
-    let disable_output = cli.run_capture(&["--json", "mobile-sync", "disable"]);
+    let disable_output = cli.run_capture(&["--json", "mobile", "disable"]);
     assert!(
         disable_output.success(),
         "disable failed (exit={}): stdout={}, stderr={}",
@@ -338,7 +347,7 @@ async fn mobile_sync_disable() {
     );
 
     // Verify status shows disabled.
-    let status_output = cli.run_capture(&["--json", "mobile-sync", "status"]);
+    let status_output = cli.run_capture(&["--json", "mobile", "status"]);
     assert!(
         status_output.success(),
         "status failed: {}",
@@ -374,7 +383,7 @@ async fn mobile_sync_disable() {
 async fn mobile_sync_network_interfaces() {
     let (_daemon, cli) = setup_initialized_node("ms-net-ifaces").await;
 
-    let output = cli.run_capture(&["--json", "mobile-sync", "network", "interfaces"]);
+    let output = cli.run_capture(&["--json", "mobile", "network", "interfaces"]);
     assert!(
         output.success(),
         "network interfaces failed (exit={}): stdout={}, stderr={}",
@@ -425,7 +434,7 @@ async fn mobile_sync_setup_custom_port() {
     );
 
     // Verify status reflects the custom port.
-    let status_output = cli.run_capture(&["--json", "mobile-sync", "status"]);
+    let status_output = cli.run_capture(&["--json", "mobile", "status"]);
     assert!(
         status_output.success(),
         "status failed: {}",


### PR DESCRIPTION
## Summary

Two related cleanups to the mobile companion-sync CLI surface, plus docs.

- **Rename `mobile-sync` → `mobile`** (cda8b52). The primary command is now `uniclip mobile`. `mobile-sync` is kept as a *hidden* deprecated alias: a separate `hide = true` subcommand variant that prints a deprecation notice on stderr (via `ui::warn`, so it never corrupts `--json` stdout) and then runs identically. Already-published scripts keep working; the canonical name moves on.
- **Simplify `mobile setup` to multi-address** (cb2b8e3). Setup no longer makes the user pick a LAN interface — the shared `register_device` use case already collects every detected interface into one multi-address connect QR, so pinning a single advertise IP was redundant friction that diverged from the GUI's one-click enable. `--ip` / `--port` become optional advanced pins; enabling now sends just `enabled + lan_listen_enabled` (matching the GUI) and no longer clears `lan_advertise_base_url`. Setup also aborts before minting credentials if the listener fails to bind, so the user never gets a QR for a dead socket.
- **docs-site** (086979b). Every `uniclip mobile-sync <verb>` invocation → `uniclip mobile <verb>` across the en/zh CLI reference, mobile-sync guide, devices, troubleshooting, and self-host pages; the `svc=mobile-sync` protocol identifier and the `core-features/mobile-sync` page slug are deliberately untouched. Dropped the now-false "`--ip` required" non-interactive setup prose.

## Test plan

- [x] `cargo test -p uc-cli` — 79 passed (includes new parse tests: `mobile` is primary, `mobile-sync` is a hidden alias resolving to its own variant).
- [x] `cargo build -p uc-cli` clean; `cargo clippy -p uc-cli` clean for the touched files.
- [x] e2e crate compiles (`cargo test --manifest-path tests/e2e/Cargo.toml --no-run`); both mobile e2e shell scripts pass `bash -n`.
- [x] Manual: `uniclip --help` lists only `mobile`; `uniclip mobile <verb>` runs with no notice; `uniclip mobile-sync <verb>` prints the deprecation warning then runs; `mobile-sync --help` still resolves (hidden).
- [ ] Reviewer: confirm the VPS provisioning flow (`deploy/vps/README.md`) still reads correctly end-to-end with `uniclip mobile network set` / `mobile add`.
- [ ] Reviewer: run the `#[ignore]` e2e suite (`tests/e2e/tests/mobile_sync.rs`) on a box with a real LAN NIC to exercise multi-address setup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `uniclip mobile setup` supports optional `--ip/--port`; in non-interactive/JSON mode only `--label` and `--accept-network-risk` are required. QR now includes every detected LAN address.
* **Bug Fixes**
  * Setup now stops early if the LAN listener can’t bind (e.g., port already in use), before credential registration.
* **Refactor**
  * Mobile sync CLI is now `uniclip mobile`; `mobile-sync` is kept as a hidden deprecated alias with a warning (including `debug`).
* **Documentation**
  * Updated CLI docs, guides, troubleshooting, and end-to-end scripts/tests to match the new command names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->