### PR TITLE
fix(ui): wire "open file location" to reveal received files

### DIFF
--- a/src/api/clipboardItems.ts
+++ b/src/api/clipboardItems.ts
@@ -9,8 +9,8 @@ import {
   getEntryDetail as daemonGetDetail,
 } from '@/api/daemon/clipboard'
 import { retryLifecycle } from '@/api/lifecycle'
+import { revealPath } from '@/api/storage'
 import { createLogger } from '@/lib/logger'
-import { invokeWithTrace } from '@/lib/tauri-command'
 
 const log = createLogger('clipboard-items')
 
@@ -261,16 +261,17 @@ export async function copyFileToClipboard(entryId: string): Promise<void> {
 }
 
 /**
- * Open the file location (containing folder) in the system file manager.
+ * Reveal a received file's local copy in the system file manager (opens the
+ * containing folder with the item selected).
  *
- * TODO(issue #698 follow-up): Rust `open_file_location` command 不存在 —
- * 调用会 runtime 报 "command not found"。同上待 daemon 化 / Rust 补 command。
+ * Received files materialize under the app cache dir
+ * (`<cache>/iroh-blobs/<entryId>/<filename>`). The daemon projection carries
+ * those `file://` URIs in `preview`, which `projectClipboardEntry` decodes into
+ * `ClipboardFileItem.file_paths`; callers resolve a concrete native path (see
+ * `firstRevealableFilePath`) and pass it here. Delegates to the native
+ * `reveal_path` command, which validates existence (404s when the file is gone)
+ * and is already used by the log/config-export flows.
  */
-export async function openFileLocation(entryId: string): Promise<void> {
-  try {
-    await invokeWithTrace('open_file_location', { entryId })
-  } catch (error) {
-    log.error({ err: error }, 'Failed to open file location')
-    throw error
-  }
+export async function openFileLocation(filePath: string): Promise<void> {
+  await revealPath(filePath)
 }

--- a/src/components/clipboard/ClipboardContent.tsx
+++ b/src/components/clipboard/ClipboardContent.tsx
@@ -13,6 +13,7 @@ import { usePlatform } from '@/hooks/usePlatform'
 import { useShortcut } from '@/hooks/useShortcut'
 import { useTransferProgress } from '@/hooks/useTransferProgress'
 import type { ClipboardFileItem, DisplayClipboardItem } from '@/lib/clipboard-entry'
+import { firstRevealableFilePath } from '@/lib/clipboard-utils'
 import { createLogger } from '@/lib/logger'
 import { cn } from '@/lib/utils'
 import { captureUserIntent } from '@/observability/breadcrumbs'
@@ -487,8 +488,15 @@ const ClipboardContent: React.FC<ClipboardContentProps> = ({
   // Open file location in system file manager
   const handleOpenFileLocation = useCallback(
     async (itemId: string) => {
+      const path = firstRevealableFilePath(flatItems.find(it => it.id === itemId)?.content ?? null)
+      if (!path) {
+        toast.error(t('clipboard.errors.openLocationFailed'), {
+          description: t('clipboard.errors.fileLocationUnavailable'),
+        })
+        return
+      }
       try {
-        await openFileLocation(itemId)
+        await openFileLocation(path)
       } catch (err) {
         log.error({ err }, 'Open file location failed')
         toast.error(t('clipboard.errors.openLocationFailed'), {
@@ -496,7 +504,7 @@ const ClipboardContent: React.FC<ClipboardContentProps> = ({
         })
       }
     },
-    [t]
+    [flatItems, t]
   )
 
   // Keyboard: C to copy (blocked for non-completed file entries)

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -753,6 +753,7 @@
     "errors": {
       "copyFailed": "Failed to copy to clipboard",
       "openLocationFailed": "Failed to open file location",
+      "fileLocationUnavailable": "This file is no longer available locally.",
       "loadDetailFailed": "Failed to load details",
       "unknown": "An unknown error occurred",
       "unavailableBadge": "Content unavailable",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -744,6 +744,7 @@
     "errors": {
       "copyFailed": "复制到剪贴板失败",
       "openLocationFailed": "打开文件位置失败",
+      "fileLocationUnavailable": "该文件本地已不可用。",
       "loadDetailFailed": "加载详情失败",
       "unknown": "发生未知错误",
       "unavailableBadge": "内容已不可用",

--- a/src/lib/__tests__/clipboard-transform.test.ts
+++ b/src/lib/__tests__/clipboard-transform.test.ts
@@ -76,6 +76,7 @@ describe('projectClipboardEntry', () => {
       file_names: ['report.pdf', 'lost.bin'],
       file_sizes: [100, 42],
       file_missing: [false, true],
+      file_paths: ['/tmp/report.pdf', null],
     })
   })
 

--- a/src/lib/__tests__/clipboard-utils.test.ts
+++ b/src/lib/__tests__/clipboard-utils.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ClipboardEntry, ClipboardEntryContent } from '@/lib/clipboard-entry'
-import { formatRelativeTime, getItemPreview } from '../clipboard-utils'
+import {
+  fileUriToLocalPath,
+  firstRevealableFilePath,
+  formatRelativeTime,
+  getItemPreview,
+} from '../clipboard-utils'
 
 function createEntry(
   type: ClipboardEntry['type'],
@@ -54,5 +59,63 @@ describe('clipboard-utils', () => {
     expect(formatRelativeTime(now - 5 * 60000)).toBe('5m')
     expect(formatRelativeTime(now - 2 * 3600000)).toBe('2h')
     expect(formatRelativeTime(now - 3 * 86400000)).toBe('3d')
+  })
+})
+
+describe('fileUriToLocalPath', () => {
+  it('decodes a POSIX file:// URI, including percent-encoded segments', () => {
+    expect(fileUriToLocalPath('file:///tmp/report.pdf')).toBe('/tmp/report.pdf')
+    expect(fileUriToLocalPath('file:///tmp/my%20file.txt')).toBe('/tmp/my file.txt')
+    expect(fileUriToLocalPath('  file:///tmp/spaced.bin  ')).toBe('/tmp/spaced.bin')
+  })
+
+  it('strips the leading slash before a Windows drive letter', () => {
+    expect(fileUriToLocalPath('file:///C:/dir/f.txt')).toBe('C:/dir/f.txt')
+  })
+
+  it('returns null for non-file URIs and unparseable input', () => {
+    expect(fileUriToLocalPath('uniclip-missing:///lost.bin?size=42')).toBeNull()
+    expect(fileUriToLocalPath('https://example.com/a')).toBeNull()
+    expect(fileUriToLocalPath('')).toBeNull()
+  })
+})
+
+describe('firstRevealableFilePath', () => {
+  it('returns the first non-missing decoded path', () => {
+    expect(
+      firstRevealableFilePath({
+        file_names: ['a', 'b'],
+        file_sizes: [1, 2],
+        file_paths: ['/tmp/a', '/tmp/b'],
+        file_missing: [false, false],
+      })
+    ).toBe('/tmp/a')
+  })
+
+  it('skips missing files and null paths', () => {
+    expect(
+      firstRevealableFilePath({
+        file_names: ['gone', 'ok'],
+        file_sizes: [1, 2],
+        file_paths: [null, '/tmp/ok'],
+        file_missing: [true, false],
+      })
+    ).toBe('/tmp/ok')
+  })
+
+  it('returns null when no file has a usable path', () => {
+    expect(
+      firstRevealableFilePath({
+        file_names: ['gone'],
+        file_sizes: [1],
+        file_paths: [null],
+        file_missing: [true],
+      })
+    ).toBeNull()
+    // Historical entry without the file_paths field.
+    expect(firstRevealableFilePath({ file_names: ['legacy'], file_sizes: [1] })).toBeNull()
+    // Non-file content.
+    expect(firstRevealableFilePath({ display_text: 'hi', has_detail: false, size: 2 })).toBeNull()
+    expect(firstRevealableFilePath(null)).toBeNull()
   })
 })

--- a/src/lib/clipboard-entry.ts
+++ b/src/lib/clipboard-entry.ts
@@ -27,6 +27,14 @@ export interface ClipboardFileItem {
   file_names: string[]
   file_sizes: number[]
   /**
+   * Per-file native local path, aligned with `file_names` by index. Decoded
+   * from the projection's `file://` URIs (received files materialize under the
+   * app cache dir). `null` for entries whose file URI couldn't be decoded or
+   * for `uniclip-missing://` placeholders. Absent for historical entries that
+   * predate this field. Backs the "open file location" action.
+   */
+  file_paths?: (string | null)[]
+  /**
    * Per-file missing flag, aligned with `file_names` / `file_sizes` by index.
    * `true` means the file never finished materializing when the entry was
    * persisted (the user cancelled the inbound transfer): it cannot be

--- a/src/lib/clipboard-transform.ts
+++ b/src/lib/clipboard-transform.ts
@@ -33,6 +33,7 @@ export function projectClipboardEntry(dto: ClipboardEntryDto): ClipboardEntry {
       file_names: parsed.map(p => p.name),
       file_sizes: dto.fileSizes ?? [],
       file_missing: parsed.map(p => p.missing),
+      file_paths: parsed.map(p => p.path),
     }
   } else if (isImage) {
     type = 'image'

--- a/src/lib/clipboard-utils.ts
+++ b/src/lib/clipboard-utils.ts
@@ -1,6 +1,7 @@
 import type {
   ClipboardCodeItem,
   ClipboardEntry,
+  ClipboardEntryContent,
   ClipboardFileItem,
   ClipboardImageItem,
   ClipboardLinkItem,
@@ -41,6 +42,30 @@ function extractFileNameFromUri(uri: string): string {
 }
 
 /**
+ * Convert a `file://` URI back to a native filesystem path.
+ *
+ * The daemon projection carries received files as `file://` URIs (produced by
+ * Rust `Url::from_file_path`); the native `reveal_path` command expects a plain
+ * filesystem path, so we decode it here. Returns `null` for non-`file://` URIs
+ * (e.g. `uniclip-missing://` placeholders) or unparseable input.
+ *
+ * Windows note: `file:///C:/dir/f.txt` decodes to a pathname of `/C:/dir/f.txt`,
+ * so the leading slash before the drive letter is stripped. Received files always
+ * land under the local app cache dir, so UNC paths are not expected.
+ */
+export function fileUriToLocalPath(uri: string): string | null {
+  const trimmed = uri.trim()
+  if (!trimmed.toLowerCase().startsWith('file://')) return null
+  try {
+    let pathname = decodeURIComponent(new URL(trimmed).pathname)
+    if (/^\/[A-Za-z]:/.test(pathname)) pathname = pathname.slice(1)
+    return pathname || null
+  } catch {
+    return null
+  }
+}
+
+/**
  * Parse a newline-separated URI list into an array of human-readable filenames.
  */
 export function parseFileNamesFromUriList(uriList: string): string[] {
@@ -75,6 +100,8 @@ function isUniclipMissingUri(uri: string): boolean {
  */
 export function parseFileItemsFromUriList(uriList: string): Array<{
   name: string
+  /** Native local path decoded from a `file://` URI, or `null` when absent. */
+  path: string | null
   missing: boolean
 }> {
   return uriList.split('\n').flatMap(s => {
@@ -83,10 +110,29 @@ export function parseFileItemsFromUriList(uriList: string): Array<{
     return [
       {
         name: extractFileNameFromUri(trimmed),
+        path: fileUriToLocalPath(trimmed),
         missing: isUniclipMissingUri(trimmed),
       },
     ]
   })
+}
+
+/**
+ * First openable native path in a file entry's content, or `null` when the
+ * entry is not a file entry, has no decoded paths, or every file is missing
+ * (cancelled transfer). Backs the "open file location" action — revealing any
+ * one file opens the containing folder with it selected.
+ */
+export function firstRevealableFilePath(content: ClipboardEntryContent | null): string | null {
+  if (!content || !('file_paths' in content)) return null
+  const paths = content.file_paths
+  if (!paths) return null
+  const missing = content.file_missing
+  for (let i = 0; i < paths.length; i++) {
+    const path = paths[i]
+    if (path && !missing?.[i]) return path
+  }
+  return null
 }
 
 /**


### PR DESCRIPTION
## Summary

- The clipboard file context menu's **Open File Location** action invoked a Tauri command `open_file_location` that was never implemented (an orphan stub from `b6eaccda1`). Every click failed at runtime with `command not found` — so the action never worked for any file, not just received ones. (90a6577a4)
- The fix needed **no daemon/DTO change**: received files already materialize on disk under the app cache dir (`<cache>/iroh-blobs/<entryId>/<filename>`) and their `file://` URIs are already carried in the entry projection's `preview` field. The frontend was simply discarding the directory while parsing, keeping only the filename. We now decode each `file://` URI back into a native path during projection (`ClipboardFileItem.file_paths`) and route the menu action to the **existing, validated `reveal_path` command** (the same one used by the log/config-export flows, which checks `exists()` and 404s on a missing file). (90a6577a4)
- When no local path is available (cancelled / missing files, undecodable URIs, historical entries), the action shows a clear toast (`clipboard.errors.fileLocationUnavailable`, en + zh) instead of silently failing. (90a6577a4)

## Test plan

- [x] `vitest run src/lib/__tests__/clipboard-utils.test.ts src/lib/__tests__/clipboard-transform.test.ts` — 14 passed (new coverage for `fileUriToLocalPath` POSIX/Windows/non-file cases and `firstRevealableFilePath` missing/legacy/non-file fallbacks; updated the file-projection assertion).
- [x] `tsc --noEmit` — clean; `eslint` on changed files — clean.
- [ ] Manual: receive a file from a peer, right-click the entry → **Open File Location**, confirm Finder/Explorer opens the cache folder with the file selected (macOS + Windows).
- [ ] Manual: cancel an inbound transfer (partial / missing file), confirm the menu item is hidden and, if reached, the "file location unavailable" toast appears.

> Note: reveal opens the app **cache** dir (the real landing spot for received files), not the user's Downloads folder. That's correct behavior here; relocating received files to a user-visible folder would be a separate product decision.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * You can now open a clipboard item’s file location using the actual local file path when it’s available.
  * File-based clipboard items now retain usable local paths for better file access.

* **Bug Fixes**
  * Improved handling for file items that can’t be opened locally, with a clearer error message.
  * Better support for file URI parsing, including encoded paths and Windows-style file paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->