### PR TITLE
fix(history): keep first card active after prepend

### DIFF
--- a/src/hooks/__tests__/useHistoryController.test.tsx
+++ b/src/hooks/__tests__/useHistoryController.test.tsx
@@ -15,6 +15,10 @@ const clipboardItemsApi = vi.hoisted(() => ({
   unfavoriteClipboardItem: vi.fn(() => Promise.resolve(true)),
 }))
 
+const historyDataState = vi.hoisted(() => ({
+  baseItems: [] as DisplayClipboardItem[],
+}))
+
 const items: DisplayClipboardItem[] = [
   {
     id: 'entry-1',
@@ -64,15 +68,15 @@ vi.mock('@/hooks/useHistoryData', () => ({
       submitQuery: vi.fn(),
     },
     sourceOptions: [],
-    baseItems: items,
+    baseItems: historyDataState.baseItems,
     liveSnapshot: {
       model: { query: '', timeRange: 'all_time' },
-      items,
-      total: items.length,
+      items: historyDataState.baseItems,
+      total: historyDataState.baseItems.length,
       hasMore: false,
       state: 'ready',
     },
-    browseCount: items.length,
+    browseCount: historyDataState.baseItems.length,
     indexState: 'ready',
     isSearchActive: false,
     searchLoading: false,
@@ -123,6 +127,7 @@ vi.mock('@/store/hooks', () => ({
 describe('useHistoryController', () => {
   beforeEach(() => {
     clearHistorySessionSnapshot()
+    historyDataState.baseItems = items
     vi.clearAllMocks()
   })
 
@@ -182,5 +187,48 @@ describe('useHistoryController', () => {
       expect(result.current.selectedItem?.isFavorited).toBe(true)
     })
     expect(clipboardItemsApi.favoriteClipboardItem).toHaveBeenCalledWith('entry-1')
+  })
+
+  it('keeps the active row on the first card when a newer card is prepended', async () => {
+    const { result, rerender } = renderHook(() => useHistoryController())
+
+    await waitFor(() => {
+      expect(result.current.selectedId).toBe('entry-1')
+    })
+
+    const incoming: DisplayClipboardItem = {
+      id: 'entry-new',
+      type: 'text',
+      content: { display_text: 'new', has_detail: false, size: 3 },
+      activeTime: 3,
+    }
+
+    await act(async () => {
+      historyDataState.baseItems = [incoming, ...items]
+      rerender()
+    })
+
+    await waitFor(() => {
+      expect(result.current.selectedId).toBe('entry-new')
+    })
+    expect(result.current.selectedItem?.id).toBe('entry-new')
+  })
+
+  it('keeps the selected id when existing cards are only reordered', async () => {
+    const { result, rerender } = renderHook(() => useHistoryController())
+
+    await waitFor(() => {
+      expect(result.current.selectedId).toBe('entry-1')
+    })
+
+    await act(async () => {
+      historyDataState.baseItems = [items[1], items[0]]
+      rerender()
+    })
+
+    await waitFor(() => {
+      expect(result.current.selectedId).toBe('entry-1')
+    })
+    expect(result.current.selectedItem?.id).toBe('entry-1')
   })
 })

--- a/src/hooks/useHistoryController.ts
+++ b/src/hooks/useHistoryController.ts
@@ -63,6 +63,8 @@ export function useHistoryController() {
   const [selectedId, setSelectedId] = useState<string | null>(
     () => initialSnapshot?.selectedId ?? null
   )
+  const previousFirstItemIdRef = useRef<string | null>(null)
+  const previousItemIdsRef = useRef<Set<string>>(new Set())
   // Stable Set of ids already rendered once; read during render to gate the
   // entrance animation, mutated only in an effect (never during render).
   const [seenIds] = useState(() => new Set<string>(initialSnapshot?.seenIds ?? []))
@@ -210,13 +212,29 @@ export function useHistoryController() {
   //   master-detail preview is never blank while there is something to show.
   useEffect(() => {
     const ids = new Set(orderedItems.map(it => it.id))
+    const firstItemId = orderedItems[0]?.id ?? null
+    const previousFirstItemId = previousFirstItemIdRef.current
+    const previousItemIds = previousItemIdsRef.current
+    previousFirstItemIdRef.current = firstItemId
+    previousItemIdsRef.current = ids
+
     if (hoveredId !== null && !ids.has(hoveredId)) setHoveredId(null)
     if (selectedId !== null && !ids.has(selectedId)) {
       setSelectedId(null)
       return
     }
-    if (selectedId === null && orderedItems.length > 0) {
-      setSelectedId(orderedItems[0].id)
+    if (firstItemId === null) return
+    if (selectedId === null) {
+      setSelectedId(firstItemId)
+      return
+    }
+    if (
+      previousFirstItemId !== null &&
+      selectedId === previousFirstItemId &&
+      firstItemId !== previousFirstItemId &&
+      !previousItemIds.has(firstItemId)
+    ) {
+      setSelectedId(firstItemId)
     }
   }, [orderedItems, hoveredId, selectedId])
 


### PR DESCRIPTION
## Summary
- keep the history active selection on the first card when a new card is prepended while the first card is active
- preserve id-based selection when existing cards are only reordered
- add controller regression coverage for both cases

## Tests
- npx vitest run src/hooks/__tests__/useHistoryController.test.tsx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved history selection behavior when the list changes.
  * If a new item is added to the top of the list, the selected row now updates to that new item.
  * If items are only reordered, the current selection stays on the same entry instead of jumping unexpectedly.
  * Added coverage for these selection scenarios to prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->