### PR TITLE
fix(tray): restart daemon + GUI from the tray Restart menu

### DIFF
--- a/src-tauri/crates/uc-tauri/src/commands/restart.rs
+++ b/src-tauri/crates/uc-tauri/src/commands/restart.rs
@@ -55,10 +55,10 @@ pub async fn restart_app(
 
 /// Graceful shutdown + `app.restart()`.
 ///
-/// Shared entry for the `restart_app` Tauri command and the tray "Restart"
-/// menu item. Does not return — `app.restart()` internally calls
-/// `std::process::exit`. Callers must therefore expect this future to never
-/// complete on the happy path.
+/// Shared entry for the `restart_app` Tauri command and the GUI half of
+/// [`perform_full_restart`]. Does not return — `app.restart()` internally
+/// calls `std::process::exit`. Callers must therefore expect this future to
+/// never complete on the happy path.
 pub(crate) async fn perform_restart(app: &tauri::AppHandle) {
     info!("restarting app for settings change");
 
@@ -74,6 +74,39 @@ pub(crate) async fn perform_restart(app: &tauri::AppHandle) {
     tokio::time::sleep(Duration::from_millis(SHUTDOWN_FRONTEND_GRACE_MS)).await;
 
     app.restart();
+}
+
+/// Restart **both** the daemon and the GUI process.
+///
+/// Shared entry for the tray "Restart" menu item. Mirrors the frontend
+/// full-restart sequence (`restart_daemon` → `restart_app`): the daemon is
+/// restarted first via [`restart_local_daemon`] so a freshly-spawned, healthy
+/// engine is already running by the time the replacement GUI bootstraps and
+/// reconnects, then the GUI process is replaced via [`perform_restart`].
+///
+/// Unlike the `restart_daemon` Tauri command we do **not** refresh the live
+/// `DaemonConnectionState` or clear the session-token cache here: the GUI is
+/// about to be torn down by `app.restart()`, so the new process bootstraps a
+/// fresh connection and mints a new JWT against the restarted daemon anyway.
+///
+/// A daemon-restart failure is logged but non-fatal — we still restart the
+/// GUI, whose bootstrap will attempt its own spawn/recovery and surface any
+/// error in the UI. Does not return on the happy path ([`perform_restart`]
+/// ends in `app.restart()` → `process::exit`).
+///
+/// [`restart_local_daemon`]: uc_desktop::daemon_probe::restart_local_daemon
+pub(crate) async fn perform_full_restart(app: &tauri::AppHandle) {
+    info!("full restart: restarting daemon before GUI");
+    match uc_desktop::daemon_probe::restart_local_daemon(env!("CARGO_PKG_VERSION")).await {
+        Ok(_) => info!("full restart: daemon restarted, proceeding to GUI restart"),
+        Err(error) => warn!(
+            %error,
+            "full restart: daemon restart failed; restarting GUI anyway — \
+             the new GUI bootstrap will retry spawn/recovery"
+        ),
+    }
+
+    perform_restart(app).await;
 }
 
 // ── restart_daemon ─────────────────────────────────────────────────────

--- a/src-tauri/crates/uc-tauri/src/tray.rs
+++ b/src-tauri/crates/uc-tauri/src/tray.rs
@@ -167,12 +167,13 @@ impl TrayState {
                     }
                 }
                 "tray.restart" => {
-                    // Fire-and-forget。`perform_restart` 内部走 graceful
+                    // Fire-and-forget。托盘"重启"是 daemon + GUI 的完整重启:
+                    // `perform_full_restart` 先重启 daemon、再走 graceful
                     // shutdown → `app.restart()`,后者调用 `process::exit`,
                     // 该 future 在 happy path 永不返回。
                     let app = app.clone();
                     tauri::async_runtime::spawn(async move {
-                        crate::commands::restart::perform_restart(&app).await;
+                        crate::commands::restart::perform_full_restart(&app).await;
                     });
                 }
                 "tray.lightweight" => {


### PR DESCRIPTION
## Summary

- The tray **Restart** menu item only restarted the GUI process (`perform_restart` → `app.restart()`), leaving the daemon running untouched. It now restarts **both** daemon and GUI, mirroring the established frontend full-restart sequence `restart_daemon` → `restart_app` (see `DiagnosticsSettings.tsx`, `useConfigImport.ts`). (952a9ab9a)
- Reuses the two existing restart primitives rather than adding new logic: `uc_desktop::daemon_probe::restart_local_daemon()` (SIGTERM old daemon → wait exit → spawn → wait healthy) followed by `restart::perform_restart()` (emit frontend WS-disconnect hint → `app.restart()`). Restarting the daemon first means a fresh, healthy engine is already up by the time the replacement GUI bootstraps and reconnects — the daemon is spawned exactly once. (952a9ab9a)
- Wrapped the daemon+GUI sequence in a reusable `perform_full_restart()` in `commands/restart.rs` so the tray handler stays thin and the full-restart flow has a single owner. A daemon-restart failure is logged (`warn!`) but non-fatal — the GUI restarts anyway and its bootstrap retries spawn/recovery. (952a9ab9a)

## Test plan

- [x] `cargo check -p uc-tauri` passes.
- [x] `rustfmt` clean (pre-commit hook).
- [ ] Manual: click tray **Restart** and confirm via logs that the old daemon receives SIGTERM, a new daemon spawns and reports healthy, then the GUI process is replaced and reconnects to the new daemon.
- [ ] Manual: trigger tray **Restart** while the daemon is wedged / left over from a prior version, and confirm the fresh daemon's instance-lock eviction reclaims the lock.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The app’s restart action now performs a full restart, including restarting the background service before relaunching the interface.

* **Bug Fixes**
  * Improved restart reliability by continuing the restart flow even if the background service restart encounters a non-fatal error.
  * Restart behavior now better preserves a clean reconnect after relaunch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->