### PR TITLE
fix: survive large multi-rep image inbound sync on Windows

### DIFF
--- a/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/materializer.rs
+++ b/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/materializer.rs
@@ -27,6 +27,21 @@ use crate::facade::blob_transfer::{
 };
 use crate::usecases::clipboard_sync::payload_codec::V3BlobRef;
 
+/// Maximum number of bytes that a single representation-bound blob may contribute
+/// as inline bytes in the clipboard snapshot forwarded to the OS clipboard write.
+///
+/// Reps exceeding this threshold are *not* inlined into the snapshot (their rep
+/// slot is removed). The entry itself is still stored — just without the oversized
+/// rep content. This acts as a defense-in-depth guard against the Windows DIBV5
+/// encode OOM path: a 64 MB PNG would decode to ~260 MB RGBA and produce a
+/// ~260 MB DIBV5 buffer; with 9 simultaneous large reps the peak climbs to
+/// several GB. `LARGE_PNG_BYTES` (4 MB) in `windows.rs` handles the normal
+/// multi-rep case; this cap catches extreme individual reps that slip through.
+///
+/// 64 MB is intentionally generous — a 4K screenshot PNG is typically 5–15 MB,
+/// so this only fires for genuinely unusual payloads.
+const MAX_REP_INLINE_BYTES: usize = 64 * 1024 * 1024; // 64 MB
+
 /// 判断 fetcher 返回的 anyhow 错误是否来自 `BlobTransferError::Cancelled`。
 /// 仅 `BlobTransferFacade` 这一条生产路径保留 thiserror chain;mock 路径
 /// 若想模拟 cancel,可以 `Err(anyhow::Error::from(BlobTransferError::Cancelled))`。
@@ -188,16 +203,27 @@ impl InboundBlobMaterializer for FileCacheBlobMaterializer {
         let batch_total = rep_refs.len() + file_refs.len();
         let mut batch_idx = 0usize;
 
-        // 收集 partial cancel 时的"未完成"轨迹:
-        // - `incomplete_rep_idxs`:rep_refs 阶段被取消的 representation index,
-        //   退出循环后从 snapshot.representations 中倒序移除,避免把声明了但
-        //   没有真实 bytes 的 rep 落库后导致 renderer 渲染失败。
-        // - `missing_files`:file_refs 阶段被取消的文件元数据,用于:
-        //   (a) 在 file-list rep 中以 `uniclip-missing://` URI 占位;
-        //   (b) 返回给上层做"是否 partial"判定。
-        // - `partial`: set when cancel or fetch error occurs; remaining blobs
+        // Collect state for two distinct "skip" scenarios:
+        //
+        // `incomplete_rep_idxs`: rep indices that were not fetched due to a
+        //   cancel or fetch error. Set alongside `partial = true`. Reps are
+        //   removed from the snapshot so the partial entry does not carry
+        //   empty-bytes stubs that would cause the renderer to fail.
+        //
+        // `size_exceeded_rep_idxs`: rep indices whose fetched bytes exceeded
+        //   MAX_REP_INLINE_BYTES. These reps are *not* inlined into the
+        //   snapshot (to prevent OOM in the downstream Windows DIBV5 encode
+        //   path) but `partial` is NOT set — the entry is stored normally
+        //   without the oversized rep content.
+        //
+        // `missing_files`: file-ref metadata for file_refs cancelled mid-fetch.
+        //   Used for (a) uniclip-missing:// URI placeholders and (b) signalling
+        //   partial state to the caller.
+        //
+        // `partial`: set when a cancel or fetch error occurs; remaining blobs
         //   are marked missing and no further fetches are attempted.
         let mut incomplete_rep_idxs: Vec<usize> = Vec::new();
+        let mut size_exceeded_rep_idxs: Vec<usize> = Vec::new();
         let mut missing_files: Vec<MissingFileRef> = Vec::new();
         let mut partial = false;
 
@@ -281,13 +307,40 @@ impl InboundBlobMaterializer for FileCacheBlobMaterializer {
             };
 
             let usize_idx = idx as usize;
+            let fetched_len = fetched.plaintext.len();
+
+            // Defense-in-depth cap: do not inline extremely large blobs into the
+            // snapshot that will be forwarded to the OS clipboard write. The Windows
+            // DIBV5 encode path (png_to_dibv5) allocates pixel_w × pixel_h × 4 bytes
+            // per rep; with multiple oversized reps the cumulative peak can exceed
+            // available memory. The per-rep encode strategy in windows.rs
+            // (LARGE_PNG_BYTES / PngEncodeSlot::Large) handles the normal multi-rep
+            // case; this cap is a last-resort guard for individually extreme payloads.
+            //
+            // The entry is still stored — only the oversized rep is absent from the
+            // inlined snapshot. `partial` is NOT set (a missing rep is not a transfer
+            // failure; the entry is complete enough to be usable).
+            if fetched_len > MAX_REP_INLINE_BYTES {
+                warn!(
+                    entry_id = %entry_id,
+                    representation_index = idx,
+                    fetched_bytes = fetched_len,
+                    cap_bytes = MAX_REP_INLINE_BYTES,
+                    mime = blob_ref.mime.as_deref().unwrap_or(""),
+                    "materialize: rep-bound blob exceeds per-rep byte cap; \
+                     skipping inline to prevent OOM in OS clipboard write \
+                     (entry is still stored without this rep)"
+                );
+                size_exceeded_rep_idxs.push(usize_idx);
+                continue;
+            }
+
             let rep_count = snapshot.representations.len();
             let rep = snapshot.representations.get_mut(usize_idx).ok_or_else(|| {
                 anyhow!(
                     "materialize: representation_index {idx} out of bounds (snapshot has {rep_count} reps)"
                 )
             })?;
-            let fetched_len = fetched.plaintext.len();
             rep.set_inline_bytes(fetched.plaintext.to_vec())
                 .map_err(|err| anyhow!("materialize: failed to set inline bytes: {err}"))?;
             info!(
@@ -295,6 +348,27 @@ impl InboundBlobMaterializer for FileCacheBlobMaterializer {
                 representation_index = idx,
                 bytes_written = fetched_len,
                 "materialize: blob inlined back into representation"
+            );
+        }
+
+        // Remove size-exceeded reps from the snapshot. These reps were not
+        // inlined (bytes too large for safe clipboard write) so their slot in
+        // `snapshot.representations` still holds the pre-fetch placeholder.
+        // Removing them prevents empty-rep stubs from reaching the DB or the
+        // clipboard writer. `partial` is intentionally NOT set.
+        if !size_exceeded_rep_idxs.is_empty() {
+            let mut sorted = size_exceeded_rep_idxs.clone();
+            sorted.sort_unstable();
+            sorted.dedup();
+            for &i in sorted.iter().rev() {
+                if i < snapshot.representations.len() {
+                    snapshot.representations.remove(i);
+                }
+            }
+            info!(
+                removed_rep_count = sorted.len(),
+                "materialize: removed oversized rep-bound reps from snapshot \
+                 (entry stored without them; not marked partial)"
             );
         }
 

--- a/crates/uc-desktop/src/daemon_monitor.rs
+++ b/crates/uc-desktop/src/daemon_monitor.rs
@@ -1,0 +1,186 @@
+//! Daemon crash detection and automatic restart for desktop GUI hosts.
+//!
+//! [`run`] is a long-lived background task registered with the process
+//! [`TaskRegistry`](uc_core::TaskRegistry) after the initial daemon bootstrap
+//! succeeds. It probes `/health` every [`CHECK_INTERVAL`]; after
+//! [`FAILURE_THRESHOLD`] consecutive misses it calls [`restart_local_daemon`]
+//! and refreshes the live [`DaemonConnectionState`], allowing the WS bridge to
+//! reconnect automatically without user intervention.
+//!
+//! ## Design notes
+//!
+//! **Start-after-bootstrap only.** This task must be spawned only after
+//! [`bootstrap_daemon_in_process`](crate::daemon_probe::bootstrap_daemon_in_process)
+//! returns `Ok`. Starting before bootstrap completes risks:
+//! - treating normal startup latency as a crash, or
+//! - calling [`restart_local_daemon`] against a daemon whose version was
+//!   legitimately refused (e.g. `RefusedNewerDaemon`), which would kill the
+//!   higher-version daemon.
+//!
+//! **Concurrency with the `restart_daemon` command.** Both this monitor and the
+//! `restart_daemon` Tauri command may call [`restart_local_daemon`] concurrently
+//! if a manual restart is triggered while the monitor is in its own restart
+//! path. The worst outcome is two overlapping restart sequences: both SIGTERM
+//! the same PID (idempotent), both wait for process exit, both attempt to
+//! spawn a new daemon (the second one fails the instance lock and exits
+//! immediately), and both poll `/health` until the winner is healthy. The
+//! resulting `connection_state.set()` calls carry the same connection info and
+//! are therefore idempotent. This race is acceptable given the low frequency
+//! of manual restarts and the idempotency of every step.
+//!
+//! **Riding out a manual restart.** With [`CHECK_INTERVAL`] = 5 s and
+//! [`FAILURE_THRESHOLD`] = 3, the monitor needs 15 s of uninterrupted absence
+//! before acting. A manual `restart_daemon` completes in ≤ 10 s end-to-end,
+//! so the monitor typically sees 2 absent probes followed by 1 healthy probe
+//! and resets its counter — never triggering its own restart.
+//!
+//! **Shutdown safety.** The task is cancelled via its [`CancellationToken`]
+//! (propagated from the process `TaskRegistry`) when the GUI exits. The token
+//! is checked at the start of every loop iteration and again immediately before
+//! the long-running restart call.
+
+use std::time::Duration;
+
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, info, warn};
+
+use uc_daemon_client::DaemonConnectionState;
+use uc_daemon_contract::probe::ProbeOutcome;
+
+use crate::daemon_probe::{probe_daemon_health, restart_local_daemon, PROBE_TIMEOUT};
+use crate::daemon_recovery::recover_after_restart;
+
+/// How often to probe the daemon `/health` endpoint.
+const CHECK_INTERVAL: Duration = Duration::from_secs(5);
+
+/// Number of consecutive probe failures that trigger an automatic daemon restart.
+///
+/// With [`CHECK_INTERVAL`] = 5 s, three failures = 15 s of confirmed absence
+/// before action is taken. This provides enough headroom to ride out a manual
+/// `restart_daemon` command (which takes ≤ ~10 s end-to-end) without reacting
+/// to a transient probe hiccup or a deliberate in-progress restart.
+const FAILURE_THRESHOLD: u32 = 3;
+
+/// Drive the daemon liveness monitor until `token` is cancelled.
+///
+/// **Must be started only after the initial daemon bootstrap has succeeded**
+/// and `connection_state` holds a valid `DaemonConnectionInfo`. See the
+/// module-level documentation for the rationale.
+///
+/// `expected_package_version` must be the shell crate's own
+/// `env!("CARGO_PKG_VERSION")` — the same value passed to
+/// [`bootstrap_daemon_in_process`](crate::daemon_probe::bootstrap_daemon_in_process).
+/// The `'static` bound ensures the future produced by this async function is
+/// `'static` and can be registered with the `TaskRegistry`.
+pub async fn run(
+    expected_package_version: &'static str,
+    connection_state: DaemonConnectionState,
+    token: CancellationToken,
+) {
+    let client = match reqwest::Client::builder().timeout(PROBE_TIMEOUT).build() {
+        Ok(c) => c,
+        Err(error) => {
+            warn!(%error, "daemon_monitor: failed to build HTTP probe client; monitor disabled");
+            return;
+        }
+    };
+
+    let mut consecutive_failures: u32 = 0;
+
+    loop {
+        // Wait for the next probe window or exit immediately on cancellation.
+        // `biased` ensures the cancellation branch is always checked first so
+        // the monitor reacts promptly to a shutdown signal.
+        tokio::select! {
+            biased;
+            _ = token.cancelled() => {
+                info!("daemon_monitor: cancellation token fired, stopping");
+                return;
+            }
+            _ = tokio::time::sleep(CHECK_INTERVAL) => {}
+        }
+
+        let probe_result = probe_daemon_health(&client, expected_package_version).await;
+
+        let alive = match &probe_result {
+            Ok(ProbeOutcome::Compatible(_)) => true,
+            Ok(other) => {
+                debug!(
+                    outcome = ?other,
+                    "daemon_monitor: probe returned non-Compatible outcome"
+                );
+                false
+            }
+            Err(error) => {
+                warn!(%error, "daemon_monitor: probe request error (treating as absence)");
+                false
+            }
+        };
+
+        if alive {
+            if consecutive_failures > 0 {
+                info!(
+                    consecutive_failures,
+                    "daemon_monitor: daemon is responding again; resetting failure counter"
+                );
+            }
+            consecutive_failures = 0;
+            continue;
+        }
+
+        consecutive_failures += 1;
+        warn!(
+            consecutive_failures,
+            threshold = FAILURE_THRESHOLD,
+            "daemon_monitor: daemon health probe failed"
+        );
+
+        if consecutive_failures < FAILURE_THRESHOLD {
+            // Not yet at threshold — keep accumulating failures before acting.
+            continue;
+        }
+
+        // Failure threshold reached — attempt automatic recovery.
+        info!(
+            consecutive_failures,
+            "daemon_monitor: failure threshold reached; triggering daemon restart"
+        );
+
+        // Reset the counter unconditionally: if the restart fails we want
+        // another full failure sequence before the next attempt, rather than
+        // retrying in the very next loop iteration.
+        consecutive_failures = 0;
+
+        // Check the token one more time before committing to the potentially
+        // long restart sequence. The exit handler handles daemon teardown
+        // through its own path, so there is no benefit in racing with it.
+        if token.is_cancelled() {
+            info!("daemon_monitor: shutdown requested before restart; aborting");
+            return;
+        }
+
+        match restart_local_daemon(expected_package_version).await {
+            Ok(new_info) => {
+                info!("daemon_monitor: daemon restarted successfully; refreshing connection state");
+                connection_state.set(new_info);
+
+                // The new daemon process has a fresh JWT secret; any cached
+                // session token from the old daemon will be rejected. Clear it
+                // so the next HTTP request mints a fresh session against the
+                // restarted daemon.
+                uc_daemon_client::http::clear_session_token_cache().await;
+
+                // Best-effort: re-unlock encryption and advance lifecycle
+                // services so the user's clipboard sync session is restored
+                // automatically without requiring manual intervention.
+                recover_after_restart(connection_state.clone()).await;
+            }
+            Err(error) => {
+                warn!(
+                    %error,
+                    "daemon_monitor: restart failed; will retry after the next failure sequence"
+                );
+            }
+        }
+    }
+}

--- a/crates/uc-desktop/src/lib.rs
+++ b/crates/uc-desktop/src/lib.rs
@@ -15,6 +15,7 @@ pub use uc_daemon_contract::DAEMON_API_REVISION;
 
 pub mod background;
 pub mod daemon;
+pub mod daemon_monitor;
 pub mod daemon_probe;
 pub mod daemon_recovery;
 pub mod file_ports;

--- a/crates/uc-platform/src/clipboard/platform/windows.rs
+++ b/crates/uc-platform/src/clipboard/platform/windows.rs
@@ -218,6 +218,48 @@ fn png_to_dibv5(png_bytes: &[u8]) -> Result<Vec<u8>> {
     Ok(out)
 }
 
+/// Source byte size threshold that determines which encode strategy to use for
+/// an image/png rep in the pre-encode phase.
+///
+/// Reps whose raw PNG source bytes are **at most** this size are pre-encoded
+/// (PNG → RGBA → DIBV5) *outside* the `OpenClipboard` session (small-rep path).
+///
+/// Reps whose source exceeds this size use the large-rep path: only the raw
+/// PNG bytes are loaded before the session; DIBV5 encoding is deferred to
+/// *inside* the session, one rep at a time, so the transient DIBV5 buffer
+/// (≈ pixel_w × pixel_h × 4 bytes) is freed before the next rep begins.
+/// This bounds peak DIBV5 memory to one large-rep budget regardless of how
+/// many large reps the snapshot contains.
+///
+/// Threshold rationale: 4 MB of PNG source typically expands to ≤ 16 MB of
+/// DIBV5 (4 MP image at 32 bpp), which is tolerable as a simultaneous
+/// per-rep peak for the pre-encode batch. A 20 MB PNG (9-rep inbound sync
+/// scenario that triggered the OOM report) decodes to ~80 MB DIBV5 per rep;
+/// pre-encoding all 9 simultaneously would peak at ~900 MB.
+const LARGE_PNG_BYTES: usize = 4 * 1024 * 1024; // 4 MB
+
+/// Encoding strategy selected for each image/png rep during the pre-encode phase.
+///
+/// See `write_snapshot_multi_windows` for the threshold logic and the
+/// memory / lock-hold-time tradeoff it encodes.
+enum PngEncodeSlot {
+    /// Both PNG bytes and CF_DIBV5 bytes were pre-encoded *outside* the
+    /// `OpenClipboard` session. Used for reps ≤ `LARGE_PNG_BYTES`.
+    /// Minimises clipboard lock hold time; peak memory grows with the number
+    /// of small reps (acceptable when they are small by definition).
+    Small {
+        png_bytes: Vec<u8>,
+        /// `None` when DIBV5 transcoding failed; only the "PNG" custom format
+        /// will be written in that case.
+        dib_bytes: Option<Vec<u8>>,
+    },
+    /// Raw PNG bytes loaded *outside* the lock (to avoid IO inside the session).
+    /// DIBV5 encoding is deferred to inside the `OpenClipboard` session, one
+    /// rep at a time: the DIBV5 buffer is allocated, written to the clipboard,
+    /// and dropped before the next rep begins. Used for reps > `LARGE_PNG_BYTES`.
+    Large { png_bytes: Vec<u8> },
+}
+
 /// 单次写入尝试的最大次数。
 ///
 /// `ERROR_CLIPBOARD_NOT_OPEN (1418)` 在大多数情况下是瞬态的（消息泵、GDI 竞争
@@ -352,15 +394,41 @@ pub(crate) fn write_snapshot_multi_windows(snapshot: SystemClipboardSnapshot) ->
         );
     }
 
-    // 预编码阶段 —— 在 OpenClipboard 会话**之外**完成两件事:
-    //   1) 把 image/png rep 的字节物化成 owned `Vec<u8>`（Inline 直接 to_vec, LocalFile
-    //      同步读盘）。在 OpenClipboard 会话内读盘会拉长持锁时间、增加 1418 风险,因此
-    //      所有 IO 都在会话外完成。
-    //   2) 把这份字节继续转码为 CF_DIBV5。失败时 `dib=None`,只写 "PNG" 自定义 format。
+    // Pre-encode phase — run OUTSIDE the OpenClipboard session.
     //
-    // 与 `rep` 一一对应；外层 `None` 表示该 rep 不走 image/png 路径（非 image/png 或读
-    // LocalFile 失败）。LocalFile 读盘失败会在这里 warn 并 None,主循环看到 None 时跳过。
-    let png_preencoded: Vec<Option<(Vec<u8>, Option<Vec<u8>>)>> = snapshot
+    // Two competing concerns must be balanced:
+    //
+    //  • Lock hold time: any significant work (image decode, DIBV5 encode,
+    //    disk IO) done *inside* the clipboard session extends the time other
+    //    Windows processes are blocked from reading the clipboard. Long holds
+    //    increase ERROR_CLIPBOARD_NOT_OPEN (1418) risk from racing processes
+    //    (AV scanners, IME hooks, clipboard managers, RDP clip proxy).
+    //
+    //  • Peak memory: pre-encoding *all* reps simultaneously keeps every
+    //    DIBV5 buffer alive until the session ends. With 9 large image reps
+    //    (e.g. TIFF/DIBV5/PNG received from macOS), a 20 MB source PNG
+    //    decodes to ~80 MB DIBV5 (pixel_w × pixel_h × 4). Pre-encoding all 9
+    //    simultaneously peaks at ~900 MB and causes OOM crashes on constrained
+    //    Windows machines.
+    //
+    // Resolution — threshold = LARGE_PNG_BYTES (4 MB per source rep):
+    //
+    //  • Small reps (≤ 4 MB source): pre-encode both PNG bytes and DIBV5
+    //    outside the lock. IO and CPU happen before the session; during the
+    //    session only cheap SetClipboardData calls run.
+    //
+    //  • Large reps (> 4 MB source): load only the raw PNG bytes outside the
+    //    lock (avoids IO inside the session). DIBV5 encoding is deferred to
+    //    inside the OpenClipboard session, processed one rep at a time.
+    //    The DIBV5 buffer is allocated, written, and dropped before the next
+    //    rep is processed, so peak DIBV5 memory stays at one large-rep budget
+    //    regardless of N. The clipboard is held longer per large rep, but the
+    //    incremental hold (encode + one SetClipboardData) is bounded and far
+    //    shorter than the multi-rep simultaneous hold of the old strategy.
+    //
+    // One entry per rep in `snapshot.representations`; `None` means the rep
+    // is not an image/png or its bytes could not be loaded (already warned).
+    let png_preencoded: Vec<Option<PngEncodeSlot>> = snapshot
         .representations
         .iter()
         .map(|rep| {
@@ -377,23 +445,39 @@ pub(crate) fn write_snapshot_multi_windows(snapshot: SystemClipboardSnapshot) ->
                         error = %err,
                         format_id = %rep.format_id,
                         size_bytes = rep.size_bytes(),
-                        "Windows 多 rep 写入：读取 LocalFile image/png rep 字节失败，跳过该 rep"
+                        "Windows multi-rep write: failed to read LocalFile image/png rep bytes; skipping rep"
                     );
                     return None;
                 }
             };
-            let dib = match png_to_dibv5(&bytes) {
-                Ok(dib) => Some(dib),
-                Err(e) => {
-                    warn!(
-                        error = %e,
-                        png_bytes = bytes.len(),
-                        "PNG→CF_DIBV5 转码失败；仅写 \"PNG\" 自定义 format"
-                    );
-                    None
-                }
-            };
-            Some((bytes, dib))
+            if bytes.len() > LARGE_PNG_BYTES {
+                // Large rep: defer DIBV5 encoding to inside the clipboard
+                // session. Only the PNG source bytes are kept here; the DIBV5
+                // buffer will be created, written, and freed one rep at a time
+                // during the write loop, keeping peak DIBV5 memory bounded.
+                debug!(
+                    format_id = %rep.format_id,
+                    png_bytes = bytes.len(),
+                    threshold_bytes = LARGE_PNG_BYTES,
+                    "Large image/png rep: deferring DIBV5 encode to inside clipboard session"
+                );
+                Some(PngEncodeSlot::Large { png_bytes: bytes })
+            } else {
+                // Small rep: pre-encode DIBV5 now, outside the clipboard
+                // session, to keep lock hold time minimal.
+                let dib = match png_to_dibv5(&bytes) {
+                    Ok(dib) => Some(dib),
+                    Err(e) => {
+                        warn!(
+                            error = %e,
+                            png_bytes = bytes.len(),
+                            "PNG->CF_DIBV5 transcode failed; will write \"PNG\" custom format only"
+                        );
+                        None
+                    }
+                };
+                Some(PngEncodeSlot::Small { png_bytes: bytes, dib_bytes: dib })
+            }
         })
         .collect();
 
@@ -484,7 +568,7 @@ pub(crate) fn write_snapshot_multi_windows(snapshot: SystemClipboardSnapshot) ->
 /// 返回 None），不包含"整体尝试失败"的情况。
 fn attempt_multi_write_inner(
     snapshot: &SystemClipboardSnapshot,
-    png_preencoded: &[Option<(Vec<u8>, Option<Vec<u8>>)>],
+    png_preencoded: &[Option<PngEncodeSlot>],
 ) -> Result<Vec<String>> {
     use clipboard_win::formats::{Html as HtmlFmt, CF_DIBV5};
     use clipboard_win::options::NoClear;
@@ -611,51 +695,84 @@ fn attempt_multi_write_inner(
                 wrote_any = true;
             }
             Some(MimeClass::Image(ImageKind::Png)) => {
-                // 双写策略：CF_DIBV5（标准格式，Windows 自动合成 CF_BITMAP/CF_DIB 给老应用）
-                // + 自定义 "PNG" format（现代应用直读 PNG 字节，保留 PNG 压缩率与 alpha 元数据）。
+                // Dual-write strategy: CF_DIBV5 (Windows-standard; auto-synthesises
+                // CF_BITMAP/CF_DIB for legacy apps) + custom "PNG" format (modern
+                // apps prefer this to preserve compression and alpha metadata).
                 //
-                // 兼容矩阵：
-                //   - CF_DIBV5 ← 画图、Office、写字板、剪贴板历史（Win+V）、第三方剪贴板工具
-                //     （合成路径覆盖所有认 CF_BITMAP / CF_DIB 的应用）
-                //   - "PNG"    ← Chrome、Firefox、Paint.NET、新版 Office、Google Docs
+                // Compatibility matrix:
+                //   CF_DIBV5 ← Paint, Office, WordPad, clipboard history (Win+V),
+                //               third-party clipboard managers (synthesis covers
+                //               all CF_BITMAP / CF_DIB consumers)
+                //   "PNG"    ← Chrome, Firefox, Paint.NET, modern Office, Google Docs
                 //
-                // PNG owned 字节 + CF_DIBV5 字节都已在 OpenClipboard 会话外完成预编码
-                // （见 `png_preencoded` 构造），这里只做纯系统调用；任一 set_* 失败都 `?`
-                // 抛到外层由重试机制兜底。
-                //
-                // 外层 None 表示该 rep 在预编码阶段读 LocalFile 失败（已 warn）,直接跳过。
-                let Some((png_bytes, dib_opt)) = png_preencoded.get(idx).and_then(|o| o.as_ref())
-                else {
+                // `None` in the pre-encode slot means the rep's bytes could not be
+                // loaded in the pre-encode phase (already warned); skip it here.
+                let Some(slot) = png_preencoded.get(idx).and_then(|o| o.as_ref()) else {
                     skipped.push(rep.format_id.as_str().to_string());
                     continue;
                 };
+
+                // For Large reps, DIBV5 encoding runs here, inside the clipboard
+                // session, to limit peak memory. The buffer is allocated below,
+                // written to the clipboard, and dropped at the end of this arm —
+                // before the next rep is processed.
+                //
+                // For Small reps, DIBV5 was pre-encoded outside the session; we
+                // just borrow its bytes here.
+                let large_dib: Option<Vec<u8>> = if let PngEncodeSlot::Large { png_bytes } = slot {
+                    match png_to_dibv5(png_bytes) {
+                        Ok(d) => Some(d),
+                        Err(e) => {
+                            warn!(
+                                error = %e,
+                                png_bytes = png_bytes.len(),
+                                "Large rep: inline DIBV5 encode failed inside clipboard \
+                                 session; writing PNG-only format"
+                            );
+                            None
+                        }
+                    }
+                } else {
+                    None
+                };
+
+                let (png_bytes_ref, dib_opt): (&[u8], Option<&[u8]>) = match slot {
+                    PngEncodeSlot::Small {
+                        png_bytes,
+                        dib_bytes,
+                    } => (png_bytes.as_slice(), dib_bytes.as_deref()),
+                    PngEncodeSlot::Large { png_bytes } => {
+                        (png_bytes.as_slice(), large_dib.as_deref())
+                    }
+                };
+
                 let mut wrote_dib = false;
                 let mut wrote_png = false;
 
-                if let Some(dib_bytes) = dib_opt.as_ref() {
+                if let Some(dib_bytes) = dib_opt {
                     cb_raw::set_without_clear(CF_DIBV5, dib_bytes)
                         .map_err(|e| anyhow::anyhow!("set CF_DIBV5 failed: {}", e))?;
                     debug!(
                         dib_bytes = dib_bytes.len(),
-                        png_bytes = png_bytes.len(),
-                        "写入 CF_DIBV5 成功"
+                        png_bytes = png_bytes_ref.len(),
+                        "wrote CF_DIBV5"
                     );
                     wrote_dib = true;
                 }
 
                 match cb_raw::register_format("PNG") {
                     Some(png_fmt) => {
-                        cb_raw::set_without_clear(png_fmt.get(), png_bytes).map_err(|e| {
+                        cb_raw::set_without_clear(png_fmt.get(), png_bytes_ref).map_err(|e| {
                             anyhow::anyhow!("set \"PNG\" custom format failed: {}", e)
                         })?;
                         debug!(
-                            png_bytes = png_bytes.len(),
-                            "写入 \"PNG\" 自定义 format 成功"
+                            png_bytes = png_bytes_ref.len(),
+                            "wrote \"PNG\" custom format"
                         );
                         wrote_png = true;
                     }
                     None => {
-                        warn!("register_format(\"PNG\") 返回 None；跳过 \"PNG\" 路径");
+                        warn!("register_format(\"PNG\") returned None; skipping \"PNG\" path");
                     }
                 }
 
@@ -664,6 +781,8 @@ fn attempt_multi_write_inner(
                 } else {
                     skipped.push(rep.format_id.as_str().to_string());
                 }
+                // `large_dib` (if any) is dropped here — the DIBV5 buffer for this
+                // large rep is freed before the loop advances to the next rep.
             }
             Some(MimeClass::UriList) => {
                 // CF_HDROP 写入路径：把 rep 里的 file:// URI 列表（接收端 materializer

--- a/src-tauri/crates/uc-tauri/src/run.rs
+++ b/src-tauri/crates/uc-tauri/src/run.rs
@@ -463,6 +463,12 @@ pub fn run(tauri_ctx: tauri::Context<tauri::Wry>) -> anyhow::Result<()> {
             let daemon_connection_state_for_setup = daemon_connection_state.clone();
             let daemon_ownership_for_setup = daemon_ownership.clone();
             let daemon_bootstrap_status_for_setup = daemon_bootstrap_status.clone();
+            // Cloned here (before the async move) so the bootstrap task can
+            // register the daemon monitor with the same registry once bootstrap
+            // succeeds. Using `runtime.task_registry()` avoids capturing `runtime`
+            // into the bootstrap async block (it is already moved into the large
+            // init task below).
+            let task_registry_for_monitor = runtime.task_registry().clone();
             tauri::async_runtime::spawn(async move {
                 match bootstrap_daemon_in_process(
                     &daemon_ownership_for_setup,
@@ -481,6 +487,25 @@ pub fn run(tauri_ctx: tauri::Context<tauri::Wry>) -> anyhow::Result<()> {
                         // (P4-3 已落地:仅显式「彻底退出」停 daemon,关窗/轻量保留)。
                         // 自启=GUI (D10 2026-06-04 修订):登录起 GUI → 这里必拉起
                         // daemon,即"自启 GUI 等于后台同步就绪"的闭环。
+
+                        // Start the daemon liveness monitor now that we have confirmed
+                        // the daemon is healthy. Spawning AFTER bootstrap avoids false
+                        // positives during startup and prevents the monitor from acting
+                        // on a legitimately-refused daemon version (RefusedNewerDaemon).
+                        // The monitor probes every 5 s and restarts automatically after
+                        // 3 consecutive failures (~15 s of confirmed absence).
+                        let monitor_conn = daemon_connection_state_for_setup.clone();
+                        task_registry_for_monitor
+                            .spawn("daemon_monitor", move |token| async move {
+                                uc_desktop::daemon_monitor::run(
+                                    EXPECTED_PACKAGE_VERSION,
+                                    monitor_conn,
+                                    token,
+                                )
+                                .await;
+                            })
+                            .await;
+                        info!("daemon_monitor task registered with TaskRegistry");
                     }
                     Err(error) => {
                         // Display 只暴露 thiserror 外层 message，会把 anyhow source chain


### PR DESCRIPTION
## Summary

Inbound sync of a ~20MB multi-representation image (a macOS screenshot carrying 9 reps: TIFF 10MB + DIBV5 10MB + PNG) silently killed the Windows daemon, after which the GUI reconnected forever but never recovered. This PR fixes both the crash and the lack of recovery.

- **Bound peak memory on the Windows clipboard write path** (`3f3f02542`). The write path pre-encoded every `image/png` rep to CF_DIBV5 *outside* the clipboard session, keeping all DIBV5 buffers (pixel_w x pixel_h x 4 each) alive at once — 9 large reps peaked at ~900MB and aborted the process with no panic/WER record. Reps are now split into Small (<=4MB source: pre-encode as before) and Large (>4MB source: defer DIBV5 encode to inside the `OpenClipboard` session, one rep at a time, freeing each buffer before the next). Peak DIBV5 memory is bounded to a single large-rep budget regardless of rep count. A defense-in-depth 64MB per-rep inline cap in the inbound materializer drops extreme individual reps from the forwarded snapshot (entry still stored, not marked partial).

- **Supervise daemon liveness and auto-restart on crash** (`6c5e6cfe0`). The GUI owns the daemon lifecycle but previously only reconnected the WS bridge passively after a crash — never respawning the dead daemon, so the user was stuck "can't connect to daemon" until a manual restart. A new `daemon_monitor` background task (registered with the process `TaskRegistry` only *after* bootstrap succeeds, to avoid false positives and avoid killing a legitimately-refused newer daemon) probes `/health` every 5s and, after 3 consecutive misses (~15s), calls `restart_local_daemon`, refreshes the connection state, clears the stale session-token cache, and re-runs `recover_after_restart` to re-unlock encryption.

## Test plan

- [x] `cargo check -p uc-application -p uc-desktop -p uc-tauri` (native) — clean.
- [x] `cargo check -p uc-platform --target x86_64-pc-windows-gnu` — clean (only pre-existing warnings, in untouched code).
- [ ] On a real Windows machine: repeatedly push a 20MB+ multi-rep screenshot from a macOS peer; confirm the daemon no longer crashes and that, if it does die, the monitor auto-restarts it within ~15s without a manual GUI restart.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic daemon health monitoring with self-restart and recovery after startup.
  * Improved clipboard handling for large images to reduce memory usage during Windows clipboard writes.

* **Bug Fixes**
  * Prevented oversized clipboard data from being inlined into snapshots, avoiding memory spikes and clipboard failures.
  * Improved handling of failed or incomplete clipboard item fetches so missing entries are cleaned up more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->