### PR TITLE
fix(ci): restore push:main trigger so Codecov has a PR base

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,6 +1,22 @@
 name: Coverage
 
 on:
+  # Codecov needs a base report on the default branch to diff PRs against.
+  # Without this push trigger, merge commits on main carry no coverage and
+  # every PR falls back to "Missing Base Commit". See #641 regression.
+  push:
+    branches: [main]
+    paths:
+      - 'crates/**'
+      - 'apps/**'
+      - 'src-tauri/**'
+      - 'tests/e2e/**'
+      - 'vendor/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'rust-toolchain.toml'
+      - 'clippy.toml'
+      - '.github/workflows/coverage.yml'
   pull_request:
     paths:
       - 'crates/**'

--- a/.github/workflows/frontend-coverage.yml
+++ b/.github/workflows/frontend-coverage.yml
@@ -1,7 +1,19 @@
 name: Frontend Coverage
-run-name: 'Frontend coverage for ${{ github.head_ref }}'
+run-name: 'Frontend coverage for ${{ github.head_ref || github.ref_name }}'
 
 on:
+  # Codecov needs a base report on the default branch to diff PRs against.
+  # Without this push trigger, merge commits on main carry no coverage and
+  # every PR falls back to "Missing Base Commit". See #641 regression.
+  push:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'package.json'
+      - 'bun.lock'
+      - 'tsconfig*.json'
+      - 'vite.config.ts'
+      - '.github/workflows/frontend-coverage.yml'
   pull_request:
     paths:
       - 'src/**'


### PR DESCRIPTION
## Problem

Codecov's project/patch coverage on the dashboard has been stale/inaccurate since **2026-05-12**. Recent PRs effectively fall back to "Missing Base Commit" and the `main` coverage trend line is flat.

## Root cause

`coverage.yml` and `frontend-coverage.yml` both trigger **only on `pull_request`** — there is no `push: main` trigger.

Codecov diffs each PR against a **base report on the default branch**. Without a push trigger, merge commits on `main` upload no coverage, so:
- `main` has no fresh report to serve as the base
- `base: auto` / `target: auto` in `codecov.yml` resolve to nothing
- PRs report "Missing Base Commit" and the comparison numbers are meaningless

### Regression timeline (git evidence)

1. `0337eaee5` (#97) — initial Codecov setup, had `push: [main, develop]` ✅
2. `2653b6261` (#570, 5/10) — fixed `develop`→`dev`, commit message explicitly: *"trigger on dev pushes so codecov has a base for PRs"* — the push trigger was known to be load-bearing
3. **`d17b83629` (#641, 5/12) — removed `push: main` as a "redundant" post-merge run** ❌ — this is the regression. It re-introduced the exact "Missing Base Commit" problem #570 had just fixed.

## Fix

Re-add `push: branches: [main]` (same `paths` filter as the PR trigger) to both workflows, and make the frontend `run-name` fall back to `ref_name` on push events where `head_ref` is empty.

The "duplicate run after merge" that #641 wanted to avoid is not waste — it is the report Codecov needs as the base.

## Verification

After merge, the next `main` push touching `crates/**` / `src/**` will upload a fresh base report; subsequent PRs should regain accurate project/patch diffs on the Codecov dashboard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated coverage workflows to trigger on pushes to the main branch alongside existing pull request triggers, enabling continuous coverage tracking.
  * Optimized run naming and path filtering for improved coverage monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->