### PR TITLE
refactor(uc-application): hide EntryIdentityCoordinator behind deps panel

### DIFF
--- a/crates/uc-application/src/deps.rs
+++ b/crates/uc-application/src/deps.rs
@@ -36,6 +36,15 @@ use uc_core::ports::*;
 use uc_core::MemberRepositoryPort;
 use uc_observability::analytics::AnalyticsPort;
 
+// §11.4.3 — the `entry_identity` module is `pub(crate)`, but its coordinator is
+// held by the `pub` `ClipboardPorts` field below and threaded into `pub` use-case
+// builders. Re-export it from this composition module so it stays reachable for
+// the composition root (`uc_application::deps::EntryIdentityCoordinator`) without
+// leaking the business submodule at the crate root; this also lifts the type's
+// effective visibility back to crate-external, keeping those `pub` signatures off
+// the `private_interfaces` lint (E0446).
+pub use crate::entry_identity::EntryIdentityCoordinator;
+
 /// Clipboard entry intent ports.
 ///
 /// The composition root coerces the single Diesel entry adapter into each of
@@ -85,7 +94,7 @@ pub struct ClipboardPorts {
     /// Per-identity (snapshot_hash) write coordinator. Shared by inbound apply
     /// and local capture so "find entry by hash → create / replace / skip"
     /// serializes across every writer of the same content (no double-create).
-    pub entry_identity_coordinator: Arc<crate::entry_identity::EntryIdentityCoordinator>,
+    pub entry_identity_coordinator: Arc<EntryIdentityCoordinator>,
     pub clipboard_event_repo: Arc<dyn ClipboardEventWriterPort>,
     /// Read port over the same clipboard-event store as `clipboard_event_repo`.
     /// Exposes read-only lookups such as the originating device of an event,

--- a/crates/uc-application/src/lib.rs
+++ b/crates/uc-application/src/lib.rs
@@ -3,7 +3,10 @@
 pub mod clipboard_capture;
 pub mod clipboard_write;
 pub mod deps;
-pub mod entry_identity;
+// §11.4.3 — internal write-coordination primitive; never exposed at the crate
+// root. The shared `EntryIdentityCoordinator` is reachable only through the
+// `deps` composition panel (`uc_application::deps::EntryIdentityCoordinator`).
+pub(crate) mod entry_identity;
 pub mod facade;
 pub mod file_sync;
 pub mod sync_planner;
@@ -19,7 +22,6 @@ pub use deps::{
 // `InboundClipboardSyncWorker` (T8). Lives inside `usecases::clipboard_sync`
 // (which is `pub(crate)`) so Phase 2 internals stay encapsulated; we
 // re-export only the small public surface here.
-pub use entry_identity::EntryIdentityCoordinator;
 pub use usecases::clipboard_sync::{
     ApplyInboundClipboardUseCase, ApplyInboundError, ApplyInboundInput, ApplyOutcome,
     FileCacheBlobMaterializer, InboundBlobFetcher, InboundBlobMaterializer, InboundCapture,

--- a/crates/uc-bootstrap/src/wiring/wire.rs
+++ b/crates/uc-bootstrap/src/wiring/wire.rs
@@ -885,7 +885,9 @@ pub fn wire_dependencies(
             // Single shared per-identity write coordinator: inbound apply and
             // local capture serialize "find entry by hash → create/replace/skip"
             // on it so the same content never lands as two entries.
-            entry_identity_coordinator: Arc::new(uc_application::EntryIdentityCoordinator::new()),
+            entry_identity_coordinator: Arc::new(
+                uc_application::deps::EntryIdentityCoordinator::new(),
+            ),
             clipboard_event_repo: encrypting_event_writer,
             clipboard_event_reader_repo: infra.clipboard_event_reader_repo.clone(),
             representation_store: decrypting_rep_repo,


### PR DESCRIPTION
## Summary

- `entry_identity` was a `pub mod` re-exported at the crate root (`pub use entry_identity::EntryIdentityCoordinator;`), pushing an internal write-coordination primitive past the facade boundary and violating `uc-application/AGENTS.md` §11.4. (b95be35)
- Make the module `pub(crate)` and drop the crate-root re-export; the coordinator is now reachable only through the `deps` composition panel (`uc_application::deps::EntryIdentityCoordinator`), which the composition root (`wire.rs`) uses to construct it.
- That single `deps` re-export also lifts the type's effective visibility back to crate-external, keeping the `pub` `ClipboardPorts` field and the `with_entry_identity_coordinator(...)` use-case builders off the `private_interfaces` lint (avoids E0446) — so no other call site needed changes (the 4 sites in `sync_engine` / `non_gui` / `runtime_assembly` only clone the `Arc`).

This is the deferred follow-up from #1173's CodeRabbit review — part of the broader §11.4 facade collection migration (§11.4.7), not a single-point hack: the type's only external reach is now the composition panel.

Closes #1175.

## Test plan

- [x] `cargo check -p uc-application -p uc-bootstrap -p uc-daemon` — all green, no E0446 / `private_interfaces`
- [x] `cargo clippy -p uc-application -p uc-bootstrap` — only pre-existing baseline warnings, none related to this change
- [x] grep: crate-root `uc_application::EntryIdentityCoordinator` path and `pub mod entry_identity` both cleared
- [ ] Reviewer: confirm CI's full-workspace build stays green (covers any consumer that reached the old crate-root path)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved internal wiring for identity-related clipboard features, helping keep app components connected more reliably.
  * Tightened module exposure to reduce accidental access to internal functionality and support cleaner app integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->