### PR TITLE
fix(ui): render file clipboard entries as files, not file:// text

### DIFF
--- a/src/api/daemon/__tests__/clipboard.test.ts
+++ b/src/api/daemon/__tests__/clipboard.test.ts
@@ -71,7 +71,9 @@ describe('ClipboardEntryDto type', () => {
       hasDetail: true,
       sizeBytes: 19,
       capturedAt: 1710000000000,
-      contentType: 'text/uri-list',
+      // Links are the `text` category plus a derived `link` tag, not a
+      // physical category of their own.
+      contentType: 'text',
       thumbnailUrl: null,
       isEncrypted: false,
       isFavorited: true,
@@ -95,7 +97,7 @@ describe('ClipboardEntryDto type', () => {
       hasDetail: true,
       sizeBytes: 102400,
       capturedAt: 1710000000000,
-      contentType: 'text/uri-list',
+      contentType: 'file',
       thumbnailUrl: null,
       isEncrypted: false,
       isFavorited: false,

--- a/src/api/daemon/clipboard.ts
+++ b/src/api/daemon/clipboard.ts
@@ -47,6 +47,12 @@ export interface ClipboardEntryDto {
   hasDetail: boolean
   sizeBytes: number
   capturedAt: number
+  /**
+   * Persisted physical content category label — one of `text` | `image` |
+   * `file` | `rich_text` | `other` (the daemon's `content_category`, not a
+   * representation MIME). The display projection keys off this label; see
+   * `isFileContentType` / `isImageContentType` / `isRichTextContentType`.
+   */
   contentType: string
   thumbnailUrl: string | null
   isEncrypted: boolean

--- a/src/lib/__tests__/clipboard-transform.test.ts
+++ b/src/lib/__tests__/clipboard-transform.test.ts
@@ -65,10 +65,13 @@ describe('projectClipboardEntry', () => {
   })
 
   it('parses file URI lists, keeping per-file missing flags', () => {
+    // The daemon list projection carries the persisted content category
+    // (`file`), not a representation MIME, so the file branch must key off
+    // that label rather than the legacy `text/uri-list` string.
     const entry = projectClipboardEntry(
       makeDto({
         preview: 'file:///tmp/report.pdf\nuniclip-missing:///lost.bin?size=42',
-        contentType: 'text/uri-list',
+        contentType: 'file',
         fileSizes: [100, 42],
       })
     )

--- a/src/lib/clipboard-utils.ts
+++ b/src/lib/clipboard-utils.ts
@@ -194,10 +194,15 @@ export function isImageFileName(name: string): boolean {
 }
 
 /**
- * Check whether a MIME content type represents a file (URI list).
+ * Check whether a content type represents a file.
+ *
+ * Accepts the daemon's persisted category label (`file`) as well as the
+ * legacy representation MIME (`text/uri-list`) so both the list/event
+ * projection (which now carries `content_category`) and any residual
+ * MIME-shaped caller resolve correctly.
  */
 export function isFileContentType(contentType: string): boolean {
-  return contentType.includes('uri-list')
+  return contentType === 'file' || contentType.includes('uri-list')
 }
 
 export function getItemPreview(entry: ClipboardEntry): string {


### PR DESCRIPTION
## Summary

- 复制的文件在历史里被错误地显示成 `file://` 开头的**文本**，而非文件卡片。根因是 #1197 把列表/事件 projection 的 DTO `contentType` 从 representation MIME（`text/uri-list`）改成了持久化的分类标签（`file`/`text`/`image`/`rich_text`/`other`），并同步更新了 `isImageContentType`/`isRichTextContentType`，**唯独漏改 `isFileContentType`** —— 它仍按旧的 `includes('uri-list')` 子串匹配，导致 `isFileContentType('file')===false`，文件 entry 在 `projectClipboardEntry` 掉进 text 分支，把 `preview`（`file://` URI）当文本渲染 (08e16e51)。
- 修复：`isFileContentType` 识别分类标签 `'file'`（保留旧 MIME 匹配作防御性兜底）。daemon 其实已正确把 entry 分类为 `file`，问题纯在前端类型守卫；search/浏览路径走独立的 `searchContentTypeToDisplayType`，本就正确，不受影响。
- 把 `ClipboardEntryDto.contentType` 的「分类标签而非 MIME」契约写进 doc-comment——这正是当初漏改、且测试没拦住的根本原因（契约从未写明）。
- 修正 file projection 回归测试改用真实契约 `contentType: 'file'`（改前会失败、改后通过），并把 DTO 类型测试里误导性的 `text/uri-list` MIME fixture 改成真实分类标签。

诊断依据：本机 dev daemon 日志显示该文件捕获被正确归为 `file`（数据库 `content_category='file'`、title 为文件名），但前端仍按文本展示，定位到 `isFileContentType` 的契约不一致。Codex 交叉评审确认根因成立、修复对症且无其它运行路径受影响。

## Test plan

- [x] `vitest run` — `clipboard-transform`、`clipboard-utils`、`api/daemon/clipboard` 三套全绿（36 cases）
- [x] `tsc --noEmit` 0 错误
- [ ] 真机回归：在桌面 GUI 从 Finder 复制一个文件，确认历史里渲染为文件卡（文件名 + 文件操作），而非 `file://` 文本

## Follow-up (out of scope)

- 建议把 `ClipboardEntryDto.contentType` 收紧为联合类型 `'text' | 'image' | 'file' | 'rich_text' | 'other'`，可在编译期拦住此类「分类标签 vs MIME」契约漂移。会波及约 8 个测试文件的 fixture，属独立的契约收紧重构，留作单独 PR。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved clipboard item handling so file-related clipboard entries are recognized consistently, even when they use the newer file category label.
  * Updated clipboard type handling to better align with link and file projections, reducing mismatches in clipboard display and processing.

* **Documentation**
  * Clarified clipboard content type labeling and the expected values used by the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->