### PR TITLE
feat(gui): destroy main window on close, recreate on reopen

### DIFF
--- a/src-tauri/crates/uc-tauri/src/commands/startup.rs
+++ b/src-tauri/crates/uc-tauri/src/commands/startup.rs
@@ -209,6 +209,56 @@ pub async fn get_daemon_bootstrap_failure(
     async move { Ok(state.get()) }.instrument(span).await
 }
 
+/// Pending deep-link route recorded by native UI surfaces (tray menu) for the
+/// frontend to consume once its router is ready.
+///
+/// The tray "Settings" item may have to recreate a destroyed main window
+/// (destroy-on-close model, see `main_window`); an `app.emit("ui://navigate",
+/// ...)` fired at that moment races the fresh webview's listener registration
+/// and is lost. The route is recorded here instead: the frontend drains it via
+/// [`take_pending_navigation`] during boot, and discards it after consuming a
+/// live `ui://navigate` event (the duplicate-record case when the window was
+/// already open).
+#[derive(Default)]
+pub struct PendingNavigation(Mutex<Option<String>>);
+
+impl PendingNavigation {
+    /// Record a route for the frontend to pick up. Overwrites any previous one.
+    pub fn set(&self, route: &str) {
+        if let Ok(mut guard) = self.0.lock() {
+            *guard = Some(route.to_string());
+        }
+    }
+
+    /// Consume the recorded route, if any.
+    pub fn take(&self) -> Option<String> {
+        self.0.lock().ok().and_then(|mut guard| guard.take())
+    }
+}
+
+/// Consume the pending deep-link route recorded by native UI surfaces.
+///
+/// Returns `Some(route)` at most once per recording; the frontend calls this
+/// on boot (to honor a deep-link that predates the webview) and after handling
+/// a live `ui://navigate` event (to discard the duplicate record).
+///
+/// Pure state handoff from managed state; no usecase orchestration is required.
+#[tauri::command]
+#[specta::specta]
+pub async fn take_pending_navigation(
+    state: tauri::State<'_, PendingNavigation>,
+    _trace: Option<TraceMetadata>,
+) -> Result<Option<String>, crate::commands::CommandError> {
+    let span = info_span!(
+        "command.startup.take_pending_navigation",
+        trace_id = tracing::field::Empty,
+        trace_ts = tracing::field::Empty,
+    );
+    record_trace_fields(&span, &_trace);
+
+    async move { Ok(state.take()) }.instrument(span).await
+}
+
 /// Startup barrier used to coordinate backend readiness.
 ///
 /// 用于协调后端就绪的启动门闩。
@@ -283,6 +333,19 @@ mod tests {
         assert!(failure.observed_version.is_none());
         assert!(failure.expected_version.is_none());
         assert!(failure.detail.contains("8000"));
+    }
+
+    #[test]
+    fn pending_navigation_is_consumed_once() {
+        let pending = PendingNavigation::default();
+        assert!(pending.take().is_none(), "fresh state must be empty");
+
+        pending.set("/settings");
+        assert_eq!(pending.take().as_deref(), Some("/settings"));
+        assert!(
+            pending.take().is_none(),
+            "route must not survive a second take (would leak into the next boot)"
+        );
     }
 
     #[test]

--- a/src-tauri/crates/uc-tauri/src/commands/startup.rs
+++ b/src-tauri/crates/uc-tauri/src/commands/startup.rs
@@ -13,7 +13,7 @@ use uc_daemon_contract::api::auth::DaemonConnectionInfo;
 use uc_daemon_process::contract::DaemonBootstrapError;
 
 use crate::commands::record_trace_fields;
-use crate::tray::show_main_window;
+use crate::main_window::show_main_window;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, specta::Type)]
 #[serde(rename_all = "camelCase")]

--- a/src-tauri/crates/uc-tauri/src/lib.rs
+++ b/src-tauri/crates/uc-tauri/src/lib.rs
@@ -11,6 +11,7 @@ pub mod analytics_forward;
 pub mod bootstrap;
 pub mod commands;
 pub mod lightweight;
+pub mod main_window;
 pub mod quick_panel;
 pub mod run;
 pub mod specta_builder;

--- a/src-tauri/crates/uc-tauri/src/lightweight.rs
+++ b/src-tauri/crates/uc-tauri/src/lightweight.rs
@@ -3,8 +3,11 @@
 //! The external `uniclipd` is always a separate process. Four exit behaviors,
 //! distinguished here and in `run.rs`'s `RunEvent` handlers:
 //!
-//! - **关窗** (window close) → hide to tray; intercepted in `run.rs`, never
-//!   reaches the exit handlers, daemon untouched.
+//! - **关窗** (window close) → the window is destroyed (freeing its webview;
+//!   see `main_window`), and the resulting `ExitRequested { code: None }` is
+//!   intercepted with `prevent_exit` while the tray is alive
+//!   ([`should_stay_resident`]) — the GUI process stays resident, daemon
+//!   untouched.
 //! - **轻量模式** (tray "Lightweight") → GUI process exits, the daemon keeps
 //!   running. [`enter_lightweight_mode`] shows a reassurance notification (so the
 //!   user knows it is still alive) then `app.exit(0)`.
@@ -20,10 +23,11 @@
 //! 2.11 on macOS, Cmd-Q and the app "Quit" menu go through
 //! `applicationWillTerminate` → `AppState::exit()`, which emits ONLY
 //! `RunEvent::Exit` — no `ExitRequested`. (`ExitRequested { code: None }` is
-//! reserved for the *last window being destroyed*, which never happens here
-//! because window-close is intercepted to hide-to-tray.) So a teardown decided
-//! solely in `ExitRequested` silently skips Cmd-Q and orphans the daemon — the
-//! bug this module now fixes.
+//! reserved for the *last window being destroyed* — the normal closed-to-tray
+//! path now that window-close destroys the window; it only proceeds to a real
+//! exit when the tray is unavailable, see [`should_stay_resident`].) So a
+//! teardown decided solely in `ExitRequested` silently skips Cmd-Q and orphans
+//! the daemon — the bug this module now fixes.
 //!
 //! Instead, `RunEvent::Exit` — which fires for every clean termination — stops
 //! the daemon by DEFAULT. The only exits that keep it (lightweight / restart) are
@@ -69,7 +73,9 @@ impl QuitIntent {
     /// Record an `ExitRequested { code }` event. Programmatic keep-alive exits
     /// (lightweight / restart) arrive as `Some(_)` without a full-quit request;
     /// flag them so the later `Exit` handler keeps the daemon. Tray "彻底退出"
-    /// (full quit) and the last-window-destroyed `None` case leave the flag unset
+    /// (full quit) and the last-window-destroyed `None` case (only reachable
+    /// when the tray is unavailable — otherwise [`should_stay_resident`]
+    /// prevents the exit before this is recorded) leave the flag unset
     /// → daemon stopped. See [`exit_keeps_daemon`].
     pub fn note_exit_requested(&self, exit_code: Option<i32>) {
         if exit_keeps_daemon(self.full_quit_requested(), exit_code) {
@@ -100,6 +106,21 @@ impl QuitIntent {
 /// handler ([`QuitIntent::should_stop_daemon_on_exit`]).
 pub fn exit_keeps_daemon(full_quit_requested: bool, exit_code: Option<i32>) -> bool {
     exit_code.is_some() && !full_quit_requested
+}
+
+/// Whether an `ExitRequested` event should be intercepted (`api.prevent_exit()`)
+/// so the GUI process stays resident in the tray.
+///
+/// `code == None` means the last window was destroyed. Window-close destroys
+/// the main window instead of hiding it (releasing its webview memory — see
+/// `main_window`), so with a live tray this is the normal "closed to tray"
+/// path, NOT a quit: the run loop must prevent the exit and must NOT cancel
+/// the tracked background tasks (update scheduler, HUD bridge, signal
+/// watcher). Without a tray there is no surface left to reopen or quit the
+/// app, so the exit proceeds. Programmatic exits (lightweight / restart /
+/// full quit) always arrive as `Some(_)` and are never intercepted.
+pub fn should_stay_resident(exit_code: Option<i32>, tray_initialized: bool) -> bool {
+    exit_code.is_none() && tray_initialized
 }
 
 /// Mark the pending exit as a full quit (stop the connected daemon), then exit.
@@ -191,11 +212,37 @@ mod tests {
 
     #[test]
     fn last_window_destroyed_stops_daemon() {
-        // The last window being destroyed surfaces as ExitRequested { code: None }
-        // — a real quit, so the daemon is stopped.
+        // The last window being destroyed surfaces as ExitRequested { code: None }.
+        // With a live tray the run loop prevents the exit before this is ever
+        // recorded (`should_stay_resident`); when it IS recorded (tray
+        // unavailable) it is a real quit, so the daemon is stopped.
         let state = QuitIntent::default();
         state.note_exit_requested(None);
         assert!(state.should_stop_daemon_on_exit());
+    }
+
+    #[test]
+    fn window_destroyed_with_tray_stays_resident() {
+        // Closing the main window destroys it; the app must keep running in
+        // the tray instead of exiting.
+        assert!(should_stay_resident(None, true));
+    }
+
+    #[test]
+    fn window_destroyed_without_tray_exits() {
+        // No tray means no surface to reopen or quit the app — let the exit
+        // proceed (daemon teardown follows the default-stop path).
+        assert!(!should_stay_resident(None, false));
+    }
+
+    #[test]
+    fn programmatic_exits_are_never_intercepted() {
+        // Lightweight (`app.exit(0)`), restart (`Some(RESTART_EXIT_CODE)`) and
+        // tray full quit all arrive as `Some(_)` — they must never be blocked,
+        // tray or not.
+        assert!(!should_stay_resident(Some(0), true));
+        assert!(!should_stay_resident(Some(i32::MAX), true));
+        assert!(!should_stay_resident(Some(0), false));
     }
 
     #[test]

--- a/src-tauri/crates/uc-tauri/src/main_window.rs
+++ b/src-tauri/crates/uc-tauri/src/main_window.rs
@@ -21,7 +21,15 @@
 //! cost up front.
 
 use tauri::Manager;
-use tracing::{error, info, warn};
+use tracing::{error, info};
+// Every `warn!` call in this file lives inside a macOS or Windows `cfg`
+// block; on other platforms (e.g. the Linux coverage runner) the import is
+// genuinely unused.
+#[cfg_attr(
+    not(any(target_os = "macos", target_os = "windows")),
+    allow(unused_imports)
+)]
+use tracing::warn;
 
 /// Label of the main window as declared in `tauri.conf.json`.
 pub const MAIN_WINDOW_LABEL: &str = "main";

--- a/src-tauri/crates/uc-tauri/src/main_window.rs
+++ b/src-tauri/crates/uc-tauri/src/main_window.rs
@@ -1,0 +1,150 @@
+//! Main-window lifecycle: destroy-on-close, recreate-on-open.
+//!
+//! The `main` window is declared in `tauri.conf.json` with `"create": false`,
+//! so Tauri never auto-creates it at startup. Every "open" entry point (tray
+//! click / tray menu, macOS Dock `Reopen`, startup barrier, single-instance
+//! second launch) funnels through [`show_main_window`], which recreates the
+//! window from that same config entry when it is gone — the config stays the
+//! single source of truth for the window's appearance.
+//!
+//! Closing the window is NOT intercepted anymore: the window (and its webview
+//! process — JS heap, DOM, image caches, WS connections) is destroyed,
+//! releasing the renderer's memory while the app stays resident in the tray.
+//! The resulting `RunEvent::ExitRequested { code: None }` is intercepted in
+//! `run.rs` (see [`crate::lightweight::should_stay_resident`]). Reopening is a
+//! fresh frontend boot that lands on the home route, reusing the exact same
+//! startup path as a cold start (daemon connection poll → session exchange →
+//! WS connect).
+//!
+//! `silent_start` benefits for free: the window is simply never created until
+//! the first explicit open, so a login autostart no longer pays the webview
+//! cost up front.
+
+use tauri::Manager;
+use tracing::{error, info, warn};
+
+/// Label of the main window as declared in `tauri.conf.json`.
+pub const MAIN_WINDOW_LABEL: &str = "main";
+
+/// Show the main window: make the Dock icon visible on macOS, recreate the
+/// window from config if it was destroyed, then unminimize, show, and focus.
+pub fn show_main_window(app: &tauri::AppHandle) {
+    #[cfg(target_os = "macos")]
+    if let Err(error) = app.set_dock_visibility(true) {
+        warn!(error = %error, "Failed to show Dock icon before showing main window");
+    }
+
+    // macOS:`set_dock_visibility(true)` 把 activation policy 从 `Accessory`
+    // 翻回 `Regular`(典型路径:关闭主窗口 → Accessory → 从托盘重新打开)。
+    // 但 macOS 把 app 重新塞回 Dock 时不会重读 bundle 图标,会留下空白图标 +
+    // 运行小圆点。这里强制重绘 Dock 图标兜底。
+    #[cfg(target_os = "macos")]
+    refresh_dock_icon(app);
+
+    let window = match app.get_webview_window(MAIN_WINDOW_LABEL) {
+        Some(window) => window,
+        None => match create_main_window(app) {
+            Ok(window) => window,
+            Err(error) => {
+                error!(error = %error, "Failed to recreate main window from config");
+                return;
+            }
+        },
+    };
+
+    let _ = window.unminimize();
+    let _ = window.show();
+    let _ = window.set_focus();
+}
+
+/// Create the main window from its `tauri.conf.json` entry (`create: false`
+/// keeps Tauri from doing this automatically at startup).
+///
+/// The config declares `visible: false`; [`show_main_window`] shows the window
+/// right after, matching the first-boot behavior (window appears while the
+/// frontend is still loading — the transparent + vibrancy background covers
+/// the load, no white flash).
+fn create_main_window(app: &tauri::AppHandle) -> tauri::Result<tauri::WebviewWindow> {
+    let config = app
+        .config()
+        .app
+        .windows
+        .iter()
+        .find(|window| window.label == MAIN_WINDOW_LABEL)
+        .cloned()
+        .ok_or_else(|| {
+            tauri::Error::Anyhow(anyhow::anyhow!(
+                "main window config missing from tauri.conf.json"
+            ))
+        })?;
+
+    let window = tauri::WebviewWindowBuilder::from_config(app, &config)?.build()?;
+    configure_for_platform(&window);
+    info!("Main window created from config");
+    Ok(window)
+}
+
+/// Windows: the config uses `titleBarStyle: Overlay` for macOS; on Windows the
+/// native decorations must be turned off after creation instead. This must run
+/// on every (re)creation, not just at startup.
+#[cfg(target_os = "windows")]
+fn configure_for_platform(window: &tauri::WebviewWindow) {
+    if let Err(error) = window.set_decorations(false) {
+        warn!(error = %error, "Failed to disable Windows main window decorations");
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+fn configure_for_platform(_window: &tauri::WebviewWindow) {}
+
+/// macOS: force the Dock to repaint this app's icon after flipping back to the
+/// `Regular` activation policy.
+///
+/// `set_dock_visibility(true)` toggles `NSApplicationActivationPolicy` from
+/// `Accessory` to `Regular`, but macOS (notably Sequoia/Tahoe) re-adds the app
+/// to the Dock without re-reading the bundle icon — leaving the running-indicator
+/// dot over a blank tile (and on some versions a template-mangled icon with a
+/// white ring around it). Reassigning `applicationIconImage` to the bundle's own
+/// `icon.icns` forces the Dock tile to redraw with the correct full-bleed art.
+///
+/// AppKit calls must run on the main thread. `show_main_window` is invoked from
+/// tray events / startup on the main thread, but we still dispatch through
+/// `run_on_main_thread` to stay consistent with `update_scheduler::window` and to
+/// defend future callers. The dispatch also lets the policy change settle before
+/// we re-push the icon.
+#[cfg(target_os = "macos")]
+fn refresh_dock_icon(app: &tauri::AppHandle) {
+    use objc2::{AnyThread, MainThreadMarker};
+    use objc2_app_kit::{NSApplication, NSImage};
+    use objc2_foundation::{ns_string, NSBundle};
+
+    if let Err(error) = app.run_on_main_thread(|| {
+        let Some(mtm) = MainThreadMarker::new() else {
+            warn!("refresh_dock_icon dispatched off the main thread; skipping");
+            return;
+        };
+        // Load the bundle's own `icon.icns` directly. We must NOT use
+        // `NSWorkspace::iconForFile`: for this full-bleed icon (no transparent
+        // padding) macOS applies its icon-template rules, shrinking it into a
+        // white rounded container — which shows up as a white ring around the
+        // Dock tile. Loading the raw icns yields the full-bleed artwork as-is.
+        let Some(icns_path) = NSBundle::mainBundle()
+            .pathForResource_ofType(Some(ns_string!("icon")), Some(ns_string!("icns")))
+        else {
+            warn!("refresh_dock_icon: icon.icns missing from bundle resources");
+            return;
+        };
+        let Some(icon) = NSImage::initWithContentsOfFile(NSImage::alloc(), &icns_path) else {
+            warn!("refresh_dock_icon: failed to decode icon.icns");
+            return;
+        };
+        // SAFETY: runs on the main thread (asserted by `mtm`); `icon` stays alive
+        // for the call. Setting the application icon image only repaints the Dock
+        // tile — no ownership transfer.
+        unsafe {
+            NSApplication::sharedApplication(mtm).setApplicationIconImage(Some(&icon));
+        }
+    }) {
+        warn!(error = %error, "Failed to dispatch Dock icon refresh to the main thread");
+    }
+}

--- a/src-tauri/crates/uc-tauri/src/run.rs
+++ b/src-tauri/crates/uc-tauri/src/run.rs
@@ -319,6 +319,7 @@ pub fn run(tauri_ctx: tauri::Context<tauri::Wry>) -> anyhow::Result<()> {
         .manage(daemon_bootstrap_status.clone())
         .manage(TrayState::default())
         .manage(crate::lightweight::QuitIntent::default())
+        .manage(crate::commands::startup::PendingNavigation::default())
         .manage(task_registry.clone())
         .on_window_event(|window, event| {
             if let tauri::WindowEvent::CloseRequested { .. } = event {

--- a/src-tauri/crates/uc-tauri/src/run.rs
+++ b/src-tauri/crates/uc-tauri/src/run.rs
@@ -94,21 +94,6 @@ async fn wait_for_daemon_connection(
     }
 }
 
-#[cfg(target_os = "windows")]
-fn configure_main_window_for_platform(app: &tauri::AppHandle) {
-    let Some(window) = app.get_webview_window("main") else {
-        warn!("Main window not found during Windows window configuration");
-        return;
-    };
-
-    if let Err(error) = window.set_decorations(false) {
-        warn!(error = %error, "Failed to disable Windows main window decorations");
-    }
-}
-
-#[cfg(not(target_os = "windows"))]
-fn configure_main_window_for_platform(_app: &tauri::AppHandle) {}
-
 /// Translate a daemon-WS [`RealtimeEvent`] into the application-layer
 /// [`HostEvent`] the activity HUD consumes (ADR-008 P3-3 B2'-3).
 ///
@@ -336,22 +321,31 @@ pub fn run(tauri_ctx: tauri::Context<tauri::Wry>) -> anyhow::Result<()> {
         .manage(crate::lightweight::QuitIntent::default())
         .manage(task_registry.clone())
         .on_window_event(|window, event| {
-            if let tauri::WindowEvent::CloseRequested { api, .. } = event {
-                if window.label() == "main" {
-                    // Only hide-to-tray if the tray actually came up. When tray
-                    // init fails (treated as non-fatal during setup), hiding
-                    // the window plus the Dock icon would leave the app
-                    // running with no UI surface to recover or quit it.
+            if let tauri::WindowEvent::CloseRequested { .. } = event {
+                if window.label() == crate::main_window::MAIN_WINDOW_LABEL {
+                    // The close proceeds in BOTH branches: destroying the
+                    // window tears down its webview (JS heap, DOM, caches, WS
+                    // connections), releasing the renderer memory while the
+                    // window is closed. What differs is what happens to the
+                    // app afterwards:
+                    //
+                    // - Tray alive: the resulting last-window-destroyed
+                    //   `ExitRequested { code: None }` is intercepted in the
+                    //   run loop (`should_stay_resident`) — the app stays
+                    //   resident and `show_main_window` recreates the window
+                    //   on the next open.
+                    // - Tray init failed (non-fatal during setup): there is no
+                    //   surface left to reopen or quit the app, so the close
+                    //   is allowed to quit it (daemon stops via the
+                    //   default-stop path in `RunEvent::Exit`).
                     if window.state::<TrayState>().is_initialized() {
-                        api.prevent_close();
-                        let _ = window.hide();
                         #[cfg(target_os = "macos")]
                         if let Err(error) = window.app_handle().set_dock_visibility(false) {
-                            warn!(error = %error, "Failed to hide Dock icon after hiding main window");
+                            warn!(error = %error, "Failed to hide Dock icon while closing main window");
                         }
-                        info!("Main window hidden to tray");
+                        info!("Main window closing; webview destroyed, app stays in tray");
                     } else {
-                        info!("Tray unavailable; allowing main window close to proceed");
+                        info!("Tray unavailable; allowing main window close to quit the app");
                     }
                 }
             }
@@ -384,7 +378,13 @@ pub fn run(tauri_ctx: tauri::Context<tauri::Wry>) -> anyhow::Result<()> {
         info!("UC_DISABLE_SINGLE_INSTANCE=1 set; skipping single-instance plugin registration");
         builder
     } else {
-        builder.plugin(tauri_plugin_single_instance::init(|_app, _args, _cwd| {}))
+        // A second launch means the user wants the window — surface it
+        // (recreating it if it was destroyed-to-tray) instead of silently
+        // doing nothing.
+        builder.plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
+            info!("Second instance launch detected; showing main window");
+            crate::main_window::show_main_window(app);
+        }))
     };
 
     let task_registry_for_run = task_registry.clone();
@@ -415,7 +415,6 @@ pub fn run(tauri_ctx: tauri::Context<tauri::Wry>) -> anyhow::Result<()> {
             // In Tauri 2, use app.handle() to get the AppHandle
             runtime.set_app_handle(app.handle().clone());
             info!("AppHandle set on TauriAppRuntime for event emission");
-            configure_main_window_for_platform(app.handle());
 
             // 文件接收 HUD:渲染 macOS 原生 AppKit panel (AirDrop 风格)。
             // ADR-008 P3-3 (B2'-3): GUI 已无 in-process host_event_bus —— HUD
@@ -662,12 +661,16 @@ pub fn run(tauri_ctx: tauri::Context<tauri::Wry>) -> anyhow::Result<()> {
                 quick_panel::pre_create(app.handle());
             }
 
-            // Show window based on silent_start setting
+            // Create + show the window based on the silent_start setting. The
+            // main window is declared with `create: false`, so a silent start
+            // never pays the webview cost — the window only comes into
+            // existence on the first explicit open (`show_main_window`
+            // creates it from config on demand).
             if !silent_start {
-                crate::tray::show_main_window(app.handle());
+                crate::main_window::show_main_window(app.handle());
                 info!("Main window show requested (silent_start=false)");
             } else {
-                info!("Silent start enabled, main window stays hidden");
+                info!("Silent start enabled, main window not created");
             }
 
             #[cfg(not(any(target_os = "android", target_os = "ios")))]
@@ -860,7 +863,22 @@ pub fn run(tauri_ctx: tauri::Context<tauri::Wry>) -> anyhow::Result<()> {
         .map_err(|error| anyhow::anyhow!("error building tauri application: {error}"))?
         .run(move |app_handle, event| {
             match event {
-                tauri::RunEvent::ExitRequested { code, .. } => {
+                tauri::RunEvent::ExitRequested { code, api, .. } => {
+                    // Window-close destroys the main window (releasing its
+                    // webview memory); when it was the last window this
+                    // surfaces as `ExitRequested { code: None }`. With a live
+                    // tray that is the normal "closed to tray" state, not a
+                    // quit: prevent the exit and — crucially — keep the
+                    // tracked background tasks (update scheduler, HUD bridge,
+                    // signal watcher) running.
+                    if crate::lightweight::should_stay_resident(
+                        code,
+                        app_handle.state::<TrayState>().is_initialized(),
+                    ) {
+                        info!("Last window destroyed; staying resident in tray");
+                        api.prevent_exit();
+                        return;
+                    }
                     info!(?code, "App exit requested, cancelling all tracked tasks");
                     task_registry_for_run.token().cancel();
                     // ADR-008 D3 (P4-3, revised): the daemon-teardown decision is
@@ -873,8 +891,9 @@ pub fn run(tauri_ctx: tauri::Context<tauri::Wry>) -> anyhow::Result<()> {
                     // full-quit request, so they flag the daemon to survive. Tray
                     // "彻底退出" / Ctrl-C / SIGTERM go through `request_full_quit`
                     // (full-quit flag set), and the last-window-destroyed `None`
-                    // case is a real quit — neither flags survival, so both stop the
-                    // daemon at `Exit`. See `lightweight::QuitIntent`.
+                    // case (tray unavailable, see above) is a real quit — neither
+                    // flags survival, so both stop the daemon at `Exit`. See
+                    // `lightweight::QuitIntent`.
                     app_handle
                         .state::<crate::lightweight::QuitIntent>()
                         .note_exit_requested(code);
@@ -913,7 +932,7 @@ pub fn run(tauri_ctx: tauri::Context<tauri::Wry>) -> anyhow::Result<()> {
                     ..
                 } => {
                     info!("Dock reopen with no visible windows, showing main window");
-                    crate::tray::show_main_window(app_handle);
+                    crate::main_window::show_main_window(app_handle);
                 }
                 _ => {}
             }

--- a/src-tauri/crates/uc-tauri/src/specta_builder.rs
+++ b/src-tauri/crates/uc-tauri/src/specta_builder.rs
@@ -20,7 +20,7 @@
 //!
 //! 所有命令在所有 OS 上都 collect，保证任何 runner 跑 `cargo test
 //! --test specta_export` 得到同一份 binding（CI 可以用单一 Linux runner
-//! 做 schema drift check）。当前 33 条命令都不依赖平台特定 mod 编译。
+//! 做 schema drift check）。当前所有命令都不依赖平台特定 mod 编译。
 
 use tauri_specta::{collect_commands, Builder};
 
@@ -49,6 +49,7 @@ pub fn build() -> Builder<tauri::Wry> {
         crate::commands::startup::get_daemon_connection_info,
         crate::commands::startup::get_daemon_session,
         crate::commands::startup::get_daemon_bootstrap_failure,
+        crate::commands::startup::take_pending_navigation,
         // ── restart ──────────────────────────────────────────────────────────
         crate::commands::restart::restart_app,
         crate::commands::restart::restart_daemon,

--- a/src-tauri/crates/uc-tauri/src/tray.rs
+++ b/src-tauri/crates/uc-tauri/src/tray.rs
@@ -8,8 +8,10 @@ use std::sync::Mutex;
 
 use tauri::menu::{MenuBuilder, MenuItem};
 use tauri::tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent};
-use tauri::{Emitter, Manager};
+use tauri::Emitter;
 use tracing::{debug, info, warn};
+
+use crate::main_window::show_main_window;
 
 /// Managed state that holds the tray icon and its menu item handles.
 ///
@@ -285,9 +287,11 @@ impl TrayState {
 
     /// Returns `true` once the tray icon has been successfully built.
     ///
-    /// Used by the main-window close handler to decide whether hiding to
-    /// tray is safe — without a tray there would be no way to bring the
-    /// window back, so we let the close proceed normally instead.
+    /// Used by the exit-decision paths: closing the main window destroys it
+    /// and the app stays resident only when the tray is alive (see
+    /// `lightweight::should_stay_resident`) — without a tray there would be
+    /// no way to bring the window back, so the close is allowed to quit the
+    /// app instead.
     pub fn is_initialized(&self) -> bool {
         self.inner
             .lock()
@@ -350,84 +354,6 @@ fn lan_only_tooltip(language: &str, lan_only_active: bool) -> String {
         ("zh-CN", false) => "UniClipboard".to_string(),
         (_, true) => "UniClipboard — LAN-only Mode is ON".to_string(),
         (_, false) => "UniClipboard".to_string(),
-    }
-}
-
-/// Show the main window: make Dock icon visible on macOS, then unminimize, show, and focus.
-pub fn show_main_window(app: &tauri::AppHandle) {
-    #[cfg(target_os = "macos")]
-    if let Err(error) = app.set_dock_visibility(true) {
-        warn!(error = %error, "Failed to show Dock icon before showing main window");
-    }
-
-    // macOS:`set_dock_visibility(true)` 把 activation policy 从 `Accessory`
-    // 翻回 `Regular`(典型路径:关闭主窗口 → Accessory → 从托盘重新打开)。
-    // 但 macOS 把 app 重新塞回 Dock 时不会重读 bundle 图标,会留下空白图标 +
-    // 运行小圆点。这里强制重绘 Dock 图标兜底。
-    #[cfg(target_os = "macos")]
-    refresh_dock_icon(app);
-
-    match app.get_webview_window("main") {
-        Some(window) => {
-            let _ = window.unminimize();
-            let _ = window.show();
-            let _ = window.set_focus();
-        }
-        None => {
-            warn!("Main window not found");
-        }
-    }
-}
-
-/// macOS: force the Dock to repaint this app's icon after flipping back to the
-/// `Regular` activation policy.
-///
-/// `set_dock_visibility(true)` toggles `NSApplicationActivationPolicy` from
-/// `Accessory` to `Regular`, but macOS (notably Sequoia/Tahoe) re-adds the app
-/// to the Dock without re-reading the bundle icon — leaving the running-indicator
-/// dot over a blank tile (and on some versions a template-mangled icon with a
-/// white ring around it). Reassigning `applicationIconImage` to the bundle's own
-/// `icon.icns` forces the Dock tile to redraw with the correct full-bleed art.
-///
-/// AppKit calls must run on the main thread. `show_main_window` is invoked from
-/// tray events / startup on the main thread, but we still dispatch through
-/// `run_on_main_thread` to stay consistent with `update_scheduler::window` and to
-/// defend future callers. The dispatch also lets the policy change settle before
-/// we re-push the icon.
-#[cfg(target_os = "macos")]
-fn refresh_dock_icon(app: &tauri::AppHandle) {
-    use objc2::{AnyThread, MainThreadMarker};
-    use objc2_app_kit::{NSApplication, NSImage};
-    use objc2_foundation::{ns_string, NSBundle};
-
-    if let Err(error) = app.run_on_main_thread(|| {
-        let Some(mtm) = MainThreadMarker::new() else {
-            warn!("refresh_dock_icon dispatched off the main thread; skipping");
-            return;
-        };
-        // Load the bundle's own `icon.icns` directly. We must NOT use
-        // `NSWorkspace::iconForFile`: for this full-bleed icon (no transparent
-        // padding) macOS applies its icon-template rules, shrinking it into a
-        // white rounded container — which shows up as a white ring around the
-        // Dock tile. Loading the raw icns yields the full-bleed artwork as-is.
-        let Some(icns_path) = NSBundle::mainBundle()
-            .pathForResource_ofType(Some(ns_string!("icon")), Some(ns_string!("icns")))
-        else {
-            warn!("refresh_dock_icon: icon.icns missing from bundle resources");
-            return;
-        };
-        let Some(icon) = NSImage::initWithContentsOfFile(NSImage::alloc(), &icns_path) else {
-            warn!("refresh_dock_icon: failed to decode icon.icns");
-            return;
-        };
-        // SAFETY: runs on the main thread (asserted by `mtm`); `icon` stays alive
-        // for the call. Setting the application icon image only repaints the Dock
-        // tile — no ownership transfer.
-        unsafe {
-            NSApplication::sharedApplication(mtm).setApplicationIconImage(Some(&icon));
-        }
-    }) {
-        warn!(error = %error, "Failed to dispatch Dock icon refresh to the main thread");
     }
 }
 

--- a/src-tauri/crates/uc-tauri/src/tray.rs
+++ b/src-tauri/crates/uc-tauri/src/tray.rs
@@ -8,7 +8,7 @@ use std::sync::Mutex;
 
 use tauri::menu::{MenuBuilder, MenuItem};
 use tauri::tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent};
-use tauri::Emitter;
+use tauri::{Emitter, Manager};
 use tracing::{debug, info, warn};
 
 use crate::main_window::show_main_window;
@@ -141,6 +141,15 @@ impl TrayState {
                     show_main_window(app);
                 }
                 "tray.settings" => {
+                    // Record the deep-link BEFORE showing: `show_main_window`
+                    // may have to recreate a destroyed window, and the emit
+                    // below would race the fresh webview's listener
+                    // registration. The frontend drains the pending route on
+                    // boot (`take_pending_navigation`) and discards it after
+                    // consuming a live `ui://navigate` event, so the two
+                    // channels never double-navigate.
+                    app.state::<crate::commands::startup::PendingNavigation>()
+                        .set("/settings");
                     show_main_window(app);
                     if let Err(e) = app.emit("ui://navigate", "/settings") {
                         warn!("Failed to emit ui://navigate event: {}", e);

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -14,6 +14,7 @@
     "windows": [
       {
         "label": "main",
+        "create": false,
         "title": "UniClipboard",
         "width": 800,
         "height": 600,

--- a/src/hooks/useUINavigateListener.ts
+++ b/src/hooks/useUINavigateListener.ts
@@ -1,5 +1,6 @@
 import { listen } from '@tauri-apps/api/event'
 import { useEffect } from 'react'
+import { commands } from '@/lib/ipc'
 import { createLogger } from '@/lib/logger'
 
 const log = createLogger('use-ui-navigate-listener')
@@ -7,13 +8,41 @@ const log = createLogger('use-ui-navigate-listener')
 const ALLOWED_ROUTES = ['/settings']
 
 /**
- * Listen for `ui://navigate` events from the backend
- * and invoke the provided callback for whitelisted routes.
+ * Navigation requests from the backend arrive over two channels:
+ *
+ * 1. A live `ui://navigate` event — works when this webview was already
+ *    running when the tray menu fired it.
+ * 2. A pending route recorded in native state — the tray "Settings" item may
+ *    have to recreate a destroyed main window (destroy-on-close model), and
+ *    an event emitted at that moment races this listener's registration. The
+ *    backend records the route instead; we drain it once on mount.
+ *
+ * The tray records AND emits on every click, so after handling a live event
+ * we discard the pending record to keep it from leaking into the next boot
+ * (which must land on the home route).
  */
 export function useUINavigateListener(onNavigate: (route: string) => void) {
   useEffect(() => {
+    let cancelled = false
+
+    commands
+      .takePendingNavigation()
+      .then(route => {
+        if (cancelled || !route) return
+        if (ALLOWED_ROUTES.includes(route)) {
+          onNavigate(route)
+        } else {
+          log.warn({ route }, 'Blocked pending navigation to non-whitelisted route')
+        }
+      })
+      .catch(error => {
+        log.warn({ error }, 'Failed to drain pending navigation')
+      })
+
     const unlistenPromise = listen<string>('ui://navigate', event => {
       const route = event.payload
+      // Discard the duplicate pending record for this click (see above).
+      commands.takePendingNavigation().catch(() => {})
       if (ALLOWED_ROUTES.includes(route)) {
         onNavigate(route)
       } else {
@@ -22,6 +51,7 @@ export function useUINavigateListener(onNavigate: (route: string) => void) {
     })
 
     return () => {
+      cancelled = true
       unlistenPromise.then(unlisten => unlisten())
     }
   }, [onNavigate])

--- a/src/lib/ipc-bindings.generated.ts
+++ b/src/lib/ipc-bindings.generated.ts
@@ -89,6 +89,19 @@ export const commands = {
 	expectedVersion: string | null,
 } | null, CommandError>(__TAURI_INVOKE("get_daemon_bootstrap_failure", { trace })),
 	/**
+	 *  Consume the pending deep-link route recorded by native UI surfaces.
+	 * 
+	 *  Returns `Some(route)` at most once per recording; the frontend calls this
+	 *  on boot (to honor a deep-link that predates the webview) and after handling
+	 *  a live `ui://navigate` event (to discard the duplicate record).
+	 * 
+	 *  Pure state handoff from managed state; no usecase orchestration is required.
+	 */
+	takePendingNavigation: (trace: {
+	trace_id: string,
+	timestamp: number,
+} | null) => typedError<string | null, CommandError>(__TAURI_INVOKE("take_pending_navigation", { trace })),
+	/**
 	 *  Restarts the running Tauri application to apply settings changes.
 	 * 
 	 *  流程:


### PR DESCRIPTION
## Summary

- Closing the main window now destroys the window (and its webview — JS heap, DOM, image caches, WS connections) instead of hiding it, releasing that memory while the app stays resident in the tray. Reopening (tray click/menu, macOS Dock reopen, second launch, startup barrier) recreates it on demand from the `tauri.conf.json` config, landing on a fresh boot at the home route. (30396b5)
- `tauri.conf.json` declares the main window with `create: false`, so a silent (login-autostart) start no longer creates a webview at all until the first explicit open. (30396b5)
- The last-window-destroyed exit path is intercepted (`prevent_exit`) while the tray is alive, and background tasks (update scheduler, HUD bridge, signal watcher) are no longer cancelled on a plain window close — only on a real quit. (30396b5)
- Fixes a navigation race the above introduces: the tray "Settings" deep link could fire before a freshly recreated webview's listener registers. A `PendingNavigation` state now records the route and the frontend drains it on boot via a new `take_pending_navigation` command. (deb485e)

## Test plan

- [x] `cargo check -p uc-tauri` / `-p uniclipboard`, `cargo test -p uc-tauri --lib` (100 passed, incl. new tests for `should_stay_resident` / `PendingNavigation`), `cargo test -p uc-tauri --test specta_export` (no binding drift), `cargo clippy -p uc-tauri`, `tsc --noEmit`, `eslint` on changed files
- [ ] macOS real-device: close/reopen the main window several times via the tray and confirm no crash/leak and a clean home-route reload each time
- [ ] Tray "Settings" click while the window is destroyed lands directly on the settings page
- [ ] Cmd-Q / tray "彻底退出" still stop the daemon; lightweight mode / restart still keep it running
- [ ] Windows: window decorations (`set_decorations(false)`) still apply after a recreate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved deep-link/navigation handling for startup and native entry points via one-time pending navigation consumption.
  * Added a new command for draining pending navigation and wired it into the UI navigation listener.
* **Bug Fixes**
  * Made navigation whitelisting consistent and reduced duplicate/missed navigation triggers.
  * Refined main window lifecycle: close behavior now keeps the app resident only when expected, and the app can reliably restore the main window.
  * A second app launch now brings the main window to the front.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->