### PR TITLE
fix(ci): keep new-cask checklist in homebrew-cask PR body for version updates

### DIFF
--- a/.github/workflows/homebrew-cask.yml
+++ b/.github/workflows/homebrew-cask.yml
@@ -132,11 +132,21 @@ jobs:
           RELEASE_URL="https://github.com/UniClipboard/UniClipboard/releases/tag/v${VERSION}"
           if [ "$IS_NEW" -eq 1 ]; then
             INTRO="Adds the UniClipboard macOS GUI cask."
-            NEW_CASK_SECTION="$(printf '\n\nAdditionally, if adding a new cask:\n\n- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).\n- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%%3AHomebrew%%2Fhomebrew-cask+is%%3Aclosed+is%%3Aunmerged+&type=pullrequests) (add your cask'\''s name to the end of the search field).\n- [ ] `brew audit --cask --new <cask>` worked successfully.\n- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.\n- [ ] `brew uninstall --cask <cask>` worked successfully.')"
+            NAMED_CASK_CHECK="[x]"
           else
             INTRO="Updates uniclipboard to ${VERSION}."
-            NEW_CASK_SECTION=""
+            NAMED_CASK_CHECK="[ ]"
           fi
+
+          # Keep the "Additionally, if adding a new cask" section in the body even for
+          # version-only updates: Homebrew/.github's check_template.rb counts every
+          # checkbox line in PULL_REQUEST_TEMPLATE.md, new-cask-only ones included, and
+          # auto-closes the PR once fewer than 75% survive verbatim. Dropping this
+          # section on update PRs left only 4 of 9 checkboxes (44%) and got PR #272721
+          # auto-closed as an "incomplete pull request template". Leave its boxes
+          # unchecked when not applicable instead of omitting the section.
+          NEW_CASK_SECTION="$(printf '\n\nAdditionally, if adding a new cask:\n\n- %s Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).\n- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%%3AHomebrew%%2Fhomebrew-cask+is%%3Aclosed+is%%3Aunmerged+&type=pullrequests) (add your cask'\''s name to the end of the search field).\n- [ ] `brew audit --cask --new <cask>` worked successfully.\n- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.\n- [ ] `brew uninstall --cask <cask>` worked successfully.' \
+            "$NAMED_CASK_CHECK")"
 
           # The checkbox lines below MUST match Homebrew's PULL_REQUEST_TEMPLATE.md
           # verbatim, including the literal `<cask>` placeholder (do NOT substitute the


### PR DESCRIPTION
## Summary
- After the workflow-scope fix landed, the manual re-run for v0.17.0 succeeded and opened `Homebrew/homebrew-cask#272721`, but it was auto-closed seconds later by `github-actions[bot]` as an "incomplete pull request template".
- Root cause: Homebrew/.github's `check_template.rb` counts every checkbox line in `PULL_REQUEST_TEMPLATE.md` — including the "Additionally, if adding a new cask" section — and auto-closes the PR once fewer than 75% survive verbatim in the body. Our script only included that section for brand-new cask PRs (`IS_NEW=1`); version-update PRs (`IS_NEW=0`, our first time hitting this path) dropped it entirely, leaving only 4 of 9 checkboxes (44%).
- Fix: always include the new-cask section verbatim, leaving its boxes unchecked when not applicable (only the intro wording and PR title/commit subject still vary by add vs. update).

## Verification
- Fetched Homebrew's actual `check_template.rb` and `PULL_REQUEST_TEMPLATE.md` and ran the script locally against both the old (broken) and new (fixed) rendered PR bodies:
  - Old body (section omitted): `false`
  - New body (section always included): `true`

## Test plan
- [ ] After merge, re-run `gh workflow run homebrew-cask.yml -f version=0.17.0` and confirm the resulting PR against `Homebrew/homebrew-cask` stays open (not auto-closed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the PR template used for Homebrew cask updates so the “new cask” checkbox is filled in only when appropriate.
  * Version-only updates now keep the full cask checklist visible, with non-applicable items left unchecked for clearer review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->