### PR TITLE
fix(ci): add TAURI_CONFIG env to cache-warmup sidecar-less builds

### DIFF
--- a/.github/workflows/cache-warmup.yml
+++ b/.github/workflows/cache-warmup.yml
@@ -51,6 +51,8 @@ jobs:
           save-if: true
 
       - name: Check Rust workspace
+        env:
+          TAURI_CONFIG: '{"bundle":{"externalBin":[]}}'
         run: cargo check --workspace --locked
 
   warmup-docs-bun:
@@ -110,5 +112,7 @@ jobs:
           sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf xvfb
 
       - name: Generate coverage report
+        env:
+          TAURI_CONFIG: '{"bundle":{"externalBin":[]}}'
         run: |
           xvfb-run -a cargo llvm-cov --lcov --output-path lcov.info --workspace


### PR DESCRIPTION
## Summary

- The `warmup-pr-check-rust` and `warmup-coverage-rust` jobs in `cache-warmup.yml` failed with `resource path binaries/uniclipd-x86_64-unknown-linux-gnu doesn't exist` because `tauri_build::build()` now requires the sidecar binary since ADR-008 D13 added `externalBin` to `tauri.conf.json`.
- Both `pr-check.yml` and `coverage.yml` already set `TAURI_CONFIG='{"bundle":{"externalBin":[]}}'` to skip the sidecar via JSON Merge Patch — the cache-warmup counterparts were simply missing the same override.
- Adds the `TAURI_CONFIG` env var to both warmup steps to match. (78c51f2)

Fixes [cache-warmup run #27926562134](https://github.com/UniClipboard/UniClipboard/actions/runs/27926562134).

## Test plan

- [x] Verified the diff matches exactly what `pr-check.yml` and `coverage.yml` already do.
- [ ] Re-run the Cache Warmup workflow via `workflow_dispatch` to confirm both jobs pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration for build process optimization.

---

*Note: This release contains no user-facing changes.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->