### PR TITLE
fix(clipboard): stabilize snapshot_hash for file entries across devices

### DIFF
--- a/apps/cli/src/commands/send.rs
+++ b/apps/cli/src/commands/send.rs
@@ -400,6 +400,7 @@ async fn run_send_file(path: PathBuf, json: bool, verbose: bool) -> i32 {
             Some(MimeType("text/uri-list".to_string())),
             uri_bytes,
         )],
+        file_content_digests: Vec::new(),
     };
     let blob_refs = vec![V3BlobRef {
         ticket: publish_result.ticket,

--- a/apps/cli/src/commands/watch.rs
+++ b/apps/cli/src/commands/watch.rs
@@ -229,5 +229,6 @@ fn decode_v3_envelope(bytes: &[u8]) -> anyhow::Result<SystemClipboardSnapshot> {
     Ok(SystemClipboardSnapshot {
         ts_ms: payload.ts_ms,
         representations,
+        file_content_digests: Vec::new(),
     })
 }

--- a/crates/uc-application/src/clipboard_capture/usecase.rs
+++ b/crates/uc-application/src/clipboard_capture/usecase.rs
@@ -131,7 +131,7 @@ impl CaptureClipboardUseCase {
     /// 本地 capture 路径传 `None` 即可,内部按既有逻辑生成新 id。
     pub async fn execute_with_origin(
         &self,
-        snapshot: SystemClipboardSnapshot,
+        mut snapshot: SystemClipboardSnapshot,
         origin: ClipboardChangeOrigin,
         preset_entry_id: Option<EntryId>,
     ) -> Result<Option<CaptureOutcome>> {
@@ -183,6 +183,25 @@ impl CaptureClipboardUseCase {
                 } => d,
                 _ => self.device_identity.current_device_id(),
             };
+            // Populate file_content_digests from LocalFile reps so that
+            // snapshot_hash() is based on file content (device-independent)
+            // rather than the text/uri-list path text (device-specific).
+            if snapshot.file_content_digests.is_empty() {
+                let digests: Vec<[u8; 32]> = snapshot
+                    .representations
+                    .iter()
+                    .filter(|r| {
+                        matches!(
+                            r.source(),
+                            uc_core::clipboard::ClipboardPayloadSource::LocalFile { .. }
+                        )
+                    })
+                    .map(|r| r.content_hash().bytes)
+                    .collect();
+                if !digests.is_empty() {
+                    snapshot.file_content_digests = digests;
+                }
+            }
             let snapshot_hash = {
                 let _guard = info_span!(
                     "clipboard.snapshot_hash",
@@ -682,6 +701,7 @@ mod tests {
         SystemClipboardSnapshot {
             ts_ms: 1_700_000_000_000,
             representations: reps,
+            file_content_digests: Vec::new(),
         }
     }
 

--- a/crates/uc-application/src/clipboard_write/coordinator.rs
+++ b/crates/uc-application/src/clipboard_write/coordinator.rs
@@ -415,6 +415,7 @@ mod tests {
                 Some(MimeType("text/plain".to_string())),
                 b"x".to_vec(),
             )],
+            file_content_digests: Vec::new(),
         }
     }
 

--- a/crates/uc-application/src/clipboard_write/primary_rep_selector.rs
+++ b/crates/uc-application/src/clipboard_write/primary_rep_selector.rs
@@ -66,6 +66,7 @@ pub fn narrow_to_primary(
     Ok(SystemClipboardSnapshot {
         ts_ms,
         representations: vec![chosen],
+        file_content_digests: Vec::new(),
     })
 }
 
@@ -91,6 +92,8 @@ mod tests {
         let snapshot = SystemClipboardSnapshot {
             ts_ms: 0,
             representations: vec![],
+
+            file_content_digests: Vec::new(),
         };
         let policy = SelectRepresentationPolicyV1::default();
         match narrow_to_primary(snapshot, &policy) {
@@ -104,6 +107,8 @@ mod tests {
         let snapshot = SystemClipboardSnapshot {
             ts_ms: 1,
             representations: vec![rep("text", Some("text/plain"), b"hello")],
+
+            file_content_digests: Vec::new(),
         };
         let original_id = snapshot.representations[0].id.clone();
         let policy = SelectRepresentationPolicyV1::default();
@@ -128,6 +133,8 @@ mod tests {
         let snapshot = SystemClipboardSnapshot {
             ts_ms: 2,
             representations: vec![plain, html, image],
+
+            file_content_digests: Vec::new(),
         };
         let policy = SelectRepresentationPolicyV1::default();
         let narrowed = narrow_to_primary(snapshot, &policy).expect("policy narrow ok");
@@ -143,6 +150,7 @@ mod tests {
                 rep("text", Some("text/plain"), b"a"),
                 rep("html", Some("text/html"), b"<p>a</p>"),
             ],
+            file_content_digests: Vec::new(),
         };
         let policy = SelectRepresentationPolicyV1::default();
         let narrowed = narrow_to_primary(snapshot, &policy).expect("ok");

--- a/crates/uc-application/src/facade/blob_transfer/facade.rs
+++ b/crates/uc-application/src/facade/blob_transfer/facade.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -26,6 +27,8 @@ use crate::facade::host_event::{HostEvent, HostEventBus, TransferHostEvent};
 use crate::usecases::blob_transfer::{
     FetchBlobInput, FetchBlobPathInput, FetchBlobUseCase, PublishBlobInput, PublishBlobUseCase,
 };
+
+const LIFECYCLE_RETRY_DELAY: Duration = Duration::from_millis(500);
 
 /// 共享的 host event 总线。
 ///
@@ -345,45 +348,48 @@ impl BlobTransferFacade {
         let Some(facade) = self.file_transfer.as_ref() else {
             return;
         };
-        if let Err(err) = facade
-            .seed_receiver_context(SeedReceiverContext {
-                transfer_id: ctx.transfer_id.clone(),
-                entry_id: ctx.transfer_id.clone(),
-                origin_device_id: ctx.peer_id.clone(),
-                filename: ctx.filename.clone(),
-                cached_path,
-            })
-            .await
-        {
-            warn!(
-                transfer_id = %ctx.transfer_id,
-                error = %err,
-                "blob fetch: seed receiver context failed"
-            );
+        let input = SeedReceiverContext {
+            transfer_id: ctx.transfer_id.clone(),
+            entry_id: ctx.transfer_id.clone(),
+            origin_device_id: ctx.peer_id.clone(),
+            filename: ctx.filename.clone(),
+            cached_path,
+        };
+        if let Err(first_err) = facade.seed_receiver_context(input.clone()).await {
+            tokio::time::sleep(LIFECYCLE_RETRY_DELAY).await;
+            if let Err(retry_err) = facade.seed_receiver_context(input).await {
+                warn!(
+                    transfer_id = %ctx.transfer_id,
+                    first_error = %first_err,
+                    error = %retry_err,
+                    "blob fetch: seed receiver context failed after retry"
+                );
+            }
         }
     }
 
-    /// 调 `FileTransferFacade::start` 让 `Started` 事件落进 store。
-    /// 失败时只 warn,不让 fetch 主路径感知—— lifecycle 错误不应该
-    /// 阻塞 blob 拉取本身,projection 后续 sweep / reconcile 会继续兜底。
+    /// Record `Started` via `FileTransferFacade::start`. Retries once after
+    /// a short delay to tolerate transient SQLite lock contention.
     async fn start_lifecycle(&self, ctx: &FetchTransferContext) {
         let Some(facade) = self.file_transfer.as_ref() else {
             return;
         };
-        if let Err(err) = facade
-            .start(StartTransfer {
-                transfer_id: ctx.transfer_id.clone(),
-                peer_id: ctx.peer_id.clone(),
-                filename: ctx.filename.clone(),
-                file_size: ctx.total_bytes,
-            })
-            .await
-        {
-            warn!(
-                transfer_id = %ctx.transfer_id,
-                error = %err,
-                "blob fetch: start lifecycle failed"
-            );
+        let input = StartTransfer {
+            transfer_id: ctx.transfer_id.clone(),
+            peer_id: ctx.peer_id.clone(),
+            filename: ctx.filename.clone(),
+            file_size: ctx.total_bytes,
+        };
+        if let Err(first_err) = facade.start(input.clone()).await {
+            tokio::time::sleep(LIFECYCLE_RETRY_DELAY).await;
+            if let Err(retry_err) = facade.start(input).await {
+                warn!(
+                    transfer_id = %ctx.transfer_id,
+                    first_error = %first_err,
+                    error = %retry_err,
+                    "blob fetch: start lifecycle failed after retry"
+                );
+            }
         }
     }
 
@@ -391,18 +397,20 @@ impl BlobTransferFacade {
         let Some(facade) = self.file_transfer.as_ref() else {
             return;
         };
-        if let Err(err) = facade
-            .complete(CompleteTransfer {
-                transfer_id: ctx.transfer_id.clone(),
-                peer_id: ctx.peer_id.clone(),
-            })
-            .await
-        {
-            warn!(
-                transfer_id = %ctx.transfer_id,
-                error = %err,
-                "blob fetch: complete lifecycle failed"
-            );
+        let input = CompleteTransfer {
+            transfer_id: ctx.transfer_id.clone(),
+            peer_id: ctx.peer_id.clone(),
+        };
+        if let Err(first_err) = facade.complete(input.clone()).await {
+            tokio::time::sleep(LIFECYCLE_RETRY_DELAY).await;
+            if let Err(retry_err) = facade.complete(input).await {
+                warn!(
+                    transfer_id = %ctx.transfer_id,
+                    first_error = %first_err,
+                    error = %retry_err,
+                    "blob fetch: complete lifecycle failed after retry"
+                );
+            }
         }
     }
 
@@ -410,20 +418,22 @@ impl BlobTransferFacade {
         let Some(facade) = self.file_transfer.as_ref() else {
             return;
         };
-        if let Err(err) = facade
-            .fail(FailTransfer {
-                transfer_id: ctx.transfer_id.clone(),
-                peer_id: ctx.peer_id.clone(),
-                reason: FileTransferFailureReason::Unknown,
-                detail: Some(detail),
-            })
-            .await
-        {
-            warn!(
-                transfer_id = %ctx.transfer_id,
-                error = %err,
-                "blob fetch: fail lifecycle failed"
-            );
+        let input = FailTransfer {
+            transfer_id: ctx.transfer_id.clone(),
+            peer_id: ctx.peer_id.clone(),
+            reason: FileTransferFailureReason::Unknown,
+            detail: Some(detail),
+        };
+        if let Err(first_err) = facade.fail(input.clone()).await {
+            tokio::time::sleep(LIFECYCLE_RETRY_DELAY).await;
+            if let Err(retry_err) = facade.fail(input).await {
+                warn!(
+                    transfer_id = %ctx.transfer_id,
+                    first_error = %first_err,
+                    error = %retry_err,
+                    "blob fetch: fail lifecycle failed after retry"
+                );
+            }
         }
     }
 

--- a/crates/uc-application/src/facade/clipboard/facade.rs
+++ b/crates/uc-application/src/facade/clipboard/facade.rs
@@ -1015,6 +1015,7 @@ mod tests {
                 Some(MimeType("text/plain".to_string())),
                 b"hello phase3".to_vec(),
             )],
+            file_content_digests: Vec::new(),
         };
         let outcome = facade
             .dispatch_snapshot(

--- a/crates/uc-application/src/facade/clipboard_capture/mod.rs
+++ b/crates/uc-application/src/facade/clipboard_capture/mod.rs
@@ -104,6 +104,8 @@ mod tests {
                 SystemClipboardSnapshot {
                     representations: Vec::new(),
                     ts_ms: 0,
+
+                    file_content_digests: Vec::new(),
                 },
                 ClipboardChangeOrigin::LocalCapture,
                 Some(EntryId::from("entry-preset")),

--- a/crates/uc-application/src/facade/clipboard_history/mod.rs
+++ b/crates/uc-application/src/facade/clipboard_history/mod.rs
@@ -367,6 +367,7 @@ impl ClipboardHistoryFacade {
                 Some(MimeType("text/plain".to_string())),
                 bytes.clone(),
             )],
+            file_content_digests: Vec::new(),
         };
         let snapshot_hash = snapshot.snapshot_hash();
 

--- a/crates/uc-application/src/facade/clipboard_live_index/mod.rs
+++ b/crates/uc-application/src/facade/clipboard_live_index/mod.rs
@@ -177,6 +177,8 @@ mod tests {
                 snapshot: Arc::new(SystemClipboardSnapshot {
                     representations: Vec::new(),
                     ts_ms: 0,
+
+                    file_content_digests: Vec::new(),
                 }),
             })
             .await

--- a/crates/uc-application/src/facade/clipboard_outbound/mod.rs
+++ b/crates/uc-application/src/facade/clipboard_outbound/mod.rs
@@ -275,9 +275,13 @@ impl ClipboardOutboundPort for ClipboardOutboundDispatcher {
         let entry_id = EntryId::from(input.entry_id.as_str());
 
         let publish_files_start = Instant::now();
-        let mut blob_refs =
+        let (mut blob_refs, file_content_digests) =
             publish_file_blob_refs(self.blob_transfer.as_ref(), &plan.files, &entry_id).await?;
         let publish_files_ms = publish_files_start.elapsed().as_millis() as u64;
+
+        if !file_content_digests.is_empty() {
+            clipboard_intent.snapshot.file_content_digests = file_content_digests;
+        }
 
         let publish_inline_start = Instant::now();
         let mut image_blob_refs = publish_oversized_inline_blob_refs(
@@ -579,21 +583,19 @@ pub(crate) async fn publish_oversized_inline_blob_refs(
     Ok(blob_refs)
 }
 
+/// Returns `(blob_refs, file_content_digests)`.  The digests are the
+/// blake3 hashes of the actual file bytes (= `PlaintextHash` from the
+/// publish result).  The caller stores them on the snapshot so that
+/// `snapshot_hash()` uses file content instead of device-local paths.
 pub(crate) async fn publish_file_blob_refs(
     blob_transfer: &dyn OutboundBlobPublishGateway,
     files: &[FileSyncIntent],
     entry_id: &EntryId,
-) -> Result<Vec<V3BlobRef>, ClipboardOutboundError> {
+) -> Result<(Vec<V3BlobRef>, Vec<[u8; 32]>), ClipboardOutboundError> {
     let mut blob_refs = Vec::with_capacity(files.len());
+    let mut file_content_digests = Vec::with_capacity(files.len());
 
     for file in files {
-        // GH#487 P1: 流式 publish。旧路径先 `tokio::fs::read` 把整个文件读到
-        // `Vec<u8>`、再 `Bytes::from` 拷贝、再 `add_bytes` 在内存里算 BAO,
-        // 1GB 文件 RSS 峰值 ≈ 2GB,且这三步全部串联完成才轮到 dispatch ——
-        // 对端因此要等 ~11s 才拿到 envelope。新路径走 iroh-blobs `add_path`,
-        // 内部 reflink_or_copy_with_progress 把磁盘文件 stream 到 store(CoW
-        // FS 上零拷贝)+ 增量 BAO 编码,内存峰值与文件大小无关。`size_bytes`
-        // 改用 plan 透传的 `FileSyncIntent.size`(metadata 阶段已查过)。
         let publish_start = Instant::now();
         let result = blob_transfer
             .publish_blob_path(PublishBlobPathCommand {
@@ -613,6 +615,8 @@ pub(crate) async fn publish_file_blob_refs(
             "outbound: file blob published (streaming)"
         );
 
+        file_content_digests.push(*result.plaintext_hash.as_bytes());
+
         blob_refs.push(V3BlobRef {
             ticket: result.ticket,
             entry_id: result.entry_id,
@@ -623,7 +627,7 @@ pub(crate) async fn publish_file_blob_refs(
         });
     }
 
-    Ok(blob_refs)
+    Ok((blob_refs, file_content_digests))
 }
 
 #[cfg(test)]
@@ -699,6 +703,8 @@ mod tests {
                 snapshot: SystemClipboardSnapshot {
                     representations: Vec::new(),
                     ts_ms: 0,
+
+                    file_content_digests: Vec::new(),
                 },
                 origin: ClipboardChangeOrigin::LocalCapture,
             })

--- a/crates/uc-application/src/facade/mobile_sync/activation_announce_adapter.rs
+++ b/crates/uc-application/src/facade/mobile_sync/activation_announce_adapter.rs
@@ -229,6 +229,7 @@ mod tests {
                 Some(MimeType("text/plain".to_string())),
                 b"hi".to_vec(),
             )],
+            file_content_digests: Vec::new(),
         }
     }
 

--- a/crates/uc-application/src/sync_planner/planner.rs
+++ b/crates/uc-application/src/sync_planner/planner.rs
@@ -220,6 +220,7 @@ mod tests {
                 Some(MimeType("text/plain".to_string())),
                 b"hi".to_vec(),
             )],
+            file_content_digests: Vec::new(),
         }
     }
 

--- a/crates/uc-application/src/usecases/clipboard_restore/file_snapshot.rs
+++ b/crates/uc-application/src/usecases/clipboard_restore/file_snapshot.rs
@@ -29,5 +29,6 @@ pub(crate) fn build_file_snapshot(uri_list: &str) -> SystemClipboardSnapshot {
             Some(MimeType::uri_list()),
             uri_list.as_bytes().to_vec(),
         )],
+        file_content_digests: Vec::new(),
     }
 }

--- a/crates/uc-application/src/usecases/clipboard_restore/restore_as_plain_text.rs
+++ b/crates/uc-application/src/usecases/clipboard_restore/restore_as_plain_text.rs
@@ -259,6 +259,7 @@ impl RestoreClipboardEntryAsPlainTextUseCase {
                     return Ok(Some(SystemClipboardSnapshot {
                         ts_ms: chrono::Utc::now().timestamp_millis(),
                         representations: vec![observed],
+                        file_content_digests: Vec::new(),
                     }));
                 }
                 Err(err) => {

--- a/crates/uc-application/src/usecases/clipboard_sync/active_state/reconcile.rs
+++ b/crates/uc-application/src/usecases/clipboard_sync/active_state/reconcile.rs
@@ -214,6 +214,7 @@ mod tests {
                 Some(MimeType("text/plain".to_string())),
                 text.as_bytes().to_vec(),
             )],
+            file_content_digests: Vec::new(),
         }
     }
 
@@ -231,6 +232,8 @@ mod tests {
                 FakeClipboard::Empty => Ok(SystemClipboardSnapshot {
                     ts_ms: 0,
                     representations: vec![],
+
+                    file_content_digests: Vec::new(),
                 }),
                 FakeClipboard::ReadError => Err(anyhow::anyhow!("clipboard unreadable")),
             }

--- a/crates/uc-application/src/usecases/clipboard_sync/active_state/serve_pull.rs
+++ b/crates/uc-application/src/usecases/clipboard_sync/active_state/serve_pull.rs
@@ -160,14 +160,14 @@ impl ActiveClipboardPullServeUseCase {
             return Err(ActiveClipboardPullServeError::NotAvailable);
         };
 
-        let mut blob_refs = match publish_file_blob_refs(
+        let (mut blob_refs, file_content_digests) = match publish_file_blob_refs(
             self.blob_publisher.as_ref(),
             &plan.files,
             &entry_id,
         )
         .await
         {
-            Ok(refs) => refs,
+            Ok(result) => result,
             Err(err) => {
                 warn!(error = %err, "pull serve: file blob publish failed");
                 return Err(ActiveClipboardPullServeError::Internal(format!(
@@ -175,6 +175,9 @@ impl ActiveClipboardPullServeUseCase {
                 )));
             }
         };
+        if !file_content_digests.is_empty() {
+            clipboard_intent.snapshot.file_content_digests = file_content_digests;
+        }
         let mut image_blob_refs = match publish_oversized_inline_blob_refs(
             self.blob_publisher.as_ref(),
             &mut clipboard_intent.snapshot,

--- a/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/materializer.rs
+++ b/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/materializer.rs
@@ -195,10 +195,11 @@ impl InboundBlobMaterializer for FileCacheBlobMaterializer {
         // - `missing_files`:file_refs 阶段被取消的文件元数据,用于:
         //   (a) 在 file-list rep 中以 `uniclip-missing://` URI 占位;
         //   (b) 返回给上层做"是否 partial"判定。
-        // - `partial_cancel`:任一阶段触发了 cancel,后续不再发起新的 fetch。
+        // - `partial`: set when cancel or fetch error occurs; remaining blobs
+        //   are marked missing and no further fetches are attempted.
         let mut incomplete_rep_idxs: Vec<usize> = Vec::new();
         let mut missing_files: Vec<MissingFileRef> = Vec::new();
-        let mut partial_cancel = false;
+        let mut partial = false;
 
         // 1. Hydrate representation-bound blobs back into the snapshot.
         //
@@ -262,7 +263,7 @@ impl InboundBlobMaterializer for FileCacheBlobMaterializer {
                         "materialize: representation-bound blob fetch cancelled, marking partial"
                     );
                     incomplete_rep_idxs.extend(pending_rep_idxs[loop_idx..].iter().copied());
-                    partial_cancel = true;
+                    partial = true;
                     break;
                 }
                 Err(e) => {
@@ -271,9 +272,11 @@ impl InboundBlobMaterializer for FileCacheBlobMaterializer {
                         size_bytes = advertised_size,
                         representation_index = idx,
                         error = %e,
-                        "materialize: representation-bound blob fetch failed"
+                        "materialize: representation-bound blob fetch failed, marking partial"
                     );
-                    return Err(e);
+                    incomplete_rep_idxs.extend(pending_rep_idxs[loop_idx..].iter().copied());
+                    partial = true;
+                    break;
                 }
             };
 
@@ -295,10 +298,9 @@ impl InboundBlobMaterializer for FileCacheBlobMaterializer {
             );
         }
 
-        // rep_refs 阶段 cancel 时不再发起任何 file_refs fetch:把所有 file_refs
-        // 标 missing,直接走 rewrite + finalize 路径(snapshot 里那些"未完成"的
-        // rep 由后面 incomplete_rep_idxs 的倒序 retain 移除)。
-        if partial_cancel {
+        // Rep-refs stage partial (cancel or error): skip all file_refs fetches,
+        // mark them missing, finalize via the partial path.
+        if partial {
             for blob_ref in file_refs.iter() {
                 missing_files.push(MissingFileRef {
                     filename: blob_ref
@@ -323,6 +325,7 @@ impl InboundBlobMaterializer for FileCacheBlobMaterializer {
 
         // 2. Free-standing files: existing cache_dir + file-list rewrite path.
         let mut local_paths = Vec::with_capacity(file_refs.len());
+        let mut file_content_digests: Vec<[u8; 32]> = Vec::with_capacity(file_refs.len());
         let mut used_names = HashSet::new();
         let blob_ref_total = file_refs.len();
 
@@ -383,51 +386,60 @@ impl InboundBlobMaterializer for FileCacheBlobMaterializer {
             let filename = unique_filename(blob_ref.filename.as_deref(), idx, &mut used_names);
             let path = entry_dir.join(filename);
 
-            let fetched = match self
-                .fetcher
-                .fetch_blob_to_path(FetchBlobToPathCommand {
-                    ticket: blob_ref.ticket,
-                    entry_id: blob_ref.entry_id.clone(),
-                    target_path: path.clone(),
-                    transfer_context: Some(transfer_context),
-                })
-                .await
-            {
-                Ok(v) => v,
-                Err(e) if is_cancel_error(&e) => {
-                    // Cancel:当前 file 的 partial cleanup 由 BlobTransferFacade
-                    // 自己在 cancel arm 里做(facade.rs:789-796)。把当前 +
-                    // file_refs[idx+1..] 全收进 missing,break 走 finalize。
-                    warn!(
-                        idx,
-                        total = blob_ref_total,
-                        entry_id = %entry_id,
-                        "materialize: blob fetch cancelled, marking partial"
-                    );
-                    for remaining in &file_refs[idx..] {
-                        missing_files.push(MissingFileRef {
-                            filename: remaining
-                                .filename
-                                .clone()
-                                .unwrap_or_else(|| format!("blob-{}", remaining.entry_id.as_ref())),
-                            size_bytes: remaining.size_bytes,
-                        });
+            let fetched =
+                match self
+                    .fetcher
+                    .fetch_blob_to_path(FetchBlobToPathCommand {
+                        ticket: blob_ref.ticket,
+                        entry_id: blob_ref.entry_id.clone(),
+                        target_path: path.clone(),
+                        transfer_context: Some(transfer_context),
+                    })
+                    .await
+                {
+                    Ok(v) => v,
+                    Err(e) if is_cancel_error(&e) => {
+                        // Cancel:当前 file 的 partial cleanup 由 BlobTransferFacade
+                        // 自己在 cancel arm 里做(facade.rs:789-796)。把当前 +
+                        // file_refs[idx+1..] 全收进 missing,break 走 finalize。
+                        warn!(
+                            idx,
+                            total = blob_ref_total,
+                            entry_id = %entry_id,
+                            "materialize: blob fetch cancelled, marking partial"
+                        );
+                        for remaining in &file_refs[idx..] {
+                            missing_files.push(MissingFileRef {
+                                filename: remaining.filename.clone().unwrap_or_else(|| {
+                                    format!("blob-{}", remaining.entry_id.as_ref())
+                                }),
+                                size_bytes: remaining.size_bytes,
+                            });
+                        }
+                        partial = true;
+                        break;
                     }
-                    partial_cancel = true;
-                    break;
-                }
-                Err(e) => {
-                    warn!(
-                        idx,
-                        total = blob_ref_total,
-                        entry_id = %entry_id,
-                        size_bytes = advertised_size,
-                        error = %e,
-                        "materialize: blob fetch failed"
-                    );
-                    return Err(e);
-                }
-            };
+                    Err(e) => {
+                        warn!(
+                            idx,
+                            total = blob_ref_total,
+                            entry_id = %entry_id,
+                            size_bytes = advertised_size,
+                            error = %e,
+                            "materialize: blob fetch failed, marking partial"
+                        );
+                        for remaining in &file_refs[idx..] {
+                            missing_files.push(MissingFileRef {
+                                filename: remaining.filename.clone().unwrap_or_else(|| {
+                                    format!("blob-{}", remaining.entry_id.as_ref())
+                                }),
+                                size_bytes: remaining.size_bytes,
+                            });
+                        }
+                        partial = true;
+                        break;
+                    }
+                };
 
             info!(
                 idx,
@@ -437,14 +449,14 @@ impl InboundBlobMaterializer for FileCacheBlobMaterializer {
                 path = %path.display(),
                 "materialize: blob cached to local path (streaming)"
             );
+            file_content_digests.push(*fetched.plaintext_hash.as_bytes());
             local_paths.push(path);
             file_idx += 1;
         }
 
-        if partial_cancel {
-            // cancel 触发的 break 已把"当前 + file_refs[idx..]"全收进
-            // missing_files(用 indexed 访问而非 into_iter,保留 idx 后置访问能力)。
-            // 这里直接落 finalize_partial 出口。
+        if partial {
+            // The break collected current + remaining file_refs into
+            // missing_files. Finalize the partial entry.
             return Ok(finalize_partial(
                 snapshot,
                 &incomplete_rep_idxs,
@@ -452,6 +464,10 @@ impl InboundBlobMaterializer for FileCacheBlobMaterializer {
                 missing_files,
                 &from_device,
             ));
+        }
+
+        if !file_content_digests.is_empty() {
+            snapshot.file_content_digests = file_content_digests;
         }
 
         let uri_list = local_file_uri_list(&local_paths)?;

--- a/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/tests.rs
+++ b/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/tests.rs
@@ -145,6 +145,7 @@ fn fixture_input(text: &str) -> (ApplyInboundInput, String) {
             Some(MimeType("text/plain".to_string())),
             text.as_bytes().to_vec(),
         )],
+        file_content_digests: Vec::new(),
     };
     let (plaintext, snapshot_hash) = encode_snapshot_to_v3_bytes(&snapshot).unwrap();
     (
@@ -376,6 +377,7 @@ async fn visible_duplicate_skipped_across_channel_representation_expansion() {
             Some(MimeType("text/plain".to_string())),
             visible_text.clone(),
         )],
+        file_content_digests: Vec::new(),
     };
     let second_snapshot = SystemClipboardSnapshot {
         ts_ms: 1_700_000_000_250,
@@ -399,6 +401,7 @@ async fn visible_duplicate_skipped_across_channel_representation_expansion() {
                 visible_text,
             ),
         ],
+        file_content_digests: Vec::new(),
     };
     let (first_input, first_hash) = fixture_input_from_snapshot(first_snapshot);
     let (second_input, second_hash) = fixture_input_from_snapshot(second_snapshot);
@@ -455,6 +458,7 @@ async fn visible_duplicate_window_expires() {
             Some(MimeType("text/plain".to_string())),
             b"expires".to_vec(),
         )],
+        file_content_digests: Vec::new(),
     };
     let second_snapshot = SystemClipboardSnapshot {
         ts_ms: 1_700_000_003_000,
@@ -464,6 +468,7 @@ async fn visible_duplicate_window_expires() {
             None,
             b"expires".to_vec(),
         )],
+        file_content_digests: Vec::new(),
     };
     let (first_input, _) = fixture_input_from_snapshot(first_snapshot);
     let (second_input, _) = fixture_input_from_snapshot(second_snapshot);
@@ -693,6 +698,7 @@ async fn materializes_blob_refs_before_capture_and_write() {
             Some(MimeType("text/uri-list".to_string())),
             b"file:///sender/original.txt\n".to_vec(),
         )],
+        file_content_digests: Vec::new(),
     };
     let blob_ref = V3BlobRef {
         ticket: BlobTicket::from_bytes(vec![9, 8, 7]),
@@ -776,6 +782,7 @@ async fn partial_materialize_persists_entry_but_skips_os_write() {
             Some(MimeType("text/uri-list".to_string())),
             b"file:///sender/big.iso\n".to_vec(),
         )],
+        file_content_digests: Vec::new(),
     };
     let blob_ref = V3BlobRef {
         ticket: BlobTicket::from_bytes(vec![5, 5, 5]),
@@ -859,6 +866,7 @@ async fn partial_materialize_does_not_register_dedup_entry() {
             Some(MimeType("text/uri-list".to_string())),
             b"file:///sender/retry.iso\n".to_vec(),
         )],
+        file_content_digests: Vec::new(),
     };
     let blob_ref = V3BlobRef {
         ticket: BlobTicket::from_bytes(vec![7, 7, 7]),
@@ -966,6 +974,7 @@ async fn file_cache_blob_materializer_writes_file_and_rewrites_file_uri_list() {
             Some(MimeType("text/uri-list".to_string())),
             b"file:///sender/report.txt\n".to_vec(),
         )],
+        file_content_digests: Vec::new(),
     };
 
     let mut fetcher = MockBlobFetcher::new();
@@ -1047,6 +1056,7 @@ async fn file_cache_blob_materializer_inlines_representation_bound_blob_into_rep
             Some(MimeType("image/png".to_string())),
             Vec::new(),
         )],
+        file_content_digests: Vec::new(),
     };
 
     let mut fetcher = MockBlobFetcher::new();
@@ -1117,6 +1127,7 @@ async fn file_cache_blob_materializer_rejects_out_of_bounds_representation_index
             Some(MimeType("image/png".to_string())),
             Vec::new(),
         )],
+        file_content_digests: Vec::new(),
     };
 
     let mut fetcher = MockBlobFetcher::new();
@@ -1182,6 +1193,7 @@ async fn file_cache_blob_materializer_partial_on_cancel_mid_batch() {
             Some(MimeType("text/uri-list".to_string())),
             b"file:///sender/first.txt\r\nfile:///sender/second.iso\r\n".to_vec(),
         )],
+        file_content_digests: Vec::new(),
     };
 
     let mut fetcher = MockBlobFetcher::new();
@@ -1264,6 +1276,7 @@ async fn file_cache_blob_materializer_partial_on_cancel_first_file() {
             Some(MimeType("text/uri-list".to_string())),
             b"file:///sender/nothing.iso\r\n".to_vec(),
         )],
+        file_content_digests: Vec::new(),
     };
 
     let mut fetcher = MockBlobFetcher::new();
@@ -1318,6 +1331,7 @@ async fn file_cache_blob_materializer_partial_on_rep_cancel_no_files() {
             Some(MimeType("image/png".to_string())),
             Vec::new(),
         )],
+        file_content_digests: Vec::new(),
     };
 
     let mut fetcher = MockBlobFetcher::new();

--- a/crates/uc-application/src/usecases/clipboard_sync/ingest_inbound.rs
+++ b/crates/uc-application/src/usecases/clipboard_sync/ingest_inbound.rs
@@ -649,6 +649,7 @@ mod tests {
                 Some(MimeType("text/plain".to_string())),
                 b"hello text".to_vec(),
             )],
+            file_content_digests: Vec::new(),
         };
         let (envelope_bytes, _hash) =
             super::super::payload_codec::encode_snapshot_to_v3_bytes(&snapshot)

--- a/crates/uc-application/src/usecases/clipboard_sync/payload_codec.rs
+++ b/crates/uc-application/src/usecases/clipboard_sync/payload_codec.rs
@@ -165,6 +165,7 @@ pub fn decode_v3_bytes_to_snapshot_and_blob_refs(
         SystemClipboardSnapshot {
             ts_ms: payload.ts_ms,
             representations,
+            file_content_digests: Vec::new(),
         },
         blob_refs,
     ))
@@ -405,6 +406,7 @@ mod tests {
                 Some(MimeType("text/plain".to_string())),
                 text.as_bytes().to_vec(),
             )],
+            file_content_digests: Vec::new(),
         }
     }
 
@@ -450,6 +452,7 @@ mod tests {
                     b"\x00\x01\x02\xDE\xAD\xBE\xEF".to_vec(),
                 ),
             ],
+            file_content_digests: Vec::new(),
         };
         let (bytes, _) = encode_snapshot_to_v3_bytes(&original).expect("encode should succeed");
         let decoded = decode_v3_bytes_to_snapshot(&bytes).expect("decode should succeed");

--- a/crates/uc-application/src/usecases/clipboard_sync/resend_entry.rs
+++ b/crates/uc-application/src/usecases/clipboard_sync/resend_entry.rs
@@ -413,10 +413,13 @@ impl ResendEntryUseCase {
             });
         };
 
-        let mut blob_refs =
+        let (mut blob_refs, file_content_digests) =
             publish_file_blob_refs(self.blob_publisher.as_ref(), &plan.files, &cmd.entry_id)
                 .await
                 .map_err(map_outbound_publish_error)?;
+        if !file_content_digests.is_empty() {
+            clipboard_intent.snapshot.file_content_digests = file_content_digests;
+        }
         let mut image_blob_refs = publish_oversized_inline_blob_refs(
             self.blob_publisher.as_ref(),
             &mut clipboard_intent.snapshot,

--- a/crates/uc-application/src/usecases/clipboard_sync/snapshot_from_entry.rs
+++ b/crates/uc-application/src/usecases/clipboard_sync/snapshot_from_entry.rs
@@ -317,6 +317,7 @@ pub(crate) async fn reconstruct_snapshot_from_entry(
     Ok(SystemClipboardSnapshot {
         ts_ms: chrono::Utc::now().timestamp_millis(),
         representations,
+        file_content_digests: Vec::new(),
     })
 }
 

--- a/crates/uc-application/src/usecases/mobile_sync/apply_incoming.rs
+++ b/crates/uc-application/src/usecases/mobile_sync/apply_incoming.rs
@@ -759,6 +759,7 @@ impl ApplyIncomingMobileClipUseCase {
             snapshot: SystemClipboardSnapshot {
                 ts_ms: self.clock.now_ms(),
                 representations: vec![rep],
+                file_content_digests: Vec::new(),
             },
             transfer_id: None,
         })
@@ -805,6 +806,7 @@ impl ApplyIncomingMobileClipUseCase {
             snapshot: SystemClipboardSnapshot {
                 ts_ms: self.clock.now_ms(),
                 representations: vec![rep],
+                file_content_digests: Vec::new(),
             },
             transfer_id: Some(transfer_id),
         })
@@ -848,6 +850,7 @@ impl ApplyIncomingMobileClipUseCase {
             snapshot: SystemClipboardSnapshot {
                 ts_ms: self.clock.now_ms(),
                 representations: vec![rep],
+                file_content_digests: Vec::new(),
             },
             transfer_id: Some(transfer_id),
         })

--- a/crates/uc-bootstrap/tests/slice2_phase2_clipboard_e2e.rs
+++ b/crates/uc-bootstrap/tests/slice2_phase2_clipboard_e2e.rs
@@ -675,6 +675,7 @@ async fn sponsor_dispatch_lands_on_joiner_within_2s() {
             Some(MimeType("text/plain".to_string())),
             text.as_bytes().to_vec(),
         )],
+        file_content_digests: Vec::new(),
     };
     let expected_hash = snapshot.snapshot_hash().to_string();
     let outcome = sponsor
@@ -775,6 +776,7 @@ async fn repeat_dispatch_lands_twice_phase2_no_dedup() {
             Some(MimeType("text/plain".to_string())),
             fixture_text.as_bytes().to_vec(),
         )],
+        file_content_digests: Vec::new(),
     };
     let canonical_hash = build_snapshot().snapshot_hash().to_string();
     for attempt in 0..2 {

--- a/crates/uc-core/src/clipboard/category.rs
+++ b/crates/uc-core/src/clipboard/category.rs
@@ -246,6 +246,7 @@ mod tests {
         SystemClipboardSnapshot {
             ts_ms: 0,
             representations: reps,
+            file_content_digests: Vec::new(),
         }
     }
 

--- a/crates/uc-core/src/clipboard/policy/v1.rs
+++ b/crates/uc-core/src/clipboard/policy/v1.rs
@@ -340,6 +340,7 @@ mod tests {
         let snapshot = SystemClipboardSnapshot {
             ts_ms: 0,
             representations: vec![large_image, files],
+            file_content_digests: Vec::new(),
         };
 
         let policy = SelectRepresentationPolicyV1::new();
@@ -373,6 +374,7 @@ mod tests {
         let snapshot = SystemClipboardSnapshot {
             ts_ms: 0,
             representations: vec![large_image, files],
+            file_content_digests: Vec::new(),
         };
 
         let policy = SelectRepresentationPolicyV1::new();
@@ -404,6 +406,7 @@ mod tests {
         let snapshot = SystemClipboardSnapshot {
             ts_ms: 0,
             representations: vec![small_image, files],
+            file_content_digests: Vec::new(),
         };
 
         let policy = SelectRepresentationPolicyV1::new();

--- a/crates/uc-core/src/clipboard/system.rs
+++ b/crates/uc-core/src/clipboard/system.rs
@@ -19,6 +19,21 @@ pub struct RepresentationHash(pub ContentHash);
 pub struct SystemClipboardSnapshot {
     pub ts_ms: i64,
     pub representations: Vec<ObservedClipboardRepresentation>,
+    /// blake3 digests of actual file content bytes, one per file in the
+    /// entry's file-list.  When non-empty, [`Self::snapshot_hash`] uses
+    /// these digests instead of hashing the `text/uri-list` representation's
+    /// inline bytes (which contain device-local file paths and therefore
+    /// differ across devices).
+    ///
+    /// Populated by:
+    /// - Sender capture: from `LocalFile` rep `content_hash()` values
+    /// - Sender outbound: from `PlaintextHash` returned by blob publish
+    /// - Receiver inbound: from `PlaintextHash` carried on the wire or
+    ///   returned by blob fetch
+    ///
+    /// Empty for text-only / image-only snapshots (no file-list rep).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub file_content_digests: Vec<[u8; 32]>,
 }
 
 /// 表示一条 rep 的负载来源。
@@ -503,13 +518,35 @@ impl SystemClipboardSnapshot {
     }
 
     pub fn snapshot_hash(&self) -> SnapshotHash {
+        // When file_content_digests are available, use them as the hash
+        // contribution for file-list reps instead of hashing the
+        // text/uri-list inline bytes (which contain device-local paths).
+        let has_file_digests = !self.file_content_digests.is_empty();
+
         let mut rep_hashes: Vec<[u8; 32]> = self
             .representations
             .iter()
-            .map(|r| r.content_hash().bytes)
+            .filter_map(|r| {
+                if has_file_digests && is_file_representation(r) {
+                    // Skip — file-list rep hash replaced by file_content_digests below
+                    None
+                } else {
+                    Some(r.content_hash().bytes)
+                }
+            })
             .collect();
 
-        // 顺序无关
+        if has_file_digests {
+            let mut file_hasher = blake3::Hasher::new();
+            file_hasher.update(b"file-content|");
+            let mut sorted_digests = self.file_content_digests.clone();
+            sorted_digests.sort_unstable();
+            for d in &sorted_digests {
+                file_hasher.update(d);
+            }
+            rep_hashes.push(*file_hasher.finalize().as_bytes());
+        }
+
         rep_hashes.sort_unstable();
 
         let mut hasher = blake3::Hasher::new();

--- a/crates/uc-platform/examples/wayland_clipboard_test.rs
+++ b/crates/uc-platform/examples/wayland_clipboard_test.rs
@@ -54,6 +54,7 @@ fn main() -> anyhow::Result<()> {
             Some(MimeType("text/plain;charset=utf-8".into())),
             payload.clone().into_bytes(),
         )],
+        file_content_digests: Vec::new(),
     };
     eprintln!("[1/3] writing via WaylandClipboard: {payload:?}");
     clipboard.write_snapshot(write_snap)?;

--- a/crates/uc-platform/examples/x11_clipboard_test.rs
+++ b/crates/uc-platform/examples/x11_clipboard_test.rs
@@ -55,6 +55,7 @@ fn main() -> anyhow::Result<()> {
             Some(MimeType("text/plain;charset=utf-8".into())),
             payload.clone().into_bytes(),
         )],
+        file_content_digests: Vec::new(),
     };
     eprintln!("[1/3] writing via X11Clipboard: {payload:?}");
     clipboard.write_snapshot(write_snap)?;

--- a/crates/uc-platform/src/clipboard/common.rs
+++ b/crates/uc-platform/src/clipboard/common.rs
@@ -751,6 +751,7 @@ impl CommonClipboardImpl {
             SystemClipboardSnapshot {
                 ts_ms: chrono::Utc::now().timestamp_millis(),
                 representations: reps,
+                file_content_digests: Vec::new(),
             },
             had_unreadable_format,
         ))
@@ -1028,6 +1029,7 @@ impl CommonClipboardImpl {
             let reduced = SystemClipboardSnapshot {
                 ts_ms,
                 representations: vec![chosen],
+                file_content_digests: Vec::new(),
             };
             return Self::write_snapshot(ctx, reduced);
         }

--- a/crates/uc-platform/src/clipboard/noop.rs
+++ b/crates/uc-platform/src/clipboard/noop.rs
@@ -27,6 +27,7 @@ impl SystemClipboardPort for NoopSystemClipboard {
         Ok(SystemClipboardSnapshot {
             ts_ms: 0,
             representations: Vec::new(),
+            file_content_digests: Vec::new(),
         })
     }
 

--- a/crates/uc-platform/src/clipboard/platform/linux/wayland/protocol/ext.rs
+++ b/crates/uc-platform/src/clipboard/platform/linux/wayland/protocol/ext.rs
@@ -635,6 +635,7 @@ fn empty_snapshot() -> SystemClipboardSnapshot {
     SystemClipboardSnapshot {
         ts_ms: chrono::Utc::now().timestamp_millis(),
         representations: Vec::new(),
+        file_content_digests: Vec::new(),
     }
 }
 

--- a/crates/uc-platform/src/clipboard/platform/linux/wayland/protocol/wlr.rs
+++ b/crates/uc-platform/src/clipboard/platform/linux/wayland/protocol/wlr.rs
@@ -647,6 +647,7 @@ fn empty_snapshot() -> SystemClipboardSnapshot {
     SystemClipboardSnapshot {
         ts_ms: chrono::Utc::now().timestamp_millis(),
         representations: Vec::new(),
+        file_content_digests: Vec::new(),
     }
 }
 

--- a/crates/uc-platform/src/clipboard/platform/linux/wayland/snapshot.rs
+++ b/crates/uc-platform/src/clipboard/platform/linux/wayland/snapshot.rs
@@ -109,5 +109,6 @@ pub(super) fn build_from_offer<O: OfferLike>(
     Ok(SystemClipboardSnapshot {
         ts_ms: chrono::Utc::now().timestamp_millis(),
         representations: reps,
+        file_content_digests: Vec::new(),
     })
 }

--- a/crates/uc-platform/src/clipboard/platform/linux/x11/reader.rs
+++ b/crates/uc-platform/src/clipboard/platform/linux/x11/reader.rs
@@ -188,6 +188,7 @@ pub(super) fn read_snapshot(
     Ok(SystemClipboardSnapshot {
         ts_ms: chrono::Utc::now().timestamp_millis(),
         representations: reps,
+        file_content_digests: Vec::new(),
     })
 }
 
@@ -195,6 +196,7 @@ fn empty_snapshot() -> SystemClipboardSnapshot {
     SystemClipboardSnapshot {
         ts_ms: chrono::Utc::now().timestamp_millis(),
         representations: Vec::new(),
+        file_content_digests: Vec::new(),
     }
 }
 

--- a/crates/uc-platform/src/clipboard/watcher.rs
+++ b/crates/uc-platform/src/clipboard/watcher.rs
@@ -364,6 +364,7 @@ mod tests {
             Ok(SystemClipboardSnapshot {
                 ts_ms: 0,
                 representations: vec![],
+                file_content_digests: Vec::new(),
             })
         }
         fn write_snapshot(&self, _snapshot: SystemClipboardSnapshot) -> anyhow::Result<()> {
@@ -390,6 +391,7 @@ mod tests {
         SystemClipboardSnapshot {
             ts_ms: 0,
             representations: vec![rep],
+            file_content_digests: Vec::new(),
         }
     }
 
@@ -418,6 +420,7 @@ mod tests {
         SystemClipboardSnapshot {
             ts_ms: 0,
             representations: vec![primary, secondary],
+            file_content_digests: Vec::new(),
         }
     }
 
@@ -433,6 +436,7 @@ mod tests {
         SystemClipboardSnapshot {
             ts_ms: 0,
             representations: vec![rep],
+            file_content_digests: Vec::new(),
         }
     }
 
@@ -472,6 +476,7 @@ mod tests {
         SystemClipboardSnapshot {
             ts_ms: 0,
             representations: vec![rep],
+            file_content_digests: Vec::new(),
         }
     }
 

--- a/crates/uc-webserver/src/api/clipboard.rs
+++ b/crates/uc-webserver/src/api/clipboard.rs
@@ -357,6 +357,7 @@ async fn dispatch_text(
             Some(MimeType("text/plain".to_string())),
             req.text.into_bytes(),
         )],
+        file_content_digests: Vec::new(),
     };
 
     let outcome = app


### PR DESCRIPTION
🤖 This PR was authored with AI assistance (Claude Code).

## Summary

- **Root cause fix**: `snapshot_hash` included device-local file paths from `text/uri-list` representations, causing sender/receiver hash mismatch → active-clipboard-state convergence failure → infinite pull retry loop with repeated "receive failed" entries
- **P1-A**: Lifecycle methods (seed/start/complete/fail) retry once with 500ms backoff to tolerate transient SQLite lock contention that caused UI cards to freeze at "Transferring"
- **P1-B**: Materializer treats non-cancel blob fetch errors as partial entries (stored with missing indicators) instead of dropping the entry entirely

## Root Cause

When a file was synced, the receiver's `snapshot_hash()` computed `blake3("file:///receiver/local/path")` while the sender computed `blake3("file:///sender/local/path")`. The active-clipboard-state path then failed to find the entry by hash → triggered unnecessary re-pull → `TryReference` export already moved the blob data → `Error::Io` → infinite retry loop.

## Fix

Added `file_content_digests: Vec<[u8; 32]>` to `SystemClipboardSnapshot`. When populated, `snapshot_hash()` uses these blake3 digests of actual file content bytes (device-independent) instead of hashing the URI path text (device-specific). Digests flow from:
- Sender: `PlaintextHash` returned by blob publish
- Receiver: `PlaintextHash` returned by blob fetch  
- Local capture: `content_hash()` of `LocalFile` representations

## Test plan

- [x] `cargo check --workspace` — zero errors
- [x] `cargo test -p uc-core --lib` — 130 passed
- [x] `cargo test -p uc-application --lib` — 663 passed
- [x] `cargo test -p uc-platform --lib` — 78 passed (1 pre-existing skip)
- [ ] Manual: send file from peer → verify no duplicate pull entries
- [ ] Verify active-state convergence completes (register advances)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of file blob transfers by retrying blob fetches once after transient failures.

* **Improvements**
  * Enhanced clipboard snapshot hashing to incorporate file content digests (when available) instead of relying on device-specific file-list details, improving consistent synchronization and deterministic snapshot identity across devices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->