### PR TITLE
fix(settings): stabilize about actions

### DIFF
--- a/src/api/sponsors.ts
+++ b/src/api/sponsors.ts
@@ -1,0 +1,70 @@
+import { createLogger } from '@/lib/logger'
+
+const log = createLogger('sponsors-api')
+
+/**
+ * Sponsor display shape returned by the public website feed
+ * (`GET https://uniclipboard.app/api/v1/sponsors`). Mirrors the wall on the
+ * marketing site; admin-only fields (e.g. amount) are never exposed here.
+ */
+export interface Sponsor {
+  /** Stable id (website DB row id) — used as a React key. */
+  id: string
+  /** Display name. */
+  name: string
+  /** Optional link to their homepage / profile. */
+  url?: string
+  /** Optional month they started sponsoring, e.g. "2026-01". */
+  since?: string
+  /** Optional one-line shout-out shown under the name. */
+  note?: string
+  /** Optional absolute avatar URL; absent → fall back to an initials monogram. */
+  avatar?: string
+  /** "gold" sponsors are highlighted and sorted to the front. */
+  tier?: 'gold' | 'regular'
+}
+
+interface SponsorsResponse {
+  items: Sponsor[]
+  count: number
+}
+
+/**
+ * Public sponsors endpoint. Overridable via `VITE_SPONSORS_API_URL` for local
+ * testing against a dev website instance.
+ *
+ * NOTE: uses the canonical `www.` host. The apex `uniclipboard.app` 308-redirects
+ * to `www`, and a cross-origin redirect aborts a CORS fetch unless every hop
+ * carries `Access-Control-Allow-Origin` (the edge redirect does not), so hit the
+ * final host directly.
+ */
+const SPONSORS_API_URL =
+  import.meta.env.VITE_SPONSORS_API_URL ?? 'https://www.uniclipboard.app/api/v1/sponsors'
+
+/** Give up rather than hang the About panel on a slow/offline network. */
+const FETCH_TIMEOUT_MS = 8000
+
+/**
+ * Fetch the public sponsor list directly from the website. Unlike the rest of
+ * the UI this bypasses the daemon and hits an external origin: the data is
+ * public, read-only, and the website serves permissive CORS for it.
+ *
+ * The caller's `signal` (component unmount) is honoured alongside an internal
+ * timeout. Network/parse failures propagate; callers degrade gracefully.
+ */
+export async function fetchSponsors(signal?: AbortSignal): Promise<Sponsor[]> {
+  const timeout = AbortSignal.timeout(FETCH_TIMEOUT_MS)
+  const combined = signal ? AbortSignal.any([signal, timeout]) : timeout
+
+  const res = await fetch(SPONSORS_API_URL, {
+    method: 'GET',
+    headers: { Accept: 'application/json' },
+    signal: combined,
+  })
+  if (!res.ok) {
+    throw new Error(`sponsors fetch failed: ${res.status}`)
+  }
+  const data = (await res.json()) as SponsorsResponse
+  log.debug({ count: data.count }, 'fetched sponsors')
+  return data.items ?? []
+}

--- a/src/components/setting/AboutSection.tsx
+++ b/src/components/setting/AboutSection.tsx
@@ -22,6 +22,7 @@ import {
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
 import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
 import { Progress } from '@/components/ui/progress'
 import {
   Select,
@@ -40,6 +41,7 @@ import { useUpdate } from '@/hooks/useUpdate'
 import { createLogger } from '@/lib/logger'
 import { cn } from '@/lib/utils'
 import type { UpdateChannel } from '@/types/setting'
+import { SponsorsGroup } from './about/SponsorsGroup'
 import { SettingGroup } from './SettingGroup'
 import { SettingRow } from './SettingRow'
 
@@ -269,69 +271,71 @@ const AboutSection: React.FC = () => {
   }
 
   return (
-    <>
-      <SettingGroup title={t('settings.sections.about.appName')}>
-        <div className="flex items-center justify-between p-4">
-          <div className="flex items-center">
-            <div className="size-12 rounded-xl bg-gradient-to-br from-primary to-primary/60 flex items-center justify-center shadow-lg shadow-primary/20">
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                className="size-7 text-primary-foreground"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-              >
-                <title>{t('settings.sections.about.appName')}</title>
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth="2"
-                  d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"
-                />
-              </svg>
-            </div>
-            <div className="ml-4 space-y-0.5">
-              <div className="flex items-center gap-2">
-                <h4 className="text-lg font-medium">{t('settings.sections.about.appName')}</h4>
-                {channel && (
-                  <Badge variant={getChannelBadgeVariant(channel)}>
-                    {getChannelLabel(channel)}
-                  </Badge>
-                )}
-              </div>
-              <p className="text-sm text-muted-foreground">
-                {appVersion
-                  ? t('settings.sections.about.version', { version: appVersion })
-                  : t('settings.sections.about.version', { version: '...' })}
-              </p>
-            </div>
-          </div>
-          <div className="flex items-center gap-2">
-            {import.meta.env.DEV && (
-              <button
-                type="button"
-                className="inline-flex items-center justify-center rounded-lg border border-dashed border-amber-500/60 bg-amber-500/10 px-3 py-2 text-xs font-medium text-amber-700 dark:text-amber-300 hover:bg-amber-500/20"
-                onClick={handleOpenUpdaterWindowDev}
-                title="Dev only: open the Sparkle-style updater window with mock data"
-              >
-                Open updater window (dev)
-              </button>
+    <div className="space-y-5">
+      {/* App identity hero */}
+      <div className="flex flex-col items-center gap-4 rounded-xl border border-border/60 bg-card px-6 py-8 text-center">
+        <div className="flex size-16 items-center justify-center rounded-2xl bg-gradient-to-br from-primary to-primary/60 shadow-lg shadow-primary/25">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            className="size-9 text-primary-foreground"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <title>{t('settings.sections.about.appName')}</title>
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth="2"
+              d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"
+            />
+          </svg>
+        </div>
+        <div className="space-y-1.5">
+          <div className="flex items-center justify-center gap-2">
+            <h3 className="text-xl font-semibold tracking-tight">
+              {t('settings.sections.about.appName')}
+            </h3>
+            {channel && (
+              <Badge variant={getChannelBadgeVariant(channel)}>{getChannelLabel(channel)}</Badge>
             )}
-            <button
-              type="button"
-              className="inline-flex min-w-36 items-center justify-center gap-2 rounded-lg border border-border bg-secondary px-4 py-2 text-sm font-medium text-secondary-foreground shadow-sm transition duration-200 hover:bg-secondary/80"
-              onClick={handleCheckUpdate}
-              disabled={isBusy || isCheckingUpdate}
-              aria-busy={isCheckingUpdate}
-            >
-              {isCheckingUpdate && <Loader2 className="size-4 animate-spin" />}
+          </div>
+          <p className="text-sm text-muted-foreground">
+            {appVersion
+              ? t('settings.sections.about.version', { version: appVersion })
+              : t('settings.sections.about.version', { version: '...' })}
+          </p>
+        </div>
+        <Button
+          size="lg"
+          className="w-44 transition-colors"
+          onClick={handleCheckUpdate}
+          disabled={isBusy || isCheckingUpdate}
+          aria-busy={isCheckingUpdate}
+        >
+          <span className="inline-flex min-w-0 items-center justify-center gap-1.5">
+            {isCheckingUpdate && <Loader2 data-icon="inline-start" className="animate-spin" />}
+            <span>
               {isCheckingUpdate
                 ? t('settings.sections.about.checkingUpdate')
                 : t('settings.sections.about.checkUpdate')}
-            </button>
-          </div>
-        </div>
+            </span>
+          </span>
+        </Button>
+        {import.meta.env.DEV && (
+          <button
+            type="button"
+            className="text-xs text-amber-600 underline-offset-2 hover:underline dark:text-amber-400"
+            onClick={handleOpenUpdaterWindowDev}
+            title="Dev only: open the Sparkle-style updater window with mock data"
+          >
+            Open updater window (dev)
+          </button>
+        )}
+      </div>
 
+      {/* Update settings */}
+      <SettingGroup title={t('settings.sections.about.updatesTitle')}>
         <SettingRow
           label={t('settings.sections.about.autoCheckUpdate.label')}
           description={t('settings.sections.about.autoCheckUpdate.description')}
@@ -383,37 +387,41 @@ const AboutSection: React.FC = () => {
             </SelectContent>
           </Select>
         </SettingRow>
-
-        <div className="p-4 space-y-3">
-          <p className="text-sm text-muted-foreground">{t('settings.sections.about.copyright')}</p>
-          <div className="flex gap-x-6 text-sm">
-            <a
-              href="https://github.com/UniClipboard/UniClipboard"
-              className="text-primary hover:text-primary/80 transition-colors"
-              target="_blank"
-              rel="noreferrer"
-            >
-              {t('settings.sections.about.links.privacyPolicy')}
-            </a>
-            <a
-              href="https://github.com/UniClipboard/UniClipboard"
-              className="text-primary hover:text-primary/80 transition-colors"
-              target="_blank"
-              rel="noreferrer"
-            >
-              {t('settings.sections.about.links.termsOfService')}
-            </a>
-            <a
-              href="https://github.com/UniClipboard/UniClipboard"
-              className="text-primary hover:text-primary/80 transition-colors"
-              target="_blank"
-              rel="noreferrer"
-            >
-              {t('settings.sections.about.links.helpCenter')}
-            </a>
-          </div>
-        </div>
       </SettingGroup>
+
+      {/* Sponsors */}
+      <SponsorsGroup />
+
+      {/* Footer: links + copyright */}
+      <div className="space-y-2.5 pt-1 text-center">
+        <div className="flex justify-center gap-x-5 text-sm">
+          <a
+            href="https://github.com/UniClipboard/UniClipboard"
+            className="text-muted-foreground transition-colors hover:text-foreground"
+            target="_blank"
+            rel="noreferrer"
+          >
+            {t('settings.sections.about.links.privacyPolicy')}
+          </a>
+          <a
+            href="https://github.com/UniClipboard/UniClipboard"
+            className="text-muted-foreground transition-colors hover:text-foreground"
+            target="_blank"
+            rel="noreferrer"
+          >
+            {t('settings.sections.about.links.termsOfService')}
+          </a>
+          <a
+            href="https://github.com/UniClipboard/UniClipboard"
+            className="text-muted-foreground transition-colors hover:text-foreground"
+            target="_blank"
+            rel="noreferrer"
+          >
+            {t('settings.sections.about.links.helpCenter')}
+          </a>
+        </div>
+        <p className="text-xs text-muted-foreground/80">{t('settings.sections.about.copyright')}</p>
+      </div>
 
       <AlertDialog open={updateDialogOpen} onOpenChange={handleUpdateDialogOpenChange}>
         <AlertDialogContent>
@@ -528,7 +536,7 @@ const AboutSection: React.FC = () => {
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
-    </>
+    </div>
   )
 }
 

--- a/src/components/setting/__tests__/AboutSection.test.tsx
+++ b/src/components/setting/__tests__/AboutSection.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { fetchSponsors } from '@/api/sponsors'
 import AboutSection from '@/components/setting/AboutSection'
 import { SettingContext } from '@/contexts/setting-context'
 import { UpdateContext } from '@/contexts/update-context'
@@ -19,6 +20,12 @@ vi.mock('react-i18next', () => ({
 vi.mock('@/hooks/useShortcutLayer', () => ({
   useShortcutLayer: vi.fn(),
 }))
+
+vi.mock('@/api/sponsors', () => ({
+  fetchSponsors: vi.fn(() => new Promise(() => undefined)),
+}))
+
+const mockFetchSponsors = vi.mocked(fetchSponsors)
 
 beforeAll(() => {
   if (!HTMLElement.prototype.hasPointerCapture) {
@@ -247,7 +254,34 @@ describe('AboutSection', () => {
 
     expect(checkButton).toBeDisabled()
     expect(checkButton).toHaveAttribute('aria-busy', 'true')
+    expect(checkButton).toHaveClass('w-44')
+    expect(checkButton).toHaveClass('transition-colors')
+    expect(checkButton).not.toHaveClass('transition-all')
+    expect(checkButton).toHaveTextContent('settings.sections.about.checkingUpdate')
+    expect(checkButton).not.toHaveTextContent('settings.sections.about.checkUpdate')
     expect(container.querySelector('.animate-spin')).toBeTruthy()
+  })
+
+  it('shows sponsor and GitHub star actions in the sponsors group', async () => {
+    mockFetchSponsors.mockResolvedValueOnce([
+      {
+        id: 'sponsor-1',
+        name: 'Ada Lovelace',
+        tier: 'regular',
+      },
+    ])
+
+    renderAboutSection()
+
+    const sponsorLink = await screen.findByRole('link', {
+      name: 'settings.sections.about.sponsors.becomeSponsor',
+    })
+    const starLink = screen.getByRole('link', {
+      name: 'settings.sections.about.sponsors.githubStar',
+    })
+
+    expect(sponsorLink).toHaveAttribute('href', 'https://afdian.com/a/mkdir700')
+    expect(starLink).toHaveAttribute('href', 'https://github.com/UniClipboard/UniClipboard')
   })
 
   it('checks the newly selected channel immediately after saving it', async () => {

--- a/src/components/setting/about/SponsorsGroup.tsx
+++ b/src/components/setting/about/SponsorsGroup.tsx
@@ -1,0 +1,142 @@
+import { Heart, Star } from 'lucide-react'
+import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { fetchSponsors, type Sponsor } from '@/api/sponsors'
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
+import { Badge } from '@/components/ui/badge'
+import { createLogger } from '@/lib/logger'
+import { cn } from '@/lib/utils'
+
+const log = createLogger('sponsors-group')
+
+/** 爱发电 sponsorship page (currently the only paid channel). */
+const SPONSOR_CHANNEL_URL = 'https://afdian.com/a/mkdir700'
+const GITHUB_REPOSITORY_URL = 'https://github.com/UniClipboard/UniClipboard'
+
+/** Deterministic 1–2 char monogram for sponsors without an avatar. */
+function initialsFor(name: string): string {
+  const trimmed = name.trim()
+  if (!trimmed) return '?'
+  const isLatin = [...trimmed].every(ch => ch.charCodeAt(0) < 128)
+  if (isLatin) {
+    const parts = trimmed.split(/\s+/).filter(Boolean)
+    return parts.length >= 2
+      ? (parts[0][0] + parts[1][0]).toUpperCase()
+      : trimmed.slice(0, 2).toUpperCase()
+  }
+  return trimmed.slice(0, 1)
+}
+
+function SponsorCard({ sponsor, goldLabel }: { sponsor: Sponsor; goldLabel: string }) {
+  const isGold = sponsor.tier === 'gold'
+
+  const card = (
+    <div
+      className={cn(
+        'flex h-full flex-col items-center gap-2 rounded-lg border p-3 text-center transition-colors',
+        isGold
+          ? 'border-amber-400/50 bg-amber-400/[0.06] hover:bg-amber-400/10'
+          : 'border-border/60 bg-background hover:bg-muted/40'
+      )}
+    >
+      <Avatar size="lg">
+        {sponsor.avatar && <AvatarImage src={sponsor.avatar} alt={sponsor.name} />}
+        <AvatarFallback>{initialsFor(sponsor.name)}</AvatarFallback>
+      </Avatar>
+      <div className="w-full min-w-0 space-y-1">
+        <p className="truncate text-sm font-medium">{sponsor.name}</p>
+        {isGold ? (
+          <Badge
+            variant="secondary"
+            className="border-amber-400/40 bg-amber-400/15 text-amber-700 dark:text-amber-300"
+          >
+            {goldLabel}
+          </Badge>
+        ) : (
+          sponsor.note && <p className="truncate text-xs text-muted-foreground">{sponsor.note}</p>
+        )}
+      </div>
+    </div>
+  )
+
+  if (sponsor.url) {
+    return (
+      <a href={sponsor.url} target="_blank" rel="noreferrer" className="block">
+        {card}
+      </a>
+    )
+  }
+  return card
+}
+
+/**
+ * "Sponsors" group on the About settings page. Thanks current sponsors with a
+ * small avatar-card grid pulled live from the public website feed; gold
+ * sponsors are highlighted. Renders nothing until at least one sponsor has
+ * loaded, so an empty list / offline / fetch error simply hides the section
+ * instead of showing a broken placeholder.
+ */
+export function SponsorsGroup() {
+  const { t } = useTranslation()
+  const [sponsors, setSponsors] = useState<Sponsor[] | null>(null)
+
+  useEffect(() => {
+    const controller = new AbortController()
+    fetchSponsors(controller.signal)
+      .then(setSponsors)
+      .catch(error => {
+        if (controller.signal.aborted) return
+        log.error({ err: error }, 'failed to load sponsors')
+        setSponsors([])
+      })
+    return () => controller.abort()
+  }, [])
+
+  // Loading, empty, or failed → hide the section entirely.
+  if (!sponsors || sponsors.length === 0) return null
+
+  return (
+    <div className="space-y-1.5">
+      <h3 className="px-1 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+        {t('settings.sections.about.sponsors.title')}
+      </h3>
+      <div className="space-y-4 rounded-lg border border-border/60 bg-card p-4">
+        <div className="flex items-center gap-2">
+          <Heart className="size-4 shrink-0 fill-rose-500/20 text-rose-500" />
+          <p className="text-xs leading-snug text-muted-foreground">
+            {t('settings.sections.about.sponsors.thanks')}
+          </p>
+        </div>
+        <div className="grid grid-cols-2 gap-2.5 sm:grid-cols-3">
+          {sponsors.map(sponsor => (
+            <SponsorCard
+              key={sponsor.id}
+              sponsor={sponsor}
+              goldLabel={t('settings.sections.about.sponsors.goldBadge')}
+            />
+          ))}
+        </div>
+        <div className="flex flex-wrap justify-center gap-2 pt-0.5">
+          <a
+            href={SPONSOR_CHANNEL_URL}
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex items-center gap-1.5 rounded-lg border border-border/60 px-3 py-1.5 text-sm text-primary transition-colors hover:bg-muted/50"
+          >
+            <Heart className="size-3.5" />
+            {t('settings.sections.about.sponsors.becomeSponsor')}
+          </a>
+          <a
+            href={GITHUB_REPOSITORY_URL}
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex items-center gap-1.5 rounded-lg border border-border/60 px-3 py-1.5 text-sm text-primary transition-colors hover:bg-muted/50"
+          >
+            <Star className="size-3.5" />
+            {t('settings.sections.about.sponsors.githubStar')}
+          </a>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -583,6 +583,7 @@
         "version": "Version {{version}}",
         "checkUpdate": "Check for updates",
         "checkingUpdate": "Checking...",
+        "updatesTitle": "Updates",
         "autoCheckUpdate": {
           "label": "Auto-check for updates",
           "description": "Automatically check for new versions when the app starts"
@@ -606,6 +607,13 @@
             "cancel": "Cancel",
             "confirm": "Switch"
           }
+        },
+        "sponsors": {
+          "title": "Sponsors",
+          "thanks": "Thanks to these wonderful people whose sponsorship keeps UniClipboard moving forward.",
+          "goldBadge": "Gold",
+          "becomeSponsor": "Become a sponsor →",
+          "githubStar": "Star on GitHub →"
         },
         "copyright": "© 2025 UniClipboard Team. All rights reserved.",
         "links": {

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -574,6 +574,7 @@
         "version": "版本 {{version}}",
         "checkUpdate": "检查更新",
         "checkingUpdate": "正在检查...",
+        "updatesTitle": "更新",
         "autoCheckUpdate": {
           "label": "自动检查更新",
           "description": "应用启动时自动检查是否有新版本"
@@ -597,6 +598,13 @@
             "cancel": "取消",
             "confirm": "继续切换"
           }
+        },
+        "sponsors": {
+          "title": "赞助者",
+          "thanks": "感谢以下朋友的赞助支持，让 UniClipboard 持续向前。",
+          "goldBadge": "金牌",
+          "becomeSponsor": "成为赞助者 →",
+          "githubStar": "去 GitHub 点 Star →"
         },
         "copyright": "© 2025 UniClipboard Team. All rights reserved.",
         "links": {


### PR DESCRIPTION
## Summary
- add a GitHub Star action alongside the sponsor action in the About sponsors section
- keep the About update-check button width stable while it is loading
- cover the loading button and support links in AboutSection tests

## Verification
- npx vitest run src/components/setting/__tests__/AboutSection.test.tsx
- npx prettier --check src/components/setting/AboutSection.tsx src/components/setting/about/SponsorsGroup.tsx src/components/setting/__tests__/AboutSection.test.tsx src/api/sponsors.ts src/i18n/locales/en-US.json src/i18n/locales/zh-CN.json
- npx eslint src/components/setting/AboutSection.tsx src/components/setting/about/SponsorsGroup.tsx src/components/setting/__tests__/AboutSection.test.tsx src/api/sponsors.ts
- npx tsc --noEmit
- bun run build

Note: browser verification in plain Vite stops on the setup screen because the app needs the Tauri desktop bridge and daemon runtime.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a sponsor section to the About page, showing sponsor cards when available.
  * Added support for loading sponsor data from a configurable feed with a built-in request timeout.
  * Added localized copy for sponsor and update-related text in English and Chinese.

* **Bug Fixes**
  * Improved the About page layout and update-check loading state for a cleaner, more consistent experience.

* **Tests**
  * Expanded About page coverage for sponsor content and update-button behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->