### PR TITLE
feat(ui): themed CSS-variable scrollbars with global base layer

### DIFF
--- a/src/styles/__tests__/theme-migration.test.js
+++ b/src/styles/__tests__/theme-migration.test.js
@@ -16,4 +16,9 @@ describe('theme migration', () => {
     expect(globals).toContain('transition')
     expect(globals).toContain('background-color 200ms')
   })
+
+  it('applies themed scrollbars from the global base layer', () => {
+    expect(globals).toContain('scrollbar-color: var(--scrollbar-thumb) transparent')
+    expect(globals).toContain('*::-webkit-scrollbar-thumb')
+  })
 })

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -137,18 +137,23 @@
   --shadow-xl: 0px 4px 6px 0px hsl(240 30% 25% / 0.12), 0px 8px 10px -1px hsl(240 30% 25% / 0.12);
   --shadow-2xl: 0px 4px 6px 0px hsl(240 30% 25% / 0.3);
   --tracking-normal: 0em;
+  --scrollbar-size: 0.625rem;
+  --scrollbar-gutter: 0.1875rem;
+  --scrollbar-thumb: color-mix(in oklch, var(--muted-foreground) 38%, transparent);
+  --scrollbar-thumb-hover: color-mix(in oklch, var(--muted-foreground) 58%, transparent);
+  --scrollbar-thumb-active: color-mix(in oklch, var(--muted-foreground) 72%, transparent);
 }
 
-/* 自定义滚动条样式 */
+/* Global scrollbar helpers. Most scroll containers inherit the base styling. */
 @layer utilities {
   .scrollbar-thin {
     scrollbar-width: thin;
-    scrollbar-color: rgb(203 213 225) transparent;
+    scrollbar-color: var(--scrollbar-thumb) transparent;
   }
 
   .scrollbar-thin::-webkit-scrollbar {
-    width: 8px;
-    height: 8px;
+    width: var(--scrollbar-size);
+    height: var(--scrollbar-size);
   }
 
   .scrollbar-thin::-webkit-scrollbar-track {
@@ -156,20 +161,20 @@
   }
 
   .scrollbar-thin::-webkit-scrollbar-thumb {
-    background-color: rgb(203 213 225);
-    border-radius: 4px;
+    min-width: 3rem;
+    min-height: 3rem;
+    border: var(--scrollbar-gutter) solid transparent;
+    border-radius: 9999px;
+    background-color: var(--scrollbar-thumb);
+    background-clip: padding-box;
   }
 
   .scrollbar-thin::-webkit-scrollbar-thumb:hover {
-    background-color: rgb(148 163 184);
+    background-color: var(--scrollbar-thumb-hover);
   }
 
-  .dark .scrollbar-thin::-webkit-scrollbar-thumb {
-    background-color: rgb(71 85 105);
-  }
-
-  .dark .scrollbar-thin::-webkit-scrollbar-thumb:hover {
-    background-color: rgb(100 116 139);
+  .scrollbar-thin::-webkit-scrollbar-thumb:active {
+    background-color: var(--scrollbar-thumb-active);
   }
 
   .scrollbar-code {
@@ -492,6 +497,41 @@ html[data-uc-low-effects='true']::view-transition-new(root) {
     margin: 0;
     padding: 0;
     overflow: hidden;
+  }
+
+  * {
+    scrollbar-width: thin;
+    scrollbar-color: var(--scrollbar-thumb) transparent;
+  }
+
+  *::-webkit-scrollbar {
+    width: var(--scrollbar-size);
+    height: var(--scrollbar-size);
+  }
+
+  *::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  *::-webkit-scrollbar-thumb {
+    min-width: 3rem;
+    min-height: 3rem;
+    border: var(--scrollbar-gutter) solid transparent;
+    border-radius: 9999px;
+    background-color: var(--scrollbar-thumb);
+    background-clip: padding-box;
+  }
+
+  *::-webkit-scrollbar-thumb:hover {
+    background-color: var(--scrollbar-thumb-hover);
+  }
+
+  *::-webkit-scrollbar-thumb:active {
+    background-color: var(--scrollbar-thumb-active);
+  }
+
+  *::-webkit-scrollbar-corner {
+    background: transparent;
   }
 
   /* 原生桌面应用约定:UI 文本默认不可框选,避免 WebKit 拖蓝选区暴露 webview。


### PR DESCRIPTION
## Summary

- 将滚动条样式重构为基于 `--scrollbar-*` CSS 变量的主题化方案（`--scrollbar-thumb` / `-hover` / `-active` 用 `color-mix` 派生自 `--muted-foreground`），取代原先写死的 `rgb(...)` 颜色与单独的 `.dark` 分支，使滚动条随主题自动适配 (cc412b0a3)
- 新增全局 `*::-webkit-scrollbar*` 基础层，让所有滚动容器默认继承主题化滚动条（pill 形 thumb、padding-box 留白、hover/active 态），`.scrollbar-thin` 工具类同步对齐 (cc412b0a3)
- 补一条 `theme-migration` 测试断言，校验全局基础层确实应用了 `scrollbar-color: var(--scrollbar-thumb) transparent` 与 `*::-webkit-scrollbar-thumb` (cc412b0a3)

## Test plan

- [x] `npx vitest run src/styles/__tests__/theme-migration.test.js` —— 3 passed
- [ ] 在 GUI 里目视确认浅色/深色主题下滚动条颜色对比与 hover/active 反馈正常（含 webview 各滚动容器）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Scrollbars now use a consistent themed style across the app, with thinner sizing and updated thumb colors.
* **Bug Fixes**
  * Improved scrollbar appearance in both light and dark modes by replacing hard-coded colors with theme-aware values.
* **Tests**
  * Expanded coverage to verify themed scrollbar styling is included in global styles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->