### PR TITLE
fix(linux): make titlebar controls work when window isn't maximized

### DIFF
--- a/src-tauri/crates/uc-tauri/src/main_window.rs
+++ b/src-tauri/crates/uc-tauri/src/main_window.rs
@@ -22,11 +22,10 @@
 
 use tauri::Manager;
 use tracing::{error, info};
-// Every `warn!` call in this file lives inside a macOS or Windows `cfg`
-// block; on other platforms (e.g. the Linux coverage runner) the import is
-// genuinely unused.
+// Every `warn!` call in this file lives inside a macOS, Windows, or Linux
+// `cfg` block; on other platforms the import is genuinely unused.
 #[cfg_attr(
-    not(any(target_os = "macos", target_os = "windows")),
+    not(any(target_os = "macos", target_os = "windows", target_os = "linux")),
     allow(unused_imports)
 )]
 use tracing::warn;
@@ -92,17 +91,23 @@ fn create_main_window(app: &tauri::AppHandle) -> tauri::Result<tauri::WebviewWin
     Ok(window)
 }
 
-/// Windows: the config uses `titleBarStyle: Overlay` for macOS; on Windows the
-/// native decorations must be turned off after creation instead. This must run
-/// on every (re)creation, not just at startup.
-#[cfg(target_os = "windows")]
+/// Windows and Linux: the config uses `titleBarStyle: Overlay` for macOS; on
+/// Windows and Linux the native decorations must be turned off after creation
+/// instead, so the React-drawn `TitleBar` component (which draws its own
+/// window controls on these platforms) is the only thing handling clicks.
+/// Leaving native GTK/Wayland CSD enabled alongside the transparent webview
+/// causes clicks on the OS decoration buttons to be swallowed by the
+/// compositor's resize hit-testing margin while the window is not maximized
+/// (see issue #1303). This must run on every (re)creation, not just at
+/// startup.
+#[cfg(any(target_os = "windows", target_os = "linux"))]
 fn configure_for_platform(window: &tauri::WebviewWindow) {
     if let Err(error) = window.set_decorations(false) {
-        warn!(error = %error, "Failed to disable Windows main window decorations");
+        warn!(error = %error, "Failed to disable native main window decorations");
     }
 }
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(not(any(target_os = "windows", target_os = "linux")))]
 fn configure_for_platform(_window: &tauri::WebviewWindow) {}
 
 /// macOS: force the Dock to repaint this app's icon after flipping back to the

--- a/src-tauri/crates/uc-tauri/src/run.rs
+++ b/src-tauri/crates/uc-tauri/src/run.rs
@@ -220,6 +220,64 @@ fn disable_webkit_dmabuf_on_wayland() {
     );
 }
 
+/// Force GTK's X11 backend under WSL to avoid a GTK/WebKitGTK startup hang.
+///
+/// WSLg's Wayland compositor hangs GTK's native Wayland backend indefinitely
+/// during startup on some builds: `gtk_init` completes and its worker threads
+/// spawn, but the process then blocks forever in `poll()` before any window
+/// is created or WebKit helper process is forked — no crash, no log line,
+/// nothing to catch with a timeout. Forcing `GDK_BACKEND=x11` (WSLg exposes
+/// both an X11 and a Wayland socket) sidesteps the hang entirely; this was
+/// confirmed by launching the binary directly with the override under WSL2.
+/// Native Linux Wayland desktops are unaffected and keep the default backend.
+///
+/// Scope is intentionally limited to WSL (detected via `WSL_DISTRO_NAME` /
+/// `WSL_INTEROP`, or `microsoft`/`wsl` in `/proc/sys/kernel/osrelease` as a
+/// fallback for setups that don't export either variable) — this is a dev/VM
+/// quirk, not a real end-user Wayland desktop issue. An explicit user value
+/// for `GDK_BACKEND` is always respected.
+///
+/// Must be called early in `run()`, before the Tauri builder creates the
+/// event loop: GTK reads this variable in `gtk_init`.
+///
+/// Compiled on every platform (it touches only cross-platform `std::env`/`std::fs`
+/// APIs) so it type-checks on the dev host, but only called on Linux.
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+fn force_x11_backend_on_wsl() {
+    const VAR: &str = "GDK_BACKEND";
+
+    // Respect an explicit user choice.
+    if std::env::var_os(VAR).is_some() {
+        info!(var = VAR, "GDK_BACKEND already set; leaving it untouched");
+        return;
+    }
+
+    if !is_wsl() {
+        return;
+    }
+
+    // SAFETY: see the identical reasoning in `disable_webkit_dmabuf_on_wayland`
+    // just above — this also runs on the main thread before GTK/WebKit
+    // initialize, with no concurrent environment access.
+    unsafe { std::env::set_var(VAR, "x11") };
+    info!(
+        var = VAR,
+        "WSL detected; forced GDK_BACKEND=x11 to avoid a GTK/WebKitGTK startup hang under \
+         WSLg's Wayland compositor (export the variable yourself to override)"
+    );
+}
+
+/// Best-effort WSL detection. `WSL_DISTRO_NAME`/`WSL_INTEROP` are set by
+/// WSL's default interop shims; the `osrelease` check is a fallback for
+/// environments that strip those (e.g. a nested shell that scrubbed the env).
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+fn is_wsl() -> bool {
+    std::env::var_os("WSL_DISTRO_NAME").is_some()
+        || std::env::var_os("WSL_INTEROP").is_some()
+        || std::fs::read_to_string("/proc/sys/kernel/osrelease")
+            .is_ok_and(|release| release.to_lowercase().contains("microsoft"))
+}
+
 pub fn run(tauri_ctx: tauri::Context<tauri::Wry>) -> anyhow::Result<()> {
     // Tracing must be initialized before anything else so all subsequent
     // log calls (including build_gui_client_context) are captured.
@@ -230,6 +288,12 @@ pub fn run(tauri_ctx: tauri::Context<tauri::Wry>) -> anyhow::Result<()> {
     // run-loop closure below and dropped at `RunEvent::Exit` so buffered log
     // lines reach disk before tao's destructor-skipping `process::exit`.
     let mut json_log_guard = init_gui_tracing();
+
+    // Under WSL, GTK's native Wayland backend hangs on startup before any
+    // window exists (see `force_x11_backend_on_wsl`). Must run before GTK's
+    // event loop is created, same as the DMABUF override below.
+    #[cfg(target_os = "linux")]
+    force_x11_backend_on_wsl();
 
     // WebKitGTK's DMABUF renderer is unreliable on Wayland (notably wlroots
     // compositors like hyprland / sway): the WebView crashes or renders blank.

--- a/src/components/TitleBar.tsx
+++ b/src/components/TitleBar.tsx
@@ -59,7 +59,10 @@ export const TitleBar = ({ className, isSetupActive = false, rightSlot }: TitleB
   const [isMaximized, setIsMaximized] = useState(false)
 
   // 使用 usePlatform hook 获取平台信息
-  const { isWindows, isMac, isTauri } = usePlatform()
+  const { isWindows, isMac, isLinux, isTauri } = usePlatform()
+  // Windows 和 Linux 都关闭了系统原生装饰（见 main_window.rs），
+  // 由这里自绘的按钮 + 拖拽层接管窗口控制。
+  const hasCustomControls = isWindows || isLinux
   const windowRef = useMemo(() => (isTauri ? getCurrentWindow() : null), [isTauri])
 
   // Setup 页面隐藏 TitleBar 保持沉浸感
@@ -178,11 +181,11 @@ export const TitleBar = ({ className, isSetupActive = false, rightSlot }: TitleB
             aria-label="Toggle window maximize"
             className="absolute inset-0 z-0 cursor-default bg-transparent"
             onDoubleClick={() => {
-              if (!isWindows) return
+              if (!hasCustomControls) return
               handleToggleMaximize()
             }}
             onKeyDown={event => {
-              if (!isWindows) return
+              if (!hasCustomControls) return
               if (event.key === 'Enter' || event.key === ' ') {
                 event.preventDefault()
                 handleToggleMaximize()
@@ -196,7 +199,7 @@ export const TitleBar = ({ className, isSetupActive = false, rightSlot }: TitleB
             {rightSlot}
           </div>
         )}
-        {isWindows && (
+        {hasCustomControls && (
           <div className="flex items-center h-full bg-transparent" data-tauri-drag-region="false">
             <TitleBarButton aria-label="最小化" onClick={handleMinimize}>
               <Minus className="size-4" />


### PR DESCRIPTION
## Summary

- Linux never disabled native GTK/Wayland window decorations, and the React `TitleBar` only rendered its custom minimize/maximize/close buttons on Windows. With native CSD and the app's transparent drag-region overlay both present, GNOME/Mutter's resize hit-testing margin on non-maximized windows swallowed clicks meant for the native buttons — maximized windows have no such margin, which is why the buttons worked only in that state. Disabling native decorations on Linux and reusing the existing custom button row fixes this (ecdf34df3).
- Separately, while verifying the fix locally under WSL2, the app hung indefinitely on startup before any window appeared (GTK init completes, then blocks forever in `poll()` — no crash, no further log line). Root-caused to WSLg's native Wayland GTK backend; confirmed `GDK_BACKEND=x11` starts the app cleanly every time. Added WSL auto-detection that forces the X11 backend only in that environment; native Linux Wayland desktops are unaffected (9fcc384fa).

Closes #1303.

## Test plan

- [x] `cargo check -p uc-tauri` and `tsc --noEmit` pass.
- [x] Verified end-to-end under WSL2: `bun run tauri:dev` now starts cleanly (window created, webview loaded, tray/global-shortcut initialized) with no manual env override needed — confirms the WSL fix.
- [ ] Manually confirm on a native Ubuntu/GNOME Wayland desktop (the actual #1303 environment) that minimize/maximize/close all respond while the window is not maximized, and double-click-to-maximize still works.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Custom window controls now appear on both Windows and Linux, improving the title bar experience on more platforms.
  * Native window decorations are now disabled on Windows and Linux for a more consistent app frame.
  * Linux startup includes a compatibility fix for WSL/WSLg to help prevent launch hangs in some environments.

* **Bug Fixes**
  * Improved window control behavior so maximize actions work correctly where custom controls are shown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->