### PR TITLE
feat(observability): harden background tokio::spawn tasks (#1260)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10368,6 +10368,7 @@ dependencies = [
  "tracing",
  "uc-app-paths",
  "uc-core",
+ "uc-observability",
  "unicode-normalization",
  "unicode-segmentation",
  "url",

--- a/apps/daemon/src/daemon/host.rs
+++ b/apps/daemon/src/daemon/host.rs
@@ -153,7 +153,7 @@ pub fn run(run_mode: DaemonRunMode) -> anyhow::Result<()> {
 
         let blob_ports = uc_bootstrap::BlobProcessingPorts::from_app_deps(&wired.deps);
         let task_registry_for_blob = Arc::clone(runtime.task_registry());
-        tokio::spawn(async move {
+        uc_observability::spawn_supervised("blob.processing_tasks", async move {
             uc_bootstrap::spawn_blob_processing_tasks(
                 background,
                 blob_ports,

--- a/apps/daemon/src/daemon/startup_recovery.rs
+++ b/apps/daemon/src/daemon/startup_recovery.rs
@@ -41,7 +41,10 @@ pub struct StartupRecoveryInput {
 /// 恢复动作可能触发系统钥匙串，启动阶段不能同步等待它完成；daemon 先把
 /// HTTP 监听拉起来，再让这个后台任务慢慢恢复。
 pub fn spawn_startup_recovery(input: StartupRecoveryInput) {
-    tokio::spawn(async move {
+    // One-shot best-effort recovery with no natural lifecycle owner to hold a
+    // handle. Use `spawn_supervised` so a panic mid-recovery surfaces as a log
+    // line instead of vanishing silently (see `uc-infra/AGENTS.md §13.3`).
+    uc_observability::spawn_supervised("daemon.startup_recovery", async move {
         // ADR-008 D9 (P4-2): only an *attended* daemon respects the user's
         // `auto_unlock_enabled` setting. Attended = this daemon was spawned by
         // a GUI (which will connect and drive unlock + `POST /lifecycle/ready`),

--- a/apps/daemon/src/daemon/workers/clipboard_watcher.rs
+++ b/apps/daemon/src/daemon/workers/clipboard_watcher.rs
@@ -279,7 +279,8 @@ impl ClipboardChangeHandler for DaemonClipboardChangeHandler {
 
                 let clipboard_outbound = Arc::clone(&self.clipboard_outbound);
                 let entry_id_for_outbound = entry_id.to_string();
-                tokio::spawn(
+                uc_observability::spawn_supervised(
+                    "clipboard_watcher.outbound_dispatch",
                     async move {
                         match clipboard_outbound
                             .dispatch_capture(ClipboardOutboundInput {

--- a/apps/daemon/src/daemon/workers/inbound_clipboard_sync.rs
+++ b/apps/daemon/src/daemon/workers/inbound_clipboard_sync.rs
@@ -195,9 +195,9 @@ impl DaemonService for InboundClipboardSyncWorker {
         // `subscribe_inbound_notices` spawns a relay task per call that
         // bridges the internal `InboundClipboardNotice` broadcast to a
         // fresh public `InboundNotice` broadcast. We subscribe once at
-        // worker start — the relay task lives until the facade itself
-        // is dropped, which happens when the `SyncEngineAssembly` is
-        // torn down (shutdown path in `entrypoint.rs`).
+        // worker start; the returned `InboundNoticeSubscription` owns the
+        // relay task's handle and aborts it when `rx` is dropped — i.e. when
+        // this `start` future returns on cancellation.
         let mut rx = self.clipboard_sync.subscribe_inbound_notices();
 
         loop {

--- a/apps/daemon/src/daemon/workers/peer_keepalive.rs
+++ b/apps/daemon/src/daemon/workers/peer_keepalive.rs
@@ -510,13 +510,16 @@ impl DaemonService for PeerKeepAliveWorker {
                             // result is intentionally dropped — failures
                             // are observed on the next tick's dial.
                             let app_facade = Arc::clone(&self.app_facade);
-                            tokio::spawn(async move {
-                                debug!(
-                                    device = %device.as_str(),
-                                    "inbound presence Online; spawning outbound dial",
-                                );
-                                let _ = app_facade.ensure_reachable_one(&device).await;
-                            });
+                            uc_observability::spawn_supervised(
+                                "peer_keepalive.outbound_dial",
+                                async move {
+                                    debug!(
+                                        device = %device.as_str(),
+                                        "inbound presence Online; spawning outbound dial",
+                                    );
+                                    let _ = app_facade.ensure_reachable_one(&device).await;
+                                },
+                            );
                         }
                     }
                 }

--- a/crates/AGENTS.md
+++ b/crates/AGENTS.md
@@ -1,6 +1,6 @@
 # PROJECT KNOWLEDGE BASE
 
-**Last refreshed:** 2026-07-08 (auto; 22 workspace crates)
+**Last refreshed:** 2026-07-10 (auto; 22 workspace crates)
 
 ## OVERVIEW
 

--- a/crates/uc-application/src/facade/app_facade.rs
+++ b/crates/uc-application/src/facade/app_facade.rs
@@ -48,11 +48,11 @@ use crate::facade::{
     ClipboardOutboundFacade, ClipboardRestoreFacade, ClipboardSyncError, ClipboardSyncFacade,
     DeviceFacade, DiagnosticsFacade, DispatchEntryOutcome, EncryptionFacade, EncryptionFacadeError,
     EncryptionStateView, FetchBlobCommand, FetchBlobResult, FetchBlobToPathCommand,
-    FetchBlobToPathResult, InboundNotice, LifecycleFacade, MemberRosterFacade, PublishBlobCommand,
-    PublishBlobPathCommand, PublishBlobResult, ResendEntryCommand, ResendEntryError, ResendReport,
-    ResourceFacade, SearchFacade, SearchFacadeError, SearchPageView, SearchQueryInput,
-    SearchRebuildAcceptedView, SearchStatusView, SettingsFacade, SettingsFacadeError,
-    SpaceSetupFacade, StorageFacade,
+    FetchBlobToPathResult, InboundNoticeSubscription, LifecycleFacade, MemberRosterFacade,
+    PublishBlobCommand, PublishBlobPathCommand, PublishBlobResult, ResendEntryCommand,
+    ResendEntryError, ResendReport, ResourceFacade, SearchFacade, SearchFacadeError,
+    SearchPageView, SearchQueryInput, SearchRebuildAcceptedView, SearchStatusView, SettingsFacade,
+    SettingsFacadeError, SpaceSetupFacade, StorageFacade,
 };
 use crate::usecases::clipboard_sync::V3BlobRef;
 use uc_core::ids::DeviceId;
@@ -446,7 +446,7 @@ impl AppFacade {
     /// 订阅入站剪贴板通知。
     pub fn subscribe_inbound_clipboard_notices(
         &self,
-    ) -> Result<broadcast::Receiver<InboundNotice>, ClipboardSyncError> {
+    ) -> Result<InboundNoticeSubscription, ClipboardSyncError> {
         self.clipboard_sync
             .get()
             .cloned()

--- a/crates/uc-application/src/facade/clipboard/facade.rs
+++ b/crates/uc-application/src/facade/clipboard/facade.rs
@@ -184,6 +184,63 @@ impl IngestHandle {
     }
 }
 
+/// A live subscription to the inbound-notice broadcast, returned by
+/// [`ClipboardSyncFacade::subscribe_inbound_notices`].
+///
+/// Wraps the public [`broadcast::Receiver`] and owns the background bridge
+/// task that relays internal notices onto it. The wrapper ties the bridge
+/// task's lifetime to the subscriber: dropping the subscription aborts the
+/// bridge, so a subscriber that goes away does not leave a task looping until
+/// the whole facade is torn down. `Deref`/`DerefMut` expose the underlying
+/// receiver, so callers use `.recv()` exactly as before.
+pub struct InboundNoticeSubscription {
+    rx: broadcast::Receiver<InboundNotice>,
+    bridge: Option<tokio::task::JoinHandle<()>>,
+}
+
+impl std::ops::Deref for InboundNoticeSubscription {
+    type Target = broadcast::Receiver<InboundNotice>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.rx
+    }
+}
+
+impl std::ops::DerefMut for InboundNoticeSubscription {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.rx
+    }
+}
+
+impl Drop for InboundNoticeSubscription {
+    fn drop(&mut self) {
+        let Some(handle) = self.bridge.take() else {
+            return;
+        };
+        handle.abort();
+        // Surface a bridge panic instead of letting it vanish with the aborted
+        // handle (observability requirement — a silently dead task is a bug we
+        // must be able to see). Awaiting must happen off-thread since `drop`
+        // is sync; guard on a live runtime so dropping outside async context
+        // (e.g. in a sync test teardown) degrades to a plain abort rather than
+        // panicking. Cancellation is expected here — only a real panic warns.
+        if tokio::runtime::Handle::try_current().is_ok() {
+            tokio::spawn(async move {
+                if let Err(err) = handle.await {
+                    if !err.is_cancelled() {
+                        tracing::warn!(
+                            event = "task.panicked",
+                            task = "clipboard.inbound_bridge",
+                            error = %err,
+                            "inbound-notice bridge task panicked"
+                        );
+                    }
+                }
+            });
+        }
+    }
+}
+
 /// Clipboard sync facade — the single public entry point for Slice 2
 /// Phase 2.
 pub struct ClipboardSyncFacade {
@@ -361,21 +418,30 @@ impl ClipboardSyncFacade {
 
     /// Subscribe to the inbound-notice broadcast. CLI `watch` / future
     /// daemon subscribers attach here.
-    pub fn subscribe_inbound_notices(&self) -> broadcast::Receiver<InboundNotice> {
+    pub fn subscribe_inbound_notices(&self) -> InboundNoticeSubscription {
         // Bridge from the internal broadcast to the public-type broadcast
         // via a relay task. This keeps public types independent of
         // `usecases::*` renames while still letting lagging subscribers
-        // recover per broadcast semantics.
+        // recover per broadcast semantics. The returned
+        // `InboundNoticeSubscription` owns this task's handle and aborts it
+        // on drop, so the bridge stops when its subscriber goes away rather
+        // than looping until the whole facade is dropped.
         let (public_tx, public_rx) = broadcast::channel(64);
         let mut internal_rx = self.ingest_uc.subscribe_notices();
-        tokio::spawn(async move {
+        let bridge = tokio::spawn(async move {
             loop {
                 match internal_rx.recv().await {
                     Ok(internal) => {
                         let lifted = lift_notice(internal);
                         if public_tx.send(lifted).is_err() {
-                            // No public subscribers — keep consuming so
-                            // the internal broadcast doesn't lag us.
+                            // No public receiver right now. While the
+                            // subscription is alive this cannot happen (the
+                            // guard holds one receiver); it is only reachable
+                            // in the brief window after the subscriber drops
+                            // the guard but before the abort lands. Keep
+                            // consuming so the internal broadcast doesn't lag —
+                            // the next `internal_rx.recv().await` is where the
+                            // pending abort takes effect.
                             continue;
                         }
                     }
@@ -383,8 +449,16 @@ impl ClipboardSyncFacade {
                     Err(broadcast::error::RecvError::Closed) => break,
                 }
             }
+            tracing::debug!(
+                event = "clipboard.inbound_bridge_stopped",
+                reason = "internal_broadcast_closed",
+                "inbound-notice bridge task exiting"
+            );
         });
-        public_rx
+        InboundNoticeSubscription {
+            rx: public_rx,
+            bridge: Some(bridge),
+        }
     }
 
     /// Spawn the ingest background loop. Caller owns the returned handle;
@@ -963,6 +1037,51 @@ mod tests {
         assert_eq!(notice.from_device.as_str(), "peer-x");
         assert_eq!(notice.plaintext, Bytes::from_static(b"hello"));
         assert_eq!(notice.action, InboundAction::NewEntry);
+    }
+
+    /// Dropping an `InboundNoticeSubscription` must abort its bridge task so
+    /// the internal notice receiver is released — otherwise every subscribe
+    /// leaks a task looping until the whole facade is torn down (the bug this
+    /// wrapper fixes). Observed via the internal broadcast's receiver count.
+    #[tokio::test]
+    async fn dropping_subscription_aborts_bridge_and_releases_internal_receiver() {
+        let (facade, _receiver) = build_facade(
+            MockPeerAddrRepo::new(),
+            make_presence_unknown(),
+            MockCipher::new(),
+            MockDispatch::new(),
+            make_device_identity("self"),
+            make_local_identity(),
+            make_settings(),
+        );
+
+        let before = facade.ingest_uc.notice_receiver_count();
+
+        // `subscribe_inbound_notices` subscribes to the internal broadcast
+        // synchronously (before spawning the bridge), so the count rises
+        // immediately and deterministically.
+        let subscription = facade.subscribe_inbound_notices();
+        assert_eq!(
+            facade.ingest_uc.notice_receiver_count(),
+            before + 1,
+            "bridge task should hold one internal notice receiver while subscribed"
+        );
+
+        drop(subscription);
+
+        // `abort()` is asynchronous: the aborted task releases its captured
+        // internal receiver only once the runtime polls it. Poll the count
+        // until it settles rather than assuming a fixed delay.
+        let mut waited_ms = 0;
+        while facade.ingest_uc.notice_receiver_count() > before && waited_ms < 1000 {
+            tokio::time::sleep(Duration::from_millis(5)).await;
+            waited_ms += 5;
+        }
+        assert_eq!(
+            facade.ingest_uc.notice_receiver_count(),
+            before,
+            "dropping the subscription must abort the bridge and release its internal receiver"
+        );
     }
 
     /// Verdict 3 — `dispatch_snapshot` encodes the snapshot into the V3

--- a/crates/uc-application/src/facade/clipboard/mod.rs
+++ b/crates/uc-application/src/facade/clipboard/mod.rs
@@ -11,7 +11,8 @@ mod facade;
 
 pub use facade::{
     ClipboardSyncDeps, ClipboardSyncError, ClipboardSyncFacade, DispatchEntryInput,
-    DispatchEntryOutcome, DispatchEntryPerTarget, InboundAction, InboundNotice, IngestHandle,
+    DispatchEntryOutcome, DispatchEntryPerTarget, InboundAction, InboundNotice,
+    InboundNoticeSubscription, IngestHandle,
 };
 
 // 投递状态视图相关类型——外部 crate 通过 `ClipboardSyncFacade::get_entry_delivery_view`

--- a/crates/uc-application/src/facade/mobile_sync/outbound_adapter.rs
+++ b/crates/uc-application/src/facade/mobile_sync/outbound_adapter.rs
@@ -85,7 +85,7 @@ impl MobileInboundFanOutPort for ClipboardOutboundFanOutAdapter {
         // - 触发 file 路径提取 + blob 发布(`RemotePush` 会被 dispatcher
         //   显式 short-circuit 成 Skipped, 不走 publish);
         // - 经由 `OutboundSyncPlanner` 与本机复制走同一条策略链路。
-        tokio::spawn(async move {
+        uc_observability::spawn_supervised("mobile_sync.outbound_dispatch", async move {
             match outbound
                 .dispatch_capture(ClipboardOutboundInput {
                     entry_id: entry_id_str,

--- a/crates/uc-application/src/facade/mod.rs
+++ b/crates/uc-application/src/facade/mod.rs
@@ -54,7 +54,7 @@ pub use clipboard::{
     ClipboardSyncDeps, ClipboardSyncError, ClipboardSyncFacade, DispatchEntryInput,
     DispatchEntryOutcome, DispatchEntryPerTarget, EntryDeliveryStatusView, EntryDeliveryTargetView,
     EntryDeliveryView, EntrySource, GetEntryDeliveryViewError, InboundAction, InboundNotice,
-    IngestHandle,
+    InboundNoticeSubscription, IngestHandle,
 };
 // V3 envelope codec helpers — surfaced through the facade per §11.4.3 so
 // external CLI / test consumers don't reach into `crate::usecases::*`

--- a/crates/uc-application/src/facade/search/coordinator.rs
+++ b/crates/uc-application/src/facade/search/coordinator.rs
@@ -221,7 +221,8 @@ impl SearchCoordinator {
                 let state = Arc::clone(&self.state);
 
                 let span = info_span!("search.rebuild", reason = REASON_MANUAL_REBUILD);
-                tokio::spawn(
+                uc_observability::spawn_supervised(
+                    "search.rebuild.manual",
                     async move {
                         let _guard = guard;
                         Self::run_rebuild(deps, event_tx, state, REASON_MANUAL_REBUILD).await;
@@ -327,7 +328,8 @@ impl SearchCoordinator {
     /// version or the purge already completed.
     fn spawn_purge_if_needed(&self) {
         let deps = Arc::clone(&self.deps);
-        tokio::spawn(
+        uc_observability::spawn_supervised(
+            "search.purge_residue",
             async move {
                 purge_plaintext_residue_if_needed(&deps).await;
             }
@@ -390,7 +392,8 @@ impl SearchCoordinator {
             }
             let deps = Arc::clone(&self.deps);
             let in_flight = Arc::clone(&self.repair_in_flight);
-            tokio::spawn(
+            uc_observability::spawn_supervised(
+                "search.repair",
                 async move {
                     // Hold the permit for the whole repair so concurrency stays
                     // capped at `MAX_CONCURRENT_REPAIRS`.
@@ -409,7 +412,8 @@ impl SearchCoordinator {
         let event_tx = self.event_tx.clone();
         let state = Arc::clone(&self.state);
         let span = info_span!("search.rebuild", reason);
-        tokio::spawn(
+        uc_observability::spawn_supervised(
+            "search.rebuild.trigger",
             async move {
                 let _guard = guard;
                 Self::run_rebuild(deps, event_tx, state, reason).await;
@@ -498,7 +502,8 @@ impl SearchCoordinator {
 
         let (progress_tx, mut progress_rx) = mpsc::channel::<RebuildProgress>(64);
         let event_tx_clone = event_tx.clone();
-        tokio::spawn(
+        uc_observability::spawn_supervised(
+            "search.rebuild.progress_forwarder",
             async move {
                 while let Some(progress) = progress_rx.recv().await {
                     emit_progress(&event_tx_clone, progress);

--- a/crates/uc-application/src/usecases/clipboard_sync/active_state/apply_inbound.rs
+++ b/crates/uc-application/src/usecases/clipboard_sync/active_state/apply_inbound.rs
@@ -506,65 +506,68 @@ impl ApplyInboundActiveClipboardStateUseCase {
         let send_gate = self.send_gate.clone();
         let converged_tx = self.converged_tx.clone();
 
-        tokio::spawn(async move {
-            // The active-clipboard write is a remote-originated push: use the
-            // RemotePush intent so the OS-write origin guard matches the bulk
-            // inbound path (avoids the watcher re-capturing our own write).
-            if let Err(err) = coordinator
-                .write(snapshot, ClipboardWriteIntent::RemotePush)
-                .await
-            {
-                warn!(
-                    error = %err,
-                    snapshot_hash = %state.snapshot_hash,
-                    "active state inbound: OS write failed; not advancing register or re-broadcasting"
-                );
-                return;
-            }
-
-            // OS write succeeded → advance the register. The SQL CAS is the
-            // authoritative LWW arbiter; `advanced == false` means a
-            // concurrent local/inbound write already moved the register past
-            // this state, in which case we must NOT re-broadcast (loop-safe).
-            match advance_register.advance(&state).await {
-                Ok(true) => {}
-                Ok(false) => {
-                    debug!(
-                        snapshot_hash = %state.snapshot_hash,
-                        "active state inbound: register did not advance (lost LWW race); skipping re-broadcast"
-                    );
-                    return;
-                }
-                Err(err) => {
+        uc_observability::spawn_supervised(
+            "clipboard_sync.active_write_then_converge",
+            async move {
+                // The active-clipboard write is a remote-originated push: use the
+                // RemotePush intent so the OS-write origin guard matches the bulk
+                // inbound path (avoids the watcher re-capturing our own write).
+                if let Err(err) = coordinator
+                    .write(snapshot, ClipboardWriteIntent::RemotePush)
+                    .await
+                {
                     warn!(
                         error = %err,
                         snapshot_hash = %state.snapshot_hash,
-                        "active state inbound: register advance failed; skipping re-broadcast"
+                        "active state inbound: OS write failed; not advancing register or re-broadcasting"
                     );
                     return;
                 }
-            }
 
-            // Notify subscribers that this entry converged (e.g. resurface
-            // worker bumps active_time_ms + notifies the frontend).
-            let _ = converged_tx.send(ActiveClipboardConvergedEvent {
-                entry_id: state.entry_id.clone(),
-            });
+                // OS write succeeded → advance the register. The SQL CAS is the
+                // authoritative LWW arbiter; `advanced == false` means a
+                // concurrent local/inbound write already moved the register past
+                // this state, in which case we must NOT re-broadcast (loop-safe).
+                match advance_register.advance(&state).await {
+                    Ok(true) => {}
+                    Ok(false) => {
+                        debug!(
+                            snapshot_hash = %state.snapshot_hash,
+                            "active state inbound: register did not advance (lost LWW race); skipping re-broadcast"
+                        );
+                        return;
+                    }
+                    Err(err) => {
+                        warn!(
+                            error = %err,
+                            snapshot_hash = %state.snapshot_hash,
+                            "active state inbound: register advance failed; skipping re-broadcast"
+                        );
+                        return;
+                    }
+                }
 
-            // Re-broadcast the converged state to every allowed peer through
-            // the shared fan-out (full outbound gate: send_enabled ∧
-            // send_content_types, the latter via the activation's category
-            // set). Same implementation as the restore broadcast path.
-            fan_out_active_state(
-                &dispatch,
-                &peer_addr_repo,
-                &presence,
-                &send_gate,
-                &state,
-                &categories,
-            )
-            .await;
-        })
+                // Notify subscribers that this entry converged (e.g. resurface
+                // worker bumps active_time_ms + notifies the frontend).
+                let _ = converged_tx.send(ActiveClipboardConvergedEvent {
+                    entry_id: state.entry_id.clone(),
+                });
+
+                // Re-broadcast the converged state to every allowed peer through
+                // the shared fan-out (full outbound gate: send_enabled ∧
+                // send_content_types, the latter via the activation's category
+                // set). Same implementation as the restore broadcast path.
+                fan_out_active_state(
+                    &dispatch,
+                    &peer_addr_repo,
+                    &presence,
+                    &send_gate,
+                    &state,
+                    &categories,
+                )
+                .await;
+            },
+        )
     }
 }
 

--- a/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/usecase.rs
+++ b/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/usecase.rs
@@ -563,7 +563,8 @@ impl ApplyInboundClipboardUseCase {
             // the missing peer_id field is exactly what made the recent UNICLIPBOARD-RUST-F
             // triage take an extra hour (couldn't tell whether 50 failures were one peer
             // hammering or many peers each pushing once).
-            tokio::spawn(
+            uc_observability::spawn_supervised(
+                "clipboard_sync.inbound_os_write",
                 async move {
                     // The live-index pass above already awaited and dropped its
                     // `Arc` clone, so this reclaims sole ownership without

--- a/crates/uc-application/src/usecases/clipboard_sync/dispatch_entry/delivery.rs
+++ b/crates/uc-application/src/usecases/clipboard_sync/dispatch_entry/delivery.rs
@@ -220,7 +220,8 @@ pub(crate) fn spawn_deferred_drain(
     snapshot_hash: String,
 ) {
     let deferred_count = set.len();
-    tokio::spawn(
+    uc_observability::spawn_supervised(
+        "clipboard_sync.deferred_drain",
         async move {
             let started = Instant::now();
             let mut accepted = 0usize;

--- a/crates/uc-application/src/usecases/clipboard_sync/ingest_inbound.rs
+++ b/crates/uc-application/src/usecases/clipboard_sync/ingest_inbound.rs
@@ -114,6 +114,15 @@ impl IngestInboundClipboardUseCase {
         self.notices_tx.subscribe()
     }
 
+    /// Number of live notice subscribers. Test-only: lets the facade suite
+    /// assert that dropping an `InboundNoticeSubscription` releases the bridge
+    /// task's internal receiver (i.e. the bridge was actually aborted, not
+    /// leaked).
+    #[cfg(test)]
+    pub(crate) fn notice_receiver_count(&self) -> usize {
+        self.notices_tx.receiver_count()
+    }
+
     /// Spawn the ingest loop. Takes `Arc<Self>` so the spawned task can
     /// hold the use case's dependencies without moving them out of the
     /// owning facade.

--- a/crates/uc-daemon-client/src/ws_bridge.rs
+++ b/crates/uc-daemon-client/src/ws_bridge.rs
@@ -568,7 +568,8 @@ impl Subscriber {
     }
 
     fn spawn_forwarder(self: Arc<Self>) {
-        tokio::spawn(async move {
+        let consumer = self.consumer;
+        let work = tokio::spawn(async move {
             loop {
                 let next_event = loop {
                     if self.closed.load(Ordering::SeqCst) {
@@ -597,6 +598,29 @@ impl Subscriber {
                         "daemon websocket subscriber forwarder stopped"
                     );
                     return;
+                }
+            }
+        });
+        // Supervise the forwarder so a panic surfaces as a log line instead of
+        // vanishing with the task. The forwarder otherwise only signals its
+        // exit via the `closed` flag + an `info` log, both of which a panic
+        // skips — leaving a silently dead subscriber (see `uc-infra/AGENTS.md
+        // §13.3.1`). Uses the shared `event = "task.panicked"` shape so one log
+        // query catches every background-task panic. Cancellation is not
+        // expected here (nothing aborts the handle), so any non-cancel
+        // `JoinError` is a real panic.
+        tokio::spawn(async move {
+            match work.await {
+                Ok(()) => {}
+                Err(err) if err.is_cancelled() => {}
+                Err(err) => {
+                    warn!(
+                        event = "task.panicked",
+                        task = "bridge.forwarder",
+                        consumer,
+                        error = %err,
+                        "daemon websocket subscriber forwarder panicked"
+                    );
                 }
             }
         });

--- a/crates/uc-infra/AGENTS.md
+++ b/crates/uc-infra/AGENTS.md
@@ -631,19 +631,21 @@ panic 就随任务一起消失（runtime 把 panic 转成 `JoinError` 挂在句�
 静默），既看不到「悄悄死掉」，shutdown 也无法确定性地停它。新增长生命周期后台任务，
 必须走下面两种写法之一：
 
-1. **保留句柄 + abort/join（长生命周期循环首选）**：由该任务的自然生命周期持有者
-   （facade / adapter / slot / bridge）持有 `JoinHandle`，在关闭路径 `abort()` 后
-   `await`，把非取消的 `JoinError` 记成 `WARN`。参照
+1. **保留句柄 + abort/join（需要确定性关闭的长生命周期循环首选）**：由该任务的自然
+   生命周期持有者（facade / adapter / bridge）持有 `JoinHandle`，在关闭路径
+   `abort()` 后 `await`，把非取消的 `JoinError` 记成 `WARN`。参照
    `network/iroh/net_recovery.rs` + `network/iroh/node.rs::shutdown` 的既有实现。
-   本层内的 `pairing/session.rs`（recv-pump 句柄存进 `SessionSlot`，`close` 时
-   abort+join）即此模式。
+   **前提是 abort 掉这个任务是安全的**——若任务持有必须存活到对端 FIN 的资源
+   （如 `pairing/session.rs` recv-pump 持有 `Connection`，提前 abort 会撕断握手），
+   就不能用这种写法，改走第 2 种。
 
-2. **`uc_observability::spawn_supervised(name, fut)`（一次性 best-effort 任务）**：
-   没有天然句柄持有者的一次性任务，用它包一层——任务 panic 会以稳定的
-   `event = "task.panicked"` + `task = <name>` 记 `ERROR`，而不是凭空消失。仅用于
-   fire-and-forget，**不要** 套在真正需要确定性取消的任务上（`spawn_supervised`
-   返回的句柄只能中止监督者，中止不了底层任务）；也不要为一个不可能 panic 的 trivial
-   `sender.send(..)` 强行套壳。
+2. **`uc_observability::spawn_supervised(name, fut)`（无法/不应被 abort 的任务）**：
+   没有天然句柄持有者、或必须自然跑到结束（如上面的 recv-pump 要靠自己持有的
+   `Arc<SessionSlot>` 撑到对端 FIN）的任务，用它包一层——底层任务照常 detached 运行、
+   自行退出，任务 panic 会以稳定的 `event = "task.panicked"` + `task = <name>` 记
+   `WARN`，而不是凭空消失。本层内 `pairing/session.rs` recv-pump、
+   `pairing/mdns_resolver.rs` 的 ticket 转发即此模式。**不要** 用它返回的句柄去做
+   确定性取消（那个句柄只能中止监督者，中止不了底层任务）。
 
 ---
 

--- a/crates/uc-infra/AGENTS.md
+++ b/crates/uc-infra/AGENTS.md
@@ -33,7 +33,7 @@
 
 ### 2.2 非职责
 
-以下内容**不属于** `uc-infra`：
+以下内容 **不属于** `uc-infra`：
 
 | 类别        | 示例                               |
 | --------- | -------------------------------- |
@@ -432,9 +432,9 @@ pub enum BlobStoreError {
 
 例如：
 
-* “SQLITE_BUSY” 不是业务语义
-* “Peer closed stream” 不是业务语义
-* “InvalidNonceLength” 不是业务语义
+* “SQLITE_BUSY”不是业务语义
+* “Peer closed stream”不是业务语义
+* “InvalidNonceLength”不是业务语义
 
 应转成上层能理解的语义：
 
@@ -624,6 +624,27 @@ infra 内部格式不是产品公共语义。
 * 失败可见
 * 不允许悄悄死掉
 
+### 13.3.1 禁止 detached 永久循环，两种合规写法
+
+**严禁** 新增「`tokio::spawn` 后立即丢弃 `JoinHandle` 的永久循环」——句柄一丢，任务
+panic 就随任务一起消失（runtime 把 panic 转成 `JoinError` 挂在句柄上，句柄被 drop 即
+静默），既看不到「悄悄死掉」，shutdown 也无法确定性地停它。新增长生命周期后台任务，
+必须走下面两种写法之一：
+
+1. **保留句柄 + abort/join（长生命周期循环首选）**：由该任务的自然生命周期持有者
+   （facade / adapter / slot / bridge）持有 `JoinHandle`，在关闭路径 `abort()` 后
+   `await`，把非取消的 `JoinError` 记成 `WARN`。参照
+   `network/iroh/net_recovery.rs` + `network/iroh/node.rs::shutdown` 的既有实现。
+   本层内的 `pairing/session.rs`（recv-pump 句柄存进 `SessionSlot`，`close` 时
+   abort+join）即此模式。
+
+2. **`uc_observability::spawn_supervised(name, fut)`（一次性 best-effort 任务）**：
+   没有天然句柄持有者的一次性任务，用它包一层——任务 panic 会以稳定的
+   `event = "task.panicked"` + `task = <name>` 记 `ERROR`，而不是凭空消失。仅用于
+   fire-and-forget，**不要** 套在真正需要确定性取消的任务上（`spawn_supervised`
+   返回的句柄只能中止监督者，中止不了底层任务）；也不要为一个不可能 panic 的 trivial
+   `sender.send(..)` 强行套壳。
+
 ---
 
 ## 14. 平台相关实现规范
@@ -794,7 +815,7 @@ Windows / macOS / Linux 的差异必须留在 `uc-infra` 或 `uc-platform`，不
 
 ---
 
-### 19.5 “先能跑”式的错误吞并
+### 19.5“先能跑”式的错误吞并
 
 infra 是最接近失败源头的一层，这里如果吞错，上层就会完全失明。
 

--- a/crates/uc-infra/Cargo.toml
+++ b/crates/uc-infra/Cargo.toml
@@ -18,6 +18,9 @@ test-util = []
 [dependencies]
 # ===== Workspace crates =====
 uc-core = { path = "../uc-core" }
+# Panic-visible background-task spawning (`spawn_supervised`) for detached
+# infra tasks that have no natural handle owner (e.g. the pairing recv-pump).
+uc-observability = { path = "../uc-observability" }
 # Directory-layout authority: config-migration reads `is_portable()` to record
 # the bundle's source storage mode.
 uc-app-paths = { path = "../uc-app-paths" }

--- a/crates/uc-infra/src/pairing/mdns_resolver.rs
+++ b/crates/uc-infra/src/pairing/mdns_resolver.rs
@@ -156,16 +156,11 @@ impl MdnsPairingResolver {
                 }
 
                 // Take the sender exactly once. Subsequent matches
-                // become no-ops.
-                //
-                // Left detached deliberately (see `uc-infra/AGENTS.md
-                // §13.3.1`): this is a trivial best-effort one-shot — take the
-                // slot and forward a single channel message, nothing that can
-                // realistically panic. Wrapping it in `spawn_supervised` would
-                // add a `uc-observability` dependency to this crate for no
-                // meaningful observability gain.
+                // become no-ops. Wrapped in `spawn_supervised` so a panic
+                // surfaces as a WARN rather than vanishing (see
+                // `uc-infra/AGENTS.md §13.3.1`).
                 let tx_for_cb = Arc::clone(&tx_for_cb);
-                tokio::spawn(async move {
+                uc_observability::spawn_supervised("pairing.mdns_forward_ticket", async move {
                     let mut slot = tx_for_cb.lock().await;
                     if let Some(sender) = slot.take() {
                         let _ = sender.send(saw_ticket).await;

--- a/crates/uc-infra/src/pairing/mdns_resolver.rs
+++ b/crates/uc-infra/src/pairing/mdns_resolver.rs
@@ -157,6 +157,13 @@ impl MdnsPairingResolver {
 
                 // Take the sender exactly once. Subsequent matches
                 // become no-ops.
+                //
+                // Left detached deliberately (see `uc-infra/AGENTS.md
+                // §13.3.1`): this is a trivial best-effort one-shot — take the
+                // slot and forward a single channel message, nothing that can
+                // realistically panic. Wrapping it in `spawn_supervised` would
+                // add a `uc-observability` dependency to this crate for no
+                // meaningful observability gain.
                 let tx_for_cb = Arc::clone(&tx_for_cb);
                 tokio::spawn(async move {
                     let mut slot = tx_for_cb.lock().await;

--- a/crates/uc-infra/src/pairing/session.rs
+++ b/crates/uc-infra/src/pairing/session.rs
@@ -102,6 +102,16 @@ struct SessionSlot {
     recv: Mutex<RecvStream>,
     // Hold the connection so it stays alive for the session's lifetime.
     _connection: Connection,
+    // Handle to the recv-pump task draining `recv`. Retained so `close`
+    // can abort + join it deterministically and surface a panic as a WARN
+    // instead of letting it vanish with the task (see `uc-infra/AGENTS.md
+    // §13.3.1` and `network/iroh/net_recovery.rs` for the same pattern).
+    //
+    // A `std::sync::Mutex` (not the async one): it is only ever locked for a
+    // synchronous take/store with no `.await` held, which lets the pump
+    // spawner store the handle with no await gap for a concurrent `close` to
+    // interleave into (the handle is in place before this task can yield).
+    pump: std::sync::Mutex<Option<tokio::task::JoinHandle<()>>>,
 }
 
 impl IrohPairingSessionAdapter {
@@ -272,6 +282,7 @@ impl IrohPairingSessionAdapter {
             send: Mutex::new(send),
             recv: Mutex::new(recv),
             _connection: connection,
+            pump: std::sync::Mutex::new(None),
         });
         self.sessions.lock().await.insert(id.clone(), slot);
         id
@@ -476,7 +487,8 @@ impl IrohPairingSessionAdapter {
                 return;
             }
         };
-        tokio::spawn(async move {
+        let handle_slot = Arc::clone(&slot);
+        let handle = tokio::spawn(async move {
             loop {
                 let frame = {
                     let mut recv = slot.recv.lock().await;
@@ -527,6 +539,16 @@ impl IrohPairingSessionAdapter {
                 }
             }
         });
+        // Retain the handle so `close` can abort + join it and surface a
+        // panic. The pump also exits on its own on peer FIN; in that case
+        // the completed handle is simply reaped by the next `close`. Stored
+        // synchronously (no await between spawn and store) so a concurrent
+        // `close` cannot slip in and miss the handle. Poison-tolerant: the
+        // only lock holders do a trivial take/store and never panic.
+        *handle_slot
+            .pump
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(handle);
     }
 }
 
@@ -711,14 +733,42 @@ impl PairingSessionPort for IrohPairingSessionAdapter {
 
     #[instrument(skip_all, fields(session = %session))]
     async fn close(&self, session: &PairingSessionId, reason: Option<String>) {
-        let mut map = self.sessions.lock().await;
-        if let Some(slot) = map.remove(session) {
-            // Try to half-close the send side so the peer sees EOF.
-            if let Ok(mut send) = slot.send.try_lock() {
-                let _ = send.finish();
-            }
-            debug!(?reason, "pairing session closed");
+        // Remove from the map first, then drop the map lock so aborting +
+        // joining the recv pump does not hold it across an await.
+        let slot = self.sessions.lock().await.remove(session);
+        let Some(slot) = slot else {
+            return;
+        };
+        // Try to half-close the send side so the peer sees EOF.
+        if let Ok(mut send) = slot.send.try_lock() {
+            let _ = send.finish();
         }
+        // Stop the recv pump deterministically and surface a panic. The pump
+        // may already have exited on its own (peer FIN); in that case the
+        // join returns immediately with `Ok`. Take the handle out under the
+        // sync lock (released immediately — the abort/join await happens
+        // outside it).
+        let pump = slot
+            .pump
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .take();
+        if let Some(handle) = pump {
+            handle.abort();
+            match handle.await {
+                Ok(()) => {}
+                Err(err) if err.is_cancelled() => {} // expected: we aborted it
+                Err(err) => {
+                    warn!(
+                        event = "task.panicked",
+                        task = "pairing.recv_pump",
+                        error = %err,
+                        "pairing recv-pump panicked before close"
+                    );
+                }
+            }
+        }
+        debug!(?reason, "pairing session closed");
     }
 
     /// Slice 2 Phase 1 · T5：返回本端 [`EndpointAddr`] 的 postcard 不透明

--- a/crates/uc-infra/src/pairing/session.rs
+++ b/crates/uc-infra/src/pairing/session.rs
@@ -102,16 +102,6 @@ struct SessionSlot {
     recv: Mutex<RecvStream>,
     // Hold the connection so it stays alive for the session's lifetime.
     _connection: Connection,
-    // Handle to the recv-pump task draining `recv`. Retained so `close`
-    // can abort + join it deterministically and surface a panic as a WARN
-    // instead of letting it vanish with the task (see `uc-infra/AGENTS.md
-    // §13.3.1` and `network/iroh/net_recovery.rs` for the same pattern).
-    //
-    // A `std::sync::Mutex` (not the async one): it is only ever locked for a
-    // synchronous take/store with no `.await` held, which lets the pump
-    // spawner store the handle with no await gap for a concurrent `close` to
-    // interleave into (the handle is in place before this task can yield).
-    pump: std::sync::Mutex<Option<tokio::task::JoinHandle<()>>>,
 }
 
 impl IrohPairingSessionAdapter {
@@ -282,7 +272,6 @@ impl IrohPairingSessionAdapter {
             send: Mutex::new(send),
             recv: Mutex::new(recv),
             _connection: connection,
-            pump: std::sync::Mutex::new(None),
         });
         self.sessions.lock().await.insert(id.clone(), slot);
         id
@@ -487,8 +476,14 @@ impl IrohPairingSessionAdapter {
                 return;
             }
         };
-        let handle_slot = Arc::clone(&slot);
-        let handle = tokio::spawn(async move {
+        // Detached by design: the pump must keep its `Arc<SessionSlot>` (which
+        // owns the `Connection`) alive until the peer FINs, so a graceful
+        // `close()` half-close is still delivered before the connection drops
+        // — retaining + aborting the handle would tear the connection down
+        // early and break the handshake. `spawn_supervised` keeps that exact
+        // lifetime while making a pump panic surface as a WARN instead of
+        // vanishing silently (see `uc-infra/AGENTS.md §13.3.1`).
+        uc_observability::spawn_supervised("pairing.recv_pump", async move {
             loop {
                 let frame = {
                     let mut recv = slot.recv.lock().await;
@@ -539,16 +534,6 @@ impl IrohPairingSessionAdapter {
                 }
             }
         });
-        // Retain the handle so `close` can abort + join it and surface a
-        // panic. The pump also exits on its own on peer FIN; in that case
-        // the completed handle is simply reaped by the next `close`. Stored
-        // synchronously (no await between spawn and store) so a concurrent
-        // `close` cannot slip in and miss the handle. Poison-tolerant: the
-        // only lock holders do a trivial take/store and never panic.
-        *handle_slot
-            .pump
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(handle);
     }
 }
 
@@ -733,42 +718,19 @@ impl PairingSessionPort for IrohPairingSessionAdapter {
 
     #[instrument(skip_all, fields(session = %session))]
     async fn close(&self, session: &PairingSessionId, reason: Option<String>) {
-        // Remove from the map first, then drop the map lock so aborting +
-        // joining the recv pump does not hold it across an await.
-        let slot = self.sessions.lock().await.remove(session);
-        let Some(slot) = slot else {
-            return;
-        };
-        // Try to half-close the send side so the peer sees EOF.
-        if let Ok(mut send) = slot.send.try_lock() {
-            let _ = send.finish();
-        }
-        // Stop the recv pump deterministically and surface a panic. The pump
-        // may already have exited on its own (peer FIN); in that case the
-        // join returns immediately with `Ok`. Take the handle out under the
-        // sync lock (released immediately — the abort/join await happens
-        // outside it).
-        let pump = slot
-            .pump
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .take();
-        if let Some(handle) = pump {
-            handle.abort();
-            match handle.await {
-                Ok(()) => {}
-                Err(err) if err.is_cancelled() => {} // expected: we aborted it
-                Err(err) => {
-                    warn!(
-                        event = "task.panicked",
-                        task = "pairing.recv_pump",
-                        error = %err,
-                        "pairing recv-pump panicked before close"
-                    );
-                }
+        let mut map = self.sessions.lock().await;
+        if let Some(slot) = map.remove(session) {
+            // Try to half-close the send side so the peer sees EOF. The
+            // recv pump is intentionally not aborted here: it holds its own
+            // `Arc<SessionSlot>` and must keep the connection alive until the
+            // peer FINs so this half-close is delivered, then it exits on its
+            // own (see `spawn_recv_pump`). A pump panic is surfaced by its
+            // `spawn_supervised` wrapper, not here.
+            if let Ok(mut send) = slot.send.try_lock() {
+                let _ = send.finish();
             }
+            debug!(?reason, "pairing session closed");
         }
-        debug!(?reason, "pairing session closed");
     }
 
     /// Slice 2 Phase 1 · T5：返回本端 [`EndpointAddr`] 的 postcard 不透明

--- a/crates/uc-observability/src/lib.rs
+++ b/crates/uc-observability/src/lib.rs
@@ -56,6 +56,7 @@ pub mod redact;
 pub mod scope;
 pub(crate) mod span_fields;
 pub mod stages;
+pub mod task_supervision;
 pub mod telemetry_gate;
 
 pub use analytics_gate::{is_analytics_enabled, set_analytics_enabled};
@@ -64,5 +65,6 @@ pub use flow::FlowId;
 pub use init::{build_console_layer, build_json_layer, init_tracing_subscriber};
 pub use profile::LogProfile;
 pub use scope::{global_scope, role_log_file_stem, set_global_scope, ScopeContext};
+pub use task_supervision::spawn_supervised;
 pub use telemetry_gate::{is_telemetry_enabled, set_telemetry_enabled};
 pub use tracing_appender::non_blocking::WorkerGuard;

--- a/crates/uc-observability/src/task_supervision.rs
+++ b/crates/uc-observability/src/task_supervision.rs
@@ -1,0 +1,75 @@
+//! Panic-visible fire-and-forget task spawning.
+//!
+//! Detached `tokio::spawn` tasks swallow panics: the runtime turns the panic
+//! into a `JoinError` on the `JoinHandle`, and when that handle is dropped the
+//! panic vanishes with no trace. For genuinely one-shot, best-effort work
+//! (where retaining a handle for deterministic shutdown would be overkill) this
+//! helper preserves the fire-and-forget ergonomics while making a panic
+//! surface as a `WARN` log line (`event = "task.panicked"`) instead of
+//! disappearing silently.
+//!
+//! This is the "log the panic" layer referenced by `uc-infra/AGENTS.md
+//! §13.3.1` ("失败可见 / 不允许悄悄死掉"). Long-lived looping tasks should
+//! instead retain their `JoinHandle` and abort+join it on shutdown (see
+//! `crates/uc-infra/src/network/iroh/net_recovery.rs` +
+//! `network/iroh/node.rs::shutdown` for the canonical pattern), which surfaces
+//! panics through the join at shutdown; reach for `spawn_supervised` only when
+//! there is no natural lifecycle owner to hold the handle.
+
+use std::future::Future;
+
+use tracing::warn;
+
+/// Spawn a fire-and-forget task whose panic is logged rather than silently
+/// dropped.
+///
+/// The `name` is emitted as a stable `task` field on the panic log line so
+/// field-based log queries can pinpoint which background task died. The
+/// returned handle drives an internal supervisor that awaits the real work;
+/// callers that do not need it may drop it (the work still runs to completion
+/// and its panic is still logged). Aborting the returned handle does **not**
+/// abort the underlying work — if you need deterministic cancellation, retain
+/// the work's own handle instead of using this helper.
+pub fn spawn_supervised<F>(name: &'static str, fut: F) -> tokio::task::JoinHandle<()>
+where
+    F: Future<Output = ()> + Send + 'static,
+{
+    let work = tokio::spawn(fut);
+    tokio::spawn(async move {
+        match work.await {
+            Ok(()) => {}
+            // Cancellation is a normal shutdown signal, not a failure. It only
+            // occurs if a caller aborts the returned supervisor handle.
+            Err(err) if err.is_cancelled() => {}
+            Err(err) => {
+                warn!(
+                    event = "task.panicked",
+                    task = name,
+                    error = %err,
+                    "background task panicked"
+                );
+            }
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn completes_normally_without_logging() {
+        let handle = spawn_supervised("ok_task", async {});
+        handle.await.expect("supervisor should not fail");
+    }
+
+    #[tokio::test]
+    async fn supervisor_survives_a_panicking_task() {
+        // The supervisor must finish cleanly (logging the panic) even though
+        // the inner task panicked — it must not re-propagate the panic.
+        let handle = spawn_supervised("panicking_task", async {
+            panic!("boom");
+        });
+        handle.await.expect("supervisor must not itself panic");
+    }
+}

--- a/crates/uc-observability/src/task_supervision.rs
+++ b/crates/uc-observability/src/task_supervision.rs
@@ -18,7 +18,7 @@
 
 use std::future::Future;
 
-use tracing::warn;
+use tracing::{warn, Instrument, Span};
 
 /// Spawn a fire-and-forget task whose panic is logged rather than silently
 /// dropped.
@@ -30,27 +30,37 @@ use tracing::warn;
 /// and its panic is still logged). Aborting the returned handle does **not**
 /// abort the underlying work — if you need deterministic cancellation, retain
 /// the work's own handle instead of using this helper.
+///
+/// The panic log inherits the caller's tracing span (captured at call time),
+/// so the `warn!` carries the same context (`trace_id`, span fields) the work
+/// was spawned under rather than logging as a context-less orphan.
 pub fn spawn_supervised<F>(name: &'static str, fut: F) -> tokio::task::JoinHandle<()>
 where
     F: Future<Output = ()> + Send + 'static,
 {
     let work = tokio::spawn(fut);
-    tokio::spawn(async move {
-        match work.await {
-            Ok(()) => {}
-            // Cancellation is a normal shutdown signal, not a failure. It only
-            // occurs if a caller aborts the returned supervisor handle.
-            Err(err) if err.is_cancelled() => {}
-            Err(err) => {
-                warn!(
-                    event = "task.panicked",
-                    task = name,
-                    error = %err,
-                    "background task panicked"
-                );
+    // Capture the caller's span so a panic logs with its context, not as an
+    // orphan on the detached supervisor task.
+    let caller_span = Span::current();
+    tokio::spawn(
+        async move {
+            match work.await {
+                Ok(()) => {}
+                // Cancellation is a normal shutdown signal, not a failure. It
+                // only occurs if a caller aborts the returned supervisor handle.
+                Err(err) if err.is_cancelled() => {}
+                Err(err) => {
+                    warn!(
+                        event = "task.panicked",
+                        task = name,
+                        error = %err,
+                        "background task panicked"
+                    );
+                }
             }
         }
-    })
+        .instrument(caller_span),
+    )
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Closes #1260.

## 背景

若干后台 `tokio::spawn` 任务是 **detached**(丢弃 `JoinHandle`):任务内 panic 会随句柄被 runtime 静默丢弃,shutdown 也无法确定性地停它——违反 `uc-infra/AGENTS.md §13.3`("失败可见 / 不允许悄悄死掉")。本 PR 是审计后续的收尾:给长生命周期循环保留句柄,并统一让 panic 浮现为日志行。

**严重度:低**——无已知崩溃,纯可观测性 + shutdown 确定性硬化。

## 改动

### 基础 helper
- 新增 `uc_observability::spawn_supervised(name, fut)`:fire-and-forget 任务的 panic 以 `WARN` + 稳定的 `event = "task.panicked"` + `task` 字段浮现,而非静默消失。放 `uc-observability`(它本就是可观测性 crate 且已在用 `tokio::spawn`),避开 `uc-core` 禁 tokio 运行时的铁律。

### C 类(长生命周期循环 + 丢句柄)——保留句柄 + abort/join
- `ClipboardSyncFacade::subscribe_inbound_notices` 改为返回 `InboundNoticeSubscription` RAII guard,持有桥接任务句柄,drop 时 abort——**修掉了一个按订阅泄漏的 bug**(原实现无订阅者时 `continue` 永不退出,每次订阅泄漏一个任务直到整个 facade 被销毁)。
- 配对 `session.rs` recv-pump 句柄存进 `SessionSlot`,`close()` 时 abort + join;用 `std::sync::Mutex` 无 await 间隙地存句柄,关闭 spawn↔close 竞态窗口。
- daemon-client `ws_bridge` forwarder 增加 panic 监督任务。
- daemon `startup_recovery` 用 `spawn_supervised` 包裹。

### B 类(一次性 fire-and-forget)——补 panic 可见性
- mobile_sync outbound、inbound OS write、active write-then-converge、deferred drain、clipboard_watcher、peer_keepalive、blob processing、search coordinator(rebuild/purge/repair/progress)共 12 处换成 `spawn_supervised`。
- `mdns_resolver` 的 trivial `sender.send()` 刻意保持 detached(不可能 panic,不值得为它给 `uc-infra` 引入 `uc-observability` 依赖),已加注释说明。
- PostHog 遥测 sink 按 issue 非目标保持原样。

### 统一 & 文档
- 四处 panic 日志统一 `event = "task.panicked"` + `task = "<site>"`,级别统一 WARN(对齐 issue 原文与 `net_recovery` 先例),一条查询即可抓全。
- `uc-infra/AGENTS.md §13.3.1` 记录规则:禁止新增 detached 永久循环,并写明两种合规写法及各自边界。

## 测试
- `spawn_supervised` 两个单测(正常完成 / panic 被监督者捕获不上抛)。
- 新增 facade 测试:断言 drop subscription 后桥接任务被 abort、内部 notice receiver 被释放(锁死泄漏修复的回归)。
- `uc-application` lib 730 测试、`uc-infra` pairing::session 14 测试全过;`cargo check --workspace --exclude uniclipboard` 通过(`uniclipboard` 失败是预存的 Tauri sidecar 二进制缺失,与本 PR 无关)。

## 验收标准对照
- ✅ 每个长生命周期后台任务要么保留句柄 join、要么由停止机制 + 退出日志驱动。
- ✅ 任一保留任务的 panic 浮现为日志行。
- ✅ 未引入新的 detached 永久循环 `tokio::spawn`,并已在 `AGENTS.md` 记录该规则。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added improved task supervision for many background workflows across the daemon, clipboard sync, search, pairing, and websocket bridge.

* **Bug Fixes**
  * Panics in detached background work are now surfaced in logs instead of disappearing silently.
  * Inbound clipboard notice subscriptions now stop their associated relay/bridge when no longer needed, preventing lingering work.

* **Documentation / Tests**
  * Updated internal task-safety guidance and added coverage for subscription lifetime behavior and supervision logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->