### PR TITLE
refactor(mobile-sync): split device repository into intent ports

### DIFF
--- a/crates/uc-application/src/deps.rs
+++ b/crates/uc-application/src/deps.rs
@@ -26,7 +26,6 @@ use uc_core::ports::search::search_index::SearchIndexPort;
 use uc_core::ports::search::search_key::SearchKeyDerivationPort;
 use uc_core::ports::search::search_pipeline::SearchPipelinePort;
 use uc_core::ports::*;
-use uc_core::ports::{MobileDeviceRepositoryPort, MobileSyncEndpointInfoPort};
 use uc_core::MemberRepositoryPort;
 use uc_observability::analytics::AnalyticsPort;
 
@@ -194,7 +193,6 @@ pub struct MobileDevicePorts {
 
 #[derive(Clone)]
 pub struct MobileSyncPorts {
-    pub device_repo: Arc<dyn MobileDeviceRepositoryPort>,
     pub devices: MobileDevicePorts,
     pub endpoint_info: Arc<dyn MobileSyncEndpointInfoPort>,
 }

--- a/crates/uc-application/src/deps.rs
+++ b/crates/uc-application/src/deps.rs
@@ -177,9 +177,25 @@ pub struct SystemPorts {
 /// `clear` 来更新这份状态;facade 通过本字段读它,看到 daemon 当前真实绑定
 /// 的 LAN URL。两端共享同一 `Arc<InMemoryMobileSyncEndpointInfoAdapter>`,通过
 /// unsizing coercion 转成 trait object。
+/// Registered-device intent ports facing the application layer.
+///
+/// The composition root coerces one Diesel device-repository adapter into each
+/// of these; each consumer takes only the slice it needs, never the whole
+/// aggregate store (see ports.md §8.3).
+#[derive(Clone)]
+pub struct MobileDevicePorts {
+    pub find_by_username: Arc<dyn FindMobileDeviceByUsernamePort>,
+    pub find_by_id: Arc<dyn FindMobileDeviceByIdPort>,
+    pub list: Arc<dyn ListMobileDevicesPort>,
+    pub save: Arc<dyn SaveMobileDevicePort>,
+    pub delete: Arc<dyn DeleteMobileDevicePort>,
+    pub update: Arc<dyn UpdateMobileDevicePort>,
+}
+
 #[derive(Clone)]
 pub struct MobileSyncPorts {
     pub device_repo: Arc<dyn MobileDeviceRepositoryPort>,
+    pub devices: MobileDevicePorts,
     pub endpoint_info: Arc<dyn MobileSyncEndpointInfoPort>,
 }
 

--- a/crates/uc-application/src/facade/clipboard/facade.rs
+++ b/crates/uc-application/src/facade/clipboard/facade.rs
@@ -691,14 +691,6 @@ mod tests {
                 &self,
                 device_id: &uc_core::mobile_sync::MobileDeviceId,
             ) -> Result<bool, uc_core::mobile_sync::MobileDeviceError>;
-            async fn record_activity(
-                &self,
-                device_id: &uc_core::mobile_sync::MobileDeviceId,
-                last_seen_at_ms: i64,
-                last_seen_ip: Option<String>,
-                reported_name: Option<String>,
-                reported_os: Option<String>,
-            ) -> Result<(), uc_core::mobile_sync::MobileDeviceError>;
             async fn update_mobile_device(
                 &self,
                 updated: &uc_core::mobile_sync::MobileDevice,

--- a/crates/uc-application/src/facade/clipboard/facade.rs
+++ b/crates/uc-application/src/facade/clipboard/facade.rs
@@ -21,7 +21,7 @@ use uc_core::ids::{DeviceId, EntryId};
 use uc_core::ports::security::TransferCipherPort;
 use uc_core::ports::{
     ClipboardDispatchPort, ClipboardReceiverPort, ClockPort, DeviceIdentityPort, DispatchAck,
-    EntryDeliveryRepositoryPort, FirstSyncStatePort, LocalIdentityPort, MobileDeviceRepositoryPort,
+    EntryDeliveryRepositoryPort, FindMobileDeviceByIdPort, FirstSyncStatePort, LocalIdentityPort,
     PeerAddressRepositoryPort, PresencePort, SettingsPort,
 };
 use uc_core::MemberRepositoryPort;
@@ -80,7 +80,7 @@ pub struct ClipboardSyncDeps {
     pub trusted_peer_repo: Arc<dyn TrustedPeerRepositoryPort>,
     /// 移动设备仓库,`GetEntryDeliveryViewUseCase` 用于把 `mobile_sync:` 前缀
     /// 的伪 DeviceId 解析为移动设备的人类可读 label。
-    pub mobile_device_repo: Arc<dyn MobileDeviceRepositoryPort>,
+    pub mobile_device_repo: Arc<dyn FindMobileDeviceByIdPort>,
     /// 共享 host-event bus。dispatch fan-out 完成、delivery 状态写入后追发
     /// 一条 `HostEvent::Delivery::StatusChanged`,GUI 前端凭此实时刷新 badge。
     /// 测试 / CLI 装配传一根空 bus(`Arc::new(HostEventBus::new())`)即可
@@ -671,30 +671,11 @@ mod tests {
     mockall::mock! {
         pub MobileDeviceRepo {}
         #[async_trait]
-        impl MobileDeviceRepositoryPort for MobileDeviceRepo {
-            async fn save(
-                &self,
-                device: &uc_core::mobile_sync::MobileDevice,
-            ) -> Result<(), uc_core::mobile_sync::MobileDeviceError>;
-            async fn find_by_username(
-                &self,
-                username: &str,
-            ) -> Result<Option<uc_core::mobile_sync::MobileDevice>, uc_core::mobile_sync::MobileDeviceError>;
+        impl FindMobileDeviceByIdPort for MobileDeviceRepo {
             async fn find_by_device_id(
                 &self,
                 device_id: &uc_core::mobile_sync::MobileDeviceId,
             ) -> Result<Option<uc_core::mobile_sync::MobileDevice>, uc_core::mobile_sync::MobileDeviceError>;
-            async fn list_all(
-                &self,
-            ) -> Result<Vec<uc_core::mobile_sync::MobileDevice>, uc_core::mobile_sync::MobileDeviceError>;
-            async fn delete(
-                &self,
-                device_id: &uc_core::mobile_sync::MobileDeviceId,
-            ) -> Result<bool, uc_core::mobile_sync::MobileDeviceError>;
-            async fn update_mobile_device(
-                &self,
-                updated: &uc_core::mobile_sync::MobileDevice,
-            ) -> Result<bool, uc_core::mobile_sync::MobileDeviceError>;
         }
     }
 

--- a/crates/uc-application/src/facade/mobile_sync/facade.rs
+++ b/crates/uc-application/src/facade/mobile_sync/facade.rs
@@ -710,16 +710,6 @@ mod tests {
             devs.retain(|d| d.device_id != *id);
             Ok(devs.len() < before)
         }
-        async fn record_activity(
-            &self,
-            _: &MobileDeviceId,
-            _: i64,
-            _: Option<String>,
-            _: Option<String>,
-            _: Option<String>,
-        ) -> Result<(), MobileDeviceError> {
-            Ok(())
-        }
         async fn update_mobile_device(
             &self,
             updated: &MobileDevice,

--- a/crates/uc-application/src/facade/mobile_sync/facade.rs
+++ b/crates/uc-application/src/facade/mobile_sync/facade.rs
@@ -45,12 +45,13 @@ use uc_core::mobile_sync::LanListenerStatus;
 use uc_core::mobile_sync::MobileDeviceId;
 use uc_core::ports::mobile_sync::LatestClipboardSnapshotPort;
 use uc_core::ports::{
-    ClockPort, LanInterfaceProbePort, MobileCredentialsMinterPort, MobileDeviceRepositoryPort,
-    MobileFileStagingPort, MobileLanLifecyclePort, MobileLanTarget, MobileSyncEndpointInfoPort,
-    PasswordHasherPort, SettingsPort,
+    ClockPort, LanInterfaceProbePort, MobileCredentialsMinterPort, MobileFileStagingPort,
+    MobileLanLifecyclePort, MobileLanTarget, MobileSyncEndpointInfoPort, PasswordHasherPort,
+    SettingsPort,
 };
 use uc_observability::analytics::AnalyticsPort;
 
+use crate::deps::MobileDevicePorts;
 use crate::facade::clipboard_outbound::ClipboardOutboundFacade;
 use crate::facade::clipboard_restore::ClipboardRestoreFacade;
 use crate::facade::file_transfer::FileTransferFacade;
@@ -154,7 +155,7 @@ pub struct MobileSyncFacadeDeps {
     pub clock: Arc<dyn ClockPort>,
     pub credentials_minter: Arc<dyn MobileCredentialsMinterPort>,
     pub password_hasher: Arc<dyn PasswordHasherPort>,
-    pub device_repo: Arc<dyn MobileDeviceRepositoryPort>,
+    pub devices: MobileDevicePorts,
     pub endpoint_info: Arc<dyn MobileSyncEndpointInfoPort>,
     pub lan_interface_probe: Arc<dyn LanInterfaceProbePort>,
     pub settings: Arc<dyn SettingsPort>,
@@ -262,7 +263,7 @@ impl MobileSyncFacade {
             clock,
             credentials_minter,
             password_hasher,
-            device_repo,
+            devices,
             endpoint_info,
             lan_interface_probe,
             settings,
@@ -284,16 +285,19 @@ impl MobileSyncFacade {
             register_device: RegisterMobileShortcutDeviceUseCase::new(
                 credentials_minter.clone(),
                 password_hasher.clone(),
-                device_repo.clone(),
+                devices.find_by_username.clone(),
+                devices.save.clone(),
                 settings.clone(),
                 clock.clone(),
                 lan_interface_probe.clone(),
                 analytics.clone(),
             ),
-            revoke_device: RevokeMobileDeviceUseCase::new(device_repo.clone()),
-            list_devices: ListMobileDevicesUseCase::new(device_repo.clone()),
+            revoke_device: RevokeMobileDeviceUseCase::new(devices.delete.clone()),
+            list_devices: ListMobileDevicesUseCase::new(devices.list.clone()),
             update_device: UpdateMobileDeviceUseCase::new(
-                device_repo.clone(),
+                devices.find_by_id.clone(),
+                devices.find_by_username.clone(),
+                devices.update.clone(),
                 password_hasher.clone(),
                 credentials_minter,
             ),
@@ -304,7 +308,7 @@ impl MobileSyncFacade {
             update_settings: UpdateMobileSyncSettingsUseCase::new(settings),
             list_lan_interfaces: ListLanInterfacesUseCase::new(lan_interface_probe),
             authenticate_basic: AuthenticateBasicAuthUseCase::new(
-                device_repo,
+                devices.find_by_username.clone(),
                 password_hasher,
                 analytics.clone(),
             ),
@@ -639,7 +643,11 @@ mod tests {
         ClipboardPayloadResolverPort, ClipboardSelectionRepositoryPort, GetRepresentationPort,
         ListClipboardEntriesPort, PayloadResolveError, ResolvedClipboardPayload,
     };
-    use uc_core::ports::{EndpointInfoError, LanInterfaceProbeError, PasswordHasherError};
+    use uc_core::ports::{
+        DeleteMobileDevicePort, EndpointInfoError, FindMobileDeviceByIdPort,
+        FindMobileDeviceByUsernamePort, LanInterfaceProbeError, ListMobileDevicesPort,
+        PasswordHasherError, SaveMobileDevicePort, UpdateMobileDevicePort,
+    };
     use uc_core::settings::model::Settings;
     use uc_core::BlobId;
     use uc_core::DeviceId;
@@ -672,11 +680,14 @@ mod tests {
         devices: Mutex<Vec<MobileDevice>>,
     }
     #[async_trait]
-    impl MobileDeviceRepositoryPort for InMemoryDeviceRepo {
+    impl SaveMobileDevicePort for InMemoryDeviceRepo {
         async fn save(&self, device: &MobileDevice) -> Result<(), MobileDeviceError> {
             self.devices.lock().unwrap().push(device.clone());
             Ok(())
         }
+    }
+    #[async_trait]
+    impl FindMobileDeviceByUsernamePort for InMemoryDeviceRepo {
         async fn find_by_username(
             &self,
             username: &str,
@@ -689,6 +700,9 @@ mod tests {
                 .find(|d| d.username == username)
                 .cloned())
         }
+    }
+    #[async_trait]
+    impl FindMobileDeviceByIdPort for InMemoryDeviceRepo {
         async fn find_by_device_id(
             &self,
             id: &MobileDeviceId,
@@ -701,15 +715,24 @@ mod tests {
                 .find(|d| d.device_id == *id)
                 .cloned())
         }
+    }
+    #[async_trait]
+    impl ListMobileDevicesPort for InMemoryDeviceRepo {
         async fn list_all(&self) -> Result<Vec<MobileDevice>, MobileDeviceError> {
             Ok(self.devices.lock().unwrap().clone())
         }
+    }
+    #[async_trait]
+    impl DeleteMobileDevicePort for InMemoryDeviceRepo {
         async fn delete(&self, id: &MobileDeviceId) -> Result<bool, MobileDeviceError> {
             let mut devs = self.devices.lock().unwrap();
             let before = devs.len();
             devs.retain(|d| d.device_id != *id);
             Ok(devs.len() < before)
         }
+    }
+    #[async_trait]
+    impl UpdateMobileDevicePort for InMemoryDeviceRepo {
         async fn update_mobile_device(
             &self,
             updated: &MobileDevice,
@@ -734,6 +757,19 @@ mod tests {
                 d.password_hash = updated.password_hash.clone();
             }
             Ok(true)
+        }
+    }
+
+    /// Build the six narrow device-repo ports from one shared
+    /// `InMemoryDeviceRepo` so all consumers see the same backing store.
+    fn device_ports_from(repo: Arc<InMemoryDeviceRepo>) -> MobileDevicePorts {
+        MobileDevicePorts {
+            find_by_username: repo.clone(),
+            find_by_id: repo.clone(),
+            list: repo.clone(),
+            save: repo.clone(),
+            delete: repo.clone(),
+            update: repo,
         }
     }
 
@@ -945,7 +981,7 @@ mod tests {
             clock: Arc::new(FixedClock(1_000)),
             credentials_minter: Arc::new(StaticMinter),
             password_hasher: Arc::new(FakeHasher),
-            device_repo: Arc::new(InMemoryDeviceRepo::default()),
+            devices: device_ports_from(Arc::new(InMemoryDeviceRepo::default())),
             endpoint_info: Arc::new(FixedEndpoint),
             lan_interface_probe: Arc::new(StubLanProbe),
             settings: Arc::new(InMemorySettings::default()),
@@ -1103,7 +1139,7 @@ mod tests {
             clock: Arc::new(FixedClock(1_000)),
             credentials_minter: Arc::new(StaticMinter),
             password_hasher: Arc::new(FakeHasher),
-            device_repo: repo,
+            devices: device_ports_from(repo),
             endpoint_info: Arc::new(FixedEndpoint),
             lan_interface_probe: Arc::new(StubLanProbe),
             settings: Arc::new(InMemorySettings::default()),
@@ -1187,7 +1223,7 @@ mod tests {
             clock: Arc::new(FixedClock(1_000)),
             credentials_minter: Arc::new(StaticMinter),
             password_hasher: Arc::new(FakeHasher),
-            device_repo: repo.clone(),
+            devices: device_ports_from(repo.clone()),
             endpoint_info: Arc::new(FixedEndpoint),
             lan_interface_probe: Arc::new(StubLanProbe),
             settings: Arc::new(InMemorySettings::default()),
@@ -1302,7 +1338,7 @@ mod tests {
             clock: Arc::new(FixedClock(1_000)),
             credentials_minter: Arc::new(StaticMinter),
             password_hasher: Arc::new(FakeHasher),
-            device_repo: Arc::new(InMemoryDeviceRepo::default()),
+            devices: device_ports_from(Arc::new(InMemoryDeviceRepo::default())),
             endpoint_info: Arc::new(FixedEndpoint),
             lan_interface_probe: Arc::new(StubLanProbe),
             settings: Arc::new(InMemorySettings::default()),
@@ -1448,7 +1484,7 @@ mod tests {
             clock: Arc::new(FixedClock(1_000)),
             credentials_minter: Arc::new(StaticMinter),
             password_hasher: Arc::new(FakeHasher),
-            device_repo: Arc::new(InMemoryDeviceRepo::default()),
+            devices: device_ports_from(Arc::new(InMemoryDeviceRepo::default())),
             // 关键:endpoint_info 装的是 BindFailureEndpoint, lifecycle 也持
             // 同一份 Arc, apply 写完 facade 立刻能读到。
             endpoint_info: endpoint.clone(),

--- a/crates/uc-application/src/usecases/clipboard_sync/get_entry_delivery_view.rs
+++ b/crates/uc-application/src/usecases/clipboard_sync/get_entry_delivery_view.rs
@@ -524,14 +524,6 @@ mod tests {
             ) -> Result<Option<MobileDevice>, MobileDeviceError>;
             async fn list_all(&self) -> Result<Vec<MobileDevice>, MobileDeviceError>;
             async fn delete(&self, device_id: &MobileDeviceId) -> Result<bool, MobileDeviceError>;
-            async fn record_activity(
-                &self,
-                device_id: &MobileDeviceId,
-                last_seen_at_ms: i64,
-                last_seen_ip: Option<String>,
-                reported_name: Option<String>,
-                reported_os: Option<String>,
-            ) -> Result<(), MobileDeviceError>;
             async fn update_mobile_device(
                 &self,
                 updated: &MobileDevice,

--- a/crates/uc-application/src/usecases/clipboard_sync/get_entry_delivery_view.rs
+++ b/crates/uc-application/src/usecases/clipboard_sync/get_entry_delivery_view.rs
@@ -78,7 +78,7 @@ pub enum GetEntryDeliveryViewError {
 
 /// `mobile_sync:` 前缀——移动端入站在 `apply_incoming.rs` 里
 /// 用 `DeviceId::new(format!("mobile_sync:{}", source_device_id))` 生成伪
-/// DeviceId。本 use case 需要识别该前缀以从 `MobileDeviceRepositoryPort`
+/// DeviceId。本 use case 需要识别该前缀以从 `FindMobileDeviceByIdPort`
 /// 查出设备 label。
 const MOBILE_SYNC_DEVICE_PREFIX: &str = "mobile_sync:";
 
@@ -862,7 +862,7 @@ mod tests {
     //
     // 移动端入站写的 from_device 是 `mobile_sync:<mobile_device_id>` 伪
     // DeviceId,不在 SpaceMember 表里。视图层应剥离前缀后从
-    // MobileDeviceRepositoryPort 查出 label 作为展示名。
+    // FindMobileDeviceByIdPort 查出 label 作为展示名。
 
     #[tokio::test]
     async fn mobile_source_device_name_resolves_from_mobile_device_repo() {

--- a/crates/uc-application/src/usecases/clipboard_sync/get_entry_delivery_view.rs
+++ b/crates/uc-application/src/usecases/clipboard_sync/get_entry_delivery_view.rs
@@ -18,7 +18,7 @@ use uc_core::mobile_sync::MobileDeviceId;
 use uc_core::ports::clipboard::GetClipboardEntryPort;
 use uc_core::ports::{
     ClipboardEventRepositoryPort, DeviceIdentityPort, EntryDeliveryRepositoryPort,
-    MobileDeviceRepositoryPort,
+    FindMobileDeviceByIdPort,
 };
 use uc_core::trusted_peer::TrustedPeerRepositoryPort;
 use uc_core::MemberRepositoryPort;
@@ -89,7 +89,7 @@ pub(crate) struct GetEntryDeliveryViewUseCase {
     entry_delivery_repo: Arc<dyn EntryDeliveryRepositoryPort>,
     device_identity: Arc<dyn DeviceIdentityPort>,
     member_repo: Arc<dyn MemberRepositoryPort>,
-    mobile_device_repo: Arc<dyn MobileDeviceRepositoryPort>,
+    mobile_device_repo: Arc<dyn FindMobileDeviceByIdPort>,
 }
 
 impl GetEntryDeliveryViewUseCase {
@@ -100,7 +100,7 @@ impl GetEntryDeliveryViewUseCase {
         entry_delivery_repo: Arc<dyn EntryDeliveryRepositoryPort>,
         device_identity: Arc<dyn DeviceIdentityPort>,
         member_repo: Arc<dyn MemberRepositoryPort>,
-        mobile_device_repo: Arc<dyn MobileDeviceRepositoryPort>,
+        mobile_device_repo: Arc<dyn FindMobileDeviceByIdPort>,
     ) -> Self {
         Self {
             entry_repo,
@@ -512,22 +512,11 @@ mod tests {
     mockall::mock! {
         MobileDeviceRepo {}
         #[async_trait]
-        impl MobileDeviceRepositoryPort for MobileDeviceRepo {
-            async fn save(&self, device: &MobileDevice) -> Result<(), MobileDeviceError>;
-            async fn find_by_username(
-                &self,
-                username: &str,
-            ) -> Result<Option<MobileDevice>, MobileDeviceError>;
+        impl FindMobileDeviceByIdPort for MobileDeviceRepo {
             async fn find_by_device_id(
                 &self,
                 device_id: &MobileDeviceId,
             ) -> Result<Option<MobileDevice>, MobileDeviceError>;
-            async fn list_all(&self) -> Result<Vec<MobileDevice>, MobileDeviceError>;
-            async fn delete(&self, device_id: &MobileDeviceId) -> Result<bool, MobileDeviceError>;
-            async fn update_mobile_device(
-                &self,
-                updated: &MobileDevice,
-            ) -> Result<bool, MobileDeviceError>;
         }
     }
 
@@ -616,7 +605,7 @@ mod tests {
         trusted_peer_repo: Arc<FakeTrustedPeerRepo>,
         delivery_repo: Arc<FakeDeliveryRepo>,
         member_repo: Arc<FakeMemberRepo>,
-        mobile_device_repo: Arc<dyn MobileDeviceRepositoryPort>,
+        mobile_device_repo: Arc<dyn FindMobileDeviceByIdPort>,
     ) -> GetEntryDeliveryViewUseCase {
         GetEntryDeliveryViewUseCase::new(
             entry_repo,

--- a/crates/uc-application/src/usecases/mobile_sync/authenticate_basic.rs
+++ b/crates/uc-application/src/usecases/mobile_sync/authenticate_basic.rs
@@ -31,7 +31,7 @@ use base64::Engine;
 use tracing::instrument;
 
 use uc_core::mobile_sync::{MobileDevice, MobileDeviceError};
-use uc_core::ports::{MobileDeviceRepositoryPort, PasswordHasherError, PasswordHasherPort};
+use uc_core::ports::{FindMobileDeviceByUsernamePort, PasswordHasherError, PasswordHasherPort};
 use uc_observability::analytics::{AnalyticsPort, Event, MobileAuthFailureKind};
 
 // ─── public-shaped (input / output / error) ─────────────────────────────
@@ -72,7 +72,7 @@ pub enum AuthenticateBasicAuthError {
 // ─── use case ───────────────────────────────────────────────────────────
 
 pub(crate) struct AuthenticateBasicAuthUseCase {
-    device_repo: Arc<dyn MobileDeviceRepositoryPort>,
+    find_by_username: Arc<dyn FindMobileDeviceByUsernamePort>,
     password_hasher: Arc<dyn PasswordHasherPort>,
     /// schema doc §7.6 / §12.2 P1：iPhone Basic Auth 失败率 anchor。
     ///
@@ -86,12 +86,12 @@ pub(crate) struct AuthenticateBasicAuthUseCase {
 
 impl AuthenticateBasicAuthUseCase {
     pub(crate) fn new(
-        device_repo: Arc<dyn MobileDeviceRepositoryPort>,
+        find_by_username: Arc<dyn FindMobileDeviceByUsernamePort>,
         password_hasher: Arc<dyn PasswordHasherPort>,
         analytics: Arc<dyn AnalyticsPort>,
     ) -> Self {
         Self {
-            device_repo,
+            find_by_username,
             password_hasher,
             analytics,
         }
@@ -120,7 +120,7 @@ impl AuthenticateBasicAuthUseCase {
         };
 
         // 2. 查仓储。
-        let found = match self.device_repo.find_by_username(&username).await {
+        let found = match self.find_by_username.find_by_username(&username).await {
             Ok(found) => found,
             Err(err) => {
                 // 仓储读失败属于服务端内部错误 —— 与"凭据无效"语义不同，

--- a/crates/uc-application/src/usecases/mobile_sync/authenticate_basic.rs
+++ b/crates/uc-application/src/usecases/mobile_sync/authenticate_basic.rs
@@ -21,9 +21,8 @@
 //!    本 use case 不在外面做"先 username 比对再说"的提前短路, 让 hasher
 //!    那 ~50ms 成为统一时长 ceiling, 哪怕命中"用户名不存在"也跑一次假
 //!    验证(实现见下文)。
-//! 4. **不更新 last_seen_*** —— 那是上层路由 happy path 后再决定是否调
-//!    `record_activity` 的事(给路由更细的控制粒度: 401 不应当 last_seen,
-//!    成功的请求才应当)。
+//! 4. **不更新 last_seen_*** —— 鉴权 use case 只回答"凭据是否合法",
+//!    活跃信息的回写不属于本职责。
 
 use std::sync::Arc;
 
@@ -46,9 +45,7 @@ pub struct AuthenticateBasicAuthInput {
 
 /// 鉴权成功的产物:已被仓储确认存在并通过密码校验的 device。
 ///
-/// 上层路由拿到它后, 通常会:
-///   1. 把 `device` 塞进 axum extension 供后续 handler 用;
-///   2. 调 facade 的 record_activity 异步更新 last_seen_*。
+/// 上层路由拿到它后, 通常会把 `device` 塞进 axum extension 供后续 handler 用。
 #[derive(Debug, Clone)]
 pub struct AuthenticatedDevice {
     pub device: MobileDevice,

--- a/crates/uc-application/src/usecases/mobile_sync/list_devices.rs
+++ b/crates/uc-application/src/usecases/mobile_sync/list_devices.rs
@@ -27,7 +27,7 @@ use std::sync::Arc;
 use tracing::instrument;
 
 use uc_core::mobile_sync::{MobileClientType, MobileDevice, MobileDeviceError, MobileDeviceId};
-use uc_core::ports::MobileDeviceRepositoryPort;
+use uc_core::ports::ListMobileDevicesPort;
 
 // ─── public-shaped (output / error) ─────────────────────────────────────
 
@@ -89,12 +89,12 @@ pub enum ListMobileDevicesError {
 // ─── use case ───────────────────────────────────────────────────────────
 
 pub(crate) struct ListMobileDevicesUseCase {
-    device_repo: Arc<dyn MobileDeviceRepositoryPort>,
+    list: Arc<dyn ListMobileDevicesPort>,
 }
 
 impl ListMobileDevicesUseCase {
-    pub(crate) fn new(device_repo: Arc<dyn MobileDeviceRepositoryPort>) -> Self {
-        Self { device_repo }
+    pub(crate) fn new(list: Arc<dyn ListMobileDevicesPort>) -> Self {
+        Self { list }
     }
 
     /// 列出全部设备，按"最近活跃 desc → 创建时间 desc"排序。
@@ -106,11 +106,7 @@ impl ListMobileDevicesUseCase {
     ///     的设备后面，而不是被夹在过期设备中间。
     #[instrument(skip(self))]
     pub(crate) async fn execute(&self) -> Result<Vec<MobileDeviceSummary>, ListMobileDevicesError> {
-        let devices = self
-            .device_repo
-            .list_all()
-            .await
-            .map_err(translate_device_error)?;
+        let devices = self.list.list_all().await.map_err(translate_device_error)?;
 
         let mut summaries: Vec<MobileDeviceSummary> = devices
             .into_iter()

--- a/crates/uc-application/src/usecases/mobile_sync/register_device.rs
+++ b/crates/uc-application/src/usecases/mobile_sync/register_device.rs
@@ -220,6 +220,7 @@ pub(crate) struct RegisterMobileShortcutDeviceUseCase {
 }
 
 impl RegisterMobileShortcutDeviceUseCase {
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         credentials_minter: Arc<dyn MobileCredentialsMinterPort>,
         password_hasher: Arc<dyn PasswordHasherPort>,

--- a/crates/uc-application/src/usecases/mobile_sync/register_device.rs
+++ b/crates/uc-application/src/usecases/mobile_sync/register_device.rs
@@ -28,8 +28,9 @@ use uc_core::mobile_sync::{
     LanInterface, MintedCredentials, MobileClientType, MobileDevice, MobileDeviceError,
 };
 use uc_core::ports::{
-    ClockPort, LanInterfaceProbeError, LanInterfaceProbePort, MobileCredentialsMinterPort,
-    MobileDeviceRepositoryPort, PasswordHasherError, PasswordHasherPort, SettingsPort,
+    ClockPort, FindMobileDeviceByUsernamePort, LanInterfaceProbeError, LanInterfaceProbePort,
+    MobileCredentialsMinterPort, PasswordHasherError, PasswordHasherPort, SaveMobileDevicePort,
+    SettingsPort,
 };
 use uc_core::settings::model::MobileSyncSettings;
 use uc_observability::analytics::{AnalyticsPort, Event};
@@ -206,7 +207,8 @@ pub const SYNC_CLIPBOARD_EX_INSTALL_URL: &str =
 pub(crate) struct RegisterMobileShortcutDeviceUseCase {
     credentials_minter: Arc<dyn MobileCredentialsMinterPort>,
     password_hasher: Arc<dyn PasswordHasherPort>,
-    device_repo: Arc<dyn MobileDeviceRepositoryPort>,
+    find_by_username: Arc<dyn FindMobileDeviceByUsernamePort>,
+    save: Arc<dyn SaveMobileDevicePort>,
     settings: Arc<dyn SettingsPort>,
     clock: Arc<dyn ClockPort>,
     lan_interface_probe: Arc<dyn LanInterfaceProbePort>,
@@ -221,7 +223,8 @@ impl RegisterMobileShortcutDeviceUseCase {
     pub(crate) fn new(
         credentials_minter: Arc<dyn MobileCredentialsMinterPort>,
         password_hasher: Arc<dyn PasswordHasherPort>,
-        device_repo: Arc<dyn MobileDeviceRepositoryPort>,
+        find_by_username: Arc<dyn FindMobileDeviceByUsernamePort>,
+        save: Arc<dyn SaveMobileDevicePort>,
         settings: Arc<dyn SettingsPort>,
         clock: Arc<dyn ClockPort>,
         lan_interface_probe: Arc<dyn LanInterfaceProbePort>,
@@ -230,7 +233,8 @@ impl RegisterMobileShortcutDeviceUseCase {
         Self {
             credentials_minter,
             password_hasher,
-            device_repo,
+            find_by_username,
+            save,
             settings,
             clock,
             lan_interface_probe,
@@ -422,7 +426,7 @@ impl RegisterMobileShortcutDeviceUseCase {
             reported_name: None,
             reported_os: None,
         };
-        self.device_repo
+        self.save
             .save(&device)
             .await
             .map_err(translate_device_error)?;
@@ -476,7 +480,7 @@ impl RegisterMobileShortcutDeviceUseCase {
         &self,
         username: &str,
     ) -> Result<(), RegisterMobileShortcutDeviceError> {
-        match self.device_repo.find_by_username(username).await {
+        match self.find_by_username.find_by_username(username).await {
             Ok(Some(_)) => Err(RegisterMobileShortcutDeviceError::UsernameTaken(
                 username.to_string(),
             )),
@@ -870,10 +874,12 @@ mod tests {
     /// 默认 LAN advertise settings / 1_000ms clock / 空 probe(LAN 已配置时
     /// 走不到 auto-pick,empty probe 即可)。`lan_listen_enabled` 控开关。
     fn build_uc(lan_listen_enabled: bool) -> RegisterMobileShortcutDeviceUseCase {
+        let device_repo = Arc::new(empty_device_repo());
         RegisterMobileShortcutDeviceUseCase::new(
             Arc::new(deterministic_minter()),
             Arc::new(recording_hasher()),
-            Arc::new(empty_device_repo()),
+            device_repo.clone(), // find_by_username
+            device_repo,         // save
             Arc::new(settings_port_lan_advertise(lan_listen_enabled)),
             Arc::new(clock_at(1_000)),
             Arc::new(probe_returning(vec![])),
@@ -890,10 +896,12 @@ mod tests {
         Arc<CapturingAnalyticsSink>,
     ) {
         let analytics = Arc::new(CapturingAnalyticsSink::default());
+        let device_repo = Arc::new(empty_device_repo());
         let uc = RegisterMobileShortcutDeviceUseCase::new(
             Arc::new(deterministic_minter()),
             Arc::new(recording_hasher()),
-            Arc::new(empty_device_repo()),
+            device_repo.clone(), // find_by_username
+            device_repo,         // save
             Arc::new(settings_port_lan_advertise(lan_listen_enabled)),
             Arc::new(clock_at(1_000)),
             Arc::new(probe_returning(vec![])),
@@ -1042,10 +1050,12 @@ mod tests {
     async fn base_url_override_takes_precedence_over_advertise_ip() {
         // settings 同时有 lan_advertise_ip 和 lan_advertise_base_url —— base_url
         // 必须胜出, 出现在 out.base_url 与 connect_uri payload 里。
+        let device_repo = Arc::new(empty_device_repo());
         let uc = RegisterMobileShortcutDeviceUseCase::new(
             Arc::new(deterministic_minter()),
             Arc::new(recording_hasher()),
-            Arc::new(empty_device_repo()),
+            device_repo.clone(), // find_by_username
+            device_repo,         // save
             Arc::new(settings_port_base_url()),
             Arc::new(clock_at(1_000)),
             // probe 永远不该被调到(base_url 已定 → 不走 auto-pick)。给个空
@@ -1167,10 +1177,12 @@ mod tests {
 
     #[tokio::test]
     async fn rejects_username_already_taken() {
+        let device_repo = Arc::new(device_repo_with_existing_username("alice_001"));
         let uc = RegisterMobileShortcutDeviceUseCase::new(
             Arc::new(deterministic_minter()),
             Arc::new(recording_hasher()),
-            Arc::new(device_repo_with_existing_username("alice_001")),
+            device_repo.clone(), // find_by_username
+            device_repo,         // save
             Arc::new(settings_port_lan_advertise(true)),
             Arc::new(clock_at(1_000)),
             Arc::new(probe_returning(vec![])),
@@ -1203,10 +1215,12 @@ mod tests {
             .times(1)
             .returning(|p| Ok(format!("phc-of:{p}")));
 
+        let device_repo = Arc::new(empty_device_repo());
         let uc = RegisterMobileShortcutDeviceUseCase::new(
             Arc::new(deterministic_minter()),
             Arc::new(hasher),
-            Arc::new(empty_device_repo()),
+            device_repo.clone(), // find_by_username
+            device_repo,         // save
             Arc::new(settings_port_lan_advertise(true)),
             Arc::new(clock_at(1_000)),
             Arc::new(probe_returning(vec![])),
@@ -1271,10 +1285,12 @@ mod tests {
 
     #[tokio::test]
     async fn translates_hasher_internal_error() {
+        let device_repo = Arc::new(empty_device_repo());
         let uc = RegisterMobileShortcutDeviceUseCase::new(
             Arc::new(deterministic_minter()),
             Arc::new(failing_hasher()),
-            Arc::new(empty_device_repo()),
+            device_repo.clone(), // find_by_username
+            device_repo,         // save
             Arc::new(settings_port_lan_advertise(true)),
             Arc::new(clock_at(1_000)),
             Arc::new(probe_returning(vec![])),
@@ -1318,10 +1334,12 @@ mod tests {
     // ── tests: auto-pick advertise_ip ─────────────────────────────────
 
     fn build_uc_auto(probe: MockProbe) -> RegisterMobileShortcutDeviceUseCase {
+        let device_repo = Arc::new(empty_device_repo());
         RegisterMobileShortcutDeviceUseCase::new(
             Arc::new(deterministic_minter()),
             Arc::new(recording_hasher()),
-            Arc::new(empty_device_repo()),
+            device_repo.clone(), // find_by_username
+            device_repo,         // save
             Arc::new(settings_port_auto()),
             Arc::new(clock_at(1_000)),
             Arc::new(probe),
@@ -1401,10 +1419,12 @@ mod tests {
         settings: MockSettingsPortImpl,
         probe: MockProbe,
     ) -> RegisterMobileShortcutDeviceUseCase {
+        let device_repo = Arc::new(empty_device_repo());
         RegisterMobileShortcutDeviceUseCase::new(
             Arc::new(deterministic_minter()),
             Arc::new(recording_hasher()),
-            Arc::new(empty_device_repo()),
+            device_repo.clone(), // find_by_username
+            device_repo,         // save
             Arc::new(settings),
             Arc::new(clock_at(1_000)),
             Arc::new(probe),

--- a/crates/uc-application/src/usecases/mobile_sync/revoke_device.rs
+++ b/crates/uc-application/src/usecases/mobile_sync/revoke_device.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 use tracing::instrument;
 
 use uc_core::mobile_sync::{MobileDeviceError, MobileDeviceId};
-use uc_core::ports::MobileDeviceRepositoryPort;
+use uc_core::ports::DeleteMobileDevicePort;
 
 // ─── public-shaped (input / error) ──────────────────────────────────────
 
@@ -41,12 +41,12 @@ pub enum RevokeMobileDeviceError {
 // ─── use case ───────────────────────────────────────────────────────────
 
 pub(crate) struct RevokeMobileDeviceUseCase {
-    device_repo: Arc<dyn MobileDeviceRepositoryPort>,
+    delete: Arc<dyn DeleteMobileDevicePort>,
 }
 
 impl RevokeMobileDeviceUseCase {
-    pub(crate) fn new(device_repo: Arc<dyn MobileDeviceRepositoryPort>) -> Self {
-        Self { device_repo }
+    pub(crate) fn new(delete: Arc<dyn DeleteMobileDevicePort>) -> Self {
+        Self { delete }
     }
 
     #[instrument(skip(self, input), fields(device_id = %input.device_id))]
@@ -55,7 +55,7 @@ impl RevokeMobileDeviceUseCase {
         input: RevokeMobileDeviceInput,
     ) -> Result<(), RevokeMobileDeviceError> {
         let removed = self
-            .device_repo
+            .delete
             .delete(&input.device_id)
             .await
             .map_err(translate_device_error)?;

--- a/crates/uc-application/src/usecases/mobile_sync/test_support.rs
+++ b/crates/uc-application/src/usecases/mobile_sync/test_support.rs
@@ -64,14 +64,6 @@ mockall::mock! {
         ) -> Result<Option<MobileDevice>, MobileDeviceError>;
         async fn list_all(&self) -> Result<Vec<MobileDevice>, MobileDeviceError>;
         async fn delete(&self, device_id: &MobileDeviceId) -> Result<bool, MobileDeviceError>;
-        async fn record_activity(
-            &self,
-            device_id: &MobileDeviceId,
-            last_seen_at_ms: i64,
-            last_seen_ip: Option<String>,
-            reported_name: Option<String>,
-            reported_os: Option<String>,
-        ) -> Result<(), MobileDeviceError>;
         async fn update_mobile_device(
             &self,
             updated: &MobileDevice,

--- a/crates/uc-application/src/usecases/mobile_sync/test_support.rs
+++ b/crates/uc-application/src/usecases/mobile_sync/test_support.rs
@@ -5,8 +5,11 @@
 //! 在多个 use case 测试里**重复出现**的 mock,集中一次写完,所有测试 `use
 //! super::test_support::*;` 即可。当前承载:
 //!
-//! - [`MockDeviceRepo`] —— [`MobileDeviceRepositoryPort`] 的 mockall mock,
-//!   被 register / authenticate / update / revoke / list 共用。
+//! - [`MockDeviceRepo`] —— the narrow device-repo ports' mockall mock
+//!   (`FindMobileDeviceByUsernamePort` / `FindMobileDeviceByIdPort` /
+//!   `ListMobileDevicesPort` / `SaveMobileDevicePort` / `DeleteMobileDevicePort`
+//!   / `UpdateMobileDevicePort`), shared by register / authenticate / update /
+//!   revoke / list.
 //! - [`MockHasher`] —— [`PasswordHasherPort`] 的 mockall mock,被 register /
 //!   authenticate / update 共用。
 //! - [`MockMinter`] —— [`MobileCredentialsMinterPort`] 的 mockall mock,被
@@ -44,26 +47,42 @@ use uc_core::mobile_sync::{
 };
 use uc_core::ports::mobile_sync::{MobileFileStagingError, MobileFileStagingPort};
 use uc_core::ports::{
-    MobileCredentialsMinterPort, MobileDeviceRepositoryPort, PasswordHasherError,
-    PasswordHasherPort,
+    DeleteMobileDevicePort, FindMobileDeviceByIdPort, FindMobileDeviceByUsernamePort,
+    ListMobileDevicesPort, MobileCredentialsMinterPort, PasswordHasherError, PasswordHasherPort,
+    SaveMobileDevicePort, UpdateMobileDevicePort,
 };
 use uc_observability::analytics::{AnalyticsPort, Event};
 
 mockall::mock! {
     pub DeviceRepo {}
     #[async_trait]
-    impl MobileDeviceRepositoryPort for DeviceRepo {
-        async fn save(&self, device: &MobileDevice) -> Result<(), MobileDeviceError>;
+    impl FindMobileDeviceByUsernamePort for DeviceRepo {
         async fn find_by_username(
             &self,
             username: &str,
         ) -> Result<Option<MobileDevice>, MobileDeviceError>;
+    }
+    #[async_trait]
+    impl FindMobileDeviceByIdPort for DeviceRepo {
         async fn find_by_device_id(
             &self,
             device_id: &MobileDeviceId,
         ) -> Result<Option<MobileDevice>, MobileDeviceError>;
+    }
+    #[async_trait]
+    impl ListMobileDevicesPort for DeviceRepo {
         async fn list_all(&self) -> Result<Vec<MobileDevice>, MobileDeviceError>;
+    }
+    #[async_trait]
+    impl SaveMobileDevicePort for DeviceRepo {
+        async fn save(&self, device: &MobileDevice) -> Result<(), MobileDeviceError>;
+    }
+    #[async_trait]
+    impl DeleteMobileDevicePort for DeviceRepo {
         async fn delete(&self, device_id: &MobileDeviceId) -> Result<bool, MobileDeviceError>;
+    }
+    #[async_trait]
+    impl UpdateMobileDevicePort for DeviceRepo {
         async fn update_mobile_device(
             &self,
             updated: &MobileDevice,

--- a/crates/uc-application/src/usecases/mobile_sync/update_device.rs
+++ b/crates/uc-application/src/usecases/mobile_sync/update_device.rs
@@ -11,8 +11,8 @@ use tracing::{debug, instrument};
 
 use uc_core::mobile_sync::{MintedCredentials, MobileDeviceError, MobileDeviceId};
 use uc_core::ports::{
-    MobileCredentialsMinterPort, MobileDeviceRepositoryPort, PasswordHasherError,
-    PasswordHasherPort,
+    FindMobileDeviceByIdPort, FindMobileDeviceByUsernamePort, MobileCredentialsMinterPort,
+    PasswordHasherError, PasswordHasherPort, UpdateMobileDevicePort,
 };
 
 use super::register_device::{
@@ -96,19 +96,25 @@ pub enum UpdateMobileDeviceError {
 }
 
 pub(crate) struct UpdateMobileDeviceUseCase {
-    device_repo: Arc<dyn MobileDeviceRepositoryPort>,
+    find_by_id: Arc<dyn FindMobileDeviceByIdPort>,
+    find_by_username: Arc<dyn FindMobileDeviceByUsernamePort>,
+    update: Arc<dyn UpdateMobileDevicePort>,
     password_hasher: Arc<dyn PasswordHasherPort>,
     credentials_minter: Arc<dyn MobileCredentialsMinterPort>,
 }
 
 impl UpdateMobileDeviceUseCase {
     pub(crate) fn new(
-        device_repo: Arc<dyn MobileDeviceRepositoryPort>,
+        find_by_id: Arc<dyn FindMobileDeviceByIdPort>,
+        find_by_username: Arc<dyn FindMobileDeviceByUsernamePort>,
+        update: Arc<dyn UpdateMobileDevicePort>,
         password_hasher: Arc<dyn PasswordHasherPort>,
         credentials_minter: Arc<dyn MobileCredentialsMinterPort>,
     ) -> Self {
         Self {
-            device_repo,
+            find_by_id,
+            find_by_username,
+            update,
             password_hasher,
             credentials_minter,
         }
@@ -127,7 +133,7 @@ impl UpdateMobileDeviceUseCase {
         input: UpdateMobileDeviceInput,
     ) -> Result<UpdateMobileDeviceOutput, UpdateMobileDeviceError> {
         let mut device = self
-            .device_repo
+            .find_by_id
             .find_by_device_id(&input.device_id)
             .await
             .map_err(translate_device_error)?
@@ -192,7 +198,7 @@ impl UpdateMobileDeviceUseCase {
         }
 
         let updated = self
-            .device_repo
+            .update
             .update_mobile_device(&device)
             .await
             .map_err(|err| translate_update_error(err, &device.username))?;
@@ -217,7 +223,7 @@ impl UpdateMobileDeviceUseCase {
         current_id: &MobileDeviceId,
         username: &str,
     ) -> Result<(), UpdateMobileDeviceError> {
-        match self.device_repo.find_by_username(username).await {
+        match self.find_by_username.find_by_username(username).await {
             Ok(Some(existing)) if existing.device_id != *current_id => {
                 Err(UpdateMobileDeviceError::UsernameTaken(username.to_string()))
             }
@@ -379,7 +385,14 @@ mod tests {
         let mut minter = MockMinter::new();
         minter.expect_mint_credentials().never();
 
-        let uc = UpdateMobileDeviceUseCase::new(Arc::new(repo), Arc::new(hasher), Arc::new(minter));
+        let device_repo = Arc::new(repo);
+        let uc = UpdateMobileDeviceUseCase::new(
+            device_repo.clone(),
+            device_repo.clone(),
+            device_repo,
+            Arc::new(hasher),
+            Arc::new(minter),
+        );
 
         let out = uc
             .execute(UpdateMobileDeviceInput {
@@ -422,8 +435,11 @@ mod tests {
         let mut hasher = MockHasher::new();
         hasher.expect_hash().never();
 
+        let device_repo = Arc::new(repo);
         let uc = UpdateMobileDeviceUseCase::new(
-            Arc::new(repo),
+            device_repo.clone(),
+            device_repo.clone(),
+            device_repo,
             Arc::new(hasher),
             Arc::new(minter_emitting("minted-update-pw-22")),
         );
@@ -462,8 +478,11 @@ mod tests {
         let mut minter = MockMinter::new();
         minter.expect_mint_credentials().never();
 
+        let device_repo = Arc::new(repo);
         let uc = UpdateMobileDeviceUseCase::new(
-            Arc::new(repo),
+            device_repo.clone(),
+            device_repo.clone(),
+            device_repo,
             Arc::new(identity_hasher_for("brand-new-pass-42")),
             Arc::new(minter),
         );
@@ -500,8 +519,11 @@ mod tests {
             });
         repo.expect_update_mobile_device().never();
 
+        let device_repo = Arc::new(repo);
         let uc = UpdateMobileDeviceUseCase::new(
-            Arc::new(repo),
+            device_repo.clone(),
+            device_repo.clone(),
+            device_repo,
             Arc::new(identity_hasher_for("minted-update-pw-22")),
             Arc::new(minter_emitting("minted-update-pw-22")),
         );
@@ -537,8 +559,11 @@ mod tests {
         repo.expect_update_mobile_device()
             .returning(|_| Err(MobileDeviceError::UsernameCollision));
 
+        let device_repo = Arc::new(repo);
         let uc = UpdateMobileDeviceUseCase::new(
-            Arc::new(repo),
+            device_repo.clone(),
+            device_repo.clone(),
+            device_repo,
             Arc::new(identity_hasher_for("minted-update-pw-22")),
             Arc::new(minter_emitting("minted-update-pw-22")),
         );

--- a/crates/uc-bootstrap/src/assembly.rs
+++ b/crates/uc-bootstrap/src/assembly.rs
@@ -301,12 +301,9 @@ struct InfraLayer {
     // handing it to the publisher and use cases).
     file_transfer_store: Arc<crate::file_transfer_lifecycle::FileTransferEventStore>,
 
-    // Mobile sync 设备仓库 — `DieselMobileDeviceRepository`,跨重启 / 跨进
-    // 程稳定的已登记设备列表(替代之前进程内 HashMap)。
-    mobile_device_repo: Arc<dyn uc_core::ports::MobileDeviceRepositoryPort>,
-
-    // Narrow device-repository intent ports, all backed by the same adapter as
-    // `mobile_device_repo` (coerced per ports.md §8.3).
+    // Mobile sync 设备仓库 — narrow device-repository intent ports, all backed
+    // by one `DieselMobileDeviceRepository` (cross-restart / cross-process
+    // stable; coerced per ports.md §8.3).
     mobile_device_ports: MobileDevicePorts,
 
     // Mobile sync LAN 端点状态(单例) — daemon listener 启停时调 inherent
@@ -545,10 +542,9 @@ fn create_infra_layer(
     );
 
     // Keep a concrete Arc so it can be coerced into each narrow device-repo
-    // intent port. The adapter still implements the aggregate
-    // MobileDeviceRepositoryPort (the intent-port impls delegate to it); the
-    // wide trait object is exposed via `mobile_device_repo` only until consumers
-    // migrate to the bundle.
+    // intent port. The adapter implements the aggregate MobileDeviceStore and
+    // each intent-port impl delegates to it (ports.md §8.3); only the narrow
+    // ports are exposed upward.
     let mobile_device_repo_arc = Arc::new(DieselMobileDeviceRepository::new(
         Arc::clone(&db_executor),
         MobileDeviceRowMapper,
@@ -559,10 +555,8 @@ fn create_infra_layer(
         list: mobile_device_repo_arc.clone(),
         save: mobile_device_repo_arc.clone(),
         delete: mobile_device_repo_arc.clone(),
-        update: mobile_device_repo_arc.clone(),
+        update: mobile_device_repo_arc,
     };
-    let mobile_device_repo: Arc<dyn uc_core::ports::MobileDeviceRepositoryPort> =
-        mobile_device_repo_arc;
 
     // endpoint_info adapter:进程级单例,daemon LAN listener 与 facade 各持
     // 一份 Arc 共享同一份内存。整个进程只跑一次 `wire_dependencies`,这里
@@ -595,7 +589,6 @@ fn create_infra_layer(
         hash,
         file_transfer,
         file_transfer_store,
-        mobile_device_repo,
         mobile_device_ports,
         mobile_sync_endpoint_info,
     };
@@ -1186,7 +1179,6 @@ pub fn wire_dependencies(
             search_pipeline,
         },
         mobile_sync: MobileSyncPorts {
-            device_repo: infra.mobile_device_repo,
             devices: infra.mobile_device_ports,
             endpoint_info: infra.mobile_sync_endpoint_info.clone(),
         },

--- a/crates/uc-bootstrap/src/assembly.rs
+++ b/crates/uc-bootstrap/src/assembly.rs
@@ -21,7 +21,8 @@ use tracing::info;
 
 use uc_application::deps::{
     AppDeps, ClipboardEntryPorts, ClipboardPorts, ClipboardRepresentationPorts, DevicePorts,
-    FileTransferPorts, MobileSyncPorts, SearchPorts, SecurityPorts, StoragePorts, SystemPorts,
+    FileTransferPorts, MobileDevicePorts, MobileSyncPorts, SearchPorts, SecurityPorts,
+    StoragePorts, SystemPorts,
 };
 use uc_application::facade::HostEventEmitterPort;
 use uc_core::blob::ports::{BlobReaderPort, BlobWriterPort};
@@ -304,6 +305,10 @@ struct InfraLayer {
     // 程稳定的已登记设备列表(替代之前进程内 HashMap)。
     mobile_device_repo: Arc<dyn uc_core::ports::MobileDeviceRepositoryPort>,
 
+    // Narrow device-repository intent ports, all backed by the same adapter as
+    // `mobile_device_repo` (coerced per ports.md §8.3).
+    mobile_device_ports: MobileDevicePorts,
+
     // Mobile sync LAN 端点状态(单例) — daemon listener 启停时调 inherent
     // `set` / `clear` 写它,facade 通过 `MobileSyncEndpointInfoPort` 只读。
     // 持有具体类型是为了让 daemon 拿到写入面;同一份 Arc 通过 unsizing
@@ -539,9 +544,25 @@ fn create_infra_layer(
         uc_infra::file_transfer::SqliteReceiverFileTransferStore::new(Arc::clone(&db_executor)),
     );
 
-    let mobile_device_repo: Arc<dyn uc_core::ports::MobileDeviceRepositoryPort> = Arc::new(
-        DieselMobileDeviceRepository::new(Arc::clone(&db_executor), MobileDeviceRowMapper),
-    );
+    // Keep a concrete Arc so it can be coerced into each narrow device-repo
+    // intent port. The adapter still implements the aggregate
+    // MobileDeviceRepositoryPort (the intent-port impls delegate to it); the
+    // wide trait object is exposed via `mobile_device_repo` only until consumers
+    // migrate to the bundle.
+    let mobile_device_repo_arc = Arc::new(DieselMobileDeviceRepository::new(
+        Arc::clone(&db_executor),
+        MobileDeviceRowMapper,
+    ));
+    let mobile_device_ports = MobileDevicePorts {
+        find_by_username: mobile_device_repo_arc.clone(),
+        find_by_id: mobile_device_repo_arc.clone(),
+        list: mobile_device_repo_arc.clone(),
+        save: mobile_device_repo_arc.clone(),
+        delete: mobile_device_repo_arc.clone(),
+        update: mobile_device_repo_arc.clone(),
+    };
+    let mobile_device_repo: Arc<dyn uc_core::ports::MobileDeviceRepositoryPort> =
+        mobile_device_repo_arc;
 
     // endpoint_info adapter:进程级单例,daemon LAN listener 与 facade 各持
     // 一份 Arc 共享同一份内存。整个进程只跑一次 `wire_dependencies`,这里
@@ -575,6 +596,7 @@ fn create_infra_layer(
         file_transfer,
         file_transfer_store,
         mobile_device_repo,
+        mobile_device_ports,
         mobile_sync_endpoint_info,
     };
 
@@ -1165,6 +1187,7 @@ pub fn wire_dependencies(
         },
         mobile_sync: MobileSyncPorts {
             device_repo: infra.mobile_device_repo,
+            devices: infra.mobile_device_ports,
             endpoint_info: infra.mobile_sync_endpoint_info.clone(),
         },
         analytics: crate::analytics::build_analytics_sink(),

--- a/crates/uc-bootstrap/src/non_gui_runtime.rs
+++ b/crates/uc-bootstrap/src/non_gui_runtime.rs
@@ -269,7 +269,7 @@ pub fn build_mobile_sync_facade(
         // 装配处直接 new 即可。
         credentials_minter: Arc::new(OsRngCredentialsMinter),
         password_hasher: Arc::new(Argon2idPasswordHasher),
-        device_repo: deps.mobile_sync.device_repo.clone(),
+        devices: deps.mobile_sync.devices.clone(),
         endpoint_info: deps.mobile_sync.endpoint_info.clone(),
         lan_interface_probe: Arc::new(NetworkInterfaceLanProbe::new()),
         settings: deps.settings.clone(),

--- a/crates/uc-bootstrap/src/space_setup.rs
+++ b/crates/uc-bootstrap/src/space_setup.rs
@@ -463,7 +463,7 @@ pub async fn build_space_setup_assembly(
         entry_repo: Arc::clone(&deps.clipboard.entry_ports.get),
         event_repo: Arc::clone(&wired.clipboard_event_reader_repo),
         trusted_peer_repo: Arc::clone(&wired.trusted_peer_repo),
-        mobile_device_repo: Arc::clone(&deps.mobile_sync.device_repo),
+        mobile_device_repo: Arc::clone(&deps.mobile_sync.devices.find_by_id),
         // Issue #747 Phase 5：与 blob_transfer / apply_inbound 共享同一根
         // host_event_bus。GUI 装配链路在 Tauri setup callback 中
         // `bus.register("tauri", TauriHostEventEmitter)`,daemon 启动时

--- a/crates/uc-bootstrap/tests/slice2_phase2_clipboard_e2e.rs
+++ b/crates/uc-bootstrap/tests/slice2_phase2_clipboard_e2e.rs
@@ -320,44 +320,13 @@ impl uc_core::ports::ClipboardEventRepositoryPort for NoopClipboardEventRepo {
 #[derive(Default)]
 struct NoopMobileDeviceRepo;
 #[async_trait]
-impl uc_core::ports::MobileDeviceRepositoryPort for NoopMobileDeviceRepo {
-    async fn save(
-        &self,
-        _device: &uc_core::mobile_sync::MobileDevice,
-    ) -> Result<(), uc_core::mobile_sync::MobileDeviceError> {
-        Ok(())
-    }
-    async fn find_by_username(
-        &self,
-        _username: &str,
-    ) -> Result<Option<uc_core::mobile_sync::MobileDevice>, uc_core::mobile_sync::MobileDeviceError>
-    {
-        Ok(None)
-    }
+impl uc_core::ports::FindMobileDeviceByIdPort for NoopMobileDeviceRepo {
     async fn find_by_device_id(
         &self,
         _device_id: &uc_core::mobile_sync::MobileDeviceId,
     ) -> Result<Option<uc_core::mobile_sync::MobileDevice>, uc_core::mobile_sync::MobileDeviceError>
     {
         Ok(None)
-    }
-    async fn list_all(
-        &self,
-    ) -> Result<Vec<uc_core::mobile_sync::MobileDevice>, uc_core::mobile_sync::MobileDeviceError>
-    {
-        Ok(Vec::new())
-    }
-    async fn delete(
-        &self,
-        _device_id: &uc_core::mobile_sync::MobileDeviceId,
-    ) -> Result<bool, uc_core::mobile_sync::MobileDeviceError> {
-        Ok(false)
-    }
-    async fn update_mobile_device(
-        &self,
-        _updated: &uc_core::mobile_sync::MobileDevice,
-    ) -> Result<bool, uc_core::mobile_sync::MobileDeviceError> {
-        Ok(false)
     }
 }
 

--- a/crates/uc-bootstrap/tests/slice2_phase2_clipboard_e2e.rs
+++ b/crates/uc-bootstrap/tests/slice2_phase2_clipboard_e2e.rs
@@ -353,16 +353,6 @@ impl uc_core::ports::MobileDeviceRepositoryPort for NoopMobileDeviceRepo {
     ) -> Result<bool, uc_core::mobile_sync::MobileDeviceError> {
         Ok(false)
     }
-    async fn record_activity(
-        &self,
-        _device_id: &uc_core::mobile_sync::MobileDeviceId,
-        _last_seen_at_ms: i64,
-        _last_seen_ip: Option<String>,
-        _reported_name: Option<String>,
-        _reported_os: Option<String>,
-    ) -> Result<(), uc_core::mobile_sync::MobileDeviceError> {
-        Ok(())
-    }
     async fn update_mobile_device(
         &self,
         _updated: &uc_core::mobile_sync::MobileDevice,

--- a/crates/uc-core/src/ports/mobile_sync.rs
+++ b/crates/uc-core/src/ports/mobile_sync.rs
@@ -73,14 +73,16 @@ pub enum PasswordHasherError {
     Internal(String),
 }
 
-// ─── device repository ───────────────────────────────────────────────────
+// ─── device store (inner aggregate) ──────────────────────────────────────
 
-/// 已登记 mobile 设备的持久化能力(v3 改用 username 索引)。
+/// Inner aggregate persistence surface for registered mobile devices
+/// (username-indexed).
 ///
-/// 鉴权热路径调用 `find_by_username` —— adapter 必须确保有 username 索引;
-/// 删除路径在撤销 / 解绑时调用,需要立即生效(不能走异步队列)。
+/// This is the low-level store (ports.md §5.1/§12): adapters implement it once
+/// and the narrow device intent ports below delegate to it. Application-layer
+/// consumers depend on the narrow ports, never on this aggregate.
 #[async_trait]
-pub trait MobileDeviceRepositoryPort: Send + Sync {
+pub trait MobileDeviceStore: Send + Sync {
     /// 持久化一台新设备。重复 device_id / username 应返回对应的领域错误。
     async fn save(&self, device: &MobileDevice) -> Result<(), MobileDeviceError>;
 
@@ -119,7 +121,7 @@ pub trait MobileDeviceRepositoryPort: Send + Sync {
 //
 // Narrow, single-responsibility views over the registered-device store. Each
 // consumer depends only on the slice it actually uses; the concrete adapter
-// implements every one of them (see ports.md §8.3). `MobileDeviceRepositoryPort`
+// implements every one of them (see ports.md §8.3). `MobileDeviceStore`
 // above remains the inner aggregate store.
 
 /// Locate a registered device by its username.

--- a/crates/uc-core/src/ports/mobile_sync.rs
+++ b/crates/uc-core/src/ports/mobile_sync.rs
@@ -103,20 +103,6 @@ pub trait MobileDeviceRepositoryPort: Send + Sync {
     /// 不存在(撤销操作幂等)。
     async fn delete(&self, device_id: &MobileDeviceId) -> Result<bool, MobileDeviceError>;
 
-    /// 鉴权链路成功后回写最近活跃信息 —— 仅运维 / UI 用。失败不应阻塞业
-    /// 务请求,调用方决定是否吞错。
-    ///
-    /// `reported_name` / `reported_os` 在 SyncClipboard 协议下永远是 `None`
-    /// (shortcut 不上报);保留参数以备 v2 ClipboardAuto 客户端扩展。
-    async fn record_activity(
-        &self,
-        device_id: &MobileDeviceId,
-        last_seen_at_ms: i64,
-        last_seen_ip: Option<String>,
-        reported_name: Option<String>,
-        reported_os: Option<String>,
-    ) -> Result<(), MobileDeviceError>;
-
     /// Replace the editable fields of one mobile device in a single write.
     ///
     /// Used by the device-management flow: label edits may keep credentials as-is,

--- a/crates/uc-core/src/ports/mobile_sync.rs
+++ b/crates/uc-core/src/ports/mobile_sync.rs
@@ -115,6 +115,72 @@ pub trait MobileDeviceRepositoryPort: Send + Sync {
         -> Result<bool, MobileDeviceError>;
 }
 
+// ─── device repository intent ports ──────────────────────────────────────
+//
+// Narrow, single-responsibility views over the registered-device store. Each
+// consumer depends only on the slice it actually uses; the concrete adapter
+// implements every one of them (see ports.md §8.3). `MobileDeviceRepositoryPort`
+// above remains the inner aggregate store.
+
+/// Locate a registered device by its username.
+#[async_trait]
+pub trait FindMobileDeviceByUsernamePort: Send + Sync {
+    /// Return the device whose username matches exactly, or `None` if there is
+    /// no such device.
+    async fn find_by_username(
+        &self,
+        username: &str,
+    ) -> Result<Option<MobileDevice>, MobileDeviceError>;
+}
+
+/// Locate a registered device by its stable device id.
+#[async_trait]
+pub trait FindMobileDeviceByIdPort: Send + Sync {
+    /// Return the device with this id, or `None` if there is no such device.
+    async fn find_by_device_id(
+        &self,
+        device_id: &MobileDeviceId,
+    ) -> Result<Option<MobileDevice>, MobileDeviceError>;
+}
+
+/// Enumerate every registered device.
+#[async_trait]
+pub trait ListMobileDevicesPort: Send + Sync {
+    /// Return all registered devices. The result is unordered and unpaged; the
+    /// expected population is small.
+    async fn list_all(&self) -> Result<Vec<MobileDevice>, MobileDeviceError>;
+}
+
+/// Persist a newly registered device.
+#[async_trait]
+pub trait SaveMobileDevicePort: Send + Sync {
+    /// Persist a brand-new device. Returns `AlreadyExists` when the device id is
+    /// already taken and `UsernameCollision` when the username is already held
+    /// by another device.
+    async fn save(&self, device: &MobileDevice) -> Result<(), MobileDeviceError>;
+}
+
+/// Remove a registered device.
+#[async_trait]
+pub trait DeleteMobileDevicePort: Send + Sync {
+    /// Delete the device with this id. Returns `true` when a row was removed,
+    /// `false` when no such device existed (the operation is idempotent).
+    async fn delete(&self, device_id: &MobileDeviceId) -> Result<bool, MobileDeviceError>;
+}
+
+/// Replace the editable fields of an existing device.
+#[async_trait]
+pub trait UpdateMobileDevicePort: Send + Sync {
+    /// Replace the editable fields of one device in a single write.
+    ///
+    /// Implementations must preserve rows not matching `updated.device_id`,
+    /// return `Ok(false)` when the device is missing, and return
+    /// `UsernameCollision` when `updated.username` is already held by another
+    /// device.
+    async fn update_mobile_device(&self, updated: &MobileDevice)
+        -> Result<bool, MobileDeviceError>;
+}
+
 // ─── endpoint info ───────────────────────────────────────────────────────
 
 /// 探测 daemon 当前对外暴露的 LAN 端点 / 启动状态。

--- a/crates/uc-core/src/ports/mod.rs
+++ b/crates/uc-core/src/ports/mod.rs
@@ -78,10 +78,9 @@ pub use local_identity::{LocalIdentityError, LocalIdentityPort};
 pub use mobile_sync::{
     DeleteMobileDevicePort, EndpointInfoError, FindMobileDeviceByIdPort,
     FindMobileDeviceByUsernamePort, LanInterfaceProbeError, LanInterfaceProbePort,
-    ListMobileDevicesPort, MobileCredentialsMinterPort, MobileDeviceRepositoryPort,
-    MobileFileStagingError, MobileFileStagingPort, MobileLanLifecyclePort, MobileLanTarget,
-    MobileSyncEndpointInfoPort, PasswordHasherError, PasswordHasherPort, SaveMobileDevicePort,
-    UpdateMobileDevicePort,
+    ListMobileDevicesPort, MobileCredentialsMinterPort, MobileDeviceStore, MobileFileStagingError,
+    MobileFileStagingPort, MobileLanLifecyclePort, MobileLanTarget, MobileSyncEndpointInfoPort,
+    PasswordHasherError, PasswordHasherPort, SaveMobileDevicePort, UpdateMobileDevicePort,
 };
 pub use observability::{extract_trace, OptionalTrace, TraceMetadata, TraceParseError};
 pub use pairing::{

--- a/crates/uc-core/src/ports/mod.rs
+++ b/crates/uc-core/src/ports/mod.rs
@@ -76,10 +76,12 @@ pub use host_event::{
 };
 pub use local_identity::{LocalIdentityError, LocalIdentityPort};
 pub use mobile_sync::{
-    EndpointInfoError, LanInterfaceProbeError, LanInterfaceProbePort, MobileCredentialsMinterPort,
-    MobileDeviceRepositoryPort, MobileFileStagingError, MobileFileStagingPort,
-    MobileLanLifecyclePort, MobileLanTarget, MobileSyncEndpointInfoPort, PasswordHasherError,
-    PasswordHasherPort,
+    DeleteMobileDevicePort, EndpointInfoError, FindMobileDeviceByIdPort,
+    FindMobileDeviceByUsernamePort, LanInterfaceProbeError, LanInterfaceProbePort,
+    ListMobileDevicesPort, MobileCredentialsMinterPort, MobileDeviceRepositoryPort,
+    MobileFileStagingError, MobileFileStagingPort, MobileLanLifecyclePort, MobileLanTarget,
+    MobileSyncEndpointInfoPort, PasswordHasherError, PasswordHasherPort, SaveMobileDevicePort,
+    UpdateMobileDevicePort,
 };
 pub use observability::{extract_trace, OptionalTrace, TraceMetadata, TraceParseError};
 pub use pairing::{

--- a/crates/uc-infra/src/db/repositories/mobile_device_repo.rs
+++ b/crates/uc-infra/src/db/repositories/mobile_device_repo.rs
@@ -16,12 +16,6 @@
 //! insert 与跟随的存在性查询都在同一个 `executor.run` 闭包(同一连接)内,
 //! 但默认 autocommit 下二者是两条独立语句,并不共享同一事务 —— 这里的
 //! 分类是失败 insert 之后的 best-effort post-hoc 读,而非事务内原子操作。
-//!
-//! ## record_activity
-//!
-//! Port 契约要求:device 不存在时**静默 no-op**,不报错(避免与撤销路径
-//! 并发时回写残留)。Diesel 的 `update().set().execute()` 在 0 行受影响
-//! 时返回 `Ok(0)`,不会变成错误,正好满足契约。
 
 use async_trait::async_trait;
 use diesel::prelude::*;
@@ -227,49 +221,6 @@ where
 
         outcome
     }
-
-    async fn record_activity(
-        &self,
-        device_id_value: &MobileDeviceId,
-        last_seen_at_ms_value: i64,
-        last_seen_ip_value: Option<String>,
-        reported_name_value: Option<String>,
-        reported_os_value: Option<String>,
-    ) -> Result<(), MobileDeviceError> {
-        let needle = device_id_value.as_str().to_string();
-
-        // AsChangeset 对 `Option<T>` 列的默认语义是 None ⇒ 不更新该列,Some
-        // ⇒ set 为对应值。这正好契合 port 契约里"Some 时回写、None 时保留
-        // 旧值"。`last_seen_at_ms` 在 port 签名里不是 Option,但 schema 是
-        // Nullable,所以这里包成 Some 写入。
-        #[derive(AsChangeset)]
-        #[diesel(table_name = crate::db::schema::mobile_device)]
-        struct Changeset {
-            last_seen_at_ms: Option<i64>,
-            last_seen_ip: Option<String>,
-            reported_name: Option<String>,
-            reported_os: Option<String>,
-        }
-
-        let changeset = Changeset {
-            last_seen_at_ms: Some(last_seen_at_ms_value),
-            last_seen_ip: last_seen_ip_value,
-            reported_name: reported_name_value,
-            reported_os: reported_os_value,
-        };
-
-        self.executor
-            .run(move |conn| {
-                // 0 行受影响在 sqlite/Diesel 都不视作错误 —— 正是 port 契约
-                // 要的"撤销路径上的并发静默 no-op"。
-                diesel::update(mobile_device.filter(device_id.eq(&needle)))
-                    .set(&changeset)
-                    .execute(conn)
-                    .map_err(|e| anyhow::anyhow!(e.to_string()))?;
-                Ok(())
-            })
-            .map_err(|e| MobileDeviceError::Storage(e.to_string()))
-    }
 }
 
 #[cfg(test)]
@@ -398,48 +349,6 @@ mod tests {
             .await
             .unwrap()
             .is_none());
-    }
-
-    #[tokio::test]
-    async fn record_activity_updates_only_provided_fields_when_device_exists() {
-        let (repo, _t) = make_repo();
-        let d = fixture("did_x", "0001", "phone");
-        repo.save(&d).await.unwrap();
-
-        // 第一次:全字段写。
-        repo.record_activity(
-            &d.device_id,
-            5_000,
-            Some("192.168.1.5".into()),
-            Some("iPhone 15".into()),
-            Some("iOS 18".into()),
-        )
-        .await
-        .unwrap();
-        let after_first = repo.find_by_device_id(&d.device_id).await.unwrap().unwrap();
-        assert_eq!(after_first.last_seen_at_ms, Some(5_000));
-        assert_eq!(after_first.last_seen_ip.as_deref(), Some("192.168.1.5"));
-        assert_eq!(after_first.reported_name.as_deref(), Some("iPhone 15"));
-        assert_eq!(after_first.reported_os.as_deref(), Some("iOS 18"));
-
-        // 第二次:仅 last_seen_at_ms 推进,其它 None 应保留旧值。
-        repo.record_activity(&d.device_id, 6_000, None, None, None)
-            .await
-            .unwrap();
-        let after_second = repo.find_by_device_id(&d.device_id).await.unwrap().unwrap();
-        assert_eq!(after_second.last_seen_at_ms, Some(6_000));
-        assert_eq!(after_second.last_seen_ip.as_deref(), Some("192.168.1.5"));
-        assert_eq!(after_second.reported_name.as_deref(), Some("iPhone 15"));
-        assert_eq!(after_second.reported_os.as_deref(), Some("iOS 18"));
-    }
-
-    #[tokio::test]
-    async fn record_activity_silent_no_op_when_device_missing() {
-        let (repo, _t) = make_repo();
-        // 不存在的 device 不应报错。
-        repo.record_activity(&MobileDeviceId::new("did_ghost"), 1, None, None, None)
-            .await
-            .unwrap();
     }
 
     #[tokio::test]

--- a/crates/uc-infra/src/db/repositories/mobile_device_repo.rs
+++ b/crates/uc-infra/src/db/repositories/mobile_device_repo.rs
@@ -1,4 +1,4 @@
-//! `DieselMobileDeviceRepository` —— `MobileDeviceRepositoryPort` 的 sqlite
+//! `DieselMobileDeviceRepository` —— `MobileDeviceStore` 的 sqlite
 //! 实现(v3 SyncClipboard 兼容版)。
 //!
 //! ## 错误映射
@@ -22,7 +22,7 @@ use diesel::prelude::*;
 use diesel::result::{DatabaseErrorKind, Error as DieselError};
 
 use uc_core::mobile_sync::{MobileDevice, MobileDeviceError, MobileDeviceId};
-use uc_core::ports::MobileDeviceRepositoryPort;
+use uc_core::ports::MobileDeviceStore;
 
 use crate::db::models::{MobileDeviceRow, NewMobileDeviceRow};
 use crate::db::ports::{DbExecutor, InsertMapper, RowMapper};
@@ -48,7 +48,7 @@ impl<E, M> DieselMobileDeviceRepository<E, M> {
 }
 
 #[async_trait]
-impl<E, M> MobileDeviceRepositoryPort for DieselMobileDeviceRepository<E, M>
+impl<E, M> MobileDeviceStore for DieselMobileDeviceRepository<E, M>
 where
     E: DbExecutor,
     M: InsertMapper<MobileDevice, NewMobileDeviceRow>
@@ -253,7 +253,7 @@ mod intent_ports {
             &self,
             username_value: &str,
         ) -> Result<Option<MobileDevice>, MobileDeviceError> {
-            MobileDeviceRepositoryPort::find_by_username(self, username_value).await
+            MobileDeviceStore::find_by_username(self, username_value).await
         }
     }
 
@@ -270,7 +270,7 @@ mod intent_ports {
             &self,
             device_id_value: &MobileDeviceId,
         ) -> Result<Option<MobileDevice>, MobileDeviceError> {
-            MobileDeviceRepositoryPort::find_by_device_id(self, device_id_value).await
+            MobileDeviceStore::find_by_device_id(self, device_id_value).await
         }
     }
 
@@ -284,7 +284,7 @@ mod intent_ports {
             + Sync,
     {
         async fn list_all(&self) -> Result<Vec<MobileDevice>, MobileDeviceError> {
-            MobileDeviceRepositoryPort::list_all(self).await
+            MobileDeviceStore::list_all(self).await
         }
     }
 
@@ -298,7 +298,7 @@ mod intent_ports {
             + Sync,
     {
         async fn save(&self, device: &MobileDevice) -> Result<(), MobileDeviceError> {
-            MobileDeviceRepositoryPort::save(self, device).await
+            MobileDeviceStore::save(self, device).await
         }
     }
 
@@ -315,7 +315,7 @@ mod intent_ports {
             &self,
             device_id_value: &MobileDeviceId,
         ) -> Result<bool, MobileDeviceError> {
-            MobileDeviceRepositoryPort::delete(self, device_id_value).await
+            MobileDeviceStore::delete(self, device_id_value).await
         }
     }
 
@@ -332,7 +332,7 @@ mod intent_ports {
             &self,
             updated: &MobileDevice,
         ) -> Result<bool, MobileDeviceError> {
-            MobileDeviceRepositoryPort::update_mobile_device(self, updated).await
+            MobileDeviceStore::update_mobile_device(self, updated).await
         }
     }
 }

--- a/crates/uc-infra/src/db/repositories/mobile_device_repo.rs
+++ b/crates/uc-infra/src/db/repositories/mobile_device_repo.rs
@@ -223,6 +223,120 @@ where
     }
 }
 
+// ---- Intent ports ----
+//
+// The single Diesel adapter satisfies every narrow device-repository port by
+// delegating to its aggregate-store methods (UFCS disambiguates the same-named
+// methods). The composition root coerces one `Arc<DieselMobileDeviceRepository>`
+// into each port (see ports.md §8.3).
+//
+// These impls live in a private submodule so the narrow port traits do not leak
+// into the test module's method-resolution scope (they share method names with
+// the aggregate store); trait-impl coherence still applies crate-wide.
+mod intent_ports {
+    use super::*;
+    use uc_core::ports::{
+        DeleteMobileDevicePort, FindMobileDeviceByIdPort, FindMobileDeviceByUsernamePort,
+        ListMobileDevicesPort, SaveMobileDevicePort, UpdateMobileDevicePort,
+    };
+
+    #[async_trait]
+    impl<E, M> FindMobileDeviceByUsernamePort for DieselMobileDeviceRepository<E, M>
+    where
+        E: DbExecutor,
+        M: InsertMapper<MobileDevice, NewMobileDeviceRow>
+            + RowMapper<MobileDeviceRow, MobileDevice>
+            + Send
+            + Sync,
+    {
+        async fn find_by_username(
+            &self,
+            username_value: &str,
+        ) -> Result<Option<MobileDevice>, MobileDeviceError> {
+            MobileDeviceRepositoryPort::find_by_username(self, username_value).await
+        }
+    }
+
+    #[async_trait]
+    impl<E, M> FindMobileDeviceByIdPort for DieselMobileDeviceRepository<E, M>
+    where
+        E: DbExecutor,
+        M: InsertMapper<MobileDevice, NewMobileDeviceRow>
+            + RowMapper<MobileDeviceRow, MobileDevice>
+            + Send
+            + Sync,
+    {
+        async fn find_by_device_id(
+            &self,
+            device_id_value: &MobileDeviceId,
+        ) -> Result<Option<MobileDevice>, MobileDeviceError> {
+            MobileDeviceRepositoryPort::find_by_device_id(self, device_id_value).await
+        }
+    }
+
+    #[async_trait]
+    impl<E, M> ListMobileDevicesPort for DieselMobileDeviceRepository<E, M>
+    where
+        E: DbExecutor,
+        M: InsertMapper<MobileDevice, NewMobileDeviceRow>
+            + RowMapper<MobileDeviceRow, MobileDevice>
+            + Send
+            + Sync,
+    {
+        async fn list_all(&self) -> Result<Vec<MobileDevice>, MobileDeviceError> {
+            MobileDeviceRepositoryPort::list_all(self).await
+        }
+    }
+
+    #[async_trait]
+    impl<E, M> SaveMobileDevicePort for DieselMobileDeviceRepository<E, M>
+    where
+        E: DbExecutor,
+        M: InsertMapper<MobileDevice, NewMobileDeviceRow>
+            + RowMapper<MobileDeviceRow, MobileDevice>
+            + Send
+            + Sync,
+    {
+        async fn save(&self, device: &MobileDevice) -> Result<(), MobileDeviceError> {
+            MobileDeviceRepositoryPort::save(self, device).await
+        }
+    }
+
+    #[async_trait]
+    impl<E, M> DeleteMobileDevicePort for DieselMobileDeviceRepository<E, M>
+    where
+        E: DbExecutor,
+        M: InsertMapper<MobileDevice, NewMobileDeviceRow>
+            + RowMapper<MobileDeviceRow, MobileDevice>
+            + Send
+            + Sync,
+    {
+        async fn delete(
+            &self,
+            device_id_value: &MobileDeviceId,
+        ) -> Result<bool, MobileDeviceError> {
+            MobileDeviceRepositoryPort::delete(self, device_id_value).await
+        }
+    }
+
+    #[async_trait]
+    impl<E, M> UpdateMobileDevicePort for DieselMobileDeviceRepository<E, M>
+    where
+        E: DbExecutor,
+        M: InsertMapper<MobileDevice, NewMobileDeviceRow>
+            + RowMapper<MobileDeviceRow, MobileDevice>
+            + Send
+            + Sync,
+    {
+        async fn update_mobile_device(
+            &self,
+            updated: &MobileDevice,
+        ) -> Result<bool, MobileDeviceError> {
+            MobileDeviceRepositoryPort::update_mobile_device(self, updated).await
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/uc-infra/src/mobile_sync/device_repo.rs
+++ b/crates/uc-infra/src/mobile_sync/device_repo.rs
@@ -1,4 +1,4 @@
-//! `InMemoryMobileDeviceRepository` —— [`MobileDeviceRepositoryPort`] 的进
+//! `InMemoryMobileDeviceRepository` —— [`MobileDeviceStore`] 的进
 //! 程内实现(v3 SyncClipboard 兼容版)。
 //!
 //! 现在 daemon 链路上默认走 [`crate::db::repositories::DieselMobileDeviceRepository`]
@@ -22,7 +22,7 @@ use async_trait::async_trait;
 use tokio::sync::Mutex;
 
 use uc_core::mobile_sync::{MobileDevice, MobileDeviceError, MobileDeviceId};
-use uc_core::ports::MobileDeviceRepositoryPort;
+use uc_core::ports::MobileDeviceStore;
 
 #[derive(Default)]
 pub struct InMemoryMobileDeviceRepository {
@@ -36,7 +36,7 @@ impl InMemoryMobileDeviceRepository {
 }
 
 #[async_trait]
-impl MobileDeviceRepositoryPort for InMemoryMobileDeviceRepository {
+impl MobileDeviceStore for InMemoryMobileDeviceRepository {
     async fn save(&self, device: &MobileDevice) -> Result<(), MobileDeviceError> {
         let mut guard = self.devices.lock().await;
 

--- a/crates/uc-infra/src/mobile_sync/device_repo.rs
+++ b/crates/uc-infra/src/mobile_sync/device_repo.rs
@@ -79,33 +79,6 @@ impl MobileDeviceRepositoryPort for InMemoryMobileDeviceRepository {
         Ok(guard.remove(device_id).is_some())
     }
 
-    async fn record_activity(
-        &self,
-        device_id: &MobileDeviceId,
-        last_seen_at_ms: i64,
-        last_seen_ip: Option<String>,
-        reported_name: Option<String>,
-        reported_os: Option<String>,
-    ) -> Result<(), MobileDeviceError> {
-        let mut guard = self.devices.lock().await;
-        // 找不到 device 不报错 —— 撤销路径下可能并发:use case 已经撤销但
-        // 鉴权链路里的 record_activity 还在路上。adapter 直接静默成功,让
-        // use case 决定是否在调用前先检查。
-        if let Some(device) = guard.get_mut(device_id) {
-            device.last_seen_at_ms = Some(last_seen_at_ms);
-            if last_seen_ip.is_some() {
-                device.last_seen_ip = last_seen_ip;
-            }
-            if reported_name.is_some() {
-                device.reported_name = reported_name;
-            }
-            if reported_os.is_some() {
-                device.reported_os = reported_os;
-            }
-        }
-        Ok(())
-    }
-
     async fn update_mobile_device(
         &self,
         updated: &MobileDevice,
@@ -218,38 +191,6 @@ mod tests {
             .unwrap()
             .is_none());
         assert!(!repo.delete(&d.device_id).await.unwrap());
-    }
-
-    #[tokio::test]
-    async fn record_activity_updates_fields_when_device_exists() {
-        let repo = InMemoryMobileDeviceRepository::new();
-        let d = device("did_x", "0001", "phone");
-        repo.save(&d).await.unwrap();
-
-        repo.record_activity(
-            &d.device_id,
-            5_000,
-            Some("192.168.1.5".into()),
-            Some("iPhone".into()),
-            Some("iOS 18".into()),
-        )
-        .await
-        .unwrap();
-
-        let got = repo.find_by_device_id(&d.device_id).await.unwrap().unwrap();
-        assert_eq!(got.last_seen_at_ms, Some(5_000));
-        assert_eq!(got.last_seen_ip.as_deref(), Some("192.168.1.5"));
-        assert_eq!(got.reported_name.as_deref(), Some("iPhone"));
-        assert_eq!(got.reported_os.as_deref(), Some("iOS 18"));
-    }
-
-    #[tokio::test]
-    async fn record_activity_is_silent_no_op_when_device_missing() {
-        // 与撤销并发场景:record_activity 不应报错。
-        let repo = InMemoryMobileDeviceRepository::new();
-        repo.record_activity(&MobileDeviceId::new("did_ghost"), 5_000, None, None, None)
-            .await
-            .unwrap();
     }
 
     #[tokio::test]

--- a/crates/uc-infra/src/mobile_sync/mod.rs
+++ b/crates/uc-infra/src/mobile_sync/mod.rs
@@ -6,7 +6,7 @@
 //!   实装(单次原子颁发 username / password / password_hash / device_id)
 //! - `password_hasher`:`PasswordHasherPort` 的 Argon2id PHC 实装,鉴权热路
 //!   径走它做 verify
-//! - `device_repo`(`#[cfg(test)]` 限定):`MobileDeviceRepositoryPort` 的进
+//! - `device_repo`(`#[cfg(test)]` 限定):`MobileDeviceStore` 的进
 //!   程内实装,仅作为本 crate 单测的轻量替身。生产路径走
 //!   `db::repositories::DieselMobileDeviceRepository`
 //! - `endpoint_info`:`MobileSyncEndpointInfoPort` 的 in-memory adapter,

--- a/crates/uc-webserver/src/mobile_lan/test_support.rs
+++ b/crates/uc-webserver/src/mobile_lan/test_support.rs
@@ -24,6 +24,7 @@ use async_trait::async_trait;
 use base64::engine::general_purpose::STANDARD as BASE64_STD;
 use base64::Engine;
 
+use uc_application::deps::MobileDevicePorts;
 use uc_application::facade::{
     IncomingMobileBuffer, MobileSyncFacade, MobileSyncFacadeDeps, MobileSyncSnapshotPorts,
 };
@@ -45,9 +46,11 @@ use uc_core::ports::clipboard::{
     ListClipboardEntriesPort, PayloadResolveError, ResolvedClipboardPayload,
 };
 use uc_core::ports::{
-    ClockPort, EndpointInfoError, LanInterfaceProbeError, LanInterfaceProbePort,
-    MobileCredentialsMinterPort, MobileDeviceRepositoryPort, MobileSyncEndpointInfoPort,
-    PasswordHasherError, PasswordHasherPort, SettingsPort,
+    ClockPort, DeleteMobileDevicePort, EndpointInfoError, FindMobileDeviceByIdPort,
+    FindMobileDeviceByUsernamePort, LanInterfaceProbeError, LanInterfaceProbePort,
+    ListMobileDevicesPort, MobileCredentialsMinterPort, MobileSyncEndpointInfoPort,
+    PasswordHasherError, PasswordHasherPort, SaveMobileDevicePort, SettingsPort,
+    UpdateMobileDevicePort,
 };
 use uc_core::settings::model::Settings;
 use uc_core::{BlobId, DeviceId, SystemClipboardSnapshot};
@@ -87,11 +90,14 @@ pub(crate) async fn build_facade_with_seeded_device(
         devices: Mutex<Vec<MobileDevice>>,
     }
     #[async_trait]
-    impl MobileDeviceRepositoryPort for InMemoryDeviceRepo {
+    impl SaveMobileDevicePort for InMemoryDeviceRepo {
         async fn save(&self, device: &MobileDevice) -> Result<(), MobileDeviceError> {
             self.devices.lock().unwrap().push(device.clone());
             Ok(())
         }
+    }
+    #[async_trait]
+    impl FindMobileDeviceByUsernamePort for InMemoryDeviceRepo {
         async fn find_by_username(
             &self,
             username: &str,
@@ -104,18 +110,30 @@ pub(crate) async fn build_facade_with_seeded_device(
                 .find(|d| d.username == username)
                 .cloned())
         }
+    }
+    #[async_trait]
+    impl FindMobileDeviceByIdPort for InMemoryDeviceRepo {
         async fn find_by_device_id(
             &self,
             _: &MobileDeviceId,
         ) -> Result<Option<MobileDevice>, MobileDeviceError> {
             Ok(None)
         }
+    }
+    #[async_trait]
+    impl ListMobileDevicesPort for InMemoryDeviceRepo {
         async fn list_all(&self) -> Result<Vec<MobileDevice>, MobileDeviceError> {
             Ok(self.devices.lock().unwrap().clone())
         }
+    }
+    #[async_trait]
+    impl DeleteMobileDevicePort for InMemoryDeviceRepo {
         async fn delete(&self, _: &MobileDeviceId) -> Result<bool, MobileDeviceError> {
             Ok(false)
         }
+    }
+    #[async_trait]
+    impl UpdateMobileDevicePort for InMemoryDeviceRepo {
         async fn update_mobile_device(
             &self,
             updated: &MobileDevice,
@@ -226,7 +244,14 @@ pub(crate) async fn build_facade_with_seeded_device(
         clock: Arc::new(FixedClock),
         credentials_minter: Arc::new(StaticMinter),
         password_hasher: Arc::new(FakeHasher),
-        device_repo: repo,
+        devices: MobileDevicePorts {
+            find_by_username: repo.clone(),
+            find_by_id: repo.clone(),
+            list: repo.clone(),
+            save: repo.clone(),
+            delete: repo.clone(),
+            update: repo,
+        },
         endpoint_info: Arc::new(FixedEndpoint),
         lan_interface_probe: Arc::new(StubLanProbe),
         settings: Arc::new(InMemorySettings::default()),

--- a/crates/uc-webserver/src/mobile_lan/test_support.rs
+++ b/crates/uc-webserver/src/mobile_lan/test_support.rs
@@ -116,16 +116,6 @@ pub(crate) async fn build_facade_with_seeded_device(
         async fn delete(&self, _: &MobileDeviceId) -> Result<bool, MobileDeviceError> {
             Ok(false)
         }
-        async fn record_activity(
-            &self,
-            _: &MobileDeviceId,
-            _: i64,
-            _: Option<String>,
-            _: Option<String>,
-            _: Option<String>,
-        ) -> Result<(), MobileDeviceError> {
-            Ok(())
-        }
         async fn update_mobile_device(
             &self,
             updated: &MobileDevice,


### PR DESCRIPTION
## Summary

Splits the catch-all `MobileDeviceRepositoryPort` (a §12 textbook catch-all mixing query + full-save + delete + field-patch) into focused intent ports, following the `ports.md` rubric and the merged clipboard split (#1104) / `FileTransferPorts` (§8.3) pattern. Each use case now depends only on the ports it actually calls (§8.1/§8.2). Additive, single-boundary commits — every commit keeps `cargo check --workspace` green.

- **Remove dead `record_activity`** (`4934bbeba`): zero production callers — only infra unit tests and two aspirational doc-comments referenced it. Dropped from the trait, both adapters, all test fakes (YAGNI).
- **Add six narrow intent ports** in `uc-core` (`f49993250`): `FindMobileDeviceByUsernamePort`, `FindMobileDeviceByIdPort`, `ListMobileDevicesPort`, `SaveMobileDevicePort`, `DeleteMobileDevicePort`, `UpdateMobileDevicePort`.
- **Implement them on the Diesel adapter** (`b2769e50f`) via UFCS delegation, kept in a private `intent_ports` submodule so the narrow traits don't collide with the aggregate store in the test module's method resolution.
- **Wire the `MobileDevicePorts` sub-bundle** in the composition root (`1769625f1`): one adapter coerced into each port (§8.3).
- **Migrate every consumer** to its narrow slice (`90f17b998`, `0f9d7d05e`): mobile_sync use cases + facade, and `get_entry_delivery_view` / clipboard facade (`find_by_device_id` only). Test mocks/fakes slimmed to the narrow ports.
- **Demote the aggregate to inner `MobileDeviceStore`** (`ce110c186`, §12) and delete the now-unused `MobileSyncPorts.device_repo` upward exposure + its wiring.

Follow-up to the clipboard split (#1104); the next HIGH finding (`SpaceAccessPort`) will be a separate PR.

## Test plan

- [x] `cargo check --workspace` green
- [x] `cargo test --workspace --lib --tests --bins` — 1990 passed / 0 failed
- [x] `cargo clippy` on changed crates — no new warnings in changed files (`RegisterMobileShortcutDeviceUseCase::new` is `#[allow(too_many_arguments)]` now that it takes `find_by_username` + `save` separately)
- [x] Scanned `docs-site/` — no user-facing surface changed (pure internal architecture refactor)
- [ ] Reviewer: confirm the `intent_ports` submodule pattern reads cleanly and the §8.3 coercion in `assembly.rs` matches the established `FileTransferPorts` / `ClipboardEntryPorts` style