### PR TITLE
fix(ui): resolve clipboard blob images via object URLs to stop 401s

### DIFF
--- a/src/api/__tests__/clipboardItems.test.ts
+++ b/src/api/__tests__/clipboardItems.test.ts
@@ -3,7 +3,7 @@ import {
   getClipboardStats,
   favoriteClipboardItem,
   unfavoriteClipboardItem,
-  resolveResourceImageUrl,
+  getResourceImageUrl,
   syncClipboardItems,
 } from '@/api/clipboardItems'
 
@@ -15,7 +15,7 @@ vi.mock('@/api/lifecycle', () => ({
 
 vi.mock('@/api/daemon/client', () => ({
   daemonClient: {
-    blobUrl: vi.fn((path: string) => `http://127.0.0.1:12345${path}?auth=Session+test`),
+    fetchBlob: vi.fn(),
     request: vi.fn(),
   },
 }))
@@ -79,8 +79,8 @@ describe('syncClipboardItems', () => {
   })
 })
 
-describe('resolveResourceImageUrl', () => {
-  it('keeps inline data URLs unchanged', () => {
+describe('getResourceImageUrl', () => {
+  it('builds an inline data URL from inline content', () => {
     const resource = {
       blobId: null,
       mimeType: 'image/png',
@@ -89,10 +89,10 @@ describe('resolveResourceImageUrl', () => {
       inlineData: 'iVBORw0KGgo=',
     }
 
-    expect(resolveResourceImageUrl(resource)).toBe('data:image/png;base64,iVBORw0KGgo=')
+    expect(getResourceImageUrl(resource)).toBe('data:image/png;base64,iVBORw0KGgo=')
   })
 
-  it('upgrades daemon blob paths to authenticated daemon URLs', () => {
+  it('returns the token-free daemon blob path for blob-backed content', () => {
     const resource = {
       blobId: 'blob-1',
       mimeType: 'image/png',
@@ -101,8 +101,6 @@ describe('resolveResourceImageUrl', () => {
       inlineData: null,
     }
 
-    expect(resolveResourceImageUrl(resource)).toBe(
-      'http://127.0.0.1:12345/clipboard/blobs/blob-1?auth=Session+test'
-    )
+    expect(getResourceImageUrl(resource)).toBe('/clipboard/blobs/blob-1')
   })
 })

--- a/src/api/clipboardItems.ts
+++ b/src/api/clipboardItems.ts
@@ -170,17 +170,14 @@ export async function fetchClipboardResourceText(
       return new TextDecoder('utf-8').decode(bytes)
     }
 
-    // Fall back to URL fetch for blob-backed content
+    // Fall back to URL fetch for blob-backed content. Route through the daemon
+    // client so the session token is refreshed (pre-emptive + 401 retry) and
+    // never baked into a URL — see `fetchBlob`.
     if (!resource.url) {
       throw new Error('Resource has neither inlineData nor url')
     }
-    const resolvedUrl = daemonClient.blobUrl(resource.url!) ?? resource.url!
-    const response = await fetch(resolvedUrl)
-    if (!response.ok) {
-      throw new Error(`Failed to fetch clipboard resource: ${response.status}`)
-    }
-    const buffer = await response.arrayBuffer()
-    return new TextDecoder('utf-8').decode(buffer)
+    const blob = await daemonClient.fetchBlob(resource.url)
+    return blob.text()
   } catch (error) {
     log.error({ err: error }, 'Failed to fetch clipboard resource text')
     throw error
@@ -188,7 +185,10 @@ export async function fetchClipboardResourceText(
 }
 
 /**
- * Get a displayable image URL from a clipboard resource.
+ * Get a token-free image descriptor for a clipboard resource: a `data:` URL for
+ * inline content, or the daemon blob path for blob-backed content (which the
+ * caller resolves to a `blob:` object URL via {@link useBlobImageObjectUrl} so
+ * no short-lived session token ends up in `<img src>`).
  */
 export function getResourceImageUrl(resource: ClipboardEntryResource): string | null {
   if (resource.url) {
@@ -198,16 +198,6 @@ export function getResourceImageUrl(resource: ClipboardEntryResource): string | 
     return `data:${resource.mimeType};base64,${resource.inlineData}`
   }
   return null
-}
-
-/**
- * Resolve a clipboard image resource into a displayable <img src> URL.
- */
-export function resolveResourceImageUrl(resource: ClipboardEntryResource): string | null {
-  const rawUrl = getResourceImageUrl(resource)
-  if (!rawUrl) return null
-  if (rawUrl.startsWith('data:')) return rawUrl
-  return daemonClient.blobUrl(rawUrl) ?? rawUrl
 }
 
 /**

--- a/src/api/clipboardItems.ts
+++ b/src/api/clipboardItems.ts
@@ -164,8 +164,10 @@ export async function fetchClipboardResourceText(
   resource: ClipboardEntryResource
 ): Promise<string> {
   try {
-    // Use inline data when available (small content stored directly)
-    if (resource.inlineData) {
+    // Use inline data when available (small content stored directly). Check for
+    // null explicitly so an empty-string payload ('') decodes to '' instead of
+    // falling through to the "neither inlineData nor url" error.
+    if (resource.inlineData !== null) {
       const bytes = Uint8Array.from(atob(resource.inlineData), c => c.charCodeAt(0))
       return new TextDecoder('utf-8').decode(bytes)
     }

--- a/src/api/daemon/__tests__/client.test.ts
+++ b/src/api/daemon/__tests__/client.test.ts
@@ -33,6 +33,10 @@ function mockFetchSequence(responses: Array<{ ok: boolean; status: number; body:
       status: resp.status,
       json: () => Promise.resolve(resp.body),
       text: () => Promise.resolve(JSON.stringify(resp.body)),
+      blob: () =>
+        Promise.resolve(
+          new Blob([typeof resp.body === 'string' ? resp.body : JSON.stringify(resp.body)])
+        ),
     })
   }
   vi.stubGlobal('fetch', fetchMock)
@@ -66,29 +70,43 @@ describe('DaemonClient', () => {
     })
   })
 
-  describe('blobUrl', () => {
-    it('returns non-daemon urls unchanged', async () => {
+  describe('fetchBlob', () => {
+    it('fetches binary content with the session auth query param', async () => {
       daemonClient.initialize(TEST_CONFIG)
       await daemonClient.refreshSession()
+      mockFetchSequence([{ ok: true, status: 200, body: 'image-bytes' }])
 
-      expect(daemonClient.blobUrl('data:image/png;base64,abc')).toBe('data:image/png;base64,abc')
-      expect(daemonClient.blobUrl('blob:http://localhost/preview-1')).toBe(
-        'blob:http://localhost/preview-1'
-      )
-      expect(daemonClient.blobUrl('https://cdn.example.com/image.png')).toBe(
-        'https://cdn.example.com/image.png'
-      )
-      expect(daemonClient.blobUrl('http://cdn.example.com/image.png')).toBe(
-        'http://cdn.example.com/image.png'
-      )
+      const blob = await daemonClient.fetchBlob('/clipboard/blobs/blob-1')
+
+      expect(blob).toBeInstanceOf(Blob)
+      const fetchMock = fetch as unknown as ReturnType<typeof vi.fn>
+      const requestedUrl = String(fetchMock.mock.calls[0][0])
+      expect(requestedUrl).toContain('/clipboard/blobs/blob-1')
+      expect(requestedUrl).toContain('auth=Session+jwt-abc')
     })
 
-    it('adds auth only for relative daemon resource paths', async () => {
+    it('refreshes the session and retries once on 401', async () => {
       daemonClient.initialize(TEST_CONFIG)
       await daemonClient.refreshSession()
+      mockFetchSequence([
+        { ok: false, status: 401, body: { error: 'expired' } },
+        { ok: true, status: 200, body: 'image-bytes' },
+      ])
 
-      expect(daemonClient.blobUrl('/clipboard/blobs/blob-1')).toBe(
-        'http://127.0.0.1:9999/clipboard/blobs/blob-1?auth=Session+jwt-abc'
+      const blob = await daemonClient.fetchBlob('/clipboard/blobs/blob-1')
+
+      expect(blob).toBeInstanceOf(Blob)
+      const fetchMock = fetch as unknown as ReturnType<typeof vi.fn>
+      expect(fetchMock).toHaveBeenCalledTimes(2)
+    })
+
+    it('throws a DaemonApiError on non-401 HTTP errors', async () => {
+      daemonClient.initialize(TEST_CONFIG)
+      await daemonClient.refreshSession()
+      mockFetchSequence([{ ok: false, status: 410, body: { error: 'gone' } }])
+
+      await expect(daemonClient.fetchBlob('/clipboard/blobs/blob-1')).rejects.toBeInstanceOf(
+        DaemonApiError
       )
     })
   })

--- a/src/api/daemon/blob-image-cache.ts
+++ b/src/api/daemon/blob-image-cache.ts
@@ -14,6 +14,30 @@ const MAX_ENTRIES = 128
 const cache = new Map<string, string>()
 /** path -> in-flight fetch, so concurrent callers share one request. */
 const inFlight = new Map<string, Promise<string | null>>()
+/**
+ * Bumped on every {@link clearBlobImageCache}. A fetch started before a teardown
+ * carries the generation it began under; if it resolves afterward it revokes its
+ * own object URL instead of repopulating the just-cleared cache.
+ */
+let cacheGeneration = 0
+
+async function fetchAndCache(path: string, generation: number): Promise<string | null> {
+  try {
+    const blob = await daemonClient.fetchBlob(path)
+    const objectUrl = URL.createObjectURL(blob)
+    // If the cache was cleared while this fetch was in flight, don't
+    // resurrect it — revoke the freshly created URL and report no result.
+    if (generation !== cacheGeneration) {
+      URL.revokeObjectURL(objectUrl)
+      return null
+    }
+    touch(path, objectUrl)
+    return objectUrl
+  } catch (err) {
+    log.error({ err, path }, 'failed to fetch blob image')
+    return null
+  }
+}
 
 function touch(path: string, objectUrl: string): void {
   // Re-insert to move this key to the most-recently-used end.
@@ -51,19 +75,10 @@ export async function getBlobImageObjectUrl(path: string): Promise<string | null
   const existing = inFlight.get(path)
   if (existing) return existing
 
-  const promise = (async () => {
-    try {
-      const blob = await daemonClient.fetchBlob(path)
-      const objectUrl = URL.createObjectURL(blob)
-      touch(path, objectUrl)
-      return objectUrl
-    } catch (err) {
-      log.error({ err, path }, 'failed to fetch blob image')
-      return null
-    } finally {
-      inFlight.delete(path)
-    }
-  })()
+  const promise = fetchAndCache(path, cacheGeneration).finally(() => {
+    // Only clear the slot we own; a clear()/refetch may have replaced it.
+    if (inFlight.get(path) === promise) inFlight.delete(path)
+  })
   inFlight.set(path, promise)
   return promise
 }
@@ -73,6 +88,7 @@ export async function getBlobImageObjectUrl(path: string): Promise<string | null
  * so the pinned image bytes are released.
  */
 export function clearBlobImageCache(): void {
+  cacheGeneration += 1
   for (const objectUrl of cache.values()) {
     URL.revokeObjectURL(objectUrl)
   }

--- a/src/api/daemon/blob-image-cache.ts
+++ b/src/api/daemon/blob-image-cache.ts
@@ -1,0 +1,81 @@
+import { createLogger } from '@/lib/logger'
+import { daemonClient } from './client'
+
+const log = createLogger('blob-image-cache')
+
+/**
+ * Upper bound on cached object URLs. Each entry pins the decoded image bytes in
+ * memory until revoked, so the cache is LRU-bounded; evicting an entry revokes
+ * its object URL. Sized for a virtualized history list's working set.
+ */
+const MAX_ENTRIES = 128
+
+/** path -> object URL. Insertion order is the LRU order (Map preserves it). */
+const cache = new Map<string, string>()
+/** path -> in-flight fetch, so concurrent callers share one request. */
+const inFlight = new Map<string, Promise<string | null>>()
+
+function touch(path: string, objectUrl: string): void {
+  // Re-insert to move this key to the most-recently-used end.
+  cache.delete(path)
+  cache.set(path, objectUrl)
+  while (cache.size > MAX_ENTRIES) {
+    const oldestKey = cache.keys().next().value as string | undefined
+    if (oldestKey === undefined) break
+    const oldest = cache.get(oldestKey)
+    cache.delete(oldestKey)
+    if (oldest) URL.revokeObjectURL(oldest)
+  }
+}
+
+/**
+ * Resolve a daemon blob path to a stable `blob:` object URL, fetching the bytes
+ * with session auth (and 401 auto-refresh) at most once per path.
+ *
+ * The object URL carries no token and never expires, so it is safe to keep in a
+ * long-lived cache or an already-mounted `<img>`. This replaces embedding a
+ * short-lived `?auth=Session <jwt>` token directly in `<img src>`, which caused
+ * periodic 401s once the 300s token outlived the cached URL (the browser image
+ * loader has no 401-refresh path; see {@link daemonClient.fetchBlob}).
+ *
+ * @param path Daemon resource path (e.g. "/clipboard/blobs/<id>").
+ * @returns A `blob:` object URL, or `null` if the fetch failed.
+ */
+export async function getBlobImageObjectUrl(path: string): Promise<string | null> {
+  const cached = cache.get(path)
+  if (cached) {
+    touch(path, cached)
+    return cached
+  }
+
+  const existing = inFlight.get(path)
+  if (existing) return existing
+
+  const promise = (async () => {
+    try {
+      const blob = await daemonClient.fetchBlob(path)
+      const objectUrl = URL.createObjectURL(blob)
+      touch(path, objectUrl)
+      return objectUrl
+    } catch (err) {
+      log.error({ err, path }, 'failed to fetch blob image')
+      return null
+    } finally {
+      inFlight.delete(path)
+    }
+  })()
+  inFlight.set(path, promise)
+  return promise
+}
+
+/**
+ * Revoke every cached object URL and clear the cache. Call on teardown / logout
+ * so the pinned image bytes are released.
+ */
+export function clearBlobImageCache(): void {
+  for (const objectUrl of cache.values()) {
+    URL.revokeObjectURL(objectUrl)
+  }
+  cache.clear()
+  inFlight.clear()
+}

--- a/src/api/daemon/client.ts
+++ b/src/api/daemon/client.ts
@@ -292,28 +292,55 @@ class DaemonClient {
   }
 
   /**
-   * Build a full daemon URL for binary resource access with session auth.
-   * Suitable for use in <img src> without JavaScript fetch.
+   * Fetch a binary daemon resource (blob) with session auth, sharing the same
+   * pre-emptive refresh + one-shot 401 retry as {@link request}. Unlike
+   * `request`, the body is returned as a {@link Blob} (no JSON parsing).
    *
-   * 构建带 session 认证的 daemon 二进制资源完整 URL。
-   * 适用于 <img src> 等无法设置请求头的场景。
+   * Use this — not a token-bearing URL embedded in `<img src>` — so the caller
+   * can wrap the bytes in a stable `blob:` object URL. A session token has a
+   * 300s TTL; baking it into a URL that outlives the token (cached thumbnail,
+   * long-mounted `<img>`) produced periodic 401s with no retry path, since the
+   * browser image loader can't refresh on 401 the way this method does.
    *
-   * @param path API path (e.g. "/clipboard/blobs/abc-123").
-   * @returns Full URL string with ?auth= query param, or null if client not ready.
+   * 以 session 认证拉取 daemon 二进制资源，与 {@link request} 共用过期预刷新 +
+   * 401 单次重试，但返回 {@link Blob}。调用方应据此生成稳定的 object URL，
+   * 避免把 300s 短期 token 烧进 `<img src>` 导致周期性 401。
+   *
+   * @param endpoint API path (e.g. "/clipboard/blobs/abc-123").
+   * @param options Optional AbortSignal.
+   * @returns The response body as a {@link Blob}.
+   * @throws {DaemonApiError} On HTTP errors (after one refresh + retry on 401).
    */
-  blobUrl(path: string): string | null {
-    if (!this.config || !this.session?.token) return null
-    if (
-      path.startsWith('data:') ||
-      path.startsWith('blob:') ||
-      path.startsWith('http://') ||
-      path.startsWith('https://')
-    ) {
-      return path
+  async fetchBlob(endpoint: string, options: { signal?: AbortSignal } = {}): Promise<Blob> {
+    if (!this.config) {
+      throw new DaemonApiError(
+        DaemonErrorCode.INTERNAL_ERROR,
+        'DaemonClient not initialized — call initialize() first'
+      )
     }
-    const url = new URL(`${this.config.baseUrl}${path}`)
-    url.searchParams.set('auth', `Session ${this.session.token}`)
-    return url.toString()
+
+    // Pre-emptive refresh if session is expired.
+    if (isSessionExpired(this.session)) {
+      await this.refreshSession()
+    }
+
+    let response = await this.sendRequest(endpoint, { method: 'GET', signal: options.signal })
+
+    // Auto-retry once on 401 (session may have been invalidated server-side).
+    if (response.status === 401) {
+      this.session = null
+      await this.refreshSession()
+      response = await this.sendRequest(endpoint, { method: 'GET', signal: options.signal })
+    }
+
+    if (!response.ok) {
+      throw new DaemonApiError(
+        mapStatusToErrorCode(response.status),
+        `${response.status} on ${endpoint}`
+      )
+    }
+
+    return response.blob()
   }
 
   /**

--- a/src/api/daemon/generated-bridge.ts
+++ b/src/api/daemon/generated-bridge.ts
@@ -8,7 +8,7 @@
  * - Sets the generated client's `baseUrl` from the daemon connection config.
  * - Injects auth as the `?auth=Session <token>` QUERY param via a request
  *   interceptor (the daemon authenticates via query param, NOT a header —
- *   see `client.ts` `sendRequest`/`blobUrl`).
+ *   see `client.ts` `sendRequest`/`fetchBlob`).
  * - Normalizes the thrown error so a 401 is observable downstream: with
  *   `throwOnError: true` the generated client throws the *parsed error body*
  *   (not an object carrying the Response), so an error interceptor re-wraps it

--- a/src/components/clipboard/__tests__/ClipboardPreview.test.tsx
+++ b/src/components/clipboard/__tests__/ClipboardPreview.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import ClipboardPreview from '@/components/clipboard/ClipboardPreview'
 import type { DisplayClipboardItem } from '@/lib/clipboard-entry'
@@ -8,12 +8,18 @@ vi.mock('@tauri-apps/api/core', () => ({
   convertFileSrc: vi.fn((path: string) => `asset://localhost/${encodeURIComponent(path)}`),
 }))
 
+// Resolve daemon blob paths to a deterministic object URL so `<img src>` is
+// assertable without standing up the real fetch + URL.createObjectURL path.
+vi.mock('@/api/daemon/blob-image-cache', () => ({
+  getBlobImageObjectUrl: vi.fn(async (path: string) => `blob:mock-${path}`),
+}))
+
 const previewMock = vi.hoisted((): { value: ClipboardPreviewData | null } => ({
   value: {
     entryId: 'image-file-entry',
     contentType: 'image',
     sizeBytes: 2048,
-    imageUrl: 'http://127.0.0.1:12345/clipboard/blobs/blob-image?auth=Session+test',
+    imageBlobPath: '/clipboard/blobs/blob-image',
   },
 }))
 
@@ -71,17 +77,17 @@ describe('ClipboardPreview', () => {
       entryId: 'image-file-entry',
       contentType: 'image',
       sizeBytes: 2048,
-      imageUrl: 'http://127.0.0.1:12345/clipboard/blobs/blob-image?auth=Session+test',
+      imageBlobPath: '/clipboard/blobs/blob-image',
     }
   })
 
-  it('renders a direct image preview with filename for image files', () => {
+  it('renders a direct image preview with filename for image files', async () => {
     render(<ClipboardPreview item={createImageFileItem()} />)
 
-    const image = screen.getByRole('img', { name: 'screenshot.png' })
-    expect(image).toHaveAttribute(
-      'src',
-      'http://127.0.0.1:12345/clipboard/blobs/blob-image?auth=Session+test'
+    // The `<img>` resolves its object URL asynchronously via the cache hook.
+    const image = await screen.findByRole('img', { name: 'screenshot.png' })
+    await waitFor(() =>
+      expect(image).toHaveAttribute('src', 'blob:mock-/clipboard/blobs/blob-image')
     )
     expect(image.closest('.max-w-sm')).not.toBeInTheDocument()
     expect(screen.getByText('screenshot.png')).toBeInTheDocument()

--- a/src/components/clipboard/preview-renderers/FilePreview.tsx
+++ b/src/components/clipboard/preview-renderers/FilePreview.tsx
@@ -216,11 +216,19 @@ const FilePreview: React.FC<FilePreviewProps> = ({
               percent={percent}
               isHero
             />
-            <img
-              src={imageObjectUrl ?? undefined}
-              alt={title}
-              className="relative z-10 max-h-[60vh] max-w-full rounded-md object-contain shadow-2xl ring-1 ring-black/5 dark:ring-white/10"
-            />
+            {imageObjectUrl ? (
+              <img
+                src={imageObjectUrl}
+                alt={title}
+                className="relative z-10 max-h-[60vh] max-w-full rounded-md object-contain shadow-2xl ring-1 ring-black/5 dark:ring-white/10"
+              />
+            ) : (
+              // imageObjectUrl is null while the blob loads and stays null if the
+              // fetch fails; show a muted placeholder instead of a broken <img>.
+              <div className="relative z-10 flex aspect-[4/3] w-full max-w-md items-center justify-center rounded-md bg-background/40">
+                <ImageIcon className="size-12 text-muted-foreground/30" />
+              </div>
+            )}
           </div>
 
           <div className="flex w-full max-w-4xl flex-col items-center gap-3 text-center">

--- a/src/components/clipboard/preview-renderers/FilePreview.tsx
+++ b/src/components/clipboard/preview-renderers/FilePreview.tsx
@@ -14,6 +14,7 @@ import {
 } from 'lucide-react'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
+import { useBlobImageObjectUrl } from '@/hooks/useBlobImageObjectUrl'
 import type { DisplayClipboardItem } from '@/lib/clipboard-entry'
 import type { ClipboardPreviewData } from '@/lib/clipboard-preview-cache'
 import { isImageFileName } from '@/lib/clipboard-utils'
@@ -165,6 +166,13 @@ const FilePreview: React.FC<FilePreviewProps> = ({
   const { t } = useTranslation()
   const fileItem = item.content
 
+  // Resolve the image preview to a token-free `blob:` object URL up front (hook
+  // must run before any early return). Null unless the entry actually has an
+  // image descriptor.
+  const imageObjectUrl = useBlobImageObjectUrl(
+    preview?.contentType === 'image' ? (preview.imageBlobPath ?? null) : null
+  )
+
   if (!fileItem || !('file_names' in fileItem)) {
     return null
   }
@@ -174,12 +182,11 @@ const FilePreview: React.FC<FilePreviewProps> = ({
   const isSingleFile = fileNames.length === 1
   const singleFileName = fileNames[0] ?? ''
   const isImageFileGroup = fileNames.length > 1 && fileNames.every(name => isImageFileName(name))
-  const imageUrl =
+  // Layout selection is synchronous (descriptor presence); the `<img src>`
+  // itself fills in once `imageObjectUrl` resolves, so the hero/grid layout
+  // never flickers through the plain file-card while bytes load.
+  const hasSingleImage =
     isSingleFile && isImageFileName(singleFileName) && preview?.contentType === 'image'
-      ? (preview.imageUrl ?? null)
-      : null
-  const groupImageUrl =
-    isImageFileGroup && preview?.contentType === 'image' ? (preview.imageUrl ?? null) : null
   const percent =
     transfer && transfer.totalBytes && transfer.totalBytes > 0
       ? Math.round((transfer.bytesTransferred / transfer.totalBytes) * 100)
@@ -199,7 +206,7 @@ const FilePreview: React.FC<FilePreviewProps> = ({
       </div>
     )
 
-    if (imageUrl) {
+    if (hasSingleImage) {
       return (
         <div className="flex min-h-full flex-col items-center justify-center gap-6 p-8">
           <div className="relative flex w-full max-w-5xl items-center justify-center overflow-hidden rounded-lg bg-muted/10 p-2">
@@ -210,7 +217,7 @@ const FilePreview: React.FC<FilePreviewProps> = ({
               isHero
             />
             <img
-              src={imageUrl}
+              src={imageObjectUrl ?? undefined}
               alt={title}
               className="relative z-10 max-h-[60vh] max-w-full rounded-md object-contain shadow-2xl ring-1 ring-black/5 dark:ring-white/10"
             />
@@ -313,7 +320,7 @@ const FilePreview: React.FC<FilePreviewProps> = ({
           {fileNames.map((name, index) => {
             const thumbnailUrl =
               getLocalImageUrl(getImageFilePath(fileItem.file_paths, index)) ??
-              (index === 0 ? groupImageUrl : null)
+              (index === 0 ? imageObjectUrl : null)
             return (
               <div
                 key={`${name}-${index}`}

--- a/src/components/clipboard/preview-renderers/ImagePreview.tsx
+++ b/src/components/clipboard/preview-renderers/ImagePreview.tsx
@@ -1,6 +1,7 @@
 import { Image as ImageIcon, ImageDown, Loader2 } from 'lucide-react'
 import React, { useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useBlobImageObjectUrl } from '@/hooks/useBlobImageObjectUrl'
 import type { ClipboardImageItem } from '@/lib/clipboard-entry'
 import type { ClipboardPreviewData } from '@/lib/clipboard-preview-cache'
 import { formatFileSize } from '@/utils/formatters'
@@ -14,7 +15,7 @@ interface ImagePreviewProps {
 
 const ImagePreview: React.FC<ImagePreviewProps> = ({ loading, preview, setImageDimensions }) => {
   const { t } = useTranslation()
-  const imageUrl = preview?.contentType === 'image' ? (preview.imageUrl ?? null) : null
+  const imageBlobPath = preview?.contentType === 'image' ? (preview.imageBlobPath ?? null) : null
 
   // D6 (ADR-008 P3-d): originals above the inline threshold are not auto-pulled.
   // Reveal the `<img>` (and its blob fetch) only after an explicit click, reset
@@ -27,6 +28,10 @@ const ImagePreview: React.FC<ImagePreviewProps> = ({ loading, preview, setImageD
     setRevealedLargeImage(false)
   }
   const gateLargeImage = preview?.requiresExplicitLoad === true && !revealedLargeImage
+
+  // Resolve to a token-free `blob:` object URL; gated large images don't fetch
+  // until revealed, preserving the D6 on-demand contract.
+  const imageUrl = useBlobImageObjectUrl(imageBlobPath, !gateLargeImage)
 
   if (gateLargeImage) {
     return (

--- a/src/components/history/history-card/useResourceImageUrl.ts
+++ b/src/components/history/history-card/useResourceImageUrl.ts
@@ -1,38 +1,48 @@
 import { useEffect, useState } from 'react'
-import { resolveResourceImageUrl } from '@/api/clipboardItems'
+import { getResourceImageUrl } from '@/api/clipboardItems'
 import { getClipboardEntryResource } from '@/api/daemon/clipboard'
+import { useBlobImageObjectUrl } from '@/hooks/useBlobImageObjectUrl'
 
-const imageUrlCache = new Map<string, string | null>()
+/**
+ * Cache the (token-free) image descriptor per entry so scrolling a virtualized
+ * list back to a row doesn't re-hit the daemon for its resource metadata. The
+ * descriptor is a `data:` URL or a daemon blob path — cheap strings, no bytes.
+ * The actual image bytes are cached separately (and LRU-bounded) by
+ * {@link useBlobImageObjectUrl}.
+ */
+const descriptorCache = new Map<string, string | null>()
 
 export function useResourceImageUrl(entryId: string): string | null {
-  const [imageUrl, setImageUrl] = useState<string | null>(() => imageUrlCache.get(entryId) ?? null)
+  const [descriptor, setDescriptor] = useState<string | null>(
+    () => descriptorCache.get(entryId) ?? null
+  )
 
   useEffect(() => {
-    if (imageUrlCache.has(entryId)) {
-      setImageUrl(imageUrlCache.get(entryId) ?? null)
+    const cached = descriptorCache.get(entryId)
+    if (cached !== undefined) {
+      setDescriptor(cached)
       return
     }
     // Row reuse (virtualized list) can hand this hook a new entry id; drop the
-    // previous entry's image immediately so a stale thumbnail never lingers
-    // while the new fetch is in flight.
-    setImageUrl(null)
+    // previous descriptor immediately so a stale thumbnail never lingers while
+    // the new resource lookup is in flight.
+    setDescriptor(null)
     let cancelled = false
     getClipboardEntryResource(entryId)
       .then(resource => {
         if (cancelled) return
-        const url = resource ? resolveResourceImageUrl(resource) : null
-        imageUrlCache.set(entryId, url)
-        setImageUrl(url)
+        const next = resource ? getResourceImageUrl(resource) : null
+        descriptorCache.set(entryId, next)
+        setDescriptor(next)
       })
       .catch(() => {
-        // Clear on failure too — an unhandled rejection must not leave the prior
-        // row's image stuck on this entry. Not cached, so a remount can retry.
-        if (!cancelled) setImageUrl(null)
+        // Don't cache failures, so a remount can retry.
+        if (!cancelled) setDescriptor(null)
       })
     return () => {
       cancelled = true
     }
   }, [entryId])
 
-  return imageUrl
+  return useBlobImageObjectUrl(descriptor)
 }

--- a/src/hooks/useBlobImageObjectUrl.ts
+++ b/src/hooks/useBlobImageObjectUrl.ts
@@ -15,26 +15,33 @@ import { getBlobImageObjectUrl } from '@/api/daemon/blob-image-cache'
  * @returns The resolved object URL / data URL, or `null` while pending or gated.
  */
 export function useBlobImageObjectUrl(descriptor: string | null, enabled = true): string | null {
-  const [url, setUrl] = useState<string | null>(null)
+  // Track the descriptor the resolved URL belongs to so a changed descriptor
+  // invalidates the old URL during the same render (before the effect runs),
+  // instead of painting one stale frame of the previous entry's image.
+  const [resolved, setResolved] = useState<{ descriptor: string | null; url: string | null }>({
+    descriptor: null,
+    url: null,
+  })
+
+  const url =
+    !descriptor || !enabled
+      ? null
+      : descriptor.startsWith('data:')
+        ? descriptor
+        : resolved.descriptor === descriptor
+          ? resolved.url
+          : null
 
   useEffect(() => {
-    if (!descriptor || !enabled) {
-      setUrl(null)
-      return
-    }
-    if (descriptor.startsWith('data:')) {
-      setUrl(descriptor)
-      return
-    }
+    if (!descriptor || !enabled || descriptor.startsWith('data:')) return
 
     let cancelled = false
-    setUrl(null)
     getBlobImageObjectUrl(descriptor)
-      .then(resolved => {
-        if (!cancelled) setUrl(resolved)
+      .then(objectUrl => {
+        if (!cancelled) setResolved({ descriptor, url: objectUrl })
       })
       .catch(() => {
-        if (!cancelled) setUrl(null)
+        if (!cancelled) setResolved({ descriptor, url: null })
       })
     return () => {
       cancelled = true

--- a/src/hooks/useBlobImageObjectUrl.ts
+++ b/src/hooks/useBlobImageObjectUrl.ts
@@ -1,0 +1,45 @@
+import { useEffect, useState } from 'react'
+import { getBlobImageObjectUrl } from '@/api/daemon/blob-image-cache'
+
+/**
+ * Resolve an image descriptor into a displayable `<img src>`.
+ *
+ * - `data:` URLs (inline content) pass through unchanged — no fetch.
+ * - Daemon blob paths are fetched with session auth and wrapped in a stable
+ *   `blob:` object URL via {@link getBlobImageObjectUrl}, so the rendered `src`
+ *   never carries a short-lived session token (which would 401 once expired).
+ *
+ * @param descriptor `data:` URL, daemon blob path, or `null`.
+ * @param enabled When false, resolves to `null` without fetching — lets callers
+ *   gate the byte pull behind an explicit action (e.g. D6 large-image reveal).
+ * @returns The resolved object URL / data URL, or `null` while pending or gated.
+ */
+export function useBlobImageObjectUrl(descriptor: string | null, enabled = true): string | null {
+  const [url, setUrl] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!descriptor || !enabled) {
+      setUrl(null)
+      return
+    }
+    if (descriptor.startsWith('data:')) {
+      setUrl(descriptor)
+      return
+    }
+
+    let cancelled = false
+    setUrl(null)
+    getBlobImageObjectUrl(descriptor)
+      .then(resolved => {
+        if (!cancelled) setUrl(resolved)
+      })
+      .catch(() => {
+        if (!cancelled) setUrl(null)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [descriptor, enabled])
+
+  return url
+}

--- a/src/lib/clipboard-preview-cache.ts
+++ b/src/lib/clipboard-preview-cache.ts
@@ -5,14 +5,20 @@ export interface ClipboardPreviewData {
   contentType: 'text' | 'image' | 'file'
   sizeBytes: number
   textContent?: string
-  imageUrl?: string
+  /**
+   * Token-free image descriptor: a `data:` URL (inline content) or a daemon
+   * blob path. Consumers resolve it to a `blob:` object URL at `<img>` mount
+   * time via `useBlobImageObjectUrl`; storing a path (not a token-bearing URL)
+   * keeps this cacheable without the 300s-token 401 churn.
+   */
+  imageBlobPath?: string
   fileNames?: string[]
   /**
    * Image preview exceeds the auto-inline threshold (D6 / ADR-008 P3-d): the
-   * original must not be auto-pulled. `imageUrl` still carries the resolved
-   * (auth-bearing) URL, but consumers must gate the actual `<img>` mount behind
-   * an explicit user action so the daemon only materializes the large payload
-   * on demand. See `INLINE_PREVIEW_MAX_BYTES`.
+   * original must not be auto-pulled. `imageBlobPath` still carries the
+   * descriptor, but consumers must gate the actual `<img>` mount (and its blob
+   * fetch) behind an explicit user action so the daemon only materializes the
+   * large payload on demand. See `INLINE_PREVIEW_MAX_BYTES`.
    */
   requiresExplicitLoad?: boolean
 }

--- a/src/lib/clipboard-preview-loader.ts
+++ b/src/lib/clipboard-preview-loader.ts
@@ -1,4 +1,4 @@
-import { fetchClipboardResourceText, resolveResourceImageUrl } from '@/api/clipboardItems'
+import { fetchClipboardResourceText, getResourceImageUrl } from '@/api/clipboardItems'
 import { getClipboardEntryDetail, getClipboardEntryResource } from '@/api/daemon/clipboard'
 import type { ClipboardPreviewData } from '@/lib/clipboard-preview-cache'
 import { INLINE_PREVIEW_MAX_BYTES } from '@/lib/clipboard-preview-constants'
@@ -12,14 +12,14 @@ export async function loadClipboardPreview(entryId: string): Promise<ClipboardPr
 
   if (resource.mimeType === 'image' || resource.mimeType.startsWith('image/')) {
     // D6 (ADR-008 P3-d): keep originals above the inline threshold off the
-    // auto-load path. We still resolve the (auth-bearing) URL — that's just a
-    // string, no bytes are pulled — but flag it so consumers gate the `<img>`
-    // mount behind an explicit user action.
+    // auto-load path. We only resolve the token-free descriptor here — no bytes
+    // are pulled — and flag large originals so consumers gate the `<img>` mount
+    // (and its blob fetch) behind an explicit user action.
     return {
       entryId,
       contentType: 'image',
       sizeBytes: resource.sizeBytes,
-      imageUrl: resolveResourceImageUrl(resource) ?? undefined,
+      imageBlobPath: getResourceImageUrl(resource) ?? undefined,
       requiresExplicitLoad: resource.sizeBytes > INLINE_PREVIEW_MAX_BYTES,
     }
   }

--- a/src/quick-panel/__tests__/ClipboardHistoryPanel.single-window.test.tsx
+++ b/src/quick-panel/__tests__/ClipboardHistoryPanel.single-window.test.tsx
@@ -92,7 +92,7 @@ vi.mock('@/api/daemon/clipboard', () => ({
 
 vi.mock('@/api/daemon/client', () => ({
   daemonClient: {
-    blobUrl: vi.fn((path: string) => `http://127.0.0.1:12345${path}?auth=Session+test`),
+    fetchBlob: vi.fn(),
     callSdk: vi.fn().mockResolvedValue({ data: [], ts: 1710000000000 }),
   },
 }))


### PR DESCRIPTION
## Summary

- **Root cause**: blob-backed image thumbnails baked a short-lived (300s TTL) session token into the `<img src>` query (`DaemonClient.blobUrl`), and `useResourceImageUrl` cached that full token-bearing URL **permanently**. Once the token expired, every re-render (virtualized scroll, quick-panel reopen) re-requested the dead URL → daemon `401`, with no refresh path because the browser image loader can't retry on 401 the way `request<T>()` does. Confirmed from the Windows daemon log: failing `GET /clipboard/blobs/<id>` carried a JWT that expired ~30 min earlier, while `/delivery` (routed through the auto-refreshing client) stayed `200`. (7c0fd44fb)
- **Fix**: add `DaemonClient.fetchBlob` (returns a `Blob`, same pre-emptive refresh + one-shot 401 retry as `request`), a path-keyed LRU object-URL cache (`blob-image-cache.ts`, revoke-on-evict + in-flight coalescing), and a `useBlobImageObjectUrl` hook. Object URLs carry no token and never expire, so the token-lifetime / cache-lifetime mismatch is gone. (7c0fd44fb)
- **Rewire**: thumbnails, resource-text fetch, and the preview loader/renderers all go through object URLs; removed the `blobUrl` foot-gun. `ClipboardPreviewData.imageUrl` → token-free `imageBlobPath`; the D6 large-image lazy-load contract is preserved via the hook's `enabled` flag (bytes only pulled after the explicit reveal click). (7c0fd44fb)

## Test plan

- [x] `tsc --noEmit` clean
- [x] vitest: client / clipboardItems / preview / history / hooks suites green (80+ cases, incl. new `fetchBlob` tests)
- [x] eslint + prettier clean on changed files
- [ ] Real GUI smoke (reviewer): image thumbnails render in history grid; large-image preview still gates behind the reveal button then loads; **leave the window idle >5 min then scroll the history list / reopen the quick panel** — thumbnails must reload without 401 (the original repro).
- [ ] Confirm no object-URL memory growth over a long browsing session (LRU cap = 128, revoke-on-evict).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Image previews now render via token-free descriptors that resolve to `blob:` URLs at display time.
  * Added an in-memory cache for blob image object URLs to improve preview performance.

* **Bug Fixes**
  * Improved clipboard resource text fetching: correctly decodes inline payloads (including empty strings) and reliably falls back to blob-backed content.
  * Updated daemon blob loading to fetch binary data directly, with proper session refresh and a single retry on authorization failures.

* **Tests**
  * Updated test suites and mocks to reflect the new blob/image URL resolution and fetchBlob behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->