### PR TITLE
chore(tooling): add design-audit skill + tech-debt ledger

### DIFF
--- a/.claude/skills/design-audit/REFERENCE.md
+++ b/.claude/skills/design-audit/REFERENCE.md
@@ -1,0 +1,149 @@
+# design-audit — REFERENCE
+
+## 7 个审计镜头（rubric）
+
+每个 audit agent 对一个目标逐镜头过一遍。**每条 finding 必须带 file:line + 一段引用代码**，并标注严重度与（若有）被违反的项目规矩。
+
+| # | 镜头 | 信号 / 怎么看 | 本项目坐标 |
+|---|------|--------------|-----------|
+| L1 | **心智复杂度 / 读起来难懂** | 「为一个概念维护 N 个互相兜底的机制」「读懂任一处必须在脑中同时持有另外几处」「同一函数靠 mode flag 串多条语义不同的流程」。问自己：要理解这段，得同时记住几件事？ | 时间窗叠层、origin 分支、跨 worker 共享可变单例 |
+| L2 | **单一真相源被破坏** | 同一事实存两份：配置写的值 vs 实际 bind 的值；状态在 orchestrator/UI/handler 各存一半 | `uc-application/AGENTS.md §10.2`；mobile 端口 vs current_status |
+| L3 | **catch-all 胖接口** | 一个 port/trait 混 query+command+field-patch；调用方依赖了用不到的方法；死方法堆在 trait 上 | `uc-core/AGENTS.md §5.2`「保持最小接口」；端口拆分先例 |
+| L4 | **死代码 / 投机泛化** | `#[allow(dead_code)]` 当「未来功能」供着；零调用方的 pub；留着的旧逻辑无移除计划 | 根 `AGENTS.md`「不保留无移除计划的并行旧逻辑」 |
+| L5 | **散落魔法字面量 / 时间耦合** | 同一物理量的 timeout 散在多文件；隐含的「A 必须 > B」关系只活在注释里 | memory `[[no-timing-coupled-coordination]]`；`uc-daemon-process::timing` 范式 |
+| L6 | **泄漏抽象 / 边界污染** | port doc 提上层模块/路由/协议名；infra 类型上浮到 core/app；adapter 长成 orchestrator | `uc-core/AGENTS.md §5.4`；`uc-infra/AGENTS.md §4.1` |
+| L7 | **资源生命周期 / 可优化** | 靠环形缓冲淘汰代替显式释放；无界缓存；每次重算可缓存的；孤儿无 TTL 清理；重复序列化；阻塞主/watcher 线程 | `uc-infra/AGENTS.md §13`；`IncomingMobileBuffer` 先例 |
+
+### 跨镜头铁律
+- **意外 vs 本质**：先判定这复杂度是不是问题本身固有（剪贴板回环、跨 iroh+DB 无事务的最终一致 = 本质）。本质的 **不报** 或仅标注「justified」；只报实现引入的意外复杂度。
+- **对照自家规矩优先**：能引到 VISION/AGENTS/memory 具体条目的 finding，severity 与可信度都更高。
+- **给修法**：P1/P2 必须带可切片的修法草图（参考 self-write 重构的 S0/S1 切片：先抽常量→删死方法→收口接口，每片单一边界、行为保持优先）。
+
+## 严重度
+
+| 级别 | 含义 | 处置 |
+|------|------|------|
+| **P1** | 严重违反工程设计 + 高心智负担，阻碍理解；或违反项目明文铁律 | 报告置顶，给切片方案，建议尽快排期 |
+| **P2** | 真实技术债，值得排期，但不阻塞 | 报告列出 + 修法草图 |
+| **P3** | 小瑕疵 / nice-to-have | 报告附录一行带过 |
+| **OPT** | 纯优化机会（性能/资源），非设计缺陷 | 单独分节，标注预期收益与成本 |
+
+## 稳定 finding ID（去重关键）
+
+格式：`<crate-or-area>:<file-basename-no-ext>:<symbol-or-area>:<lens>`
+例：`uc-application:coordinator:write:L5`、`uc-application:cleanup:check_device_quota:L4`
+
+同一问题跨周必须解析到同一 ID，台账才能去重。symbol 优先用稳定的函数/类型名，避免行号（行号会漂）。
+
+## 台账 `.planning/design-audit/ledger.md`
+
+```markdown
+# Design Audit Ledger
+
+last_audited_commit: <full-sha>
+last_audited_at: <YYYY-MM-DD>
+
+| id | severity | lens | title | status | first_seen | last_seen | note |
+|----|----------|------|-------|--------|-----------|-----------|------|
+| uc-application:coordinator:write:L5 | P1 | L5 | echo 时间窗散落字面量 | fixed | 2026-W25 | 2026-W25 | S0 33f4ace2c |
+| uc-application:cleanup:check_device_quota:L4 | P2 | L4 | 配额死代码当未来功能 | open | 2026-W25 | 2026-W26 | |
+```
+
+- `status` ∈ `open | accepted | wontfix | fixed`。
+- 新一轮：命中已有 ID 且 status∈{accepted,wontfix} → **跳过不报**；status=open → 更新 last_seen；status=fixed 但又出现 → 标 `regressed` 重报（P1）。
+- 全新 ID → 追加 `open`。
+- 跑完更新 `last_audited_commit = HEAD`、`last_audited_at`。
+- 用户对某条说「接受/不修」→ 把该行改成 accepted/wontfix（以后不再烦）。
+
+## 报告 `.planning/design-audit/YYYY-Www.md`
+
+```markdown
+# 设计审计 YYYY-Www
+
+**范围**: <last_sha>..<HEAD>（N commits, M 文件）
+**目标分组**: <子系统列表>
+**新增 finding**: P1×a P2×b P3×c OPT×d（已跳过台账已知 e 条）
+
+## P1 — 严重
+### [id] 标题
+- **位置**: `path/file.rs:line` (`symbol`)
+- **证据**: <一段引用代码 / 为什么读起来难懂：要同时记住哪几件事>
+- **意外而非本质**: <为什么这是实现引入的，不是问题固有>
+- **违反**: <VISION/AGENTS/memory 具体条目，若有>
+- **修法草图**: <S0/S1 风格切片，单一边界、行为保持优先>
+
+## P2 — 值得排期
+（同上精简）
+
+## P3 — 小瑕疵
+- 一行带过
+
+## OPT — 优化机会
+- `path:line` <收益 / 成本>
+
+## 本质复杂度（已审，判定不动）
+- <列出审过但判为 justified 的，避免下轮重审 + 让 reviewer 放心>
+```
+
+## Workflow skeleton
+
+scout 阶段（churn 分组）在 skill 主体里 inline 做完，把 `targets` 和台账 `knownSkipIds` 作为 `args` 传入。脚本按 REFERENCE 的 rubric/schema fan-out。
+
+```js
+export const meta = {
+  name: 'design-audit',
+  description: 'Audit recent-churn targets for accidental-complexity design smells, verify, dedup, rank',
+  phases: [{ title: 'Audit' }, { title: 'Verify' }, { title: 'Synthesize' }],
+}
+
+const { targets, knownSkipIds, ruleRefs } = args // ruleRefs: VISION/AGENTS/memory 路径清单
+const FINDING = { type:'object', additionalProperties:false,
+  required:['id','severity','lens','title','file','symbol','evidence','accidental_why','violates','fix_sketch'],
+  properties:{
+    id:{type:'string'}, severity:{enum:['P1','P2','P3','OPT']}, lens:{type:'string'},
+    title:{type:'string'}, file:{type:'string',description:'repo-rel path:line'},
+    symbol:{type:'string'}, evidence:{type:'string',description:'引用代码/为什么难懂'},
+    accidental_why:{type:'string',description:'为何是意外而非本质复杂度；若判本质则写 justified'},
+    violates:{type:'string',description:'VISION/AGENTS/memory 条目或 none'},
+    fix_sketch:{type:'string'},
+  }}
+const FINDINGS = { type:'object', additionalProperties:false, required:['findings'],
+  properties:{ findings:{type:'array', items:FINDING} } }
+const VERDICT = { type:'object', additionalProperties:false, required:['id','is_real','is_accidental','keep'],
+  properties:{ id:{type:'string'}, is_real:{type:'boolean'}, is_accidental:{type:'boolean'},
+    keep:{type:'boolean'}, reason:{type:'string'} } }
+
+const rubric = `按 7 镜头审：L1 心智复杂度/难懂、L2 单一真相源、L3 catch-all 胖接口、L4 死代码/投机泛化、`
+  + `L5 散落字面量/时间耦合、L6 泄漏抽象/边界污染、L7 资源生命周期/可优化。`
+  + `铁律：先读代码建图再判；每条 finding 必带 file:line + 引用代码；区分意外 vs 本质（本质判 justified）；`
+  + `对照项目规矩(${ruleRefs.join(', ')})；P1/P2 给可切片修法。stable id=<area>:<file>:<symbol>:<lens>。`
+
+const results = await pipeline(
+  targets,
+  t => agent(`${rubric}\n\n审计目标「${t.label}」，文件：\n${t.files.join('\n')}`,
+             { label:`audit:${t.label}`, phase:'Audit', schema:FINDINGS, agentType:'Explore' }),
+  (res, t) => parallel((res?.findings||[]).map(f => () =>
+    agent(`对抗核实这条 finding（默认怀疑，证据不足就 keep=false）：${JSON.stringify(f)}\n`
+        + `判定：is_real（代码真这样？）、is_accidental（意外复杂度而非问题固有？本质则 false）、`
+        + `keep（值得进报告？）。可重读 ${f.file} 求证。`,
+        { label:`verify:${f.id}`, phase:'Verify', schema:VERDICT })
+      .then(v => ({ ...f, verdict:v }))))
+)
+const confirmed = results.flat().filter(Boolean)
+  .filter(f => f.verdict?.keep && f.verdict?.is_real && f.verdict?.is_accidental)
+  .filter(f => !knownSkipIds.includes(f.id)) // 台账 accepted/wontfix 去重
+
+const report = await agent(
+  `把以下已核实 finding 合成设计审计报告（Markdown），按 P1>P2>P3>OPT 排序，`
+  + `每条含 位置/证据/意外而非本质/违反/修法草图；末尾列「本质复杂度（已审不动）」。\n`
+  + `FINDINGS:\n${JSON.stringify(confirmed, null, 2)}`,
+  { label:'synthesize', phase:'Synthesize' })
+
+return { report, confirmed, skipped: knownSkipIds.length }
+```
+
+## 规模建议
+
+- targets ≤ 6、churn 小 → 直接跑；targets 多 → 按子系统切，优先 COMPLEXITY HOTSPOTS 命中的。
+- 对抗核实是质量关键：宁可 Verify 阶段砍掉一半「看着像但其实是本质复杂度」的 finding，也不要污染报告。
+- 报告只进 `.planning/design-audit/`（`.planning/` 是开发自留路径，不受语言审查、CodeRabbit 已跳过）。

--- a/.claude/skills/design-audit/SKILL.md
+++ b/.claude/skills/design-audit/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: design-audit
+description: 定期审计代码库的工程设计问题（高心智复杂度、单一真相源被破坏、catch-all 胖接口、死代码、散落魔法字面量、泄漏抽象、资源生命周期靠环形缓冲）与可优化点，范围限定为自上次审计以来的 git churn，每条发现都落到 file:line 并对照本项目自己的 VISION.md / 各级 AGENTS.md / memory 规则，明确区分「意外复杂度」（要修）与「本质复杂度」（不动）。维护去重台账，重复运行只报新增。Use when 用户要做设计审计 / 每周设计复盘 / 技术债扫描，或运行 /design-audit；不用于行级 bug review（用 /code-review）或写功能。
+---
+
+# design-audit
+
+每周一次的工程设计体检。复刻一套被验证有效的方法：**先理解，再批判；用「读起来难不难懂」当心智复杂度信号；每个结论落到真实代码；对照项目自己的规矩；只骂意外复杂度。**
+
+详细的审计镜头、严重度定义、台账与报告格式、workflow 脚本骨架见 [REFERENCE.md](REFERENCE.md)。
+
+## 何时触发
+
+- 用户运行 `/design-audit`，或说"设计审计 / 每周复盘 / 技术债扫描 / 有哪些可优化的地方"
+- **不是** 行级 bug review（那是 `/code-review`），**不是** 写功能
+
+## 工作流（按序执行）
+
+### 1. 读台账，定基线
+- 读 `.planning/design-audit/ledger.md`。取 `last_audited_commit`（无则用 4 周前或 `main~200`）。
+- 记下所有 `accepted` / `wontfix` 的 finding ID——本轮 **不再报** 这些。
+
+### 2. 算 churn，定范围（核心：近期改动优先）
+```bash
+git log --oneline <last_audited_commit>..HEAD | head -50
+git diff --stat <last_audited_commit>..HEAD
+```
+- 取改动文件，按 crate/子系统分组成 **审计目标**（每组 ≤ ~8 文件）。
+- 叠加 `crates/AGENTS.md` 的 COMPLEXITY HOTSPOTS：churn 命中热点的目标优先级拉高。
+- churn 为空 → 报告"无新改动"并退出。
+
+### 3. 先理解，再批判（不可跳过）
+- 对每个目标，先 **读关键文件** 建立局部地图，再判断。没有地图的批判是瞎猜。
+- 准备好规矩参照系：`VISION.md`、相关 crate 的 `AGENTS.md`、`crates/uc-core/AGENTS.md §5.4`、
+  memory 目录的规则（如 `[[no-timing-coupled-coordination]]`、`[[minimize-crate-api-surface]]`）。
+
+### 4. 多 agent workflow 审计 + 对抗核实
+- 调 `Workflow`（脚本骨架见 REFERENCE.md「Workflow skeleton」）：
+  - **Audit 阶段**：每个目标一个 agent，按 REFERENCE.md 的 7 个镜头审，**每条 finding 必须带 file:line + 一段引用代码证据**。
+  - **Verify 阶段**：对每条 finding 派对抗 agent 核实——是真的吗？是 **意外** 复杂度还是 **本质** 复杂度？违反了哪条项目规矩？默认怀疑，证据不足就降级/丢弃。
+  - **Synthesize 阶段**：传入台账已知 ID 去重，按严重度排序，产出报告。
+
+### 5. 落盘报告 + 更新台账
+- 写 `.planning/design-audit/YYYY-Www.md`（报告格式见 REFERENCE.md）。
+- 更新 `.planning/design-audit/ledger.md`：新 finding 追加为 `open`；记录本轮 `last_audited_commit = HEAD`。
+- **不提交、不开 PR**（除非用户要）。最后在对话里给 P1/P2 的精简清单 + 推荐先动哪一条。
+
+## 铁律（来自有效的那次）
+
+- **落到代码**：没有 file:line + 代码证据的 finding 一律不写。宁可少报，不可臆测。
+- **意外 vs 本质**：本质复杂度（问题本身就难，如剪贴板回环、分布式最终一致）**不报** 或只标注，只报实现引入的意外复杂度。
+- **对照自家规矩**："违反你自己立的规矩"（VISION/AGENTS/memory）比"违反通用原则"更该优先。
+- **去重**：台账里 accepted/wontfix 的不再报；同一 finding 跨周用稳定 ID 映射。
+- **可执行**：每条 P1/P2 给出可切片的修法草图（S0/S1… 风格），不是空泛的"建议重构"。

--- a/.planning/design-audit/ledger.md
+++ b/.planning/design-audit/ledger.md
@@ -1,0 +1,16 @@
+# Design Audit Ledger
+
+> 由 `/design-audit` 维护。`status`: open=已知未修 / accepted=认了不改 / wontfix=明确不修 / fixed=已修（再现则 regressed）。
+> 下一轮审计范围 = `last_audited_commit`..HEAD 的 churn。accepted/wontfix/fixed 不再报，open 仅 carryover。
+
+last_audited_commit: f0a33197809641e607d89635d6387e9f5d33a20f
+last_audited_at: 2026-06-23
+
+| id | severity | lens | title | status | first_seen | last_seen | note |
+|----|----------|------|-------|--------|-----------|-----------|------|
+| uc-application:coordinator:write:L5 | P1 | L5 | echo 防回环时间窗散落字面量 + 注释漂移（违反 [[no-timing-coupled-coordination]]） | fixed | 2026-W25 | 2026-W25 | S0 33f4ace2c → timing 模块；S2 用户已合并成单窗 |
+| uc-core:self_write_ledger:ClipboardChangeOriginPort:L3 | P1 | L3 | 6 方法 catch-all 端口（2 死方法 + 2 冗余 consume 变体），调用方手编排 4 个 guard | fixed | 2026-W25 | 2026-W25 | S1 886c908d0+f0a331978 → 2 方法 SelfWriteLedgerPort |
+| uc-application:cleanup:check_device_quota:L4 | P2 | L4 | 配额检查死代码当「未来功能」供着，且路径布局是错的 | open | 2026-W25 | 2026-W25 | `file_sync/cleanup.rs` `#[allow(dead_code)]`；要么实现要么删 |
+| uc-application:apply_incoming:IncomingMobileBuffer:L7 | P2 | L7 | 两阶段文件上传的孤儿靠环形缓冲 (上限 16) 回绕淘汰，无 TTL sweep | open | 2026-W25 | 2026-W25 | `usecases/mobile_sync/apply_incoming.rs:246` 注释自承认 TODO |
+| uc-webserver:mobile_lan:port-resolution:L2 | P2 | L2 | mobile 端口双真相源：settings 写的值 vs FNV 派生实际 bind，BindFailed 不回滚 | open | 2026-W25 | 2026-W25 | 真实状态只在 current_status；排障易被误导 |
+| uc-application:apply_inbound:dedup-windows:L1 | P3 | L1 | 入站幂等 3 窗口与 echo 回环叙事混在一起，增加理解成本 | open | 2026-W25 | 2026-W25 | S3 计划正名「入站幂等」+ 独立 timing 家 |


### PR DESCRIPTION
## Summary

- Add a project-local `/design-audit` skill (`.claude/skills/design-audit/`) — a recurring engineering-design review that mirrors the method which surfaced the self-write-attribution debt: **understand before judging, use "is this hard to read" as the cognitive-complexity signal, ground every finding in actual code (file:line), cross-reference the project's own VISION/AGENTS/memory rules, and only flag accidental complexity (not essential)** (`3eeb35ecc`).
- The skill is scoped to recent git churn, fans out across a multi-agent workflow (audit → adversarial verify → synthesize), and maintains a dedup ledger so repeat runs only surface new findings. `SKILL.md` holds the process; `REFERENCE.md` holds the 7 audit lenses, severity scale, ledger/report schemas, and the workflow-script skeleton.
- Seed `.planning/design-audit/ledger.md` with the findings from the self-write audit: two fixed P1s (echo timing literals, 6-method catch-all port) recorded for regression detection, plus open backlog items (dead `check_device_quota`, mobile orphan ring-buffer, mobile-port dual source of truth, inbound-dedup naming).

Docs-site: no user-facing surface changed (agent tooling + planning ledger only) — left as-is.

## Test plan

- [x] Skill registers (appears in the available-skills list as `design-audit`).
- [x] `SKILL.md` 54 lines (< 100); description 317 chars (< 1024); structure validated.
- [ ] First real run after the next batch of churn lands — confirm churn scoping, workflow fan-out, and ledger dedup work end-to-end and the report renders under `.planning/design-audit/`.