### PR TITLE
refactor(delivery): promote peer-offline from failure to Unreachable status

### DIFF
--- a/crates/uc-application/src/usecases/clipboard_sync/dispatch_entry/delivery.rs
+++ b/crates/uc-application/src/usecases/clipboard_sync/dispatch_entry/delivery.rs
@@ -96,13 +96,11 @@ pub(crate) fn classify_dispatch_result(
             }
         }
         Ok((device_id, Err(ClipboardDispatchError::Offline))) => {
-            debug!(device_id = %device_id.as_str(), "dispatch → Offline");
+            debug!(device_id = %device_id.as_str(), "dispatch → Offline (unreachable)");
             let delivery_record = entry_id.map(|eid| EntryDeliveryRecord {
                 entry_id: eid.clone(),
                 target_device_id: device_id.clone(),
-                status: EntryDeliveryStatus::Failed {
-                    reason: DeliveryFailureReason::Offline,
-                },
+                status: EntryDeliveryStatus::Unreachable,
                 reason_detail: None,
                 updated_at_ms: now_ms,
             });
@@ -118,8 +116,11 @@ pub(crate) fn classify_dispatch_result(
         Ok((device_id, Err(err))) => {
             warn!(device_id = %device_id.as_str(), error = %err, "dispatch failed");
             let (failure_reason, reason_detail) = match &err {
-                // Offline is handled in the previous arm; kept for exhaustiveness.
-                ClipboardDispatchError::Offline => (DeliveryFailureReason::Offline, None),
+                // Offline is handled in the previous arm (Unreachable); this
+                // arm only fires for the non-Offline error variants.
+                ClipboardDispatchError::Offline => {
+                    unreachable!("Offline is matched in the dedicated arm above")
+                }
                 ClipboardDispatchError::LocalPolicyExceeded(s) => {
                     (DeliveryFailureReason::LocalPolicy, Some(s.clone()))
                 }
@@ -296,16 +297,14 @@ mod tests {
     }
 
     #[test]
-    fn offline_maps_to_failed_offline_and_offline_bucket() {
+    fn offline_maps_to_unreachable_record_and_offline_bucket() {
         let joined = Ok((dev("peer-a"), Err(ClipboardDispatchError::Offline)));
         let p = classify_dispatch_result(joined, Some(&eid()), 1);
         assert!(matches!(p.bucket, DispatchResultBucket::Offline));
         assert!(matches!(p.per_target.unwrap().outcome, Err(ref s) if s == "offline"));
         assert!(matches!(
             p.delivery_record.unwrap().status,
-            EntryDeliveryStatus::Failed {
-                reason: DeliveryFailureReason::Offline
-            }
+            EntryDeliveryStatus::Unreachable,
         ));
     }
 

--- a/crates/uc-application/src/usecases/clipboard_sync/dispatch_entry/mod.rs
+++ b/crates/uc-application/src/usecases/clipboard_sync/dispatch_entry/mod.rs
@@ -2028,13 +2028,11 @@ mod tests {
 
         assert!(matches!(
             by_target["peer-off"].status,
-            EntryDeliveryStatus::Failed {
-                reason: DeliveryFailureReason::Offline
-            }
+            EntryDeliveryStatus::Unreachable,
         ));
         assert!(
             by_target["peer-off"].reason_detail.is_none(),
-            "Offline 无人类可读补充"
+            "Unreachable 无人类可读补充"
         );
 
         assert!(matches!(

--- a/crates/uc-application/src/usecases/clipboard_sync/get_entry_delivery_view.rs
+++ b/crates/uc-application/src/usecases/clipboard_sync/get_entry_delivery_view.rs
@@ -65,7 +65,12 @@ pub enum EntryDeliveryStatusView {
     Pending,
     Delivered,
     Duplicate,
-    Failed { reason: DeliveryFailureReason },
+    /// Peer was unreachable (offline / dial failure). Not a fault — the peer
+    /// is simply not available right now.
+    Unreachable,
+    Failed {
+        reason: DeliveryFailureReason,
+    },
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -280,6 +285,7 @@ fn map_status(status: &DomainDeliveryStatus) -> EntryDeliveryStatusView {
     match status {
         DomainDeliveryStatus::Delivered => EntryDeliveryStatusView::Delivered,
         DomainDeliveryStatus::Duplicate => EntryDeliveryStatusView::Duplicate,
+        DomainDeliveryStatus::Unreachable => EntryDeliveryStatusView::Unreachable,
         DomainDeliveryStatus::Failed { reason } => EntryDeliveryStatusView::Failed {
             reason: reason.clone(),
         },
@@ -555,13 +561,11 @@ mod tests {
             updated_at_ms: at,
         }
     }
-    fn failed_offline(entry: &str, target: DeviceId, at: i64) -> EntryDeliveryRecord {
+    fn unreachable_record(entry: &str, target: DeviceId, at: i64) -> EntryDeliveryRecord {
         EntryDeliveryRecord {
             entry_id: entry_id(entry),
             target_device_id: target,
-            status: DomainDeliveryStatus::Failed {
-                reason: DeliveryFailureReason::Offline,
-            },
+            status: DomainDeliveryStatus::Unreachable,
             reason_detail: None,
             updated_at_ms: at,
         }
@@ -733,7 +737,7 @@ mod tests {
         ]));
         let delivery = Arc::new(FakeDeliveryRepo::new(vec![
             delivered("e1", peer("p1"), 100),
-            failed_offline("e1", peer("p2"), 200),
+            unreachable_record("e1", peer("p2"), 200),
             // p3 不在 delivery 表 → 应合成 Pending
         ]));
         let uc = build_uc(entries, events, trusted, delivery);
@@ -748,12 +752,7 @@ mod tests {
             .collect();
         assert_eq!(by_target["p1"].status, EntryDeliveryStatusView::Delivered);
         assert_eq!(by_target["p1"].updated_at_ms, Some(100));
-        assert!(matches!(
-            by_target["p2"].status,
-            EntryDeliveryStatusView::Failed {
-                reason: DeliveryFailureReason::Offline
-            }
-        ));
+        assert_eq!(by_target["p2"].status, EntryDeliveryStatusView::Unreachable);
         assert_eq!(by_target["p2"].updated_at_ms, Some(200));
         assert_eq!(by_target["p3"].status, EntryDeliveryStatusView::Pending);
         assert_eq!(by_target["p3"].updated_at_ms, None);

--- a/crates/uc-application/src/usecases/clipboard_sync/resend_entry.rs
+++ b/crates/uc-application/src/usecases/clipboard_sync/resend_entry.rs
@@ -1,7 +1,7 @@
 //! ADR-005 Stage 1a · user-initiated resend.
 //!
 //!补齐 desktop 缺失的"重发"能力:用户在 entry detail view 上看到对某 peer
-//! 是 `Failed { Offline }`,主动点重发。本用例**不引入新表、不新增 Port、
+//! 是 `Unreachable`(或 `Failed`),主动点重发。本用例**不引入新表、不新增 Port、
 //! 不自动触发**,候选集合由 [`EntryDeliveryRepositoryPort::list_by_entry`]
 //! 与 [`TrustedPeerRepositoryPort::list`] 在本调用内派生(差集),与 ADR
 //! §3.3 铁律 6 一致。
@@ -942,13 +942,11 @@ mod tests {
         }
     }
 
-    fn failed_offline_record(entry: &EntryId, target: &str, ms: i64) -> EntryDeliveryRecord {
+    fn unreachable_record(entry: &EntryId, target: &str, ms: i64) -> EntryDeliveryRecord {
         EntryDeliveryRecord {
             entry_id: entry.clone(),
             target_device_id: DeviceId::new(target),
-            status: EntryDeliveryStatus::Failed {
-                reason: uc_core::clipboard::DeliveryFailureReason::Offline,
-            },
+            status: EntryDeliveryStatus::Unreachable,
             reason_detail: None,
             updated_at_ms: ms,
         }
@@ -1113,7 +1111,7 @@ mod tests {
     }
 
     /// V5 — `target_filter = None`,3 个 trusted peer:peer-a Delivered、
-    /// peer-b Failed{Offline}、peer-c 从未尝试。差集 = {peer-b, peer-c}。
+    /// peer-b Unreachable、peer-c 从未尝试。差集 = {peer-b, peer-c}。
     /// dispatch 必须收到 `target_filter = Some([peer-b, peer-c])`(顺序与
     /// trusted_peer.list 一致),entry_id = Some。
     #[tokio::test]
@@ -1126,7 +1124,7 @@ mod tests {
         let (uc, entry_id) = build_uc(
             vec![
                 delivered_record(&entry, "peer-a", 50),
-                failed_offline_record(&entry, "peer-b", 60),
+                unreachable_record(&entry, "peer-b", 60),
             ],
             vec![
                 trusted(&local, "peer-a", 1),
@@ -1223,12 +1221,8 @@ mod tests {
             Ok(outcome)
         }));
         let (uc, entry_id) = build_uc(
-            // 既有一条 Failed{Offline} → 在 diff set 内,resend 会再发。
-            vec![failed_offline_record(
-                &EntryId::from("entry-1"),
-                "peer-b",
-                100,
-            )],
+            // 既有一条 Unreachable → 在 diff set 内,resend 会再发。
+            vec![unreachable_record(&EntryId::from("entry-1"), "peer-b", 100)],
             vec![trusted(&local, "peer-a", 1), trusted(&local, "peer-b", 2)],
             runner.clone(),
         );

--- a/crates/uc-core/src/clipboard/delivery.rs
+++ b/crates/uc-core/src/clipboard/delivery.rs
@@ -15,14 +15,19 @@ use crate::ids::{DeviceId, EntryId};
 /// 一条 entry 对单个对端的最新投递结果。
 ///
 /// `Delivered` / `Duplicate` 对用户视角都属于"对端已经持有这条内容",
-/// 但保留区分以便排障 / 后续策略需要。`Failed` 携带细分原因,文案与
-/// 决策都基于 `DeliveryFailureReason`。
+/// 但保留区分以便排障 / 后续策略需要。`Unreachable` 表示对端不可达
+/// (离线或拨号失败)——这不是故障,只是时机不对,后续上线时可自然
+/// 恢复;`Failed` 携带细分原因,代表需要关注或干预的真正失败。
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum EntryDeliveryStatus {
     /// 对端节点接收了 bytes(adapter 层 ack)。
     Delivered,
     /// 对端节点报告"已存在",通常因为对端从另一路径已收到同一内容。
     Duplicate,
+    /// 对端节点不可达(没有可用地址或拨号失败)。不属于故障——对端
+    /// 当前离线,下次上线时可重试送达。与 `Failed` 的区别:
+    /// `Unreachable` 是预期的临时状态,`Failed` 是需要关注的异常。
+    Unreachable,
     /// 投递失败,`reason` 给出失败类别。
     Failed { reason: DeliveryFailureReason },
 }
@@ -30,10 +35,11 @@ pub enum EntryDeliveryStatus {
 /// 失败原因的领域分类。每个变体对应 wire 层一类可识别的失败信号,
 /// 用于驱动 UI 文案与可能的恢复策略。变体集合与 wire 失败类型保持
 /// 1:1 对应,新增 wire 失败类型时同步扩展。
+///
+/// 注意:`Offline`(对端不可达)不在此枚举中——它已提升为独立的
+/// `EntryDeliveryStatus::Unreachable`,不属于"失败"语义。
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DeliveryFailureReason {
-    /// 对端节点不可达(没有可用地址或拨号失败)。
-    Offline,
     /// 本地策略在 wire 前拒绝(例如 payload 超过本地限制)。
     LocalPolicy,
     /// 对端在 wire 层显式拒绝(协议版本不兼容、header 不合法等)。

--- a/crates/uc-daemon-contract/src/api/dto/clipboard_delivery.rs
+++ b/crates/uc-daemon-contract/src/api/dto/clipboard_delivery.rs
@@ -62,14 +62,21 @@ pub enum EntryDeliveryStatusDto {
     Pending,
     Delivered,
     Duplicate,
-    Failed { reason: DeliveryFailureReasonDto },
+    /// Peer was unreachable (offline or dial failure). Not a fault — the peer
+    /// is simply not online right now.
+    Unreachable,
+    Failed {
+        reason: DeliveryFailureReasonDto,
+    },
 }
 
 /// Failure reason. i18n key convention: `delivery.failureReason.<variant>`.
+///
+/// Note: "peer offline" is NOT in this enum — it is represented as
+/// `EntryDeliveryStatusDto::Unreachable` (a separate status, not a failure).
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub enum DeliveryFailureReasonDto {
-    Offline,
     LocalPolicy,
     PeerRejected,
     Io,

--- a/crates/uc-infra/src/db/repositories/entry_delivery_repo.rs
+++ b/crates/uc-infra/src/db/repositories/entry_delivery_repo.rs
@@ -236,6 +236,20 @@ mod tests {
         }
     }
 
+    #[test]
+    fn decode_legacy_failed_offline_as_unreachable() {
+        let status = status_codec::decode("failed_offline").unwrap();
+        assert!(matches!(status, EntryDeliveryStatus::Unreachable));
+    }
+
+    #[test]
+    fn decode_new_unreachable_round_trips() {
+        let encoded = status_codec::encode(&EntryDeliveryStatus::Unreachable);
+        assert_eq!(encoded, "unreachable");
+        let decoded = status_codec::decode(encoded).unwrap();
+        assert!(matches!(decoded, EntryDeliveryStatus::Unreachable));
+    }
+
     #[tokio::test]
     async fn record_attempt_inserts_new_row() {
         let (repo, seed_exec, _tempdir) = make_repo();

--- a/crates/uc-infra/src/db/repositories/entry_delivery_repo.rs
+++ b/crates/uc-infra/src/db/repositories/entry_delivery_repo.rs
@@ -36,7 +36,10 @@ mod status_codec {
 
     pub const DELIVERED: &str = "delivered";
     pub const DUPLICATE: &str = "duplicate";
-    pub const FAILED_OFFLINE: &str = "failed_offline";
+    pub const UNREACHABLE: &str = "unreachable";
+    // Legacy alias: rows written before the Unreachable promotion decode as
+    // Unreachable for seamless migration without a schema rewrite.
+    const LEGACY_FAILED_OFFLINE: &str = "failed_offline";
     pub const FAILED_LOCAL_POLICY: &str = "failed_local_policy";
     pub const FAILED_PEER_REJECTED: &str = "failed_peer_rejected";
     pub const FAILED_IO: &str = "failed_io";
@@ -46,8 +49,8 @@ mod status_codec {
         match status {
             EntryDeliveryStatus::Delivered => DELIVERED,
             EntryDeliveryStatus::Duplicate => DUPLICATE,
+            EntryDeliveryStatus::Unreachable => UNREACHABLE,
             EntryDeliveryStatus::Failed { reason } => match reason {
-                DeliveryFailureReason::Offline => FAILED_OFFLINE,
                 DeliveryFailureReason::LocalPolicy => FAILED_LOCAL_POLICY,
                 DeliveryFailureReason::PeerRejected => FAILED_PEER_REJECTED,
                 DeliveryFailureReason::Io => FAILED_IO,
@@ -60,9 +63,7 @@ mod status_codec {
         match raw {
             DELIVERED => Ok(EntryDeliveryStatus::Delivered),
             DUPLICATE => Ok(EntryDeliveryStatus::Duplicate),
-            FAILED_OFFLINE => Ok(EntryDeliveryStatus::Failed {
-                reason: DeliveryFailureReason::Offline,
-            }),
+            UNREACHABLE | LEGACY_FAILED_OFFLINE => Ok(EntryDeliveryStatus::Unreachable),
             FAILED_LOCAL_POLICY => Ok(EntryDeliveryStatus::Failed {
                 reason: DeliveryFailureReason::LocalPolicy,
             }),
@@ -267,21 +268,14 @@ mod tests {
         repo.record_attempt(&make_record(
             "entry-1",
             "peer-A",
-            EntryDeliveryStatus::Failed {
-                reason: DeliveryFailureReason::Offline,
-            },
+            EntryDeliveryStatus::Unreachable,
         ))
         .await
         .unwrap();
 
         let listed = repo.list_by_entry(&EntryId::from("entry-1")).await.unwrap();
         assert_eq!(listed.len(), 1, "upsert 不应增加行数");
-        assert!(matches!(
-            listed[0].status,
-            EntryDeliveryStatus::Failed {
-                reason: DeliveryFailureReason::Offline
-            }
-        ));
+        assert!(matches!(listed[0].status, EntryDeliveryStatus::Unreachable));
     }
 
     #[tokio::test]

--- a/crates/uc-webserver/src/api/projection/clipboard.rs
+++ b/crates/uc-webserver/src/api/projection/clipboard.rs
@@ -143,6 +143,7 @@ impl IntoApiDto<EntryDeliveryStatusDto> for EntryDeliveryStatusView {
             EntryDeliveryStatusView::Pending => EntryDeliveryStatusDto::Pending,
             EntryDeliveryStatusView::Delivered => EntryDeliveryStatusDto::Delivered,
             EntryDeliveryStatusView::Duplicate => EntryDeliveryStatusDto::Duplicate,
+            EntryDeliveryStatusView::Unreachable => EntryDeliveryStatusDto::Unreachable,
             EntryDeliveryStatusView::Failed { reason } => EntryDeliveryStatusDto::Failed {
                 reason: reason.into_api_dto(),
             },
@@ -153,7 +154,6 @@ impl IntoApiDto<EntryDeliveryStatusDto> for EntryDeliveryStatusView {
 impl IntoApiDto<DeliveryFailureReasonDto> for DeliveryFailureReason {
     fn into_api_dto(self) -> DeliveryFailureReasonDto {
         match self {
-            DeliveryFailureReason::Offline => DeliveryFailureReasonDto::Offline,
             DeliveryFailureReason::LocalPolicy => DeliveryFailureReasonDto::LocalPolicy,
             DeliveryFailureReason::PeerRejected => DeliveryFailureReasonDto::PeerRejected,
             DeliveryFailureReason::Io => DeliveryFailureReasonDto::Io,

--- a/schema/openapi.json
+++ b/schema/openapi.json
@@ -581,9 +581,8 @@
         "type": "object"
       },
       "DeliveryFailureReasonDto": {
-        "description": "Failure reason. i18n key convention: `delivery.failureReason.<variant>`.",
+        "description": "Failure reason. i18n key convention: `delivery.failureReason.<variant>`.\n\nNote: \"peer offline\" is NOT in this enum — it is represented as\n`EntryDeliveryStatusDto::Unreachable` (a separate status, not a failure).",
         "enum": [
-          "offline",
           "localPolicy",
           "peerRejected",
           "io",
@@ -777,6 +776,20 @@
               "tag": {
                 "enum": [
                   "duplicate"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "tag"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "tag": {
+                "enum": [
+                  "unreachable"
                 ],
                 "type": "string"
               }

--- a/src/api/generated/types.gen.ts
+++ b/src/api/generated/types.gen.ts
@@ -376,6 +376,9 @@ export type DebugStatusEnvelope = {
 
 /**
  * Failure reason. i18n key convention: `delivery.failureReason.<variant>`.
+ *
+ * Note: "peer offline" is NOT in this enum — it is represented as
+ * `EntryDeliveryStatusDto::Unreachable` (a separate status, not a failure).
  */
 export type DeliveryFailureReasonDto = 'localPolicy' | 'peerRejected' | 'io' | 'internal';
 

--- a/src/api/generated/types.gen.ts
+++ b/src/api/generated/types.gen.ts
@@ -377,7 +377,7 @@ export type DebugStatusEnvelope = {
 /**
  * Failure reason. i18n key convention: `delivery.failureReason.<variant>`.
  */
-export type DeliveryFailureReasonDto = 'offline' | 'localPolicy' | 'peerRejected' | 'io' | 'internal';
+export type DeliveryFailureReasonDto = 'localPolicy' | 'peerRejected' | 'io' | 'internal';
 
 /**
  * Canonical success envelope: `{ "data": T, "ts": <unix millis i64> }`.
@@ -503,6 +503,8 @@ export type EntryDeliveryStatusDto = {
     tag: 'delivered';
 } | {
     tag: 'duplicate';
+} | {
+    tag: 'unreachable';
 } | {
     reason: DeliveryFailureReasonDto;
     tag: 'failed';

--- a/src/api/tauri-command/clipboard_delivery.ts
+++ b/src/api/tauri-command/clipboard_delivery.ts
@@ -38,13 +38,14 @@ export type EntrySourceView =
   | { tag: 'historical' }
 
 /** 失败原因细分,与 i18n key `delivery.failureReason.<variant>` 对应。 */
-export type DeliveryFailureReason = 'offline' | 'localPolicy' | 'peerRejected' | 'io' | 'internal'
+export type DeliveryFailureReason = 'localPolicy' | 'peerRejected' | 'io' | 'internal'
 
 /** 单条投递状态。`Pending` 来自视图层合成 (trusted_peer ∖ 已尝试)。 */
 export type EntryDeliveryStatusView =
   | { tag: 'pending' }
   | { tag: 'delivered' }
   | { tag: 'duplicate' }
+  | { tag: 'unreachable' }
   | { tag: 'failed'; reason: DeliveryFailureReason }
 
 /** 单个对端的当前同步状态。 */

--- a/src/components/clipboard/EntryDeliveryBadge.tsx
+++ b/src/components/clipboard/EntryDeliveryBadge.tsx
@@ -44,10 +44,9 @@ interface EntryDeliveryBadgeProps {
   delivery: EntryDeliveryView | null
 }
 
-type SyncSummary = 'synced' | 'syncing' | 'partial' | 'failed' | 'pending'
+type SyncSummary = 'synced' | 'syncing' | 'partial' | 'failed' | 'waiting' | 'pending'
 
 const FAILURE_REASON_KEYS: Record<DeliveryFailureReason, string> = {
-  offline: 'delivery.failureReason.offline',
   localPolicy: 'delivery.failureReason.localPolicy',
   peerRejected: 'delivery.failureReason.peerRejected',
   io: 'delivery.failureReason.io',
@@ -69,6 +68,7 @@ function summarize(targets: readonly EntryDeliveryTargetView[]): SyncSummary | n
   if (targets.length === 0) return null
   let delivered = 0
   let failed = 0
+  let unreachable = 0
   let pending = 0
   for (const t of targets) {
     switch (t.status.tag) {
@@ -79,15 +79,21 @@ function summarize(targets: readonly EntryDeliveryTargetView[]): SyncSummary | n
       case 'failed':
         failed += 1
         break
+      case 'unreachable':
+        unreachable += 1
+        break
       case 'pending':
         pending += 1
         break
     }
   }
+  if (delivered === targets.length) return 'synced'
   if (failed === targets.length) return 'failed'
   if (failed > 0) return 'partial'
-  if (delivered === targets.length) return 'synced'
+  if (unreachable > 0 && delivered > 0) return 'partial'
+  if (unreachable === targets.length) return 'waiting'
   if (delivered > 0 && pending > 0) return 'syncing'
+  if (unreachable > 0) return 'waiting'
   return 'pending'
 }
 
@@ -227,6 +233,13 @@ const SyncBadge: React.FC<SyncBadgeProps> = ({
           tone: 'text-destructive',
           spin: false,
         }
+      case 'waiting':
+        return {
+          Icon: CircleDashed,
+          label: t('delivery.summary.waiting'),
+          tone: 'text-muted-foreground/70',
+          spin: false,
+        }
       case 'pending':
         return {
           Icon: CircleDashed,
@@ -310,7 +323,10 @@ const DeliveryRow: React.FC<DeliveryRowProps> = ({ target, resendable, entryId, 
   // 行级 resend 只在该 peer 处于 failed / pending 时出现 ——
   // delivered / duplicate 重试无意义,既不画按钮也不响应 action。
   const canResendThis =
-    resendable && (target.status.tag === 'failed' || target.status.tag === 'pending')
+    resendable &&
+    (target.status.tag === 'failed' ||
+      target.status.tag === 'unreachable' ||
+      target.status.tag === 'pending')
 
   return (
     <li
@@ -435,6 +451,8 @@ const StatusIcon: React.FC<{ status: EntryDeliveryStatusView }> = ({ status }) =
       return <Check className="size-3" />
     case 'pending':
       return <CircleDashed className="size-3" />
+    case 'unreachable':
+      return <CircleDashed className="size-3" />
     case 'failed':
       return <X className="size-3" />
   }
@@ -451,6 +469,8 @@ function getStatusLabel(
       return t('delivery.status.duplicate')
     case 'pending':
       return t('delivery.status.pending')
+    case 'unreachable':
+      return t('delivery.status.unreachable')
     case 'failed':
       return t('delivery.status.failedWithReason', {
         reason: t(FAILURE_REASON_KEYS[status.reason]),
@@ -470,6 +490,8 @@ function renderStatusTone(status: EntryDeliveryStatusView): StatusTone {
     case 'duplicate':
       return { icon: 'text-emerald-500/70', label: 'text-muted-foreground' }
     case 'pending':
+      return { icon: 'text-muted-foreground/60', label: 'text-muted-foreground' }
+    case 'unreachable':
       return { icon: 'text-muted-foreground/60', label: 'text-muted-foreground' }
     case 'failed':
       return { icon: 'text-destructive', label: 'text-destructive' }

--- a/src/components/clipboard/EntryDeliveryBadge.tsx
+++ b/src/components/clipboard/EntryDeliveryBadge.tsx
@@ -320,7 +320,7 @@ interface DeliveryRowProps {
 const DeliveryRow: React.FC<DeliveryRowProps> = ({ target, resendable, entryId, action }) => {
   const { t } = useTranslation()
   const tone = renderStatusTone(target.status)
-  // 行级 resend 只在该 peer 处于 failed / pending 时出现 ——
+  // 行级 resend 只在该 peer 处于 failed / unreachable / pending 时出现 ——
   // delivered / duplicate 重试无意义,既不画按钮也不响应 action。
   const canResendThis =
     resendable &&

--- a/src/components/clipboard/__tests__/EntryDeliveryBadge.test.tsx
+++ b/src/components/clipboard/__tests__/EntryDeliveryBadge.test.tsx
@@ -61,7 +61,7 @@ function mixedDelivery(): EntryDeliveryView {
     deliveries: [
       target('did_a1b2c3d4e5', null, { tag: 'delivered' }),
       target('did_f6g7h8i9j0', null, { tag: 'duplicate' }),
-      target('did_k1l2m3n4o5', null, { tag: 'failed', reason: 'offline' }, 'no route to host'),
+      target('did_k1l2m3n4o5', null, { tag: 'unreachable' }, 'no route to host'),
       target('did_p6q7r8s9t0', null, { tag: 'pending' }),
     ],
   }
@@ -145,6 +145,7 @@ describe('EntryDeliveryBadge', () => {
   it.each<[Exclude<EntryDeliveryView['deliveries'][number]['status']['tag'], 'failed'>, string]>([
     ['delivered', 'synced'],
     ['duplicate', 'synced'],
+    ['unreachable', 'waiting'],
     ['pending', 'pending'],
   ])('summarizes single %s peer as %s', (statusTag, summary) => {
     const delivery: EntryDeliveryView = {
@@ -167,8 +168,8 @@ describe('EntryDeliveryBadge', () => {
       entryId: 'entry-failed-all',
       source: { tag: 'local' },
       deliveries: [
-        target('did_a', null, { tag: 'failed', reason: 'offline' }),
-        target('did_b', null, { tag: 'failed', reason: 'io' }),
+        target('did_a', null, { tag: 'failed', reason: 'io' }),
+        target('did_b', null, { tag: 'failed', reason: 'internal' }),
       ],
     }
     render(<EntryDeliveryBadge delivery={delivery} />)
@@ -176,6 +177,22 @@ describe('EntryDeliveryBadge', () => {
     const trigger = screen.getByRole('button', { name: i18n.t('delivery.popover.ariaTrigger') })
     expect(trigger).toHaveAttribute('data-summary', 'failed')
     expect(trigger).toHaveTextContent(i18n.t('delivery.summary.failed'))
+  })
+
+  it('summarizes all-unreachable peers as waiting', () => {
+    const delivery: EntryDeliveryView = {
+      entryId: 'entry-waiting-all',
+      source: { tag: 'local' },
+      deliveries: [
+        target('did_a', null, { tag: 'unreachable' }),
+        target('did_b', null, { tag: 'unreachable' }),
+      ],
+    }
+    render(<EntryDeliveryBadge delivery={delivery} />)
+
+    const trigger = screen.getByRole('button', { name: i18n.t('delivery.popover.ariaTrigger') })
+    expect(trigger).toHaveAttribute('data-summary', 'waiting')
+    expect(trigger).toHaveTextContent(i18n.t('delivery.summary.waiting'))
   })
 
   it('summarizes delivered + pending as syncing', () => {
@@ -206,13 +223,7 @@ describe('EntryDeliveryBadge', () => {
     expect(screen.getByText(i18n.t('delivery.status.delivered'))).toBeInTheDocument()
     expect(screen.getByText(i18n.t('delivery.status.duplicate'))).toBeInTheDocument()
     expect(screen.getByText(i18n.t('delivery.status.pending'))).toBeInTheDocument()
-    expect(
-      screen.getByText(
-        i18n.t('delivery.status.failedWithReason', {
-          reason: i18n.t('delivery.failureReason.offline'),
-        })
-      )
-    ).toBeInTheDocument()
+    expect(screen.getByText(i18n.t('delivery.status.unreachable'))).toBeInTheDocument()
 
     // 截断后的 device id 渲染
     expect(screen.getByText('did_a1b2…')).toBeInTheDocument()
@@ -249,7 +260,7 @@ describe('EntryDeliveryBadge', () => {
         source: { tag: 'local' },
         deliveries: [
           target('did_ok_aaaaaa', 'Mac', { tag: 'delivered' }),
-          target('did_failed_bbbb', 'iPad', { tag: 'failed', reason: 'offline' }, 'unreachable'),
+          target('did_failed_bbbb', 'iPad', { tag: 'unreachable' }, 'unreachable'),
         ],
       }
     }
@@ -274,7 +285,7 @@ describe('EntryDeliveryBadge', () => {
       const delivery: EntryDeliveryView = {
         entryId: 'entry-from-other',
         source: { tag: 'remote', deviceId: 'did_other_xyz', deviceName: 'Other' },
-        deliveries: [target('did_local_self', 'Self', { tag: 'failed', reason: 'offline' })],
+        deliveries: [target('did_local_self', 'Self', { tag: 'unreachable' })],
       }
       render(<EntryDeliveryBadge delivery={delivery} />)
 
@@ -316,7 +327,7 @@ describe('EntryDeliveryBadge', () => {
       expect(button).toBeDisabled()
     })
 
-    it('renders per-peer Resend only for failed/pending peers', async () => {
+    it('renders per-peer Resend only for failed/unreachable/pending peers', async () => {
       const user = userEvent.setup()
       render(<EntryDeliveryBadge delivery={deliveryWithFailingPeer()} />)
 
@@ -325,7 +336,7 @@ describe('EntryDeliveryBadge', () => {
       })
       await user.hover(trigger)
 
-      // Failed peer 有按钮
+      // Unreachable peer 有按钮
       expect(
         await screen.findByRole('button', {
           name: i18n.t('delivery.resend.button.peerAria', { device: 'iPad' }),
@@ -439,10 +450,9 @@ describe('EntryDeliveryBadge', () => {
     })
   })
 
-  it('maps all five failure reasons to their i18n labels in popover', async () => {
+  it('maps all four failure reasons to their i18n labels in popover', async () => {
     const user = userEvent.setup()
     const reasons: ReadonlyArray<DeliveryFailureReason> = [
-      'offline',
       'localPolicy',
       'peerRejected',
       'io',

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -1473,6 +1473,7 @@
       "delivered": "delivered",
       "duplicate": "delivered (duplicate)",
       "pending": "not attempted",
+      "unreachable": "peer offline",
       "failedWithReason": "failed · {{reason}}"
     },
     "summary": {
@@ -1480,6 +1481,7 @@
       "partial": "Partially synced",
       "syncing": "Syncing",
       "failed": "Sync failed",
+      "waiting": "Peer offline",
       "pending": "Awaiting sync"
     },
     "popover": {
@@ -1487,7 +1489,6 @@
       "ariaTrigger": "View per-device sync details"
     },
     "failureReason": {
-      "offline": "peer offline",
       "localPolicy": "blocked by local policy",
       "peerRejected": "peer rejected",
       "io": "network error",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -1464,6 +1464,7 @@
       "delivered": "已接收",
       "duplicate": "已接收(去重)",
       "pending": "未尝试",
+      "unreachable": "对端离线",
       "failedWithReason": "失败 · {{reason}}"
     },
     "summary": {
@@ -1471,6 +1472,7 @@
       "partial": "部分同步",
       "syncing": "同步中",
       "failed": "同步失败",
+      "waiting": "对端离线",
       "pending": "等待同步"
     },
     "popover": {
@@ -1478,7 +1480,6 @@
       "ariaTrigger": "查看每台设备的同步详情"
     },
     "failureReason": {
-      "offline": "对端离线",
       "localPolicy": "本地策略阻断",
       "peerRejected": "对端拒收",
       "io": "网络错误",


### PR DESCRIPTION
## Summary

- Introduce `EntryDeliveryStatus::Unreachable` as a first-class delivery status, replacing the previous `Failed { reason: Offline }` classification
- Peer offline is NOT a sync failure — it's a temporary, expected state meaning "peer is simply not online right now"
- Frontend now shows neutral grey "peer offline" / "对端离线" instead of alarming red "sync failed" indicators

## Motivation

Users were seeing red error badges whenever a paired device was turned off or sleeping. This was misleading — "peer offline" is a normal, expected condition, not a fault requiring attention. The status model was too binary (success vs failure) and needed a middle ground.

## Changes

| Layer | Change |
|-------|--------|
| **uc-core** | New `EntryDeliveryStatus::Unreachable` variant; removed `DeliveryFailureReason::Offline` |
| **uc-infra** | New `"unreachable"` DB codec; legacy `"failed_offline"` rows decode as `Unreachable` (no migration) |
| **uc-daemon-contract** | `EntryDeliveryStatusDto::Unreachable`; removed `DeliveryFailureReasonDto::Offline` |
| **uc-webserver** | Projection mapping updated |
| **uc-application** | `classify_dispatch_result` maps `Offline` → `Unreachable`; view layer adds `Unreachable` variant |
| **Frontend** | New `'unreachable'` status tag + `'waiting'` summary tier with neutral grey styling; resend button enabled for unreachable peers |
| **i18n** | en-US / zh-CN labels for new status and summary |
| **OpenAPI + client** | Regenerated to reflect DTO changes |

## Test plan

- [x] 440+ Rust lib tests pass (`cargo test -p uc-core -p uc-application -p uc-infra -p uc-webserver --lib`)
- [x] 644 frontend tests pass (`bun run test -- --run`)
- [x] `cargo check` workspace clean
- [x] `bun run build` (tsc + vite) clean
- [x] OpenAPI schema + generated client regenerated and drift-free
- [ ] Verify badge renders grey "对端离线" instead of red "同步失败" with a real offline peer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a new delivery state for peers that are offline/unreachable, and updated resend behavior to treat it as eligible.
* **UI/UX Improvements**
  * Updated delivery badges, popovers, and resend controls to show “unreachable” (including dashed-circle styling) and a new overall “waiting” summary when applicable.
* **API & Data Compatibility**
  * Updated backend persistence, DTOs, and the OpenAPI schema to represent “peer offline” as `unreachable` (removing the prior offline failure reason).
* **Localization**
  * Refreshed English and Chinese delivery/sync status strings for the new `unreachable`/`waiting` semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->