### PR TITLE
fix(quick-panel): remount session on re-open to avoid stale search flash

### DIFF
--- a/src/quick-panel/ClipboardHistoryPanel.tsx
+++ b/src/quick-panel/ClipboardHistoryPanel.tsx
@@ -96,12 +96,20 @@ interface ClipboardHistoryPanelProps {
   onShowPrepared?: (requestId: number) => void
 }
 
-const ClipboardHistoryPanel: React.FC<ClipboardHistoryPanelProps> = ({
+/**
+ * Outer shell: remount the session on every `showRequestId` so search buffer,
+ * filters, and the live-search item list cannot flash the previous show's
+ * results. The webview stays alive between hides; only this tree is recreated.
+ */
+const ClipboardHistoryPanel: React.FC<ClipboardHistoryPanelProps> = props => {
+  useThemeSync()
+  return <ClipboardHistoryPanelSession key={props.showRequestId ?? 0} {...props} />
+}
+
+const ClipboardHistoryPanelSession: React.FC<ClipboardHistoryPanelProps> = ({
   showRequestId = 0,
   onShowPrepared,
 }) => {
-  useThemeSync()
-
   const { t } = useTranslation()
   const dispatch = useAppDispatch()
 
@@ -109,19 +117,22 @@ const ClipboardHistoryPanel: React.FC<ClipboardHistoryPanelProps> = ({
   // submenu shows current names and connection state. The quick panel is a
   // separate webview with its own store and — unlike the main window's
   // DevicesPage — does not subscribe to `peers.changed`, so this snapshot is the
-  // only source. Re-run on every re-open (`showRequestId`), mirroring the
-  // clipboard `refetch()` below, so a long-lived hidden window doesn't serve a
-  // stale device list.
+  // only source. Fresh on every session mount (each re-open).
   useEffect(() => {
     dispatch(fetchSpaceMembers())
       .unwrap()
       .catch(err => {
         log.warn({ err }, 'failed to prime paired-device list')
       })
-  }, [dispatch, showRequestId])
+  }, [dispatch])
 
   const [searchQuery, setSearchQuery] = useState('')
+  // Debounce typing only; clearing must hit the data layer immediately so the
+  // list does not keep showing matches for ~300ms after the box is empty. The
+  // `.trim()` here only gates empty-vs-not (whitespace-only reads as cleared);
+  // `useHistorySearch` owns the actual query normalization for the daemon call.
   const debouncedSearchQuery = useDebounce(searchQuery, 300)
+  const activeSearchQuery = searchQuery.trim() === '' ? '' : debouncedSearchQuery
   const [activeFilter, setActiveFilter] = useState<Filter>(Filter.All)
   const [tagFilter, setTagFilter] = useState<string | null>(null)
   const [sourceFilter, setSourceFilter] = useState<string | null>(null)
@@ -164,23 +175,15 @@ const ClipboardHistoryPanel: React.FC<ClipboardHistoryPanelProps> = ({
   const historyLockedWidth = previewState.historyLockedWidth
   const previewFocusSource = previewState.focusSource
 
-  const {
-    filteredItems,
-    previewItems,
-    isSearching,
-    searchTotal,
-    loading,
-    isLocked,
-    removeItem,
-    refetch,
-  } = useHistorySearch({
-    searchQuery: debouncedSearchQuery,
-    activeFilter,
-    tagFilter,
-    sourceFilter,
-    extensionFilter,
-    timeRange,
-  })
+  const { filteredItems, previewItems, isSearching, searchTotal, loading, isLocked, removeItem } =
+    useHistorySearch({
+      searchQuery: activeSearchQuery,
+      activeFilter,
+      tagFilter,
+      sourceFilter,
+      extensionFilter,
+      timeRange,
+    })
 
   // Latest `filteredItems` for `handleKeyDown` to read by index without
   // depending on the array's identity — `filteredItems` gets a new reference
@@ -212,30 +215,11 @@ const ClipboardHistoryPanel: React.FC<ClipboardHistoryPanelProps> = ({
     [clearPreviewTimer]
   )
 
+  // Session remount already resets search/filters/list. This only focuses the
+  // search box and tells the host the UI is ready to finalize the show.
   useEffect(() => {
     if (showRequestId === 0) return
     setSkipTransition(true)
-    clearPreviewTimer()
-    previewLayoutTokenRef.current += 1
-    dispatchPreview({ type: 'reset' })
-    setPreviewSide('right')
-    setSearchQuery('')
-    setActiveFilter(Filter.All)
-    setTagFilter(null)
-    setSourceFilter(null)
-    setExtensionFilter(null)
-    setTimeRange('all_time')
-    setSelectedIndex(0)
-    setHoveredIndex(null)
-    setIsKeyboardNav(true)
-    setHasPointerMovedSinceShow(false)
-    setPreviewTargetId(null)
-    // Drop stale optimistic favorite flips; the refetch below re-reads the
-    // authoritative `isFavorited` from the daemon.
-    setFavoriteOverrides({})
-    // Refresh on every re-open so the panel shows the latest clipboard even if
-    // the filters were already at their defaults (no model change to trigger it).
-    refetch()
 
     const focusTimer = setTimeout(() => {
       setSkipTransition(false)
@@ -246,7 +230,7 @@ const ClipboardHistoryPanel: React.FC<ClipboardHistoryPanelProps> = ({
     return () => {
       clearTimeout(focusTimer)
     }
-  }, [clearPreviewTimer, onShowPrepared, refetch, showRequestId])
+  }, [onShowPrepared, showRequestId])
 
   useEffect(() => {
     void setQuickPanelLayout(uiScale, previewExpanded).catch(() => {})

--- a/src/quick-panel/__tests__/ClipboardHistoryPanel.single-window.test.tsx
+++ b/src/quick-panel/__tests__/ClipboardHistoryPanel.single-window.test.tsx
@@ -8,6 +8,7 @@ import { __resetResendActionStoreForTests } from '@/hooks/useResendAction'
 import i18n from '@/i18n'
 import devicesReducer from '@/store/slices/devicesSlice'
 import ClipboardHistoryPanel from '../ClipboardHistoryPanel'
+import { useHistorySearch } from '../hooks/useHistorySearch'
 
 const invokeMock = vi.fn()
 
@@ -79,7 +80,6 @@ vi.mock('../hooks/useHistorySearch', () => ({
     loading: false,
     isLocked: false,
     removeItem: vi.fn(),
-    refetch: vi.fn(),
   })),
 }))
 
@@ -412,6 +412,13 @@ describe('ClipboardHistoryPanel hover/focus keyboard shortcuts', () => {
     return screen.getByRole('combobox') as HTMLInputElement
   }
 
+  // The `searchQuery` the data layer was last asked for. Proxies "what the list
+  // is actually showing" without unmocking the data layer.
+  function lastHistoryQuery() {
+    const calls = vi.mocked(useHistorySearch).mock.calls
+    return calls.at(-1)?.[0]?.searchQuery
+  }
+
   it('acts on the hovered row rather than the keyboard-selected row when both differ', async () => {
     renderPanel()
     // Panel opens with entry-1 selected by keyboard.
@@ -481,5 +488,48 @@ describe('ClipboardHistoryPanel hover/focus keyboard shortcuts', () => {
     await waitFor(() => {
       expect(deleteClipboardEntry).toHaveBeenCalledWith('entry-1')
     })
+  })
+
+  it('remounts a fresh session on re-open so a settled prior query does not carry over', async () => {
+    // The outer shell keys the session on showRequestId: buffer, filters, and
+    // the live-search query all start empty instead of flashing the last show.
+    const store = configureStore({ reducer: { devices: devicesReducer } })
+    const { rerender } = render(
+      <Provider store={store}>
+        <ClipboardHistoryPanel showRequestId={1} />
+      </Provider>
+    )
+    // Let the first show settle into an active 'invoice' query (past the
+    // debounce), so the remount has a real prior query to discard.
+    fireEvent.change(searchBox(), { target: { value: 'invoice' } })
+    await waitFor(() => expect(lastHistoryQuery()).toBe('invoice'))
+    expect(searchBox()).toHaveValue('invoice')
+
+    rerender(
+      <Provider store={store}>
+        <ClipboardHistoryPanel showRequestId={2} />
+      </Provider>
+    )
+
+    // Both the box and the query the data layer sees reset to empty; the list
+    // never re-queries with the previous show's 'invoice'.
+    await waitFor(() => expect(searchBox()).toHaveValue(''))
+    expect(lastHistoryQuery()).toBe('')
+  })
+
+  it('debounces typing but sends the cleared query to the data layer immediately', async () => {
+    renderPanel()
+    const input = searchBox()
+
+    // Typing does not reach the data layer synchronously — it waits for the
+    // debounce, so the browse query stays empty until the timer fires.
+    fireEvent.change(input, { target: { value: 'abc' } })
+    expect(lastHistoryQuery()).toBe('')
+    await waitFor(() => expect(lastHistoryQuery()).toBe('abc'))
+
+    // Clearing bypasses the debounce: the empty browse query is applied on the
+    // next render, not ~300ms later, so the list stops matching 'abc' at once.
+    fireEvent.change(input, { target: { value: '' } })
+    expect(lastHistoryQuery()).toBe('')
   })
 })

--- a/src/quick-panel/hooks/useHistorySearch.ts
+++ b/src/quick-panel/hooks/useHistorySearch.ts
@@ -59,8 +59,6 @@ interface UseHistorySearchResult {
   isLocked: boolean
   /** Optimistically drop an entry after the user deletes it. */
   removeItem: (id: string) => void
-  /** Re-issue the current query (used to refresh on every panel re-open). */
-  refetch: () => void
 }
 
 /**
@@ -123,6 +121,5 @@ export function useHistorySearch({
     loading: live.isLoading && !narrowed,
     isLocked,
     removeItem: live.removeItem,
-    refetch: live.refetch,
   }
 }


### PR DESCRIPTION
## Summary

- Split `ClipboardHistoryPanel` into an outer shell plus a `ClipboardHistoryPanelSession` keyed on `showRequestId`; every re-open now remounts the session tree, so the search buffer, filters, and live-search list start empty instead of briefly flashing the previous show's results. This replaces the hand-written state-reset block that ran in the show effect. (4df6179e2)
- Clearing the search box now bypasses the 300ms debounce (`activeSearchQuery`), so the list stops matching the old query immediately rather than ~300ms later. (4df6179e2)
- Dropped the now-unused `refetch` from `useHistorySearch` — the session remount re-seeds the query via `useLiveSearch`'s base effect, so the manual `refetch()` on re-open is dead code. `useLiveSearch.refetch` is untouched (other consumers still use it). (4df6179e2)

This reinforces the documented contract in `docs-site/.../quick-panel.mdx` ("every reopen starts unfiltered"); no docs change needed.

## Test plan

- [x] `bun run test` for `ClipboardHistoryPanel.single-window` + `useHistorySearch` (21 passed), including a new test that a settled prior query does not carry over the remount, and one asserting typing is debounced while clearing hits the data layer immediately.
- [x] `eslint` clean on the three changed files; `tsc --noEmit` passes.
- [ ] Manual: open the quick panel, type a query, dismiss, re-open — confirm no flash of prior results and the box is empty/focused.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reopening Clipboard History now starts with a clean search, filter, and results state.
  * Clearing the search field updates results immediately.
  * Search results no longer briefly display stale content when reopening the panel.
  * Typing continues to use debounce behavior for smoother searching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->