### PR TITLE
fix(iroh): actually reset wedged relay DNS resolver + self-test diagnostics

### DIFF
--- a/crates/uc-infra/src/network/iroh/net_recovery.rs
+++ b/crates/uc-infra/src/network/iroh/net_recovery.rs
@@ -53,6 +53,19 @@ use iroh::{Endpoint, Watcher as _};
 use tokio::task::JoinHandle;
 use tracing::{info, warn};
 
+/// Diagnostic DNS self-test target. Resolving it exercises the *same* resolver
+/// the relay/net-report path uses, so a failure here mirrors the relay
+/// "Resolve failed" wedge. `dns.iroh.link` is the N0 discovery domain the
+/// endpoint already depends on under the default relay mode, so probing it adds
+/// no new external dependency. Diagnostic only — nothing branches on the
+/// result; it exists so field logs can distinguish "this process's resolver was
+/// born wedged" from "reset fixed it".
+const DNS_SELFTEST_HOST: &str = "dns.iroh.link";
+
+/// Budget for one self-test lookup. Short so a wedged resolver's timeout does
+/// not stall the watchdog loop for long.
+const DNS_SELFTEST_TIMEOUT: Duration = Duration::from_secs(5);
+
 /// Pacing for the relay self-healing watchdog. All values live here so the
 /// recovery cadence is defined in one place rather than scattered as literals.
 #[derive(Debug, Clone, Copy)]
@@ -195,6 +208,12 @@ async fn run(endpoint: Endpoint, policy: RecoveryPolicy) {
         "relay self-healing watchdog started"
     );
 
+    // Baseline: can this process's resolver resolve at all, right now? On a
+    // healthy start this succeeds; on the wedge (e.g. installer auto-relaunch)
+    // it fails from the very first attempt — the evidence that the resolver was
+    // born with a stale/empty nameserver config, before any reset runs.
+    dns_selftest(&endpoint, "startup").await;
+
     loop {
         let healthy = relay_healthy(&watcher.get());
         let wait = match state.observe(healthy, Instant::now()) {
@@ -226,6 +245,11 @@ async fn run(endpoint: Endpoint, policy: RecoveryPolicy) {
                 // re-check when the network genuinely changed. Harmless no-op
                 // otherwise, and prompts the relay actor to redial sooner.
                 endpoint.network_change().await;
+                // Did the reset restore resolution? Compare against "startup":
+                // startup FAIL + post-reset OK ⇒ the wedge was a stale resolver
+                // and reset is the fix. Still failing ⇒ the root cause is
+                // elsewhere (socket/env) and reset alone is insufficient.
+                dns_selftest(&endpoint, "post-reset").await;
                 Some(next)
             }
         };
@@ -254,6 +278,47 @@ async fn sleep_opt(d: Option<Duration>) {
     match d {
         Some(d) => tokio::time::sleep(d).await,
         None => std::future::pending::<()>().await,
+    }
+}
+
+/// Resolve [`DNS_SELFTEST_HOST`] through the endpoint's own resolver and log
+/// the outcome. Purely diagnostic: it does not gate any decision — it exists so
+/// field logs can pin down *why* the relay is wedged (resolver born with a bad
+/// config vs. reset restoring it). `stage` labels which point in the lifecycle
+/// this probe ran at (`"startup"` / `"post-reset"`).
+async fn dns_selftest(endpoint: &Endpoint, stage: &'static str) {
+    let resolver = match endpoint.dns_resolver() {
+        Ok(resolver) => resolver,
+        Err(err) => {
+            warn!(target: "iroh.net_recovery", stage, error = %err, "DNS self-test skipped: resolver unavailable");
+            return;
+        }
+    };
+    match resolver
+        .lookup_ipv4(DNS_SELFTEST_HOST, DNS_SELFTEST_TIMEOUT)
+        .await
+    {
+        Ok(addrs) => {
+            let count = addrs.count();
+            info!(
+                target: "iroh.net_recovery",
+                stage,
+                host = DNS_SELFTEST_HOST,
+                resolved = true,
+                addr_count = count,
+                "DNS self-test resolved",
+            );
+        }
+        Err(err) => {
+            warn!(
+                target: "iroh.net_recovery",
+                stage,
+                host = DNS_SELFTEST_HOST,
+                resolved = false,
+                error = %err,
+                "DNS self-test FAILED — resolver cannot resolve (likely a stale/empty nameserver config captured at process start)",
+            );
+        }
     }
 }
 

--- a/crates/uc-infra/src/network/iroh/net_recovery.rs
+++ b/crates/uc-infra/src/network/iroh/net_recovery.rs
@@ -18,18 +18,28 @@
 //! ## What it does
 //!
 //! Watches [`Endpoint::home_relay_status`]. When the home relay stays
-//! continuously unhealthy past a grace period, it calls
-//! [`Endpoint::network_change`] — the public, documented, side-effect-free
-//! nudge that runs the same major-link-change path a restart would
-//! (`rebind` + `check_relay_connection` + `dns_resolver.reset()` + re-STUN).
-//! In other words it re-delivers the notification the OS dropped, in-process,
-//! so recovery no longer requires a user restart. Retries escalate with
-//! exponential backoff and stop the moment the relay reconnects.
+//! continuously unhealthy past a short grace period, it **resets the
+//! endpoint's DNS resolver directly** (`endpoint.dns_resolver().reset()`),
+//! which re-reads the current system DNS config, then calls
+//! [`Endpoint::network_change`] to prompt a relay redial. Retries escalate
+//! with exponential backoff and stop the moment the relay reconnects.
 //!
-//! This is a root-cause fix for the dropped-notification wedge, not a symptom
-//! mask: calling `network_change()` when the network is genuinely down is
-//! harmless (iroh's own docs say so), and the resolver reset is lazy (no IO
-//! until the next lookup).
+//! **Why the direct reset, not just `network_change()`:** the first draft
+//! only called `network_change()`, on the assumption it runs the same
+//! `dns_resolver.reset()` path a restart would. It does not, reliably:
+//! `network_change()` only reaches that reset when netwatch observes an
+//! actual interface delta — `netmon::actor::handle_potential_change`
+//! early-returns on `old_state == new_state`. The dominant repro is a process
+//! restart on an *unchanged* network (installer auto-relaunch), so the
+//! interface state is identical, the "major change" path never fires, and the
+//! reset never happens (confirmed in field logs: a nudge with no recovery).
+//! Resetting the resolver ourselves is unconditional and is the actual fix.
+//!
+//! This targets the root cause, not a symptom: a manual app restart recovers
+//! instantly (proving the *system* DNS is healthy — only this process's
+//! resolver is wedged), and `reset()` reproduces that recovery in-process
+//! without a restart. The reset is lazy (no IO until the next lookup) and
+//! harmless even when the network is genuinely down.
 //!
 //! ## Scope
 //!
@@ -48,11 +58,12 @@ use tracing::{info, warn};
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct RecoveryPolicy {
     /// How long the home relay must be *continuously* unhealthy before the
-    /// first nudge. Sized comfortably above a normal cold-start relay
-    /// negotiation so ordinary startup churn never triggers a nudge, while
-    /// still recovering the wedged state within ~a minute instead of never.
+    /// first reset. Above a normal cold-start relay negotiation (which
+    /// connects within a few seconds) so ordinary startup churn doesn't
+    /// trigger it, but short so the wedge recovers quickly. The reset itself
+    /// is cheap and harmless, so we bias toward acting sooner.
     grace: Duration,
-    /// Delay after the first nudge before the next one, if still unhealthy.
+    /// Delay after the first reset before the next one, if still unhealthy.
     initial_backoff: Duration,
     /// Upper bound the backoff escalates to. Keeps a genuinely-offline node
     /// (relay really unreachable) probing at a low, steady rate.
@@ -62,9 +73,9 @@ pub(crate) struct RecoveryPolicy {
 impl Default for RecoveryPolicy {
     fn default() -> Self {
         Self {
-            grace: Duration::from_secs(45),
-            initial_backoff: Duration::from_secs(30),
-            max_backoff: Duration::from_secs(300),
+            grace: Duration::from_secs(20),
+            initial_backoff: Duration::from_secs(15),
+            max_backoff: Duration::from_secs(120),
         }
     }
 }
@@ -193,8 +204,27 @@ async fn run(endpoint: Endpoint, policy: RecoveryPolicy) {
                 warn!(
                     target: "iroh.net_recovery",
                     next_recheck_ms = next.as_millis() as u64,
-                    "home relay unhealthy past grace; nudging endpoint (network_change) to rebuild DNS resolver + relay connection",
+                    "home relay unhealthy past grace; resetting DNS resolver + nudging endpoint to rebuild relay connection",
                 );
+                // The load-bearing action: rebuild the endpoint's DNS resolver
+                // from the *current* system config. `endpoint.network_change()`
+                // is NOT enough on its own — it only reaches iroh's internal
+                // `dns_resolver.reset()` when netwatch observes an actual
+                // interface delta (`handle_potential_change` early-returns on
+                // `old_state == new_state`). Our wedge is a process restart on
+                // an unchanged network (e.g. installer auto-relaunch), so the
+                // interface state is identical and that path never fires. Reset
+                // the resolver directly — it re-reads /etc/resolv.conf / the
+                // Windows registry (lazily, no IO here).
+                match endpoint.dns_resolver() {
+                    Ok(resolver) => resolver.reset(),
+                    Err(err) => {
+                        warn!(target: "iroh.net_recovery", error = %err, "cannot reset DNS resolver");
+                    }
+                }
+                // Additionally nudge the endpoint: re-STUN + relay-connection
+                // re-check when the network genuinely changed. Harmless no-op
+                // otherwise, and prompts the relay actor to redial sooner.
                 endpoint.network_change().await;
                 Some(next)
             }


### PR DESCRIPTION
## Summary

Follow-up to #1261. The watchdog shipped in #1261 fired correctly in the field but **did not recover the relay** — its nudge was a no-op. This PR fixes the actual mechanism and adds diagnostics to confirm the root cause on the next repro.

- **Reset the DNS resolver directly** (`0f5b989e3`). #1261 relied on `endpoint.network_change()` to trigger iroh's internal `dns_resolver.reset()`. But that only fires when netwatch observes a real interface delta — `netmon::actor::handle_potential_change` early-returns on `old_state == new_state`. The confirmed repro (app running → installer auto-relaunches it after update → offline) is a **process restart on an unchanged network**, so the interface state is identical and the reset never ran. Field log confirmed: watchdog nudged at the grace mark, relay stayed on `Resolve failed`. Fix: call `endpoint.dns_resolver().reset()` directly (same resolver instance the relay path uses), which unconditionally re-reads current system DNS. Grace tightened 45s→20s and backoff cap 300s→120s since the reset is cheap and safe.
- **DNS self-test diagnostics** (`c1f143806`). Resolve `dns.iroh.link` through the endpoint's own resolver at watchdog `startup` and after every `post-reset`, logged under `target: iroh.net_recovery`. Purely diagnostic. Next repro's log will show whether the process was born wedged (`startup resolved=false`) and whether reset fixes it (`post-reset resolved=true`) — closing the loop on root cause vs. fix.

### Root-cause status (honest)

Confirmed: `network_change()` doesn't reset on an unchanged network (why #1261's nudge was a no-op), and a manual restart recovers instantly (so the *system* DNS is healthy — only this process's resolver is wedged). **Not yet confirmed:** *why* the installer-relaunched process is born with a stale resolver (hypothesis: it reads Windows DNS config in a not-yet-ready window at process start). The reset is a correct event-driven self-heal regardless; the self-test logs exist to nail down that remaining unknown.

## Test plan

- [x] `cargo test -p uc-infra --lib net_recovery` — 4/4 (backoff state machine: grace, escalation/cap, recovery reset).
- [x] `cargo check -p uc-infra` clean.
- [ ] **Windows repro (needs a CI-built installer):** app running → run the new installer → after auto-relaunch, confirm it recovers **without a manual restart** within ~grace+backoff. Cannot cross-build a Windows installer from WSL, and the repro *requires* the installer's auto-relaunch path — must use a Windows-runner artifact or a local Windows build.
- [ ] In that repro's daemon log, verify `iroh.net_recovery`: `startup resolved=false` then `post-reset resolved=true` (root cause + fix confirmation).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery when network connectivity becomes unhealthy for too long.
  * Added a more direct DNS reset step during recovery to better restore connectivity.
  * Added automatic DNS self-checks before and after recovery attempts to help detect resolver issues earlier.
  * Tuned recovery timing defaults for faster, more responsive retries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->