### PR TITLE
refactor(space-access): split SpaceAccessPort into narrow intent ports

### DIFF
--- a/crates/uc-application/src/deps.rs
+++ b/crates/uc-application/src/deps.rs
@@ -25,6 +25,11 @@ use uc_core::ports::clipboard::{
 use uc_core::ports::search::search_index::SearchIndexPort;
 use uc_core::ports::search::search_key::SearchKeyDerivationPort;
 use uc_core::ports::search::search_pipeline::SearchPipelinePort;
+use uc_core::ports::space::{
+    CurrentSessionProofKeyPort, DeriveProofKeyPort, DeriveSpaceSubkeyPort, FactoryResetSpacePort,
+    InitializeSpacePort, IsSpaceUnlockedPort, LockSpacePort, PrepareJoinOfferPort,
+    ResumeSpaceSessionPort, UnlockSpacePort, VerifyKeychainAccessPort,
+};
 use uc_core::ports::*;
 use uc_core::MemberRepositoryPort;
 use uc_observability::analytics::AnalyticsPort;
@@ -79,16 +84,73 @@ pub struct ClipboardPorts {
     pub payload_resolver: Arc<dyn ClipboardPayloadResolverPort>,
 }
 
+/// Narrow space-access intent ports facing the application layer.
+///
+/// The composition root coerces one space-access adapter into each of these;
+/// every consumer takes only the slice it needs, never a catch-all surface
+/// (ports.md §8.1/§8.3). Distribution hubs (facade dep bundles) carry the
+/// whole struct and hand each use case its slice.
+#[derive(Clone)]
+pub struct SpaceAccessPorts {
+    pub initialize: Arc<dyn InitializeSpacePort>,
+    pub unlock: Arc<dyn UnlockSpacePort>,
+    pub is_unlocked: Arc<dyn IsSpaceUnlockedPort>,
+    pub lock: Arc<dyn LockSpacePort>,
+    pub factory_reset: Arc<dyn FactoryResetSpacePort>,
+    pub resume_session: Arc<dyn ResumeSpaceSessionPort>,
+    pub verify_keychain_access: Arc<dyn VerifyKeychainAccessPort>,
+    pub derive_subkey: Arc<dyn DeriveSpaceSubkeyPort>,
+    pub current_session_proof_key: Arc<dyn CurrentSessionProofKeyPort>,
+    pub prepare_join_offer: Arc<dyn PrepareJoinOfferPort>,
+    pub derive_proof_key: Arc<dyn DeriveProofKeyPort>,
+}
+
+impl SpaceAccessPorts {
+    /// Fan one concrete adapter — implementing every narrow space-access intent
+    /// port — out into the bundle. Used by the composition root and by
+    /// integration tests that build a single adapter (ports.md §8.3).
+    pub fn from_adapter<A>(adapter: Arc<A>) -> Self
+    where
+        A: InitializeSpacePort
+            + UnlockSpacePort
+            + IsSpaceUnlockedPort
+            + LockSpacePort
+            + FactoryResetSpacePort
+            + ResumeSpaceSessionPort
+            + VerifyKeychainAccessPort
+            + DeriveSpaceSubkeyPort
+            + CurrentSessionProofKeyPort
+            + PrepareJoinOfferPort
+            + DeriveProofKeyPort
+            + 'static,
+    {
+        Self {
+            initialize: adapter.clone(),
+            unlock: adapter.clone(),
+            is_unlocked: adapter.clone(),
+            lock: adapter.clone(),
+            factory_reset: adapter.clone(),
+            resume_session: adapter.clone(),
+            verify_keychain_access: adapter.clone(),
+            derive_subkey: adapter.clone(),
+            current_session_proof_key: adapter.clone(),
+            prepare_join_offer: adapter.clone(),
+            derive_proof_key: adapter,
+        }
+    }
+}
+
 /// Security-domain ports bundle.
 /// 安全领域端口组。
 #[derive(Clone)]
 pub struct SecurityPorts {
     pub current_profile: Arc<dyn uc_core::ports::security::current_profile::CurrentProfilePort>,
     pub secure_storage: Arc<dyn SecureStoragePort>,
-    /// 单一空间访问 port——initialize / unlock / try_resume_session /
-    /// verify_keychain_access / derive_subkey / current_session_proof_key 等
-    /// 业务动作的统一入口。所有会话/密钥访问都从这里走。
-    pub space_access: Arc<dyn uc_core::ports::space::SpaceAccessPort>,
+    /// Narrow space-access intent ports (initialize / unlock / lock / resume /
+    /// factory-reset / keychain-probe / subkey / proof-key, etc.). Each
+    /// consumer depends on the slice it calls; nothing holds a catch-all
+    /// space-access surface.
+    pub space_access_ports: SpaceAccessPorts,
     /// 业务 blob 加解密 port——4 个剪切板 decorator 通过此 port 加解密
     /// inline_data。adapter 内部端到端自管会话与 V1 AEAD。
     pub blob_cipher: Arc<dyn uc_core::ports::security::BlobCipherPort>,

--- a/crates/uc-application/src/facade/encryption/mod.rs
+++ b/crates/uc-application/src/facade/encryption/mod.rs
@@ -4,14 +4,23 @@ use tracing::instrument;
 use uc_core::crypto::model::Passphrase;
 use uc_core::ids::SpaceId;
 use uc_core::ports::setup::SetupStatusPort;
-use uc_core::ports::space::{SpaceAccessError, SpaceAccessPort};
+use uc_core::ports::space::{
+    InitializeSpacePort, IsSpaceUnlockedPort, LockSpacePort, ResumeSpaceSessionPort,
+    SpaceAccessError, VerifyKeychainAccessPort,
+};
 
 const DEFAULT_SPACE_ID: &str = "space";
 
+/// Narrow space-access ports consumed by [`EncryptionFacade`]. Each maps to one
+/// facade method; the facade holds only the slices it calls (ports.md §8.1).
 #[derive(Clone)]
 pub struct EncryptionFacadeDeps {
     pub setup_status: Arc<dyn SetupStatusPort>,
-    pub space_access: Arc<dyn SpaceAccessPort>,
+    pub initialize: Arc<dyn InitializeSpacePort>,
+    pub resume_session: Arc<dyn ResumeSpaceSessionPort>,
+    pub is_unlocked: Arc<dyn IsSpaceUnlockedPort>,
+    pub lock: Arc<dyn LockSpacePort>,
+    pub verify_keychain_access: Arc<dyn VerifyKeychainAccessPort>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -55,7 +64,7 @@ impl EncryptionFacade {
             .map_err(|err| EncryptionFacadeError::SetupStatus(err.to_string()))?;
         let space_id = default_space_id();
         let session_ready = if initialized {
-            self.deps.space_access.is_unlocked(&space_id).await
+            self.deps.is_unlocked.is_unlocked(&space_id).await
         } else {
             false
         };
@@ -79,7 +88,7 @@ impl EncryptionFacade {
         let domain_passphrase = uc_core::crypto::domain::Passphrase::new(passphrase.0);
 
         self.deps
-            .space_access
+            .initialize
             .initialize(&space_id, &domain_passphrase)
             .await
             .map_err(|err| match err {
@@ -107,7 +116,7 @@ impl EncryptionFacade {
     pub async fn unlock(&self) -> Result<bool, EncryptionFacadeError> {
         match self
             .deps
-            .space_access
+            .resume_session
             .try_resume_session(&default_space_id())
             .await
         {
@@ -120,7 +129,7 @@ impl EncryptionFacade {
     #[instrument(skip_all)]
     pub async fn lock(&self) -> Result<(), EncryptionFacadeError> {
         self.deps
-            .space_access
+            .lock
             .lock(&default_space_id())
             .await
             .map_err(space_access_error)
@@ -129,7 +138,7 @@ impl EncryptionFacade {
     #[instrument(skip_all)]
     pub async fn verify_keychain_access(&self) -> Result<bool, EncryptionFacadeError> {
         self.deps
-            .space_access
+            .verify_keychain_access
             .verify_keychain_access()
             .await
             .map_err(space_access_error)
@@ -152,7 +161,6 @@ mod tests {
     use std::sync::Mutex;
     use uc_core::crypto::domain::{ActiveSpace, Passphrase};
     use uc_core::setup::SetupStatus;
-    use uc_core::space_access::{JoinOffer, ProofDerivedKey};
 
     #[derive(Default)]
     struct FakeSetupStatus {
@@ -182,7 +190,7 @@ mod tests {
     }
 
     #[async_trait]
-    impl SpaceAccessPort for FakeSpaceAccess {
+    impl InitializeSpacePort for FakeSpaceAccess {
         async fn initialize(
             &self,
             space_id: &SpaceId,
@@ -194,29 +202,26 @@ mod tests {
             }
             Ok(ActiveSpace::new(space_id.clone()))
         }
+    }
 
-        async fn unlock(
-            &self,
-            space_id: &SpaceId,
-            _passphrase: &Passphrase,
-        ) -> Result<ActiveSpace, SpaceAccessError> {
-            Ok(ActiveSpace::new(space_id.clone()))
-        }
-
+    #[async_trait]
+    impl IsSpaceUnlockedPort for FakeSpaceAccess {
         async fn is_unlocked(&self, _space_id: &SpaceId) -> bool {
             *self.unlocked.lock().expect("unlocked lock")
         }
+    }
 
+    #[async_trait]
+    impl LockSpacePort for FakeSpaceAccess {
         async fn lock(&self, _space_id: &SpaceId) -> Result<(), SpaceAccessError> {
             *self.unlocked.lock().expect("unlocked lock") = false;
             *self.lock_calls.lock().expect("lock calls lock") += 1;
             Ok(())
         }
+    }
 
-        async fn factory_reset(&self, _space_id: &SpaceId) -> Result<(), SpaceAccessError> {
-            Ok(())
-        }
-
+    #[async_trait]
+    impl ResumeSpaceSessionPort for FakeSpaceAccess {
         async fn try_resume_session(
             &self,
             space_id: &SpaceId,
@@ -228,43 +233,12 @@ mod tests {
                 Ok(None)
             }
         }
+    }
 
+    #[async_trait]
+    impl VerifyKeychainAccessPort for FakeSpaceAccess {
         async fn verify_keychain_access(&self) -> Result<bool, SpaceAccessError> {
             Ok(*self.verify_granted.lock().expect("verify lock"))
-        }
-
-        async fn derive_subkey(
-            &self,
-            _salt: &[u8],
-            _info: &[u8],
-        ) -> Result<[u8; 32], SpaceAccessError> {
-            Ok([0; 32])
-        }
-
-        async fn current_session_proof_key(
-            &self,
-        ) -> Result<Option<ProofDerivedKey>, SpaceAccessError> {
-            Ok(None)
-        }
-
-        async fn prepare_join_offer(
-            &self,
-            space_id: &SpaceId,
-            _passphrase: &Passphrase,
-        ) -> Result<JoinOffer, SpaceAccessError> {
-            Ok(JoinOffer {
-                space_id: space_id.clone(),
-                keyslot_blob: Vec::new(),
-                challenge_nonce: [0; 32],
-            })
-        }
-
-        async fn derive_master_key_for_proof(
-            &self,
-            _offer: &JoinOffer,
-            _passphrase: &Passphrase,
-        ) -> Result<ProofDerivedKey, SpaceAccessError> {
-            Ok(ProofDerivedKey::from_bytes([0; 32]))
         }
     }
 
@@ -291,7 +265,11 @@ mod tests {
         (
             EncryptionFacade::new(EncryptionFacadeDeps {
                 setup_status,
-                space_access: space_access.clone(),
+                initialize: space_access.clone(),
+                resume_session: space_access.clone(),
+                is_unlocked: space_access.clone(),
+                lock: space_access.clone(),
+                verify_keychain_access: space_access.clone(),
             }),
             space_access,
         )

--- a/crates/uc-application/src/facade/space_setup/deps.rs
+++ b/crates/uc-application/src/facade/space_setup/deps.rs
@@ -15,7 +15,7 @@ use uc_core::ports::pairing_invitation::{
 };
 use uc_core::ports::security::{BlobCipherPort, KeyMigrationPort};
 use uc_core::ports::setup::MigrationStatePort;
-use uc_core::ports::space::{ProofPort, SpaceAccessPort};
+use uc_core::ports::space::ProofPort;
 use uc_core::ports::{
     ClockPort, DeviceIdentityPort, LocalIdentityPort, PeerAddressRepositoryPort, PresencePort,
     SettingsPort, SetupStatusPort,
@@ -23,14 +23,17 @@ use uc_core::ports::{
 use uc_core::trusted_peer::TrustedPeerRepositoryPort;
 use uc_observability::analytics::AnalyticsFacade;
 
+use crate::deps::SpaceAccessPorts;
+
 /// Dependencies for [`super::SpaceSetupFacade`].
 ///
-/// `SpaceAccessPort` / `SetupStatusPort` are shared between A1 and A2
-/// because the underlying adapter keeps the active space / setup status
-/// as process-wide singletons; the facade clones these `Arc`s when
-/// constructing each use case.
+/// The space-access bundle / `SetupStatusPort` are shared across A1, A2, the
+/// pairing handshakes, and the facade's own silent-resume / factory-reset
+/// paths because the underlying adapter keeps the active space / setup status
+/// as process-wide singletons; the facade hands each use case the narrow slice
+/// it needs (ports.md §8.2/§8.3).
 pub struct SpaceSetupDeps {
-    pub space_access: Arc<dyn SpaceAccessPort>,
+    pub space_access: SpaceAccessPorts,
     pub local_identity: Arc<dyn LocalIdentityPort>,
     pub device_identity: Arc<dyn DeviceIdentityPort>,
     pub member_repo: Arc<dyn MemberRepositoryPort>,

--- a/crates/uc-application/src/facade/space_setup/errors.rs
+++ b/crates/uc-application/src/facade/space_setup/errors.rs
@@ -215,7 +215,7 @@ pub enum ResetSpaceError {
 /// Failure modes of [`crate::facade::space_setup::SpaceSetupFacade::factory_reset`].
 ///
 /// 用户级"重置并重新开始"的失败原因。与 `ResetSpaceError` 不同,本路径
-/// 还会调 `SpaceAccessPort::factory_reset` 删 keyslot + KEK,所以多了
+/// 还会调 `FactoryResetSpacePort::factory_reset` 删 keyslot + KEK,所以多了
 /// `KeyMaterialWipeFailed` 变体——磁盘上残留的 keyslot 会让后续
 /// `InitializeSpaceUseCase` 撞到 `AlreadyInitialized`,把用户卡死,所以
 /// 这一步失败必须显式上抛而不是吞掉。
@@ -225,7 +225,7 @@ pub enum ResetSpaceError {
 /// keyslot 残留"的更糟状态。
 #[derive(Debug, Error)]
 pub enum FactoryResetError {
-    /// `SpaceAccessPort::factory_reset` 失败 —— keyslot / KEK 删除出错,
+    /// `FactoryResetSpacePort::factory_reset` 失败 —— keyslot / KEK 删除出错,
     /// 后续重新 setup 会撞 `AlreadyInitialized`。
     #[error("failed to wipe key material: {0}")]
     KeyMaterialWipeFailed(String),

--- a/crates/uc-application/src/facade/space_setup/facade.rs
+++ b/crates/uc-application/src/facade/space_setup/facade.rs
@@ -25,7 +25,7 @@ use tokio::task::JoinHandle;
 use tracing::{info, instrument, warn};
 
 use uc_core::ids::{DeviceId, SpaceId};
-use uc_core::ports::space::{SpaceAccessError, SpaceAccessPort};
+use uc_core::ports::space::{FactoryResetSpacePort, ResumeSpaceSessionPort, SpaceAccessError};
 use uc_core::ports::{
     PeerAddressRepositoryPort, PresenceError, PresencePort, ReachabilityState, SettingsPort,
     SetupStatusPort,
@@ -83,11 +83,14 @@ pub struct SpaceSetupFacade {
     /// Held on the facade so [`Self::subscribe_pairing_completion`] can
     /// hand out fresh receivers as long as the facade is alive.
     pairing_outcome_tx: broadcast::Sender<PairingOutcome>,
-    /// Held for [`Self::try_resume_session`] — the silent resume path
-    /// needs both the setup flag (to decide whether there's anything
-    /// to resume at all) and direct access to `SpaceAccessPort::try_resume_session`.
+    /// Held for [`Self::try_resume_session`] — the silent resume path needs
+    /// both the setup flag (to decide whether there's anything to resume at
+    /// all) and direct access to [`ResumeSpaceSessionPort::try_resume_session`].
     /// Everything else still goes through use cases.
-    space_access: Arc<dyn SpaceAccessPort>,
+    resume_session: Arc<dyn ResumeSpaceSessionPort>,
+    /// Held for [`Self::factory_reset`] — wipes persisted key material before
+    /// clearing setup status.
+    factory_reset: Arc<dyn FactoryResetSpacePort>,
     setup_status: Arc<dyn SetupStatusPort>,
     /// Slice4 P3 T3.2 · `query_setup_state` reads `device_name` from
     /// `Settings.general`; `cancel_invitation` / `reset` need no
@@ -159,11 +162,12 @@ impl SpaceSetupFacade {
             analytics,
         } = deps;
 
-        // Stash handles for `try_resume_session` before the originals
-        // get moved into the respective use cases below. Needed so the
-        // facade itself owns a silent-resume path without routing
-        // through a use case that would only wrap two port calls.
-        let space_access_for_facade = Arc::clone(&space_access);
+        // Stash the narrow slices the facade itself drives (`try_resume_session`
+        // / `factory_reset`) before the bundle's other slices are handed to the
+        // use cases below. The facade owns these two paths directly rather than
+        // routing through a use case that would only wrap a single port call.
+        let resume_session_for_facade = Arc::clone(&space_access.resume_session);
+        let factory_reset_for_facade = Arc::clone(&space_access.factory_reset);
         let setup_status_for_facade = Arc::clone(&setup_status);
         // Slice4 P3 T3.2 · facade-local handle for `query_setup_state`
         // (reads `Settings.general.device_name`).
@@ -178,7 +182,7 @@ impl SpaceSetupFacade {
         let invitation_holder_for_facade = Arc::clone(&invitation_holder);
 
         let initialize_space = Arc::new(InitializeSpaceUseCase::new(
-            Arc::clone(&space_access),
+            Arc::clone(&space_access.initialize),
             Arc::clone(&local_identity),
             Arc::clone(&device_identity),
             Arc::clone(&member_repo),
@@ -188,7 +192,7 @@ impl SpaceSetupFacade {
             Arc::clone(&analytics),
         ));
         let unlock_space = Arc::new(UnlockSpaceUseCase::new(
-            Arc::clone(&space_access),
+            Arc::clone(&space_access.unlock),
             Arc::clone(&setup_status),
             Arc::clone(&analytics),
         ));
@@ -239,7 +243,7 @@ impl SpaceSetupFacade {
 
         let sponsor_handshake = SponsorHandshakeCoordinator::new(
             Arc::clone(&pairing_session),
-            Arc::clone(&space_access),
+            Arc::clone(&space_access.prepare_join_offer),
             Arc::clone(&proof_port),
             Arc::clone(&local_identity),
             Arc::clone(&device_identity),
@@ -273,7 +277,7 @@ impl SpaceSetupFacade {
         // case composes it with admit/trust/setup-status.
         let joiner_handshake = JoinerHandshakeCoordinator::new(
             pairing_session,
-            space_access,
+            Arc::clone(&space_access.derive_proof_key),
             proof_port,
             local_identity,
             device_identity,
@@ -318,7 +322,8 @@ impl SpaceSetupFacade {
             redeem_pairing_invitation,
             pairing_inbound_handle,
             pairing_outcome_tx,
-            space_access: space_access_for_facade,
+            resume_session: resume_session_for_facade,
+            factory_reset: factory_reset_for_facade,
             setup_status: setup_status_for_facade,
             settings: settings_for_facade,
             invitation_holder: invitation_holder_for_facade,
@@ -382,7 +387,7 @@ impl SpaceSetupFacade {
         // passed here is an opaque handle rather than a lookup key.
         // Minting a fresh UUID matches how A2 `unlock` does it.
         let space_id = SpaceId::new();
-        let resumed = match self.space_access.try_resume_session(&space_id).await {
+        let resumed = match self.resume_session.try_resume_session(&space_id).await {
             Ok(Some(_)) => true,
             // Keyslot missing despite has_completed == true — treat
             // as "nothing to resume" rather than an error: can happen
@@ -633,7 +638,7 @@ impl SpaceSetupFacade {
     ///
     /// Step order matters:
     ///
-    /// 1. `SpaceAccessPort::factory_reset` — wipe keyslot + KEK first. If
+    /// 1. `FactoryResetSpacePort::factory_reset` — wipe keyslot + KEK first. If
     ///    this fails we leave `setup_status.has_completed = true` so the
     ///    UI still routes the user to `UnlockPage` (where they can retry)
     ///    rather than `SetupPage` (which would immediately fail with
@@ -651,7 +656,7 @@ impl SpaceSetupFacade {
     #[instrument(skip_all)]
     pub async fn factory_reset(&self) -> Result<(), FactoryResetError> {
         let space_id = SpaceId::new();
-        self.space_access
+        self.factory_reset
             .factory_reset(&space_id)
             .await
             .map_err(|err| FactoryResetError::KeyMaterialWipeFailed(err.to_string()))?;
@@ -834,11 +839,18 @@ mod tests {
         CodeOrigin, ConsumeInvitationError, InvitationError, IssuedInvitation,
         PairingInvitationAddressQueryPort, PairingInvitationByAddressPort, PairingInvitationPort,
     };
-    use uc_core::ports::space::{ProofPort, SpaceAccessError, SpaceAccessPort};
+    use uc_core::ports::space::{
+        CurrentSessionProofKeyPort, DeriveProofKeyPort, DeriveSpaceSubkeyPort,
+        FactoryResetSpacePort, InitializeSpacePort, IsSpaceUnlockedPort, LockSpacePort,
+        PrepareJoinOfferPort, ProofPort, ResumeSpaceSessionPort, SpaceAccessError, UnlockSpacePort,
+        VerifyKeychainAccessPort,
+    };
     use uc_core::ports::{
         ClockPort, DeviceIdentityPort, LocalIdentityError, LocalIdentityPort, SettingsPort,
         SetupStatusPort,
     };
+
+    use crate::deps::SpaceAccessPorts;
     use uc_core::security::IdentityFingerprint;
     use uc_core::settings::model::Settings;
     use uc_core::setup::SetupStatus;
@@ -856,7 +868,7 @@ mod tests {
     }
 
     #[async_trait]
-    impl SpaceAccessPort for FakeSpaceAccess {
+    impl InitializeSpacePort for FakeSpaceAccess {
         async fn initialize(
             &self,
             space_id: &SpaceId,
@@ -864,6 +876,9 @@ mod tests {
         ) -> Result<ActiveSpace, SpaceAccessError> {
             Ok(ActiveSpace::new(space_id.clone()))
         }
+    }
+    #[async_trait]
+    impl UnlockSpacePort for FakeSpaceAccess {
         async fn unlock(
             &self,
             space_id: &SpaceId,
@@ -874,12 +889,21 @@ mod tests {
             }
             Ok(ActiveSpace::new(space_id.clone()))
         }
+    }
+    #[async_trait]
+    impl IsSpaceUnlockedPort for FakeSpaceAccess {
         async fn is_unlocked(&self, _space_id: &SpaceId) -> bool {
             true
         }
+    }
+    #[async_trait]
+    impl LockSpacePort for FakeSpaceAccess {
         async fn lock(&self, _space_id: &SpaceId) -> Result<(), SpaceAccessError> {
             Ok(())
         }
+    }
+    #[async_trait]
+    impl FactoryResetSpacePort for FakeSpaceAccess {
         async fn factory_reset(&self, _space_id: &SpaceId) -> Result<(), SpaceAccessError> {
             *self.factory_reset_calls.lock().unwrap() += 1;
             if let Some(err) = self.factory_reset_err.lock().unwrap().take() {
@@ -887,15 +911,24 @@ mod tests {
             }
             Ok(())
         }
+    }
+    #[async_trait]
+    impl ResumeSpaceSessionPort for FakeSpaceAccess {
         async fn try_resume_session(
             &self,
             _space_id: &SpaceId,
         ) -> Result<Option<ActiveSpace>, SpaceAccessError> {
             Ok(None)
         }
+    }
+    #[async_trait]
+    impl VerifyKeychainAccessPort for FakeSpaceAccess {
         async fn verify_keychain_access(&self) -> Result<bool, SpaceAccessError> {
             Ok(true)
         }
+    }
+    #[async_trait]
+    impl DeriveSpaceSubkeyPort for FakeSpaceAccess {
         async fn derive_subkey(
             &self,
             _salt: &[u8],
@@ -903,11 +936,17 @@ mod tests {
         ) -> Result<[u8; 32], SpaceAccessError> {
             Ok([0; 32])
         }
+    }
+    #[async_trait]
+    impl CurrentSessionProofKeyPort for FakeSpaceAccess {
         async fn current_session_proof_key(
             &self,
         ) -> Result<Option<ProofDerivedKey>, SpaceAccessError> {
             Ok(None)
         }
+    }
+    #[async_trait]
+    impl PrepareJoinOfferPort for FakeSpaceAccess {
         async fn prepare_join_offer(
             &self,
             _space_id: &SpaceId,
@@ -915,6 +954,9 @@ mod tests {
         ) -> Result<JoinOffer, SpaceAccessError> {
             unimplemented!("not used by A1/A2")
         }
+    }
+    #[async_trait]
+    impl DeriveProofKeyPort for FakeSpaceAccess {
         async fn derive_master_key_for_proof(
             &self,
             _offer: &JoinOffer,
@@ -1411,7 +1453,7 @@ mod tests {
     }
 
     fn make_facade(
-        space_access: Arc<dyn SpaceAccessPort>,
+        space_access: Arc<FakeSpaceAccess>,
         setup_status: Arc<dyn SetupStatusPort>,
         settings: Arc<dyn SettingsPort>,
     ) -> (
@@ -1428,7 +1470,7 @@ mod tests {
     }
 
     fn make_facade_with_migration_state(
-        space_access: Arc<dyn SpaceAccessPort>,
+        space_access: Arc<FakeSpaceAccess>,
         setup_status: Arc<dyn SetupStatusPort>,
         settings: Arc<dyn SettingsPort>,
         migration_state: Arc<FakeMigrationState>,
@@ -1440,7 +1482,7 @@ mod tests {
         let pairing_invitation = Arc::new(FakeInvitationPort::default());
         let peer_addr_repo = Arc::new(FakePeerAddrRepo::default());
         let facade = SpaceSetupFacade::new(SpaceSetupDeps {
-            space_access,
+            space_access: SpaceAccessPorts::from_adapter(space_access),
             local_identity: Arc::new(FakeLocalIdentity {
                 fp: default_fingerprint(),
             }),

--- a/crates/uc-application/src/pairing_inbound/orchestrator.rs
+++ b/crates/uc-application/src/pairing_inbound/orchestrator.rs
@@ -609,14 +609,14 @@ mod tests {
     use chrono::{DateTime, Duration};
     use tokio::sync::mpsc;
 
-    use uc_core::crypto::domain::{ActiveSpace, Passphrase};
+    use uc_core::crypto::domain::Passphrase;
     use uc_core::ids::{DeviceId, SessionId, SpaceId};
     use uc_core::membership::{MembershipError, SpaceMember};
     use uc_core::pairing::invitation::{InvitationCode, PairingInvitation};
     use uc_core::pairing::session_message::{JoinerChallengeResponse, PairingReject};
     use uc_core::ports::pairing::{DialError, DialOutcome, PairingSessionPort, SessionError};
     use uc_core::ports::pairing_invitation::{InvitationError, IssuedInvitation};
-    use uc_core::ports::space::{ProofPort, SpaceAccessError, SpaceAccessPort};
+    use uc_core::ports::space::{PrepareJoinOfferPort, ProofPort, SpaceAccessError};
     use uc_core::ports::LocalIdentityError;
     use uc_core::ports::{DeviceIdentityPort, LocalIdentityPort, SettingsPort};
     use uc_core::security::IdentityFingerprint;
@@ -725,47 +725,7 @@ mod tests {
         challenge_nonce: [u8; 32],
     }
     #[async_trait]
-    impl SpaceAccessPort for StubSpaceAccess {
-        async fn initialize(
-            &self,
-            _: &SpaceId,
-            _: &Passphrase,
-        ) -> Result<ActiveSpace, SpaceAccessError> {
-            unimplemented!()
-        }
-        async fn unlock(
-            &self,
-            _: &SpaceId,
-            _: &Passphrase,
-        ) -> Result<ActiveSpace, SpaceAccessError> {
-            unimplemented!()
-        }
-        async fn is_unlocked(&self, _: &SpaceId) -> bool {
-            true
-        }
-        async fn lock(&self, _: &SpaceId) -> Result<(), SpaceAccessError> {
-            Ok(())
-        }
-        async fn factory_reset(&self, _: &SpaceId) -> Result<(), SpaceAccessError> {
-            Ok(())
-        }
-        async fn try_resume_session(
-            &self,
-            _: &SpaceId,
-        ) -> Result<Option<ActiveSpace>, SpaceAccessError> {
-            Ok(None)
-        }
-        async fn verify_keychain_access(&self) -> Result<bool, SpaceAccessError> {
-            Ok(true)
-        }
-        async fn derive_subkey(&self, _: &[u8], _: &[u8]) -> Result<[u8; 32], SpaceAccessError> {
-            Ok([0; 32])
-        }
-        async fn current_session_proof_key(
-            &self,
-        ) -> Result<Option<ProofDerivedKey>, SpaceAccessError> {
-            Ok(None)
-        }
+    impl PrepareJoinOfferPort for StubSpaceAccess {
         async fn prepare_join_offer(
             &self,
             _: &SpaceId,
@@ -776,13 +736,6 @@ mod tests {
                 keyslot_blob: vec![0xAA; 32],
                 challenge_nonce: self.challenge_nonce,
             })
-        }
-        async fn derive_master_key_for_proof(
-            &self,
-            _: &JoinOffer,
-            _: &Passphrase,
-        ) -> Result<ProofDerivedKey, SpaceAccessError> {
-            unimplemented!()
         }
     }
 

--- a/crates/uc-application/src/pairing_inbound/sponsor_handshake.rs
+++ b/crates/uc-application/src/pairing_inbound/sponsor_handshake.rs
@@ -52,7 +52,7 @@ use uc_core::pairing::session_message::{
     PairingSessionMessage, SponsorConfirm, SponsorKeyslotOffer,
 };
 use uc_core::ports::pairing::{PairingSessionId, PairingSessionPort};
-use uc_core::ports::space::{ProofPort, SpaceAccessPort};
+use uc_core::ports::space::{PrepareJoinOfferPort, ProofPort};
 use uc_core::ports::{DeviceIdentityPort, LocalIdentityPort, SettingsPort, SetupStatusPort};
 use uc_core::security::IdentityFingerprint;
 use uc_core::space_access::domain::SpaceAccessProofArtifact;
@@ -98,7 +98,7 @@ struct SessionCtx {
 
 pub(crate) struct SponsorHandshakeCoordinator {
     pairing_session: Arc<dyn PairingSessionPort>,
-    space_access: Arc<dyn SpaceAccessPort>,
+    space_access: Arc<dyn PrepareJoinOfferPort>,
     proof_port: Arc<dyn ProofPort>,
     local_identity: Arc<dyn LocalIdentityPort>,
     device_identity: Arc<dyn DeviceIdentityPort>,
@@ -127,7 +127,7 @@ pub(crate) struct SponsorHandshakeCoordinator {
 impl SponsorHandshakeCoordinator {
     pub(crate) fn new(
         pairing_session: Arc<dyn PairingSessionPort>,
-        space_access: Arc<dyn SpaceAccessPort>,
+        space_access: Arc<dyn PrepareJoinOfferPort>,
         proof_port: Arc<dyn ProofPort>,
         local_identity: Arc<dyn LocalIdentityPort>,
         device_identity: Arc<dyn DeviceIdentityPort>,
@@ -505,11 +505,10 @@ mod tests {
 
     use async_trait::async_trait;
 
-    use uc_core::crypto::domain::ActiveSpace;
     use uc_core::ids::DeviceId;
     use uc_core::pairing::invitation::InvitationCode;
     use uc_core::ports::pairing::{DialError, DialOutcome, SessionError};
-    use uc_core::ports::space::SpaceAccessError;
+    use uc_core::ports::space::{PrepareJoinOfferPort, SpaceAccessError};
     use uc_core::ports::LocalIdentityError;
     use uc_core::settings::model::Settings;
     use uc_core::space_access::domain::{JoinOffer, ProofDerivedKey};
@@ -568,47 +567,7 @@ mod tests {
         fail: StdMutex<bool>,
     }
     #[async_trait]
-    impl SpaceAccessPort for StubSpaceAccess {
-        async fn initialize(
-            &self,
-            _: &SpaceId,
-            _: &Passphrase,
-        ) -> Result<ActiveSpace, SpaceAccessError> {
-            unimplemented!()
-        }
-        async fn unlock(
-            &self,
-            _: &SpaceId,
-            _: &Passphrase,
-        ) -> Result<ActiveSpace, SpaceAccessError> {
-            unimplemented!()
-        }
-        async fn is_unlocked(&self, _: &SpaceId) -> bool {
-            true
-        }
-        async fn lock(&self, _: &SpaceId) -> Result<(), SpaceAccessError> {
-            Ok(())
-        }
-        async fn factory_reset(&self, _: &SpaceId) -> Result<(), SpaceAccessError> {
-            Ok(())
-        }
-        async fn try_resume_session(
-            &self,
-            _: &SpaceId,
-        ) -> Result<Option<ActiveSpace>, SpaceAccessError> {
-            Ok(None)
-        }
-        async fn verify_keychain_access(&self) -> Result<bool, SpaceAccessError> {
-            Ok(true)
-        }
-        async fn derive_subkey(&self, _: &[u8], _: &[u8]) -> Result<[u8; 32], SpaceAccessError> {
-            Ok([0; 32])
-        }
-        async fn current_session_proof_key(
-            &self,
-        ) -> Result<Option<ProofDerivedKey>, SpaceAccessError> {
-            Ok(None)
-        }
+    impl PrepareJoinOfferPort for StubSpaceAccess {
         async fn prepare_join_offer(
             &self,
             _: &SpaceId,
@@ -622,13 +581,6 @@ mod tests {
                 keyslot_blob: vec![0xAA; 32],
                 challenge_nonce: self.challenge_nonce,
             })
-        }
-        async fn derive_master_key_for_proof(
-            &self,
-            _: &JoinOffer,
-            _: &Passphrase,
-        ) -> Result<ProofDerivedKey, SpaceAccessError> {
-            unimplemented!()
         }
     }
 

--- a/crates/uc-application/src/pairing_outbound/joiner_handshake.rs
+++ b/crates/uc-application/src/pairing_outbound/joiner_handshake.rs
@@ -52,7 +52,7 @@ use uc_core::pairing::session_message::{
 use uc_core::ports::pairing::{
     DialError, DialOutcome, DiscoveryChannel, PairingSessionId, PairingSessionPort, SessionError,
 };
-use uc_core::ports::space::{ProofPort, SpaceAccessError, SpaceAccessPort};
+use uc_core::ports::space::{DeriveProofKeyPort, ProofPort, SpaceAccessError};
 use uc_core::ports::{DeviceIdentityPort, LocalIdentityPort, SettingsPort};
 use uc_core::security::IdentityFingerprint;
 use uc_core::space_access::JoinOffer;
@@ -94,7 +94,7 @@ pub(crate) struct JoinerHandshakeOutcome {
 
 pub(crate) struct JoinerHandshakeCoordinator {
     pairing_session: Arc<dyn PairingSessionPort>,
-    space_access: Arc<dyn SpaceAccessPort>,
+    space_access: Arc<dyn DeriveProofKeyPort>,
     proof_port: Arc<dyn ProofPort>,
     local_identity: Arc<dyn LocalIdentityPort>,
     device_identity: Arc<dyn DeviceIdentityPort>,
@@ -109,7 +109,7 @@ impl JoinerHandshakeCoordinator {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         pairing_session: Arc<dyn PairingSessionPort>,
-        space_access: Arc<dyn SpaceAccessPort>,
+        space_access: Arc<dyn DeriveProofKeyPort>,
         proof_port: Arc<dyn ProofPort>,
         local_identity: Arc<dyn LocalIdentityPort>,
         device_identity: Arc<dyn DeviceIdentityPort>,
@@ -442,13 +442,13 @@ mod tests {
     use async_trait::async_trait;
     use chrono::Duration as ChronoDuration;
 
-    use uc_core::crypto::domain::{ActiveSpace, Passphrase};
+    use uc_core::crypto::domain::Passphrase;
     use uc_core::ids::{DeviceId, SpaceId};
     use uc_core::pairing::session_message::{
         JoinerChallengeResponse, JoinerRequest, PairingReject, SponsorConfirm, SponsorKeyslotOffer,
     };
     use uc_core::ports::pairing::{DialError, DialOutcome, DiscoveryChannel, SessionError};
-    use uc_core::ports::space::SpaceAccessError;
+    use uc_core::ports::space::{DeriveProofKeyPort, SpaceAccessError};
     use uc_core::ports::LocalIdentityError;
     use uc_core::security::IdentityFingerprint;
     use uc_core::settings::model::Settings;
@@ -568,54 +568,7 @@ mod tests {
         }
     }
     #[async_trait]
-    impl SpaceAccessPort for ScriptedSpaceAccess {
-        async fn initialize(
-            &self,
-            _: &SpaceId,
-            _: &Passphrase,
-        ) -> Result<ActiveSpace, SpaceAccessError> {
-            unimplemented!()
-        }
-        async fn unlock(
-            &self,
-            _: &SpaceId,
-            _: &Passphrase,
-        ) -> Result<ActiveSpace, SpaceAccessError> {
-            unimplemented!()
-        }
-        async fn is_unlocked(&self, _: &SpaceId) -> bool {
-            true
-        }
-        async fn lock(&self, _: &SpaceId) -> Result<(), SpaceAccessError> {
-            Ok(())
-        }
-        async fn factory_reset(&self, _: &SpaceId) -> Result<(), SpaceAccessError> {
-            Ok(())
-        }
-        async fn try_resume_session(
-            &self,
-            _: &SpaceId,
-        ) -> Result<Option<ActiveSpace>, SpaceAccessError> {
-            Ok(None)
-        }
-        async fn verify_keychain_access(&self) -> Result<bool, SpaceAccessError> {
-            Ok(true)
-        }
-        async fn derive_subkey(&self, _: &[u8], _: &[u8]) -> Result<[u8; 32], SpaceAccessError> {
-            Ok([0; 32])
-        }
-        async fn current_session_proof_key(
-            &self,
-        ) -> Result<Option<ProofDerivedKey>, SpaceAccessError> {
-            Ok(None)
-        }
-        async fn prepare_join_offer(
-            &self,
-            _: &SpaceId,
-            _: &Passphrase,
-        ) -> Result<JoinOffer, SpaceAccessError> {
-            unimplemented!()
-        }
+    impl DeriveProofKeyPort for ScriptedSpaceAccess {
         async fn derive_master_key_for_proof(
             &self,
             _: &JoinOffer,

--- a/crates/uc-application/src/proof.rs
+++ b/crates/uc-application/src/proof.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use tokio::sync::Mutex;
 
 use uc_core::ids::{SessionId, SpaceId};
-use uc_core::ports::space::{ProofPort, SpaceAccessPort};
+use uc_core::ports::space::{CurrentSessionProofKeyPort, ProofPort};
 use uc_core::space_access::{ProofDerivedKey, SpaceAccessProofArtifact};
 
 type HmacSha256 = Hmac<Sha256>;
@@ -20,7 +20,7 @@ struct ProofCacheKey {
 
 pub struct HmacProofAdapter {
     key_cache: Mutex<HashMap<ProofCacheKey, [u8; 32]>>,
-    space_access: Option<Arc<dyn SpaceAccessPort>>,
+    space_access: Option<Arc<dyn CurrentSessionProofKeyPort>>,
 }
 
 impl HmacProofAdapter {
@@ -33,7 +33,7 @@ impl HmacProofAdapter {
 
     /// 给 sponsor 侧 verify_proof 的 cache miss fallback 路径注入会话访问器。
     /// 不传时 cache miss 直接判失败,适合无持久会话的测试场景。
-    pub fn new_with_space_access(space_access: Arc<dyn SpaceAccessPort>) -> Self {
+    pub fn new_with_space_access(space_access: Arc<dyn CurrentSessionProofKeyPort>) -> Self {
         Self {
             key_cache: Mutex::new(HashMap::new()),
             space_access: Some(space_access),

--- a/crates/uc-application/src/usecases/pairing/redeem_invitation.rs
+++ b/crates/uc-application/src/usecases/pairing/redeem_invitation.rs
@@ -354,7 +354,7 @@ mod tests {
     use async_trait::async_trait;
     use uuid::Uuid;
 
-    use uc_core::crypto::domain::{ActiveSpace, Passphrase};
+    use uc_core::crypto::domain::Passphrase;
     use uc_core::ids::{DeviceId, SessionId, SpaceId};
     use uc_core::membership::{MembershipError, SpaceMember};
     use uc_core::pairing::invitation::InvitationCode;
@@ -365,7 +365,7 @@ mod tests {
         DialError, DialOutcome, DiscoveryChannel, PairingSessionId, PairingSessionPort,
         SessionError,
     };
-    use uc_core::ports::space::{ProofPort, SpaceAccessError, SpaceAccessPort};
+    use uc_core::ports::space::{DeriveProofKeyPort, ProofPort, SpaceAccessError};
     use uc_core::ports::{DeviceIdentityPort, LocalIdentityError, LocalIdentityPort, SettingsPort};
     use uc_core::security::IdentityFingerprint;
     use uc_core::settings::model::Settings;
@@ -462,54 +462,7 @@ mod tests {
 
     struct HappySpaceAccess;
     #[async_trait]
-    impl SpaceAccessPort for HappySpaceAccess {
-        async fn initialize(
-            &self,
-            _: &SpaceId,
-            _: &Passphrase,
-        ) -> Result<ActiveSpace, SpaceAccessError> {
-            unimplemented!()
-        }
-        async fn unlock(
-            &self,
-            _: &SpaceId,
-            _: &Passphrase,
-        ) -> Result<ActiveSpace, SpaceAccessError> {
-            unimplemented!()
-        }
-        async fn is_unlocked(&self, _: &SpaceId) -> bool {
-            true
-        }
-        async fn lock(&self, _: &SpaceId) -> Result<(), SpaceAccessError> {
-            Ok(())
-        }
-        async fn factory_reset(&self, _: &SpaceId) -> Result<(), SpaceAccessError> {
-            Ok(())
-        }
-        async fn try_resume_session(
-            &self,
-            _: &SpaceId,
-        ) -> Result<Option<ActiveSpace>, SpaceAccessError> {
-            Ok(None)
-        }
-        async fn verify_keychain_access(&self) -> Result<bool, SpaceAccessError> {
-            Ok(true)
-        }
-        async fn derive_subkey(&self, _: &[u8], _: &[u8]) -> Result<[u8; 32], SpaceAccessError> {
-            Ok([0; 32])
-        }
-        async fn current_session_proof_key(
-            &self,
-        ) -> Result<Option<ProofDerivedKey>, SpaceAccessError> {
-            Ok(None)
-        }
-        async fn prepare_join_offer(
-            &self,
-            _: &SpaceId,
-            _: &Passphrase,
-        ) -> Result<JoinOffer, SpaceAccessError> {
-            unimplemented!()
-        }
+    impl DeriveProofKeyPort for HappySpaceAccess {
         async fn derive_master_key_for_proof(
             &self,
             _: &JoinOffer,

--- a/crates/uc-application/src/usecases/setup/initialize_space.rs
+++ b/crates/uc-application/src/usecases/setup/initialize_space.rs
@@ -7,7 +7,7 @@
 //!    A2 (unlock) instead, or factory-reset first.
 //! 1. Validate the passphrase confirmation.
 //! 2. Resolve & persist `device_name` (`Settings.general.device_name`).
-//! 3. `SpaceAccessPort::initialize` — create the encrypted space.
+//! 3. `InitializeSpacePort::initialize` — create the encrypted space.
 //! 4. `LocalIdentityPort::ensure` — read or lazily generate the Ed25519
 //!    identity fingerprint. In Slice 1 the iroh endpoint binds its
 //!    identity at bootstrap, so by the time A1 runs the identity already
@@ -30,7 +30,7 @@ use tracing::{debug, info, instrument, warn};
 
 use uc_core::ids::SpaceId;
 use uc_core::membership::{MemberRepositoryPort, MemberSyncPreferences, SpaceMember};
-use uc_core::ports::space::{SpaceAccessError, SpaceAccessPort};
+use uc_core::ports::space::{InitializeSpacePort, SpaceAccessError};
 use uc_core::ports::{
     ClockPort, DeviceIdentityPort, LocalIdentityError, LocalIdentityPort, SettingsPort,
     SetupStatusPort,
@@ -44,7 +44,7 @@ use crate::facade::space_setup::commands::InitializeSpaceCommand;
 use crate::facade::space_setup::{InitializeSpaceError, InitializeSpaceResult};
 
 pub(crate) struct InitializeSpaceUseCase {
-    space_access: Arc<dyn SpaceAccessPort>,
+    space_access: Arc<dyn InitializeSpacePort>,
     local_identity: Arc<dyn LocalIdentityPort>,
     device_identity: Arc<dyn DeviceIdentityPort>,
     member_repo: Arc<dyn MemberRepositoryPort>,
@@ -61,7 +61,7 @@ pub(crate) struct InitializeSpaceUseCase {
 
 impl InitializeSpaceUseCase {
     pub(crate) fn new(
-        space_access: Arc<dyn SpaceAccessPort>,
+        space_access: Arc<dyn InitializeSpacePort>,
         local_identity: Arc<dyn LocalIdentityPort>,
         device_identity: Arc<dyn DeviceIdentityPort>,
         member_repo: Arc<dyn MemberRepositoryPort>,
@@ -291,10 +291,9 @@ mod tests {
     use uc_core::crypto::domain::{ActiveSpace, Passphrase};
     use uc_core::ids::{DeviceId, SpaceId};
     use uc_core::membership::{MembershipError, SpaceMember};
-    use uc_core::ports::space::{SpaceAccessError, SpaceAccessPort};
+    use uc_core::ports::space::{InitializeSpacePort, SpaceAccessError};
     use uc_core::security::IdentityFingerprint;
     use uc_core::settings::model::Settings;
-    use uc_core::space_access::{JoinOffer, ProofDerivedKey};
 
     // ---------- Fakes ----------
 
@@ -302,12 +301,10 @@ mod tests {
     struct FakeSpaceAccess {
         initialized: Mutex<bool>,
         initialize_err: Mutex<Option<SpaceAccessError>>,
-        unlock_err: Mutex<Option<SpaceAccessError>>,
-        unlock_calls: Mutex<u32>,
     }
 
     #[async_trait]
-    impl SpaceAccessPort for FakeSpaceAccess {
+    impl InitializeSpacePort for FakeSpaceAccess {
         async fn initialize(
             &self,
             space_id: &SpaceId,
@@ -318,61 +315,6 @@ mod tests {
             }
             *self.initialized.lock().unwrap() = true;
             Ok(ActiveSpace::new(space_id.clone()))
-        }
-        async fn unlock(
-            &self,
-            space_id: &SpaceId,
-            _passphrase: &Passphrase,
-        ) -> Result<ActiveSpace, SpaceAccessError> {
-            *self.unlock_calls.lock().unwrap() += 1;
-            if let Some(err) = self.unlock_err.lock().unwrap().take() {
-                return Err(err);
-            }
-            Ok(ActiveSpace::new(space_id.clone()))
-        }
-        async fn is_unlocked(&self, _space_id: &SpaceId) -> bool {
-            true
-        }
-        async fn lock(&self, _space_id: &SpaceId) -> Result<(), SpaceAccessError> {
-            Ok(())
-        }
-        async fn factory_reset(&self, _space_id: &SpaceId) -> Result<(), SpaceAccessError> {
-            Ok(())
-        }
-        async fn try_resume_session(
-            &self,
-            _space_id: &SpaceId,
-        ) -> Result<Option<ActiveSpace>, SpaceAccessError> {
-            Ok(None)
-        }
-        async fn verify_keychain_access(&self) -> Result<bool, SpaceAccessError> {
-            Ok(true)
-        }
-        async fn derive_subkey(
-            &self,
-            _salt: &[u8],
-            _info: &[u8],
-        ) -> Result<[u8; 32], SpaceAccessError> {
-            Ok([0; 32])
-        }
-        async fn current_session_proof_key(
-            &self,
-        ) -> Result<Option<ProofDerivedKey>, SpaceAccessError> {
-            Ok(None)
-        }
-        async fn prepare_join_offer(
-            &self,
-            _space_id: &SpaceId,
-            _passphrase: &Passphrase,
-        ) -> Result<JoinOffer, SpaceAccessError> {
-            unimplemented!("not used in A1/A2 tests")
-        }
-        async fn derive_master_key_for_proof(
-            &self,
-            _offer: &JoinOffer,
-            _passphrase: &Passphrase,
-        ) -> Result<ProofDerivedKey, SpaceAccessError> {
-            unimplemented!("not used in A1/A2 tests")
         }
     }
 

--- a/crates/uc-application/src/usecases/setup/unlock_space.rs
+++ b/crates/uc-application/src/usecases/setup/unlock_space.rs
@@ -1,7 +1,7 @@
 //! A2 · `UnlockSpaceUseCase`.
 //!
 //! Post-setup start-up flow: check `SetupStatus.has_completed`, then
-//! forward to `SpaceAccessPort::unlock`. Because A1 is atomic, if we
+//! forward to `UnlockSpacePort::unlock`. Because A1 is atomic, if we
 //! ever reach A2 we can assume the owner `SpaceMember` / identity are
 //! already persisted — A2 does not do a "self-member self-heal" round
 //! (decision from Slice 1 outside-in session).
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use tracing::{debug, info, instrument, warn};
 
 use uc_core::ids::SpaceId;
-use uc_core::ports::space::{SpaceAccessError, SpaceAccessPort};
+use uc_core::ports::space::{SpaceAccessError, UnlockSpacePort};
 use uc_core::ports::SetupStatusPort;
 use uc_observability::analytics::{AnalyticsFacade, Event, UnlockFailureReason};
 
@@ -19,7 +19,7 @@ use crate::facade::space_setup::commands::UnlockSpaceCommand;
 use crate::facade::space_setup::{UnlockSpaceError, UnlockSpaceResult};
 
 pub(crate) struct UnlockSpaceUseCase {
-    space_access: Arc<dyn SpaceAccessPort>,
+    space_access: Arc<dyn UnlockSpacePort>,
     setup_status: Arc<dyn SetupStatusPort>,
     /// schema doc §12.1 · 每次 daemon 重启的可靠性 anchor。成功路径发
     /// `space_unlocked`，失败路径按 `UnlockFailureReason` 映射发
@@ -30,7 +30,7 @@ pub(crate) struct UnlockSpaceUseCase {
 
 impl UnlockSpaceUseCase {
     pub(crate) fn new(
-        space_access: Arc<dyn SpaceAccessPort>,
+        space_access: Arc<dyn UnlockSpacePort>,
         setup_status: Arc<dyn SetupStatusPort>,
         analytics: Arc<dyn AnalyticsFacade>,
     ) -> Self {
@@ -119,9 +119,8 @@ mod tests {
 
     use uc_core::crypto::domain::{ActiveSpace, Passphrase};
     use uc_core::ids::SpaceId;
-    use uc_core::ports::space::{SpaceAccessError, SpaceAccessPort};
+    use uc_core::ports::space::{SpaceAccessError, UnlockSpacePort};
     use uc_core::setup::SetupStatus;
-    use uc_core::space_access::{JoinOffer, ProofDerivedKey};
 
     #[derive(Default)]
     struct FakeSpaceAccess {
@@ -129,14 +128,7 @@ mod tests {
         unlock_calls: Mutex<u32>,
     }
     #[async_trait]
-    impl SpaceAccessPort for FakeSpaceAccess {
-        async fn initialize(
-            &self,
-            _space_id: &SpaceId,
-            _passphrase: &Passphrase,
-        ) -> Result<ActiveSpace, SpaceAccessError> {
-            unimplemented!("A2 test does not touch initialize")
-        }
+    impl UnlockSpacePort for FakeSpaceAccess {
         async fn unlock(
             &self,
             space_id: &SpaceId,
@@ -147,50 +139,6 @@ mod tests {
                 return Err(err);
             }
             Ok(ActiveSpace::new(space_id.clone()))
-        }
-        async fn is_unlocked(&self, _space_id: &SpaceId) -> bool {
-            true
-        }
-        async fn lock(&self, _space_id: &SpaceId) -> Result<(), SpaceAccessError> {
-            Ok(())
-        }
-        async fn factory_reset(&self, _space_id: &SpaceId) -> Result<(), SpaceAccessError> {
-            Ok(())
-        }
-        async fn try_resume_session(
-            &self,
-            _space_id: &SpaceId,
-        ) -> Result<Option<ActiveSpace>, SpaceAccessError> {
-            Ok(None)
-        }
-        async fn verify_keychain_access(&self) -> Result<bool, SpaceAccessError> {
-            Ok(true)
-        }
-        async fn derive_subkey(
-            &self,
-            _salt: &[u8],
-            _info: &[u8],
-        ) -> Result<[u8; 32], SpaceAccessError> {
-            Ok([0; 32])
-        }
-        async fn current_session_proof_key(
-            &self,
-        ) -> Result<Option<ProofDerivedKey>, SpaceAccessError> {
-            Ok(None)
-        }
-        async fn prepare_join_offer(
-            &self,
-            _space_id: &SpaceId,
-            _passphrase: &Passphrase,
-        ) -> Result<JoinOffer, SpaceAccessError> {
-            unimplemented!()
-        }
-        async fn derive_master_key_for_proof(
-            &self,
-            _offer: &JoinOffer,
-            _passphrase: &Passphrase,
-        ) -> Result<ProofDerivedKey, SpaceAccessError> {
-            unimplemented!()
         }
     }
 

--- a/crates/uc-bootstrap/src/assembly.rs
+++ b/crates/uc-bootstrap/src/assembly.rs
@@ -22,7 +22,7 @@ use tracing::info;
 use uc_application::deps::{
     AppDeps, ClipboardEntryPorts, ClipboardPorts, ClipboardRepresentationPorts, DevicePorts,
     FileTransferPorts, MobileDevicePorts, MobileSyncPorts, SearchPorts, SecurityPorts,
-    StoragePorts, SystemPorts,
+    SpaceAccessPorts, StoragePorts, SystemPorts,
 };
 use uc_application::facade::HostEventEmitterPort;
 use uc_core::blob::ports::{BlobReaderPort, BlobWriterPort};
@@ -985,21 +985,27 @@ pub fn wire_dependencies(
         storage_config.clone(),
     )?;
 
-    // SpaceAccessPort——单一会话/密钥访问入口。adapter 自管 KeyMaterialStore +
-    // InMemorySession + CurrentProfilePort,V1 AEAD 走 v1_aead helper。
-    // Phase C 起不再依赖 EncryptionStatePort (已物理删除);adapter 用
-    // `key_material.keyslot_exists()` 判断是否已初始化。
-    let space_access: Arc<dyn uc_core::ports::space::SpaceAccessPort> =
-        Arc::new(uc_infra::security::DefaultSpaceAccessAdapter::new(
-            infra.key_material.clone(),
-            platform.current_profile.clone(),
-            platform.session.clone(),
-        ));
+    // Space access——单一会话/密钥访问入口。adapter 自管 KeyMaterialStore +
+    // InMemorySession + CurrentProfilePort,V1 AEAD 走 v1_aead helper。adapter
+    // 用 `key_material.keyslot_exists()` 判断是否已初始化。
+    //
+    // One concrete adapter is coerced into each narrow space-access intent port
+    // (the adapter implements the aggregate `SpaceAccessStore` and every
+    // intent-port impl delegates to it, ports.md §8.3); the narrow bundle is
+    // the only space-access surface the application layer consumes.
+    let space_access_adapter = Arc::new(uc_infra::security::DefaultSpaceAccessAdapter::new(
+        infra.key_material.clone(),
+        platform.current_profile.clone(),
+        platform.session.clone(),
+    ));
+    let space_access_ports = SpaceAccessPorts::from_adapter(space_access_adapter);
 
-    // Wire the search bundle (Phase 92).
-    let search_key_derivation: Arc<dyn SearchKeyDerivationPort> = Arc::new(
-        HkdfSearchKeyDerivation::new(space_access.clone(), platform.current_profile.clone()),
-    );
+    // Wire the search bundle (Phase 92). Search only derives a subkey.
+    let search_key_derivation: Arc<dyn SearchKeyDerivationPort> =
+        Arc::new(HkdfSearchKeyDerivation::new(
+            space_access_ports.derive_subkey.clone(),
+            platform.current_profile.clone(),
+        ));
     let search_index: Arc<dyn SearchIndexPort> = Arc::new(SqliteSearchIndex::new(
         db_pool_for_search,
         platform.current_profile.clone(),
@@ -1146,7 +1152,7 @@ pub fn wire_dependencies(
         security: SecurityPorts {
             current_profile: platform.current_profile,
             secure_storage: platform.secure_storage,
-            space_access: space_access.clone(),
+            space_access_ports,
             blob_cipher: blob_cipher.clone(),
             transfer_cipher: transfer_cipher.clone(),
             pin_hasher: Arc::new(Argon2PinHasher),

--- a/crates/uc-bootstrap/src/non_gui_runtime.rs
+++ b/crates/uc-bootstrap/src/non_gui_runtime.rs
@@ -417,7 +417,15 @@ pub fn build_app_facade_from_deps(
         })),
         encryption: Arc::new(EncryptionFacade::new(EncryptionFacadeDeps {
             setup_status: deps.setup_status.clone(),
-            space_access: deps.security.space_access.clone(),
+            initialize: deps.security.space_access_ports.initialize.clone(),
+            resume_session: deps.security.space_access_ports.resume_session.clone(),
+            is_unlocked: deps.security.space_access_ports.is_unlocked.clone(),
+            lock: deps.security.space_access_ports.lock.clone(),
+            verify_keychain_access: deps
+                .security
+                .space_access_ports
+                .verify_keychain_access
+                .clone(),
         })),
         resource: Arc::new(ResourceFacade::new(ResourceFacadeDeps {
             representation_by_blob_id: deps.clipboard.representation_ports.get_by_blob_id.clone(),

--- a/crates/uc-bootstrap/src/space_setup.rs
+++ b/crates/uc-bootstrap/src/space_setup.rs
@@ -384,18 +384,18 @@ pub async fn build_space_setup_assembly(
         Arc::clone(&wired.host_event_bus),
     );
 
-    // HMAC proof adapter verifies the joiner's ChallengeResponse against
-    // the master key that `SpaceAccessPort::derive_master_key_for_proof`
-    // stashes in-session. Fed the same `space_access` the use cases use
-    // so the cache-miss fallback can still find the current session key.
+    // HMAC proof adapter verifies the joiner's ChallengeResponse against the
+    // master key that `DeriveProofKeyPort::derive_master_key_for_proof` stashes
+    // in-session. Fed the same session-proof-key port the use cases share so
+    // the cache-miss fallback can still find the current session key.
     let proof_port: Arc<dyn ProofPort> = Arc::new(HmacProofAdapter::new_with_space_access(
-        Arc::clone(&deps.security.space_access),
+        Arc::clone(&deps.security.space_access_ports.current_session_proof_key),
     ));
 
     let local_identity: Arc<dyn LocalIdentityPort> = identity_store;
 
     let facade = Arc::new(SpaceSetupFacade::new(SpaceSetupDeps {
-        space_access: Arc::clone(&deps.security.space_access),
+        space_access: deps.security.space_access_ports.clone(),
         local_identity: Arc::clone(&local_identity),
         device_identity: Arc::clone(&deps.device.device_identity),
         member_repo: Arc::clone(&deps.device.member_repo),

--- a/crates/uc-bootstrap/tests/mdns_only_pairing_e2e.rs
+++ b/crates/uc-bootstrap/tests/mdns_only_pairing_e2e.rs
@@ -40,6 +40,7 @@ use tempfile::TempDir;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
+use uc_application::deps::SpaceAccessPorts;
 use uc_application::facade::space_setup::{
     InitializeSpaceInput, RedeemPairingInvitationInput, SpaceSetupDeps, SpaceSetupFacade,
 };
@@ -48,7 +49,7 @@ use uc_bootstrap::IrohNodeConfig;
 use uc_core::ids::DeviceId;
 use uc_core::membership::{MemberRepositoryPort, MembershipError, SpaceMember};
 use uc_core::ports::pairing::PairingSessionPort;
-use uc_core::ports::space::{ProofPort, SpaceAccessPort};
+use uc_core::ports::space::ProofPort;
 use uc_core::ports::{
     ClockPort, DeviceIdentityPort, LocalIdentityPort, SecureStorageError, SecureStoragePort,
     SettingsPort, SetupStatusPort,
@@ -298,7 +299,7 @@ async fn build_side(name: &'static str, rendezvous_base_url: String) -> Side {
     ));
     let current_profile = Arc::new(DefaultCurrentProfile::new());
     let session = Arc::new(InMemorySession::new());
-    let space_access: Arc<dyn SpaceAccessPort> = Arc::new(DefaultSpaceAccessAdapter::new(
+    let space_access = Arc::new(DefaultSpaceAccessAdapter::new(
         key_material,
         current_profile,
         Arc::clone(&session) as Arc<InMemorySession>,
@@ -338,14 +339,14 @@ async fn build_side(name: &'static str, rendezvous_base_url: String) -> Side {
     let iroh_node = builder.spawn();
 
     let proof_port: Arc<dyn ProofPort> = Arc::new(HmacProofAdapter::new_with_space_access(
-        Arc::clone(&space_access),
+        space_access.clone(),
     ));
     let local_identity: Arc<dyn LocalIdentityPort> = Arc::clone(&identity_store) as _;
 
     let (migration_state, key_migration, blob_migration_repo, blob_cipher) =
         common::migration_noop_deps();
     let facade = Arc::new(SpaceSetupFacade::new(SpaceSetupDeps {
-        space_access,
+        space_access: SpaceAccessPorts::from_adapter(space_access),
         local_identity,
         device_identity,
         member_repo: Arc::clone(&member_repo) as Arc<dyn MemberRepositoryPort>,

--- a/crates/uc-bootstrap/tests/slice1_handshake_e2e.rs
+++ b/crates/uc-bootstrap/tests/slice1_handshake_e2e.rs
@@ -23,6 +23,7 @@ use tempfile::TempDir;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, Request, Respond, ResponseTemplate};
 
+use uc_application::deps::SpaceAccessPorts;
 use uc_application::facade::space_setup::{
     InitializeSpaceInput, RedeemPairingInvitationInput, SpaceSetupDeps, SpaceSetupFacade,
 };
@@ -31,7 +32,7 @@ use uc_bootstrap::IrohNodeConfig;
 use uc_core::ids::DeviceId;
 use uc_core::membership::{MemberRepositoryPort, MembershipError, SpaceMember};
 use uc_core::ports::pairing::PairingSessionPort;
-use uc_core::ports::space::{ProofPort, SpaceAccessPort};
+use uc_core::ports::space::ProofPort;
 use uc_core::ports::{
     ClockPort, DeviceIdentityPort, LocalIdentityPort, SecureStorageError, SecureStoragePort,
     SettingsPort, SetupStatusPort,
@@ -329,7 +330,7 @@ async fn build_side(name: &'static str, rendezvous_base_url: String) -> Side {
     ));
     let current_profile = Arc::new(DefaultCurrentProfile::new());
     let session = Arc::new(InMemorySession::new());
-    let space_access: Arc<dyn SpaceAccessPort> = Arc::new(DefaultSpaceAccessAdapter::new(
+    let space_access = Arc::new(DefaultSpaceAccessAdapter::new(
         key_material,
         current_profile,
         Arc::clone(&session) as Arc<InMemorySession>,
@@ -375,14 +376,14 @@ async fn build_side(name: &'static str, rendezvous_base_url: String) -> Side {
     let iroh_node = builder.spawn();
 
     let proof_port: Arc<dyn ProofPort> = Arc::new(HmacProofAdapter::new_with_space_access(
-        Arc::clone(&space_access),
+        space_access.clone(),
     ));
     let local_identity: Arc<dyn LocalIdentityPort> = Arc::clone(&identity_store) as _;
 
     let (migration_state, key_migration, blob_migration_repo, blob_cipher) =
         common::migration_noop_deps();
     let facade = Arc::new(SpaceSetupFacade::new(SpaceSetupDeps {
-        space_access,
+        space_access: SpaceAccessPorts::from_adapter(space_access),
         local_identity,
         device_identity,
         member_repo: Arc::clone(&member_repo) as Arc<dyn MemberRepositoryPort>,

--- a/crates/uc-bootstrap/tests/slice2_phase1_presence_e2e.rs
+++ b/crates/uc-bootstrap/tests/slice2_phase1_presence_e2e.rs
@@ -38,6 +38,7 @@ use tempfile::TempDir;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, Request, Respond, ResponseTemplate};
 
+use uc_application::deps::SpaceAccessPorts;
 use uc_application::facade::roster::{MemberRosterDeps, MemberRosterFacade};
 use uc_application::facade::space_setup::{
     InitializeSpaceInput, RedeemPairingInvitationInput, SpaceSetupDeps, SpaceSetupFacade,
@@ -47,7 +48,7 @@ use uc_bootstrap::IrohNodeConfig;
 use uc_core::ids::DeviceId;
 use uc_core::membership::{MemberRepositoryPort, MembershipError, SpaceMember};
 use uc_core::ports::pairing::PairingSessionPort;
-use uc_core::ports::space::{ProofPort, SpaceAccessPort};
+use uc_core::ports::space::ProofPort;
 use uc_core::ports::{
     ClockPort, DeviceIdentityPort, LocalIdentityPort, PresencePort, ReachabilityState,
     SecureStorageError, SecureStoragePort, SettingsPort, SetupStatusPort,
@@ -340,7 +341,7 @@ async fn build_side(name: &'static str, rendezvous_base_url: String) -> Side {
     ));
     let current_profile = Arc::new(DefaultCurrentProfile::new());
     let session = Arc::new(InMemorySession::new());
-    let space_access: Arc<dyn SpaceAccessPort> = Arc::new(DefaultSpaceAccessAdapter::new(
+    let space_access = Arc::new(DefaultSpaceAccessAdapter::new(
         key_material,
         current_profile,
         Arc::clone(&session) as Arc<InMemorySession>,
@@ -380,7 +381,7 @@ async fn build_side(name: &'static str, rendezvous_base_url: String) -> Side {
     let iroh_node = builder.spawn();
 
     let proof_port: Arc<dyn ProofPort> = Arc::new(HmacProofAdapter::new_with_space_access(
-        Arc::clone(&space_access),
+        space_access.clone(),
     ));
     let local_identity: Arc<dyn LocalIdentityPort> = Arc::clone(&identity_store) as _;
 
@@ -394,7 +395,7 @@ async fn build_side(name: &'static str, rendezvous_base_url: String) -> Side {
     let (migration_state, key_migration, blob_migration_repo, blob_cipher) =
         common::migration_noop_deps();
     let facade = Arc::new(SpaceSetupFacade::new(SpaceSetupDeps {
-        space_access,
+        space_access: SpaceAccessPorts::from_adapter(space_access),
         local_identity,
         device_identity,
         member_repo: Arc::clone(&member_repo) as Arc<dyn MemberRepositoryPort>,

--- a/crates/uc-bootstrap/tests/slice2_phase2_clipboard_e2e.rs
+++ b/crates/uc-bootstrap/tests/slice2_phase2_clipboard_e2e.rs
@@ -37,6 +37,7 @@ use tempfile::TempDir;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, Request, Respond, ResponseTemplate};
 
+use uc_application::deps::SpaceAccessPorts;
 use uc_application::facade::space_setup::{
     InitializeSpaceInput, RedeemPairingInvitationInput, SpaceSetupDeps, SpaceSetupFacade,
 };
@@ -50,7 +51,7 @@ use uc_core::ids::{DeviceId, FormatId, RepresentationId};
 use uc_core::membership::{MemberRepositoryPort, MembershipError, SpaceMember};
 use uc_core::ports::pairing::PairingSessionPort;
 use uc_core::ports::security::TransferCipherPort;
-use uc_core::ports::space::{ProofPort, SpaceAccessPort};
+use uc_core::ports::space::ProofPort;
 use uc_core::ports::{
     ClipboardDispatchPort, ClipboardReceiverPort, ClockPort, DeviceIdentityPort,
     FirstSyncStateError, FirstSyncStatePort, LocalIdentityPort, PresencePort, SecureStorageError,
@@ -437,7 +438,7 @@ async fn build_side(name: &'static str, rendezvous_base_url: String) -> Side {
     ));
     let current_profile = Arc::new(DefaultCurrentProfile::new());
     let session = Arc::new(InMemorySession::new());
-    let space_access: Arc<dyn SpaceAccessPort> = Arc::new(DefaultSpaceAccessAdapter::new(
+    let space_access = Arc::new(DefaultSpaceAccessAdapter::new(
         key_material,
         current_profile,
         Arc::clone(&session),
@@ -494,7 +495,7 @@ async fn build_side(name: &'static str, rendezvous_base_url: String) -> Side {
     let iroh_node = builder.spawn();
 
     let proof_port: Arc<dyn ProofPort> = Arc::new(HmacProofAdapter::new_with_space_access(
-        Arc::clone(&space_access),
+        space_access.clone(),
     ));
     let local_identity: Arc<dyn LocalIdentityPort> = Arc::clone(&identity_store) as _;
 
@@ -511,7 +512,7 @@ async fn build_side(name: &'static str, rendezvous_base_url: String) -> Side {
     let (migration_state, key_migration, blob_migration_repo, blob_cipher) =
         common::migration_noop_deps();
     let facade = Arc::new(SpaceSetupFacade::new(SpaceSetupDeps {
-        space_access,
+        space_access: SpaceAccessPorts::from_adapter(space_access),
         local_identity,
         device_identity,
         member_repo: Arc::clone(&member_repo) as Arc<dyn MemberRepositoryPort>,

--- a/crates/uc-core/src/ports/security/blob_cipher.rs
+++ b/crates/uc-core/src/ports/security/blob_cipher.rs
@@ -23,7 +23,7 @@ pub enum BlobCipherError {
     /// `ActiveSpace` 所对应的会话已经不再持有密钥（例如被 lock 过）。
     ///
     /// 正常情况下拿到 `ActiveSpace` 意味着已解锁；出现此错误通常代表
-    /// 调用方把句柄抱过了 lock 边界——调用方应重新走 `SpaceAccessPort::unlock`。
+    /// 调用方把句柄抱过了 lock 边界——调用方应重新走 `UnlockSpacePort::unlock`。
     #[error("space session is no longer unlocked")]
     NotUnlocked,
 

--- a/crates/uc-core/src/ports/space/access.rs
+++ b/crates/uc-core/src/ports/space/access.rs
@@ -1,10 +1,14 @@
-//! 空间访问 port。
+//! 空间访问端口。
 //!
-//! 以"用户口令视角"把空间的初始化 / 解锁 / 换口令 / 加锁 /
-//! 就绪查询合并到一个业务动作 port。签名里只出现领域中性类型
-//! （`Passphrase` / `ActiveSpace`），密钥物料（KEK / MasterKey /
-//! KeySlot / WrappedMasterKey 等）一律在 adapter 内部生成和持有，
-//! 不穿过这一层。
+//! 以"用户口令视角"覆盖空间的初始化 / 解锁 / 加锁 / 就绪查询 /
+//! 工厂重置 / 静默恢复 / 子密钥派生 / pairing offer 与 proof 派生。签名里
+//! 只出现领域中性类型（`Passphrase` / `ActiveSpace` / `JoinOffer` /
+//! `ProofDerivedKey`），密钥物料（KEK / MasterKey / KeySlot /
+//! WrappedMasterKey 等）一律在 adapter 内部生成和持有，不穿过这一层。
+//!
+//! 本模块同时定义内层聚合 trait [`SpaceAccessStore`]（adapter 实现一次）
+//! 与一组窄意图端口（每个表示一个业务动作）。应用层消费方只依赖窄端口，
+//! 不依赖聚合 store（ports.md §12）。
 //!
 //! 合并了原先的 `EncryptionPort`（KDF + wrap/unwrap 部分）、
 //! `EncryptionSessionPort`、`KeyMaterialPort`、以及已删除的 `space::CryptoPort`
@@ -47,12 +51,17 @@ pub enum SpaceAccessError {
     Internal(String),
 }
 
-/// 空间访问 port。
+/// Inner aggregate surface for space access.
 ///
-/// 所有方法都以"空间"为中心——adapter 需要把 `SpaceId` 作为
-/// 内部会话/密钥物料查找的键，外部调用方不感知 KEK / MasterKey。
+/// 所有方法都以"空间"为中心——adapter 需要把 `SpaceId` 作为内部
+/// 会话/密钥物料查找的键，外部调用方不感知 KEK / MasterKey。
+///
+/// This is the low-level store (ports.md §5.1/§12): a single adapter
+/// implements it once and the narrow space-access intent ports below delegate
+/// to it. Application-layer consumers depend on the narrow ports, never on this
+/// aggregate.
 #[async_trait]
-pub trait SpaceAccessPort: Send + Sync {
+pub trait SpaceAccessStore: Send + Sync {
     /// 首次初始化一个空间。
     ///
     /// 语义：
@@ -162,6 +171,165 @@ pub trait SpaceAccessPort: Send + Sync {
     /// 返回的 `ProofDerivedKey` 是只在本次 pairing proof 链路里有意义的
     /// 32 字节秘密——后续直接喂给 `ProofPort::build_proof` 计算 HMAC,
     /// 领域代码无需也无法把它当作 `MasterKey` 转用到其它路径。
+    async fn derive_master_key_for_proof(
+        &self,
+        offer: &JoinOffer,
+        passphrase: &Passphrase,
+    ) -> Result<ProofDerivedKey, SpaceAccessError>;
+}
+
+// ─── space-access intent ports ───────────────────────────────────────────
+//
+// Narrow, single-responsibility views over space access. Each represents one
+// business action and each consumer depends only on the slice it actually
+// uses (ports.md §4.1/§8.1/§8.2). The concrete adapter implements every one
+// of them and the composition root coerces a single instance into each
+// (ports.md §8.3); `SpaceAccessStore` above remains the inner aggregate the
+// impls delegate to (ports.md §12).
+
+/// Create the key material for a space for the first time.
+#[async_trait]
+pub trait InitializeSpacePort: Send + Sync {
+    /// Generate fresh key material for `space_id`, protect it with
+    /// `passphrase`, persist it, and leave the in-memory session unlocked.
+    /// Returns an [`ActiveSpace`] credential on success.
+    ///
+    /// Returns [`SpaceAccessError::AlreadyInitialized`] when the space already
+    /// has persisted key material.
+    async fn initialize(
+        &self,
+        space_id: &SpaceId,
+        passphrase: &Passphrase,
+    ) -> Result<ActiveSpace, SpaceAccessError>;
+}
+
+/// Unlock an already-initialized space with its passphrase.
+#[async_trait]
+pub trait UnlockSpacePort: Send + Sync {
+    /// Unlock `space_id` by unwrapping its persisted key material with
+    /// `passphrase`, leaving the session unlocked and returning an
+    /// [`ActiveSpace`] credential.
+    ///
+    /// Returns [`SpaceAccessError::WrongPassphrase`] on passphrase mismatch
+    /// and [`SpaceAccessError::NotInitialized`] when the space has no
+    /// persisted material.
+    async fn unlock(
+        &self,
+        space_id: &SpaceId,
+        passphrase: &Passphrase,
+    ) -> Result<ActiveSpace, SpaceAccessError>;
+}
+
+/// Query whether a space session is currently unlocked.
+#[async_trait]
+pub trait IsSpaceUnlockedPort: Send + Sync {
+    /// Return whether `space_id` currently holds an unlocked in-memory session.
+    async fn is_unlocked(&self, space_id: &SpaceId) -> bool;
+}
+
+/// Clear the in-memory session of a space.
+#[async_trait]
+pub trait LockSpacePort: Send + Sync {
+    /// Drop the in-memory key material for `space_id`. Persisted material is
+    /// untouched, so the space can be unlocked again afterwards. Idempotent.
+    async fn lock(&self, space_id: &SpaceId) -> Result<(), SpaceAccessError>;
+}
+
+/// Wipe all persisted key material for a space.
+#[async_trait]
+pub trait FactoryResetSpacePort: Send + Sync {
+    /// Delete every persisted key artifact for `space_id` and clear the
+    /// in-memory session. Deleting material that is already absent is treated
+    /// as idempotent success.
+    async fn factory_reset(&self, space_id: &SpaceId) -> Result<(), SpaceAccessError>;
+}
+
+/// Silently restore a previously unlocked session without a passphrase.
+#[async_trait]
+pub trait ResumeSpaceSessionPort: Send + Sync {
+    /// Attempt to restore the session for `space_id` from persisted key
+    /// material without prompting for a passphrase.
+    ///
+    /// - Returns `Ok(None)` when the space was never initialized (not an
+    ///   error; the caller decides whether first-time setup is needed).
+    /// - Returns `Ok(Some(ActiveSpace))` when the session is restored.
+    /// - Returns an error when persisted material exists but is unreadable,
+    ///   corrupted, or access is denied.
+    ///
+    /// Unlike [`UnlockSpacePort::unlock`] this takes no passphrase; when the
+    /// silent path cannot recover the key the caller falls back to a
+    /// passphrase unlock.
+    async fn try_resume_session(
+        &self,
+        space_id: &SpaceId,
+    ) -> Result<Option<ActiveSpace>, SpaceAccessError>;
+}
+
+/// Probe whether the persistent secret store can silently yield a space's
+/// wrapping key.
+#[async_trait]
+pub trait VerifyKeychainAccessPort: Send + Sync {
+    /// Check whether the wrapping key can be read from the persistent secret
+    /// store without further user authorization.
+    ///
+    /// - `Ok(true)`: the key is silently available.
+    /// - `Ok(false)`: access is denied or the store is temporarily
+    ///   unavailable; treat as "authorization not granted".
+    /// - `Err(NotInitialized)`: the space has no persisted wrapping key.
+    /// - `Err(Internal)`: any other unrecoverable failure.
+    async fn verify_keychain_access(&self) -> Result<bool, SpaceAccessError>;
+}
+
+/// Derive a purpose-scoped 32-byte subkey from the unlocked session.
+#[async_trait]
+pub trait DeriveSpaceSubkeyPort: Send + Sync {
+    /// Derive a 32-byte subkey bound to the current session's key material,
+    /// scoped by caller-chosen `salt` and `info`. The same inputs always
+    /// yield the same bytes; a different `info` yields an independent subkey.
+    ///
+    /// Returns [`SpaceAccessError::NotUnlocked`] when the session is locked.
+    async fn derive_subkey(&self, salt: &[u8], info: &[u8]) -> Result<[u8; 32], SpaceAccessError>;
+}
+
+/// Read the proof credential of the currently unlocked session.
+#[async_trait]
+pub trait CurrentSessionProofKeyPort: Send + Sync {
+    /// Return the opaque proof credential derived from the currently unlocked
+    /// session, or `None` when the session is locked.
+    ///
+    /// The returned [`ProofDerivedKey`] is the same secret a joiner derives
+    /// from a [`JoinOffer`] via [`DeriveProofKeyPort`], so both sides compute
+    /// matching proofs.
+    async fn current_session_proof_key(&self) -> Result<Option<ProofDerivedKey>, SpaceAccessError>;
+}
+
+/// Build a pairing offer that lets another device join a space.
+#[async_trait]
+pub trait PrepareJoinOfferPort: Send + Sync {
+    /// Build a [`JoinOffer`] for `space_id`: the serialized key material plus
+    /// a fresh challenge nonce.
+    ///
+    /// When the space is not yet initialized this first-time-initializes it
+    /// with `passphrase` (leaving the session unlocked); when it is already
+    /// initialized the existing material is read and `passphrase` is ignored.
+    async fn prepare_join_offer(
+        &self,
+        space_id: &SpaceId,
+        passphrase: &Passphrase,
+    ) -> Result<JoinOffer, SpaceAccessError>;
+}
+
+/// Derive the proof credential needed to join a space from an offer.
+#[async_trait]
+pub trait DeriveProofKeyPort: Send + Sync {
+    /// Unwrap the key material carried by `offer` using `passphrase` and
+    /// return the opaque [`ProofDerivedKey`] used to answer the offer's
+    /// challenge. Symmetric counterpart to
+    /// [`CurrentSessionProofKeyPort::current_session_proof_key`].
+    ///
+    /// Returns [`SpaceAccessError::WrongPassphrase`] when the passphrase does
+    /// not match the offer, and [`SpaceAccessError::CorruptedKeyMaterial`]
+    /// when the offer payload cannot be parsed.
     async fn derive_master_key_for_proof(
         &self,
         offer: &JoinOffer,

--- a/crates/uc-core/src/ports/space/mod.rs
+++ b/crates/uc-core/src/ports/space/mod.rs
@@ -2,6 +2,11 @@ mod access;
 mod persistence;
 mod proof;
 
-pub use access::{SpaceAccessError, SpaceAccessPort};
+pub use access::{
+    CurrentSessionProofKeyPort, DeriveProofKeyPort, DeriveSpaceSubkeyPort, FactoryResetSpacePort,
+    InitializeSpacePort, IsSpaceUnlockedPort, LockSpacePort, PrepareJoinOfferPort,
+    ResumeSpaceSessionPort, SpaceAccessError, SpaceAccessStore, UnlockSpacePort,
+    VerifyKeychainAccessPort,
+};
 pub use persistence::*;
 pub use proof::*;

--- a/crates/uc-core/src/ports/space/proof.rs
+++ b/crates/uc-core/src/ports/space/proof.rs
@@ -3,7 +3,8 @@ use crate::space_access::{ProofDerivedKey, SpaceAccessProofArtifact};
 
 #[async_trait::async_trait]
 pub trait ProofPort: Send + Sync {
-    /// 用 SpaceAccessPort 派生出的不透明凭据计算 HMAC proof。
+    /// 用 `DeriveProofKeyPort` / `CurrentSessionProofKeyPort` 派生出的不透明
+    /// 凭据计算 HMAC proof。
     ///
     /// 签名里只出现领域级"本次 proof 链路的派生密钥"——adapter 内部如何
     /// 把它映射到具体算法（HMAC-SHA256 等）属于实现细节。

--- a/crates/uc-core/src/space_access/domain.rs
+++ b/crates/uc-core/src/space_access/domain.rs
@@ -27,7 +27,7 @@ pub struct JoinOffer {
 
 /// Pairing proof 链路上的不透明派生密钥。
 ///
-/// 由 `SpaceAccessPort::derive_master_key_for_proof` 构造（adapter 内部
+/// 由 `DeriveProofKeyPort::derive_master_key_for_proof` 构造（adapter 内部
 /// 从 keyslot 解出原始密钥字节后包装），传给 `ProofPort::build_proof`
 /// 用于 HMAC 计算。两端都看不到 `MasterKey`——领域层只看到一段
 /// "本次 proof 链路专用的 32 字节秘密"。

--- a/crates/uc-infra/src/search/search_key_derivation.rs
+++ b/crates/uc-infra/src/search/search_key_derivation.rs
@@ -1,11 +1,11 @@
 //! HKDF-SHA256 backed implementation of `SearchKeyDerivationPort`.
 //!
-//! Slice 3 起通过 `SpaceAccessPort::derive_subkey` 派生——adapter 内部
+//! Slice 3 起通过 `DeriveSpaceSubkeyPort::derive_subkey` 派生——adapter 内部
 //! 用 IKM = MasterKey + HKDF-SHA256,本 adapter 只负责构造 salt (profile_id)
 //! 与 info ("uniclipboard-search-index/v1"),并把 32 字节字节包装成 `SearchKey`。
 //!
-//! 不再持有 `EncryptionSessionPort`——会话状态由 SpaceAccessPort adapter
-//! 端到端管理,本 adapter 不直接接触 master_key。
+//! 不再持有 `EncryptionSessionPort`——会话状态由空间访问 adapter 端到端
+//! 管理,本 adapter 不直接接触 master_key。
 
 use std::sync::Arc;
 
@@ -16,7 +16,7 @@ use sha2::Sha256;
 
 use uc_core::ports::search::search_key::SearchKeyDerivationPort;
 use uc_core::ports::security::current_profile::CurrentProfilePort;
-use uc_core::ports::space::{SpaceAccessError, SpaceAccessPort};
+use uc_core::ports::space::{DeriveSpaceSubkeyPort, SpaceAccessError};
 use uc_core::search::error::SearchError;
 use uc_core::search::key::SearchKey;
 
@@ -31,13 +31,13 @@ type HmacSha256 = Hmac<Sha256>;
 /// 行为与历史一致——同一 master_key + 同一 profile_id 总是派生出同一 SearchKey,
 /// 不同 profile 派生不同 key。
 pub struct HkdfSearchKeyDerivation {
-    space_access: Arc<dyn SpaceAccessPort>,
+    space_access: Arc<dyn DeriveSpaceSubkeyPort>,
     current_profile: Arc<dyn CurrentProfilePort>,
 }
 
 impl HkdfSearchKeyDerivation {
     pub fn new(
-        space_access: Arc<dyn SpaceAccessPort>,
+        space_access: Arc<dyn DeriveSpaceSubkeyPort>,
         current_profile: Arc<dyn CurrentProfilePort>,
     ) -> Self {
         Self {

--- a/crates/uc-infra/src/security/space_access_adapter.rs
+++ b/crates/uc-infra/src/security/space_access_adapter.rs
@@ -1,13 +1,15 @@
-//! `SpaceAccessPort` 的基础设施适配器。
+//! 空间访问的基础设施适配器。
 //!
 //! Slice 3 - C8 起完全独立运行: 不再依赖任何已删除的 port trait
 //! (EncryptionPort / EncryptionSessionPort / KeyMaterialPort),
 //! 改用 uc-infra 内部具体类型 `KeyMaterialStore` + `InMemorySession`,
 //! AEAD 算法走 `super::v1_aead` helper。
 //!
-//! 公共 port 边界保持稳定: `SpaceAccessPort` trait + 全部方法签名不变。
-//! 字节级行为与历史 `EncryptionRepository` 一致——V1 加密协议
-//! (Argon2id KDF + XChaCha20-Poly1305 wrap/unwrap) ironclad 保留。
+//! 该 adapter 实现内层聚合 trait `SpaceAccessStore`,并把每个窄意图 port
+//! (`InitializeSpacePort` / `UnlockSpacePort` / … )经 UFCS 委托给它
+//! (ports.md §8.3);全部方法签名保持稳定。字节级行为与历史
+//! `EncryptionRepository` 一致——V1 加密协议 (Argon2id KDF +
+//! XChaCha20-Poly1305 wrap/unwrap) ironclad 保留。
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -25,7 +27,7 @@ use super::crypto_model::{KeyScope, KeySlot, WrappedMasterKey};
 use super::secrets::MasterKey;
 use uc_core::ids::{ProfileId, SpaceId};
 use uc_core::ports::security::current_profile::CurrentProfilePort;
-use uc_core::ports::space::{SpaceAccessError, SpaceAccessPort};
+use uc_core::ports::space::{SpaceAccessError, SpaceAccessStore};
 use uc_core::space_access::{JoinOffer, ProofDerivedKey};
 
 use super::key_material::KeyMaterialStore;
@@ -33,7 +35,7 @@ use super::scope_identifier::scope_identifier;
 use super::session::InMemorySession;
 use super::v1_aead;
 
-/// `SpaceAccessPort` 默认实现。
+/// `SpaceAccessStore` 默认实现(同时提供全部窄意图 port)。
 pub struct DefaultSpaceAccessAdapter {
     key_material: Arc<KeyMaterialStore>,
     current_profile: Arc<dyn CurrentProfilePort>,
@@ -208,7 +210,7 @@ impl DefaultSpaceAccessAdapter {
 }
 
 #[async_trait]
-impl SpaceAccessPort for DefaultSpaceAccessAdapter {
+impl SpaceAccessStore for DefaultSpaceAccessAdapter {
     async fn initialize(
         &self,
         space_id: &SpaceId,
@@ -704,5 +706,126 @@ impl SpaceAccessPort for DefaultSpaceAccessAdapter {
         }
         .instrument(span)
         .await
+    }
+}
+
+// ---- Intent ports ----
+//
+// The single adapter satisfies every narrow space-access intent port by
+// delegating to its aggregate-store methods (UFCS disambiguates the same-named
+// methods). The composition root coerces one
+// `Arc<DefaultSpaceAccessAdapter>` into each port (see ports.md §8.3).
+//
+// These impls live in a private submodule so the narrow port traits do not
+// leak into other method-resolution scopes (they share method names with the
+// aggregate store); trait-impl coherence still applies crate-wide.
+mod intent_ports {
+    use super::*;
+    use uc_core::ports::space::{
+        CurrentSessionProofKeyPort, DeriveProofKeyPort, DeriveSpaceSubkeyPort,
+        FactoryResetSpacePort, InitializeSpacePort, IsSpaceUnlockedPort, LockSpacePort,
+        PrepareJoinOfferPort, ResumeSpaceSessionPort, UnlockSpacePort, VerifyKeychainAccessPort,
+    };
+
+    #[async_trait]
+    impl InitializeSpacePort for DefaultSpaceAccessAdapter {
+        async fn initialize(
+            &self,
+            space_id: &SpaceId,
+            passphrase: &DomainPassphrase,
+        ) -> Result<ActiveSpace, SpaceAccessError> {
+            SpaceAccessStore::initialize(self, space_id, passphrase).await
+        }
+    }
+
+    #[async_trait]
+    impl UnlockSpacePort for DefaultSpaceAccessAdapter {
+        async fn unlock(
+            &self,
+            space_id: &SpaceId,
+            passphrase: &DomainPassphrase,
+        ) -> Result<ActiveSpace, SpaceAccessError> {
+            SpaceAccessStore::unlock(self, space_id, passphrase).await
+        }
+    }
+
+    #[async_trait]
+    impl IsSpaceUnlockedPort for DefaultSpaceAccessAdapter {
+        async fn is_unlocked(&self, space_id: &SpaceId) -> bool {
+            SpaceAccessStore::is_unlocked(self, space_id).await
+        }
+    }
+
+    #[async_trait]
+    impl LockSpacePort for DefaultSpaceAccessAdapter {
+        async fn lock(&self, space_id: &SpaceId) -> Result<(), SpaceAccessError> {
+            SpaceAccessStore::lock(self, space_id).await
+        }
+    }
+
+    #[async_trait]
+    impl FactoryResetSpacePort for DefaultSpaceAccessAdapter {
+        async fn factory_reset(&self, space_id: &SpaceId) -> Result<(), SpaceAccessError> {
+            SpaceAccessStore::factory_reset(self, space_id).await
+        }
+    }
+
+    #[async_trait]
+    impl ResumeSpaceSessionPort for DefaultSpaceAccessAdapter {
+        async fn try_resume_session(
+            &self,
+            space_id: &SpaceId,
+        ) -> Result<Option<ActiveSpace>, SpaceAccessError> {
+            SpaceAccessStore::try_resume_session(self, space_id).await
+        }
+    }
+
+    #[async_trait]
+    impl VerifyKeychainAccessPort for DefaultSpaceAccessAdapter {
+        async fn verify_keychain_access(&self) -> Result<bool, SpaceAccessError> {
+            SpaceAccessStore::verify_keychain_access(self).await
+        }
+    }
+
+    #[async_trait]
+    impl DeriveSpaceSubkeyPort for DefaultSpaceAccessAdapter {
+        async fn derive_subkey(
+            &self,
+            salt: &[u8],
+            info: &[u8],
+        ) -> Result<[u8; 32], SpaceAccessError> {
+            SpaceAccessStore::derive_subkey(self, salt, info).await
+        }
+    }
+
+    #[async_trait]
+    impl CurrentSessionProofKeyPort for DefaultSpaceAccessAdapter {
+        async fn current_session_proof_key(
+            &self,
+        ) -> Result<Option<ProofDerivedKey>, SpaceAccessError> {
+            SpaceAccessStore::current_session_proof_key(self).await
+        }
+    }
+
+    #[async_trait]
+    impl PrepareJoinOfferPort for DefaultSpaceAccessAdapter {
+        async fn prepare_join_offer(
+            &self,
+            space_id: &SpaceId,
+            passphrase: &DomainPassphrase,
+        ) -> Result<JoinOffer, SpaceAccessError> {
+            SpaceAccessStore::prepare_join_offer(self, space_id, passphrase).await
+        }
+    }
+
+    #[async_trait]
+    impl DeriveProofKeyPort for DefaultSpaceAccessAdapter {
+        async fn derive_master_key_for_proof(
+            &self,
+            offer: &JoinOffer,
+            passphrase: &DomainPassphrase,
+        ) -> Result<ProofDerivedKey, SpaceAccessError> {
+            SpaceAccessStore::derive_master_key_for_proof(self, offer, passphrase).await
+        }
     }
 }


### PR DESCRIPTION
> 🤖 This PR was prepared with AI assistance (Claude Code).

Closes #1107. Independent of #1106 (already merged); does not stack.

## What

Splits the 11-method catch-all `SpaceAccessPort` into eleven narrow,
single-responsibility intent ports so each consumer depends only on the slice
it calls — the last **HIGH** finding from the port audit. Follows the
device-repo split (#1106) and the clipboard split (#1104).

## How (additive → migrate → cleanup)

- **uc-core** — added `InitializeSpacePort`, `UnlockSpacePort`,
  `IsSpaceUnlockedPort`, `LockSpacePort`, `FactoryResetSpacePort`,
  `ResumeSpaceSessionPort`, `VerifyKeychainAccessPort`, `DeriveSpaceSubkeyPort`,
  `CurrentSessionProofKeyPort`, `PrepareJoinOfferPort`, `DeriveProofKeyPort`
  with domain-only docs (`uc-core/AGENTS.md §5.4`). The catch-all is demoted to
  the inner aggregate `SpaceAccessStore` (`ports.md §12`).
- **uc-infra** — `DefaultSpaceAccessAdapter` implements `SpaceAccessStore` plus
  every narrow port via UFCS delegation in a private `intent_ports` submodule
  (same-named methods don't leak into other resolution scopes; coherence still
  applies crate-wide).
- **bootstrap** — new `SpaceAccessPorts` bundle (+ generic `from_adapter`); the
  composition root coerces one adapter `Arc` into each port (`ports.md §8.3`).
  `SecurityPorts` no longer exposes a catch-all space-access surface.
- **consumers** (each on its minimal subset, `ports.md §8.2`):
  `proof.rs` → `CurrentSessionProofKeyPort`; search derivation →
  `DeriveSpaceSubkeyPort`; initialize/unlock use cases →
  `InitializeSpacePort`/`UnlockSpacePort`; sponsor/joiner handshakes →
  `PrepareJoinOfferPort`/`DeriveProofKeyPort`; `EncryptionFacade` → 5 narrow
  ports; `SpaceSetupFacade` → resume + factory_reset (distributes the rest to
  its use cases). Test fakes/stubs and the four uc-bootstrap e2e tests slimmed
  to the narrow ports.

## DoD

- [x] core narrow intent ports added; old `SpaceAccessPort` demoted to
  `SpaceAccessStore` inner-aggregate marker
- [x] adapter implements all narrow ports; `SecurityPorts` no longer exposes the
  catch-all
- [x] all 24 consumers migrated to their minimal subset; `proof.rs` holds only
  `CurrentSessionProofKeyPort`
- [x] `cargo check/test --workspace --lib --tests --bins` green; e2e (incl.
  `--ignored` mdns) pass
- [x] independent PR to `main` (does not depend on #1106)

## Test plan

- `cargo check --workspace` green (the `uniclipboard` Tauri bundle fails only on
  a pre-existing missing daemon sidecar binary, unrelated to this change).
- `cargo test --workspace --lib --tests --bins` green. The single red —
  `uc-platform` `effective_mime::parameterized_text_plain_classifies_as_text_plain`
  — reproduces on pristine `main` (this diff does not touch `uc-platform` or the
  clipboard/mime code).
- `cargo clippy` on the four touched crates: no new warnings (baseline 437 ==
  after 437).
- `cargo fmt --check` clean.
- uc-bootstrap e2e: three default-run files pass; `mdns_only_pairing_e2e
  --ignored` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured internal space-access dependency layer to use narrower, task-specific interfaces instead of a single monolithic interface. Updated dependency wiring and component initialization throughout the codebase to use granular port abstractions for better separation of concerns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->