### PR TITLE
fix(blob): derive ingest content hash from stored bytes to close TOCTOU

### DIFF
--- a/crates/uc-infra/src/blob/blob_writer.rs
+++ b/crates/uc-infra/src/blob/blob_writer.rs
@@ -1,14 +1,14 @@
 use anyhow::{Context, Result};
 use async_trait::async_trait;
-use std::io::Read;
 use std::path::Path;
-use tracing::{debug, debug_span, Instrument};
+use tracing::{debug, debug_span, warn, Instrument};
 use uc_core::blob::ports::{BlobContentIngestPort, BlobWriterPort, IngestedBlob};
 use uc_core::ports::ClockPort;
 use uc_core::BlobId;
 use uc_core::ContentHash;
 
-use crate::blob::{Blob, BlobRepositoryPort, BlobStorageLocator, BlobStorePort};
+use crate::blob::hashing::stream_hash_file;
+use crate::blob::{Blob, BlobRepositoryPort, BlobStorageLocator, BlobStorePort, StoredPathBlob};
 
 pub struct BlobWriter<B, BR, C>
 where
@@ -37,10 +37,17 @@ where
 
     /// Stream a path-backed file into blob storage, deduplicating by content
     /// hash, and surface the storage handle together with the content hash and
-    /// byte size computed during the single streaming pass.
+    /// byte size computed during the single storing pass.
     ///
     /// Shared core for both `BlobWriterPort::write_path_if_absent` (which
     /// discards everything but the `BlobId`) and `BlobContentIngestPort::ingest_path`.
+    ///
+    /// The content hash is derived by the store from the exact bytes it persists
+    /// (a single pass), so the recorded `content_hash`/`size_bytes` can never
+    /// diverge from the stored blob — there is no separate hash pass that a
+    /// concurrent source rewrite could race against. Deduplication therefore runs
+    /// *after* the write, against the authoritative hash; on a dedup hit the
+    /// freshly written blob is dropped and the existing record is reused.
     async fn ingest_path_inner(&self, source_path: &Path) -> Result<IngestedBlob> {
         // No source_path field: a clipboard file path is user content (it can
         // carry usernames / sensitive filenames). The inner logs identify the
@@ -49,72 +56,95 @@ where
         let source = source_path.to_path_buf();
 
         async move {
-            // 1. 流式读取源文件计算 ContentHash —— 不把整文件载入内存,以支持任意大小。
-            let hash_source = source.clone();
-            let (content_id, file_size) =
-                tokio::task::spawn_blocking(move || stream_hash_file(&hash_source))
-                    .await
-                    .context("hash join failed")??;
+            // 1. 落盘:store 在写入的同一遍里算出权威 content_hash + size,二者与实际
+            //    持有的字节同源(hardlink 时哈希 dest,copy/加密时哈希落盘字节流)。
+            let blob_id = BlobId::new();
+            let StoredPathBlob {
+                storage_path,
+                content_hash,
+                size_bytes,
+                compressed_size,
+            } = match self.blob_store.put_from_path(&blob_id, &source).await {
+                Ok(stored) => stored,
+                Err(err) => {
+                    // A partial write (mid-copy read error, post-link hash
+                    // failure, …) may have left a file under this blob_id. Clean
+                    // it up so a failed ingest never leaks an orphan blob.
+                    self.discard_blob(&blob_id, "put_from_path failed").await;
+                    return Err(err);
+                }
+            };
             debug!(
-                content_hash = %content_id,
-                file_size,
-                "Computed content hash for path-backed ingest"
+                content_hash = %content_hash,
+                file_size = size_bytes,
+                "Persisted path-backed blob; recording by authoritative content hash"
             );
 
-            // 2. 已有同 hash blob → 直接复用,不再做盘 IO。
-            if let Some(existing) = self.blob_repo.find_by_hash(&content_id).await? {
+            // 2. 按权威 hash 去重:已有同内容 blob → 丢弃刚落盘的副本,复用既有记录。
+            if let Some(existing) = self.blob_repo.find_by_hash(&content_hash).await? {
                 debug!(
-                    content_hash = %content_id,
+                    content_hash = %content_hash,
                     blob_id = %existing.blob_id,
-                    "Path ingest: dedup hit, reusing existing blob"
+                    "Path ingest: dedup hit, dropping freshly written blob and reusing existing"
                 );
+                self.discard_blob(&blob_id, "dedup hit").await;
                 return Ok(IngestedBlob {
                     blob_id: existing.blob_id,
-                    content_hash: content_id,
-                    size_bytes: file_size,
+                    content_hash,
+                    size_bytes,
                 });
             }
-
-            // 3. 未命中 → 走 BlobStorePort.put_from_path(hardlink 优先,跨卷 fallback copy;
-            //    加密 decorator 会 override 为读 → 加密 → 写)。
-            let blob_id = BlobId::new();
-            let (storage_path, compressed_size) =
-                self.blob_store.put_from_path(&blob_id, &source).await?;
 
             let created_at_ms = self.clock.now_ms();
             let blob_storage_locator = BlobStorageLocator::new_local_fs(storage_path);
             let record = Blob::new(
                 blob_id.clone(),
                 blob_storage_locator,
-                file_size as i64,
-                content_id.clone(),
+                size_bytes as i64,
+                content_hash.clone(),
                 created_at_ms,
                 compressed_size,
             );
 
             if let Err(err) = self.blob_repo.insert_blob(&record).await {
-                if let Some(existing) = self.blob_repo.find_by_hash(&content_id).await? {
+                if let Some(existing) = self.blob_repo.find_by_hash(&content_hash).await? {
                     debug!(
                         error = %err,
-                        content_hash = %content_id,
-                        "Path ingest insert raced with existing blob; returning existing record",
+                        content_hash = %content_hash,
+                        "Path ingest insert raced with existing blob; dropping freshly written blob and returning existing record",
                     );
+                    self.discard_blob(&blob_id, "insert race").await;
                     return Ok(IngestedBlob {
                         blob_id: existing.blob_id,
-                        content_hash: content_id,
-                        size_bytes: file_size,
+                        content_hash,
+                        size_bytes,
                     });
                 }
                 return Err(err);
             }
             Ok(IngestedBlob {
                 blob_id,
-                content_hash: content_id,
-                size_bytes: file_size,
+                content_hash,
+                size_bytes,
             })
         }
         .instrument(span)
         .await
+    }
+
+    /// Remove a blob that was written but will not be referenced by any record
+    /// (dedup hit, insert race, or a failed write that left a partial file). A
+    /// failed cleanup is logged but not propagated: the redundant blob is an
+    /// orphan, not a correctness fault for the ingest the caller asked for.
+    async fn discard_blob(&self, blob_id: &BlobId, reason: &str) {
+        if let Err(err) = self.blob_store.delete(blob_id).await {
+            warn!(
+                error = %err,
+                blob_id = %blob_id,
+                reason,
+                "Failed to remove redundant blob during path ingest cleanup"
+            );
+        }
     }
 }
 
@@ -215,22 +245,100 @@ where
     }
 }
 
-/// 对 `path` 流式做 blake3 哈希,返回 (ContentHash, file_size_bytes)。
-/// 64 KiB 缓冲,常驻内存与文件大小无关。
-fn stream_hash_file(path: &Path) -> Result<(ContentHash, u64)> {
-    let mut file = std::fs::File::open(path)
-        .with_context(|| format!("failed to open {} for hashing", path.display()))?;
-    let mut hasher = blake3::Hasher::new();
-    let mut buf = [0u8; 64 * 1024];
-    let mut total: u64 = 0;
-    loop {
-        let n = file.read(&mut buf).context("read failed during hashing")?;
-        if n == 0 {
-            break;
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::blob::FilesystemBlobStore;
+    use std::sync::{Arc, Mutex};
+
+    struct FixedClock(i64);
+    impl ClockPort for FixedClock {
+        fn now_ms(&self) -> i64 {
+            self.0
         }
-        hasher.update(&buf[..n]);
-        total = total.saturating_add(n as u64);
     }
-    let hash = hasher.finalize();
-    Ok((ContentHash::from(hash.as_bytes()), total))
+
+    /// In-memory blob repository that enforces the same `content_hash UNIQUE`
+    /// constraint the SQLite-backed repository relies on, so the dedup/insert-race
+    /// paths exercise realistic behaviour.
+    #[derive(Default)]
+    struct InMemoryBlobRepo {
+        rows: Mutex<Vec<Blob>>,
+    }
+
+    #[async_trait]
+    impl BlobRepositoryPort for InMemoryBlobRepo {
+        async fn insert_blob(&self, blob: &Blob) -> Result<()> {
+            let mut rows = self.rows.lock().unwrap();
+            if rows.iter().any(|b| b.content_hash == blob.content_hash) {
+                anyhow::bail!("UNIQUE constraint failed: blob.content_hash");
+            }
+            rows.push(blob.clone());
+            Ok(())
+        }
+
+        async fn find_by_hash(&self, content_hash: &ContentHash) -> Result<Option<Blob>> {
+            let rows = self.rows.lock().unwrap();
+            Ok(rows
+                .iter()
+                .find(|b| &b.content_hash == content_hash)
+                .cloned())
+        }
+    }
+
+    fn hash_of(bytes: &[u8]) -> ContentHash {
+        ContentHash::from(blake3::hash(bytes).as_bytes())
+    }
+
+    fn count_blob_files(dir: &Path) -> usize {
+        std::fs::read_dir(dir).map(|rd| rd.count()).unwrap_or(0)
+    }
+
+    #[tokio::test]
+    async fn ingest_records_hash_matching_stored_bytes() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = Arc::new(FilesystemBlobStore::new(tmp.path().join("blobs")));
+        let repo = Arc::new(InMemoryBlobRepo::default());
+        let writer = BlobWriter::new(store.clone(), repo, FixedClock(123));
+
+        let src = tmp.path().join("a.bin");
+        let content = b"writer ingest: identity matches stored bytes".to_vec();
+        tokio::fs::write(&src, &content).await.unwrap();
+
+        let ingested = writer.ingest_path(&src).await.unwrap();
+        assert_eq!(ingested.content_hash, hash_of(&content));
+        assert_eq!(ingested.size_bytes, content.len() as u64);
+
+        let stored_bytes = BlobStorePort::get(store.as_ref(), &ingested.blob_id)
+            .await
+            .unwrap();
+        assert_eq!(hash_of(&stored_bytes), ingested.content_hash);
+    }
+
+    #[tokio::test]
+    async fn second_ingest_of_same_content_dedups_without_orphan() {
+        let tmp = tempfile::tempdir().unwrap();
+        let blob_dir = tmp.path().join("blobs");
+        let store = Arc::new(FilesystemBlobStore::new(blob_dir.clone()));
+        let repo = Arc::new(InMemoryBlobRepo::default());
+        let writer = BlobWriter::new(store.clone(), repo.clone(), FixedClock(0));
+
+        // Two distinct source paths carrying identical bytes.
+        let content = b"dedupe me across two paths".to_vec();
+        let src1 = tmp.path().join("one.bin");
+        let src2 = tmp.path().join("two.bin");
+        tokio::fs::write(&src1, &content).await.unwrap();
+        tokio::fs::write(&src2, &content).await.unwrap();
+
+        let first = writer.ingest_path(&src1).await.unwrap();
+        let second = writer.ingest_path(&src2).await.unwrap();
+
+        // Same content → same identity, and the existing blob is reused.
+        assert_eq!(first.content_hash, second.content_hash);
+        assert_eq!(first.blob_id, second.blob_id);
+        // The redundant second write was discarded: exactly one blob on disk and
+        // one row in the repository, no orphan left behind.
+        assert_eq!(count_blob_files(&blob_dir), 1);
+        assert_eq!(repo.rows.lock().unwrap().len(), 1);
+    }
 }

--- a/crates/uc-infra/src/blob/blob_writer.rs
+++ b/crates/uc-infra/src/blob/blob_writer.rs
@@ -81,18 +81,27 @@ where
             );
 
             // 2. 按权威 hash 去重:已有同内容 blob → 丢弃刚落盘的副本,复用既有记录。
-            if let Some(existing) = self.blob_repo.find_by_hash(&content_hash).await? {
-                debug!(
-                    content_hash = %content_hash,
-                    blob_id = %existing.blob_id,
-                    "Path ingest: dedup hit, dropping freshly written blob and reusing existing"
-                );
-                self.discard_blob(&blob_id, "dedup hit").await;
-                return Ok(IngestedBlob {
-                    blob_id: existing.blob_id,
-                    content_hash,
-                    size_bytes,
-                });
+            //    blob 此刻已落盘但尚无 DB 记录,因此每一条 post-write 失败退出路径都必须
+            //    先 discard,否则会留下无记录引用的孤儿 blob。
+            match self.blob_repo.find_by_hash(&content_hash).await {
+                Ok(Some(existing)) => {
+                    debug!(
+                        content_hash = %content_hash,
+                        blob_id = %existing.blob_id,
+                        "Path ingest: dedup hit, dropping freshly written blob and reusing existing"
+                    );
+                    self.discard_blob(&blob_id, "dedup hit").await;
+                    return Ok(IngestedBlob {
+                        blob_id: existing.blob_id,
+                        content_hash,
+                        size_bytes,
+                    });
+                }
+                Ok(None) => {}
+                Err(err) => {
+                    self.discard_blob(&blob_id, "dedup lookup failed").await;
+                    return Err(err);
+                }
             }
 
             let created_at_ms = self.clock.now_ms();
@@ -106,10 +115,12 @@ where
                 compressed_size,
             );
 
-            if let Err(err) = self.blob_repo.insert_blob(&record).await {
-                if let Some(existing) = self.blob_repo.find_by_hash(&content_hash).await? {
+            if let Err(insert_err) = self.blob_repo.insert_blob(&record).await {
+                // Insert most likely lost the content_hash UNIQUE race with a
+                // concurrent ingest; reuse the winner's record if it is present.
+                if let Ok(Some(existing)) = self.blob_repo.find_by_hash(&content_hash).await {
                     debug!(
-                        error = %err,
+                        error = %insert_err,
                         content_hash = %content_hash,
                         "Path ingest insert raced with existing blob; dropping freshly written blob and returning existing record",
                     );
@@ -120,7 +131,10 @@ where
                         size_bytes,
                     });
                 }
-                return Err(err);
+                // No existing record (or the re-check itself errored): the stored
+                // blob has no owning row, so drop it before surfacing the error.
+                self.discard_blob(&blob_id, "insert failed").await;
+                return Err(insert_err);
             }
             Ok(IngestedBlob {
                 blob_id,

--- a/crates/uc-infra/src/blob/filesystem_store.rs
+++ b/crates/uc-infra/src/blob/filesystem_store.rs
@@ -98,9 +98,9 @@ impl BlobStorePort for FilesystemBlobStore {
                     tokio::task::spawn_blocking(move || copy_and_hash(&copy_source, &copy_dest))
                         .await
                         .context("blob copy join failed")?
-                        .with_context(|| {
-                            format!("failed to copy {} -> {}", source.display(), dest.display())
-                        })?
+                        // No source path in the context: it is user content. The
+                        // dest path is our own blob-store location (blob_id).
+                        .with_context(|| format!("failed to copy source into blob {blob_id}"))?
                 }
             };
 

--- a/crates/uc-infra/src/blob/filesystem_store.rs
+++ b/crates/uc-infra/src/blob/filesystem_store.rs
@@ -7,7 +7,8 @@ use tracing::debug;
 use uc_core::blob::ports::BlobReaderPort;
 use uc_core::BlobId;
 
-use crate::blob::BlobStorePort;
+use crate::blob::hashing::{copy_and_hash, stream_hash_file};
+use crate::blob::{BlobStorePort, StoredPathBlob};
 
 /// Filesystem-based blob storage.
 pub struct FilesystemBlobStore {
@@ -55,11 +56,7 @@ impl BlobStorePort for FilesystemBlobStore {
         <Self as BlobReaderPort>::get(self, blob_id).await
     }
 
-    async fn put_from_path(
-        &self,
-        blob_id: &BlobId,
-        source_path: &Path,
-    ) -> Result<(PathBuf, Option<i64>)> {
+    async fn put_from_path(&self, blob_id: &BlobId, source_path: &Path) -> Result<StoredPathBlob> {
         self.ensure_dir().await?;
         let dest = self.blob_path(blob_id);
         let source = source_path.to_path_buf();
@@ -68,52 +65,73 @@ impl BlobStorePort for FilesystemBlobStore {
         // 跨卷(EXDEV)或某些文件系统(SMB/NFS 部分配置)不支持 hardlink,回退到 copy。
         let link_dest = dest.clone();
         let link_source = source.clone();
-        match tokio::task::spawn_blocking(move || std::fs::hard_link(&link_source, &link_dest))
-            .await
-            .context("hardlink join failed")?
-        {
-            Ok(()) => {
-                debug!(
-                    blob_id = %blob_id,
-                    source = %source.display(),
-                    dest = %dest.display(),
-                    "Hardlinked source file into blob store"
-                );
-                return Ok((dest, None));
-            }
-            Err(err) => {
-                debug!(
-                    blob_id = %blob_id,
-                    source = %source.display(),
-                    dest = %dest.display(),
-                    error = %err,
-                    "Hardlink failed; falling back to streaming copy (likely EXDEV or unsupported FS)"
-                );
-            }
-        }
+        let (content_hash, size_bytes) =
+            match tokio::task::spawn_blocking(move || std::fs::hard_link(&link_source, &link_dest))
+                .await
+                .context("hardlink join failed")?
+            {
+                Ok(()) => {
+                    debug!(
+                        blob_id = %blob_id,
+                        "Hardlinked source file into blob store; hashing stored blob"
+                    );
+                    // Hash the destination (== the linked inode), not the source:
+                    // the recorded identity is then of the exact bytes the blob
+                    // points at, closing the hash/store divergence window even if
+                    // the source path is replaced right after the link.
+                    let hash_dest = dest.clone();
+                    tokio::task::spawn_blocking(move || stream_hash_file(&hash_dest))
+                        .await
+                        .context("blob hash join failed")??
+                }
+                Err(err) => {
+                    debug!(
+                        blob_id = %blob_id,
+                        error = %err,
+                        "Hardlink failed; streaming copy+hash (likely EXDEV or unsupported FS)"
+                    );
+                    // Streaming copy that hashes in the same pass: the source is
+                    // read exactly once and the hash is of the bytes written to
+                    // dest, so no second read can observe a rewritten source.
+                    let copy_source = source.clone();
+                    let copy_dest = dest.clone();
+                    tokio::task::spawn_blocking(move || copy_and_hash(&copy_source, &copy_dest))
+                        .await
+                        .context("blob copy join failed")?
+                        .with_context(|| {
+                            format!("failed to copy {} -> {}", source.display(), dest.display())
+                        })?
+                }
+            };
 
-        // 流式 copy 回退:tokio::fs::copy 内部按块读写,常驻内存极小。
-        let copied = tokio::fs::copy(&source, &dest).await.with_context(|| {
-            format!("failed to copy {} -> {}", source.display(), dest.display())
-        })?;
         debug!(
             blob_id = %blob_id,
-            source = %source.display(),
-            dest = %dest.display(),
-            bytes = copied,
-            "Copied source file into blob store"
+            size_bytes,
+            "Persisted source file into blob store"
         );
 
-        // 与 put() 行为对齐:确保字节真正落盘后再返回。
-        let dest_file = tokio::fs::File::open(&dest)
-            .await
-            .context("failed to reopen blob file for sync")?;
-        dest_file
-            .sync_all()
-            .await
-            .context("failed to sync blob file after copy")?;
+        Ok(StoredPathBlob {
+            storage_path: dest,
+            content_hash,
+            size_bytes,
+            // Raw filesystem store doesn't track compression.
+            compressed_size: None,
+        })
+    }
 
-        Ok((dest, None))
+    async fn delete(&self, blob_id: &BlobId) -> Result<()> {
+        let path = self.blob_path(blob_id);
+        match tokio::fs::remove_file(&path).await {
+            Ok(()) => {
+                debug!(blob_id = %blob_id, "Deleted blob from filesystem store");
+                Ok(())
+            }
+            // Idempotent: an already-absent blob is a no-op, not an error.
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(err) => {
+                Err(err).with_context(|| format!("failed to delete blob {}", path.display()))
+            }
+        }
     }
 }
 
@@ -131,5 +149,58 @@ impl BlobReaderPort for FilesystemBlobStore {
             .context("Failed to read blob data")?;
 
         Ok(data)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use uc_core::ContentHash;
+
+    fn hash_of(bytes: &[u8]) -> ContentHash {
+        ContentHash::from(blake3::hash(bytes).as_bytes())
+    }
+
+    #[tokio::test]
+    async fn put_from_path_records_hash_matching_stored_bytes() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = FilesystemBlobStore::new(tmp.path().join("blobs"));
+
+        let src = tmp.path().join("source.bin");
+        let content = b"toctou-regression: recorded hash must match stored bytes".to_vec();
+        tokio::fs::write(&src, &content).await.unwrap();
+
+        let blob_id = BlobId::new();
+        let stored = store.put_from_path(&blob_id, &src).await.unwrap();
+
+        // The returned identity is derived from the bytes the store persisted.
+        assert_eq!(stored.size_bytes, content.len() as u64);
+        assert_eq!(stored.content_hash, hash_of(&content));
+        assert_eq!(stored.compressed_size, None);
+
+        // And those persisted bytes hash back to the very same identity.
+        let got = BlobReaderPort::get(&store, &blob_id).await.unwrap();
+        assert_eq!(got, content);
+        assert_eq!(hash_of(&got), stored.content_hash);
+    }
+
+    #[tokio::test]
+    async fn delete_removes_blob_and_is_idempotent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = FilesystemBlobStore::new(tmp.path().join("blobs"));
+
+        let blob_id = BlobId::new();
+        // Deleting an absent blob is a no-op, not an error.
+        store.delete(&blob_id).await.unwrap();
+
+        let src = tmp.path().join("source.bin");
+        tokio::fs::write(&src, b"bytes").await.unwrap();
+        store.put_from_path(&blob_id, &src).await.unwrap();
+        assert!(BlobReaderPort::get(&store, &blob_id).await.is_ok());
+
+        store.delete(&blob_id).await.unwrap();
+        assert!(BlobReaderPort::get(&store, &blob_id).await.is_err());
+        // A second delete still succeeds.
+        store.delete(&blob_id).await.unwrap();
     }
 }

--- a/crates/uc-infra/src/blob/hashing.rs
+++ b/crates/uc-infra/src/blob/hashing.rs
@@ -1,0 +1,67 @@
+//! Streaming blake3 helpers for path-backed blob ingest.
+//!
+//! Both helpers run on a single read of the source and keep resident memory
+//! independent of file size (64 KiB buffer), so they are safe for arbitrarily
+//! large files. `copy_and_hash` derives the content hash from the exact bytes it
+//! writes to the destination, which is what lets the ingest path record a hash
+//! that can never diverge from the stored blob.
+
+use anyhow::{Context, Result};
+use std::io::{Read, Write};
+use std::path::Path;
+use uc_core::ContentHash;
+
+/// Buffer size for streaming reads/writes. Resident memory stays constant
+/// regardless of file size.
+const STREAM_BUF_LEN: usize = 64 * 1024;
+
+/// Stream `path` through blake3, returning `(ContentHash, byte_size)` without
+/// loading the file into memory.
+pub(crate) fn stream_hash_file(path: &Path) -> Result<(ContentHash, u64)> {
+    let mut file = std::fs::File::open(path)
+        .with_context(|| format!("failed to open {} for hashing", path.display()))?;
+    let mut hasher = blake3::Hasher::new();
+    let mut buf = [0u8; STREAM_BUF_LEN];
+    let mut total: u64 = 0;
+    loop {
+        let n = file.read(&mut buf).context("read failed during hashing")?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+        total = total.saturating_add(n as u64);
+    }
+    let hash = hasher.finalize();
+    Ok((ContentHash::from(hash.as_bytes()), total))
+}
+
+/// Copy `source` to `dest` while hashing the bytes in the same pass, returning
+/// `(ContentHash, byte_size)`.
+///
+/// The source is read exactly once and the returned hash is of the exact bytes
+/// written to `dest`, so a caller can record an identity that matches the stored
+/// blob even if the source is rewritten right after this returns. The bytes are
+/// flushed and fsync'd before returning.
+pub(crate) fn copy_and_hash(source: &Path, dest: &Path) -> Result<(ContentHash, u64)> {
+    let mut src = std::fs::File::open(source)
+        .with_context(|| format!("failed to open {} for copy+hash", source.display()))?;
+    let mut out = std::fs::File::create(dest)
+        .with_context(|| format!("failed to create {} for copy+hash", dest.display()))?;
+    let mut hasher = blake3::Hasher::new();
+    let mut buf = [0u8; STREAM_BUF_LEN];
+    let mut total: u64 = 0;
+    loop {
+        let n = src.read(&mut buf).context("read failed during copy+hash")?;
+        if n == 0 {
+            break;
+        }
+        out.write_all(&buf[..n])
+            .context("write failed during copy+hash")?;
+        hasher.update(&buf[..n]);
+        total = total.saturating_add(n as u64);
+    }
+    out.flush().context("flush failed during copy+hash")?;
+    out.sync_all().context("sync failed during copy+hash")?;
+    let hash = hasher.finalize();
+    Ok((ContentHash::from(hash.as_bytes()), total))
+}

--- a/crates/uc-infra/src/blob/hashing.rs
+++ b/crates/uc-infra/src/blob/hashing.rs
@@ -18,8 +18,9 @@ const STREAM_BUF_LEN: usize = 64 * 1024;
 /// Stream `path` through blake3, returning `(ContentHash, byte_size)` without
 /// loading the file into memory.
 pub(crate) fn stream_hash_file(path: &Path) -> Result<(ContentHash, u64)> {
-    let mut file = std::fs::File::open(path)
-        .with_context(|| format!("failed to open {} for hashing", path.display()))?;
+    // No path in the error context: `path` may be a clipboard source file, whose
+    // name is user content and would leak through the propagated error chain.
+    let mut file = std::fs::File::open(path).context("failed to open file for hashing")?;
     let mut hasher = blake3::Hasher::new();
     let mut buf = [0u8; STREAM_BUF_LEN];
     let mut total: u64 = 0;
@@ -43,10 +44,16 @@ pub(crate) fn stream_hash_file(path: &Path) -> Result<(ContentHash, u64)> {
 /// blob even if the source is rewritten right after this returns. The bytes are
 /// flushed and fsync'd before returning.
 pub(crate) fn copy_and_hash(source: &Path, dest: &Path) -> Result<(ContentHash, u64)> {
-    let mut src = std::fs::File::open(source)
-        .with_context(|| format!("failed to open {} for copy+hash", source.display()))?;
-    let mut out = std::fs::File::create(dest)
-        .with_context(|| format!("failed to create {} for copy+hash", dest.display()))?;
+    // No source path in the error context: it is user content. The dest path is
+    // our own blob-store location (a blob_id), so it is safe to surface.
+    let mut src =
+        std::fs::File::open(source).context("failed to open source file for copy+hash")?;
+    let mut out = std::fs::File::create(dest).with_context(|| {
+        format!(
+            "failed to create blob file {} for copy+hash",
+            dest.display()
+        )
+    })?;
     let mut hasher = blake3::Hasher::new();
     let mut buf = [0u8; STREAM_BUF_LEN];
     let mut total: u64 = 0;

--- a/crates/uc-infra/src/blob/mod.rs
+++ b/crates/uc-infra/src/blob/mod.rs
@@ -1,6 +1,7 @@
 mod blob_writer;
 mod domain;
 mod filesystem_store;
+mod hashing;
 mod repository_port;
 mod store_port;
 
@@ -8,7 +9,7 @@ pub use blob_writer::BlobWriter;
 pub use domain::{Blob, BlobStorageLocator};
 pub use filesystem_store::FilesystemBlobStore;
 pub use repository_port::BlobRepositoryPort;
-pub use store_port::BlobStorePort;
+pub use store_port::{BlobStorePort, StoredPathBlob};
 // Re-export uc-core's BlobWriterPort under the existing path to keep
 // downstream `uc_infra::blob::BlobWriterPort` imports working during the
 // transition. New code should import directly from `uc_core::blob::ports`.

--- a/crates/uc-infra/src/blob/store_port.rs
+++ b/crates/uc-infra/src/blob/store_port.rs
@@ -12,7 +12,26 @@ use anyhow::Result;
 use async_trait::async_trait;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use uc_core::BlobId;
+use uc_core::{BlobId, ContentHash};
+
+/// Outcome of persisting a path-backed file into blob storage.
+///
+/// The `content_hash` and `size_bytes` are derived from the exact bytes the
+/// store persisted (computed in the same pass that wrote them), so a caller can
+/// record an identity that cannot diverge from the stored blob — even if the
+/// source file is rewritten immediately after the call returns.
+#[derive(Debug, Clone)]
+pub struct StoredPathBlob {
+    /// On-disk location of the stored blob.
+    pub storage_path: PathBuf,
+    /// blake3 content hash of the source file's plaintext bytes.
+    pub content_hash: ContentHash,
+    /// Plaintext byte size of the source file.
+    pub size_bytes: u64,
+    /// On-disk byte count after any compression+encryption. `None` if the store
+    /// does not track compressed size (e.g., raw filesystem).
+    pub compressed_size: Option<i64>,
+}
 
 #[async_trait]
 pub trait BlobStorePort: Send + Sync {
@@ -28,16 +47,23 @@ pub trait BlobStorePort: Send + Sync {
     /// 把 `source_path` 上的本地文件登记进 blob 存储。
     ///
     /// 推荐实现策略:先尝试 `hard_link`(O(1) 不占额外磁盘),失败(典型 EXDEV — 跨卷 /
-    /// 跨文件系统)再回退到流式 copy。返回 `(storage_path, compressed_size)`,语义与
-    /// `put` 一致。
+    /// 跨文件系统)再回退到流式 copy。
+    ///
+    /// 返回的 [`StoredPathBlob`] 携带由 store **实际落盘的同一份字节**单遍算出的
+    /// `content_hash` 与 `size_bytes`——调用方据此记录身份,即可保证 DB 记的 hash/size
+    /// 与 blob 持有的字节永不分叉(消除 hash 与落盘之间的 TOCTOU 窗口)。
     ///
     /// 实现不得改动 source 文件;若 store 是带加密 decorator,该接口会被 decorator
-    /// 重写为"读 → 加密 → 写新文件",而不是直接 hardlink(因为加密产物字节不同)。
-    async fn put_from_path(
-        &self,
-        blob_id: &BlobId,
-        source_path: &Path,
-    ) -> Result<(PathBuf, Option<i64>)>;
+    /// 重写为"读 → 加密 → 写新文件",而不是直接 hardlink(因为加密产物字节不同),
+    /// 但 `content_hash` 始终是源文件明文的 hash。
+    async fn put_from_path(&self, blob_id: &BlobId, source_path: &Path) -> Result<StoredPathBlob>;
+
+    /// Remove a stored blob's bytes from storage.
+    ///
+    /// Idempotent: removing a blob that is already absent is not an error. Used
+    /// to drop a freshly written blob when content-hash deduplication finds an
+    /// existing record for the same bytes.
+    async fn delete(&self, blob_id: &BlobId) -> Result<()>;
 }
 
 #[async_trait]
@@ -50,11 +76,11 @@ impl<T: BlobStorePort + ?Sized> BlobStorePort for Arc<T> {
         (**self).get(blob_id).await
     }
 
-    async fn put_from_path(
-        &self,
-        blob_id: &BlobId,
-        source_path: &Path,
-    ) -> Result<(PathBuf, Option<i64>)> {
+    async fn put_from_path(&self, blob_id: &BlobId, source_path: &Path) -> Result<StoredPathBlob> {
         (**self).put_from_path(blob_id, source_path).await
+    }
+
+    async fn delete(&self, blob_id: &BlobId) -> Result<()> {
+        (**self).delete(blob_id).await
     }
 }

--- a/crates/uc-infra/src/security/encrypted_blob_store.rs
+++ b/crates/uc-infra/src/security/encrypted_blob_store.rs
@@ -27,11 +27,11 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use tracing::{debug, info_span, Instrument};
 
-use uc_core::{blob::ports::BlobReaderPort, crypto::aad, BlobId};
+use uc_core::{blob::ports::BlobReaderPort, crypto::aad, BlobId, ContentHash};
 
 use super::session::InMemorySession;
 use super::v1_aead;
-use crate::blob::BlobStorePort;
+use crate::blob::{BlobStorePort, StoredPathBlob};
 
 /// Magic bytes identifying a UniClipboard blob file ("UCBL")
 const BLOB_MAGIC: [u8; 4] = [0x55, 0x43, 0x42, 0x4C];
@@ -145,7 +145,7 @@ impl BlobStorePort for EncryptedBlobStore {
         &self,
         blob_id: &BlobId,
         source_path: &std::path::Path,
-    ) -> Result<(PathBuf, Option<i64>)> {
+    ) -> Result<StoredPathBlob> {
         // AEAD wire format(v1_aead::encrypt_blob_xchacha)是 one-shot,目前不支持流式
         // 加密。这里先把源文件整文件读进内存再走 put() —— 与 capture-side 调用方约定:
         // 加密 store 启用时,path-backed ingest 的"任意大小"语义降级为"内存里能放得下",
@@ -153,11 +153,28 @@ impl BlobStorePort for EncryptedBlobStore {
         let bytes = tokio::fs::read(source_path)
             .await
             .with_context(|| format!("failed to read {} for encryption", source_path.display()))?;
-        self.put(blob_id, &bytes).await
+        // Hash the exact plaintext buffer that gets compressed+encrypted below,
+        // in the same read pass — no second read of the source can observe a
+        // rewritten file, so the recorded identity matches the stored blob.
+        let content_hash = ContentHash::from(blake3::hash(&bytes).as_bytes());
+        let size_bytes = bytes.len() as u64;
+        let (storage_path, compressed_size) = self.put(blob_id, &bytes).await?;
+        Ok(StoredPathBlob {
+            storage_path,
+            content_hash,
+            size_bytes,
+            compressed_size,
+        })
     }
 
     async fn get(&self, blob_id: &BlobId) -> Result<Vec<u8>> {
         <Self as BlobReaderPort>::get(self, blob_id).await
+    }
+
+    async fn delete(&self, blob_id: &BlobId) -> Result<()> {
+        // Encryption is transparent to deletion: drop the stored bytes via the
+        // inner store.
+        self.inner.delete(blob_id).await
     }
 }
 
@@ -196,5 +213,63 @@ impl BlobReaderPort for EncryptedBlobStore {
         );
 
         Ok(plaintext)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::blob::FilesystemBlobStore;
+    use crate::security::secrets::MasterKey;
+
+    fn hash_of(bytes: &[u8]) -> ContentHash {
+        ContentHash::from(blake3::hash(bytes).as_bytes())
+    }
+
+    fn store_with_key(dir: PathBuf) -> EncryptedBlobStore {
+        let inner: Arc<dyn BlobStorePort> = Arc::new(FilesystemBlobStore::new(dir));
+        let session = Arc::new(InMemorySession::new());
+        session.set_master_key(MasterKey::from_bytes(&[7u8; 32]).unwrap());
+        EncryptedBlobStore::new(inner, session)
+    }
+
+    #[tokio::test]
+    async fn put_from_path_hashes_plaintext_and_roundtrips() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = store_with_key(tmp.path().join("blobs"));
+
+        let src = tmp.path().join("plain.bin");
+        let content = b"encrypted store: recorded identity is the plaintext hash".to_vec();
+        tokio::fs::write(&src, &content).await.unwrap();
+
+        let blob_id = BlobId::new();
+        let stored = store.put_from_path(&blob_id, &src).await.unwrap();
+
+        assert_eq!(stored.size_bytes, content.len() as u64);
+        // Identity is the device-independent *plaintext* hash, never the ciphertext.
+        assert_eq!(stored.content_hash, hash_of(&content));
+        // Encrypted store tracks the on-disk (ciphertext) size.
+        assert!(stored.compressed_size.is_some());
+
+        // Decrypts back to the same plaintext, which hashes to the recorded id.
+        let got = BlobReaderPort::get(&store, &blob_id).await.unwrap();
+        assert_eq!(got, content);
+        assert_eq!(hash_of(&got), stored.content_hash);
+    }
+
+    #[tokio::test]
+    async fn delete_removes_encrypted_blob_and_is_idempotent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = store_with_key(tmp.path().join("blobs"));
+
+        let src = tmp.path().join("plain.bin");
+        tokio::fs::write(&src, b"bytes").await.unwrap();
+        let blob_id = BlobId::new();
+        store.put_from_path(&blob_id, &src).await.unwrap();
+        assert!(BlobReaderPort::get(&store, &blob_id).await.is_ok());
+
+        store.delete(&blob_id).await.unwrap();
+        assert!(BlobReaderPort::get(&store, &blob_id).await.is_err());
+        store.delete(&blob_id).await.unwrap();
     }
 }

--- a/crates/uc-infra/src/security/encrypted_blob_store.rs
+++ b/crates/uc-infra/src/security/encrypted_blob_store.rs
@@ -150,9 +150,12 @@ impl BlobStorePort for EncryptedBlobStore {
         // 加密。这里先把源文件整文件读进内存再走 put() —— 与 capture-side 调用方约定:
         // 加密 store 启用时,path-backed ingest 的"任意大小"语义降级为"内存里能放得下",
         // 流式 AEAD 重构属于独立 phase。
-        let bytes = tokio::fs::read(source_path)
-            .await
-            .with_context(|| format!("failed to read {} for encryption", source_path.display()))?;
+        // No source path in the error context: a clipboard file path is user
+        // content (usernames / sensitive filenames) and would leak through the
+        // propagated error chain. Correlate by blob_id instead.
+        let bytes = tokio::fs::read(source_path).await.with_context(|| {
+            format!("failed to read source file for encryption (blob {blob_id})")
+        })?;
         // Hash the exact plaintext buffer that gets compressed+encrypted below,
         // in the same read pass — no second read of the source can observe a
         // rewritten file, so the recorded identity matches the stored blob.


### PR DESCRIPTION
> 🤖 This PR was authored with AI assistance and reviewed by the maintainer before submission.

Closes #1174.

## Problem

`BlobWriter::ingest_path_inner` hashed the source file in one pass (`stream_hash_file`) and then re-read it in `put_from_path` to persist it. A source rewrite in the window between the two reads let the recorded `content_hash`/`size` diverge from the bytes the blob store actually holds — breaking hash-based dedup (`find_by_hash` points at the wrong record) and metadata correctness. The window is longest on the copy/encrypted paths, which genuinely read the bytes a second time.

## Fix (single-pass authoritative hash)

Make the store the single authority for *what bytes were stored and what is their hash*. `BlobStorePort::put_from_path` now returns a `StoredPathBlob { storage_path, content_hash, size_bytes, compressed_size }`, where the hash/size are computed in the same pass that persisted the bytes:

- **`FilesystemBlobStore`**: hardlink, then hash the *dest* (== the linked inode), so identity reflects the exact bytes the blob points at; the cross-volume fallback copies and hashes in one streaming pass (`copy_and_hash`).
- **`EncryptedBlobStore`**: hash the in-memory plaintext buffer it already reads (zero extra read), recording the device-independent *plaintext* identity.

`ingest_path_inner` now stores first and dedups against the authoritative hash. On a dedup hit / insert race / partial-write failure it drops the redundant blob via the new `BlobStorePort::delete` — which also closes the pre-existing orphan-blob leak on insert race. The redundant hash pass is gone, so the copy/encrypted miss path reads the file **once** instead of twice.

Scope is fully contained to `uc-infra` (`BlobStorePort` is infra-internal); `uc-core` ports (`IngestedBlob`, `BlobContentIngestPort`, `BlobWriterPort`) and the app layer are unchanged.

## Tradeoff (accepted)

Dedup now runs after the write, so a blob-level dedup hit on the copy/encrypted path stores then deletes the redundant bytes. This is rare in the capture path (snapshot-level dedup short-circuits re-copies upstream) and bounded, and it buys a 2→1 read reduction on the common miss path plus the orphan-leak fix.

## Tests

New regression tests across the filesystem store, encrypted store, and `BlobWriter` assert that the recorded hash matches the stored bytes and that dedup leaves no orphan. `cargo test -p uc-infra --lib` green (498 incl. 6 new); clippy clean on changed files; consuming crates compile.

## Out of scope

Encrypted blobs still load the whole file into memory (one-shot AEAD has no streaming format). That orthogonal scalability limit is tracked in #1176.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Blob uploads now return structured persistence metadata, including the exact stored `content_hash` and `size_bytes`.
  * Encrypted blob uploads now preserve and report plaintext identity metadata alongside stored results.

* **Bug Fixes**
  * Deduplication now occurs using the authoritative persisted bytes, reducing redundant stored blobs and handling insert conflicts more reliably.
  * Improved cleanup behavior for redundant/orphan blobs; delete failures no longer block ingestion.

* **Tests**
  * Added coverage for persisted-byte hashing correctness, duplicate ingest behavior, and delete idempotency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->