### PR TITLE
refactor(history): move card tags to their own footer row

### DIFF
--- a/src/components/history/HistoryCard.tsx
+++ b/src/components/history/HistoryCard.tsx
@@ -13,6 +13,7 @@ import {
 import HistoryCardActions from './history-card/HistoryCardActions'
 import HistoryCardContent from './history-card/HistoryCardContent'
 import HistoryCardHeader from './history-card/HistoryCardHeader'
+import HistoryCardTags from './history-card/HistoryCardTags'
 import HistoryCardTransferProgress from './history-card/HistoryCardTransferProgress'
 
 interface HistoryCardProps {
@@ -123,6 +124,7 @@ const HistoryCard: React.FC<HistoryCardProps> = ({
       >
         <HistoryCardContent item={item} />
       </div>
+      <HistoryCardTags tags={item.contentTags} />
       <HistoryCardActions
         itemId={item.id}
         state={{ isHovered: showActions, isTransferring, isPending, isFavorited }}

--- a/src/components/history/history-card/HistoryCardHeader.tsx
+++ b/src/components/history/history-card/HistoryCardHeader.tsx
@@ -17,7 +17,6 @@ import {
   describeSource,
   detectCodeLanguage,
   getContentSizeLabel,
-  TAG_STYLE,
   TYPE_COLOR,
   TYPE_ICONS,
 } from './history-card-utils'
@@ -75,20 +74,6 @@ function HistoryCardHeader({
       >
         {codeLanguage ?? t(`history.type.${item.type}`, item.type)}
       </span>
-
-      {item.contentTags?.map(tag => (
-        <span
-          key={tag}
-          className="rounded border px-1 py-0 text-[9px] font-medium leading-[1.25]"
-          style={{
-            backgroundColor: TAG_STYLE[tag].background,
-            borderColor: TAG_STYLE[tag].border,
-            color: TAG_STYLE[tag].text,
-          }}
-        >
-          {t(`history.type.${tag}`, tag)}
-        </span>
-      ))}
 
       {sizeLabel && !isTransferring && (
         <>

--- a/src/components/history/history-card/HistoryCardTags.tsx
+++ b/src/components/history/history-card/HistoryCardTags.tsx
@@ -1,0 +1,34 @@
+import { useTranslation } from 'react-i18next'
+import type { ClipboardEntryTag } from '@/lib/clipboard-entry'
+import { TAG_STYLE } from './history-card-utils'
+
+interface HistoryCardTagsProps {
+  tags?: ClipboardEntryTag[]
+}
+
+// Renders the content tags on the card's last line, kept separate from the
+// header so the type label stays uncluttered.
+function HistoryCardTags({ tags }: HistoryCardTagsProps) {
+  const { t } = useTranslation()
+  if (!tags?.length) return null
+
+  return (
+    <div className="pointer-events-none relative z-10 mt-1.5 flex flex-wrap items-center gap-1">
+      {tags.map(tag => (
+        <span
+          key={tag}
+          className="rounded border px-1 py-0 text-[9px] font-medium leading-[1.25]"
+          style={{
+            backgroundColor: TAG_STYLE[tag].background,
+            borderColor: TAG_STYLE[tag].border,
+            color: TAG_STYLE[tag].text,
+          }}
+        >
+          {t(`history.type.${tag}`, tag)}
+        </span>
+      ))}
+    </div>
+  )
+}
+
+export default HistoryCardTags


### PR DESCRIPTION
## Summary

- Move the content-tag chips (`link` / `code`) out of the history card header — where they crowded the type label — into a dedicated footer row on the card's last line (e97bd8b).
- Extract the tag rendering into a new `HistoryCardTags` component so the header keeps only "type · size · source/time"; the footer uses `flex-wrap` to handle multiple tags gracefully.

## Test plan

- [x] `tsc --noEmit` passes (typed the footer prop as `ClipboardEntryTag[]`).
- [x] lint/format via pre-commit hook (eslint + prettier) passed on the staged files.
- [ ] Visual check in the History page: tags appear on the last line, header no longer shows chips next to the type, and the hover action bar (bottom-right overlay) still renders correctly over the tag row.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Clipboard history cards now display item tags directly in the card view.
  * Tags are shown only when available, with consistent badge styling and localized labels.

* **UI Improvements**
  * Simplified the card header by removing duplicate tag chips, making key details easier to scan.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->