### PR TITLE
fix(settings): keep debug-mode restart dialog open while restarting

### DIFF
--- a/src/components/setting/GeneralSection.tsx
+++ b/src/components/setting/GeneralSection.tsx
@@ -1,3 +1,4 @@
+import { Loader2 } from 'lucide-react'
 import { useState, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { exportLogs, updateDebugMode } from '@/api/daemon/diagnostics'
@@ -49,6 +50,7 @@ export default function GeneralSection() {
   )
   const [debugMode, setDebugMode] = useState(setting?.general.debugMode ?? false)
   const [debugConfirmOpen, setDebugConfirmOpen] = useState(false)
+  const [debugRestarting, setDebugRestarting] = useState(false)
   const [exportPath, setExportPath] = useState<string | null>(null)
   const [exportingLogs, setExportingLogs] = useState(false)
   const [language, setLanguage] = useState<SupportedLanguage>(() => {
@@ -175,8 +177,10 @@ export default function GeneralSection() {
   }
 
   const handleConfirmDebugMode = async () => {
-    setDebugConfirmOpen(false)
+    // Keep the dialog open and switch it into a forced "restarting" state so the
+    // user cannot dismiss it while the app and daemon are coming back up.
     try {
+      setDebugRestarting(true)
       setSaving(true)
       const result = await updateDebugMode(true)
       await reloadSetting()
@@ -191,7 +195,9 @@ export default function GeneralSection() {
     } catch (error) {
       log.error({ err: error }, 'Failed to enable debug mode and restart')
       toast.error(t('settings.sections.general.logs.debug.error'))
+      // Restart failed: leave the dialog open but allow the user to dismiss it.
       setSaving(false)
+      setDebugRestarting(false)
     }
   }
 
@@ -380,24 +386,58 @@ export default function GeneralSection() {
         </SettingRow>
       </SettingGroup>
 
-      <AlertDialog open={debugConfirmOpen} onOpenChange={setDebugConfirmOpen}>
-        <AlertDialogContent className="bg-card text-card-foreground">
+      <AlertDialog
+        open={debugConfirmOpen}
+        onOpenChange={open => {
+          // While restarting, the dialog is forced: ignore every close request
+          // (Escape, overlay, programmatic) until the restart finishes or fails.
+          if (debugRestarting) return
+          setDebugConfirmOpen(open)
+        }}
+      >
+        <AlertDialogContent
+          className="bg-card text-card-foreground"
+          onEscapeKeyDown={event => {
+            if (debugRestarting) event.preventDefault()
+          }}
+        >
           <AlertDialogHeader>
             <AlertDialogTitle>
-              {t('settings.sections.general.logs.debug.confirmTitle')}
+              {debugRestarting
+                ? t('settings.sections.general.logs.debug.restartingTitle')
+                : t('settings.sections.general.logs.debug.confirmTitle')}
             </AlertDialogTitle>
             <AlertDialogDescription>
-              {t('settings.sections.general.logs.debug.confirmDescription')}
+              {debugRestarting
+                ? t('settings.sections.general.logs.debug.restartingDescription')
+                : t('settings.sections.general.logs.debug.confirmDescription')}
             </AlertDialogDescription>
           </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={saving}>
-              {t('settings.sections.general.logs.debug.cancel')}
-            </AlertDialogCancel>
-            <AlertDialogAction disabled={saving} onClick={handleConfirmDebugMode}>
-              {t('settings.sections.general.logs.debug.confirm')}
-            </AlertDialogAction>
-          </AlertDialogFooter>
+          {debugRestarting ? (
+            <AlertDialogFooter>
+              <div className="flex w-full items-center justify-center gap-2 text-sm text-muted-foreground">
+                <Loader2 className="size-4 animate-spin" />
+                {t('settings.sections.general.logs.debug.restartingTitle')}
+              </div>
+            </AlertDialogFooter>
+          ) : (
+            <AlertDialogFooter>
+              <AlertDialogCancel disabled={saving}>
+                {t('settings.sections.general.logs.debug.cancel')}
+              </AlertDialogCancel>
+              <AlertDialogAction
+                disabled={saving}
+                onClick={event => {
+                  // Prevent Radix from auto-closing the dialog on action click;
+                  // we keep it open to show the forced restarting state.
+                  event.preventDefault()
+                  void handleConfirmDebugMode()
+                }}
+              >
+                {t('settings.sections.general.logs.debug.confirm')}
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          )}
         </AlertDialogContent>
       </AlertDialog>
     </>

--- a/src/components/setting/__tests__/GeneralSection.debug.test.tsx
+++ b/src/components/setting/__tests__/GeneralSection.debug.test.tsx
@@ -169,6 +169,33 @@ describe('GeneralSection debug diagnostics controls', () => {
     expect(mockRestartApp).toHaveBeenCalledTimes(1)
   })
 
+  it('keeps the dialog open in a forced restarting state after confirmation', async () => {
+    const user = userEvent.setup()
+    mockUpdateDebugMode.mockResolvedValue({ debugMode: true, restartRequired: true })
+    setup()
+
+    render(<GeneralSection />)
+
+    await user.click(screen.getByRole('switch', { name: /logs\.debug\.label/ }))
+    await user.click(screen.getByRole('button', { name: /logs\.debug\.confirm$/ }))
+
+    // Once restarting, the dialog switches to the waiting copy and removes the
+    // confirm/cancel actions so the user cannot dismiss or re-trigger it.
+    await waitFor(() => {
+      expect(
+        screen.getByText('settings.sections.general.logs.debug.restartingDescription')
+      ).toBeInTheDocument()
+    })
+    expect(screen.queryByRole('button', { name: /logs\.debug\.confirm$/ })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /logs\.debug\.cancel$/ })).not.toBeInTheDocument()
+
+    // Escape must not close the forced dialog.
+    await user.keyboard('{Escape}')
+    expect(
+      screen.getByText('settings.sections.general.logs.debug.restartingDescription')
+    ).toBeInTheDocument()
+  })
+
   it('exports the last 24 hours of logs and shows the path', async () => {
     const user = userEvent.setup()
     mockExportLogs.mockResolvedValue({

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -161,7 +161,9 @@
             "confirm": "Enable & Restart",
             "cancel": "Cancel",
             "restartToast": "Restart the app or daemon for the logging change to fully take effect.",
-            "error": "Failed to change Debug mode"
+            "error": "Failed to change Debug mode",
+            "restartingTitle": "Restarting…",
+            "restartingDescription": "Restarting the app and background daemon to apply Debug mode. Please wait and do not close this window."
           },
           "export": {
             "label": "Export logs",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -161,7 +161,9 @@
             "confirm": "开启并重启",
             "cancel": "取消",
             "restartToast": "请重启应用或 daemon，使日志级别变更完全生效。",
-            "error": "更改 Debug 模式失败"
+            "error": "更改 Debug 模式失败",
+            "restartingTitle": "正在重启…",
+            "restartingDescription": "正在重启应用与后台 daemon 以应用 Debug 模式，请稍候，期间请勿关闭窗口。"
           },
           "export": {
             "label": "导出日志",


### PR DESCRIPTION
## Summary

- Confirming Debug mode used to close the dialog immediately, leaving the user with no feedback while the daemon and GUI restarted. The dialog now stays open in a forced "restarting" state until the processes come back up (9ae4906).
- Prevent Radix `AlertDialogAction` from auto-closing on confirm, and block Escape / overlay / programmatic close while restarting; only a *failed* restart re-enables dismissal so the user can recover.
- The footer is swapped for a spinner + waiting copy; added `restartingTitle` / `restartingDescription` strings to both `en-US` and `zh-CN`.

## Test plan

- [x] `bun run test -- --run src/components/setting/__tests__/GeneralSection.debug.test.tsx` — 3/3 pass, including a new test asserting the dialog stays open, drops the confirm/cancel buttons, and ignores Escape while restarting.
- [x] `eslint` + `tsc --noEmit` clean on the changed files.
- [ ] Manual: toggle Debug mode on in Settings → General; confirm the dialog stays visible with the spinner/"restarting" copy and cannot be dismissed (Esc / click-away) until the app restarts.

Docs: scanned `docs-site/`; the Debug-mode row in `settings.mdx` (en/zh) documents the confirm→auto-restart contract, which is unchanged — this PR only improves the in-restart feedback. Left as-is.