### PR TITLE
fix(clipboard): pair next-change fallback to its write to stop leak

### DIFF
--- a/crates/uc-application/src/clipboard_write/coordinator.rs
+++ b/crates/uc-application/src/clipboard_write/coordinator.rs
@@ -326,10 +326,12 @@ impl ClipboardWriteCoordinator {
             match intent {
                 ClipboardWriteIntent::LocalRestore => {
                     // File restores can come back from the platform clipboard with rewritten
-                    // URI/path bytes, so the content record alone is not sufficient.
+                    // URI/path bytes, so the content record alone is not sufficient. Pair the
+                    // fallback to this write via its guard key so a repeat write of the same
+                    // snapshot coalesces instead of leaving a stray fallback behind.
                     self.clipboard_change_origin
                         .record_self_write(
-                            SelfWriteMatch::ByNextChange,
+                            SelfWriteMatch::ByNextChange(origin_guard_key.clone()),
                             SelfWriteAttribution::Local,
                             LOCAL_ECHO_RTT_MAX,
                         )
@@ -339,10 +341,12 @@ impl ClipboardWriteCoordinator {
                     // Some platforms (e.g. Windows clipboard-rs) re-encode images (PNG→DIB→PNG),
                     // producing different bytes than the original. The content record above won't
                     // match the re-encoded content, so we arm a next-change record: the NEXT
-                    // clipboard change is treated as RemotePush regardless of hash.
+                    // clipboard change is treated as RemotePush regardless of hash. The guard key
+                    // pairs the fallback to this write so a duplicated push of the same snapshot
+                    // coalesces instead of leaking a fallback that would swallow a later copy.
                     self.clipboard_change_origin
                         .record_self_write(
-                            SelfWriteMatch::ByNextChange,
+                            SelfWriteMatch::ByNextChange(origin_guard_key.clone()),
                             SelfWriteAttribution::Remote,
                             REMOTE_ECHO_RTT_MAX,
                         )

--- a/crates/uc-core/src/ports/clipboard/self_write_ledger.rs
+++ b/crates/uc-core/src/ports/clipboard/self_write_ledger.rs
@@ -11,7 +11,15 @@ pub enum SelfWriteMatch {
     /// Match the very next observed change regardless of its content. Used when
     /// the bytes may be re-encoded between write and observation, so a content
     /// key cannot be relied on.
-    ByNextChange,
+    ///
+    /// The carried key is the content guard key of the same write this fallback
+    /// backs — the key that write also armed as [`ByContent`]. It pairs the
+    /// fallback to its write so a content match can retire exactly the
+    /// now-redundant fallback (and not a concurrent write's), and so repeated
+    /// arms of one write coalesce instead of accumulating duplicate fallbacks.
+    /// The key never gates matching: consumption still resolves the next change
+    /// regardless of its hash.
+    ByNextChange(String),
 }
 
 /// What a matched self-write should attribute the observed change to.

--- a/crates/uc-infra/src/clipboard/change_origin.rs
+++ b/crates/uc-infra/src/clipboard/change_origin.rs
@@ -35,6 +35,12 @@ struct ContentRecord {
 /// did not resolve against a content record (covers bytes re-encoded between
 /// write and echo, where no content key can be relied on).
 struct NextChangeRecord {
+    /// Content guard key of the write this fallback backs. Pairs the fallback to
+    /// its write so a content match retires exactly the redundant one (not a
+    /// concurrent write's), and keys arm-time de-duplication. Never consulted
+    /// when the fallback is consumed by an unmatched change — consumption stays
+    /// content-agnostic to catch re-encoded echoes under an unknown hash.
+    guard_key: String,
     attribution: SelfWriteAttribution,
     expires_at: Instant,
 }
@@ -128,18 +134,34 @@ impl SelfWriteLedgerPort for InMemorySelfWriteLedger {
                 );
                 Self::remember_content_record(&mut state, snapshot_hash, attribution, expires_at);
             }
-            SelfWriteMatch::ByNextChange => {
+            SelfWriteMatch::ByNextChange(guard_key) => {
                 debug!(
                     ?attribution,
                     ttl_ms = ttl.as_millis(),
                     "self_write_ledger record next-change fallback"
                 );
-                state.next_changes.push_back(NextChangeRecord {
-                    attribution,
-                    expires_at,
-                });
-                while state.next_changes.len() > NEXT_CHANGE_MAX {
-                    state.next_changes.pop_front();
+                // De-duplicate by (guard_key, attribution). One write may arm
+                // its fallback more than once — the same snapshot written twice
+                // coalesces into a single OS echo, so a duplicate fallback would
+                // linger past that lone echo and swallow the next genuine change.
+                // Same key+attribution is the same write, so refreshing the
+                // existing record's backstop is correct; a different key (a
+                // concurrent write) keeps its own independent fallback.
+                if let Some(idx) = state
+                    .next_changes
+                    .iter()
+                    .position(|r| r.guard_key == guard_key && r.attribution == attribution)
+                {
+                    state.next_changes[idx].expires_at = expires_at;
+                } else {
+                    state.next_changes.push_back(NextChangeRecord {
+                        guard_key,
+                        attribution,
+                        expires_at,
+                    });
+                    while state.next_changes.len() > NEXT_CHANGE_MAX {
+                        state.next_changes.pop_front();
+                    }
                 }
             }
         }
@@ -156,17 +178,15 @@ impl SelfWriteLedgerPort for InMemorySelfWriteLedger {
             .position(|r| r.snapshot_hash == snapshot_hash)
         {
             if let Some(stored) = state.content_records.remove(idx) {
-                // The content match resolved this write's echo, so its paired
-                // next-change fallback is now redundant and would otherwise
-                // misclassify the next genuine user action. Same-attribution
-                // fallbacks are interchangeable, so dropping any one of the
-                // matching attribution is correct — and, unlike clearing the
-                // whole queue, it leaves a concurrent write's fallback intact.
-                if let Some(fidx) = state
-                    .next_changes
-                    .iter()
-                    .position(|r| r.attribution == stored.attribution)
-                {
+                // The content match resolved this write's echo, so the fallback
+                // paired to the SAME write is now redundant and would otherwise
+                // misclassify the next genuine user action. Match by guard_key
+                // (the paired write's content key), not merely attribution, so a
+                // concurrent write's independent fallback — which may still need
+                // to absorb a re-encoded echo — survives.
+                if let Some(fidx) = state.next_changes.iter().position(|r| {
+                    r.guard_key == snapshot_hash && r.attribution == stored.attribution
+                }) {
                     state.next_changes.remove(fidx);
                 }
                 debug!(
@@ -256,7 +276,7 @@ mod tests {
         let ledger = InMemorySelfWriteLedger::new();
         ledger
             .record_self_write(
-                SelfWriteMatch::ByNextChange,
+                SelfWriteMatch::ByNextChange("h1".into()),
                 SelfWriteAttribution::Remote,
                 LONG,
             )
@@ -286,7 +306,7 @@ mod tests {
             .await;
         ledger
             .record_self_write(
-                SelfWriteMatch::ByNextChange,
+                SelfWriteMatch::ByNextChange("h1".into()),
                 SelfWriteAttribution::Local,
                 LONG,
             )
@@ -321,7 +341,7 @@ mod tests {
             .await;
         ledger
             .record_self_write(
-                SelfWriteMatch::ByNextChange,
+                SelfWriteMatch::ByNextChange("h1".into()),
                 SelfWriteAttribution::Remote,
                 LONG,
             )
@@ -336,7 +356,7 @@ mod tests {
             .await;
         ledger
             .record_self_write(
-                SelfWriteMatch::ByNextChange,
+                SelfWriteMatch::ByNextChange("h2".into()),
                 SelfWriteAttribution::Remote,
                 LONG,
             )
@@ -352,6 +372,60 @@ mod tests {
         assert_eq!(
             ledger.attribute_observed_change("h2-reencoded").await,
             ClipboardChangeOrigin::remote_push_anonymous()
+        );
+    }
+
+    /// Regression: an inbound sync that writes the SAME snapshot twice (e.g. an
+    /// apply followed by an active-state rebroadcast) arms two content records
+    /// and two fallbacks under one attribution. The OS coalesces the two
+    /// identical writes into a single observed echo, so only one content match
+    /// fires. Under the old design the second fallback leaked and the next
+    /// genuine user copy — arbitrary unrelated content — was swallowed as a
+    /// RemotePush echo, producing zero capture entries.
+    #[tokio::test]
+    async fn double_write_same_content_does_not_leak_fallback() {
+        let ledger = InMemorySelfWriteLedger::new();
+        // First write of the snapshot: content guard + paired fallback.
+        ledger
+            .record_self_write(
+                SelfWriteMatch::ByContent("h".into()),
+                SelfWriteAttribution::Remote,
+                LONG,
+            )
+            .await;
+        ledger
+            .record_self_write(
+                SelfWriteMatch::ByNextChange("h".into()),
+                SelfWriteAttribution::Remote,
+                LONG,
+            )
+            .await;
+        // Second write of the IDENTICAL snapshot (same hash, same attribution).
+        ledger
+            .record_self_write(
+                SelfWriteMatch::ByContent("h".into()),
+                SelfWriteAttribution::Remote,
+                LONG,
+            )
+            .await;
+        ledger
+            .record_self_write(
+                SelfWriteMatch::ByNextChange("h".into()),
+                SelfWriteAttribution::Remote,
+                LONG,
+            )
+            .await;
+
+        // The OS merged both writes into one observed echo.
+        assert_eq!(
+            ledger.attribute_observed_change("h").await,
+            ClipboardChangeOrigin::remote_push_anonymous()
+        );
+        // A genuine, unrelated user copy must resolve to a fresh capture, NOT be
+        // eaten by a leaked fallback from the duplicated write.
+        assert_eq!(
+            ledger.attribute_observed_change("a-real-user-copy").await,
+            ClipboardChangeOrigin::LocalCapture
         );
     }
 


### PR DESCRIPTION
## Summary

- The self-write ledger leaked a next-change fallback when an inbound sync wrote the **same** snapshot twice. Content records de-duplicate by `(hash, attribution)` but the fallback queue did not, so two identical writes left one content record and two fallbacks. The OS coalesces the two writes into a single observed echo → one content match fires and removes one fallback → the second fallback survives and, within its 60s TTL, `pop_front`s the next genuine user copy and misattributes it as a RemotePush echo. The watcher then skips it and **no capture entry is produced** — observed on Windows as "copying a file is simply not detected" (zero entries). (`899655e46`)
- Fix pairs each next-change fallback to its write via that write's content guard key:
  - `uc-core`: `SelfWriteMatch::ByNextChange` now carries the guard key (the hash the same write also armed as `ByContent`). The key never gates matching — consumption stays content-agnostic.
  - `uc-infra` (`change_origin.rs`): fallbacks de-duplicate by `(guard_key, attribution)` at arm time (a repeated write of the same snapshot coalesces instead of accumulating), and a content match retires only the fallback paired to **that** write — by `guard_key`, not merely attribution — so a concurrent write's independent fallback (which may still need to absorb a re-encoded echo) survives.
  - `uc-application`: the write coordinator passes the write's `origin_guard_key` when arming the fallback.

This is the root-cause defensive fix: the ledger no longer leaks regardless of how many times the inbound path writes the same content. Eliminating the inbound double-write itself is now an efficiency-only concern (no correctness impact) and is left as a separate follow-up to avoid touching the large `apply_inbound` path here.

## Test plan

- [x] Unit (red→green): new regression `double_write_same_content_does_not_leak_fallback` fails before the fix (next genuine copy resolves to `RemotePush`) and passes after (`LocalCapture`); all 8 ledger tests + `clipboard_write` / `clipboard_restore` suites green. The pre-existing `concurrent_remote_writes_keep_independent_fallbacks` invariant is preserved.
- [x] Real-machine Windows validation (by author): copying a fresh file within a Mac→Windows active-state churn window now resolves to `LocalCapture` and produces exactly one entry, instead of being swallowed as a RemotePush echo.
- [ ] (optional follow-up) Eliminate the inbound same-content double-write at its source (`apply_inbound` + active-state rebroadcast) — efficiency only after this fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved clipboard self-write tracking so repeated writes of the same content no longer leave behind stale fallback records.
  * Fixed an issue where a later clipboard action could be incorrectly suppressed after duplicate self-writes.
  * Clipboard origin matching now more precisely pairs fallback records with the related write, reducing unintended cross-matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->