### PR TITLE
ci: fix release build cache misses (GHA quota eviction + rust-cache key drift)

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -95,11 +95,25 @@ jobs:
         with:
           node-version: lts/*
 
-      - name: install Rust stable
-        uses: dtolnay/rust-toolchain@stable
+      - name: resolve pinned Rust channel
+        id: rust-channel
+        # 见 build.yml 同名 step:CI 装 rust-toolchain.toml 钉死的 channel
+        # (而非浮动 @stable),让 Swatinem/rust-cache 的 rust-environment-hash
+        # key 在 warmup 与 tag build 之间保持稳定,避免 stable 补丁版漂移
+        # (如 1.96.0 -> 1.96.1)导致缓存 key 失配、全量冷编译。
+        shell: bash
+        run: |
+          channel=$(grep -oE 'channel[[:space:]]*=[[:space:]]*"[^"]+"' rust-toolchain.toml | head -1 | sed -E 's/.*"([^"]+)".*/\1/')
+          echo "pinned Rust channel: $channel"
+          echo "channel=$channel" >> "$GITHUB_OUTPUT"
+
+      - name: install Rust toolchain
+        uses: dtolnay/rust-toolchain@master
         with:
-          # Linux 走 musl,需要 rustup 装对应 musl target;
-          # macOS 装两个 darwin target;Windows host=msvc 装 noop。
+          toolchain: ${{ steps.rust-channel.outputs.channel }}
+          # Cross target 直接装到 cargo 实际使用的 pinned toolchain 上,
+          # 因此不再需要单独的 `rustup target add` step。Linux 走 musl,
+          # macOS 装两个 darwin target,Windows host=msvc 为 noop。
           targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || matrix.target }}
 
       - name: Prepend cargo bin to PATH
@@ -107,22 +121,6 @@ jobs:
         # Homebrew rustup 多链导致 `cargo` 落到 rustup-init 的问题。
         shell: bash
         run: echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> "$GITHUB_PATH"
-
-      - name: ensure rust target installed on pinned toolchain
-        # rust-toolchain.toml (repo root) 把 cargo 锁到一个具体 channel,
-        # 跟 dtolnay 装的 stable 是两个独立 toolchain。CLI build 跑 cargo
-        # 时,必须把 target 装到 pinned channel,否则
-        # 与 build.yml 一样会报 `Target ... is not installed`。
-        # 见 dtolnay/rust-toolchain#75。Windows host=msvc 不用装。
-        shell: bash
-        run: |
-          TC=$(rustup show active-toolchain | awk '{print $1}')
-          echo "pinned toolchain: $TC"
-          if [ "${{ matrix.platform }}" = "macos-latest" ]; then
-            rustup target add --toolchain "$TC" aarch64-apple-darwin x86_64-apple-darwin
-          elif [ -n "${{ matrix.target }}" ] && [ "${{ matrix.target }}" != "x86_64-pc-windows-msvc" ]; then
-            rustup target add --toolchain "$TC" "${{ matrix.target }}"
-          fi
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/build-server-image.yml
+++ b/.github/workflows/build-server-image.yml
@@ -93,8 +93,17 @@ jobs:
           context: .
           file: deploy/vps/Dockerfile
           platforms: ${{ matrix.platform }}
-          cache-from: type=gha,scope=server-${{ env.PLATFORM_PAIR }}
-          cache-to: type=gha,mode=max,scope=server-${{ env.PLATFORM_PAIR }}
+          # Registry cache (not type=gha): this workflow only runs on tag
+          # pushes, so a GHA cache would (1) write ~1.4GB of buildkit blobs
+          # scoped to each tag ref that no future tag build can ever restore
+          # (GHA cache is ref-isolated; tags can only read their own ref or
+          # main), and (2) accumulate one such garbage set per release,
+          # blowing past the repo's 10GB GHA cache quota and evicting the
+          # Rust/Bun build caches that release.yml needs. A registry cache
+          # lives in GHCR instead: it costs no GHA quota and is shared across
+          # every tag build, so the Docker layer cache actually gets reused.
+          cache-from: type=registry,ref=${{ steps.img.outputs.image }}:buildcache-${{ env.PLATFORM_PAIR }}
+          cache-to: type=registry,ref=${{ steps.img.outputs.image }}:buildcache-${{ env.PLATFORM_PAIR }},mode=max
           outputs: type=image,name=${{ steps.img.outputs.image }},push-by-digest=true,name-canonical=true,push=true
 
       - name: Export digest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -123,9 +123,32 @@ jobs:
         with:
           bun-version: latest
 
-      - name: install Rust stable
-        uses: dtolnay/rust-toolchain@stable
+      - name: resolve pinned Rust channel
+        id: rust-channel
+        # Single source of truth: rust-toolchain.toml (repo root). CI installs
+        # that SAME pinned channel below instead of a floating `@stable`, so
+        # Swatinem/rust-cache's rust-environment-hash key stays stable between
+        # the weekly cache-warmup run and this release/tag build. A floating
+        # stable drifts (e.g. 1.96.0 -> 1.96.1 between a Monday warmup and a
+        # midweek release) and silently invalidates every Rust cache key,
+        # forcing a full cold rebuild.
+        shell: bash
+        run: |
+          channel=$(grep -oE 'channel[[:space:]]*=[[:space:]]*"[^"]+"' rust-toolchain.toml | head -1 | sed -E 's/.*"([^"]+)".*/\1/')
+          echo "pinned Rust channel: $channel"
+          echo "channel=$channel" >> "$GITHUB_OUTPUT"
+
+      - name: install Rust toolchain
+        uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: ${{ steps.rust-channel.outputs.channel }}
+          # Cross-compile targets are installed straight onto the pinned
+          # toolchain that cargo actually uses (rust-toolchain.toml override),
+          # so no separate `rustup target add` step is needed. Missing targets
+          # here were the real cause of `Target ... is not installed`
+          # (25960898069 / 25961183688, dtolnay/rust-toolchain#75), which only
+          # happened because CI used to install `@stable` — a different
+          # toolchain than the pinned channel cargo runs.
           targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || matrix.target == 'aarch64-pc-windows-msvc' && 'aarch64-pc-windows-msvc' || '' }}
 
       - name: Prepend cargo bin to PATH
@@ -136,34 +159,6 @@ jobs:
         # 这里强制把 rustup 真 proxy 所在目录前置,覆盖 brew 那条。
         shell: bash
         run: echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> "$GITHUB_PATH"
-
-      - name: ensure darwin targets installed on pinned toolchain
-        # rust-toolchain.toml (repo root) 把 cargo 锁到一个具体 channel
-        # (例如 1.95.0),而 dtolnay/rust-toolchain@stable 装的是 stable —
-        # 这是两个独立的 toolchain。跑 cargo 时,target 必须
-        # 已经装到 pinned channel,否则报 `Target ... is not installed`
-        # (25960898069 / 25961183688 的真因,见 dtolnay/rust-toolchain#75)。
-        # 这里先触发 rustup auto-install pinned toolchain,
-        # 再读出 channel 名,显式 `rustup target add --toolchain <channel>`。
-        if: matrix.platform == 'macos-latest'
-        shell: bash
-        run: |
-          TC=$(rustup show active-toolchain | awk '{print $1}')
-          echo "pinned toolchain: $TC"
-          rustup target add --toolchain "$TC" aarch64-apple-darwin x86_64-apple-darwin
-
-      - name: ensure windows arm64 target installed on pinned toolchain
-        # Same pinned-vs-stable split as the darwin step above: the arm64
-        # Windows portable / NSIS build cross-compiles from the x64
-        # windows-latest runner, so the pinned toolchain must have the
-        # aarch64-pc-windows-msvc target (MSVC ARM64 cross tools ship with the
-        # runner's Visual Studio install).
-        if: matrix.target == 'aarch64-pc-windows-msvc'
-        shell: bash
-        run: |
-          TC=$(rustup show active-toolchain | awk '{print $1}')
-          echo "pinned toolchain: $TC"
-          rustup target add --toolchain "$TC" aarch64-pc-windows-msvc
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
## Problem

Recent releases rebuilt Rust from scratch (cold builds) because **every** cache missed. Two independent root causes, both confirmed from the live `v0.17.1-alpha.1` release run logs + the repo's actual cache list.

### Root cause 1 — GHA cache quota blown, Rust caches LRU-evicted

The repo cache totaled **11.22 GB, over GitHub's 10 GB hard limit**:

| type | size | count |
|------|------|-------|
| `buildkit-blob-*` (docker) | **7.04 GB (63%)** | 185 |
| `v0-rust-coverage-*` | 2.72 GB | 5 |
| `Linux-bun-*` | 1.57 GB | 12 |
| `v0-rust-<target>` (what release builds need) | **0 GB** | **0** |

`build-server-image.yml` runs only on tag pushes and used `type=gha,mode=max`. GHA cache is ref-isolated, so each tag wrote ~1.4 GB of buildkit blobs scoped to its own tag ref that **no future tag build can ever restore** — one garbage set accumulated per release. This evicted the `v0-rust-<target>` caches `cache-warmup.yml` writes weekly (verified: the 2026-06-29 warmup saved them; they were gone 3 days later at release time → `No cache found`).

**Fix:** switch the server-image build to a **GHCR registry cache**. Costs no GHA quota and is shared across every tag build, so the Docker layer cache is actually reused.

### Root cause 2 — rust-cache environment-hash key drift

Even a surviving cache wouldn't match. `build.yml` / `build-cli.yml` installed a floating `dtolnay/rust-toolchain@stable` alongside the pinned channel from `rust-toolchain.toml`. `Swatinem/rust-cache` folds every installed rustc version into its env-hash key:

- warmup (06-29): pinned 1.95.0 + stable **1.96.0** → key `...-78c2f855-...`
- release (07-02): pinned 1.95.0 + stable **1.96.1** → key `...-e882b208-...`

Stable drifted, so the key changed and the warmed cache never matched.

**Fix:** install the same pinned channel as `rust-toolchain.toml` (single source of truth) via `@master` + `toolchain` input; cross targets go straight onto it, making the separate "ensure target on pinned toolchain" steps redundant (removed).

## Changes

- `build-server-image.yml`: GHA cache → GHCR registry cache
- `build.yml`, `build-cli.yml`: pin toolchain to `rust-toolchain.toml` channel; drop now-redundant target-install steps

## Ops done alongside this PR

Deleted the existing ~7 GB of `buildkit-blob-*` caches so the quota is freed immediately (they'd otherwise linger until 7-day expiry and keep evicting the next warmup's Rust caches).

## Known residual risk

Even after freeing 7 GB, the sum of warmed Rust caches (6 app targets + CLI + pr-check + 2.7 GB coverage) may still approach 10 GB. If misses persist, next step is trimming which targets get warmed or moving the coverage cache off GHA.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * CI now uses the repository-pinned Rust version for builds, improving consistency across environments.
  * Server image builds now use registry-backed caching, which can speed up repeated builds and better manage cache usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->