### PR TITLE
fix(ui): unify CJK fonts across UI and code cards via OS-native stack

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -393,6 +393,19 @@
   z-index: 9999;
 }
 
+/* Windows typography: resolve CJK glyphs to the OS-native Microsoft YaHei
+   instead of the bundled Noto Sans SC variable webfont. Under WebView2's
+   DirectWrite, the variable webfont lacks the small-size TrueType hinting that
+   YaHei ships with, so Chinese text looks soft/blurry at UI sizes (13-14px);
+   `-webkit-font-smoothing` is a no-op on Windows, so font selection is the only
+   effective lever. Latin glyphs still fall to Inter/Segoe UI via per-glyph
+   fallback. */
+html[data-uc-platform='windows'] {
+  --font-sans:
+    'Inter Variable', 'Segoe UI', 'Microsoft YaHei UI', 'Microsoft YaHei', system-ui, sans-serif;
+  --font-chinese: 'Microsoft YaHei UI', 'Microsoft YaHei', system-ui, sans-serif;
+}
+
 /* Linux WebKit 低特效模式：优先保证响应速度与稳定渲染。 */
 html[data-uc-low-effects='true'] {
   --shadow-2xs: none;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -102,11 +102,23 @@
 
   --chart-5: oklch(0.424 0.199 265.638);
 
+  /* Latin first, then OS-native CJK per platform (PingFang on macOS, YaHei on
+     Windows), with the bundled Noto Sans SC as the final CJK fallback for Linux
+     and any host missing both. Per-glyph fallback keeps Latin on Inter/Segoe
+     while CJK resolves to the crisp, hinted system font on each OS. */
   --font-sans:
-    'Inter Variable', 'Segoe UI', 'Noto Sans SC Variable', 'Microsoft YaHei', system-ui, sans-serif;
+    'Inter Variable', 'Segoe UI', 'PingFang SC', 'Microsoft YaHei UI', 'Microsoft YaHei',
+    'Noto Sans SC Variable', system-ui, sans-serif;
   --font-serif: Georgia, serif;
-  --font-mono: 'JetBrains Mono', 'Consolas', monospace;
-  --font-chinese: 'Noto Sans SC Variable', 'Microsoft YaHei', system-ui, sans-serif;
+  /* Same CJK fallback chain as --font-sans so code/text preview cards render
+     CJK in the exact UI font (not the OS monospace SimSun/etc.); Latin/digits
+     stay monospace for code alignment. */
+  --font-mono:
+    'JetBrains Mono', 'Consolas', 'PingFang SC', 'Microsoft YaHei UI', 'Microsoft YaHei',
+    'Noto Sans SC Variable', monospace;
+  --font-chinese:
+    'PingFang SC', 'Microsoft YaHei UI', 'Microsoft YaHei', 'Noto Sans SC Variable', system-ui,
+    sans-serif;
   --radius: 0.35rem;
   --shadow-color: hsl(240 30% 25%);
   --shadow-opacity: 0.12;
@@ -204,8 +216,11 @@
 
 @theme inline {
   --font-sans:
-    'Inter Variable', 'Segoe UI', 'Noto Sans SC Variable', 'Microsoft YaHei', system-ui, sans-serif;
-  --font-mono: 'JetBrains Mono', 'Consolas', monospace;
+    'Inter Variable', 'Segoe UI', 'PingFang SC', 'Microsoft YaHei UI', 'Microsoft YaHei',
+    'Noto Sans SC Variable', system-ui, sans-serif;
+  --font-mono:
+    'JetBrains Mono', 'Consolas', 'PingFang SC', 'Microsoft YaHei UI', 'Microsoft YaHei',
+    'Noto Sans SC Variable', monospace;
   --font-serif: Georgia, serif;
   --radius: 0.35rem;
   --tracking-tighter: calc(var(--tracking-normal) - 0.05em);
@@ -391,19 +406,6 @@
 
 ::view-transition-new(root) {
   z-index: 9999;
-}
-
-/* Windows typography: resolve CJK glyphs to the OS-native Microsoft YaHei
-   instead of the bundled Noto Sans SC variable webfont. Under WebView2's
-   DirectWrite, the variable webfont lacks the small-size TrueType hinting that
-   YaHei ships with, so Chinese text looks soft/blurry at UI sizes (13-14px);
-   `-webkit-font-smoothing` is a no-op on Windows, so font selection is the only
-   effective lever. Latin glyphs still fall to Inter/Segoe UI via per-glyph
-   fallback. */
-html[data-uc-platform='windows'] {
-  --font-sans:
-    'Inter Variable', 'Segoe UI', 'Microsoft YaHei UI', 'Microsoft YaHei', system-ui, sans-serif;
-  --font-chinese: 'Microsoft YaHei UI', 'Microsoft YaHei', system-ui, sans-serif;
 }
 
 /* Linux WebKit 低特效模式：优先保证响应速度与稳定渲染。 */


### PR DESCRIPTION
## Summary

- **统一中文字体策略为「系统原生优先」**：界面与代码卡片的中文都按平台解析到该平台渲染最佳的中文字体——macOS `PingFang SC`、Windows `Microsoft YaHei`、Linux 及兜底 `Noto Sans SC`(已打包)。靠浏览器逐字形回退，拉丁字形仍由 `Inter`/`Segoe UI`/`JetBrains Mono` 渲染。零额外字体打包。(f08d366b7)
- **修 Windows 中文发虚**：旧栈让中文落到打包的 `Noto Sans SC Variable`,它在 WebView2(DirectWrite) 下缺小字号 hinting,13–14px 偏糊;现在 Windows 中文走系统自带、为 ClearType 调过 hinting 的 `Microsoft YaHei`,清晰锐利。
- **修代码卡片字体不一致**：`--font-mono` 旧值 `'JetBrains Mono','Consolas',monospace` 不含中文字形,代码/文本预览卡片(CodePreview / CodeEntryContent / TextPreview / VirtualizedText)里的中文会掉到系统等宽中文(宋体)、与界面雅黑风格割裂。现在给 mono 栈补上与 sans 相同的 CJK 回退链:英文/数字保留等宽对齐,中文与界面同款一致。
- 在统一基础栈后移除了上一版临时的 `html[data-uc-platform='windows']` 覆盖,保持单一真相源。

## Test plan

- [x] `prettier --check src/styles/globals.css` 通过;两处定义点(`:root` + `@theme inline`)同步,无残留 Windows override
- [x] 改动仅 CSS,靠逐字形回退,不影响拉丁文本渲染
- [ ] 真机 Windows `bun run build` 跑 GUI:确认界面中文锐利、代码/文本卡片中文与界面一致(不再是宋体)
- [ ] macOS 抽查:界面与卡片中文均为 PingFang SC,中英混排协调