### PR TITLE
fix(homebrew): drop per-release cask auto-PR, keep manual dispatch

### DIFF
--- a/.github/workflows/homebrew-cask.yml
+++ b/.github/workflows/homebrew-cask.yml
@@ -1,12 +1,12 @@
 name: 'Homebrew Official Cask'
-run-name: >-
-  ${{ github.event_name == 'release'
-    && format('homebrew-cask-{0}', github.event.release.tag_name)
-    || format('homebrew-cask-manual-{0}', inputs.version) }}
+run-name: homebrew-cask-manual-${{ inputs.version }}
 
+# Manual-only. Version bumps for the existing cask are handled automatically by
+# Homebrew's BrewTestBot (the cask carries a `livecheck` stanza), so a
+# per-release auto-PR here only duplicated that work and risked auto-closed PRs.
+# Run this workflow by hand for the initial cask submission or metadata changes
+# (desc/zap/depends_on/livecheck) that BrewTestBot won't make on its own.
 on:
-  release:
-    types: [published]
   workflow_dispatch:
     inputs:
       version:
@@ -25,7 +25,6 @@ permissions:
 jobs:
   submit:
     name: Submit official cask PR
-    if: github.event_name == 'workflow_dispatch' || github.event.release.prerelease == false
     runs-on: macos-latest
     env:
       CASK_TOKEN: ${{ secrets.HOMEBREW_CASK_TOKEN }}
@@ -38,16 +37,10 @@ jobs:
         id: release
         env:
           GH_TOKEN: ${{ github.token }}
-          EVENT_NAME: ${{ github.event_name }}
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
           INPUT_VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
-          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-            VERSION="${INPUT_VERSION#v}"
-          else
-            VERSION="${RELEASE_TAG#v}"
-          fi
+          VERSION="${INPUT_VERSION#v}"
 
           if [ -z "$VERSION" ]; then
             echo "Could not derive version" >&2

--- a/docs/packaging/homebrew-cask.md
+++ b/docs/packaging/homebrew-cask.md
@@ -29,7 +29,14 @@ brew install --cask uniclipboard
 
 ## 发布后维护
 
-`release.published` 事件只会对非 prerelease 触发官方 Cask 提交流程。若 Homebrew 侧已有自动 bump 或维护者要求手动更新，可临时禁用 `.github/workflows/homebrew-cask.yml` 的 release 触发，只保留 `workflow_dispatch`。
+Cask 一旦进入官方仓库并带有 `livecheck` stanza，Homebrew 的 **BrewTestBot** 会自动检测新 stable release 并自动提交纯版本 bump（只改 `version` + `sha256`）的 PR。因此 **版本升级不再需要我们主动提 PR**，`.github/workflows/homebrew-cask.yml` 已移除 `release.published` 自动触发，只保留 `workflow_dispatch`。
+
+手动运行该 workflow 的场景仅限 BrewTestBot 不会代劳的情况：
+
+- **首次新增 cask**（BrewTestBot 不会从零创建）。
+- **元数据变更**（`desc` / `zap` / `depends_on` / `livecheck` 等）。这类改动应与版本 bump 分开提，单独一个 PR。
+
+> **注意：模板必须与上游保持一致。** workflow 采用整文件替换（`cp ... > Casks/u/uniclipboard.rb`），所以模板里任何与上游 cask 不一致的字段都会搭着这次提交一起进 PR。历史上模板 `desc` 漂移成 `"Privacy-first cross-device clipboard sync"`，把元数据修改夹进版本 bump PR，导致 [homebrew-cask#272803](https://github.com/Homebrew/homebrew-cask/pull/272803) 被维护者以"改动范围超出 bump"为由关闭。修改元数据前先确认上游当前值，避免夹带。
 
 ## 本地校验
 

--- a/packaging/homebrew/casks/uniclipboard.rb
+++ b/packaging/homebrew/casks/uniclipboard.rb
@@ -8,7 +8,7 @@ cask "uniclipboard" do
   url "https://github.com/UniClipboard/UniClipboard/releases/download/v#{version}/UniClipboard_#{version}_#{arch}.dmg",
       verified: "github.com/UniClipboard/UniClipboard/"
   name "UniClipboard"
-  desc "Privacy-first cross-device clipboard sync"
+  desc "Cross-device clipboard syncing tool"
   homepage "https://www.uniclipboard.app/"
 
   livecheck do


### PR DESCRIPTION
## Summary

- The macOS cask already lives in `Homebrew/homebrew-cask` and carries a `livecheck` stanza, so Homebrew's **BrewTestBot** auto-opens pure version-bump PRs on each new stable release. Our own `release.published`-triggered workflow duplicated that work — and because it does a whole-file replace of the cask, any template drift rode along into the bump PR. That's what got [homebrew-cask#272803](https://github.com/Homebrew/homebrew-cask/pull/272803) closed by a maintainer for "scope wider than a bump" (dd75e20c).
- **Workflow:** removed the `release.published` trigger; `workflow_dispatch` only. Version bumps are BrewTestBot's job now; the workflow is run by hand for the initial cask submission or metadata changes it won't make on its own. Also cleaned up the now-dead release-event branches (`run-name`, job `if:`, `EVENT_NAME`/`RELEASE_TAG` resolution).
- **Template drift fix:** reverted the cask `desc` from `"Privacy-first cross-device clipboard sync"` back to upstream's current `"Cross-device clipboard syncing tool"`, so a future manual run doesn't re-bundle a metadata edit into a bump.
- **Docs:** `docs/packaging/homebrew-cask.md` now documents the BrewTestBot handoff and the template-must-match-upstream rule.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — workflow YAML parses.
- [x] Verified no `docs-site/` page depends on the changed `desc` (only `brew info` surfaces it; install docs reference the command/token, unchanged).
- [ ] Next stable release: confirm BrewTestBot opens the bump PR and our workflow does **not** fire.
- [ ] If a metadata change is ever needed, confirm a manual `workflow_dispatch` run still renders and opens a clean PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Homebrew cask guidance to match the new release workflow and clarify when manual runs are needed.
  * Added notes about version-bump updates and how to avoid out-of-scope changes in cask submissions.

* **Chores**
  * Simplified the cask submission workflow to use manual version input consistently.
  * Updated the `uniclipboard` cask description to a clearer, more general label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->