### PR TITLE
fix(ui): polish code preview scrollbar

### DIFF
--- a/src/components/clipboard/preview-renderers/CodePreview.tsx
+++ b/src/components/clipboard/preview-renderers/CodePreview.tsx
@@ -18,7 +18,7 @@ const CodePreview: React.FC<CodePreviewProps> = ({ item, preview }) => {
         <div className="pointer-events-none absolute inset-0 rounded-xl bg-primary/5 opacity-0 blur-xl transition-opacity group-hover:opacity-100" />
         {/* Single scroll container: vertical scroll grows the whole grid, horizontal
             scroll slides the code while the sticky gutter stays pinned at left. */}
-        <div className="relative h-full overflow-auto rounded-xl border border-white/5 bg-[#0d1117] font-mono text-[13px] leading-relaxed text-blue-100/90 shadow-2xl">
+        <div className="scrollbar-code relative h-full overflow-auto rounded-xl border border-white/5 bg-[#0d1117] font-mono text-[13px] leading-relaxed text-blue-100/90 shadow-2xl">
           <div className="flex w-max min-w-full">
             <div
               aria-hidden

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -172,6 +172,37 @@
     background-color: rgb(100 116 139);
   }
 
+  .scrollbar-code {
+    scrollbar-width: thin;
+    scrollbar-color: rgb(148 163 184 / 0.45) transparent;
+  }
+
+  .scrollbar-code::-webkit-scrollbar {
+    width: 10px;
+    height: 10px;
+  }
+
+  .scrollbar-code::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  .scrollbar-code::-webkit-scrollbar-thumb {
+    min-width: 48px;
+    min-height: 48px;
+    border: 3px solid transparent;
+    border-radius: 9999px;
+    background-color: rgb(148 163 184 / 0.38);
+    background-clip: padding-box;
+  }
+
+  .scrollbar-code::-webkit-scrollbar-thumb:hover {
+    background-color: rgb(203 213 225 / 0.62);
+  }
+
+  .scrollbar-code::-webkit-scrollbar-corner {
+    background: transparent;
+  }
+
   /* 隐藏滚动条但保留功能 */
   .no-scrollbar {
     -ms-overflow-style: none;


### PR DESCRIPTION
## Summary
- add a dedicated code preview scrollbar utility with a subtler thumb and transparent track
- apply it to the code preview scroll container so horizontal overflow no longer uses the native browser scrollbar

## Verification
- npx vitest run src/components/clipboard/__tests__/ClipboardPreview.test.tsx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added custom scrollbar styling for code previews, improving readability and visual consistency across browsers.
  * Updated code display areas to use the new scrollbar style for a smoother viewing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->