### PR TITLE
feat(skills): add 6 Agent Loop skills for recurring workflow automation

### DIFF
--- a/.claude/skills/continue-task/SKILL.md
+++ b/.claude/skills/continue-task/SKILL.md
@@ -1,0 +1,227 @@
+---
+name: continue-task
+description: "Resume work from a /wrap state file. Reads the structured active-task.json, presents a context summary, restores branch state, and lets you pick up exactly where the last session left off — no manual context rebuild."
+user-invocable: true
+allowed-tools: Bash(git:*), Bash(gh:*), Bash(grep:*), Bash(jq:*), Bash(cat:*), Bash(find:*), Read, Edit, AskUserQuestion
+---
+
+# continue-task
+
+## Purpose
+
+The counterpart to `/wrap`. When a previous session ended with `/wrap`, this skill reads the structured state file and rebuilds context in seconds instead of minutes.
+
+**Before (observed pattern):**
+```
+User: "继续上次的工作"
+Agent: [reads git log, guesses what was happening, asks 3 questions, reads 5 files] — 3-8 minutes
+```
+
+**After:**
+```
+User: /continue
+Agent: [reads active-task.json + context.md, presents summary] — 10 seconds
+  "上次你在 active-clipboard-state 分支做 PR8 (pull store-only LWW),
+   已完成 PR1-7, 下一步是加双节点 e2e 测试。继续？"
+```
+
+## When to trigger
+
+- `/continue` — resume from state file
+- User says "继续上次的", "pick up where I left off", "resume the task"
+- At the start of a new session when the user references prior work
+
+## Workflow
+
+### Step 1 — Find and read state file
+
+```bash
+PROJECT_KEY=$(pwd | sed 's|^/||; s|/|-|g')
+STATE_DIR="$HOME/.claude/projects/-${PROJECT_KEY}"
+STATE_FILE="${STATE_DIR}/active-task.json"
+CONTEXT_FILE="${STATE_DIR}/active-task-context.md"
+```
+
+If the state file does not exist:
+```
+No active task found for this project.
+Last /wrap state file not found at: <path>
+
+Options:
+  A) Check git log and branch state to reconstruct context
+  B) Start fresh
+```
+
+If the state file exists, read both files.
+
+### Step 2 — Validate state freshness
+
+Check if the state is stale:
+
+```bash
+# Is the branch still current?
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+STATE_BRANCH=$(jq -r '.branch' "$STATE_FILE")
+
+# Has the branch moved since state was written?
+STATE_TIME=$(jq -r '.created_at' "$STATE_FILE")
+
+# Is there a PR and what's its status?
+PR_NUMBER=$(jq -r '.pr.number // empty' "$STATE_FILE")
+if [ -n "$PR_NUMBER" ]; then
+  gh pr view "$PR_NUMBER" --json state --jq '.state' 2>/dev/null
+fi
+```
+
+Staleness conditions:
+- State is more than 7 days old → warn, but still usable
+- Branch was deleted or merged → state is stale, report and offer to clean up
+- PR was closed/merged → task may be done, confirm with user
+- Current branch differs from state branch → ask which to use
+
+### Step 3 — Present context summary
+
+Render a concise briefing:
+
+```
+📋 Active task: Implement ActiveClipboardState for cross-device LWW register
+   Branch: active-clipboard-state
+   PR: #1117 (open, 2 checks pending)
+   Last wrapped: 2026-06-20 08:49
+
+   ✅ Done:
+     • PR1-PR6: core state machine, reconcile, sync
+     • PR7: mobile cutover
+
+   ➡️ Next:
+     • PR8: pull store-only LWW starvation workaround
+     • Add dual-node e2e test for PR8
+
+   📁 Key context:
+     • .planning/2026-06-19-issue-1017-active-clipboard.md
+     • docs/architecture/active-clipboard-state.md
+```
+
+If there's an active debug state:
+
+```
+   🔍 Debug session in progress:
+     Symptom: Windows restore → Mac sync delay ~3.4s
+     
+     Ruled out:
+       ✗ #1017 logic bug (disproven: timing issue, not state bug)
+       ✗ relay latency (disproven: direct conn established)
+     
+     Current hypothesis: iroh candidate address filtering not excluding Tailscale 100.x
+     Next step: grep CIDR constants in node.rs, check filter function
+```
+
+### Step 4 — Offer actions
+
+```
+What would you like to do?
+  A) Continue from where we left off (start with next steps)
+  B) Review the changes made so far (git diff, PR status)
+  C) Start a different task (archive this state)
+  D) Read the full context document first
+```
+
+On choice A:
+- If the branch differs from current, offer to switch: `git switch <state_branch>`
+- Read the context references listed in the state file
+- Begin working on the first item in `task.next`
+
+On choice B:
+```bash
+git log main..HEAD --oneline
+git diff main...HEAD --stat
+gh pr view <number> --json statusCheckRollup,reviews 2>/dev/null
+```
+
+On choice C:
+- Rename the state file to `archived-task-<date>.json`
+- Start fresh
+
+On choice D:
+- Read and present the full `active-task-context.md`
+
+### Step 5 — Load context references
+
+For each file in `context_refs`, check if it exists and is relevant:
+
+```bash
+for ref in $(jq -r '.context_refs[]' "$STATE_FILE"); do
+  if [ -f "$ref" ]; then
+    echo "Reading: $ref"
+    # Read the file to load context
+  else
+    echo "⚠️ Referenced file not found: $ref (may have been moved or deleted)"
+  fi
+done
+```
+
+### Step 6 — Clear state on completion
+
+When the resumed task is completed (user confirms or `/wrap` is called again with a new task), the old state is naturally overwritten.
+
+If the user explicitly says "this task is done" or "任务完成了":
+
+```bash
+# Archive the state
+mv "$STATE_FILE" "${STATE_DIR}/archived-task-$(date +%Y%m%d-%H%M).json"
+mv "$CONTEXT_FILE" "${STATE_DIR}/archived-task-$(date +%Y%m%d-%H%M)-context.md" 2>/dev/null
+```
+
+## Handling edge cases
+
+### No state file, but user wants to continue
+
+Fall back to git-based reconstruction:
+
+```bash
+git log --oneline -10
+git status
+git branch -v
+gh pr list --author @me --json number,title,headRefName --jq '.[]' 2>/dev/null
+```
+
+Present what can be inferred and ask the user to fill in gaps.
+
+### State file from a different branch
+
+If the user switched branches between sessions:
+
+```
+⚠️ State file references branch 'active-clipboard-state',
+   but you're currently on 'main'.
+
+   A) Switch to active-clipboard-state and continue
+   B) Stay on main, ignore the state file
+   C) Show me what's in the state file first
+```
+
+### Multiple projects with state files
+
+If the user works on multiple projects (uniclipboard, uc-website, uniclipboard-android), each has its own state file under its own project key. No conflict.
+
+### Parallel branches in the same project (worktrees)
+
+Each worktree has a different `pwd` and therefore a different project key. State files are naturally isolated.
+
+## Interaction with other skills
+
+| Skill | How it interacts |
+|-------|-----------------|
+| `/wrap` | Creates the state file that `/continue` reads |
+| `/handoff` | Produces prose-only document; `/continue` cannot consume it (but the context.md from `/wrap` is similar) |
+| `/resume` (built-in) | Resumes the Claude Code conversation itself; `/continue` restores task-level context which is a higher-level concept |
+| `/pr-greenlight` | Can be the "next step" suggested by the state file |
+| `/error-diagnose-fix` | Debug state section helps this skill avoid retrying ruled-out hypotheses |
+
+## Anti-patterns
+
+- Reading the state file but then ignoring it and asking the user "what are you working on?"
+- Loading all context references even when the user only wants to do a quick commit
+- Treating a stale state file (7+ days old) as current without warning
+- Not checking if the branch still exists before suggesting to switch
+- Spending 5 minutes "analyzing" the state when a 10-second summary suffices

--- a/.claude/skills/cross-device-diagnose/SKILL.md
+++ b/.claude/skills/cross-device-diagnose/SKILL.md
@@ -1,0 +1,417 @@
+---
+name: cross-device-diagnose
+description: "Agent Loop for cross-device sync/transfer issues: collect environment fingerprints from BOTH machines first, check memory for known patterns, manage hypotheses with forced falsification, and persist evidence via /wrap. Orchestrates dual-side-debug + local-log-debug + systematic-debugging into a structured loop."
+user-invocable: true
+allowed-tools: Bash(git:*), Bash(ssh:*), Bash(sshpass:*), Bash(grep:*), Bash(rg:*), Bash(jq:*), Bash(cat:*), Bash(find:*), Bash(ifconfig:*), Bash(networksetup:*), Bash(scutil:*), Bash(netstat:*), Bash(lsof:*), Bash(pgrep:*), Bash(ps:*), Bash(mount:*), Bash(ping:*), Bash(curl:*), Bash(date:*), Bash(rm:*), Bash(wc:*), Bash(head:*), Bash(tail:*), Read, Edit, Write, AskUserQuestion, Agent
+---
+
+# cross-device-diagnose
+
+## Purpose
+
+An Agent Loop that orchestrates cross-device debugging with a disciplined, evidence-based process. It eliminates the recurring pattern where 50% of hypotheses are wrong, environment issues masquerade as code bugs, and debug context is lost across sessions.
+
+**Observed anti-patterns (from 50 recent sessions):**
+- Session S35: 25 prompts to diagnose LAN sync speed → root cause was BBR3 congestion controller, not code logic
+- Session S29: 10 prompts chasing overlay address filtering → half spent on environment (Clash TUN, Tailscale)
+- Session S22: 7 prompts on restore sync delay → ended up being iroh relay path, not application bug
+- Session S28: 6 prompts on file sync failure → needed SSH password 3 times across retries
+
+**The loop:**
+```
+1. Environment fingerprint (BOTH machines)  ← catches 40% of issues upfront
+2. Memory pattern matching                  ← avoids re-investigating known issues
+3. Hypothesis registration + prior ranking  ← parallel hypotheses, not serial guessing
+4. Evidence collection (logs, state)        ← using existing tools
+5. Forced falsification                     ← try to DISPROVE before concluding
+6. Loop or escalate
+```
+
+## When to trigger
+
+- `/cross-device-diagnose` — start the diagnostic loop
+- User reports a sync, transfer, pairing, or connectivity issue between two devices
+- Symptoms like "Mac sent but Windows didn't receive", "同步很慢", "文件/图片同步失败"
+- Any issue where the problem might be on either end
+
+## When NOT to use
+
+- Single-machine issues → use `local-log-debug` + `systematic-debugging`
+- Build/compilation errors → use `error-diagnose-fix`
+- CI/PR failures → use `pr-greenlight`
+- Just reading logs (no diagnosis needed) → use `dual-side-debug` directly
+
+## State file
+
+`/tmp/claude-xdd-state.json`:
+
+```json
+{
+  "started_at": "ISO timestamp",
+  "round": 0,
+  "max_rounds": 5,
+  "symptom": "Windows restore does not sync to Mac within 3s",
+  "environment": {
+    "mac": { "fingerprint_collected": true, "data": {} },
+    "win": { "fingerprint_collected": true, "data": {} }
+  },
+  "memory_matches": [],
+  "hypotheses": [
+    {
+      "id": 1,
+      "description": "iroh relay path instead of direct LAN connection",
+      "prior": "high",
+      "status": "active|confirmed|ruled_out",
+      "evidence_for": [],
+      "evidence_against": [],
+      "falsification_test": "check conn_type in logs for direct IP vs relay"
+    }
+  ],
+  "evidence_ledger": [
+    {
+      "round": 0,
+      "source": "mac-env-fingerprint",
+      "observation": "Clash TUN active, 198.18.0.1 is default gateway",
+      "hypothesis_impact": { "1": "supports" }
+    }
+  ],
+  "ssh_config": {
+    "host": "win",
+    "needs_password": true
+  }
+}
+```
+
+## Phase 1 — Environment Fingerprint (MANDATORY FIRST STEP)
+
+**Before looking at ANY logs or code**, collect environment fingerprints from both machines. This catches proxy/VPN/network issues that masquerade as application bugs.
+
+### 1a — Mac fingerprint
+
+Run all of these in parallel:
+
+```bash
+# Network interfaces and IPs
+ifconfig | grep -E 'flags|inet ' | grep -B1 'inet '
+
+# Default route
+netstat -rn | grep default | head -3
+
+# DNS configuration
+scutil --dns | grep 'nameserver' | head -5
+
+# Proxy/VPN detection
+pgrep -lf 'clash|mihomo|v2ray|tailscale|wireguard|openvpn' 2>/dev/null
+networksetup -getwebproxy Wi-Fi 2>/dev/null
+networksetup -getsocksfirewallproxy Wi-Fi 2>/dev/null
+
+# Check for TUN interfaces (198.18.x = Clash fake-ip, 100.x = Tailscale)
+ifconfig | grep -A2 'utun\|tun' | grep inet
+
+# Uniclipboard daemon status
+pgrep -lf uniclip 2>/dev/null
+.claude/skills/local-log-debug/uc-logs.sh status 2>/dev/null
+```
+
+### 1b — Windows fingerprint (via SSH)
+
+```bash
+ssh win "ipconfig & netstat -rn | findstr 0.0.0.0 & tasklist | findstr /i \"clash mihomo tailscale wireguard v2ray\" & netstat -an | findstr 42720"
+```
+
+If SSH fails or needs password, ask the user ONCE and note the config in state. Do not ask again.
+
+### 1c — Analyze fingerprints
+
+Build a structured assessment:
+
+```
+Environment Assessment:
+  Mac:
+    LAN IP: 192.168.1.100 (en0, Wi-Fi)
+    Proxy: Clash TUN active (utun3, 198.18.0.1 gateway) ⚠️
+    Tailscale: active (100.114.7.75 on utun4) ⚠️
+    Daemon: running (PID 12345, profile=dev, log fresh)
+
+  Windows:
+    LAN IP: 192.168.1.129 (Ethernet)
+    Proxy: Clash active (PID 5678) ⚠️
+    Tailscale: not detected ✓
+    Daemon: running (profile=dev)
+
+  ⚠️ Both machines have Clash TUN active.
+     Known issue: TUN mode hijacks UDP (198.18.0.1) and breaks iroh hole-punching.
+     See memory: lan-sync-slow-tun-proxy-tailscale.md
+```
+
+### 1d — Check memory for matching patterns
+
+Read the MEMORY.md index and scan for relevant entries:
+
+```bash
+grep -i "sync\|slow\|proxy\|tun\|tailscale\|relay\|transfer\|clipboard\|restore" \
+  ~/.claude/projects/-Users-mark-MyProjects-uniclipboard/memory/MEMORY.md
+```
+
+For each match, read the memory file and check if the current symptom fits. Known patterns in this project:
+
+| Memory | Pattern | Quick check |
+|--------|---------|-------------|
+| `lan-sync-slow-tun-proxy-tailscale.md` | LAN slow = both sides have TUN proxy | Check for 198.18.0.1 gateway |
+| `presence-asymmetry-and-restart-red-herrings.md` | Text works but images don't = blob channel issue | Test text vs image separately |
+| `mobile-sync-file-becomes-url.md` | File copied → URL received = outbound meta/file fork | Check entry type on sender |
+| `issue1029-image-xpm-undecodable.md` | Image syncs "successfully" but can't paste = wrong MIME | Check image MIME in logs |
+| `macos-text-dedup-permanent-swallows-recopy.md` | Re-copy same text = watcher dedup swallows it | Check for MEANINGFUL_REDEDUP |
+| `iroh-production-perf-gotchas.md` | Hairpin NAT, CUBIC/BBR3, FsStore blocking | Check conn_type stability |
+
+If a memory matches, report it immediately — it may short-circuit the entire investigation.
+
+## Phase 2 — Hypothesis Registration
+
+Based on the symptom + environment fingerprint + memory matches, register ALL plausible hypotheses at once (not just one):
+
+```
+Hypotheses (ranked by prior probability):
+
+  H1 [HIGH] Clash TUN intercepting iroh UDP
+     Prior: Both machines have TUN active; known issue in memory
+     Falsification: Disable Clash on one side, retry
+
+  H2 [MEDIUM] iroh selecting relay instead of direct LAN path
+     Prior: conn_type logs previously showed relay/LAN oscillation
+     Falsification: grep conn_type in logs, check if direct IP used
+
+  H3 [LOW] Application-layer bug in restore dispatch
+     Prior: Only if H1/H2 ruled out; restore logic was recently refactored
+     Falsification: Check dispatch logs for error/skip/timeout
+```
+
+### Prior probability guidelines
+
+| Prior | When to assign |
+|-------|---------------|
+| **HIGH** | Environment fingerprint shows a known issue, OR memory match is exact |
+| **MEDIUM** | Symptom is consistent but environment looks clean; needs log evidence |
+| **LOW** | Requires a code bug in recently-tested logic; unlikely but possible |
+
+**Always test HIGH-prior hypotheses first.** This is the key efficiency gain — environment issues are caught before wasting rounds on code investigation.
+
+## Phase 3 — Evidence Collection
+
+### 3a — Quick tests for HIGH-prior hypotheses
+
+For environment issues, run quick experiments first:
+
+```bash
+# H1: Can the machines reach each other directly on LAN?
+ping -c 3 192.168.1.129
+
+# H1: Is iroh using direct connection?
+.claude/skills/dual-side-debug/dual-logs.sh grep "conn_type" --lines 20
+
+# H2: What address is iroh connecting to?
+.claude/skills/dual-side-debug/dual-logs.sh grep "connect selected path" --lines 10
+```
+
+### 3b — Log analysis for MEDIUM-prior hypotheses
+
+Use the existing tools — don't hand-roll:
+
+```bash
+# Time-aligned view around the symptom
+.claude/skills/dual-side-debug/dual-logs.sh merge --since "2026-06-21T10:00:00Z" --lines 400
+
+# Filter to relevant subsystem
+.claude/skills/dual-side-debug/dual-logs.sh query --filter '.target | test("sync|dispatch|transfer|restore")'
+
+# Errors only
+.claude/skills/dual-side-debug/dual-logs.sh query --filter '.level == "ERROR" or .level == "WARN"'
+```
+
+### 3c — Record every observation
+
+Every piece of evidence goes into the ledger with its hypothesis impact:
+
+```json
+{
+  "round": 1,
+  "source": "dual-logs merge",
+  "observation": "conn_type = Ip(100.79.191.42:56445) — Tailscale address, not LAN",
+  "hypothesis_impact": {
+    "H1": "strongly supports",
+    "H2": "supports (relay not used, but wrong IP chosen)",
+    "H3": "neutral"
+  }
+}
+```
+
+## Phase 4 — Forced Falsification
+
+**Before declaring a root cause, actively try to disprove it.**
+
+For each hypothesis marked as "supported by evidence":
+
+1. **State the falsification test**: "If H1 is correct, then disabling Clash should immediately improve speed. If speed doesn't improve, H1 is wrong."
+
+2. **Run the test** (or ask the user to run it if it requires their action):
+   ```
+   To test H1, please:
+     1. Disable Clash on your Mac (quit the app or toggle TUN off)
+     2. Restart the uniclipboard daemon
+     3. Try the sync again
+   
+   If it's still slow after this, H1 is ruled out.
+   ```
+
+3. **Record the result**:
+   - Falsified → mark hypothesis as `ruled_out`, never revisit
+   - Survived → hypothesis is strengthened but still not proven
+   - Need another round → register what additional evidence would prove/disprove it
+
+### Falsification discipline
+
+- A hypothesis is NOT confirmed just because evidence is consistent with it
+- At least ONE attempt to disprove is required before confirming
+- If the user provides the falsification result ("still slow after disabling Clash"), update the hypothesis immediately
+
+## Phase 5 — Loop or Conclude
+
+### Conclude (root cause found)
+
+When a hypothesis has:
+1. Multiple pieces of supporting evidence
+2. Survived at least one falsification attempt
+3. No contradicting evidence
+
+→ Declare root cause with confidence level:
+
+```
+Root cause identified (HIGH confidence):
+
+  H1: Clash TUN intercepting iroh UDP traffic
+  
+  Evidence:
+    ✓ Both machines have TUN active (env fingerprint)
+    ✓ iroh conn_type using 100.x Tailscale address instead of 192.168.x LAN
+    ✓ Known pattern from memory (lan-sync-slow-tun-proxy-tailscale.md)
+    ✓ Falsification survived: disabling Clash on Mac → sync improved to 17MB/s
+
+  Recommended fix:
+    - Short term: disable Clash TUN when using uniclipboard
+    - Long term: filter Clash fake-ip (198.18.0.0/15) from iroh candidates
+```
+
+### Loop (need more evidence)
+
+If no hypothesis is conclusive after a round:
+- Increment round
+- Re-rank hypotheses based on new evidence
+- Promote MEDIUM → HIGH or demote HIGH → LOW based on evidence
+- Collect more targeted evidence
+
+### Escalate (stuck)
+
+If stuck after 3 rounds (same hypotheses, no new evidence):
+
+```
+⚠️ Diagnosis inconclusive after 3 rounds.
+
+  Active hypotheses:
+    H2 [MEDIUM] iroh relay path — some evidence but not conclusive
+    H3 [LOW] application bug — no evidence for or against
+
+  Ruled out:
+    H1 ✗ Clash TUN — falsified (still slow after disabling)
+
+  Suggested next steps:
+    A) Add diagnostic tracing to the suspect code path and reproduce
+    B) Run a minimal reproduction (p2p-bench between the two machines)
+    C) Escalate to iroh upstream (if the issue is in the networking layer)
+```
+
+### Max rounds (5): stop
+
+```bash
+rm -f /tmp/claude-xdd-state.json
+```
+
+Report all findings, ruled-out hypotheses, and remaining unknowns. Suggest whether to file an issue or continue in a focused session.
+
+## Phase 6 — Persist via /wrap
+
+When the session ends (user says "enough for now" or switches tasks), remind them to `/wrap`. The debug state from this skill's state file should be captured in `/wrap`'s `active-task.json` under the `debug` section:
+
+```json
+"debug": {
+  "active": true,
+  "symptom": "Windows restore → Mac sync delay ~3.4s",
+  "hypotheses_tried": ["H1: Clash TUN (ruled out)", "H2: relay path (partially confirmed)"],
+  "hypotheses_ruled_out": ["H1"],
+  "evidence": ["conn_type=Ip(100.x)", "ping LAN=1ms", "Clash disabled no improvement"],
+  "current_hypothesis": "H2: iroh candidate selection prefers Tailscale over LAN"
+}
+```
+
+The next session's `/continue` will present this debug state, and this skill can resume from round N instead of restarting.
+
+## SSH workflow
+
+### First connection
+
+Ask the user for SSH details exactly once:
+```
+To diagnose both sides, I need SSH access to the Windows machine.
+  Host: win (or IP?)
+  Password needed? (will not be stored in state file)
+```
+
+### Subsequent connections
+
+Use `ssh win` (relies on `~/.ssh/config`). If password is needed:
+```bash
+sshpass -p "$WIN_PASS" ssh win "<command>"
+```
+
+**Never store the password in the state file or any persisted document.**
+
+### Windows command gotchas
+
+- Default shell is `cmd.exe`, not PowerShell
+- Use `findstr` instead of `grep`
+- Use `type` instead of `cat`
+- Use `tasklist` instead of `ps`
+- Paths use backslashes: `%LOCALAPPDATA%\app.uniclipboard.desktop-dev\logs\`
+- For complex queries, use `powershell -Command "..."` explicitly
+
+## Safety guardrails
+
+- Environment fingerprint is MANDATORY before any hypothesis work
+- Never confirm a root cause without at least one falsification attempt
+- Never retry a ruled-out hypothesis (even across sessions via /wrap state)
+- SSH password is never persisted — ask the user each session
+- Max 5 rounds (cross-device debug is expensive in time)
+- Don't modify code during diagnosis — this skill is read-only investigation
+- If the root cause is environmental (not a code bug), say so clearly — don't force a code fix
+
+## Relationship to other skills
+
+| Skill | Role in this loop |
+|-------|-------------------|
+| `dual-side-debug` | **Tool**: fetches and merges logs from both machines |
+| `local-log-debug` | **Tool**: reads single-machine logs |
+| `systematic-debugging` | **Methodology**: Phase 4 falsification discipline comes from here |
+| `/wrap` | **Persistence**: saves debug state for cross-session continuity |
+| `/continue` | **Resume**: restores debug state to avoid re-investigating |
+| `error-diagnose-fix` | **Not used**: that's for build errors, not runtime/sync issues |
+
+## Anti-patterns
+
+- Diving into code before collecting environment fingerprints
+- Pursuing a single hypothesis serially (test H1 → fail → test H2 → fail → ...) instead of registering all hypotheses upfront and ranking by prior
+- Declaring root cause without falsification ("evidence supports H1" ≠ "H1 is the root cause")
+- Ignoring memory matches ("I know this looks like the TUN issue, but let me investigate from scratch")
+- Asking for the SSH password more than once per session
+- Dumping 200 lines of raw logs without interpretation
+- Blaming code when the environment is the problem (and vice versa)
+- Spending 5 rounds on a LOW-prior hypothesis while a HIGH-prior one was never tested
+- Losing debug state across sessions because /wrap wasn't called

--- a/.claude/skills/error-diagnose-fix/SKILL.md
+++ b/.claude/skills/error-diagnose-fix/SKILL.md
@@ -1,0 +1,429 @@
+---
+name: error-diagnose-fix
+description: "Agent Loop for build/compilation errors: run the build yourself, collect ALL errors at once, find root causes via dependency analysis, fix in order, revert failed hypotheses, loop until green. Eliminates the user-paste-error → agent-guess → still-broken ping-pong."
+user-invocable: true
+allowed-tools: Bash(cargo:*), Bash(bun:*), Bash(npm:*), Bash(npx:*), Bash(node:*), Bash(git:*), Bash(grep:*), Bash(rg:*), Bash(jq:*), Bash(cat:*), Bash(find:*), Bash(diff:*), Bash(rm:*), Bash(wc:*), Bash(eas:*), Bash(pod:*), Bash(xcodebuild:*), Read, Edit, Write, AskUserQuestion, Agent, mcp__context7__resolve-library-id, mcp__context7__query-docs
+---
+
+# error-diagnose-fix
+
+## Purpose
+
+An Agent Loop that takes ownership of build/compilation errors instead of waiting for the user to paste them one by one. The agent runs the build command itself, collects all errors at once, analyzes their dependency relationships, fixes root causes first, and loops until the build succeeds.
+
+This eliminates the ping-pong pattern observed in sessions:
+```
+User: [pastes error]
+Agent: [fixes one thing]
+User: [pastes next error]
+Agent: [fixes, breaks something else]
+... 5-10 rounds later ...
+```
+
+Replaced by:
+```
+Agent: [runs build, sees 7 errors, identifies 2 root causes, fixes both, re-runs, 0 errors]
+```
+
+## When to trigger
+
+- `/error-diagnose-fix` or `/edf` — start the loop
+- `/error-diagnose-fix <command>` — specify the build command explicitly
+- User pastes a build error and says "fix this", "搞定这个报错", "编译不过"
+- User says "build is broken", "构建失败", "编译错误"
+- Framework upgrade just broke the build (expo upgrade, dependency bump, etc.)
+- Multiple cascading errors after a refactor
+
+## When NOT to use
+
+- Runtime bugs (wrong behavior, not build failure) → use `systematic-debugging`
+- Cross-device sync issues → use `dual-side-debug`
+- CI-specific failures (works locally) → use `pr-greenlight` or `babysit-pr`
+- Single obvious typo the user already knows about → just fix it directly
+
+## State file
+
+`/tmp/claude-edf-state.json`:
+
+```json
+{
+  "build_command": "cargo check --workspace",
+  "build_system": "cargo",
+  "round": 0,
+  "max_rounds": 6,
+  "started_at": "ISO timestamp",
+  "error_snapshots": [
+    {
+      "round": 0,
+      "error_count": 7,
+      "error_signatures": ["E0308@uc-core/src/lib.rs:42", "E0599@..."],
+      "root_causes_identified": ["type mismatch in ContentHash refactor"],
+      "fixes_applied": [],
+      "hypothesis": null
+    }
+  ],
+  "reverted_hypotheses": [],
+  "resolved_errors": []
+}
+```
+
+## Phase 1 — Perceive: Detect build system and run build
+
+### 1a — Identify build system and command
+
+If the user provided a command, use it. Otherwise, auto-detect:
+
+| Signal | Build command | Build system |
+|--------|---------------|--------------|
+| `Cargo.toml` at workspace root | `cargo check --workspace 2>&1` | `cargo` |
+| `package.json` with `build` script | `bun run build 2>&1` | `bun` |
+| `expo` in dependencies | `npx expo prebuild --clean 2>&1` or `npx expo run:ios 2>&1` | `expo` |
+| Both Rust and frontend changed | Run both sequentially | `mixed` |
+
+For this repo specifically, common commands are:
+- Rust: `cargo check --workspace --locked`
+- Frontend: `bun run build` (tsc + vite)
+- Full: both of the above
+- Expo (android project): `npx expo run:android` / `npx expo run:ios`
+
+If unclear, ask the user which build to fix.
+
+### 1b — Run the build and capture ALL output
+
+```bash
+# Example for cargo
+cargo check --workspace --locked 2>&1 | tee /tmp/claude-edf-build-output.txt
+echo "EXIT_CODE=$?"
+```
+
+**Critical:** capture the FULL output, not just `tail`. Errors at the top of the output often contain the root cause, while the bottom has cascading failures.
+
+### 1c — Parse errors into a structured list
+
+For each build system, parse errors into a uniform structure:
+
+**Cargo errors:**
+```
+{
+  "code": "E0308",           // error code
+  "message": "mismatched types",
+  "file": "crates/uc-core/src/active_clipboard.rs",
+  "line": 42,
+  "span": "expected `String`, found `&str`",
+  "suggestion": "try using `.to_string()`",   // if rustc suggests
+  "note": "..."              // additional context from rustc
+}
+```
+
+**TypeScript errors:**
+```
+{
+  "code": "TS2322",
+  "message": "Type 'X' is not assignable to type 'Y'",
+  "file": "src/components/Foo.tsx",
+  "line": 15
+}
+```
+
+**ESLint/Prettier:**
+```
+{
+  "rule": "no-unused-vars",
+  "message": "'x' is defined but never used",
+  "file": "src/utils.ts",
+  "line": 8,
+  "fixable": true
+}
+```
+
+Store the error list and count as `error_snapshots[round]`.
+
+## Phase 2 — Reason: Analyze error dependencies
+
+### 2a — Group errors by file and crate/package
+
+Errors in the same file are often related. Errors in downstream crates that depend on an upstream crate with errors are likely cascading.
+
+### 2b — Identify root cause vs cascade
+
+**Root cause signals:**
+- Error in a type definition, trait impl, or function signature → changes cascade to all callers
+- Error in a `mod.rs` or re-export → cascades to all importers
+- "cannot find" / "not defined" errors pointing to something recently renamed/moved
+- Version mismatch in `Cargo.toml` / `package.json` → cascading API breakage
+
+**Cascade signals:**
+- Errors that reference a type/function from another file that also has errors
+- "method not found" when the trait/struct definition has a separate error
+- Many errors in different files all pointing to the same root type/function
+- "unused import" errors appearing alongside "not found" errors (import was for something removed)
+
+### 2c — Build a fix order
+
+```
+Root causes (fix first):
+  1. [E0308] crates/uc-core/src/types.rs:42 — ContentHash type changed
+     Cascading errors: 5 errors in 3 files that use ContentHash
+
+  2. [E0432] crates/uc-core/src/lib.rs:8 — module `old_name` not found
+     Cascading errors: 2 errors in files that import from old_name
+
+Independent errors (fix after):
+  3. [E0599] crates/uc-daemon/src/api.rs:100 — method not found (unrelated)
+```
+
+### 2d — For framework/dependency errors: check docs
+
+If errors are caused by a version upgrade or unfamiliar API:
+
+```
+Use context7 MCP:
+1. mcp__context7__resolve-library-id("expo-router") → get library ID
+2. mcp__context7__query-docs(libraryId, "migration guide from v3 to v4")
+```
+
+This replaces guessing at breaking changes from training data.
+
+## Phase 3 — Act: Fix root causes
+
+### 3a — State the hypothesis
+
+Before fixing, record in the state file:
+```json
+{
+  "hypothesis": "ContentHash changed from String to [u8; 32], need to update all call sites",
+  "files_to_change": ["crates/uc-core/src/dispatch.rs", "crates/uc-daemon/src/sync.rs"],
+  "expected_outcome": "7 errors → ~2 errors (cascade eliminated, independent errors remain)"
+}
+```
+
+### 3b — Create a revert point
+
+```bash
+git stash push -m "edf-round-N-checkpoint" --include-untracked 2>/dev/null
+# Or if working tree is clean, just note the current HEAD
+git rev-parse HEAD > /tmp/claude-edf-revert-point.txt
+```
+
+### 3c — Apply fixes
+
+Fix root causes first, in the order from Phase 2c. Guidelines:
+
+- **Type mismatch / API change:** Read the new type definition, update all call sites consistently
+- **Missing module / function:** Check if renamed (git log, grep old name) or removed
+- **Version breaking change:** Check migration guide (context7), apply required changes
+- **Import errors:** Update import paths, re-export if needed
+
+**After fixing each root cause**, do NOT re-run the full build yet. Fix all identified root causes first, then re-run once.
+
+### 3d — Handle auto-fixable errors
+
+Some errors have automatic fixes:
+
+```bash
+# Rust: apply compiler suggestions
+# (rustc often suggests exact fix, apply them)
+
+# ESLint: auto-fix
+bun run lint:fix -- <specific files>
+
+# Prettier: auto-format
+bun run format
+```
+
+## Phase 4 — Observe: Re-run build and compare
+
+### 4a — Re-run the same build command
+
+```bash
+cargo check --workspace --locked 2>&1 | tee /tmp/claude-edf-build-output.txt
+echo "EXIT_CODE=$?"
+```
+
+### 4b — Compare error sets
+
+Parse the new errors and compare with the previous round:
+
+| Outcome | Meaning | Next action |
+|---------|---------|-------------|
+| **0 errors** | Build succeeds | **Success → cleanup** |
+| **Fewer errors, different ones** | Root cause fixed, cascade eliminated, new errors revealed | Progress. Go to Phase 2 with remaining errors |
+| **Same error count, same errors** | Fix didn't work | **Revert. Record failed hypothesis. Try different approach** |
+| **More errors than before** | Fix introduced new problems | **Revert immediately.** |
+| **Same count but different errors** | Partial progress, some regressions | Analyze carefully. May need partial revert |
+
+### 4c — On regression: revert
+
+```bash
+# If fix made things worse or didn't help
+git checkout -- .
+# Or restore from stash
+git stash pop
+```
+
+Record the failed hypothesis:
+```json
+{
+  "hypothesis": "...",
+  "result": "no improvement — same 7 errors",
+  "reverted": true
+}
+```
+
+Add to `reverted_hypotheses` in state. **Never retry a reverted hypothesis.**
+
+### 4d — Progress check
+
+If errors decreased, celebrate and continue:
+```
+Round 1: 7 errors → 2 errors (fixed ContentHash cascade)
+Round 2: 2 errors → 0 errors ✓
+```
+
+## Phase 5 — Loop or escalate
+
+### Loop condition
+
+```
+while error_count > 0 AND round < max_rounds AND no_stuck_condition:
+    Phase 2 → Phase 3 → Phase 4
+    round++
+```
+
+### Stuck detection
+
+You are stuck if:
+- Same error count for 2 consecutive rounds after different fix attempts
+- 3+ hypotheses reverted without progress
+- A single error persists across 3+ rounds despite different fix approaches
+
+### On stuck: escalate to user
+
+```
+⚠️ Stuck after 3 rounds. The build still has 2 errors:
+
+  1. [E0308] crates/uc-core/src/types.rs:42
+     Tried: type conversion (reverted), trait impl (reverted)
+     
+  2. [TS2322] src/components/Foo.tsx:15
+     Tried: type assertion (reverted)
+
+Hypotheses exhausted. Would you like to:
+  A) Give me a hint about the intended design
+  B) Let me try a broader approach (refactor the affected area)
+  C) Stop here — you'll fix these manually
+```
+
+### On max rounds (6): report and stop
+
+```bash
+rm -f /tmp/claude-edf-state.json
+```
+
+```
+Build fix attempted for 6 rounds. Progress:
+  Round 0: 12 errors
+  Round 1: 12 → 5 errors (fixed import paths)
+  Round 2: 5 → 3 errors (fixed type mismatches)
+  Round 3: 3 → 2 errors (fixed missing trait impl)
+  Round 4-5: stuck on 2 errors (2 hypotheses reverted)
+
+Remaining errors:
+  [details]
+
+Failed hypotheses (do NOT retry):
+  - "add Default impl for FooBar" — reverted, caused 4 new errors
+  - "convert FooBar to enum" — reverted, type mismatch cascade
+```
+
+## Success cleanup
+
+```bash
+rm -f /tmp/claude-edf-state.json /tmp/claude-edf-build-output.txt /tmp/claude-edf-revert-point.txt
+```
+
+```
+✅ Build succeeded after N round(s).
+
+Fix summary:
+  Round 1: Fixed ContentHash type across 3 files (5 cascade errors eliminated)
+  Round 2: Updated import paths in uc-daemon (2 errors)
+  
+Total: 7 errors → 0 errors in 2 rounds.
+```
+
+Do NOT auto-commit. The user decides when and how to commit the fixes.
+
+## Special scenarios
+
+### Framework upgrade (Expo, React, dependency bump)
+
+When errors come from a version upgrade:
+
+1. **First**, use context7 to get the migration guide:
+   ```
+   resolve-library-id("expo") → query-docs(id, "upgrading from SDK 55 to 56")
+   ```
+2. **Second**, check `CHANGELOG` or release notes of the upgraded package
+3. **Third**, look for a codemod or automated migration tool:
+   ```bash
+   npx expo-doctor     # Expo-specific
+   npx @next/codemod   # Next.js-specific
+   ```
+4. Apply migration steps systematically, not one error at a time
+
+### Cargo workspace: cross-crate cascades
+
+When errors cascade across workspace crates:
+
+1. Check `cargo tree -p <failing-crate>` to understand dependency direction
+2. Fix errors in the most-upstream crate first
+3. After fixing upstream, many downstream errors will disappear automatically
+4. Only then address remaining downstream errors
+
+### Mixed Rust + Frontend errors
+
+When both `cargo check` and `bun run build` fail:
+
+1. Fix Rust errors first (they often regenerate TypeScript bindings)
+2. After Rust fixes, re-run code generation:
+   ```bash
+   bun run gen:openapi
+   cargo test -p uc-tauri --test specta_export
+   bun run gen:client
+   ```
+3. Then fix remaining TypeScript errors (many will have been resolved by codegen)
+
+## Safety guardrails
+
+- Max **6 rounds** (more than pr-greenlight because build fixes can be iterative)
+- Always create a revert point before applying fixes
+- **Revert immediately** if error count increases
+- Never retry a reverted hypothesis — record and move on
+- Do NOT auto-commit fixes (user decides)
+- If the same error persists for 3 rounds, escalate to user
+- For ambiguous design decisions (e.g., "should this be an enum or a struct?"), ask the user
+- Track all hypotheses in state file for cross-session continuity
+
+## Relationship to other skills
+
+| Skill | When to use instead |
+|-------|---------------------|
+| `systematic-debugging` | Runtime bugs, wrong behavior (not build failure) |
+| `pr-greenlight` | Build passes locally but CI fails |
+| `babysit-pr` | PR is already open, CI is failing |
+| `diagnosing-bugs` | Functional bugs, not compilation errors |
+
+This skill can be invoked **by** `pr-greenlight` Phase 2d when `cargo check` or `bun run build` fails during pre-flight.
+
+## Anti-patterns
+
+- Waiting for user to paste errors instead of running the build command yourself
+- Fixing errors one at a time without analyzing cascades
+- Guessing at version compatibility instead of checking context7 docs
+- Piling fix upon fix without re-running the build to check progress
+- Reverting a fix that made *different* errors (that's progress, not regression)
+- Using `--force` or `#[allow(...)]` to silence errors instead of fixing them
+- Modifying test expectations to match broken behavior
+- Fixing errors in generated files (fix the generator input, then regenerate)
+- Attempting more than 2 fixes for the same error without asking the user

--- a/.claude/skills/pr-greenlight/SKILL.md
+++ b/.claude/skills/pr-greenlight/SKILL.md
@@ -1,0 +1,374 @@
+---
+name: pr-greenlight
+description: "Agent Loop that runs local pre-flight CI checks, auto-fixes issues, creates/pushes the PR, monitors CI, and loops until all checks pass. Replaces the manual chain of preflight → create-pr → babysit-pr."
+user-invocable: true
+allowed-tools: Bash(git:*), Bash(gh:*), Bash(cargo:*), Bash(bun:*), Bash(grep:*), Bash(rg:*), Bash(jq:*), Bash(diff:*), Bash(cat:*), Bash(rm:*), Bash(date:*), Bash(wc:*), Bash(find:*), Bash(node:*), Read, Edit, Write, AskUserQuestion, ScheduleWakeup, Agent
+---
+
+# pr-greenlight
+
+## Purpose
+
+A single Agent Loop that takes uncommitted or committed work on a feature branch all the way to a green PR. It replaces the manual chain of:
+
+1. (forgotten) local checks → push → CI fails → new session to fix → repeat
+2. `/create-pr` → wait → `/babysit-pr` → wait → fix → push → wait
+
+The loop runs: **Pre-flight → Auto-fix → Push/PR → Monitor CI → Fix CI → Loop until green**.
+
+## When to trigger
+
+- `/pr-greenlight` — full loop: preflight + create PR + babysit
+- `/pr-greenlight preflight` or `/preflight` — only run local pre-flight checks, no push
+- User says "帮我把这个 PR 搞绿", "run preflight", "pre-flight checks", "搞定 PR"
+
+## State file
+
+`/tmp/claude-pr-greenlight-state.json`:
+
+```json
+{
+  "phase": "preflight|pushed|monitoring",
+  "pr_number": null,
+  "round": 0,
+  "max_rounds": 4,
+  "preflight_passed": false,
+  "checks_run": [],
+  "fixes_applied": [],
+  "processed_comment_ids": [],
+  "started_at": "ISO timestamp"
+}
+```
+
+Lock file: `/tmp/claude-pr-greenlight.lock`
+
+## Phase 1 — Perceive: Analyze what changed
+
+```bash
+touch /tmp/claude-pr-greenlight.lock
+```
+
+Run in parallel:
+
+```bash
+git rev-parse --abbrev-ref HEAD
+git status --short
+git diff main...HEAD --stat
+git diff main...HEAD --name-only
+git log main..HEAD --format="%h %s"
+```
+
+From the file list, classify what changed into categories:
+
+| Category | Detection pattern |
+|----------|-------------------|
+| `rust` | `*.rs`, `Cargo.toml`, `Cargo.lock` |
+| `frontend` | `src/**/*.{ts,tsx,js,jsx,css}`, `package.json`, `bun.lockb` |
+| `api-endpoints` | `*.rs` files containing `#[utoipa::path]` or `#[tauri::command]` changes |
+| `tauri-ipc` | changes in `src-tauri/src/`, DTO structs used by Tauri commands |
+| `openapi` | `schema/openapi.json`, files with `#[utoipa::path]` |
+| `docs-site` | `docs-site/**` |
+| `markdown` | `*.md` (outside docs-site) |
+| `generated` | `src/api/generated/**`, `src/lib/ipc-bindings.generated.ts` |
+
+Store the categories in state as `change_categories`.
+
+**Refuse conditions** (same as create-pr):
+- On `main` → refuse
+- `git log main..HEAD` empty → refuse (nothing to PR)
+- `gh auth status` fails → ask user to auth
+
+## Phase 2 — Reason & Act: Pre-flight checks
+
+Run ONLY the checks relevant to `change_categories`. Each check follows: run → detect failure → auto-fix → re-run → confirm.
+
+### 2a — Format (always run)
+
+```bash
+# Rust format (if rust changed)
+cargo fmt --all --check 2>&1
+# If fails:
+cargo fmt --all
+git add -u '*.rs'
+
+# Frontend format (if frontend/markdown/docs changed)
+bun run format 2>&1
+# Prettier auto-fixes; stage changed files
+git add -u
+```
+
+### 2b — Code generation drift (the #1 CI failure cause)
+
+Only if `rust` or `api-endpoints` changed:
+
+```bash
+# 1. OpenAPI schema
+bun run gen:openapi 2>&1
+git diff --exit-code schema/openapi.json
+# If diff: stage it
+git add schema/openapi.json
+
+# 2. IPC bindings (if tauri-ipc changed)
+cargo test -p uc-tauri --test specta_export 2>&1
+git diff --exit-code src/lib/ipc-bindings.generated.ts
+# If diff: stage it
+git add src/lib/ipc-bindings.generated.ts
+
+# 3. API client (if openapi.json changed in step 1 or was already changed)
+bun run gen:client 2>&1
+git diff --exit-code src/api/generated/
+# If diff: stage it
+git add src/api/generated/
+```
+
+### 2c — Lint (scoped to changed files)
+
+```bash
+# Frontend lint — scope to changed files only (full repo has baseline debt)
+CHANGED_TS=$(git diff main...HEAD --name-only --diff-filter=d -- '*.ts' '*.tsx' '*.js' '*.jsx' | head -50)
+if [ -n "$CHANGED_TS" ]; then
+  bun run lint --fix -- $CHANGED_TS 2>&1
+  git add -u
+fi
+```
+
+### 2d — Compilation & type check
+
+```bash
+# Rust check (if rust changed)
+cargo check --workspace --locked 2>&1 | tail -40
+
+# Frontend build = tsc + vite (if frontend changed)
+bun run build 2>&1 | tail -40
+```
+
+If either fails, **do NOT auto-fix** — these are real errors. Report to user with the error output and ask how to proceed.
+
+### 2e — Tests (if relevant code changed)
+
+```bash
+# Frontend tests (if frontend changed)
+bun run test -- --run 2>&1 | tail -40
+
+# Rust tests are slow — only run focused tests for changed crates
+# Detect changed crates from file paths
+CHANGED_CRATES=$(git diff main...HEAD --name-only -- 'crates/*/src' 'apps/*/src' | sed 's|.*/\(crates/[^/]*\)/.*|\1|;s|.*/\(apps/[^/]*\)/.*|\1|' | sort -u)
+for crate_path in $CHANGED_CRATES; do
+  crate_name=$(basename $crate_path)
+  cargo test -p $crate_name --lib 2>&1 | tail -20
+done
+```
+
+### 2f — Markdown lint-staged simulation (if markdown changed)
+
+```bash
+# Only for non-docs-site markdown
+CHANGED_MD=$(git diff main...HEAD --name-only --diff-filter=d -- '*.md' ':!docs-site/**' | head -20)
+if [ -n "$CHANGED_MD" ]; then
+  for f in $CHANGED_MD; do
+    node scripts/fix-md-cjk-emphasis.mjs "$f" 2>/dev/null
+    npx autocorrect --fix "$f" 2>/dev/null
+    npx prettier --write "$f" 2>/dev/null
+  done
+  git add -u '*.md'
+fi
+```
+
+### 2g — Commit pre-flight fixes
+
+If any files were staged by auto-fix steps:
+
+```bash
+git diff --cached --stat
+```
+
+If there are staged changes, commit them:
+
+```bash
+git commit -m "$(cat <<'EOF'
+chore: pre-flight auto-fix (format, codegen, lint)
+EOF
+)"
+```
+
+Update state: `preflight_passed = true`.
+
+### Pre-flight summary
+
+Print a table:
+
+```
+Pre-flight results:
+  ✓ cargo fmt
+  ✓ prettier
+  ✓ OpenAPI schema (regenerated, +12 -3)
+  ✓ IPC bindings (no drift)
+  ✓ API client (regenerated)
+  ✓ ESLint (2 auto-fixed)
+  ✓ cargo check
+  ✓ tsc + vite build
+  ✓ vitest (14 passed)
+  ✓ cargo test uc-core (23 passed)
+  — cargo test uc-daemon (skipped, no changes)
+```
+
+If the user only asked for `/pr-greenlight preflight` or `/preflight`, **stop here**. Clean up lock file and report results.
+
+## Phase 3 — Push & Create PR
+
+If pre-flight passed, proceed to push and create PR.
+
+**Delegate to the `create-pr` skill logic**:
+
+1. Branch name review (propose rename if needed)
+2. docs-site impact scan
+3. Push and `gh pr create`
+
+Key points:
+- Follow all `create-pr` conventions (title format, body format, branch name check)
+- Record the PR number in state
+
+After PR is created, immediately proceed to Phase 4.
+
+## Phase 4 — Monitor CI (Agent Loop)
+
+This is the core monitoring loop, similar to `babysit-pr` but integrated.
+
+### 4a — Wait for CI to start
+
+```bash
+# Give CI 30s to register checks
+sleep 30
+gh pr checks --json name,state,conclusion 2>/dev/null
+```
+
+If no checks registered yet, schedule wakeup:
+```
+ScheduleWakeup(120s, "waiting for CI checks to register")
+```
+
+### 4b — Check status
+
+```bash
+gh pr checks --json name,state,conclusion,link 2>/dev/null
+```
+
+Classify:
+- **All passed** → go to 4c (check for review comments before declaring victory)
+- **Some pending** → schedule wakeup (180s)
+- **Some failed** → proceed to 4d
+
+### 4c — Check for bot review comments
+
+Same as babysit-pr Step 2b — check all three GitHub comment endpoints:
+
+```bash
+BOT_FILTER='select(.user.login | test("coderabbitai|github-actions|codecov"))'
+
+# Inline review comments
+gh api repos/UniClipboard/UniClipboard/pulls/<PR>/comments \
+  --jq "[.[] | ${BOT_FILTER} | {id, user: .user.login, body, path, line}]"
+
+# Review bodies
+gh api repos/UniClipboard/UniClipboard/pulls/<PR>/reviews \
+  --jq "[.[] | ${BOT_FILTER} | {id, user: .user.login, body, state}]"
+
+# Issue comments (CodeRabbit walkthrough lives here)
+gh api repos/UniClipboard/UniClipboard/issues/<PR>/comments \
+  --jq "[.[] | ${BOT_FILTER} | {id, user: .user.login, body: (.body | .[0:2000])}]"
+```
+
+Filter out `processed_comment_ids`. If zero unprocessed actionable comments AND all checks pass → **Success. Clean up.**
+
+### 4d — Fix failures
+
+For each failed check or new review comment:
+
+1. **Diagnose**: Fetch logs (`gh run view <run_id> --log-failed | tail -100`), read relevant code
+2. **Classify**:
+   - Format/lint failure → auto-fix (same as pre-flight 2a-2c)
+   - Code generation drift → re-run gen commands (same as 2b)
+   - Compilation error → fix the code
+   - Test failure → fix the code
+   - CodeRabbit comment → evaluate: must-fix (correctness/security) vs nit (skip)
+3. **Fix**: Edit files surgically
+4. **Validate locally**: Run the same check that failed to confirm fix works
+5. **Commit and push**:
+
+```bash
+git add <specific files>
+git commit -m "$(cat <<'EOF'
+fix: address CI feedback (pr-greenlight round N)
+EOF
+)"
+git push
+```
+
+Increment `round` in state. If `round >= max_rounds` → clean up with warning.
+
+### 4e — Loop back
+
+```
+ScheduleWakeup(180s, "CI running after pr-greenlight round N fix")
+```
+
+Re-enter at Phase 4b.
+
+## Cleanup
+
+**On success:**
+```bash
+rm -f /tmp/claude-pr-greenlight.lock /tmp/claude-pr-greenlight-state.json
+```
+```
+✅ PR #<N> is green. All CI checks passed after <round> round(s).
+   URL: <pr_url>
+   Pre-flight caught: <list of issues auto-fixed before push>
+   CI rounds: <N>
+```
+
+**On max rounds (4):**
+```bash
+rm -f /tmp/claude-pr-greenlight.lock /tmp/claude-pr-greenlight-state.json
+```
+```
+⚠️ PR #<N> still has failures after 4 rounds. Manual review needed.
+   Remaining failures: <list>
+   URL: <pr_url>
+```
+
+**On timeout (90 min):**
+```bash
+rm -f /tmp/claude-pr-greenlight.lock /tmp/claude-pr-greenlight-state.json
+```
+
+## Safety guardrails
+
+- Max **4 rounds** of CI fix cycles (round only increments on push)
+- **90-minute hard timeout**
+- **Lock file** prevents re-entrant triggering
+- Never `--force` push
+- Never amend existing commits
+- If a fix breaks something else (cargo check / tsc fails after edit), **revert** the fix and report
+- Skip CodeRabbit style nits — only fix correctness/security/performance issues
+- Pre-flight auto-fixes go in a dedicated commit, not mixed with feature work
+- Scoped lint: only lint changed files (repo has baseline ESLint debt)
+- `processed_comment_ids` prevents duplicate processing
+
+## Interaction with existing skills
+
+- **Supersedes** manual `/create-pr` + `/babysit-pr` chain for the common case
+- `/create-pr` and `/babysit-pr` remain available for standalone use
+- If a PR already exists for the branch, skip Phase 3 (push only, no `gh pr create`)
+- If user runs `/pr-greenlight preflight`, only Phase 1-2 execute (no push, no PR)
+
+## Anti-patterns
+
+- Running all checks regardless of what changed (wastes time on unrelated failures)
+- Auto-fixing compilation errors without understanding them
+- Pushing broken code because "CI will catch it"
+- Running `bun run lint` on entire repo (33 baseline errors will confuse the loop)
+- Treating `cargo fmt` failures as real bugs (they're always auto-fixable)
+- Skipping the local validation step after fixing a CI failure (leads to ping-pong)
+- Processing old/already-addressed CodeRabbit comments
+- Applying every CodeRabbit nit blindly

--- a/.claude/skills/research-then-implement/SKILL.md
+++ b/.claude/skills/research-then-implement/SKILL.md
@@ -1,0 +1,308 @@
+---
+name: research-then-implement
+description: "Agent Loop for tasks that need research before implementation: check existing research first, run structured investigation (bb-browser/context7/code study), produce a Brief, then implement against the Brief. Prevents repeated research on already-studied topics and research-to-implementation drift."
+user-invocable: true
+allowed-tools: Bash(git:*), Bash(grep:*), Bash(rg:*), Bash(jq:*), Bash(find:*), Bash(cat:*), Bash(bb-browser:*), Read, Edit, Write, AskUserQuestion, Agent, mcp__context7__resolve-library-id, mcp__context7__query-docs
+---
+
+# research-then-implement
+
+## Purpose
+
+An Agent Loop for tasks where the right approach isn't obvious and requires investigation before coding. It prevents two recurring problems:
+
+1. **Repeated research**: Re-investigating topics that were already studied in prior sessions (e.g., researching Expo UI components twice because the first research wasn't captured)
+2. **Research-implementation drift**: Research conclusions are in the agent's context but not in a durable artifact, so the implementation silently diverges from what was learned
+
+**Before:**
+```
+Session N: [researches via bb-browser, learns best practices] → implements → session ends
+Session N+1: [re-researches the same topic from scratch because findings weren't saved]
+```
+
+**After:**
+```
+Session N: /research-then-implement → checks .planning/research/ → no prior research →
+           researches → writes BRIEF.md → implements against BRIEF → done
+Session N+1: /research-then-implement → checks .planning/research/ → finds BRIEF.md →
+           skips research → implements directly
+```
+
+## When to trigger
+
+- `/research-then-implement` or `/rti` — start the full loop
+- `/research-then-implement research-only` — just do the research, save Brief, don't implement
+- User says "先研究一下再做", "research this first", "我不确定怎么做"
+- Tasks involving unfamiliar frameworks, APIs, or design patterns
+- Cross-platform porting (iOS → Android, native → Expo)
+- Evaluating multiple approaches before choosing one
+
+## When NOT to use
+
+- The implementation approach is already clear → just do it
+- Bug fixes with known root cause → use `systematic-debugging` or `error-diagnose-fix`
+- Pure research without implementation → use `deep-research` skill instead
+
+## Directory convention
+
+```
+.planning/research/
+  <topic-slug>/
+    BRIEF.md          ← the deliverable: findings + recommendation + constraints
+    sources.md        ← raw notes, URLs, code snippets from investigation
+```
+
+This convention already partially exists in the project (`.planning/research/` has prior work). The skill formalizes it.
+
+## Phase 1 — Check for existing research
+
+Before doing any new research, check if the topic was already studied:
+
+```bash
+# Check .planning/research/ for matching topics
+ls .planning/research/ 2>/dev/null
+
+# Check memory for relevant entries
+grep -i "<topic keywords>" \
+  ~/.claude/projects/-Users-mark-MyProjects-uniclipboard/memory/MEMORY.md 2>/dev/null
+
+# Check if there's a planning doc that covers this
+find .planning -name "*.md" -newer .planning/research 2>/dev/null | \
+  xargs grep -li "<topic>" 2>/dev/null
+```
+
+If existing research is found:
+```
+📚 Found existing research on this topic:
+  .planning/research/expo-ui-migration/BRIEF.md (2026-06-21)
+
+  Summary: Expo UI (@expo/ui) provides native iOS components...
+  Recommendation: Use @expo/ui for iOS, custom components for Android
+  
+  A) Use this research and proceed to implementation
+  B) Research is stale — redo from scratch
+  C) Supplement — do additional research on specific gaps
+```
+
+## Phase 2 — Structured Investigation
+
+If no existing research, or user wants fresh research, run the investigation.
+
+### 2a — Define the research question
+
+Clarify what needs to be learned:
+```
+Research question: How to implement a native-feel bottom sheet in Expo
+                   that matches iOS UISheetPresentationController behavior?
+
+Sub-questions:
+  1. Does @expo/ui provide a native BottomSheet component?
+  2. What's the standard pattern for iOS Sheet in React Native/Expo?
+  3. How does the iOS 26 Liquid Glass design affect this?
+  4. What are the platform-specific considerations (iOS vs Android)?
+```
+
+### 2b — Multi-source investigation
+
+Use the appropriate tool for each source type:
+
+**Official documentation (context7):**
+```
+mcp__context7__resolve-library-id("expo-ui")
+mcp__context7__query-docs(id, "BottomSheet sheet presentation")
+```
+
+**Design trends and community practices (bb-browser):**
+```bash
+bb-browser site google/search "expo bottom sheet native iOS 2026 best practice"
+bb-browser open <relevant-url>
+bb-browser eval "document.querySelector('article')?.innerText?.substring(0, 5000)"
+bb-browser close
+```
+
+**Reference implementations (code study):**
+```bash
+# If porting from an existing implementation:
+find /Users/mark/MyProjects/iOSApp/UniClipboard -name "*.swift" | \
+  xargs grep -l "sheet\|presentation" 2>/dev/null
+
+# Read the reference implementation
+Read <file>
+```
+
+**Package ecosystem:**
+```bash
+# Check what's available
+bb-browser site google/search "npm expo bottom sheet native 2026"
+```
+
+### 2c — Record raw findings
+
+Write sources and raw notes to `sources.md`:
+
+```markdown
+# Sources: <topic>
+
+## Official docs
+- expo-ui BottomSheet: [url] — supports detents, grabber, native iOS sheet
+- ...
+
+## Community
+- Blog post: [url] — recommends X over Y because...
+- GitHub issue: [url] — known limitation with...
+
+## Reference implementation
+- iOS app uses UISheetPresentationController with custom detents
+- File: /Users/mark/.../ServerSwitcherView.swift:42-80
+- Key pattern: .presentationDetents([.medium, .large])
+
+## Raw code snippets
+...
+```
+
+## Phase 3 — Produce the Brief
+
+The Brief is the key deliverable — a concise, actionable document that locks the research findings.
+
+### BRIEF.md template
+
+```markdown
+# Brief: <topic>
+
+**Date:** <date>
+**Status:** Draft | Reviewed | Locked
+**Research question:** <the original question>
+
+## Recommendation
+
+<1-3 sentences: what to do and why>
+
+## Key findings
+
+1. <finding 1 — with source reference>
+2. <finding 2>
+3. <finding 3>
+
+## Approach
+
+<The specific implementation approach chosen>
+
+### What to use
+- <library/API/pattern>: <why>
+
+### What NOT to use
+- <rejected alternative>: <why not>
+
+## Constraints
+
+- <constraint from docs/API limitations>
+- <constraint from project architecture>
+- <platform-specific constraint>
+
+## Implementation checklist
+
+- [ ] <step 1>
+- [ ] <step 2>
+- [ ] <step 3>
+
+## Cross-platform considerations
+
+| Aspect | iOS | Android |
+|--------|-----|---------|
+| Component | ... | ... |
+| Behavior | ... | ... |
+
+## Open questions
+
+- <anything not resolved by research>
+```
+
+### Brief quality gate
+
+Before proceeding to implementation, verify:
+1. The recommendation is specific enough to implement (not "use the best library")
+2. At least one alternative was considered and rejected with reasons
+3. Constraints are concrete (not "be careful about performance")
+4. The checklist has actionable items
+
+If the user passed `research-only`, **stop here**.
+
+## Phase 4 — Implement against the Brief
+
+### 4a — Load the Brief as constraints
+
+The Brief is now the specification. Implementation must:
+- Follow the recommended approach
+- Respect all listed constraints
+- Use the specified libraries/APIs (not alternatives)
+- Check off items from the implementation checklist
+
+### 4b — Implement
+
+Standard implementation, but with one key rule:
+
+**If during implementation you discover the Brief's recommendation doesn't work** (API doesn't exist, behavior differs from docs, breaking change):
+
+1. **STOP** — don't silently work around it
+2. Update the Brief with the new finding
+3. Tell the user: "The Brief said X, but in practice Y. Updated the Brief. Proceeding with Z instead."
+
+### 4c — Mark Brief as complete
+
+After implementation:
+```markdown
+**Status:** Locked
+**Implemented:** 2026-06-21
+**Branch:** feature/bottom-sheet-native
+```
+
+Update the implementation checklist with completion marks.
+
+## Cross-platform porting (special case)
+
+When the task is porting from one platform to another (iOS → Expo, Swift → React Native):
+
+### Transfer Spec
+
+Before implementation, create a Transfer Spec that maps source → target:
+
+```markdown
+## Transfer Spec: iOS → Expo BottomSheet
+
+| iOS (source) | Expo (target) | Notes |
+|-------------|---------------|-------|
+| UISheetPresentationController | @expo/ui Sheet | Native on iOS |
+| .presentationDetents([.medium]) | snapPoints={['50%']} | Different API |
+| .prefersGrabberVisible(true) | enableGrabber={true} | Same concept |
+| UIAction in menu | Context menu from @expo/ui | Not 1:1 |
+
+### Behavioral parity checklist
+- [ ] Half-screen snap point
+- [ ] Full-screen expansion
+- [ ] Drag-to-dismiss
+- [ ] Grabber indicator
+- [ ] Background dimming
+```
+
+This Transfer Spec is reusable — if the same port needs refinement later, the mapping is already done.
+
+## Interaction with other skills
+
+| Skill | Relationship |
+|-------|-------------|
+| `deep-research` | For pure research questions without implementation intent |
+| `bb-browser` | Tool used in Phase 2 for web research |
+| `context7` | Tool used in Phase 2 for official docs |
+| `/wrap` | Should persist the Brief path in `context_refs` |
+| `/continue` | Should read the Brief on resume |
+| `codebase-design` | May inform the Brief's constraints section |
+
+## Anti-patterns
+
+- Researching and implementing in the same mental breath (research, then implement — don't interleave)
+- Re-researching a topic that has a valid Brief in `.planning/research/`
+- Writing a Brief so vague it doesn't constrain implementation ("use best practices")
+- Silently deviating from the Brief during implementation without updating it
+- Spending 3 rounds researching when the topic is well-documented (use context7 first)
+- Researching without producing a Brief (findings evaporate with the session)
+- Porting code line-by-line instead of understanding the design intent first

--- a/.claude/skills/ui-iteration/SKILL.md
+++ b/.claude/skills/ui-iteration/SKILL.md
@@ -1,0 +1,211 @@
+---
+name: ui-iteration
+description: "Agent Loop for pixel-perfect UI adjustments: extract a structured spec from the user's intent, apply changes one property at a time, self-verify via screenshot, and converge instead of ping-ponging. Designed for high-fidelity UI cloning and spacing/style iteration."
+user-invocable: true
+allowed-tools: Bash(git:*), Bash(grep:*), Bash(rg:*), Bash(find:*), Bash(cat:*), Bash(npx:*), Bash(bun:*), Bash(npm:*), Bash(xcrun:*), Bash(screenshot:*), Read, Edit, Write, AskUserQuestion, Agent
+---
+
+# ui-iteration
+
+## Purpose
+
+An Agent Loop for UI polish work where the user needs pixel-level adjustments and the current pattern ping-pongs between overshooting and undershooting.
+
+**Observed anti-pattern (Session S47: 29 prompts!):**
+```
+User: "padding 太大"
+Agent: [changes 24→16]
+User: "太小了"
+Agent: [changes 16→28]
+User: "还是不对, 调到 24"
+Agent: [changes 28→24]  ← back to where we started
+User: "horizontal 也调一下"
+Agent: [changes horizontal too, now vertical is wrong again]
+... 20 more rounds ...
+```
+
+**After:**
+```
+/ui-iteration
+Agent: "What needs to change? Let me build a spec."
+User: "底部胶囊的间距和图标大小"
+Agent: [builds spec: 3 properties to adjust]
+Agent: [changes property 1, screenshots, confirms]
+Agent: [changes property 2, screenshots, confirms]
+Agent: [changes property 3, screenshots, confirms]
+Done in 3 rounds.
+```
+
+## When to trigger
+
+- `/ui-iteration` — start the structured UI adjustment loop
+- User sends a screenshot with complaints about spacing, sizing, colors, alignment
+- Multiple rounds of "还是不对", "间距不对", "太大/太小" style feedback
+- High-fidelity cloning from a reference app or design mockup
+- Any time you've made 3+ UI adjustments and the user is still not satisfied
+
+## When NOT to use
+
+- New feature implementation (layout, components) → just build it
+- Functional bugs (button doesn't work, data not loading) → use `systematic-debugging`
+- Color theme / dark mode issues → direct fix, no loop needed
+
+## Core principles
+
+### 1. One property per iteration
+
+Never change multiple visual properties at once. If the user says "padding is wrong and the icon is too small", that's two iterations, not one. Changing both at once means you can't tell which change fixed (or broke) the layout.
+
+### 2. Use design tokens, not magic numbers
+
+When adjusting spacing, prefer values from an established scale rather than arbitrary numbers:
+
+**Spacing scale (4px base):**
+```
+0, 2, 4, 6, 8, 10, 12, 16, 20, 24, 28, 32, 40, 48, 64
+```
+
+When the user says "a bit more padding", move ONE step up the scale, not +2px.
+
+### 3. Always read before editing
+
+Before changing a UI value, read the component to understand:
+- What other components share this value (changing it may break siblings)
+- Whether the value comes from a theme/token or is hardcoded
+- The component hierarchy (is this padding on the parent or the child?)
+
+## Workflow
+
+### Step 1 — Build the adjustment spec
+
+When the user describes what's wrong, extract a structured spec:
+
+```
+UI Adjustment Spec:
+  Component: ServerSwitcherModal
+  File: src/components/ServerSwitcher.tsx
+
+  Adjustments:
+    1. [SPACING] top padding: currently 16, user wants "more breathing room"
+       → Try: 24 (next scale step up)
+    2. [SIZE] close icon: currently 18, user says "too thin"
+       → Try: 22 (next size step)
+    3. [ALIGNMENT] empty state text: currently top-aligned, user wants centered
+       → Try: flex justify-center
+```
+
+Present the spec to the user for confirmation before making any changes.
+
+### Step 2 — Apply one change at a time
+
+For each adjustment in the spec:
+
+1. **Read** the current file and identify the exact property
+2. **Change** only that one property
+3. **Verify** — if possible, take a screenshot or describe the expected visual result
+4. **Confirm** with the user before moving to the next adjustment
+
+```
+Applied adjustment 1/3: top padding 16 → 24
+
+Next: adjustment 2 (close icon size). Proceed?
+```
+
+### Step 3 — Handle user feedback
+
+When the user says the adjustment is wrong:
+
+**"Too much" / "太大了"**: Move one scale step DOWN from the attempted value
+**"Too little" / "太小了"**: Move one scale step UP from the attempted value
+**"Not what I meant"**: Ask for clarification, update the spec
+**"Perfect" / accepted**: Mark adjustment as done, move to next
+
+### Step 4 — Reference-based iteration
+
+When cloning from a reference app or screenshot:
+
+1. **Study the reference** thoroughly before making any changes:
+   ```bash
+   # If reference is a file in the repo
+   Read /Users/mark/MyProjects/iOSApp/UniClipboard/Views/ServerSwitcherView.swift
+   
+   # If reference is a screenshot
+   # Read the image file for visual analysis
+   Read /tmp/reference-screenshot.png
+   ```
+
+2. **Build a Transfer Spec** mapping reference → implementation:
+   ```
+   Reference → Implementation mapping:
+     iOS .presentationDetents([.medium]) → snapPoints={['50%']}
+     iOS .padding(.horizontal, 24) → paddingHorizontal: 24
+     iOS .font(.body) → fontSize: 17 (iOS body = 17pt)
+     iOS .foregroundStyle(.secondary) → color: theme.textSecondary
+   ```
+
+3. **Apply each mapping one at a time**, verifying after each
+
+### Step 5 — Platform-specific considerations
+
+#### iOS (Expo)
+- Use `@expo/ui` components for native feel when available
+- iOS system font sizes: caption2=11, caption=12, footnote=13, subheadline=15, body=17, title3=20, title2=22, title1=28, largeTitle=34
+- Standard iOS margins: 16 (compact), 20 (regular)
+- Use SafeAreaView for edge-to-edge layouts
+
+#### Android (Expo)
+- Material Design 3 spacing: 4, 8, 12, 16, 24, 32
+- Use elevation for depth instead of shadows
+- Bottom sheet: use `@gorhom/bottom-sheet` with proper Android styling
+
+#### React (Tauri desktop)
+- Tailwind spacing scale: 0.5=2px, 1=4px, 1.5=6px, 2=8px, 3=12px, 4=16px, 5=20px, 6=24px, 8=32px
+- Use CSS variables from the project's theme
+- Check both light and dark mode after changes
+
+## Convergence strategy
+
+If after 3 rounds of adjusting the same property the user is still not satisfied:
+
+```
+We've adjusted top padding three times (16 → 24 → 20 → 22).
+Let me ask more precisely:
+
+What's the visual effect you're aiming for?
+  A) Match the iOS Settings app spacing
+  B) Equal spacing top and sides
+  C) Specific pixel value you have in mind
+  D) Show me a reference screenshot
+```
+
+Getting explicit alignment on the target prevents further oscillation.
+
+## Layout consistency check
+
+After all adjustments are made, do a quick consistency audit:
+
+```bash
+# Check if the adjusted values are consistent with sibling components
+grep -n "padding\|margin\|gap\|spacing" <file> | head -20
+```
+
+If the same component family uses different padding values after adjustments, flag it:
+
+```
+⚠️ Consistency note:
+  ServerSwitcherModal: paddingHorizontal=24
+  AddServerSheet: paddingHorizontal=16
+  
+  These are sibling sheets — should they use the same value?
+```
+
+## Anti-patterns
+
+- Changing 3+ properties at once ("I'll fix padding, margin, and font size together")
+- Using magic numbers instead of scale values (17px padding, 13px gap)
+- Not reading the component before editing (missing shared styles, theme tokens)
+- Oscillating between two values without asking for clarification
+- Applying iOS design values to Android without adaptation
+- Making spacing changes without checking dark mode / different screen sizes
+- Spending 10 rounds on one property without asking the user for a reference
+- Changing the component's structure/layout when only spacing was requested

--- a/.claude/skills/wrap/SKILL.md
+++ b/.claude/skills/wrap/SKILL.md
@@ -1,0 +1,255 @@
+---
+name: wrap
+description: "Session wrap-up: commit pending changes, push, write structured state for the next session to resume from. Eliminates 'glue sessions' that exist only to commit/push, and preserves debug context across sessions."
+user-invocable: true
+allowed-tools: Bash(git:*), Bash(gh:*), Bash(grep:*), Bash(jq:*), Bash(cat:*), Bash(rm:*), Bash(date:*), Bash(wc:*), Read, Edit, Write, AskUserQuestion
+---
+
+# wrap
+
+## Purpose
+
+A session-ending skill that wraps up the current work into a clean state for the next session. It replaces the pattern of opening a new "glue session" just to commit and push, and it replaces ad-hoc `/handoff` prose with a structured, machine-readable state file that `/continue` can consume.
+
+**Before (observed in 29 of 50 recent sessions):**
+```
+Session N: [does the work] → ends without committing
+Session N+1: "commit and push" → 1 prompt, done   ← wasted session
+Session N+2: "继续" → spends 3-8 min rebuilding context
+```
+
+**After:**
+```
+Session N: [does the work] → /wrap → committed, pushed, state saved
+Session N+1: /continue → full context in 10 seconds
+```
+
+## When to trigger
+
+- `/wrap` — full wrap-up: commit + push + state file
+- `/wrap --no-push` — commit + state file, skip push
+- `/wrap --no-commit` — state file only (for when changes aren't ready to commit)
+- User says "收工", "wrap up", "结束今天的工作", "保存进度"
+- End of a long session where context will be lost
+
+## State file location
+
+```bash
+PROJECT_KEY=$(pwd | sed 's|^/||; s|/|-|g')
+STATE_FILE="$HOME/.claude/projects/-${PROJECT_KEY}/active-task.json"
+```
+
+This places the state file alongside Claude Code's own session data for the project. It is NOT tracked in git.
+
+## Workflow
+
+### Step 1 — Take stock (parallel)
+
+```bash
+git status --short
+git rev-parse --abbrev-ref HEAD
+git log --oneline -5
+git diff --stat                        # unstaged changes
+git diff --cached --stat               # staged changes
+gh pr list --head $(git rev-parse --abbrev-ref HEAD) --json number,url,title --jq '.[0]' 2>/dev/null
+```
+
+### Step 2 — Commit pending changes
+
+Skip if `--no-commit` or if working tree is clean.
+
+If there are changes:
+
+1. Show the user what will be committed:
+   ```
+   Uncommitted changes:
+     M  crates/uc-core/src/types.rs
+     M  crates/uc-daemon/src/api.rs
+     A  crates/uc-core/src/new_module.rs
+   ```
+
+2. Ask the user:
+   ```
+   Commit these changes?
+   A) Yes, commit all
+   B) Let me pick which files
+   C) Skip commit (just save state)
+   ```
+
+3. On commit, draft a message from the diff context:
+   ```bash
+   git add <files>
+   git commit -m "$(cat <<'EOF'
+   <type>(<scope>): <message>
+   EOF
+   )"
+   ```
+
+### Step 3 — Push
+
+Skip if `--no-push` or if no remote tracking branch.
+
+```bash
+git push
+```
+
+If a PR exists for this branch, note the PR URL in the state file.
+
+### Step 4 — Write state file
+
+Build a structured state file. The state file has two parts:
+- **JSON** (`active-task.json`) — machine-readable, consumed by `/continue`
+- **Markdown** (`active-task-context.md`) — human-readable handoff detail
+
+#### 4a — active-task.json
+
+```json
+{
+  "version": 1,
+  "created_at": "2026-06-21T14:30:00Z",
+  "project": "/Users/mark/MyProjects/uniclipboard",
+  "branch": "active-clipboard-state",
+  "pr": {
+    "number": 1117,
+    "url": "https://github.com/UniClipboard/UniClipboard/pulls/1117"
+  },
+  "task": {
+    "summary": "Implement ActiveClipboardState for cross-device LWW register",
+    "status": "in_progress",
+    "done": [
+      "PR1-PR6: core state machine, reconcile, sync",
+      "PR7: mobile cutover"
+    ],
+    "next": [
+      "PR8: pull store-only LWW starvation workaround",
+      "Add dual-node e2e test for PR8"
+    ],
+    "blocked_on": null
+  },
+  "debug": {
+    "active": false,
+    "symptom": null,
+    "hypotheses_tried": [],
+    "hypotheses_ruled_out": [],
+    "evidence": [],
+    "current_hypothesis": null
+  },
+  "pending_actions": {
+    "needs_push": false,
+    "needs_pr": false,
+    "needs_rebase": false,
+    "uncommitted_files": []
+  },
+  "context_refs": [
+    ".planning/2026-06-19-issue-1017-active-clipboard.md",
+    "docs/architecture/active-clipboard-state.md"
+  ]
+}
+```
+
+#### 4b — active-task-context.md
+
+This replaces the freeform `/handoff` document. Written to the same directory.
+
+```markdown
+# Active Task: <summary>
+
+**Branch:** `<branch>`
+**PR:** #<number> (<url>)
+**Last updated:** <timestamp>
+
+## What's done
+<bulleted list from task.done>
+
+## What's next
+<bulleted list from task.next>
+
+## Key decisions made
+<non-obvious decisions from this session that the next agent needs to know>
+
+## Debug state (if active)
+### Symptom
+<what's broken>
+
+### Hypotheses tried
+| # | Hypothesis | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | ... | Ruled out | ... |
+| 2 | ... | Partially confirmed | ... |
+
+### Current hypothesis
+<what to test next>
+
+## Files changed this session
+<git diff --stat output>
+
+## Suggested skills
+<relevant skills for the next session>
+```
+
+### Step 5 — Report
+
+```
+✅ Session wrapped.
+  Branch: active-clipboard-state
+  Committed: 3 files (feat(core): add ActiveClipboardState reconcile)
+  Pushed: ✓
+  PR: #1117
+  State saved: ~/.claude/projects/-Users-mark-.../active-task.json
+  
+  Next session: /continue to pick up where you left off.
+```
+
+## Populating the state file
+
+### Task information
+
+Derive from the conversation context:
+- `summary`: One line describing the overall task (not just the last thing done)
+- `done`: What was accomplished in this session AND prior sessions (cumulative)
+- `next`: Specific next steps, not vague ("implement X" not "continue working")
+- `blocked_on`: If waiting on something external (CI, user decision, another PR)
+
+### Debug state
+
+Only populate if the session involved debugging:
+- `hypotheses_tried`: Each hypothesis with its result and evidence
+- `hypotheses_ruled_out`: Explicitly mark what was disproven (prevents next session from retrying)
+- `evidence`: Key observations (log snippets, test results, measurements)
+- `current_hypothesis`: What to test next
+
+### Context references
+
+List files that the next session should read for context:
+- Planning docs in `.planning/`
+- Architecture docs in `docs/`
+- Relevant issue URLs
+- Do NOT duplicate content from these files — just reference them
+
+## Interaction with existing /handoff
+
+- `/wrap` supersedes `/handoff` for the common case (end of session)
+- `/handoff` remains available for when you want a standalone document without committing/pushing
+- If `/wrap` is called, it creates both the structured state AND the markdown context (no need for separate `/handoff`)
+
+## Cleanup
+
+The state file is overwritten by each `/wrap` call. `/continue` clears it after successful resume. Old state files are not cleaned up automatically — they're small (< 5KB) and serve as history.
+
+## Safety guardrails
+
+- Never force-push
+- Never amend already-pushed commits
+- Ask before committing if there are unstaged changes (user might not want all of them)
+- Redact passwords, API keys, and PII from the state file and context document
+- Do NOT write the state file into the git-tracked repo
+- Do NOT commit the state file
+- If the working tree has merge conflicts, warn and skip commit
+
+## Anti-patterns
+
+- Writing a 500-line handoff document that duplicates the planning doc
+- Using vague next steps ("continue the work" — useless for /continue)
+- Including raw log output in the context file (summarize, don't paste)
+- Forgetting to populate debug state when the session was a debugging session
+- Overwriting state without checking if there's important state from a parallel session on a different branch


### PR DESCRIPTION
🤖 AI-assisted PR

## Summary

- Add 7 new Agent Loop skill files (6 distinct loops) derived from analysis of 50 recent sessions, targeting the highest-frequency workflow bottlenecks (`a824ad947`)
- **pr-greenlight**: local pre-flight CI checks → auto-fix codegen drift/format/lint → push → create PR → monitor CI → fix failures → loop until green
- **error-diagnose-fix**: agent runs the build itself, collects ALL errors, builds dependency graph, fixes root causes first, reverts failed hypotheses, loops until compilation succeeds
- **wrap + continue-task**: structured session wrap-up (commit + push + JSON state file) paired with smart resume that restores task context in 10s instead of 3-8min
- **cross-device-diagnose**: environment fingerprint collection on BOTH machines before any log analysis, memory-based pattern matching, hypothesis management with forced falsification
- **research-then-implement**: checks `.planning/research/` for prior work, runs multi-source investigation (bb-browser/context7/code study), produces a Brief that constrains implementation
- **ui-iteration**: extracts structured spec from user intent, applies one visual property per round, uses design token scale to prevent spacing ping-pong

## Test plan

- [x] All 7 skill files pass lint-staged (autocorrect, prettier, CJK emphasis)
- [x] Claude Code recognizes all skills in the `system-reminder` skill list
- [x] All referenced scripts and paths verified to exist (`gen-openapi`, `specta_export`, `dual-logs.sh`, etc.)
- [ ] Exercise `/pr-greenlight preflight` on a real feature branch
- [ ] Exercise `/wrap` → `/continue` across two sessions
- [ ] Exercise `/error-diagnose-fix` on an intentionally broken build