### PR TITLE
fix(mobile-sync): send preview representation, not html, to mobile clients

### DIFF
--- a/crates/uc-application/src/usecases/mobile_sync/get_file.rs
+++ b/crates/uc-application/src/usecases/mobile_sync/get_file.rs
@@ -12,7 +12,7 @@
 //!
 //! ## File 类型出站(P5a.3.5 后)
 //!
-//! 当前 paste rep 对 File 类型的 wire 形态是 `text/uri-list`(`format_id=files`,
+//! 当前 preview rep 对 File 类型的 wire 形态是 `text/uri-list`(`format_id=files`,
 //! `mime=text/uri-list`,bytes 是 `\n` 分隔的 `file:///...` URI 列表)。本 use
 //! case 在 File 命中分支:
 //!
@@ -105,7 +105,7 @@ impl GetMobileSyncFileUseCase {
     ) -> Result<GetMobileSyncFileOutput, GetMobileSyncFileError> {
         let rep = self
             .snapshot_port
-            .latest_paste_representation()
+            .latest_preview_representation()
             .await?
             .ok_or(GetMobileSyncFileError::NotFound)?;
 
@@ -215,7 +215,7 @@ impl GetMobileSyncFileUseCase {
             item_type = ?item_type,
             mime = %mime,
             bytes_len = rep.bytes.len(),
-            "mobile_sync get_file: serving paste rep bytes"
+            "mobile_sync get_file: serving preview rep bytes"
         );
 
         Ok(GetMobileSyncFileOutput {
@@ -304,7 +304,7 @@ mod tests {
         staging: Arc<MockStaging>,
     ) -> GetMobileSyncFileUseCase {
         let mut port = MockSnapPort::new();
-        port.expect_latest_paste_representation()
+        port.expect_latest_preview_representation()
             .times(1)
             .return_once(move || rep);
         GetMobileSyncFileUseCase::new(Arc::new(port), staging)

--- a/crates/uc-application/src/usecases/mobile_sync/get_file.rs
+++ b/crates/uc-application/src/usecases/mobile_sync/get_file.rs
@@ -272,7 +272,7 @@ mod tests {
             async fn latest_paste_representation(
                 &self,
             ) -> Result<Option<LatestPasteRepresentation>, LatestClipboardSnapshotError>;
-            async fn latest_plain_text_preferred_representation(
+            async fn latest_preview_representation(
                 &self,
             ) -> Result<Option<LatestPasteRepresentation>, LatestClipboardSnapshotError>;
         }

--- a/crates/uc-application/src/usecases/mobile_sync/get_latest_doc.rs
+++ b/crates/uc-application/src/usecases/mobile_sync/get_latest_doc.rs
@@ -15,9 +15,9 @@
 //!   ↓
 //! GetLatestMobileSyncDocUseCase::execute          (本 use case)
 //!   ↓
-//! LatestClipboardSnapshotPort::latest_plain_text_preferred_representation
+//! LatestClipboardSnapshotPort::latest_preview_representation
 //!   ↓
-//! adapter (P5a.8): clipboard_entry → selection → 选 plaintext rep → blob
+//! adapter (P5a.8): clipboard_entry → selection → preview_rep_id → blob
 //! ```
 //!
 //! ## 类型映射(rep mime/format → SyncClipboard `type`)
@@ -28,15 +28,17 @@
 //! | `image/*` 或 `format_id == image` | `Image` | filename | `Some(filename)` | `true` |
 //! | 其他 | `Text` | utf-8 内容 | `None` | `false` |
 //!
-//! ## plaintext 偏好(port 端已收口)
+//! ## 内容优先级(复用 UiPreview 选型,port 端已收口)
 //!
-//! 移动端只能正确解释纯文本字节,所以这里调
-//! [`LatestClipboardSnapshotPort::latest_plain_text_preferred_representation`]
-//! 而不是 paste-priority 入口 —— 当 entry 同时承载 `text/plain` 与 `text/rtf`
-//! / `text/html` 时,port 已经把 plaintext rep 挑出来,iPhone 不再收到
-//! `{\rtf1\ansi…}` 或 HTML 片段。entry 里只有富文本时 port 会兜底回退到
-//! paste rep,此时这里仍会按 Text 分支 `from_utf8_lossy` 字节流不让整条
-//! GET 链路断,但这是"没有更好的选择"的副作用,而非默认行为。
+//! 移动端只能正确解释纯文本 / 图片 / 文件字节,不能渲染 markup,所以这里调
+//! [`LatestClipboardSnapshotPort::latest_preview_representation`] 而不是
+//! paste-priority 入口 —— 后者按"系统默认粘贴目标"选型(为本机粘贴保格式,
+//! `text/html` / `text/rtf` 可能排在 `image/*` 之前),前者复用桌面 UI 已经
+//! 在用的 `preview_rep_id`(files > plain text > image > rich text > uri >
+//! unknown,由 `uc-core` 选型策略统一算好),不会把一段网页 markup 当作主体
+//! 同步出去。entry 里确实只有富文本(没有更优先的候选)时,`preview_rep_id`
+//! 仍会退化成富文本 rep,这里按 Text 分支 `from_utf8_lossy` 兜底不让整条
+//! GET 链路断,但这是"没有更好选择"时的兜底,而非默认行为。
 //!
 //! ## 方案 X(不区分来源)
 //!
@@ -83,7 +85,7 @@ impl GetLatestMobileSyncDocUseCase {
     pub(crate) async fn execute(&self) -> Result<SyncClipboardMeta, GetLatestMobileSyncDocError> {
         let rep = self
             .snapshot_port
-            .latest_plain_text_preferred_representation()
+            .latest_preview_representation()
             .await?
             .ok_or(GetLatestMobileSyncDocError::NotFound)?;
 
@@ -191,7 +193,7 @@ mod tests {
             async fn latest_paste_representation(
                 &self,
             ) -> Result<Option<LatestPasteRepresentation>, LatestClipboardSnapshotError>;
-            async fn latest_plain_text_preferred_representation(
+            async fn latest_preview_representation(
                 &self,
             ) -> Result<Option<LatestPasteRepresentation>, LatestClipboardSnapshotError>;
         }
@@ -201,9 +203,9 @@ mod tests {
         rep: Result<Option<LatestPasteRepresentation>, LatestClipboardSnapshotError>,
     ) -> GetLatestMobileSyncDocUseCase {
         let mut port = MockSnapPort::new();
-        // use case 走 plaintext-preferred 入口; 这里 mock 该方法即可,
-        // adapter 内部的"选哪条 rep"逻辑由 adapter 自己的单测覆盖。
-        port.expect_latest_plain_text_preferred_representation()
+        // use case 走 preview 入口; 这里 mock 该方法即可, adapter 内部
+        // "选哪条 rep"的逻辑由 adapter 自己的单测覆盖。
+        port.expect_latest_preview_representation()
             .times(1)
             .return_once(move || rep);
         GetLatestMobileSyncDocUseCase::new(Arc::new(port))
@@ -365,10 +367,11 @@ mod tests {
 
     #[tokio::test]
     async fn rich_text_html_classified_as_text() {
-        // 现在的语义: port 在 entry 里找不到 text/plain rep 时, 兜底返回 paste
-        // rep (这里是 text/html), use case 仍按 Text 分支 from_utf8_lossy 兜底,
-        // 不让整条 GET 链路断。配合 adapter 的 plaintext-preferred 选择, html
-        // 字节落到 iPhone 的概率只剩"entry 里压根没有 plaintext"这一种情况。
+        // 现在的语义: port 返回的 preview rep 如果本身就是 text/html(entry
+        // 里没有更优先的候选 —— 没有 files/plain text/image), use case 仍按
+        // Text 分支 from_utf8_lossy 兜底,不让整条 GET 链路断。配合 adapter
+        // 复用的 UiPreview 选型, html 字节落到 iPhone 的概率只剩"entry 里
+        // 确实只有富文本"这一种情况。
         let body = b"<p>hi</p>".to_vec();
         let uc = build_uc_returning(Ok(Some(rep(
             "entry-html-1",
@@ -385,9 +388,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn use_case_consumes_plain_text_preferred_entry_point() {
-        // 回归测: 锁定 use case 调的是 latest_plain_text_preferred_representation
-        // 而非 latest_paste_representation。build_uc_returning 仅 expect 新方法
+    async fn use_case_consumes_preview_representation_entry_point() {
+        // 回归测: 锁定 use case 调的是 latest_preview_representation 而非
+        // latest_paste_representation。build_uc_returning 仅 expect 新方法
         // (调用次数 = 1), 若 use case 退回去调老方法这条测试会因为 mockall
         // strict mode 在 drop 时 panic。
         let uc = build_uc_returning(Ok(Some(rep(

--- a/crates/uc-application/src/usecases/mobile_sync/latest_snapshot_adapter.rs
+++ b/crates/uc-application/src/usecases/mobile_sync/latest_snapshot_adapter.rs
@@ -52,8 +52,7 @@ use async_trait::async_trait;
 
 use uc_core::blob::ports::BlobReaderPort;
 use uc_core::clipboard::{
-    is_plain_text_mime_or_format, ClipboardEntry, ClipboardSelectionDecision,
-    PersistedClipboardRepresentation,
+    ClipboardEntry, ClipboardSelectionDecision, PersistedClipboardRepresentation,
 };
 use uc_core::ids::{EntryId, EventId, RepresentationId};
 use uc_core::mobile_sync::LatestPasteRepresentation;
@@ -236,55 +235,22 @@ impl LatestClipboardSnapshotPort for LatestClipboardSnapshotAdapter {
         ))
     }
 
-    async fn latest_plain_text_preferred_representation(
+    async fn latest_preview_representation(
         &self,
     ) -> Result<Option<LatestPasteRepresentation>, LatestClipboardSnapshotError> {
         let Some((entry, decision, snapshot_hash)) = self.load_entry_and_selection().await? else {
             return Ok(None);
         };
-        let paste_rep_id = decision.selection.paste_rep_id.clone();
 
-        // 候选顺序: paste 优先(若它本身就是 plaintext, 一次 IO 直接命中);
-        // 再依次扫 primary 与 secondary 中其余的 rep。policy v1 下 primary 与
-        // paste 同一份, 这里靠去重短路; 但代码不再依赖该等式 —— 未来若 v2
-        // 让 primary ≠ paste, 本方法仍能正确扫描全部候选。
-        let mut candidates: Vec<RepresentationId> =
-            Vec::with_capacity(2 + decision.selection.secondary_rep_ids.len());
-        let push_unique = |id: RepresentationId, list: &mut Vec<RepresentationId>| {
-            if !list.contains(&id) {
-                list.push(id);
-            }
-        };
-        push_unique(paste_rep_id.clone(), &mut candidates);
-        push_unique(decision.selection.primary_rep_id.clone(), &mut candidates);
-        for sid in &decision.selection.secondary_rep_ids {
-            push_unique(sid.clone(), &mut candidates);
-        }
-
-        // 扫描时缓存 paste rep —— 找不到 plaintext 时直接复用, 避免二次 IO。
-        let mut paste_rep_cached: Option<PersistedClipboardRepresentation> = None;
-        for rep_id in &candidates {
-            let Some(rep) = self.fetch_representation(&entry.event_id, rep_id).await? else {
-                continue;
-            };
-            if is_plain_text_mime_or_format(rep.mime_type.as_ref(), &rep.format_id) {
-                return Ok(Some(
-                    self.materialize(entry.entry_id, snapshot_hash, rep).await?,
-                ));
-            }
-            if rep_id == &paste_rep_id {
-                paste_rep_cached = Some(rep);
-            }
-        }
-
-        // 无 plaintext rep —— 回退到 paste rep(可能是 text/rtf / text/html /
-        // image 等), 由消费方按 mime 自己处理。
-        let Some(paste_rep) = paste_rep_cached else {
+        let Some(rep) = self
+            .fetch_representation(&entry.event_id, &decision.selection.preview_rep_id)
+            .await?
+        else {
             return Ok(None);
         };
+
         Ok(Some(
-            self.materialize(entry.entry_id, snapshot_hash, paste_rep)
-                .await?,
+            self.materialize(entry.entry_id, snapshot_hash, rep).await?,
         ))
     }
 }
@@ -310,17 +276,17 @@ mod tests {
     //! | resolver error | Err(Resolution) |
     //! | blob_reader error | Err(Resolution) |
     //!
-    //! plaintext-preference (latest_plain_text_preferred_representation)
-    //! incremental coverage:
+    //! latest_preview_representation incremental coverage:
     //!
     //! | input | expected |
     //! |---|---|
-    //! | paste is itself text/plain | use paste directly, do not read secondary |
-    //! | paste is text/rtf, secondary has text/plain | switch to the plaintext rep |
-    //! | paste is text/html, secondary all non-plaintext | fall back to the paste rep |
-    //! | paste is image, no secondary | use the paste rep directly |
-    //! | format_id=text but mime=None | treated as plaintext (via the format_id fallback) |
-    //! | paste rep row missing but secondary has plaintext | return the plaintext secondary |
+    //! | preview_rep_id differs from paste_rep_id (e.g. paste=html, preview=image) | resolve preview_rep_id, never touch paste_rep_id |
+    //! | preview_rep_id row missing | Ok(None) |
+    //!
+    //! The relative ranking of representations (files > plain text > image >
+    //! rich text > uri > unknown) is `SelectRepresentationPolicyV1`'s
+    //! responsibility (`uc-core::clipboard::policy::v1`), not this adapter's —
+    //! it is covered there.
 
     use super::*;
 
@@ -774,16 +740,15 @@ mod tests {
         assert!(matches!(err, LatestClipboardSnapshotError::Resolution(_)));
     }
 
-    // ─── plaintext-preferred path ───────────────────────────────────────
+    // ─── preview (UiPreview-selected) representation ────────────────────
     //
-    // 这条路径会反复读 representation_repo / resolver, 单次返回的旧 fake 顶不
-    // 住,这里另起一套按 RepresentationId 路由的 fake。每个 rep_id 注册一份
-    // (metadata, resolved-payload) 配对, fake 各自挑各自要的部分。
+    // This path resolves by `RepresentationId`, not a single fixed rep — the
+    // one-shot fakes above can't route by id, so it gets its own fakes.
 
     use std::collections::HashMap;
 
-    /// 按 rep_id 路由的 RepresentationRepo —— 注册哪些 rep 存在 / 各自的
-    /// metadata, 调用次数不限。
+    /// Routes `get_representation` by rep id — register whichever reps exist
+    /// for the scenario, callable any number of times.
     struct FakeRepRepoById {
         reps: HashMap<RepresentationId, PersistedClipboardRepresentation>,
     }
@@ -805,7 +770,7 @@ mod tests {
         }
     }
 
-    /// 按 rep.id 路由的 Resolver —— 用 rep_id 找对应的 ResolvedClipboardPayload。
+    /// Routes `resolve` by rep id to a registered `ResolvedClipboardPayload`.
     struct FakeResolverById {
         payloads: HashMap<RepresentationId, ResolvedClipboardPayload>,
     }
@@ -832,157 +797,46 @@ mod tests {
         }
     }
 
-    fn selection_with_secondary(
-        entry_id: &str,
-        paste_rep: &str,
-        secondary: &[&str],
-    ) -> ClipboardSelectionDecision {
-        let paste = RepresentationId::from(paste_rep);
-        ClipboardSelectionDecision::new(
-            EntryId::from(entry_id),
+    #[tokio::test]
+    async fn preview_resolves_preview_rep_id_not_paste_rep_id() {
+        // Regression for issue #1210: a browser image copy leaves
+        // `paste_rep_id` pointing at the DefaultPaste-selected text/html
+        // markup (RichText outranks Image there, to preserve formatting on
+        // local paste), while `preview_rep_id` — the same choice already
+        // used to render the desktop UI — correctly points at the image/png
+        // representation (UiPreview ranks Image above RichText). This method
+        // must follow `preview_rep_id`.
+        //
+        // The html rep is deliberately left unregistered in
+        // `FakeRepRepoById`: if the adapter regresses to reading
+        // `paste_rep_id` again, the lookup returns `None` and this test
+        // fails loudly instead of silently passing.
+        let image = rep("r-image", "image", Some("image/png"));
+        let selection = ClipboardSelectionDecision::new(
+            EntryId::from("e1"),
             ClipboardSelection {
-                primary_rep_id: paste.clone(),
-                secondary_rep_ids: secondary
-                    .iter()
-                    .map(|s| RepresentationId::from(*s))
-                    .collect(),
-                preview_rep_id: paste.clone(),
-                paste_rep_id: paste,
+                primary_rep_id: RepresentationId::from("r-html"),
+                secondary_rep_ids: vec![RepresentationId::from("r-image")],
+                preview_rep_id: RepresentationId::from("r-image"),
+                paste_rep_id: RepresentationId::from("r-html"),
                 policy_version: SelectionPolicyVersion::V1,
             },
-        )
-    }
-
-    #[tokio::test]
-    async fn plain_text_pref_uses_paste_when_paste_is_plain_text() {
-        // paste rep 本身就是 text/plain → 一次命中, 不需要扫 secondary。
-        let plain = rep("r-plain", "text", Some("text/plain"));
+        );
         let adapter = build_adapter(
             FakeSource::with_entry(entry("e1", "ev1")),
-            Arc::new(FakeSelectionRepo::ok(Some(selection_with_secondary(
-                "e1",
-                "r-plain",
-                &[],
-            )))),
-            Arc::new(FakeRepRepoById::new(vec![plain])),
+            Arc::new(FakeSelectionRepo::ok(Some(selection))),
+            Arc::new(FakeRepRepoById::new(vec![image])),
             Arc::new(FakeResolverById::new(vec![(
-                RepresentationId::from("r-plain"),
+                RepresentationId::from("r-image"),
                 ResolvedClipboardPayload::Inline {
-                    mime: "text/plain".into(),
-                    bytes: b"hello".to_vec(),
-                },
-            )])),
-            dummy_blob_reader(),
-        );
-        let out = adapter
-            .latest_plain_text_preferred_representation()
-            .await
-            .unwrap()
-            .unwrap();
-        assert_eq!(out.format_id, FormatId::from("text"));
-        assert_eq!(out.mime.as_ref().map(|m| m.as_str()), Some("text/plain"));
-        assert_eq!(out.bytes, b"hello".to_vec());
-    }
-
-    #[tokio::test]
-    async fn plain_text_pref_swaps_rtf_paste_for_plain_text_secondary() {
-        // paste 是 text/rtf, secondary 有 text/plain → 切到 plaintext rep。
-        // 这是修复的关键路径: 移动端不再收到 `{\rtf1\ansi...}` 字节流。
-        let rtf = rep("r-rtf", "rtf", Some("text/rtf"));
-        let plain = rep("r-plain", "text", Some("text/plain"));
-        let adapter = build_adapter(
-            FakeSource::with_entry(entry("e1", "ev1")),
-            Arc::new(FakeSelectionRepo::ok(Some(selection_with_secondary(
-                "e1",
-                "r-rtf",
-                &["r-plain"],
-            )))),
-            Arc::new(FakeRepRepoById::new(vec![rtf, plain])),
-            Arc::new(FakeResolverById::new(vec![
-                (
-                    RepresentationId::from("r-rtf"),
-                    ResolvedClipboardPayload::Inline {
-                        mime: "text/rtf".into(),
-                        bytes: b"{\\rtf1\\ansi hello}".to_vec(),
-                    },
-                ),
-                (
-                    RepresentationId::from("r-plain"),
-                    ResolvedClipboardPayload::Inline {
-                        mime: "text/plain".into(),
-                        bytes: b"hello".to_vec(),
-                    },
-                ),
-            ])),
-            dummy_blob_reader(),
-        );
-        let out = adapter
-            .latest_plain_text_preferred_representation()
-            .await
-            .unwrap()
-            .unwrap();
-        assert_eq!(out.format_id, FormatId::from("text"));
-        assert_eq!(out.mime.as_ref().map(|m| m.as_str()), Some("text/plain"));
-        assert_eq!(out.bytes, b"hello".to_vec());
-    }
-
-    #[tokio::test]
-    async fn plain_text_pref_falls_back_to_paste_when_no_plain_text_available() {
-        // paste 是 text/html, secondary 也是 text/html (无 plaintext) → 兜底
-        // 用 paste rep 本身, 与 latest_paste_representation 行为一致。
-        let html_paste = rep("r-html", "html", Some("text/html"));
-        let html_alt = rep("r-html-alt", "html", Some("text/html"));
-        let adapter = build_adapter(
-            FakeSource::with_entry(entry("e1", "ev1")),
-            Arc::new(FakeSelectionRepo::ok(Some(selection_with_secondary(
-                "e1",
-                "r-html",
-                &["r-html-alt"],
-            )))),
-            Arc::new(FakeRepRepoById::new(vec![html_paste, html_alt])),
-            Arc::new(FakeResolverById::new(vec![(
-                RepresentationId::from("r-html"),
-                ResolvedClipboardPayload::Inline {
-                    mime: "text/html".into(),
-                    bytes: b"<p>hi</p>".to_vec(),
-                },
-            )])),
-            dummy_blob_reader(),
-        );
-        let out = adapter
-            .latest_plain_text_preferred_representation()
-            .await
-            .unwrap()
-            .unwrap();
-        assert_eq!(out.format_id, FormatId::from("html"));
-        assert_eq!(out.mime.as_ref().map(|m| m.as_str()), Some("text/html"));
-        assert_eq!(out.bytes, b"<p>hi</p>".to_vec());
-    }
-
-    #[tokio::test]
-    async fn plain_text_pref_keeps_image_paste_when_no_secondary() {
-        // paste 是 image, 没 secondary → 直接用 paste rep。Image rep 不会被
-        // 误判为 plaintext, 行为与 latest_paste_representation 一致。
-        let img = rep("r-img", "image", Some("image/png"));
-        let adapter = build_adapter(
-            FakeSource::with_entry(entry("e1", "ev1")),
-            Arc::new(FakeSelectionRepo::ok(Some(selection_with_secondary(
-                "e1",
-                "r-img",
-                &[],
-            )))),
-            Arc::new(FakeRepRepoById::new(vec![img])),
-            Arc::new(FakeResolverById::new(vec![(
-                RepresentationId::from("r-img"),
-                ResolvedClipboardPayload::BlobRef {
                     mime: "image/png".into(),
-                    blob_id: BlobId::from("blob-img"),
+                    bytes: vec![0x89, 0x50, 0x4E, 0x47],
                 },
             )])),
-            Arc::new(FakeBlobReader::ok(vec![0x89, 0x50, 0x4E, 0x47])),
+            dummy_blob_reader(),
         );
         let out = adapter
-            .latest_plain_text_preferred_representation()
+            .latest_preview_representation()
             .await
             .unwrap()
             .unwrap();
@@ -992,74 +846,18 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn plain_text_pref_recognizes_format_id_text_without_mime() {
-        // 没有显式 mime, 但 format_id="text" → 走 is_plain_text_mime_or_format
-        // 的 format_id 兜底分支, 仍然识别为 plaintext。
-        let no_mime = rep("r-text-only", "text", None);
+    async fn preview_returns_none_when_representation_row_missing() {
         let adapter = build_adapter(
             FakeSource::with_entry(entry("e1", "ev1")),
-            Arc::new(FakeSelectionRepo::ok(Some(selection_with_secondary(
-                "e1",
-                "r-text-only",
-                &[],
-            )))),
-            Arc::new(FakeRepRepoById::new(vec![no_mime])),
-            Arc::new(FakeResolverById::new(vec![(
-                RepresentationId::from("r-text-only"),
-                ResolvedClipboardPayload::Inline {
-                    mime: "".into(),
-                    bytes: b"hi".to_vec(),
-                },
-            )])),
+            Arc::new(FakeSelectionRepo::ok(Some(selection("e1", "r1")))),
+            Arc::new(FakeRepRepo::ok(None)),
+            dummy_resolver(),
             dummy_blob_reader(),
         );
-        let out = adapter
-            .latest_plain_text_preferred_representation()
+        assert!(adapter
+            .latest_preview_representation()
             .await
             .unwrap()
-            .unwrap();
-        assert_eq!(out.format_id, FormatId::from("text"));
-        assert!(out.mime.is_none());
-        assert_eq!(out.bytes, b"hi".to_vec());
-    }
-
-    #[tokio::test]
-    async fn plain_text_pref_returns_secondary_plain_text_when_paste_rep_row_missing() {
-        // 边界: selection 指向的 paste_rep_id 在 representation_repo 里查不到
-        // (Ok(None)), 但 secondary 中存在 plaintext rep。
-        //
-        // 与 latest_paste_representation 的语义差异: 后者一旦 paste rep 查
-        // 不到就直接 Ok(None); 而 plaintext 偏好入口的目标是"尽量给出可读
-        // 纯文本", 因此即便 paste rep 行缺失, secondary 里有 plaintext 也
-        // 应当返回它。该测试锁定这条语义不被无意改回去。
-        //
-        // 注: FakeRepRepoById 只注册 plaintext rep, 不注册 paste rep ——
-        // 模拟 paste 行被外部清理 / 还未落库的场景。
-        let plain = rep("r-plain", "text", Some("text/plain"));
-        let adapter = build_adapter(
-            FakeSource::with_entry(entry("e1", "ev1")),
-            Arc::new(FakeSelectionRepo::ok(Some(selection_with_secondary(
-                "e1",
-                "r-missing-paste",
-                &["r-plain"],
-            )))),
-            Arc::new(FakeRepRepoById::new(vec![plain])),
-            Arc::new(FakeResolverById::new(vec![(
-                RepresentationId::from("r-plain"),
-                ResolvedClipboardPayload::Inline {
-                    mime: "text/plain".into(),
-                    bytes: b"hello".to_vec(),
-                },
-            )])),
-            dummy_blob_reader(),
-        );
-        let out = adapter
-            .latest_plain_text_preferred_representation()
-            .await
-            .unwrap()
-            .unwrap();
-        assert_eq!(out.format_id, FormatId::from("text"));
-        assert_eq!(out.mime.as_ref().map(|m| m.as_str()), Some("text/plain"));
-        assert_eq!(out.bytes, b"hello".to_vec());
+            .is_none());
     }
 }

--- a/crates/uc-core/src/clipboard/policy/v1.rs
+++ b/crates/uc-core/src/clipboard/policy/v1.rs
@@ -417,4 +417,45 @@ mod tests {
             "Small image-from-file should still receive UiPreview 100 boost"
         );
     }
+
+    #[test]
+    fn ui_preview_prefers_image_over_html_when_no_plain_text() {
+        // Issue #1210: copying an image from a browser puts both text/html
+        // (a markup fragment describing the page, not the image itself) and
+        // image/png on the clipboard, with no text/plain. DefaultPaste ranks
+        // RichText above Image (preserves formatting when pasted into e.g.
+        // Word), but mobile sync's outbound path reuses UiPreview — it must
+        // not surface raw HTML markup when a real image representation is
+        // available.
+        let html = rep(
+            "html",
+            "text/html",
+            b"<img src=\"https://example.com/x.png\">".to_vec(),
+        );
+        let image = rep(
+            "image",
+            "image/png",
+            vec![0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A],
+        );
+        let image_id = image.id.clone();
+        let html_id = html.id.clone();
+
+        let snapshot = SystemClipboardSnapshot {
+            ts_ms: 0,
+            representations: vec![html, image],
+            file_content_digests: Vec::new(),
+        };
+
+        let policy = SelectRepresentationPolicyV1::new();
+        let selection = policy.select(&snapshot).expect("selection succeeds");
+
+        assert_eq!(
+            selection.preview_rep_id, image_id,
+            "UiPreview should pick Image (80) over RichText/html (70) when no plain text is present"
+        );
+        assert_ne!(
+            selection.preview_rep_id, html_id,
+            "UiPreview must not surface the html markup rep as the entry's content"
+        );
+    }
 }

--- a/crates/uc-core/src/ports/mobile_sync.rs
+++ b/crates/uc-core/src/ports/mobile_sync.rs
@@ -260,21 +260,25 @@ pub trait LatestClipboardSnapshotPort: Send + Sync {
         &self,
     ) -> Result<Option<LatestPasteRepresentation>, LatestClipboardSnapshotError>;
 
-    /// 拿到当前 entry 中**plain-text 偏好**的 representation。
+    /// Return the entry's UiPreview-selected representation, materialized with
+    /// its bytes.
     ///
-    /// 选择规则:在该 entry 的 selection 涉及的全部 rep(primary +
-    /// secondary)中,优先返回 mime `text/plain` 或 format_id `text` 的 rep;
-    /// 若都没有,fallback 到 paste-priority rep,与
-    /// [`Self::latest_paste_representation`] 行为一致。
+    /// Selection rule: this is `preview_rep_id` from the entry's persisted
+    /// `ClipboardSelection` — a single representation chosen across the whole
+    /// representation set by relative legibility (files > plain text > image >
+    /// rich text / markup > uri > unknown), computed once by the selection
+    /// policy at capture time.
     ///
-    /// 领域定位:与 [`Self::latest_paste_representation`] 的差异在于优先级
-    /// 不再是"系统默认粘贴目标",而是"纯文本字节"。当 paste-priority rep
-    /// 是富文本(`text/rtf` / `text/html`)而 entry 同时承载了 `text/plain`
-    /// 备选时,本方法返回 plaintext 备选;反之,当 entry 不存在 plaintext
-    /// 备选时,行为退化为 paste 入口。
+    /// Domain positioning: differs from [`Self::latest_paste_representation`],
+    /// which is anchored on `paste_rep_id` (the system default-paste target,
+    /// tuned to preserve formatting when pasted into a desktop app) and can
+    /// resolve to a markup representation (`text/html` / `text/rtf`) even when
+    /// a plainer, more broadly consumable representation exists on the same
+    /// entry.
     ///
-    /// 无任何 entry 时返回 `Ok(None)`,与 paste 入口语义一致。
-    async fn latest_plain_text_preferred_representation(
+    /// Returns `Ok(None)` when there is no entry, or when the referenced
+    /// representation row cannot be found.
+    async fn latest_preview_representation(
         &self,
     ) -> Result<Option<LatestPasteRepresentation>, LatestClipboardSnapshotError>;
 }


### PR DESCRIPTION
## Summary

- Browser image copies leave both `text/html` and `image/png` on the clipboard with no `text/plain`. The mobile-sync outbound path reused the DefaultPaste-selected `paste_rep_id` (which ranks RichText above Image, to preserve formatting on local paste) with an ad-hoc plaintext-scan-then-fallback bolted on top, so entries with no plain-text candidate fell back to the html markup rep — iOS received a line of HTML instead of the image (5030dd3).
- Rename the port method to `latest_preview_representation` and read `preview_rep_id` directly — the same UiPreview selection already used to render the desktop UI, which already ranks files > plain text > image > rich text > uri > unknown. This drops the adapter's duplicated scan/fallback/guard logic entirely and reuses the single source of truth computed once by the selection policy at capture time (5030dd3).
- Add a regression test at the actual decision point (`SelectRepresentationPolicyV1`) locking in that UiPreview picks the image representation over html when no plain-text candidate exists (add53c0).

Closes #1210.

## Test plan

- [x] `cargo test -p uc-application -p uc-core` — 884 tests passed, 0 failed
- [x] `cargo clippy -p uc-application -p uc-core --all-targets` — no new warnings in touched files
- [ ] Manual repro on the reporter's setup: copy an image inside a Win10 browser, confirm the iOS client (SyncClipboard-compatible client) receives the image instead of an HTML fragment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mobile clipboard sync now uses the captured *preview* representation for the latest item, improving what appears in mobile preview views.
  * Preview selection prioritizes the most legible visual content (for example, images) when plain text isn’t available.

* **Bug Fixes**
  * Fixed preview retrieval to avoid falling back to an incorrect representation source.
  * Updated behavior so missing preview data safely returns “no result” instead of disrupting sync.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->