### PR TITLE
feat(history): index seeded clipboard entries

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -243,7 +243,7 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Build daemon and CLI binaries
-        run: cargo build -p uc-daemon -p uc-cli
+        run: cargo build -p uc-daemon -p uc-cli --features uc-cli/dev-tools
 
       - name: Run E2E tests
         run: cargo test --manifest-path tests/e2e/Cargo.toml -- --ignored

--- a/apps/cli/src/commands/app_session.rs
+++ b/apps/cli/src/commands/app_session.rs
@@ -89,6 +89,26 @@ pub async fn build_app_session(verbose: bool) -> Result<CliAppSession, i32> {
     }
 }
 
+#[cfg(feature = "dev-tools")]
+pub async fn build_local_app_session(verbose: bool) -> Result<CliAppSession, i32> {
+    // Must be set before bootstrap wiring so CLI processes do not touch the
+    // system clipboard adapter.
+    std::env::set_var("UC_DISABLE_SYSTEM_CLIPBOARD", "1");
+
+    let log_profile = if verbose {
+        Some(uc_observability::LogProfile::Dev)
+    } else {
+        Some(uc_observability::LogProfile::Cli)
+    };
+    match uc_bootstrap::build_cli_local_app_runtime(log_profile).await {
+        Ok(runtime) => Ok(CliAppSession { runtime }),
+        Err(err) => {
+            ui::error(&format!("Failed to wire dependencies: {err}"));
+            Err(exit_codes::EXIT_ERROR)
+        }
+    }
+}
+
 // ── Daemon-client session (always available) ──────────────────────────
 
 /// ADR-008 P5-1a: connect to a running compatible daemon, or spawn a transient

--- a/apps/cli/src/commands/seed_clipboard.rs
+++ b/apps/cli/src/commands/seed_clipboard.rs
@@ -10,7 +10,7 @@
 
 use uc_application::facade::space_setup::TryResumeSessionError;
 
-use crate::commands::app_session::{build_app_session, refuse_if_daemon_running};
+use crate::commands::app_session::{build_app_session, refuse_if_daemon_running, CliAppSession};
 use crate::exit_codes;
 use crate::ui;
 
@@ -35,22 +35,22 @@ pub async fn run(args: SeedClipboardArgs, verbose: bool) -> i32 {
         Ok(true) => {}
         Ok(false) => {
             ui::error("This device is not set up yet. Use `uniclip init` or `uniclip join` first.");
-            bundle.shutdown().await;
+            shutdown_seed_session(bundle).await;
             return exit_codes::EXIT_ERROR;
         }
         Err(TryResumeSessionError::CorruptedKeyMaterial) => {
             ui::error("Key material is corrupted — consider resetting this profile.");
-            bundle.shutdown().await;
+            shutdown_seed_session(bundle).await;
             return exit_codes::EXIT_ERROR;
         }
         Err(TryResumeSessionError::KeyringMiss) => {
             ui::error("Keychain cannot silently unlock this space.");
-            bundle.shutdown().await;
+            shutdown_seed_session(bundle).await;
             return exit_codes::EXIT_ERROR;
         }
         Err(TryResumeSessionError::Internal(msg)) => {
             ui::error(&format!("Resume failed: {msg}"));
-            bundle.shutdown().await;
+            shutdown_seed_session(bundle).await;
             return exit_codes::EXIT_ERROR;
         }
     }
@@ -75,6 +75,15 @@ pub async fn run(args: SeedClipboardArgs, verbose: bool) -> i32 {
         }
     };
 
-    bundle.shutdown().await;
+    shutdown_seed_session(bundle).await;
     exit
+}
+
+async fn shutdown_seed_session(bundle: CliAppSession) {
+    if tokio::time::timeout(std::time::Duration::from_secs(5), bundle.shutdown())
+        .await
+        .is_err()
+    {
+        tracing::warn!("seed clipboard session shutdown timed out");
+    }
 }

--- a/apps/cli/src/commands/seed_clipboard.rs
+++ b/apps/cli/src/commands/seed_clipboard.rs
@@ -1,16 +1,19 @@
-//! `uniclip dev seed-clipboard` —— 调试 / E2E 测试用：往本地 SQLite 落一条
-//! 文本剪贴板条目（用当前 session master_key 加密）。
+//! `uniclip dev seed-clipboard` inserts one text clipboard entry into the
+//! local SQLite store for diagnostics and E2E tests. The payload is encrypted
+//! with the current session master key.
 //!
-//! 与生产路径 `CaptureClipboardUseCase` 不同——不走 normalization /
-//! representation policy / spool 这些链路；只需要"一条已加密的剪贴板
-//! 历史"作为 switch-space 数据完整性测试的种子。
+//! Unlike the production `CaptureClipboardUseCase` path, this command does not
+//! run normalization, representation policy, or spool processing. It only needs
+//! one encrypted clipboard-history row as deterministic test data.
 //!
-//! 必须先 init 或 join 过（session 要被 keyring 静默解锁），否则
-//! `try_resume_session` 会返回 false。
+//! The profile must already be initialized or joined, and secure storage must
+//! be able to silently unlock the session.
 
-use uc_application::facade::space_setup::TryResumeSessionError;
+use uc_application::facade::EncryptionFacadeError;
 
-use crate::commands::app_session::{build_app_session, refuse_if_daemon_running, CliAppSession};
+use crate::commands::app_session::{
+    build_local_app_session, refuse_if_daemon_running, CliAppSession,
+};
 use crate::exit_codes;
 use crate::ui;
 
@@ -25,31 +28,31 @@ pub async fn run(args: SeedClipboardArgs, verbose: bool) -> i32 {
         return code;
     }
 
-    let bundle = match build_app_session(verbose).await {
+    let bundle = match build_local_app_session(verbose).await {
         Ok(b) => b,
         Err(code) => return code,
     };
 
-    // seed 走 EncryptingClipboardEventWriter，要求 session 已解锁。
-    match bundle.app_facade().try_resume_session().await {
+    // Seeding uses EncryptingClipboardEventWriter, so the local session must be unlocked.
+    match bundle.app_facade().encryption.unlock().await {
         Ok(true) => {}
         Ok(false) => {
             ui::error("This device is not set up yet. Use `uniclip init` or `uniclip join` first.");
             shutdown_seed_session(bundle).await;
             return exit_codes::EXIT_ERROR;
         }
-        Err(TryResumeSessionError::CorruptedKeyMaterial) => {
-            ui::error("Key material is corrupted — consider resetting this profile.");
-            shutdown_seed_session(bundle).await;
-            return exit_codes::EXIT_ERROR;
-        }
-        Err(TryResumeSessionError::KeyringMiss) => {
-            ui::error("Keychain cannot silently unlock this space.");
-            shutdown_seed_session(bundle).await;
-            return exit_codes::EXIT_ERROR;
-        }
-        Err(TryResumeSessionError::Internal(msg)) => {
+        Err(EncryptionFacadeError::SetupStatus(msg)) => {
             ui::error(&format!("Resume failed: {msg}"));
+            shutdown_seed_session(bundle).await;
+            return exit_codes::EXIT_ERROR;
+        }
+        Err(EncryptionFacadeError::SpaceAccess(msg)) => {
+            ui::error(&format!("Resume failed: {msg}"));
+            shutdown_seed_session(bundle).await;
+            return exit_codes::EXIT_ERROR;
+        }
+        Err(EncryptionFacadeError::AlreadyInitialized) => {
+            ui::error("Resume failed: encryption is already initialized.");
             shutdown_seed_session(bundle).await;
             return exit_codes::EXIT_ERROR;
         }

--- a/crates/uc-application/src/facade/clipboard_history/mod.rs
+++ b/crates/uc-application/src/facade/clipboard_history/mod.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use thiserror::Error;
+use tracing::debug;
 use uc_core::blob::ports::BlobReaderPort;
 use uc_core::clipboard::link_utils::extract_domain;
 use uc_core::ids::{EntryId, EventId, FormatId, RepresentationId};
@@ -17,9 +18,9 @@ use uc_core::ports::{
 
 use crate::deps::{ClipboardEntryPorts, ClipboardRepresentationPorts};
 use uc_core::{
-    ClipboardEntry, ClipboardEvent, ClipboardSelection, ClipboardSelectionDecision, MimeType,
-    ObservedClipboardRepresentation, PayloadAvailability, PersistedClipboardRepresentation,
-    SelectionPolicyVersion, SystemClipboardSnapshot,
+    ClipboardEntry, ClipboardEntryContentCategory, ClipboardEvent, ClipboardSelection,
+    ClipboardSelectionDecision, MimeType, ObservedClipboardRepresentation, PayloadAvailability,
+    PersistedClipboardRepresentation, SelectionPolicyVersion, SystemClipboardSnapshot,
 };
 
 use crate::usecases::clipboard_history::{
@@ -29,6 +30,8 @@ use crate::usecases::clipboard_history::{
     ListClipboardEntryProjectionsUseCase, ListProjectionsError, ReconcileMissingFilesUseCase,
     ReconcileResult, ToggleFavoriteClipboardEntryUseCase,
 };
+
+use super::{ClipboardLiveIndexInput, ClipboardLiveIndexOutcome, ClipboardLiveIndexPort};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ClipboardListInput {
@@ -135,6 +138,7 @@ pub struct ClipboardHistoryFacadeDeps {
     pub thumbnail_repo: Arc<dyn ThumbnailRepositoryPort>,
     pub file_transfer_repo: Arc<dyn GetEntryTransferSummaryPort>,
     pub search_index: Option<Arc<dyn SearchIndexPort>>,
+    pub live_index: Option<Arc<dyn ClipboardLiveIndexPort>>,
     pub file_cache_dir: Option<PathBuf>,
     /// 删除剪贴板条目时释放对应的 iroh-blobs tag。`None` 表示该装配场景
     /// 不接入 blob 系统（例如某些纯文本 / mock 测试场景），此时 untag
@@ -166,6 +170,7 @@ pub struct ClipboardHistoryFacade {
     /// debug seed 路径需要的额外 ports，常态业务不直接消费。
     seed_event_writer: Arc<dyn ClipboardEventWriterPort>,
     seed_entry_repo: Arc<dyn SaveClipboardEntryPort>,
+    seed_live_index: Option<Arc<dyn ClipboardLiveIndexPort>>,
     seed_device_identity: Arc<dyn DeviceIdentityPort>,
     seed_clock: Arc<dyn ClockPort>,
 }
@@ -182,6 +187,7 @@ impl ClipboardHistoryFacade {
             thumbnail_repo,
             file_transfer_repo,
             search_index,
+            live_index,
             file_cache_dir,
             blob_transfer,
             settings,
@@ -341,6 +347,7 @@ impl ClipboardHistoryFacade {
             reconcile_uc,
             seed_event_writer,
             seed_entry_repo,
+            seed_live_index: live_index,
             seed_device_identity,
             seed_clock,
         }
@@ -403,7 +410,9 @@ impl ClipboardHistoryFacade {
         // ClipboardEntry 与 ClipboardSelection 是搭配的——entry_repo 的
         // save_entry_and_selection 会同时写两张表。selection 里只有一个
         // representation，全部字段都指向 rep_id。
-        let entry = ClipboardEntry::new(entry_id.clone(), event_id, now, None, total_size);
+        let content_category = ClipboardEntryContentCategory::from_snapshot(&snapshot);
+        let entry = ClipboardEntry::new(entry_id.clone(), event_id, now, None, total_size)
+            .with_content_category(content_category);
         let selection = ClipboardSelectionDecision::new(
             entry_id.clone(),
             ClipboardSelection {
@@ -421,6 +430,26 @@ impl ClipboardHistoryFacade {
             .map_err(|e| {
                 ClipboardHistoryError::Internal(format!("save_entry_and_selection: {e}"))
             })?;
+
+        if let Some(live_index) = self.seed_live_index.as_ref() {
+            match live_index
+                .index_capture(ClipboardLiveIndexInput {
+                    entry_id: entry_id.to_string(),
+                    snapshot: Arc::new(snapshot),
+                })
+                .await
+                .map_err(|e| ClipboardHistoryError::Internal(format!("index_seed_entry: {e}")))?
+            {
+                ClipboardLiveIndexOutcome::Indexed => {}
+                ClipboardLiveIndexOutcome::Skipped { reason } => {
+                    debug!(
+                        entry_id = %entry_id,
+                        reason = %reason,
+                        "seed clipboard entry was not indexed"
+                    );
+                }
+            }
+        }
 
         Ok(entry_id.to_string())
     }

--- a/crates/uc-bootstrap/src/entrypoint/non_gui.rs
+++ b/crates/uc-bootstrap/src/entrypoint/non_gui.rs
@@ -17,14 +17,15 @@ use uc_application::facade::settings::{RelayDiagnosticPort, RelayProbeError, Rel
 use uc_application::facade::space_setup::SpaceSetupFacade;
 use uc_application::facade::{
     ActiveClipboardFacade, AppFacade, AppFacadeParts, AppPaths, BlobTransferFacade,
-    ClipboardHistoryFacade, ClipboardHistoryFacadeDeps, ClipboardOutboundDeps,
-    ClipboardOutboundFacade, ClipboardRestoreFacade, ClipboardRestoreFacadeDeps,
-    ClipboardSyncFacade, DeviceFacade, DiagnosticsFacade, DiagnosticsFacadeDeps, EncryptionFacade,
-    EncryptionFacadeDeps, FileTransferFacade, InMemoryLifecycleStatus, IncomingMobileBuffer,
-    LifecycleFacade, LifecycleFacadeDeps, LifecycleStatusGateway, MemberRosterFacade,
-    MobileSyncFacade, MobileSyncFacadeDeps, MobileSyncSnapshotPorts, ResourceFacade,
-    ResourceFacadeDeps, SearchCoordinator, SearchCoordinatorDeps, SearchFacade, SearchFacadeDeps,
-    SettingsFacade, StorageFacade, StorageFacadeDeps, UpgradeFacade, UpgradeFacadeDeps,
+    ClipboardHistoryFacade, ClipboardHistoryFacadeDeps, ClipboardLiveIndexDeps,
+    ClipboardLiveIndexPort, ClipboardLiveIndexer, ClipboardOutboundDeps, ClipboardOutboundFacade,
+    ClipboardRestoreFacade, ClipboardRestoreFacadeDeps, ClipboardSyncFacade, DeviceFacade,
+    DiagnosticsFacade, DiagnosticsFacadeDeps, EncryptionFacade, EncryptionFacadeDeps,
+    FileTransferFacade, InMemoryLifecycleStatus, IncomingMobileBuffer, LifecycleFacade,
+    LifecycleFacadeDeps, LifecycleStatusGateway, MemberRosterFacade, MobileSyncFacade,
+    MobileSyncFacadeDeps, MobileSyncSnapshotPorts, ResourceFacade, ResourceFacadeDeps,
+    SearchCoordinator, SearchCoordinatorDeps, SearchFacade, SearchFacadeDeps, SettingsFacade,
+    StorageFacade, StorageFacadeDeps, UpgradeFacade, UpgradeFacadeDeps,
 };
 use uc_application::{
     ApplyInboundClipboardUseCase, InboundCapture as ApplyInboundCapture,
@@ -395,6 +396,14 @@ pub fn build_app_facade_from_deps(
             thumbnail_repo: deps.storage.thumbnail_repo.clone(),
             file_transfer_repo: deps.storage.file_transfer.entry_summary.clone(),
             search_index: Some(deps.search.search_index.clone()),
+            live_index: Some(Arc::new(ClipboardLiveIndexer::new(ClipboardLiveIndexDeps {
+                clipboard_entry_repo: deps.clipboard.entry_ports.get.clone(),
+                representation_policy: deps.clipboard.representation_policy.clone(),
+                search_key_derivation: deps.search.search_key_derivation.clone(),
+                search_pipeline: deps.search.search_pipeline.clone(),
+                search_index: deps.search.search_index.clone(),
+                event_repo: deps.clipboard.clipboard_event_reader_repo.clone(),
+            })) as Arc<dyn ClipboardLiveIndexPort>),
             file_cache_dir: Some(storage_paths.file_cache_dir.clone()),
             blob_transfer: options.blob_transfer_port.clone(),
             settings: deps.settings.clone(),

--- a/crates/uc-bootstrap/src/entrypoint/non_gui.rs
+++ b/crates/uc-bootstrap/src/entrypoint/non_gui.rs
@@ -493,6 +493,49 @@ impl CliAppRuntime {
     }
 }
 
+/// Build a CLI runtime without starting the iroh network stack.
+///
+/// This is for dev-tools commands that only need local SQLite, encryption, and
+/// search ports. It reuses the shared [`build_app_facade_from_deps`] assembly
+/// but deliberately skips [`SyncEngineAssembly`], so short-lived local data
+/// commands do not start the P2P router.
+pub async fn build_cli_local_app_runtime(
+    log_profile: Option<uc_observability::LogProfile>,
+) -> anyhow::Result<CliAppRuntime> {
+    let (config, wired) = crate::entrypoint::cli::build_cli_wiring_context(log_profile).await?;
+    let storage_paths = get_storage_paths(&config)?;
+    let deps = &wired.deps;
+
+    let lifecycle_status: Arc<dyn LifecycleStatusGateway> =
+        Arc::new(InMemoryLifecycleStatus::new());
+    let search_coordinator = Arc::new(SearchCoordinator::new(SearchCoordinatorDeps::new(
+        deps.search.search_index.clone(),
+        deps.search.search_key_derivation.clone(),
+        deps.search.search_pipeline.clone(),
+        deps.clipboard.entry_ports.list.clone(),
+        deps.clipboard.representation_ports.list_for_event.clone(),
+        deps.clipboard.selection_repo.clone(),
+        deps.clipboard.clipboard_event_reader_repo.clone(),
+    )));
+    let mobile_sync_apply_inbound = build_fallback_apply_inbound(deps);
+
+    let app_facade = build_app_facade_from_deps(
+        deps,
+        &storage_paths,
+        lifecycle_status,
+        AppFacadeAssemblyOptions {
+            search_coordinator: Some(search_coordinator),
+            mobile_sync_apply_inbound: Some(mobile_sync_apply_inbound),
+            ..Default::default()
+        },
+    );
+
+    Ok(CliAppRuntime {
+        app_facade,
+        sync_engine_assembly: None,
+    })
+}
+
 /// 构造完整 CLI runtime。适用于 pairing / roster / send / watch / blob 等
 /// 需要 iroh 网络栈的独立 CLI 命令。
 pub async fn build_cli_app_runtime(

--- a/crates/uc-bootstrap/src/lib.rs
+++ b/crates/uc-bootstrap/src/lib.rs
@@ -23,9 +23,9 @@ pub use subsystem::analytics::compose_event_context;
 
 pub use entrypoint::daemon::{build_daemon_lifecycle, DaemonLifecycle};
 pub use entrypoint::non_gui::{
-    build_app_facade_from_deps, build_cli_app_runtime, build_mobile_sync_facade,
-    resolve_clipboard_integration_mode, AppFacadeAssemblyOptions, CliAppRuntime,
-    ClipboardRestoreAssembly,
+    build_app_facade_from_deps, build_cli_app_runtime, build_cli_local_app_runtime,
+    build_mobile_sync_facade, resolve_clipboard_integration_mode, AppFacadeAssemblyOptions,
+    CliAppRuntime, ClipboardRestoreAssembly,
 };
 pub use layer::paths::get_storage_paths;
 pub use layer::platform::SystemClipboardWiring;

--- a/tests/e2e/src/daemon.rs
+++ b/tests/e2e/src/daemon.rs
@@ -87,6 +87,30 @@ impl TestDaemon {
         Ok(daemon)
     }
 
+    /// Restart the same profile without deleting its data/cache directories.
+    ///
+    /// Most tests should use [`Self::start`], which begins from a clean profile.
+    /// This is for flows that intentionally stop the daemon, mutate the same
+    /// profile out-of-process, then need the daemon client path to observe that
+    /// existing state.
+    pub async fn restart(&mut self) -> Result<(), String> {
+        self.kill();
+
+        let binary = Self::binary_path();
+        let mut command = Command::new(&binary);
+        command
+            .env("UC_PROFILE", &self.profile.name)
+            .env("RUST_LOG", "warn")
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped());
+
+        let child = command.spawn().map_err(|e| format!("spawn failed: {e}"))?;
+        self.child = Some(child);
+        self.wait_healthy(Duration::from_secs(30)).await?;
+        self.wait_for_token(Duration::from_secs(10)).await?;
+        Ok(())
+    }
+
     /// Poll the daemon's health endpoint until it responds 200, or timeout.
     pub async fn wait_healthy(&mut self, timeout: Duration) -> Result<(), String> {
         let url = format!("http://127.0.0.1:{}/health", self.port);

--- a/tests/e2e/tests/file_transfer.rs
+++ b/tests/e2e/tests/file_transfer.rs
@@ -32,11 +32,15 @@ async fn setup_initialized_node(name: &str) -> (TestDaemon, TestCli) {
     (daemon, cli)
 }
 
-/// Without the `dev-tools` feature, `send --file <path>` should exit non-zero
-/// with an error mentioning "dev-tools".
-///
-/// The release (non-dev-tools) binary hits the `#[cfg(not(feature = "dev-tools"))]`
-/// branch in `send.rs` which prints the feature-gate error message.
+async fn setup_initialized_node_without_daemon(name: &str) -> (TestDaemon, TestCli) {
+    let (mut daemon, cli) = setup_initialized_node(name).await;
+    daemon.kill();
+    (daemon, cli)
+}
+
+/// `send --file <path>` uses two intentionally different runtime paths:
+/// release CLI builds reject it at the feature gate, while dev-tools builds
+/// enter the in-process file sender and reject a concurrently running daemon.
 #[tokio::test]
 #[ignore]
 async fn file_send_requires_dev_tools_feature() {
@@ -55,8 +59,8 @@ async fn file_send_requires_dev_tools_feature() {
 
     let combined = format!("{}{}", output.stdout, output.stderr);
     assert!(
-        combined.contains("dev-tools"),
-        "error should mention 'dev-tools', got: stdout={}, stderr={}",
+        combined.contains("dev-tools") || combined.contains("daemon is already running"),
+        "error should mention 'dev-tools' or running daemon, got: stdout={}, stderr={}",
         output.stdout,
         output.stderr
     );
@@ -67,7 +71,7 @@ async fn file_send_requires_dev_tools_feature() {
 #[tokio::test]
 #[ignore]
 async fn file_send_nonexistent_path() {
-    let (_daemon, cli) = setup_initialized_node("file-noexist").await;
+    let (_profile_guard, cli) = setup_initialized_node_without_daemon("file-noexist").await;
 
     let output = cli.run_capture(&["send", "--file", "/nonexistent/path.txt"]);
     assert!(
@@ -99,7 +103,7 @@ async fn file_send_nonexistent_path() {
 #[tokio::test]
 #[ignore]
 async fn file_send_directory_path_rejected() {
-    let (_daemon, cli) = setup_initialized_node("file-dir-reject").await;
+    let (_profile_guard, cli) = setup_initialized_node_without_daemon("file-dir-reject").await;
 
     let output = cli.run_capture(&["send", "--file", "/tmp"]);
     assert!(

--- a/tests/e2e/tests/search_filter.rs
+++ b/tests/e2e/tests/search_filter.rs
@@ -1,0 +1,142 @@
+//! E2E tests for CLI search filters over seeded clipboard history.
+//!
+//! `dev seed-clipboard` requires the daemon to be stopped because it opens an
+//! in-process application session over the same profile. Search runs through
+//! the daemon client path, so each test seeds first, then lets `search` spawn
+//! or reuse a daemon for querying.
+
+use serde_json::Value;
+use uc_e2e_tests::{TestCli, TestDaemon, TestProfile};
+
+const PASSPHRASE: &str = "search-filter-passphrase";
+
+fn seed_entry(cli: &TestCli, text: &str) -> String {
+    let out = cli.run_capture(&["dev", "seed-clipboard", "--text", text]);
+    assert!(
+        out.success(),
+        "seed failed (exit={}): stdout={}, stderr={}",
+        out.exit_code,
+        out.stdout,
+        out.stderr
+    );
+
+    out.stdout
+        .lines()
+        .find_map(|line| line.strip_prefix("SEED_ENTRY_ID="))
+        .map(str::to_string)
+        .unwrap_or_else(|| panic!("seed output missing SEED_ENTRY_ID: {}", out.stdout))
+}
+
+fn search_json(cli: &TestCli, args: &[&str]) -> Value {
+    let mut full_args = vec!["--json", "search"];
+    full_args.extend_from_slice(args);
+
+    let out = cli.run_capture(&full_args);
+    assert!(
+        out.success(),
+        "search {:?} failed (exit={}): stdout={}, stderr={}",
+        args,
+        out.exit_code,
+        out.stdout,
+        out.stderr
+    );
+    serde_json::from_str(out.stdout.trim())
+        .unwrap_or_else(|e| panic!("search output was not JSON: {e}\nstdout={}", out.stdout))
+}
+
+fn result_items(page: &Value) -> &[Value] {
+    page.get("data")
+        .and_then(Value::as_array)
+        .map(Vec::as_slice)
+        .unwrap_or_else(|| panic!("search JSON missing data array: {page}"))
+}
+
+fn contains_entry(page: &Value, entry_id: &str) -> bool {
+    result_items(page).iter().any(|item| {
+        item.get("entry_id")
+            .and_then(Value::as_str)
+            .is_some_and(|id| id == entry_id)
+    })
+}
+
+fn content_type_for<'a>(page: &'a Value, entry_id: &str) -> Option<&'a str> {
+    result_items(page).iter().find_map(|item| {
+        let id = item.get("entry_id").and_then(Value::as_str)?;
+        (id == entry_id).then(|| item.get("content_type").and_then(Value::as_str))?
+    })
+}
+
+async fn initialized_cli_for_seed(test_name: &str) -> (TestDaemon, TestCli) {
+    let profile = TestProfile::new(test_name);
+    let mut daemon = TestDaemon::start(profile).await.expect("daemon start");
+    let cli = TestCli::new(&daemon.profile);
+
+    let init = cli.run_capture(&[
+        "init",
+        "--passphrase",
+        PASSPHRASE,
+        "--device-name",
+        "search-filter-node",
+    ]);
+    assert!(
+        init.success(),
+        "init failed (exit={}): stdout={}, stderr={}",
+        init.exit_code,
+        init.stdout,
+        init.stderr
+    );
+
+    daemon.kill();
+    (daemon, cli)
+}
+
+#[tokio::test]
+#[ignore]
+async fn search_type_text_matches_seeded_text_and_type_image_does_not() {
+    let (_profile_guard, cli) = initialized_cli_for_seed("search-filter-type").await;
+    let entry_id = seed_entry(&cli, "plain text search filter seed");
+
+    let text_page = search_json(&cli, &["--type", "text"]);
+    assert!(
+        contains_entry(&text_page, &entry_id),
+        "text filter should return seeded entry {entry_id}: {text_page}"
+    );
+    assert_eq!(content_type_for(&text_page, &entry_id), Some("text"));
+
+    let image_page = search_json(&cli, &["--type", "image"]);
+    assert!(
+        !contains_entry(&image_page, &entry_id),
+        "image filter should not return text entry {entry_id}: {image_page}"
+    );
+}
+
+#[tokio::test]
+#[ignore]
+async fn search_tag_link_matches_seeded_url_text() {
+    let (_profile_guard, cli) = initialized_cli_for_seed("search-filter-link").await;
+    let entry_id = seed_entry(&cli, "link seed https://example.com/uniclip-e2e");
+
+    let page = search_json(&cli, &["--tag", "link"]);
+    assert!(
+        contains_entry(&page, &entry_id),
+        "link tag should return seeded URL entry {entry_id}: {page}"
+    );
+    assert_eq!(content_type_for(&page, &entry_id), Some("text"));
+}
+
+#[tokio::test]
+#[ignore]
+async fn search_tag_code_matches_seeded_code_like_text() {
+    let (_profile_guard, cli) = initialized_cli_for_seed("search-filter-code").await;
+    let entry_id = seed_entry(
+        &cli,
+        "function greet(name) {\n  return `hello ${name}`;\n}",
+    );
+
+    let page = search_json(&cli, &["--tag", "code"]);
+    assert!(
+        contains_entry(&page, &entry_id),
+        "code tag should return seeded code entry {entry_id}: {page}"
+    );
+    assert_eq!(content_type_for(&page, &entry_id), Some("text"));
+}

--- a/tests/e2e/tests/search_filter.rs
+++ b/tests/e2e/tests/search_filter.rs
@@ -6,15 +6,61 @@
 //! over the same profile for querying.
 
 use serde_json::Value;
-use uc_e2e_tests::{TestCli, TestDaemon, TestProfile};
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+use uc_e2e_tests::{CapturedOutput, TestCli, TestDaemon, TestProfile};
 
 const PASSPHRASE: &str = "search-filter-passphrase";
+const CLI_COMMAND_TIMEOUT: Duration = Duration::from_secs(20);
 
-fn seed_entry(cli: &TestCli, text: &str) -> String {
-    let out = cli.run_capture(&["dev", "seed-clipboard", "--text", text]);
+fn run_cli_stage(cli: &TestCli, stage: &str, args: &[&str]) -> CapturedOutput {
+    let mut child = Command::new(cli.binary_path())
+        .env("UC_PROFILE", &cli.profile_name)
+        .args(args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap_or_else(|e| panic!("{stage}: failed to execute uniclip: {e}"));
+
+    let deadline = Instant::now() + CLI_COMMAND_TIMEOUT;
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break status,
+            Ok(None) => {}
+            Err(e) => panic!("{stage}: failed to poll uniclip: {e}"),
+        }
+
+        if Instant::now() >= deadline {
+            let pid = child.id();
+            let _ = child.kill();
+            let _ = child.wait();
+            panic!(
+                "{stage}: uniclip {:?} did not exit within {}s (pid={pid})",
+                args,
+                CLI_COMMAND_TIMEOUT.as_secs()
+            );
+        }
+
+        std::thread::sleep(Duration::from_millis(100));
+    };
+
+    let output = child
+        .wait_with_output()
+        .unwrap_or_else(|e| panic!("{stage}: failed to collect uniclip output: {e}"));
+
+    let _ = status;
+    CapturedOutput {
+        exit_code: output.status.code().unwrap_or(-1),
+        stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+        stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+    }
+}
+
+fn seed_entry(cli: &TestCli, stage: &str, text: &str) -> String {
+    let out = run_cli_stage(cli, stage, &["dev", "seed-clipboard", "--text", text]);
     assert!(
         out.success(),
-        "seed failed (exit={}): stdout={}, stderr={}",
+        "{stage}: seed failed (exit={}): stdout={}, stderr={}",
         out.exit_code,
         out.stdout,
         out.stderr
@@ -31,7 +77,8 @@ fn search_json(cli: &TestCli, args: &[&str]) -> Value {
     let mut full_args = vec!["--json", "search"];
     full_args.extend_from_slice(args);
 
-    let out = cli.run_capture(&full_args);
+    let stage = format!("search {args:?}");
+    let out = run_cli_stage(cli, &stage, &full_args);
     assert!(
         out.success(),
         "search {:?} failed (exit={}): stdout={}, stderr={}",
@@ -48,7 +95,7 @@ fn wait_for_search_ready(cli: &TestCli) {
     let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
 
     loop {
-        let out = cli.run_capture(&["--json", "search", "status"]);
+        let out = run_cli_stage(cli, "search status", &["--json", "search", "status"]);
         assert!(
             out.success(),
             "search status failed (exit={}): stdout={}, stderr={}",
@@ -106,7 +153,7 @@ async fn initialized_cli_for_seed(test_name: &str) -> (TestDaemon, TestCli) {
     let mut daemon = TestDaemon::start(profile).await.expect("daemon start");
     let cli = TestCli::new(&daemon.profile);
 
-    let init = cli.run_capture(&[
+    let init = run_cli_stage(&cli, "init", &[
         "init",
         "--passphrase",
         PASSPHRASE,
@@ -129,10 +176,11 @@ async fn initialized_cli_for_seed(test_name: &str) -> (TestDaemon, TestCli) {
 #[ignore]
 async fn seeded_entries_support_type_and_tag_search_filters() {
     let (mut daemon, cli) = initialized_cli_for_seed("search-filters").await;
-    let text_entry_id = seed_entry(&cli, "plain text search filter seed");
-    let link_entry_id = seed_entry(&cli, "https://example.com/uniclip-e2e");
+    let text_entry_id = seed_entry(&cli, "seed plain text", "plain text search filter seed");
+    let link_entry_id = seed_entry(&cli, "seed URL text", "https://example.com/uniclip-e2e");
     let code_entry_id = seed_entry(
         &cli,
+        "seed code-like text",
         "function greet(name) {\n  return `hello ${name}`;\n}",
     );
 

--- a/tests/e2e/tests/search_filter.rs
+++ b/tests/e2e/tests/search_filter.rs
@@ -2,8 +2,8 @@
 //!
 //! `dev seed-clipboard` requires the daemon to be stopped because it opens an
 //! in-process application session over the same profile. Search runs through
-//! the daemon client path, so each test seeds first, then lets `search` spawn
-//! or reuse a daemon for querying.
+//! the daemon client path, so this test seeds first, then restarts the daemon
+//! over the same profile for querying.
 
 use serde_json::Value;
 use uc_e2e_tests::{TestCli, TestDaemon, TestProfile};
@@ -42,6 +42,41 @@ fn search_json(cli: &TestCli, args: &[&str]) -> Value {
     );
     serde_json::from_str(out.stdout.trim())
         .unwrap_or_else(|e| panic!("search output was not JSON: {e}\nstdout={}", out.stdout))
+}
+
+fn wait_for_search_ready(cli: &TestCli) {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+
+    loop {
+        let out = cli.run_capture(&["--json", "search", "status"]);
+        assert!(
+            out.success(),
+            "search status failed (exit={}): stdout={}, stderr={}",
+            out.exit_code,
+            out.stdout,
+            out.stderr
+        );
+        let status: Value = serde_json::from_str(out.stdout.trim()).unwrap_or_else(|e| {
+            panic!(
+                "search status output was not JSON: {e}\nstdout={}",
+                out.stdout
+            )
+        });
+        if status
+            .get("state")
+            .and_then(Value::as_str)
+            .is_some_and(|state| state == "ready")
+        {
+            return;
+        }
+
+        assert!(
+            std::time::Instant::now() < deadline,
+            "search index did not become ready; last status: {}",
+            out.stdout
+        );
+        std::thread::sleep(std::time::Duration::from_millis(200));
+    }
 }
 
 fn result_items(page: &Value) -> &[Value] {
@@ -92,51 +127,42 @@ async fn initialized_cli_for_seed(test_name: &str) -> (TestDaemon, TestCli) {
 
 #[tokio::test]
 #[ignore]
-async fn search_type_text_matches_seeded_text_and_type_image_does_not() {
-    let (_profile_guard, cli) = initialized_cli_for_seed("search-filter-type").await;
-    let entry_id = seed_entry(&cli, "plain text search filter seed");
-
-    let text_page = search_json(&cli, &["--type", "text"]);
-    assert!(
-        contains_entry(&text_page, &entry_id),
-        "text filter should return seeded entry {entry_id}: {text_page}"
-    );
-    assert_eq!(content_type_for(&text_page, &entry_id), Some("text"));
-
-    let image_page = search_json(&cli, &["--type", "image"]);
-    assert!(
-        !contains_entry(&image_page, &entry_id),
-        "image filter should not return text entry {entry_id}: {image_page}"
-    );
-}
-
-#[tokio::test]
-#[ignore]
-async fn search_tag_link_matches_seeded_url_text() {
-    let (_profile_guard, cli) = initialized_cli_for_seed("search-filter-link").await;
-    let entry_id = seed_entry(&cli, "link seed https://example.com/uniclip-e2e");
-
-    let page = search_json(&cli, &["--tag", "link"]);
-    assert!(
-        contains_entry(&page, &entry_id),
-        "link tag should return seeded URL entry {entry_id}: {page}"
-    );
-    assert_eq!(content_type_for(&page, &entry_id), Some("text"));
-}
-
-#[tokio::test]
-#[ignore]
-async fn search_tag_code_matches_seeded_code_like_text() {
-    let (_profile_guard, cli) = initialized_cli_for_seed("search-filter-code").await;
-    let entry_id = seed_entry(
+async fn seeded_entries_support_type_and_tag_search_filters() {
+    let (mut daemon, cli) = initialized_cli_for_seed("search-filters").await;
+    let text_entry_id = seed_entry(&cli, "plain text search filter seed");
+    let link_entry_id = seed_entry(&cli, "https://example.com/uniclip-e2e");
+    let code_entry_id = seed_entry(
         &cli,
         "function greet(name) {\n  return `hello ${name}`;\n}",
     );
 
-    let page = search_json(&cli, &["--tag", "code"]);
+    daemon.restart().await.expect("daemon restart after seed");
+    wait_for_search_ready(&cli);
+
+    let text_page = search_json(&cli, &["--type", "text"]);
     assert!(
-        contains_entry(&page, &entry_id),
-        "code tag should return seeded code entry {entry_id}: {page}"
+        contains_entry(&text_page, &text_entry_id),
+        "text filter should return seeded entry {text_entry_id}: {text_page}"
     );
-    assert_eq!(content_type_for(&page, &entry_id), Some("text"));
+    assert_eq!(content_type_for(&text_page, &text_entry_id), Some("text"));
+
+    let image_page = search_json(&cli, &["--type", "image"]);
+    assert!(
+        !contains_entry(&image_page, &text_entry_id),
+        "image filter should not return text entry {text_entry_id}: {image_page}"
+    );
+
+    let link_page = search_json(&cli, &["--tag", "link"]);
+    assert!(
+        contains_entry(&link_page, &link_entry_id),
+        "link tag should return seeded URL entry {link_entry_id}: {link_page}"
+    );
+    assert_eq!(content_type_for(&link_page, &link_entry_id), Some("text"));
+
+    let code_page = search_json(&cli, &["--tag", "code"]);
+    assert!(
+        contains_entry(&code_page, &code_entry_id),
+        "code tag should return seeded code entry {code_entry_id}: {code_page}"
+    );
+    assert_eq!(content_type_for(&code_page, &code_entry_id), Some("text"));
 }

--- a/tests/e2e/tests/switch_space.rs
+++ b/tests/e2e/tests/switch_space.rs
@@ -6,12 +6,10 @@
 //! --yes` against Alice's invitation and ends up a member of Alice's space.
 //!
 //! NOTE: data round-trip integrity — seeded clipboard history surviving the
-//! re-encryption — is intentionally NOT covered here. The headless E2E binary
-//! has no real OS clipboard, and it is built without `dev-tools` (CI runs
-//! `cargo build -p uc-daemon -p uc-cli`), so there is no `dev seed-clipboard`
-//! / `dev dump-clipboard` and no way to populate or read local history. That
-//! assertion lives in `scripts/test_switch_space_e2e.sh`, which runs with
-//! `dev-tools` against a real macOS clipboard.
+//! re-encryption — is intentionally NOT covered here. The headless E2E runner
+//! has no real OS clipboard, so this test only proves the switch routing and
+//! membership migration. Seeded-history integrity lives in the dedicated
+//! switch-space script.
 //!
 //! Run with: cargo test -p uc-e2e-tests -- --ignored
 


### PR DESCRIPTION
## Summary
- persist `content_category` for `dev seed-clipboard` entries and route them through the shared live search indexer
- add CLI E2E coverage for `search --type text`, negative `--type image`, `--tag link`, and `--tag code` over seeded entries
- build CLI E2E binaries with `uc-cli/dev-tools` so the hidden seed command is available in CI

## Verification
- `cargo fmt --check`
- `cargo check -p uc-application`
- `cargo check -p uc-cli --features dev-tools`
- `cargo check --manifest-path tests/e2e/Cargo.toml`
- `cargo check -p uc-daemon -p uc-cli --features uc-cli/dev-tools`

Follow-up after merged PR #1197; PR #1197 is already merged into `main`, so this is a new branch rather than an update to that PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Clipboard seeding can now optionally perform “live” indexing to strengthen later search and filtering.
* **Bug Fixes**
  * Seeded clipboard entries now record `content_category` consistently, improving type/tag search filter accuracy.
  * Improved `seed clipboard` session resume error handling with safer shutdown behavior (including timeout protection).
* **Tests / CI**
  * Added E2E validation for `uc search` filters using `--json` output and index readiness polling.
  * Enhanced E2E stability with a daemon restart helper and non-daemon setup for path-validation tests.
  * Updated macOS E2E workflow to build `uc-cli` with the `dev-tools` feature enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->