### PR TITLE
fix(mobile): post-#1113 follow-up fixes for the shared Rust core

### DIFF
--- a/.github/workflows/build-mobile-core.yml
+++ b/.github/workflows/build-mobile-core.yml
@@ -37,6 +37,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          # No authenticated git operations run after checkout (the Release is
+          # cut via the `gh` CLI using GH_TOKEN), so don't leave the checkout
+          # token behind in `.git/config`.
+          persist-credentials: false
           # The cargo workspace `[patch.crates-io]` points at vendor/iroh-blobs;
           # cargo metadata/build fails to parse the manifest if it is absent,
           # even though uc-mobile does not pull it.

--- a/crates/uc-mobile-proto/src/net_class.rs
+++ b/crates/uc-mobile-proto/src/net_class.rs
@@ -159,7 +159,15 @@ fn extract_host(s: &str) -> Option<String> {
         // lenient about the contents (verified: `http://[10.0.0.5]` → host
         // `10.0.0.5` → LAN, `http://[x.local]` → `x.local`), so decode the
         // inner text like a reg-name but additionally allow ':'.
-        let (h, _) = bracketed.split_once(']')?;
+        let (h, tail) = bracketed.split_once(']')?;
+        // After the closing bracket Foundation accepts only an optional
+        // `:port` (digits, possibly empty); any other tail fails its URL
+        // parse → host nil → WAN.
+        match tail.strip_prefix(':') {
+            Some(port) if port.bytes().all(|b| b.is_ascii_digit()) => {}
+            None if tail.is_empty() => {}
+            _ => return None,
+        }
         decode_host(h, true)?
     } else {
         let h = match host_port.rsplit_once(':') {
@@ -537,6 +545,9 @@ mod tests {
         // inner text classifies as-is.
         assert_eq!(classify_url("http://[10.0.0.5]"), ServerUrlClass::Lan);
         assert_eq!(classify_url("http://[x.local]"), ServerUrlClass::Lan);
+        // A `:port` after the bracket is accepted; any other tail is not.
+        assert_eq!(classify_url("http://[10.0.0.5]:80"), ServerUrlClass::Lan);
+        assert_eq!(classify_url("http://[10.0.0.5]x"), ServerUrlClass::Wan);
         // Invalid userinfo never invalidates the host (Foundation drops it).
         assert_eq!(classify_url("http://a%zz b@nas.local"), ServerUrlClass::Lan);
     }

--- a/crates/uc-mobile/ios-demo/main.swift
+++ b/crates/uc-mobile/ios-demo/main.swift
@@ -54,10 +54,10 @@ print("1/7 parseConnectUri golden vector OK")
 do {
     _ = try parseConnectUri(uri: "uniclip://connect?v=1&svc=mobile-sync&p=eyJ2IjoxfQ")
     fail("uniclip:// alias must be rejected")
-} catch let e as ConnectUriError {
-    print("2/7 error mapping OK: \(e)")
+} catch ConnectUriError.InvalidScheme {
+    print("2/7 error mapping OK: InvalidScheme")
 } catch {
-    fail("expected ConnectUriError, got \(error)")
+    fail("expected ConnectUriError.InvalidScheme, got \(error)")
 }
 
 final class DemoBridge: PlatformBridge {

--- a/crates/uc-mobile/scripts/run-ios-demo.sh
+++ b/crates/uc-mobile/scripts/run-ios-demo.sh
@@ -41,6 +41,9 @@ if [ -z "$UDID" ]; then
   [ -n "$UDID" ] || { echo "no available iPhone simulator found" >&2; exit 1; }
   echo "    booting $UDID"
   xcrun simctl boot "$UDID"
+  # `boot` returns immediately; block until the device finishes booting so the
+  # `simctl spawn` below doesn't race a half-booted simulator (flaky failures).
+  xcrun simctl bootstatus "$UDID"
   BOOTED_BY_SCRIPT=1
 else
   BOOTED_BY_SCRIPT=0


### PR DESCRIPTION
## Summary

Follow-up hardening on top of the `uc-mobile` shared Rust core landed in #1113. Three independent fixes, no shared surface:

- **`fix(mobile-proto)`** — `extract_host` now rejects a bracketed URL authority with a non-`:port` tail (e.g. `http://[10.0.0.5]x`), matching Foundation's behavior (host nil → WAN). Previously such inputs decoded the inner text and mis-classified as LAN. (66dcb12e1)
- **`ci(mobile-core)`** — set `persist-credentials: false` on the `actions/checkout` step. No authenticated git operations run after checkout (the Release is cut via `gh` with `GH_TOKEN`), so the checkout token shouldn't be left behind in `.git/config`. (13e4c8f3b)
- **`chore(mobile)`** — `ios-demo` now asserts the specific `ConnectUriError.InvalidScheme` variant instead of any `ConnectUriError`, and `run-ios-demo.sh` blocks on `simctl bootstatus` so the `simctl spawn` no longer races a half-booted simulator (flaky failures). (f4500c168)

## Test plan

- [x] `cargo test -p uc-mobile-proto` — covers the new `http://[10.0.0.5]:80` (LAN) / `http://[10.0.0.5]x` (WAN) classification assertions.
- [ ] CI `build-mobile-core` workflow runs green with `persist-credentials: false` (verify the Release step still authenticates via `GH_TOKEN`).
- [ ] `crates/uc-mobile/scripts/run-ios-demo.sh` runs cleanly on a cold simulator (no half-boot race; `2/7` step reports `InvalidScheme`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved validation of bracketed host URLs to match standard parsing behavior.
  * Fixed iOS simulator boot timing to prevent flaky demo startup failures.

* **Chores**
  * Enhanced CI/CD security by disabling credential persistence after checkout.
  * Refined error handling specificity for invalid URI scheme detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->