### PR TITLE
docs: add maintainer/trust disclosure page (ABOUT.md)

### DIFF
--- a/ABOUT.md
+++ b/ABOUT.md
@@ -1,0 +1,46 @@
+# About & Maintainers
+
+> A Chinese version is available — see [`ABOUT_ZH.md`](./ABOUT_ZH.md).
+
+UniClipboard syncs clipboard content — potentially sensitive data such as
+passwords, tokens, and personal notes — across your devices. Before trusting a
+tool with that kind of access, it's reasonable to want to know who's behind
+it. This page answers that, alongside [`SECURITY.md`](./SECURITY.md), which
+already covers vulnerability reporting and release verification.
+
+## Who maintains this project
+
+UniClipboard is maintained by a single independent maintainer:
+
+- **Yuhang Wu** ([@mkdir700](https://github.com/mkdir700) on GitHub)
+
+The repository lives under the [`UniClipboard`](https://github.com/UniClipboard)
+GitHub organization. The org exists to host the project's repositories; it is
+not a company, foundation, or legal entity.
+
+## Governance
+
+This is a solo-maintained, part-time open-source project — not a company-backed
+or foundation-backed effort. There is no core team. Roadmap, architecture, and
+release decisions are made by the maintainer, informed by community issues and
+pull requests.
+
+## How to reach us
+
+- **General questions, feedback, feature requests:** open a
+  [GitHub Issue](https://github.com/UniClipboard/UniClipboard/issues).
+  (GitHub Discussions is not enabled on this repository — Issues are the
+  primary channel.)
+- **Security vulnerabilities:** do **not** open a public issue. Follow the
+  private reporting process in [`SECURITY.md`](./SECURITY.md) instead.
+
+## Legal entity / jurisdiction
+
+There is no registered company, foundation, or other legal entity behind
+UniClipboard. The project is released by an individual maintainer under the
+[AGPL-3.0 license](./LICENSE), on an as-is basis.
+
+This disclosure is not a legally mandated notice (e.g. Germany's
+*Impressumspflicht* applies to commercial telemedia, not to a personal,
+non-commercial open-source project) — it's provided voluntarily for
+transparency.

--- a/ABOUT_ZH.md
+++ b/ABOUT_ZH.md
@@ -1,0 +1,29 @@
+# 关于本项目 & 维护者信息
+
+[English](./ABOUT.md) | 简体中文
+
+UniClipboard 会在你的设备之间同步剪贴板内容——其中可能包含密码、令牌、个人笔记等敏感数据。在信任一个拥有这类访问权限的工具之前，了解"这背后是谁"是合理的诉求。本页面就是回答这个问题，与已经覆盖漏洞上报和发布包校验的 [`SECURITY.md`](./SECURITY.md) 互为补充。
+
+## 谁在维护这个项目
+
+UniClipboard 由一名独立维护者维护：
+
+- **吴雨航**（GitHub：[@mkdir700](https://github.com/mkdir700)）
+
+仓库托管在 [`UniClipboard`](https://github.com/UniClipboard) 这个 GitHub 组织下。该组织的作用只是承载项目仓库，并非公司、基金会或任何法律实体。
+
+## 治理模式
+
+这是一个个人业余维护的开源项目，不是公司或基金会背景的项目，目前没有核心团队。路线图、架构和发版决策均由维护者本人做出，会参考社区的 issue 与 PR 反馈。
+
+## 如何联系我们
+
+- **一般咨询、反馈、功能建议**：请提交 [GitHub Issue](https://github.com/UniClipboard/UniClipboard/issues)。
+  （本仓库尚未启用 GitHub Discussions，Issue 是目前的主要沟通渠道。）
+- **安全漏洞**：请勿提交公开 issue，按照 [`SECURITY.md`](./SECURITY.md) 中的私下上报流程处理。
+
+## 法律实体 / 司法管辖区
+
+UniClipboard 背后没有注册的公司、基金会或其他法律实体。项目由个人维护者以 [AGPL-3.0 协议](./LICENSE) 发布，按现状（as-is）提供，不附加额外担保。
+
+这份声明并非法律强制要求的披露（例如德国的 *Impressumspflicht* 适用于商业性电信媒体服务，而非个人的、非商业性质的开源项目）——它是我们出于透明度考虑主动提供的信息。

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@
 </div>
 
 <p align="center">English | <a href="./README_ZH.md">简体中文</a></p>
+<p align="center"><a href="./ABOUT.md">Who maintains this project? (About &amp; Trust)</a></p>
 
 ## Project Overview
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -50,6 +50,7 @@
 </div>
 
 <p align="center"><a href="./README.md">English</a> | 简体中文</p>
+<p align="center"><a href="./ABOUT_ZH.md">谁在维护这个项目？（关于本项目 & 信任说明）</a></p>
 
 ## 项目介绍
 

--- a/src/components/setting/AboutSection.tsx
+++ b/src/components/setting/AboutSection.tsx
@@ -412,12 +412,12 @@ const AboutSection: React.FC = () => {
             {t('settings.sections.about.links.termsOfService')}
           </a>
           <a
-            href="https://github.com/UniClipboard/UniClipboard"
+            href="https://github.com/UniClipboard/UniClipboard/blob/main/ABOUT.md"
             className="text-muted-foreground transition-colors hover:text-foreground"
             target="_blank"
             rel="noreferrer"
           >
-            {t('settings.sections.about.links.helpCenter')}
+            {t('settings.sections.about.links.aboutMaintainers')}
           </a>
         </div>
         <p className="text-xs text-muted-foreground/80">{t('settings.sections.about.copyright')}</p>

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -615,11 +615,11 @@
           "becomeSponsor": "Become a sponsor →",
           "githubStar": "Star on GitHub →"
         },
-        "copyright": "© 2025 UniClipboard Team. All rights reserved.",
+        "copyright": "© 2025 UniClipboard. All rights reserved.",
         "links": {
           "privacyPolicy": "Privacy Policy",
           "termsOfService": "Terms of Service",
-          "helpCenter": "Help Center"
+          "aboutMaintainers": "About & Maintainers"
         }
       }
     }

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -606,11 +606,11 @@
           "becomeSponsor": "成为赞助者 →",
           "githubStar": "去 GitHub 点 Star →"
         },
-        "copyright": "© 2025 UniClipboard Team. All rights reserved.",
+        "copyright": "© 2025 UniClipboard. All rights reserved.",
         "links": {
           "privacyPolicy": "隐私政策",
           "termsOfService": "使用条款",
-          "helpCenter": "帮助中心"
+          "aboutMaintainers": "关于与维护者"
         }
       }
     }


### PR DESCRIPTION
## Summary

- Add `ABOUT.md`/`ABOUT_ZH.md` disclosing who maintains UniClipboard (solo maintainer, Yuhang Wu / [@mkdir700](https://github.com/mkdir700), under the `UniClipboard` GitHub org), how to reach them for non-security questions, the governance model, and legal-entity status (f052c8c9d)
- Link both pages prominently from the top of `README.md`/`README_ZH.md`, right under the language switcher, so they're discoverable and not buried (f052c8c9d)
- In the desktop app's Settings → About page, repoint the previously-mislabeled "Help Center" footer link (it duplicated the Privacy Policy / Terms of Service placeholders, all pointing at the repo root) to `ABOUT.md`, relabeled "About & Maintainers", and drop the inaccurate "Team" wording from the in-app copyright line (8d3ca8c2f)

Closes #1223.

## Test plan

- [x] `bun run test -- src/components/setting/__tests__/AboutSection.test.tsx` (8 passed)
- [ ] Reviewer: open Settings → About in the app and confirm the "About & Maintainers" link opens `ABOUT.md` on GitHub, in both English and Chinese locales

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new “About” pages in English and Chinese with project background, maintainer info, contact paths, and trust/privacy guidance.
  * Added prominent links from the main README pages to the new About pages.

* **Changes**
  * Updated the app’s About section footer link to point to the new maintainer information page.
  * Refreshed footer text and links in both languages, including a new maintainer-focused link and updated attribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->