### PR TITLE
docs(architecture): ADR-010 directory sync as file-set manifest

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -133,7 +133,16 @@ _Avoid_: clipboard state、current clip、selection、LWW key
 **ClipboardEvent** 的 `snapshot_hash`（同一个 hash、同一个名字：寄存器 / 线格 / 持久
 层共用，不是新立的量）。注意两条独立版本线：wire 串前缀 `blake3v1:` 标的是 hash
 **算法** 版本，聚合时另有域分隔前缀 `snapshot-hash-v1|` 标的是 **快照聚合方案** 版本，
-二者各自演进。
+二者各自演进。对含目录结构的 **EntryFileSet**（任一 root 是目录），**结构入
+身份**：文件内容组件不再是裸摘要集合，而是逐成员 leaf 的聚合——
+`leaf = BLAKE3("file-set-member-v1|" ‖ root_name ‖ 0x00 ‖ relative_path ‖ 0x00 ‖
+kind_tag ‖ 0x00 ‖ file_digest)`（relative_path 经 NFC 归一化、`/` 分隔；kind_tag
+`f` 普通文件 / `x` 可执行文件 / `d` 空目录——exec bit 影响粘贴产物故入身份，
+Windows 源端恒为 `f`；空目录以 `d` leaf 参与；大小写不折叠），组件 =
+`BLAKE3("file-set-v1|" ‖ sort(leaves))`。**版本化落在文件内容组件上**
+（`file-content|` → `file-set-v1|`），外层 `snapshot-hash-v1|` 聚合方案不动；纯裸
+文件集合仍走原算法，存量 entry 身份逐字节不变、零迁移。root 目录名入身份，其
+父目录绝对路径不入（设备本地）。
 _Avoid_: entry_id、digest、checksum、transfer_id、blob 的 content_hash、单条
 representation 的 hash
 
@@ -172,7 +181,56 @@ _Avoid_: download、resend、fetch、sync
   于是源端「按 `snapshot_hash` 反查本机 entry」必然落空，pull 取不到内容
 - active-clipboard 的投递同样遵循 **Transient sync semantics**（失败不重试）
 
-## Language — 文件传输（接收侧）
+## Language — 文件集与目录
+
+**EntryFileSet**：
+一条 entry 名下「本次复制涉及的全部文件系统对象」的逐行 manifest。每行由
+`(root_index, relative_path)` 定位：`root_index` 对应 uri-list 中第几条顶层 URI，
+`relative_path` 是该成员在其 root 内的相对路径（裸文件为空串，`kind = dir` 行表达
+空目录）。「复制 3 个文件」「复制 1 个文件夹」「文件与文件夹混选」统一为同一个
+概念——文件集；**目录不是独立聚合，只是带相对路径的文件集成员**。
+_Avoid_: directory manifest、folder entry、file list（指 uri-list rep 文本）
+
+**Sync-ineligible entry**：
+已正常落入本地历史、但被判定不参与同步的 entry（带原因：超文件集限额、单成员
+超限、摄取期间目录被修改、含不可传输成员等）。本地粘贴不受影响——它是「同步
+资格」维度，不是 entry 的生命周期状态。它从未摄取 blob、无就绪的
+`snapshot_hash`，故 **手动重发对它不可用**（没有"事后补摄取"的口子——那会让身份
+脱离任何被复制过的内容）；想同步须解决原因后重新复制。
+_Avoid_: failed entry、local entry、skipped
+
+**文件集成员边界**（EntryFileSet 收什么）：
+普通文件与空目录入集；隐藏文件（dotfiles）照常包含；硬链接当独立普通文件
+（不保留链接关系，传输侧靠内容去重只传一份字节）；executable bit 保留（manifest
+行级标志，Unix 落盘置位、Windows 忽略）；**符号链接与特殊文件（FIFO / socket /
+设备节点）→ 整个目录判 Sync-ineligible**——不静默跳过（违背全有或全无）、不解
+引用（循环 / 树外逃逸 / 语义漂移），拒绝并报明确原因。权限位（除 exec bit）、
+xattr、时间戳不保留，落盘按接收端默认 umask。
+_Avoid_: 部分同步、跳过 symlink、dereference
+
+**Deferred snapshot identity**：
+文件集 entry 的 `snapshot_hash` 依赖读完全部成员字节，故相对捕获时刻 **延迟就绪**：
+捕获热路径只做毫秒级元数据预检（总大小、成员数限额），内容哈希与 blob 摄取
+异步进行；就绪前该 entry 不参与 dispatch 与 active-clipboard 广播。就绪前剪贴板
+被新内容顶替 → 放弃摄取，降级为 **Sync-ineligible entry**。摄取结束对已见成员做
+`(mtime, size)` 漂移复核，发现目录在复制后被修改 → 同样放弃（不传混合态快照）。
+_Avoid_: lazy hash、pending entry、async capture
+
+### 关系（文件集与目录）
+
+- 接收侧对文件集 entry 是 **全有或全无**：全部成员 `Completed` 后才重建目录树并
+  改写本机 uri-list（此前不可粘贴）；任一成员失败 → 按 **Entry transfer summary**
+  聚合为 `Failed`，用户手动重发时已到 blob 按内容去重、只补缺
+- 落盘位置沿用单文件规则（保存目录或托管缓存）；root 目录名冲突**仅对 root 加
+  后缀**（`photos (2)/`），树内部原封不动；重发的重建视为新投递、新建后缀目录，
+  不合并、不覆盖
+- 相对路径落盘做穿越防护（拒 `..`、绝对路径、越界）
+- 手机端（pull-only）不消费文件集 entry：register 指向它时，`GET
+  /SyncClipboard.json` 保持上一个手机可消费的值不变
+- 目录支持以 dedup 计划的 `entry_file_set` 表先落地为前置（目录成员 = 带
+  `(root_index, relative_path)` 的行），不另建平行 schema
+
+
 
 **Tracked inbound file transfer**：
 接收设备本地为「一个正在/已经收下的文件」维护的一条投影记录（id、来源设备、

--- a/docs/architecture/adr-010-directory-sync-as-file-set-manifest.md
+++ b/docs/architecture/adr-010-directory-sync-as-file-set-manifest.md
@@ -1,0 +1,47 @@
+# ADR-010: 目录同步建模为逐文件 manifest（EntryFileSet），而非归档 blob
+
+Status: accepted (2026-07-03)
+
+## 决策
+
+支持「复制/同步目录」时，目录 **不打包成单一归档 blob 传输**，而是展开为逐文件
+manifest：复用 dedup 计划的 `entry_file_set` 逐行表，每行以
+`(root_index, relative_path)` 定位成员，成员文件各自走既有的单文件 blob 通道。
+「复制 3 个文件」「复制 1 个文件夹」「混合选择」统一为同一个概念——entry 的
+文件集（**EntryFileSet**）；目录不是独立聚合。
+
+## 被否掉的方案：tar/zip 归档为单一 blob
+
+归档方案改动面小（传输层仍只见一个 blob），但被否，理由：
+
+- **废掉内容级去重**：目录里改一个文件，归档整体 hash 变、全量重传；manifest
+  方案只重传变化的成员。与进行中的 dual-channel dedup 设计（内容寻址、
+  `entry_file_set`）方向正冲突，等于开一条平行旧逻辑。
+- 打包需要与目录等大的临时磁盘空间。
+- `max_file_size` 的每文件语义被改变成对归档总量限制。
+- 跨平台归档元数据（权限、符号链接）是持续的坑。
+
+## 关键连带决策
+
+1. **结构入身份**：含目录的文件集，`snapshot_hash` 的文件内容组件由逐成员
+   leaf 聚合——`BLAKE3("file-set-member-v1|" ‖ root_name ‖ 0x00 ‖ relative_path
+   ‖ 0x00 ‖ kind_tag ‖ 0x00 ‖ file_digest)`，组件 = `BLAKE3("file-set-v1|" ‖
+   sort(leaves))`。relative_path 经 NFC 归一化、`/` 分隔；kind_tag `f`/`x`
+   （可执行）/`d`（空目录），exec bit 影响粘贴产物故入身份。**版本化落在文件
+   内容组件**（`file-content|` → `file-set-v1|`），外层 `snapshot-hash-v1|`
+   聚合不动——纯裸文件集合哈希逐字节不变，存量 entry 身份零迁移。
+2. **全有或全无的接收语义**：全部成员完成后才重建目录树、改写 uri-list；部分
+   失败按 Entry transfer summary 聚合为 `Failed`，手动重发靠 blob 内容去重
+   增量补缺。不粘贴静默缺文件的目录（准数据丢失比失败更糟）。
+3. **捕获侧护栏**：捕获热路径只做毫秒级元数据预检（文件集总大小上限 ~1 GiB、
+   成员数上限 ~2000，`file_sync` 设置可调）；内容哈希/摄取异步（Deferred
+   snapshot identity），就绪前不 dispatch、不广播；摄取毕做 `(mtime, size)`
+   漂移复核，目录被改则放弃。内容 hash 物理上受磁盘 I/O 限制（1 GiB ≈ 秒级），
+   不可能毫秒级；元数据身份（mtime）方案因跨设备不可比、破坏 pull 反查而被否。
+4. **成员边界**：symlink 与特殊文件（FIFO/socket/设备节点）→ 整个目录判
+   Sync-ineligible（不静默跳过、不解引用）；隐藏文件包含；硬链接当独立文件；
+   除 exec bit 外权限/xattr/时间戳不保留。
+5. **范围**：桌面三平台；移动端不消费文件集 entry（register 指向它时 mobile
+   GET 保持上一个可消费值）。前置依赖：dedup 计划的 `entry_file_set` 表先落地。
+
+领域术语与完整语义见 `CONTEXT.md`「Language — 文件集与目录」。


### PR DESCRIPTION
## Summary

- Record the design for directory copy/sync support as ADR-010 (c558ebf80): directories are modeled as a per-file **EntryFileSet** manifest reusing the existing single-file blob channel, rejecting the tar/zip-archive-blob alternative (it defeats content-level dedup and conflicts with the in-flight dual-channel dedup plan).
- The ADR also pins the load-bearing follow-on decisions: structure enters `snapshot_hash` via a new `file-set-v1` file-content component (outer `snapshot-hash-v1|` scheme untouched — existing entries keep byte-identical identity), all-or-nothing receive semantics, capture-side metadata guards with deferred snapshot identity, member-type boundaries (symlinks/special files → whole directory sync-ineligible; exec bit preserved and identity-bearing), and desktop-only scope.
- Extend `CONTEXT.md` with a new "文件集与目录" language section (EntryFileSet, Sync-ineligible entry, Deferred snapshot identity, member boundaries, receiver-side relationships) and amend the `snapshot_hash` term with the structured aggregation definition.

Design-docs only — no code changes. Implementation is gated on the dedup plan's `entry_file_set` table landing first (see ADR §5).

## Test plan

- [x] Docs-only change; verified the hash-scheme description against the current implementation in `crates/uc-core/src/clipboard/system.rs` (`snapshot_hash`, lines 541-582).
- [ ] Reviewer: sanity-check that the identity-scheme wording (component-level versioning, v1 bare-file sets unchanged) matches the dual-channel dedup plan in `.planning/2026-06-25-*`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clearer guidance for how directory sync works when copying folder-like content.
  * Clarified which items are included, which are rejected, and when a sync attempt may be deferred or retried.
  * Documented the expected behavior for empty folders, hidden files, permissions, and unsupported special items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->