### PR TITLE
feat(history): add favorite action and shortcut to clipboard preview

### DIFF
--- a/src/components/clipboard/ClipboardActionBar.tsx
+++ b/src/components/clipboard/ClipboardActionBar.tsx
@@ -1,5 +1,5 @@
 import { AnimatePresence, m } from 'framer-motion'
-import { Check, Copy, Trash2 } from 'lucide-react'
+import { Check, Copy, Star, Trash2 } from 'lucide-react'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 import { Kbd } from '@/components/ui/kbd'
@@ -13,20 +13,27 @@ export interface ClipboardActionBarTransferStatus {
 interface ClipboardActionBarProps {
   hasActiveItem: boolean
   copySuccess: boolean
+  isFavorited: boolean
   transferStatus?: ClipboardActionBarTransferStatus
   onCopy: () => void
   onDelete: () => void
+  onToggleFavorite: () => void
 }
 
 const ClipboardActionBar: React.FC<ClipboardActionBarProps> = ({
   hasActiveItem,
   copySuccess,
+  isFavorited,
   transferStatus,
   onCopy,
   onDelete,
+  onToggleFavorite,
 }) => {
   const { isCopyBlocked, copyBlockedReason } = transferStatus ?? {}
   const { t } = useTranslation()
+  const favoriteLabel = isFavorited
+    ? t('clipboard.actionBar.unfavorite')
+    : t('clipboard.actionBar.favorite')
 
   return (
     <div
@@ -36,6 +43,7 @@ const ClipboardActionBar: React.FC<ClipboardActionBarProps> = ({
       )}
     >
       <m.button
+        type="button"
         whileTap={{ scale: 0.97 }}
         className={cn(
           'flex items-center gap-2 px-2.5 py-1 rounded-md text-xs transition-all duration-200 relative group',
@@ -46,6 +54,7 @@ const ClipboardActionBar: React.FC<ClipboardActionBarProps> = ({
         onClick={hasActiveItem && !isCopyBlocked ? onCopy : undefined}
         disabled={!hasActiveItem || isCopyBlocked}
         aria-disabled={isCopyBlocked}
+        aria-label={copyBlockedReason || t('clipboard.actionBar.copy')}
         title={copyBlockedReason || undefined}
       >
         <AnimatePresence mode="wait" initial={false}>
@@ -90,6 +99,32 @@ const ClipboardActionBar: React.FC<ClipboardActionBarProps> = ({
       </m.button>
 
       <m.button
+        type="button"
+        whileTap={{ scale: 0.97 }}
+        className={cn(
+          'flex items-center gap-2 px-2.5 py-1 rounded-md text-xs transition-all duration-200 group',
+          hasActiveItem
+            ? isFavorited
+              ? 'text-amber-600 hover:bg-amber-500/10 dark:text-amber-400'
+              : 'text-muted-foreground hover:bg-muted hover:text-foreground'
+            : 'text-muted-foreground/30 cursor-default'
+        )}
+        onClick={hasActiveItem ? onToggleFavorite : undefined}
+        disabled={!hasActiveItem}
+        aria-pressed={isFavorited}
+        aria-label={favoriteLabel}
+      >
+        <Star className={cn('size-3', isFavorited && 'fill-current')} />
+        <span className="font-medium whitespace-nowrap">{favoriteLabel}</span>
+        {hasActiveItem && (
+          <Kbd className="bg-transparent opacity-20 group-hover:opacity-100 transition-opacity border-none h-3 min-w-3 p-0 text-[9px]">
+            F
+          </Kbd>
+        )}
+      </m.button>
+
+      <m.button
+        type="button"
         whileTap={{ scale: 0.97 }}
         className={cn(
           'flex items-center gap-2 px-2.5 py-1 rounded-md text-xs transition-all duration-200 group',
@@ -99,6 +134,7 @@ const ClipboardActionBar: React.FC<ClipboardActionBarProps> = ({
         )}
         onClick={hasActiveItem ? onDelete : undefined}
         disabled={!hasActiveItem}
+        aria-label={t('clipboard.actionBar.delete')}
       >
         <Trash2 className="size-3" />
         <span className="font-medium whitespace-nowrap">{t('clipboard.actionBar.delete')}</span>

--- a/src/components/clipboard/__tests__/ClipboardActionBar.test.tsx
+++ b/src/components/clipboard/__tests__/ClipboardActionBar.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import ClipboardActionBar from '@/components/clipboard/ClipboardActionBar'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string) => fallback ?? key,
+  }),
+}))
+
+describe('ClipboardActionBar', () => {
+  it('renders favorite action and toggles the active item', async () => {
+    const user = userEvent.setup()
+    const onToggleFavorite = vi.fn()
+
+    render(
+      <ClipboardActionBar
+        hasActiveItem
+        copySuccess={false}
+        isFavorited={false}
+        onCopy={vi.fn()}
+        onDelete={vi.fn()}
+        onToggleFavorite={onToggleFavorite}
+      />
+    )
+
+    const favoriteButton = screen.getByRole('button', { name: 'clipboard.actionBar.favorite' })
+
+    expect(favoriteButton).toBeEnabled()
+    expect(screen.getByText('F')).toBeInTheDocument()
+
+    await user.click(favoriteButton)
+
+    expect(onToggleFavorite).toHaveBeenCalledTimes(1)
+  })
+
+  it('labels an already favorited item as unfavorite', () => {
+    render(
+      <ClipboardActionBar
+        hasActiveItem
+        copySuccess={false}
+        isFavorited
+        onCopy={vi.fn()}
+        onDelete={vi.fn()}
+        onToggleFavorite={vi.fn()}
+      />
+    )
+
+    expect(
+      screen.getByRole('button', { name: 'clipboard.actionBar.unfavorite' })
+    ).toBeInTheDocument()
+  })
+})

--- a/src/components/history/HistoryCard.tsx
+++ b/src/components/history/HistoryCard.tsx
@@ -59,15 +59,18 @@ const HistoryCard: React.FC<HistoryCardProps> = ({
       ? Math.round((transfer.bytesTransferred / transfer.totalBytes) * 100)
       : 0
 
-  const handleMouseEnter = useCallback(() => onHoverChange(item.id), [item.id, onHoverChange])
-  const handleMouseLeave = useCallback(() => onHoverChange(null), [onHoverChange])
-  const handleClick = useCallback(() => onClick(item.id), [item.id, onClick])
-
   // Reveal the action bar on keyboard focus too, not just mouse hover — its
   // buttons are otherwise untabbable, so keyboard users could never reach
   // copy/favorite/delete. Tracked locally (separate from the parent's hover
   // selection) so it doesn't disturb the hover-driven keyboard shortcuts.
   const [focusWithin, setFocusWithin] = useState(false)
+  const handleMouseEnter = useCallback(() => onHoverChange(item.id), [item.id, onHoverChange])
+  const handleMouseLeave = useCallback(() => onHoverChange(null), [onHoverChange])
+  const handleClick = useCallback(() => onClick(item.id), [item.id, onClick])
+  const handleActionComplete = useCallback(() => {
+    setFocusWithin(false)
+    onHoverChange(null)
+  }, [onHoverChange])
   const handleFocus = useCallback(() => setFocusWithin(true), [])
   const handleBlur = useCallback((e: React.FocusEvent<HTMLDivElement>) => {
     if (!e.currentTarget.contains(e.relatedTarget as Node | null)) setFocusWithin(false)
@@ -126,6 +129,7 @@ const HistoryCard: React.FC<HistoryCardProps> = ({
         onCopy={onCopy}
         onDelete={onDelete}
         onToggleFavorite={onToggleFavorite}
+        onActionComplete={handleActionComplete}
       />
     </div>
   )

--- a/src/components/history/HistoryGridRow.tsx
+++ b/src/components/history/HistoryGridRow.tsx
@@ -1,5 +1,6 @@
 import { m } from 'framer-motion'
 import React, { useEffect } from 'react'
+import { HISTORY_ENTRY_ANIMATION } from '@/components/history/history-entry-animation'
 import HistoryCard from '@/components/history/HistoryCard'
 import type { DisplayClipboardItem } from '@/lib/clipboard-entry'
 import { cn } from '@/lib/utils'
@@ -52,9 +53,9 @@ const HistoryGridRow: React.FC<HistoryGridRowProps> = React.memo(
 
     return (
       <m.div
-        initial={isNew ? { opacity: 0, y: 16 } : false}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ type: 'spring', stiffness: 400, damping: 30 }}
+        initial={isNew ? HISTORY_ENTRY_ANIMATION.initial : false}
+        animate={HISTORY_ENTRY_ANIMATION.animate}
+        transition={HISTORY_ENTRY_ANIMATION.transition}
         className={cn(
           rowHeightClass(item),
           'relative overflow-hidden transition-colors',

--- a/src/components/history/__tests__/HistoryCard.test.tsx
+++ b/src/components/history/__tests__/HistoryCard.test.tsx
@@ -1,4 +1,6 @@
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { useState } from 'react'
 import { describe, expect, it, vi } from 'vitest'
 import HistoryCard from '@/components/history/HistoryCard'
 import type { DisplayClipboardItem } from '@/lib/clipboard-entry'
@@ -38,6 +40,31 @@ function renderCard(item: DisplayClipboardItem) {
       onHoverChange={noop}
     />
   )
+}
+
+function renderInteractiveCard(item: DisplayClipboardItem, onCopy = vi.fn()) {
+  const onCardClick = vi.fn()
+
+  function InteractiveCard() {
+    const [hoveredId, setHoveredId] = useState<string | null>(item.id)
+
+    return (
+      <HistoryCard
+        item={item}
+        isHovered={hoveredId === item.id}
+        copySuccess={false}
+        isDeleting={false}
+        onCopy={onCopy}
+        onDelete={noop}
+        onToggleFavorite={noop}
+        onClick={onCardClick}
+        onHoverChange={setHoveredId}
+      />
+    )
+  }
+
+  render(<InteractiveCard />)
+  return { onCardClick, onCopy }
 }
 
 describe('HistoryCard', () => {
@@ -101,5 +128,26 @@ describe('HistoryCard', () => {
     expect(screen.getByText('return')).toBeInTheDocument()
     expect(screen.getAllByText('1').length).toBeGreaterThanOrEqual(2)
     expect(screen.getByText('2')).toBeInTheDocument()
+  })
+
+  it('hides the hover actions after clicking an action button', async () => {
+    const user = userEvent.setup()
+    const { onCardClick, onCopy } = renderInteractiveCard({
+      id: 'copy-entry',
+      type: 'text',
+      content: { display_text: 'copy me', char_count: 7 },
+      activeTime: 1,
+    } as DisplayClipboardItem)
+
+    const copyButton = screen.getByRole('button', { name: 'clipboard.item.actions.copy' })
+
+    expect(copyButton.parentElement).toHaveClass('opacity-100')
+
+    await user.click(copyButton)
+
+    expect(onCopy).toHaveBeenCalledWith('copy-entry')
+    expect(onCardClick).not.toHaveBeenCalled()
+    expect(copyButton).toHaveAttribute('tabindex', '-1')
+    expect(copyButton.parentElement).toHaveClass('opacity-0')
   })
 })

--- a/src/components/history/composite-search/HistoryFilterPanel.tsx
+++ b/src/components/history/composite-search/HistoryFilterPanel.tsx
@@ -39,11 +39,11 @@ function PanelRow({
       className={cn(
         'flex w-full items-center gap-2 rounded-[1.25rem] px-2.5 py-1.5 text-left text-[13px] transition-colors',
         active
-          ? 'bg-primary/10 font-medium text-foreground'
+          ? 'bg-muted/50 text-foreground ring-1 ring-border/50'
           : 'text-muted-foreground hover:bg-muted/60 hover:text-foreground'
       )}
     >
-      <Icon className={cn('size-3.5 shrink-0', active ? 'text-primary' : 'opacity-70')} />
+      <Icon className={cn('size-3.5 shrink-0', active ? 'text-muted-foreground' : 'opacity-70')} />
       <span className="truncate">{label}</span>
     </button>
   )

--- a/src/components/history/composite-search/__tests__/CompositeSearchBar.test.tsx
+++ b/src/components/history/composite-search/__tests__/CompositeSearchBar.test.tsx
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { Filter } from '@/api/clipboardItems'
 import type { TimeRangePreset } from '@/api/daemon/search'
 import CompositeSearchBar from '../CompositeSearchBar'
+import HistoryFilterPanel from '../HistoryFilterPanel'
 
 vi.mock('@/hooks/useShortcut', () => ({
   useShortcut: vi.fn(),
@@ -81,5 +82,44 @@ describe('CompositeSearchBar', () => {
     expect(props.onSourceFilterChange).toHaveBeenCalledWith(null)
     expect(props.onTimeRangeChange).toHaveBeenCalledWith('all_time')
     expect(props.onQueryChange).toHaveBeenCalledWith('')
+  })
+})
+
+function renderFilterPanel(
+  overrides: Partial<React.ComponentProps<typeof HistoryFilterPanel>> = {}
+) {
+  const props: React.ComponentProps<typeof HistoryFilterPanel> = {
+    contentFilter: Filter.Favorited,
+    sourceFilter: null,
+    tagFilter: null,
+    timeRange: 'all_time' as TimeRangePreset,
+    onContentFilterChange: vi.fn(),
+    onTagFilterChange: vi.fn(),
+    onSourceFilterChange: vi.fn(),
+    onTimeRangeChange: vi.fn(),
+    sourceOptions: [],
+    tagOptions: [],
+    ...overrides,
+  }
+
+  render(<HistoryFilterPanel {...props} />)
+  return props
+}
+
+describe('HistoryFilterPanel', () => {
+  it('uses a restrained selected-row treatment', () => {
+    renderFilterPanel()
+
+    const selectedRow = screen.getByRole('button', {
+      name: 'history.filter.favorited',
+      pressed: true,
+    })
+    const selectedIcon = selectedRow.querySelector('svg')
+
+    expect(selectedRow.className).toContain('bg-muted/50')
+    expect(selectedRow.className).toContain('text-foreground')
+    expect(selectedRow.className).not.toContain('bg-primary')
+    expect(selectedRow.className).not.toContain('font-medium')
+    expect(selectedIcon).toHaveClass('text-muted-foreground')
   })
 })

--- a/src/components/history/history-card/HistoryCardActions.tsx
+++ b/src/components/history/history-card/HistoryCardActions.tsx
@@ -1,4 +1,5 @@
 import { Copy, Star, Trash2 } from 'lucide-react'
+import type { MouseEvent } from 'react'
 import { useTranslation } from 'react-i18next'
 import { cn } from '@/lib/utils'
 
@@ -13,6 +14,7 @@ interface HistoryCardActionsProps {
   onCopy: (id: string) => void
   onDelete: (id: string) => void
   onToggleFavorite: (id: string, current: boolean) => void
+  onActionComplete: () => void
 }
 
 function HistoryCardActions({
@@ -21,11 +23,18 @@ function HistoryCardActions({
   onCopy,
   onDelete,
   onToggleFavorite,
+  onActionComplete,
 }: HistoryCardActionsProps) {
   const { t } = useTranslation()
   const { isHovered, isTransferring, isPending, isFavorited } = state
   const actionBtnClass =
     'flex size-6 items-center justify-center rounded-lg text-muted-foreground/70 transition-colors hover:bg-foreground/10 hover:text-foreground'
+  const runAction = (e: MouseEvent<HTMLButtonElement>, action: () => void) => {
+    e.stopPropagation()
+    action()
+    e.currentTarget.blur()
+    onActionComplete()
+  }
 
   return (
     <div
@@ -38,10 +47,7 @@ function HistoryCardActions({
         type="button"
         aria-label={t('clipboard.item.actions.copy')}
         tabIndex={isHovered ? 0 : -1}
-        onClick={e => {
-          e.stopPropagation()
-          onCopy(itemId)
-        }}
+        onClick={e => runAction(e, () => onCopy(itemId))}
         className={actionBtnClass}
       >
         <Copy className="size-3" />
@@ -52,10 +58,7 @@ function HistoryCardActions({
           isFavorited ? 'clipboard.item.actions.unfavorite' : 'clipboard.item.actions.favorite'
         )}
         tabIndex={isHovered ? 0 : -1}
-        onClick={e => {
-          e.stopPropagation()
-          onToggleFavorite(itemId, isFavorited)
-        }}
+        onClick={e => runAction(e, () => onToggleFavorite(itemId, isFavorited))}
         className={actionBtnClass}
       >
         <Star className={cn('size-3', isFavorited && 'fill-amber-400 text-amber-400')} />
@@ -64,10 +67,7 @@ function HistoryCardActions({
         type="button"
         aria-label={t('clipboard.item.actions.delete')}
         tabIndex={isHovered ? 0 : -1}
-        onClick={e => {
-          e.stopPropagation()
-          onDelete(itemId)
-        }}
+        onClick={e => runAction(e, () => onDelete(itemId))}
         className={cn(actionBtnClass, 'hover:bg-destructive/10 hover:text-destructive')}
       >
         <Trash2 className="size-3" />

--- a/src/components/history/history-entry-animation.ts
+++ b/src/components/history/history-entry-animation.ts
@@ -1,0 +1,10 @@
+export const HISTORY_ENTRY_ANIMATION = {
+  animate: { opacity: 1, y: 0 },
+  initial: { opacity: 0, y: 16 },
+  transition: { type: 'spring', stiffness: 400, damping: 30 },
+} as const
+
+export const HISTORY_PREVIEW_ENTRY_TRANSITION = {
+  ...HISTORY_ENTRY_ANIMATION.transition,
+  delay: 0.08,
+} as const

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -1,4 +1,3 @@
-import { m } from 'framer-motion'
 import {
   ArrowUpCircle,
   Bug,
@@ -49,7 +48,7 @@ const NavButton: React.FC<{
   icon: React.ComponentType<{ className?: string }>
   label: string
   isActive: boolean
-  layoutId: string
+  showActiveBackground?: boolean
   onClick?: (e: React.MouseEvent<HTMLAnchorElement>) => void
   'data-settings-icon'?: boolean
 }> = ({
@@ -57,7 +56,7 @@ const NavButton: React.FC<{
   icon: Icon,
   label,
   isActive,
-  layoutId,
+  showActiveBackground = true,
   onClick,
   'data-settings-icon': dataSettingsIcon,
 }) => {
@@ -79,17 +78,8 @@ const NavButton: React.FC<{
                 : undefined
             }
           >
-            {isActive && (
-              <m.div
-                layoutId={layoutId}
-                className="absolute inset-0 bg-primary/10 dark:bg-primary/20 rounded-lg"
-                initial={false}
-                transition={{
-                  type: 'spring',
-                  stiffness: 500,
-                  damping: 30,
-                }}
-              />
+            {isActive && showActiveBackground && (
+              <div className="absolute inset-0 rounded-lg bg-primary/10 dark:bg-primary/20" />
             )}
             <div
               className={cn(
@@ -209,6 +199,7 @@ const Sidebar: React.FC<SidebarProps> = ({ className }) => {
     { to: '/history', icon: Layers, label: t('nav.history') },
     { to: '/devices', icon: Monitor, label: t('nav.devices') },
   ]
+  const activeTopNavIndex = navItems.findIndex(item => location.pathname === item.to)
 
   useEffect(() => {
     if (!setting?.general.autoCheckUpdate) {
@@ -328,6 +319,13 @@ const Sidebar: React.FC<SidebarProps> = ({ className }) => {
       >
         {/* Main Navigation */}
         <div className="relative z-10 flex flex-col gap-3 w-full items-center">
+          {activeTopNavIndex >= 0 && (
+            <div
+              aria-hidden
+              className="absolute left-2 top-0 size-10 rounded-lg bg-primary/10 transition-transform duration-200 ease-out will-change-transform dark:bg-primary/20"
+              style={{ transform: `translateY(${activeTopNavIndex * 3.25}rem)` }}
+            />
+          )}
           {navItems.map(item => (
             <NavButton
               key={item.to}
@@ -335,7 +333,7 @@ const Sidebar: React.FC<SidebarProps> = ({ className }) => {
               icon={item.icon}
               label={item.label}
               isActive={location.pathname === item.to}
-              layoutId="sidebar-nav-top"
+              showActiveBackground={false}
             />
           ))}
         </div>
@@ -467,7 +465,6 @@ const Sidebar: React.FC<SidebarProps> = ({ className }) => {
             icon={Settings}
             label={t('nav.settings')}
             isActive={location.pathname.startsWith('/settings')}
-            layoutId="sidebar-nav-bottom"
             onClick={() => {
               if (location.pathname.startsWith('/settings')) return
               navigate('/settings')

--- a/src/components/layout/__tests__/SidebarUpdateIndicator.test.tsx
+++ b/src/components/layout/__tests__/SidebarUpdateIndicator.test.tsx
@@ -12,6 +12,20 @@ vi.mock('@/api/daemon/diagnostics', () => ({
   updateDebugMode: vi.fn(),
 }))
 
+vi.mock('framer-motion', async () => {
+  const ReactModule = await import('react')
+  return {
+    m: {
+      div: ({
+        children,
+        layoutId,
+        ...props
+      }: React.HTMLAttributes<HTMLDivElement> & { layoutId?: string }) =>
+        ReactModule.createElement('div', { ...props, 'data-layout-id': layoutId }, children),
+    },
+  }
+})
+
 const mockUpdateDebugMode = vi.mocked(updateDebugMode)
 
 beforeAll(() => {
@@ -145,7 +159,50 @@ function renderSidebar(state: UpdateState, setting: Settings = baseSetting) {
   )
 }
 
+function renderSidebarAt(pathname: string) {
+  return render(
+    <SettingContext.Provider
+      value={{
+        setting: baseSetting,
+        loading: false,
+        error: null,
+        reloadSetting: vi.fn(),
+        updateSetting: vi.fn(),
+        updateGeneralSetting: vi.fn(),
+        updateAutostart: vi.fn(),
+        updateSyncSetting: vi.fn(),
+        updateSecuritySetting: vi.fn(),
+        updateRetentionPolicy: vi.fn(),
+        updateKeyboardShortcuts: vi.fn(),
+        updateFileSyncSetting: vi.fn(),
+        updateNetworkSetting: vi.fn().mockResolvedValue({ restartRequired: false }),
+        updateQuickPanelSetting: vi.fn().mockResolvedValue({ restartRequired: false }),
+      }}
+    >
+      <UpdateContext.Provider
+        value={buildUpdateValue({ phase: 'idle', info: null, downloaded: 0, total: null })}
+      >
+        <MemoryRouter initialEntries={[pathname]}>
+          <Sidebar />
+        </MemoryRouter>
+      </UpdateContext.Provider>
+    </SettingContext.Provider>
+  )
+}
+
 describe('Sidebar update indicator', () => {
+  it('keeps primary navigation highlight on a lightweight CSS path', () => {
+    renderSidebarAt('/devices')
+
+    expect(document.querySelector('[data-layout-id="sidebar-nav-top"]')).not.toBeInTheDocument()
+
+    const movingHighlight = document.querySelector('aside > div:first-of-type > div[aria-hidden]')
+    expect(movingHighlight).toHaveClass('transition-transform')
+    expect(movingHighlight).toHaveClass('left-2')
+    expect(movingHighlight).not.toHaveClass('-translate-x-1/2')
+    expect(movingHighlight).toHaveStyle({ transform: 'translateY(3.25rem)' })
+  })
+
   it('shows the amber "available" icon when an update is available', async () => {
     renderSidebar({
       phase: 'available',

--- a/src/components/setting/ShortcutsSection.tsx
+++ b/src/components/setting/ShortcutsSection.tsx
@@ -14,7 +14,7 @@ import {
 const log = createLogger('shortcuts-section')
 
 /** Display order for shortcut scopes */
-const SCOPE_ORDER: ShortcutScope[] = ['global']
+const SCOPE_ORDER: ShortcutScope[] = ['global', 'clipboard']
 
 const ShortcutsSection: React.FC = () => {
   const { t } = useTranslation()

--- a/src/hooks/__tests__/useHistoryController.test.tsx
+++ b/src/hooks/__tests__/useHistoryController.test.tsx
@@ -1,6 +1,7 @@
 import { act, renderHook, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { Filter } from '@/api/clipboardItems'
+import { useShortcut } from '@/hooks/useShortcut'
 import type { DisplayClipboardItem } from '@/lib/clipboard-entry'
 import {
   clearHistorySessionSnapshot,
@@ -8,6 +9,11 @@ import {
   writeHistorySessionSnapshot,
 } from '../historySessionSnapshot'
 import { useHistoryController } from '../useHistoryController'
+
+const clipboardItemsApi = vi.hoisted(() => ({
+  favoriteClipboardItem: vi.fn(() => Promise.resolve(true)),
+  unfavoriteClipboardItem: vi.fn(() => Promise.resolve(true)),
+}))
 
 const items: DisplayClipboardItem[] = [
   {
@@ -23,6 +29,15 @@ const items: DisplayClipboardItem[] = [
     activeTime: 2,
   },
 ]
+
+vi.mock('@/api/clipboardItems', async importOriginal => {
+  const actual = await importOriginal<typeof import('@/api/clipboardItems')>()
+  return {
+    ...actual,
+    favoriteClipboardItem: clipboardItemsApi.favoriteClipboardItem,
+    unfavoriteClipboardItem: clipboardItemsApi.unfavoriteClipboardItem,
+  }
+})
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
@@ -71,9 +86,7 @@ vi.mock('@/hooks/useSearchTags', () => ({
   useSearchTags: () => [],
 }))
 
-vi.mock('@/hooks/useShortcut', () => ({
-  useShortcut: vi.fn(),
-}))
+vi.mock('@/hooks/useShortcut', () => ({ useShortcut: vi.fn() }))
 
 vi.mock('@/hooks/useShortcutScope', () => ({
   useShortcutScope: vi.fn(),
@@ -142,5 +155,29 @@ describe('useHistoryController', () => {
     await waitFor(() => {
       expect(readHistorySessionSnapshot()?.selectedId).toBe('entry-2')
     })
+  })
+
+  it('registers a shortcut to favorite the selected preview entry', async () => {
+    const { result } = renderHook(() => useHistoryController())
+
+    await waitFor(() => {
+      expect(result.current.selectedItem?.id).toBe('entry-1')
+    })
+
+    const shortcutConfigs = vi.mocked(useShortcut).mock.calls.map(([config]) => config)
+    const favoriteShortcut = [...shortcutConfigs]
+      .reverse()
+      .find(config => config.id === 'clipboard.favorite' && config.scope === 'clipboard')
+
+    expect(favoriteShortcut).toBeDefined()
+
+    await act(async () => {
+      await favoriteShortcut?.handler()
+    })
+
+    await waitFor(() => {
+      expect(result.current.selectedItem?.isFavorited).toBe(true)
+    })
+    expect(clipboardItemsApi.favoriteClipboardItem).toHaveBeenCalledWith('entry-1')
   })
 })

--- a/src/hooks/useHistoryController.ts
+++ b/src/hooks/useHistoryController.ts
@@ -134,6 +134,11 @@ export function useHistoryController() {
     return [base[idx], ...base.slice(0, idx), ...base.slice(idx + 1)]
   }, [data.baseItems, promotedId, favoriteOverrides])
 
+  const selectedItem = useMemo(
+    () => orderedItems.find(it => it.id === selectedId) ?? null,
+    [orderedItems, selectedId]
+  )
+
   // ── Hover keyboard shortcuts ──────────────────────────────────
   useShortcut({
     key: 'c',
@@ -155,6 +160,18 @@ export function useHistoryController() {
     preventDefault: false,
   })
 
+  useShortcut({
+    key: 'f',
+    id: 'clipboard.favorite',
+    scope: 'clipboard',
+    enabled: selectedItem !== null,
+    handler: () => {
+      if (!selectedItem) return
+      void handleToggleFavorite(selectedItem.id, selectedItem.isFavorited === true)
+    },
+    preventDefault: false,
+  })
+
   // CMD/Ctrl+F focuses the search box (works even while another input is focused).
   useShortcut({
     key: 'mod+f',
@@ -168,11 +185,6 @@ export function useHistoryController() {
     enableOnFormTags: true,
     preventDefault: true,
   })
-
-  const selectedItem = useMemo(
-    () => orderedItems.find(it => it.id === selectedId) ?? null,
-    [orderedItems, selectedId]
-  )
 
   // Keep hover/selection valid and the preview pane populated:
   // - drop a hover/selection that points at an entry no longer in the list

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -539,6 +539,7 @@
         "actions": {
           "goSettings": "Go to settings",
           "toggleQuickPanel": "Toggle quick panel",
+          "favoriteClipboardItem": "Favorite current clipboard item",
           "zoomIn": "Zoom in",
           "zoomOut": "Zoom out"
         },
@@ -886,6 +887,8 @@
     "actionBar": {
       "title": "Clipboard History",
       "copy": "Copy",
+      "favorite": "Favorite",
+      "unfavorite": "Unfavorite",
       "delete": "Delete"
     },
     "notification": {

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -530,6 +530,7 @@
         "actions": {
           "goSettings": "前往设置",
           "toggleQuickPanel": "切换快捷面板",
+          "favoriteClipboardItem": "收藏当前剪贴板项目",
           "zoomIn": "放大界面",
           "zoomOut": "缩小界面"
         },
@@ -876,6 +877,8 @@
     "actionBar": {
       "title": "剪贴板历史",
       "copy": "复制",
+      "favorite": "收藏",
+      "unfavorite": "取消收藏",
       "delete": "删除"
     },
     "notification": {

--- a/src/pages/HistoryPage.tsx
+++ b/src/pages/HistoryPage.tsx
@@ -1,9 +1,14 @@
+import { m } from 'framer-motion'
 import React, { useEffect, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import ClipboardActionBar from '@/components/clipboard/ClipboardActionBar'
 import ClipboardPreview from '@/components/clipboard/ClipboardPreview'
 import DeleteConfirmDialog from '@/components/clipboard/DeleteConfirmDialog'
 import { CompositeSearchBar, HistoryFilterPanel } from '@/components/history/composite-search'
+import {
+  HISTORY_ENTRY_ANIMATION,
+  HISTORY_PREVIEW_ENTRY_TRANSITION,
+} from '@/components/history/history-entry-animation'
 import HistoryGrid from '@/components/history/HistoryGrid'
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from '@/components/ui/resizable'
 import { useTitleBarSlot } from '@/contexts/titlebar-slot-context'
@@ -129,7 +134,13 @@ const HistoryPage: React.FC = () => {
 
           {/* Preview */}
           <ResizablePanel id="history-preview" defaultSize="58%" minSize="35%">
-            <div className="flex h-full min-w-0 flex-col">
+            <m.div
+              data-testid="history-preview-motion"
+              initial={HISTORY_ENTRY_ANIMATION.initial}
+              animate={HISTORY_ENTRY_ANIMATION.animate}
+              transition={HISTORY_PREVIEW_ENTRY_TRANSITION}
+              className="flex h-full min-w-0 flex-col"
+            >
               <ClipboardPreview
                 item={c.selectedItem}
                 actions={
@@ -145,7 +156,7 @@ const HistoryPage: React.FC = () => {
                   />
                 }
               />
-            </div>
+            </m.div>
           </ResizablePanel>
         </ResizablePanelGroup>
       </div>

--- a/src/pages/HistoryPage.tsx
+++ b/src/pages/HistoryPage.tsx
@@ -147,8 +147,17 @@ const HistoryPage: React.FC = () => {
                   <ClipboardActionBar
                     hasActiveItem={c.selectedItem !== null}
                     copySuccess={c.copySuccessId !== null && c.copySuccessId === c.selectedId}
+                    isFavorited={c.selectedItem?.isFavorited === true}
                     onCopy={() => {
                       if (c.selectedId) c.handleCopy(c.selectedId)
+                    }}
+                    onToggleFavorite={() => {
+                      if (c.selectedItem) {
+                        c.handleToggleFavorite(
+                          c.selectedItem.id,
+                          c.selectedItem.isFavorited === true
+                        )
+                      }
                     }}
                     onDelete={() => {
                       if (c.selectedId) c.requestDelete(c.selectedId)

--- a/src/pages/__tests__/HistoryPage.test.tsx
+++ b/src/pages/__tests__/HistoryPage.test.tsx
@@ -1,0 +1,188 @@
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { useHistoryController } from '@/hooks/useHistoryController'
+import HistoryPage from '@/pages/HistoryPage'
+
+type HistoryControllerState = ReturnType<typeof useHistoryController>
+
+const controller = vi.hoisted(() => ({
+  current: null as unknown,
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+vi.mock('framer-motion', async () => {
+  const ReactModule = await import('react')
+  return {
+    m: {
+      div: ({
+        animate,
+        children,
+        initial,
+        transition,
+        ...props
+      }: React.HTMLAttributes<HTMLDivElement> & {
+        animate?: unknown
+        initial?: unknown
+        transition?: unknown
+      }) =>
+        ReactModule.createElement(
+          'div',
+          {
+            ...props,
+            'data-motion-animate': JSON.stringify(animate),
+            'data-motion-initial': JSON.stringify(initial),
+            'data-motion-transition': JSON.stringify(transition),
+          },
+          children
+        ),
+    },
+  }
+})
+
+vi.mock('@/hooks/usePlatform', () => ({
+  usePlatform: () => ({ isMac: false }),
+}))
+
+vi.mock('@/contexts/titlebar-slot-context', () => ({
+  useTitleBarSlot: () => ({ setRightSlot: vi.fn() }),
+}))
+
+vi.mock('@/hooks/useHistoryController', () => ({
+  useHistoryController: () => controller.current,
+}))
+
+vi.mock('@/components/history/composite-search', async () => {
+  const ReactModule = await import('react')
+  return {
+    CompositeSearchBar: () => ReactModule.createElement('div', { 'data-testid': 'search-bar' }),
+    HistoryFilterPanel: () =>
+      ReactModule.createElement('aside', { 'data-testid': 'history-filter-panel' }),
+  }
+})
+
+vi.mock('@/components/history/HistoryGrid', async () => {
+  const ReactModule = await import('react')
+  return {
+    default: () => ReactModule.createElement('section', { 'data-testid': 'history-grid' }),
+  }
+})
+
+vi.mock('@/components/clipboard/ClipboardPreview', async () => {
+  const ReactModule = await import('react')
+  return {
+    default: ({ item }: { item: unknown | null }) =>
+      ReactModule.createElement(
+        'section',
+        { 'data-testid': 'clipboard-preview' },
+        item ? 'preview item' : 'preview empty'
+      ),
+  }
+})
+
+vi.mock('@/components/clipboard/ClipboardActionBar', async () => {
+  const ReactModule = await import('react')
+  return {
+    default: () => ReactModule.createElement('div', { 'data-testid': 'clipboard-actions' }),
+  }
+})
+
+vi.mock('@/components/clipboard/DeleteConfirmDialog', async () => {
+  const ReactModule = await import('react')
+  return {
+    default: () => ReactModule.createElement('div', { 'data-testid': 'delete-dialog' }),
+  }
+})
+
+vi.mock('@/components/ui/resizable', async () => {
+  const ReactModule = await import('react')
+  return {
+    ResizableHandle: () => ReactModule.createElement('div', { 'data-testid': 'resize-handle' }),
+    ResizablePanel: ({ children }: { children: React.ReactNode }) =>
+      ReactModule.createElement('section', null, children),
+    ResizablePanelGroup: ({ children }: { children: React.ReactNode }) =>
+      ReactModule.createElement('div', { 'data-testid': 'resizable-group' }, children),
+  }
+})
+
+function makeControllerState(
+  overrides: Partial<HistoryControllerState> = {}
+): HistoryControllerState {
+  return {
+    browseCount: 0,
+    confirmDelete: vi.fn(),
+    copySuccessId: null,
+    deleteDialogOpen: false,
+    deletingId: null,
+    filter: {
+      activeFilter: 'all',
+      sourceFilter: null,
+      submittedQuery: '',
+      tagFilter: null,
+      timeRange: null,
+    },
+    filterActions: {
+      setContentFilter: vi.fn(),
+      setQuery: vi.fn(),
+      setSourceFilter: vi.fn(),
+      setTagFilter: vi.fn(),
+      setTimeRange: vi.fn(),
+      submitQuery: vi.fn(),
+    },
+    handleCardClick: vi.fn(),
+    handleCopy: vi.fn(),
+    handleLoadMore: vi.fn(),
+    handleToggleFavorite: vi.fn(),
+    hasMore: false,
+    hoveredId: null,
+    indexState: 'ready',
+    isSearchActive: false,
+    items: [],
+    listRef: { current: null },
+    requestDelete: vi.fn(),
+    scrollState: null,
+    searchInputRef: { current: null },
+    searchLoading: false,
+    searchableTags: [],
+    seenIds: new Set<string>(),
+    selectedId: null,
+    selectedItem: null,
+    setDeleteDialogOpen: vi.fn(),
+    setHoveredId: vi.fn(),
+    setScrollState: vi.fn(),
+    sourceOptions: [],
+    viewLabel: 'history.filter.all',
+    ...overrides,
+  } as HistoryControllerState
+}
+
+describe('HistoryPage', () => {
+  beforeEach(() => {
+    controller.current = makeControllerState()
+  })
+
+  it('animates the preview pane shortly after history rows start entering', () => {
+    render(<HistoryPage />)
+
+    const previewMotion = screen.getByTestId('history-preview-motion')
+
+    expect(previewMotion).toHaveAttribute(
+      'data-motion-initial',
+      JSON.stringify({ opacity: 0, y: 16 })
+    )
+    expect(previewMotion).toHaveAttribute(
+      'data-motion-animate',
+      JSON.stringify({ opacity: 1, y: 0 })
+    )
+    expect(previewMotion).toHaveAttribute(
+      'data-motion-transition',
+      JSON.stringify({ type: 'spring', stiffness: 400, damping: 30, delay: 0.08 })
+    )
+    expect(screen.getByTestId('clipboard-preview')).toBeInTheDocument()
+  })
+})

--- a/src/shortcuts/definitions.ts
+++ b/src/shortcuts/definitions.ts
@@ -9,6 +9,7 @@ export type ShortcutAction =
   | 'global.zoomIn'
   | 'global.zoomOut'
   | 'global.toggleQuickPanel'
+  | 'clipboard.favorite'
   | 'navigation.settings'
   | string
 
@@ -55,7 +56,7 @@ export interface ShortcutDefinition {
  * Central shortcut definitions
  *
  * 仅收录"在前端/后端真正被实装"的快捷键。
- * 历史上这里还有 clipboard.{esc,selectAll,delete,favorite}、nav.{dashboard,devices}、
+ * 历史上这里还有 clipboard.{esc,selectAll,delete}、nav.{dashboard,devices}、
  * search.focus、modal.close —— 它们只在设置页面"看起来可定制",但没有 handler 读取
  * override,改了也不生效,因此从设置面板里下掉,避免对用户产生误导。
  */
@@ -90,5 +91,14 @@ export const SHORTCUT_DEFINITIONS: ShortcutDefinition[] = [
     action: 'global.zoomOut',
     scope: 'global',
     description: 'settings.sections.shortcuts.actions.zoomOut',
+  },
+
+  // ===== Clipboard page =====
+  {
+    id: 'clipboard.favorite',
+    key: 'f',
+    action: 'clipboard.favorite',
+    scope: 'clipboard',
+    description: 'settings.sections.shortcuts.actions.favoriteClipboardItem',
   },
 ]


### PR DESCRIPTION
Resolved #140 

## Summary

- Add a **Favorite / Unfavorite** action to the clipboard preview action bar, backed by a new `F` keyboard shortcut (`clipboard.favorite`, scope `clipboard`). The shortcut is wired through `useHistoryController` against the currently selected entry, and the action bar button reflects favorited state with a filled star + amber accent (2083d49d4).
- Surface the `clipboard` shortcut scope in Settings → Shortcuts (`SCOPE_ORDER` now includes `clipboard`), and prune the stale `clipboard.favorite` mention from the "not implemented" comment in `definitions.ts` now that it is real (2083d49d4).
- Polish history card actions: copy/favorite/delete now `blur()` and fire `onActionComplete` after running, so focus/hover state stays consistent (2083d49d4).
- Polish entrance/active-state animation: extract shared `HISTORY_ENTRY_ANIMATION` constants, animate the preview pane on entry, and replace the sidebar's framer-motion `layoutId` indicator with a lightweight CSS `transform` sliding highlight (9ce533730, 2083d49d4).

## Test plan

- [x] `HistoryPage`, `ClipboardActionBar`, `HistoryCard`, `CompositeSearchBar`, `SidebarUpdateIndicator`, and `useHistoryController` unit tests added/updated and passing.
- [ ] Manual GUI check: select a history entry, press `F` to toggle favorite, and confirm the action-bar star + state mirror the per-card star button.
- [ ] Manual GUI check: Settings → Shortcuts now lists the Clipboard scope with the Favorite binding, and rebinding it works.

---

docs-site left as-is — the only adjacent surface is the generic Clipboard-scope description in `guides/settings.mdx`, which doesn't enumerate individual keys; no user-facing contract changed. No telemetry surface (frontend only, no `uc-application`/mobile-sync changes) and no tracing changes (no Rust).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a favorite/unfavorite action for clipboard items, including keyboard shortcut support and updated labels.
  * Improved the history preview and action controls so actions close more reliably after use.
  * Updated sidebar navigation highlighting and shortcut ordering for a cleaner experience.

* **Bug Fixes**
  * Improved action button accessibility with clearer labels and button behavior.
  * Refined animation and focus behavior in history views for smoother interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->