### PR TITLE
fix(ci): sync homebrew-cask fork before branching to avoid workflow-scope push rejection

### DIFF
--- a/.github/workflows/homebrew-cask.yml
+++ b/.github/workflows/homebrew-cask.yml
@@ -103,6 +103,16 @@ jobs:
           git config user.email "release@uniclipboard.app"
           git remote add upstream https://github.com/Homebrew/homebrew-cask.git || true
           DEFAULT_BRANCH=$(gh repo view Homebrew/homebrew-cask --json defaultBranchRef --jq '.defaultBranchRef.name')
+
+          # Keep the fork's default branch fast-forwarded to upstream before branching.
+          # Building the working branch straight off upstream/$DEFAULT_BRANCH (below) carries
+          # whatever .github/workflows/* content upstream currently has. If that differs from
+          # what's already stored on the fork, GitHub refuses the later `git push` because
+          # HOMEBREW_CASK_TOKEN has no `workflow` scope. The merge-upstream API performs the
+          # sync server-side and isn't subject to that scope check, so doing it first keeps
+          # the fork's stored workflow files identical to upstream's and avoids the rejection.
+          gh api -X POST "repos/${FORK_REPO}/merge-upstream" -f branch="$DEFAULT_BRANCH" >/dev/null
+
           git fetch upstream "$DEFAULT_BRANCH"
           git checkout -B "uniclipboard-${VERSION}" "upstream/$DEFAULT_BRANCH"
 


### PR DESCRIPTION
## Summary
- The `homebrew-cask.yml` release job builds the cask-update branch directly off `upstream/main` (Homebrew/homebrew-cask) and force-pushes it to our fork. When upstream's `.github/workflows/actionlint.yml` drifts from what the fork has stored, GitHub rejects the push because `HOMEBREW_CASK_TOKEN` has no `workflow` scope — this is what broke the v0.17.0 run (https://github.com/UniClipboard/UniClipboard/actions/runs/28532241402/job/84584494025).
- Fix: sync the fork's default branch to upstream via the `merge-upstream` API before branching. That's a server-side GitHub operation, not a client push, so it isn't subject to the workflow-scope restriction — it keeps the fork's stored workflow files byte-identical to upstream and avoids the rejection on the subsequent push.

## Test plan
- [x] Verified via API that the fork's `.github/workflows/actionlint.yml` blob SHA (`f1543b1a...`) differs from upstream's (`b0352df8...`), confirming the drift causing the failure.
- [x] Confirmed the prior successful run (2026-06-23, v0.16.0) had matching workflow files, and no successful run has occurred since upstream's drift.
- [ ] After merge, re-run `gh workflow run homebrew-cask.yml -f version=0.17.0` to confirm the cask PR now submits successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the Homebrew cask release process so it stays aligned with the latest upstream workflow changes before continuing.
  * Reduced the chance of release failures caused by outdated workflow content or permission-related push issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->