### PR TITLE
test(history): cover content-tag label and other category

### DIFF
--- a/src/components/history/__tests__/HistoryCard.test.tsx
+++ b/src/components/history/__tests__/HistoryCard.test.tsx
@@ -81,6 +81,24 @@ describe('HistoryCard', () => {
     expect(screen.getByText('code')).toBeInTheDocument()
   })
 
+  it('keeps the rich text label when a content tag is present', () => {
+    renderCard({
+      id: 'richtext-entry',
+      type: 'richtext',
+      content: {
+        display_text: 'https://example.com/article',
+        has_detail: false,
+        size: 28,
+      },
+      activeTime: 1,
+      contentTags: ['link'],
+    } as DisplayClipboardItem)
+
+    expect(screen.getByText('richtext')).toBeInTheDocument()
+    expect(screen.getByText('link')).toBeInTheDocument()
+    expect(screen.queryByText('text')).not.toBeInTheDocument()
+  })
+
   it('shows links as text cards with a link tag', () => {
     renderCard({
       id: 'link-entry',

--- a/src/lib/__tests__/clipboard-transform.test.ts
+++ b/src/lib/__tests__/clipboard-transform.test.ts
@@ -113,6 +113,18 @@ describe('projectClipboardEntry', () => {
     expect(entry.contentTags).toEqual(['code'])
   })
 
+  it('surfaces the other physical category as unknown, not text', () => {
+    const entry = projectClipboardEntry(
+      makeDto({
+        preview: 'opaque payload',
+        contentType: 'other',
+      })
+    )
+
+    expect(entry.type).toBe('unknown')
+    expect(entry.contentTags).toBeUndefined()
+  })
+
   it('projects rich text entries without the code tag', () => {
     const entry = projectClipboardEntry(
       makeDto({


### PR DESCRIPTION
## Summary

- Add the two frontend regression guards deferred from #1197 (commit `b742a439a`), which shipped without test coverage (e465215d9).
- `HistoryCard.test.tsx`: a `richtext` entry carrying a `link` content tag now asserts its header label renders as `richtext` (not the old `text` fallback that triggered whenever any tag was present).
- `clipboard-transform.test.ts`: `projectClipboardEntry` with `contentType: 'other'` now asserts `type === 'unknown'`, matching the search projection instead of collapsing to `text`.

Closes #1200.

## Test plan

- [x] `bunx vitest run src/lib/__tests__/clipboard-transform.test.ts src/components/history/__tests__/HistoryCard.test.tsx` — 19 passed.
- [x] `bunx eslint` on both files — clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for history cards to ensure rich text items display the correct label and any associated tag, without falling back to the plain text label.
  * Added coverage for clipboard transformation to verify unknown content types are mapped correctly and no extra tags are added.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->