### PR TITLE
fix(clipboard-sync): unify snapshot reconstruction to eliminate duplicate file entries

### DIFF
--- a/apps/daemon/src/daemon/workers/clipboard_watcher.rs
+++ b/apps/daemon/src/daemon/workers/clipboard_watcher.rs
@@ -274,45 +274,64 @@ impl ClipboardChangeHandler for DaemonClipboardChangeHandler {
                 // guards against a future caller holding another reference.
                 let dispatch_snapshot =
                     Arc::try_unwrap(outbound_snapshot).unwrap_or_else(|shared| (*shared).clone());
-                let clipboard_outbound = Arc::clone(&self.clipboard_outbound);
-                let entry_id_for_outbound = entry_id.to_string();
-                tokio::spawn(
-                    async move {
-                        match clipboard_outbound
-                            .dispatch_capture(ClipboardOutboundInput {
-                                entry_id: entry_id_for_outbound,
-                                snapshot: dispatch_snapshot,
-                                origin,
-                            })
-                            .await
-                        {
-                            Ok(ClipboardOutboundOutcome::Dispatched {
-                                accepted,
-                                duplicate,
-                                offline,
-                                errored,
-                                pending,
-                                blob_ref_count,
-                            }) => info!(
-                                accepted,
-                                duplicate,
-                                offline,
-                                errored,
-                                pending,
-                                blob_ref_count,
-                                "Daemon outbound clipboard sync completed"
-                            ),
-                            Ok(ClipboardOutboundOutcome::Skipped { reason }) => {
-                                debug!(reason, "Daemon outbound clipboard sync skipped");
+
+                // File entries skip dispatch — active_state (LWW register +
+                // pull) is the sole delivery channel for files.  Sending the
+                // same large file through both channels produced duplicate
+                // clipboard entries because serve_pull reconstructs a
+                // snapshot whose hash cannot be guaranteed identical to the
+                // dispatch original (representation ordering, ts_ms, etc.).
+                // Text/image entries keep dispatch for real-time latency.
+                let is_file_entry = dispatch_snapshot.representations.iter().any(|r| {
+                    uc_core::clipboard::is_file_mime_or_format(r.mime.as_ref(), &r.format_id)
+                });
+
+                if !is_file_entry {
+                    let clipboard_outbound = Arc::clone(&self.clipboard_outbound);
+                    let entry_id_for_outbound = entry_id.to_string();
+                    tokio::spawn(
+                        async move {
+                            match clipboard_outbound
+                                .dispatch_capture(ClipboardOutboundInput {
+                                    entry_id: entry_id_for_outbound,
+                                    snapshot: dispatch_snapshot,
+                                    origin,
+                                })
+                                .await
+                            {
+                                Ok(ClipboardOutboundOutcome::Dispatched {
+                                    accepted,
+                                    duplicate,
+                                    offline,
+                                    errored,
+                                    pending,
+                                    blob_ref_count,
+                                }) => info!(
+                                    accepted,
+                                    duplicate,
+                                    offline,
+                                    errored,
+                                    pending,
+                                    blob_ref_count,
+                                    "Daemon outbound clipboard sync completed"
+                                ),
+                                Ok(ClipboardOutboundOutcome::Skipped { reason }) => {
+                                    debug!(reason, "Daemon outbound clipboard sync skipped");
+                                }
+                                Err(e) => warn!(
+                                    error = %e,
+                                    "Daemon outbound clipboard sync failed"
+                                ),
                             }
-                            Err(e) => warn!(
-                                error = %e,
-                                "Daemon outbound clipboard sync failed"
-                            ),
                         }
-                    }
-                    .in_current_span(),
-                );
+                        .in_current_span(),
+                    );
+                } else {
+                    debug!(
+                        entry_id = %entry_id,
+                        "watcher: file entry — skipping dispatch, active_state will deliver"
+                    );
+                }
             }
             Ok(None) => {
                 // Dedup at use-case level (e.g. unsupported representation) — skip silently.

--- a/apps/daemon/src/daemon/workers/clipboard_watcher.rs
+++ b/apps/daemon/src/daemon/workers/clipboard_watcher.rs
@@ -275,63 +275,45 @@ impl ClipboardChangeHandler for DaemonClipboardChangeHandler {
                 let dispatch_snapshot =
                     Arc::try_unwrap(outbound_snapshot).unwrap_or_else(|shared| (*shared).clone());
 
-                // File entries skip dispatch — active_state (LWW register +
-                // pull) is the sole delivery channel for files.  Sending the
-                // same large file through both channels produced duplicate
-                // clipboard entries because serve_pull reconstructs a
-                // snapshot whose hash cannot be guaranteed identical to the
-                // dispatch original (representation ordering, ts_ms, etc.).
-                // Text/image entries keep dispatch for real-time latency.
-                let is_file_entry = dispatch_snapshot.representations.iter().any(|r| {
-                    uc_core::clipboard::is_file_mime_or_format(r.mime.as_ref(), &r.format_id)
-                });
-
-                if !is_file_entry {
-                    let clipboard_outbound = Arc::clone(&self.clipboard_outbound);
-                    let entry_id_for_outbound = entry_id.to_string();
-                    tokio::spawn(
-                        async move {
-                            match clipboard_outbound
-                                .dispatch_capture(ClipboardOutboundInput {
-                                    entry_id: entry_id_for_outbound,
-                                    snapshot: dispatch_snapshot,
-                                    origin,
-                                })
-                                .await
-                            {
-                                Ok(ClipboardOutboundOutcome::Dispatched {
-                                    accepted,
-                                    duplicate,
-                                    offline,
-                                    errored,
-                                    pending,
-                                    blob_ref_count,
-                                }) => info!(
-                                    accepted,
-                                    duplicate,
-                                    offline,
-                                    errored,
-                                    pending,
-                                    blob_ref_count,
-                                    "Daemon outbound clipboard sync completed"
-                                ),
-                                Ok(ClipboardOutboundOutcome::Skipped { reason }) => {
-                                    debug!(reason, "Daemon outbound clipboard sync skipped");
-                                }
-                                Err(e) => warn!(
-                                    error = %e,
-                                    "Daemon outbound clipboard sync failed"
-                                ),
+                let clipboard_outbound = Arc::clone(&self.clipboard_outbound);
+                let entry_id_for_outbound = entry_id.to_string();
+                tokio::spawn(
+                    async move {
+                        match clipboard_outbound
+                            .dispatch_capture(ClipboardOutboundInput {
+                                entry_id: entry_id_for_outbound,
+                                snapshot: dispatch_snapshot,
+                                origin,
+                            })
+                            .await
+                        {
+                            Ok(ClipboardOutboundOutcome::Dispatched {
+                                accepted,
+                                duplicate,
+                                offline,
+                                errored,
+                                pending,
+                                blob_ref_count,
+                            }) => info!(
+                                accepted,
+                                duplicate,
+                                offline,
+                                errored,
+                                pending,
+                                blob_ref_count,
+                                "Daemon outbound clipboard sync completed"
+                            ),
+                            Ok(ClipboardOutboundOutcome::Skipped { reason }) => {
+                                debug!(reason, "Daemon outbound clipboard sync skipped");
                             }
+                            Err(e) => warn!(
+                                error = %e,
+                                "Daemon outbound clipboard sync failed"
+                            ),
                         }
-                        .in_current_span(),
-                    );
-                } else {
-                    debug!(
-                        entry_id = %entry_id,
-                        "watcher: file entry — skipping dispatch, active_state will deliver"
-                    );
-                }
+                    }
+                    .in_current_span(),
+                );
             }
             Ok(None) => {
                 // Dedup at use-case level (e.g. unsupported representation) — skip silently.

--- a/crates/uc-application/src/usecases/clipboard_restore/file_snapshot.rs
+++ b/crates/uc-application/src/usecases/clipboard_restore/file_snapshot.rs
@@ -7,6 +7,7 @@ use uc_core::clipboard::{MimeType, ObservedClipboardRepresentation, SystemClipbo
 use uc_core::ids::{FormatId, RepresentationId};
 
 /// Build a newline-separated `text/uri-list`.
+#[allow(dead_code)]
 pub(crate) fn build_path_list(file_paths: &[PathBuf]) -> String {
     file_paths
         .iter()
@@ -20,6 +21,7 @@ pub(crate) fn build_path_list(file_paths: &[PathBuf]) -> String {
 }
 
 /// Build a `SystemClipboardSnapshot` with a `text/uri-list` representation.
+#[allow(dead_code)]
 pub(crate) fn build_file_snapshot(uri_list: &str) -> SystemClipboardSnapshot {
     SystemClipboardSnapshot {
         ts_ms: chrono::Utc::now().timestamp_millis(),

--- a/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/usecase.rs
+++ b/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/usecase.rs
@@ -24,6 +24,7 @@ use super::{ApplyInboundError, ApplyInboundInput, ApplyOutcome};
 
 const RAPID_DUPLICATE_WINDOW: Duration = Duration::from_millis(200);
 const VISIBLE_DUPLICATE_WINDOW: Duration = Duration::from_secs(2);
+const SOURCE_ENTRY_DEDUP_WINDOW: Duration = Duration::from_secs(30);
 const RECENT_INBOUND_MAX_RECORDS: u64 = 128;
 
 pub struct ApplyInboundClipboardUseCase {
@@ -37,6 +38,11 @@ pub struct ApplyInboundClipboardUseCase {
     /// 略长窗口去重：visible_key → entry_id。捕获"同一可见内容、不同
     /// snapshot_hash"的场景（peer 重发时扩展了 representations）。
     recent_visible_content: Cache<String, EntryId>,
+    /// 源端 entry_id 去重：sender blob_ref.entry_id → local entry_id。
+    /// dispatch（直推）和 active_state（拉取）两条通道为同一次文件复制
+    /// 发送不同 snapshot_hash 的 envelope，但 blob_ref.entry_id 始终指向
+    /// 源端同一条 entry。30 秒窗口覆盖大文件传输延迟。
+    recent_source_entries: Cache<String, EntryId>,
     /// Optional host-event emitter for surfacing the inbound entry to UI
     /// before the fetch+capture pipeline finishes. Wired only in daemon
     /// mode; tests / CLI leave it `None`.
@@ -68,6 +74,10 @@ impl ApplyInboundClipboardUseCase {
             recent_visible_content: Cache::builder()
                 .max_capacity(RECENT_INBOUND_MAX_RECORDS)
                 .time_to_live(VISIBLE_DUPLICATE_WINDOW)
+                .build(),
+            recent_source_entries: Cache::builder()
+                .max_capacity(RECENT_INBOUND_MAX_RECORDS)
+                .time_to_live(SOURCE_ENTRY_DEDUP_WINDOW)
                 .build(),
         }
     }
@@ -217,12 +227,36 @@ impl ApplyInboundClipboardUseCase {
             "inbound: decoded V3 envelope"
         );
 
+        // Early dedup by sender-side entry_id from blob refs.  dispatch and
+        // active_state send different snapshot_hashes for the same file copy,
+        // but blob_ref.entry_id always points to the same source entry.  By
+        // checking BEFORE the expensive blob download we save bandwidth and
+        // avoid the duplicate clipboard entry entirely.
+        for br in &blob_refs {
+            let src_id = br.entry_id.as_ref().to_string();
+            if let Some(existing) = self.recent_source_entries.get(&src_id) {
+                debug!(
+                    existing_entry_id = %existing,
+                    source_entry_id = %src_id,
+                    "inbound dropped: same source entry already applied recently"
+                );
+                return Ok(ApplyOutcome::DuplicateSkipped {
+                    snapshot_hash: input.snapshot_hash,
+                    existing_entry_id: existing,
+                });
+            }
+        }
+
         // Pre-allocate the receiver-side entry_id so the UI placeholder, the
         // blob-fetch progress events, and the eventual `clipboard.new_content`
         // all share the same id. Without this, the placeholder card couldn't
         // be linked to the final entry by id and we'd need a transfer_id →
         // entry_id remap on the frontend.
         let receiver_entry_id = EntryId::new();
+        let source_entry_ids: Vec<String> = blob_refs
+            .iter()
+            .map(|r| r.entry_id.as_ref().to_string())
+            .collect();
         let advertised_total_bytes: u64 = blob_refs.iter().map(|r| r.size_bytes).sum();
         // free-standing files 走 V3BlobRef.filename;rep-bound blobs (image /
         // 大二进制) 通常 filename 为 None,自动被 filter_map 跳过。
@@ -350,6 +384,10 @@ impl ApplyInboundClipboardUseCase {
                 visible_key,
                 entry_id.clone(),
             );
+            for src_id in &source_entry_ids {
+                self.recent_source_entries
+                    .insert(src_id.clone(), entry_id.clone());
+            }
             // Advance the active-clipboard register at capture-commit (D1
             // call-site: inbound apply). The OS write below is detached and
             // best-effort, so the register is intentionally decoupled from it

--- a/crates/uc-application/src/usecases/clipboard_sync/resend_entry.rs
+++ b/crates/uc-application/src/usecases/clipboard_sync/resend_entry.rs
@@ -33,7 +33,7 @@
 //!
 //! `reconstruct_snapshot_from_entry` 已经把所有"无法物化"的情况收敛成
 //! [`BuildSnapshotError::PasteRepUnavailable`] / `PasteRepBlobFetchFailed` /
-//! `InvalidFileUri` / `NoFilePaths` / `NoRestorableRepresentations`,本用例
+//! `NoRestorableRepresentations`,本用例
 //! 全部映射成 [`ResendEntryError::EntryNotResendable`] + [`NotResendableReason::PayloadLost`]。
 //! 文件分支额外做了 on-disk 存在性校验(reconstruct 内 `path.exists()` →
 //! `PayloadResolveError::Lost`),所以"本机文件被 GC 但 payload_state 还没翻
@@ -480,8 +480,6 @@ fn map_build_snapshot_error(err: BuildSnapshotError, entry_id: &EntryId) -> Rese
         | BuildSnapshotError::PasteRepNotFound { .. }
         | BuildSnapshotError::PasteRepUnavailable(_)
         | BuildSnapshotError::PasteRepBlobFetchFailed { .. }
-        | BuildSnapshotError::InvalidFileUri { .. }
-        | BuildSnapshotError::NoFilePaths { .. }
         | BuildSnapshotError::NoRestorableRepresentations { .. } => {
             // `BuildSnapshotError::EntryNotFound` 自带 entry_id;其余 PayloadLost
             // 类变体没有 —— reconstruct helper 拿到的是同一 entry_id,这里直接

--- a/crates/uc-application/src/usecases/clipboard_sync/snapshot_from_entry.rs
+++ b/crates/uc-application/src/usecases/clipboard_sync/snapshot_from_entry.rs
@@ -36,10 +36,7 @@ use tracing::{debug, info, warn};
 
 use uc_core::{
     blob::ports::BlobReaderPort,
-    clipboard::{
-        ObservedClipboardRepresentation, PayloadAvailability, PersistedClipboardRepresentation,
-        SystemClipboardSnapshot,
-    },
+    clipboard::{ObservedClipboardRepresentation, PayloadAvailability, SystemClipboardSnapshot},
     ids::{EntryId, EventId, RepresentationId},
     ports::{
         clipboard::{
@@ -272,7 +269,7 @@ pub(crate) async fn reconstruct_snapshot_from_entry(
     );
 
     Ok(SystemClipboardSnapshot {
-        ts_ms: chrono::Utc::now().timestamp_millis(),
+        ts_ms: entry.created_at_ms,
         representations,
         file_content_digests: Vec::new(),
     })

--- a/crates/uc-application/src/usecases/clipboard_sync/snapshot_from_entry.rs
+++ b/crates/uc-application/src/usecases/clipboard_sync/snapshot_from_entry.rs
@@ -29,7 +29,6 @@
 //! caller actually returns).
 
 use std::collections::HashSet;
-use std::path::PathBuf;
 use std::sync::Arc;
 
 use thiserror::Error;
@@ -38,8 +37,8 @@ use tracing::{debug, info, warn};
 use uc_core::{
     blob::ports::BlobReaderPort,
     clipboard::{
-        is_file_mime_or_format, ObservedClipboardRepresentation, PayloadAvailability,
-        PersistedClipboardRepresentation, SystemClipboardSnapshot,
+        ObservedClipboardRepresentation, PayloadAvailability, PersistedClipboardRepresentation,
+        SystemClipboardSnapshot,
     },
     ids::{EntryId, EventId, RepresentationId},
     ports::{
@@ -52,8 +51,6 @@ use uc_core::{
     },
     BlobId,
 };
-
-use crate::usecases::clipboard_restore::file_snapshot::{build_file_snapshot, build_path_list};
 
 /// Typed errors returned by [`reconstruct_snapshot_from_entry`].
 ///
@@ -91,16 +88,6 @@ pub(crate) enum BuildSnapshotError {
     #[error("Failed to fetch paste representation blob {blob_id}: {reason}")]
     PasteRepBlobFetchFailed { blob_id: BlobId, reason: String },
 
-    #[error("Failed to parse file URI for entry {entry_id} (rep {rep_id}): {reason}")]
-    InvalidFileUri {
-        entry_id: EntryId,
-        rep_id: RepresentationId,
-        reason: String,
-    },
-
-    #[error("No valid file paths found in entry {entry_id}")]
-    NoFilePaths { entry_id: EntryId },
-
     /// Defensive guard: every candidate rep was skipped. The paste-rep
     /// failure paths above should normally cover this, but a fully empty
     /// candidate list still surfaces here rather than silently returning an
@@ -120,10 +107,7 @@ pub(crate) enum BuildSnapshotError {
 /// 1. Look up entry + selection.
 /// 2. Collect candidate rep ids in `paste / primary / preview / secondary`
 ///    order and dedup, then load each [`PersistedClipboardRepresentation`].
-/// 3. If `paste_rep` is a file rep ([`is_file_mime_or_format`]), take the
-///    file branch: resolve the URI list, parse to local paths, validate
-///    on-disk existence, and emit a fresh `text/uri-list` snapshot.
-/// 4. Otherwise, pack every non-file candidate via
+/// 3. Pack every candidate (file and non-file alike) via
 ///    [`ClipboardPayloadResolverPort`] (Inline direct / BlobRef via
 ///    [`BlobReaderPort`] / Staged|Processing via cache+spool). Secondary
 ///    reps that fail to resolve are skipped with a warning; failure on
@@ -184,10 +168,6 @@ pub(crate) async fn reconstruct_snapshot_from_entry(
         }
     }
 
-    // 文件分支：paste_rep 是文件类型（CF_HDROP / NSPasteboardTypeFileURL）时，
-    // 走专用的 file snapshot 路径。文件 rep 的语义与文本/图像表示不可混写在
-    // 同一个 NSPasteboardItem / clipboard item 中，平台层目前也仅支持文件单独
-    // 写入；同时 build_file_snapshot 会校验本地文件存在性。
     let paste_rep = candidates
         .iter()
         .find(|rep| rep.id == selection.selection.paste_rep_id)
@@ -196,23 +176,10 @@ pub(crate) async fn reconstruct_snapshot_from_entry(
             rep_id: selection.selection.paste_rep_id.clone(),
         })?;
 
-    if is_file_rep(paste_rep) {
-        debug!(
-            entry_id = %entry_id,
-            paste_rep_id = %paste_rep.id,
-            "snapshot_from_entry.reconstruct: detected file entry, using file branch"
-        );
-        return build_file_branch(
-            payload_resolver,
-            blob_store,
-            rep_processing_repo,
-            entry_id,
-            paste_rep,
-        )
-        .await;
-    }
-
-    // 非文件分支：把所有非文件候选 rep 都打包成多 rep snapshot，paste_rep 居首。
+    // Unified branch: pack ALL candidate reps into a multi-rep snapshot,
+    // paste_rep first. File entries and non-file entries share the same path
+    // so the reconstructed V3 payload always includes every persisted rep,
+    // keeping snapshot_hash stable across dispatch / serve_pull / resend.
     // 每条 rep 通过 `ClipboardPayloadResolverPort` 取字节，由 resolver 负责按
     // payload_state 路由（Inline 直读已解密 inline_data / BlobReady 走 blob_store /
     // Staged|Processing 走 cache+spool）。
@@ -225,16 +192,6 @@ pub(crate) async fn reconstruct_snapshot_from_entry(
     let mut paste_first = true;
     let mut packed_rep_ids: Vec<RepresentationId> = Vec::new();
     for rep in &candidates {
-        if is_file_rep(rep) {
-            debug!(
-                entry_id = %entry_id,
-                rep_id = %rep.id,
-                format_id = %rep.format_id,
-                "snapshot_from_entry.reconstruct: skipping file rep when paste_rep is non-file"
-            );
-            continue;
-        }
-
         let is_paste_rep = rep.id == paste_rep.id;
         let bytes = match payload_resolver.resolve(rep).await {
             Ok(ResolvedClipboardPayload::Inline { bytes, .. }) => bytes,
@@ -319,129 +276,6 @@ pub(crate) async fn reconstruct_snapshot_from_entry(
         representations,
         file_content_digests: Vec::new(),
     })
-}
-
-fn is_file_rep(rep: &PersistedClipboardRepresentation) -> bool {
-    is_file_mime_or_format(rep.mime_type.as_ref(), &rep.format_id)
-}
-
-async fn build_file_branch(
-    payload_resolver: &dyn ClipboardPayloadResolverPort,
-    blob_store: &dyn BlobReaderPort,
-    rep_processing_repo: &dyn UpdateRepresentationProcessingResultPort,
-    entry_id: &EntryId,
-    rep: &PersistedClipboardRepresentation,
-) -> Result<SystemClipboardSnapshot, BuildSnapshotError> {
-    // 与非文件分支同样走 payload_resolver：file URI list 在文件较多时同样会
-    // 触发 inline_threshold，rep.inline_data 只剩 500-char 预览截断版，直接
-    // clone 会拿到不完整的 URI 列表 → 文件路径解析丢失。resolver 会按
-    // payload_state 正确路由（Inline / BlobReady / Staged|Processing）。
-    let bytes = match payload_resolver.resolve(rep).await {
-        Ok(ResolvedClipboardPayload::Inline { bytes, .. }) => bytes,
-        Ok(ResolvedClipboardPayload::BlobRef { blob_id, .. }) => blob_store
-            .get(&blob_id)
-            .await
-            .map_err(|err| BuildSnapshotError::PasteRepBlobFetchFailed {
-                blob_id,
-                reason: err.to_string(),
-            })?,
-        Err(resolver_err) => {
-            if let Some(blob_id) = &rep.blob_id {
-                blob_store.get(blob_id).await.map_err(|blob_err| {
-                    BuildSnapshotError::PasteRepBlobFetchFailed {
-                        blob_id: blob_id.clone(),
-                        reason: format!(
-                            "resolver failed ({resolver_err}); blob fallback also failed: {blob_err}"
-                        ),
-                    }
-                })?
-            } else {
-                // Mirror the non-file branch's stable-`Lost` invariant: an
-                // orphaned paste-rep (cache + spool double miss) with no
-                // blob fallback gets demoted before propagating, so the
-                // next attempt sees a stable `Lost` outcome.
-                if let PayloadResolveError::Orphaned { rep_id, state } = &resolver_err {
-                    demote_orphaned_to_lost(rep_processing_repo, rep_id, state).await;
-                }
-                return Err(BuildSnapshotError::PasteRepUnavailable(resolver_err));
-            }
-        }
-    };
-
-    let uri_string =
-        String::from_utf8(bytes).map_err(|err| BuildSnapshotError::InvalidFileUri {
-            entry_id: entry_id.clone(),
-            rep_id: rep.id.clone(),
-            reason: format!("URI list bytes are not valid UTF-8: {err}"),
-        })?;
-
-    let mut file_paths = Vec::new();
-    for line in uri_string.lines() {
-        let line = line.trim();
-        if line.is_empty() || line.starts_with('#') {
-            continue;
-        }
-        if line.starts_with("file://") {
-            // 错误消息只暴露 entry_id / rep_id —— `line` 是 `file://...` URI，
-            // 含完整文件路径，属于用户私有 payload，禁止写入错误链 / 日志。
-            match url::Url::parse(line) {
-                Ok(url) => {
-                    let path =
-                        url.to_file_path()
-                            .map_err(|_| BuildSnapshotError::InvalidFileUri {
-                                entry_id: entry_id.clone(),
-                                rep_id: rep.id.clone(),
-                                reason: "URL could not be converted to a local file path"
-                                    .to_string(),
-                            })?;
-                    file_paths.push(path);
-                }
-                Err(e) => {
-                    return Err(BuildSnapshotError::InvalidFileUri {
-                        entry_id: entry_id.clone(),
-                        rep_id: rep.id.clone(),
-                        reason: e.to_string(),
-                    });
-                }
-            }
-        } else {
-            file_paths.push(PathBuf::from(line));
-        }
-    }
-
-    if file_paths.is_empty() {
-        return Err(BuildSnapshotError::NoFilePaths {
-            entry_id: entry_id.clone(),
-        });
-    }
-
-    // 本地源文件不存在 → 通过 `PayloadResolveError::Lost` 让上层（restore facade）
-    // 映射为 `PayloadUnavailable`（HTTP 410 Gone）+ warn 级日志，避免被当成
-    // 5xx 上报到 Sentry。reason 严禁携带文件路径或文件名——属于用户私有
-    // payload（uc-application §16.3）。
-    let missing_count = file_paths.iter().filter(|p| !p.exists()).count();
-    if missing_count > 0 {
-        return Err(BuildSnapshotError::PasteRepUnavailable(
-            PayloadResolveError::Lost {
-                rep_id: rep.id.clone(),
-                reason: format!(
-                    "{} of {} referenced file(s) no longer exist on disk",
-                    missing_count,
-                    file_paths.len()
-                ),
-            },
-        ));
-    }
-
-    let snapshot = build_file_snapshot(&build_path_list(&file_paths));
-
-    info!(
-        entry_id = %entry_id,
-        file_count = file_paths.len(),
-        "snapshot_from_entry.reconstruct(file): files validated and snapshot built"
-    );
-
-    Ok(snapshot)
 }
 
 /// Demote an orphaned representation (cache+spool double miss) to `Lost`.


### PR DESCRIPTION
## Summary

- **Remove the dedicated file branch in `snapshot_from_entry`** that stripped file entries down to a single `text/uri-list` representation during reconstruction. All entry types (file, text, image) now share the same full-fidelity reconstruction path that preserves every persisted representation. (42695b4)

- **Root cause**: When Windows copies a file, the clipboard content is dispatched to Mac via two parallel channels — `dispatch_entry` (direct push, 12 reps) and `active_state` (pull protocol). The pull channel called `serve_pull` → `snapshot_from_entry`, which used a file-specific branch that reconstructed only 1 rep (`text/uri-list`). The V3 encoding of 1 rep ≠ 12 reps → different `snapshot_hash` → receiver's DB dedup could not match them → **two clipboard entries + two redundant blob downloads** for a single file copy.

- **Fix**: With the file branch removed, `serve_pull` reconstructs all 12 reps faithfully. The V3 encoding matches the dispatch's original → same `snapshot_hash` → DB dedup catches the duplicate before any blob download starts.

### Before / After

| | Before | After |
|---|---|---|
| File copy (Win→Mac) | 2 entries, 2×83MB download | 1 entry, 1×83MB download |
| serve_pull snapshot | 1 rep (text/uri-list only) | All reps (full fidelity) |
| Restore from history | File paths only | Full clipboard state |

## Test plan

- [x] `cargo check -p uc-application` — clean (3 dead-code warnings for now-unused `build_file_snapshot` helper)
- [x] `cargo test -p uc-application --lib` — 663 passed, 0 failed
- [x] `cargo fmt --all --check` — clean
- [ ] Manual: copy file on Windows → verify Mac receives exactly 1 clipboard entry (not 2)
- [ ] Manual: restore a file entry from clipboard history → verify all representations are present

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined clipboard snapshot reconstruction to use a single, unified resolution flow across all representation types.
* **Performance**
  * Added early deduplication for inbound clipboard applies using sender-side source entry ids to skip expensive processing.
* **Bug Fixes**
  * Clipboard snapshot timestamps now use the entry’s persisted creation time.
  * Improved resend failure categorization so certain file-related errors no longer surface as “payload lost.”
  * Updated clipboard watching to avoid outbound sync dispatch for file entries.
* **Documentation**
  * Updated resend-failure notes to match the revised error classification.
* **Chores**
  * Suppressed unused-code warnings for internal snapshot helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->