### PR TITLE
feat(file-sync): directory-sync phase 3 — encrypted paths + local capture

### DIFF
--- a/.planning/2026-07-10-adr010-directory-sync-phase3-plan.md
+++ b/.planning/2026-07-10-adr010-directory-sync-phase3-plan.md
@@ -1,0 +1,182 @@
+# ADR-010 目录同步 · 第三阶段规划（目录捕获）
+
+Status: draft (2026-07-10)
+Issue: #875 · ADR: `docs/architecture/adr-010-directory-sync-as-file-set-manifest.md`
+Phase 1: PR #1290 (merged 2026-07-10) · Phase 2: PR #1313 + #1314 (merged 2026-07-10)
+前序规划: `.planning/2026-07-10-adr010-directory-sync-phase2-plan.md`
+
+## 1. 现状盘点（阶段 1+2 落地了什么）
+
+- **领域模型**（`crates/uc-core/src/clipboard/file_set.rs`）：`EntryFileSet` 逐行清单，
+  行 kind = `File { content_hash, blob_id, size_bytes }` / `NonFile` /
+  `Excluded { reason }`。`content_digest_contribution()` all-or-nothing：任一
+  `Excluded` 行 → 空贡献 → 回退路径文本身份。**尚无 `root_index` / `relative_path` /
+  `kind_tag`——扁平逐行，无目录树语义。**
+- **持久化**（`crates/uc-infra/migrations/2026-07-03-000000_create_entry_file_set/` +
+  `db/repositories/entry_file_set_repo.rs`）：`entry_file_set` 表 8 列，
+  `(entry_id, line_index)` PK，整体 replace/load。**`original_text` 明文 TEXT 落库**
+  （见 §4 合规缺口）。
+- **身份计算**（`crates/uc-core/src/clipboard/system.rs:531`
+  `SystemClipboardSnapshot::snapshot_hash`）：文件类 rep 的路径文本 hash 被
+  `file_content_digests`（排序后的成员 content hash 平集）经
+  `uc_content_hash::file_content_wrapper`（前缀 `file-content|`）替换，再进外层
+  `snapshot_hash`（前缀 `snapshot-hash-v1|`）。**平集聚合，无结构/路径信息。**
+- **捕获遍历**（`crates/uc-application/src/clipboard_capture/usecase.rs:838`
+  `build_entry_file_set`）：只处理平铺文件集（LocalFile reps 或 inline uri-list），
+  逐行 `classify_file_path`（`hash_path` 仅身份不物化 blob）。caps 预检
+  `file_set_exceeds_caps`（阶段 2 落地，毫秒级元数据预检）已就位。**不遍历目录。**
+- **出站单一真相源**（阶段 2，`facade/clipboard_outbound/mod.rs:581`
+  `resolve_outbound_file_set`）：dispatch 优先读 manifest 还原路径参与
+  `publish_file_blob_refs`；manifest 缺失/读错回退 `extract_file_paths_from_snapshot`；
+  含 `Excluded` 行 → `Skipped { reason: "file_set_excluded" }`。
+
+**关键缺口**：整条链路只认「平铺文件集」。目录被复制时，捕获侧当前把目录路径当普通文件行
+`hash_path`（对目录会 `IngestFailed` → 整体回退路径文本身份），不展开、不进同步。
+
+## 2. 阶段 3 拆分为 3a / 3b（已拍板）
+
+ADR 开放问题 #3 提示阶段 3 可能大到需要拆。**决策：拆 3a / 3b，先做 3a。**
+
+| 子阶段 | 内容 | 用户可见性 |
+| --- | --- | --- |
+| **3a（本文重点）** | schema 密文化升级 + 目录遍历 + 成员边界规则 + `file-set-v1` 结构入身份；**同步遍历**（靠阶段 2 的限额压住时延，1 GiB ≈ 秒级） | 目录进本地历史，dispatch 判 Sync-ineligible 不出站 |
+| 3b（本文只勾勒） | 延迟身份就绪（捕获流水线异步化，就绪前不广播/不 dispatch）+ 摄取毕 `(mtime, size)` 漂移复核 | 无（内部加固，去掉同步遍历对捕获热路径的时延占用） |
+
+排序理由（沿用 ADR）：
+
+- **3a 同步遍历可先行**：限额护栏（阶段 2）已把成员数/总量压在 2000 / 1 GiB，同步遍历+哈希
+  时延有界（秒级），不必先做异步化就能让目录进本地历史并为阶段 4 准备结构化身份。
+- **异步化是独立大改动**：延迟身份就绪 = 捕获流水线异步化 + 就绪前不广播 + 漂移复核，与
+  遍历/身份逻辑正交，拆到 3b 独立验证，避免 3a 面过大。
+
+## 3. 3a 范围（三个 PR）
+
+ADR 连带决策 1 明言「遍历与身份升级不可拆」——无结构入身份的目录 entry 会与同名文件集
+**内容碰撞**（`{a/1.txt, a/2.txt}` 目录 vs `{1.txt, 2.txt}` 两个同内容平铺文件，排序后
+content-digest 平集相同 → `file-content|` 身份相同 → 接收端建重复 entry）。
+
+本拆分用**安全阀**化解，使 PR 可切分：**PR-B 落地遍历时，含目录结构的 entry 一律回退
+路径文本身份**（贡献空集，与 `Excluded` 行同一机制）——路径文本天然区分目录与平铺文件，
+不碰撞；PR-C 再把路径文本回退替换为 `file-set-v1` 结构化身份。任一 PR 落地后系统都自洽。
+
+### PR-A：合规基座 —— 路径列加密 + schema 预留列（零行为变更）✅ 已实现
+
+落地记录：迁移 `2026-07-10-000001_encrypt_entry_file_set_paths`（DELETE 存量 →
+`original_text` 改 `original_text_ct BLOB` + 预留 `root_index`/`relative_path_ct`/
+`kind_tag`）；`EntryFileSetPathCipher`（UCFS 信封,XChaCha20-Poly1305,AAD=
+`for_file_set_line(entry_id,line_index)`）；repo 持 `DeriveSpaceSubkeyPort`+
+`CurrentProfilePort`,per-op 派生子密钥（`info=uniclipboard-file-set/v1`,salt=profile）;
+因密钥依赖 `platform`,repo 构造移到 space-access 之后（`InfraLayer` 暴露 `db_executor`）。
+测试 18 绿（10 codec + 8 repo:往返/密文非明文/锁定报错/chunk 边界/FK CASCADE）。
+
+1. **密文化迁移**：`entry_file_set` 表 2026-07-03 建、捕获写入今日才合并，**几乎无存量
+   数据**——迁移直接 DROP+重建带密文列，无需 app 侧回填（用 MasterKey 不可在 Diesel
+   迁移期取得，回填方案不成立；无存量数据使这一点无关紧要）。
+   - `original_text` TEXT → `original_text_ct BLOB`（AEAD 密文）。
+   - 预留三列 `root_index BIGINT NULL` / `relative_path_ct BLOB NULL`（密文）/
+     `kind_tag TEXT NULL`（分类枚举 f/x/d，同 `kind`/`content_category` 例外，明文）。
+     **本 PR 不写这三列**（保持 NULL），只开 schema headroom。
+2. **AEAD codec**：新增 `FileSetPathCodec`（`uc-infra/src/db/...` 或 `security/`），复刻
+   `search/render_payload.rs::RenderPayloadCodec` 模式——`v1_aead::{encrypt,decrypt}
+   _xchacha_raw`，per-session 子密钥经 `DeriveSpaceSubkeyPort::derive_subkey`（IKM=
+   MasterKey，HKDF-SHA256，独立 `info` 标签 `b"uniclipboard-file-set/v1"`），
+   **AAD 绑定 `entry_id ‖ line_index`**（防跨行/跨 entry 密文搬运）。
+3. **repo 穿线**：`DieselEntryFileSetRepository::new` 增加 key-derivation 依赖
+   （`wire.rs:571`）；`encode_line` 密封 `original_text`、`decode_row` 解封。
+   密钥不可用（未解锁）时 save/load 的错误语义需明确（沿用现有 `Storage` 翻译或
+   新增语义，见开放问题 #2）。
+4. **测试**：加密往返、AAD 绑定（换 `entry_id`/`line_index` 解密失败）、`save`→`load`
+   契约不变（既有测试全绿）、密文列非明文（落库字节不含路径子串）。
+5. **合规论证**：路径/文件名是用户内容，本 PR 对齐铁律「持久化即密文」，并顺带补齐
+   阶段 1 的明文欠账（见 §4）。`kind_tag` 明文豁免需在 PR 描述论证（分类枚举，
+   目录重建/展示按类型分支依赖其明文，与 `content_category` 同性质）。
+
+### PR-B：目录遍历 + 成员边界规则（含目录 entry 判 Sync-ineligible）
+
+1. **领域模型扩展**：`EntryFileSetLine` 增加成员定位（`root_index` / `relative_path` /
+   `kind_tag`）。平铺文件行：`root_index` = 其位置、`relative_path` = basename、
+   `kind_tag` = f/x。目录成员行：`root_index` = 所属目录 root 的序号、`relative_path` =
+   相对该 root 的路径。建议抽 `FileSetMemberLocation` 值对象承载三者。
+2. **遍历**（`build_entry_file_set`）：LocalFile/uri-list 成员若为目录 → 遍历展开为逐叶子
+   文件行。遍历在 caps 命中时**早停**（避免遍历超大目录树；阶段 2 的
+   `file_set_exceeds_caps` 需接上目录展开的成员流，而非只数顶层条目）。
+3. **成员边界**（ADR 连带决策 4）：
+   - symlink 与特殊文件（FIFO/socket/设备节点）→ **整个目录判 Sync-ineligible**
+     （不静默跳过、不解引用；可观测原因）。
+   - 隐藏文件包含；硬链接当独立文件；除 exec bit 外权限/xattr/时间戳不保留。
+   - `relative_path` 经 NFC 归一化、`/` 分隔；`kind_tag` = `f`/`x`（可执行）/`d`（空目录）。
+4. **身份安全阀（关键）**：含目录结构的 entry，本 PR **一律回退路径文本身份**——遍历出的
+   叶子 content digests **不**喂进 `file_content_digests`（等价于存在 `Excluded` 行的
+   处理）。既避免 §3 的内容碰撞，也不需要 PR-C 先落地。目录本地去重靠路径文本（复制同一
+   目录两次 → 同路径 → 同身份），够用。
+5. **dispatch 门控**：`resolve_outbound_file_set`（`clipboard_outbound/mod.rs:581`）检测
+   manifest 含目录结构（`kind_tag=d` 或 `relative_path` 跨层 / `root_index` 语义）→
+   `Skipped { reason: "directory_not_yet_syncable" }`（可观测，不静默）。旧接收端在阶段 4
+   之前不认识目录成员，含目录 entry 一律不出站。
+6. **测试**：单目录展开（叶子行的 root/relative_path/kind_tag）/ 混合选择（文件+目录）/
+   空目录（kind_tag=d）/ 隐藏文件包含 / symlink 或特殊文件 → 整目录 Sync-ineligible /
+   可执行位 → kind_tag=x / caps 在遍历中早停（panic-on-hash 证明超限跳哈希）/ 含目录
+   entry 身份走路径文本回退（`content_digest_contribution` 空）/ dispatch 门控 Skipped。
+
+### PR-C：`file-set-v1` 结构入身份（替换 PR-B 的路径文本回退）
+
+1. **叶子与组件公式**（ADR 连带决策 1）：
+   - leaf = `BLAKE3("file-set-member-v1|" ‖ root_name ‖ 0x00 ‖ relative_path ‖ 0x00 ‖
+     kind_tag ‖ 0x00 ‖ file_digest)`
+   - 文件内容组件 = `BLAKE3("file-set-v1|" ‖ sort(leaves))`
+   - 新增 `uc_content_hash::file_set_v1_wrapper(leaves)`，与既有
+     `file_content_wrapper`（`file-content|`）并列。
+2. **版本化落在文件内容组件**：外层 `snapshot-hash-v1|` 聚合不动。
+   **仅当文件集含目录结构时**用 `file-set-v1|`；**纯平铺文件集继续走 `file-content|`
+   平集**——存量与纯裸文件集合哈希逐字节不变，身份零迁移。
+3. **捕获侧接线**：含目录时，`build_entry_file_set` 产出结构化 leaves，
+   `snapshot.file_content_digests`（或新字段）承载 file-set-v1 组件，替换 PR-B 的
+   路径文本回退。exec bit 入身份（影响粘贴产物）。
+4. **注意**：阶段 3 目录仍不出站（dispatch 门控保留），结构化身份此阶段主要服务**本地
+   去重的正确性**与**阶段 4 接收侧重建的前置**。若 3a 体量过大，PR-C 可评估延到阶段 4
+   前置（ADR 允许，但默认留在 3a 以尊重连带决策 1）。
+5. **测试**：`{a/1.txt,a/2.txt}` 目录 vs `{1.txt,2.txt}` 平铺同内容 → **身份不同**
+   （碰撞回归）/ 同目录跨设备/重试 → 身份稳定 / relative_path NFC 归一 / kind_tag
+   f↔x 改变 → 身份改变 / 纯平铺文件集身份与阶段 2 逐字节一致（零迁移回归）。
+
+## 4. 合规缺口：`entry_file_set` 路径明文落库（本阶段顺带修复）
+
+已确认：连接层只设常规 pragma（`db/pool.rs`），**无整库加密**（无 `PRAGMA key`/cipher）。
+`entry_file_set.original_text` 存设备本地文件路径（用户内容，暴露文件名与目录结构），
+与项目铁律「持久化即密文（不可打破的基石）」冲突。对照 `search_document.render_payload`
+（走 Binary 密文）与 `search_posting.term_tag`（走 tag）——规则确实要求用户内容加密。
+
+**决策：阶段 3 顺带修复**——PR-A 把 `original_text` 与新增 `relative_path` 一并 AEAD
+加密落库。阶段 1 表几乎无存量数据，迁移成本可忽略。`content_hash`（单向摘要）与
+`kind_tag`（分类枚举）按现有豁免保持明文。
+
+## 5. 3b 勾勒（延迟身份就绪 + 漂移复核，本文不细化）
+
+- **延迟身份就绪**：捕获流水线异步化——文件类 entry 先进本地历史（identity pending），
+  遍历/哈希移出捕获热路径异步执行；就绪前不广播、不 dispatch。
+- **漂移复核**：摄取毕对成员做 `(mtime, size)` 复核；目录被改则放弃该次身份
+  （阶段 2 已埋下漂移观测基线：publish 后比对 wire digests 与捕获时刻贡献值记 WARN）。
+- 细化推迟到 3a 落地后单独规划（ADR 开放问题 #3：若 3a 中同步遍历时延在真实目录上不可
+  接受，再评估 3b 是否需提前，或 3a 内先接 (mtime,size) 观测）。
+
+## 6. 明确不在阶段 3
+
+- wire 格式携带成员相对路径、接收侧全有或全无重建目录树、root 冲突加后缀、uri-list
+  改写、协议版本门控（阶段 4）。
+- Sync-ineligible 的 UI 展示与 `file_sync` 设置界面（阶段 5；阶段 3 只保证日志/错误可观测）。
+- 移动端消费目录文件集（ADR 范围：mobile 不消费，register 指向时保持上一可消费值）。
+
+## 7. 待拍板的开放问题
+
+1. **PR-C 去留**：`file-set-v1` 结构化身份留在 3a（尊重 ADR 连带决策 1）还是延到阶段 4
+   前置（目录阶段 3 本就不出站，结构化身份主要服务阶段 4）？倾向留 3a，但若 3a 体量过大
+   可外移。
+2. **密钥未解锁时的 manifest 读写语义**：PR-A 后 `original_text` 需密钥才能解封。设备
+   锁定/未解锁时 dispatch 读 manifest 应回退（`extract_file_paths_from_snapshot`）还是
+   报可观测错误？倾向回退（与既有 manifest-missing 回退一致），但需确认捕获侧写入时机
+   密钥必然可用。
+3. **`root_index` 语义细化**：混合选择「2 个文件 + 1 个目录」时，root 的编号与 root_name
+   的取值（顶层文件的 root_name = 自身 basename？目录的 root_name = 目录名）需在 PR-B
+   定稿并写进 leaf 公式，与阶段 4 接收侧重建对齐。
+4. **遍历实现依赖**：是否引入 `walkdir` 等遍历库，还是手写 `tokio::fs` 递归（异步、可在
+   caps 命中时早停）？倾向手写异步递归以贴合 caps 早停与 3b 异步化，避免同步阻塞库。

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10074,6 +10074,7 @@ dependencies = [
  "uc-mobile-proto",
  "uc-observability",
  "uc-platform",
+ "unicode-normalization",
  "url",
  "uuid",
  "zip 2.4.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1761,9 +1761,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -136,7 +136,11 @@ uniclip dev seed-clipboard --text <TEXT>  # 写入一条加密文本记录（测
 uniclip dev dump-clipboard --limit <N>    # 打印最近的解密记录预览
 uniclip dev pairing addrs                 # 列出配对邀请候选地址
 uniclip dev pairing issue --addr <IP>     # 指定本机 IP 发起配对邀请
+uniclip --dev --json dev capture-files --path <PATH>  # 捕获文件或目录并输出持久化清单
 ```
+
+`capture-files` 可重复传入 `--path`，也可用 `--max-members` 和
+`--max-bytes` 临时覆盖本次捕获的目录上限。临时上限不会写回 profile 设置。
 
 ## 行为边界
 
@@ -154,6 +158,13 @@ uniclip dev pairing issue --addr <IP>     # 指定本机 IP 发起配对邀请
 ```bash
 cargo test -p uc-cli
 cargo run -p uc-cli -- --help
+```
+
+目录捕获端到端测试需要先构建同目录下的 daemon，再显式运行忽略的真实进程测试：
+
+```bash
+cargo build -p uc-daemon
+cargo test -p uc-cli --features dev-tools --test directory_capture_e2e -- --ignored --nocapture
 ```
 
 如果改动涉及搜索或 blob 命令，也要查看对应帮助：

--- a/apps/cli/src/commands/capture_files.rs
+++ b/apps/cli/src/commands/capture_files.rs
@@ -32,6 +32,7 @@ struct CaptureFilesOutput {
 struct CaptureFilesLineOutput {
     line_index: i64,
     root_index: Option<i64>,
+    root_name: Option<String>,
     relative_path: Option<String>,
     member_kind: Option<String>,
     line_kind: String,
@@ -55,6 +56,7 @@ impl From<CapturedFileSetLineView> for CaptureFilesLineOutput {
         Self {
             line_index: value.line_index,
             root_index: value.root_index,
+            root_name: value.root_name,
             relative_path: value.relative_path,
             member_kind: value.member_kind,
             line_kind: value.line_kind,

--- a/apps/cli/src/commands/capture_files.rs
+++ b/apps/cli/src/commands/capture_files.rs
@@ -1,0 +1,191 @@
+//! Hidden CLI diagnostic for capturing explicit file and directory paths.
+
+use std::path::PathBuf;
+
+use serde::Serialize;
+use uc_application::facade::space_setup::TryResumeSessionError;
+use uc_application::facade::{
+    CapturedFileSetLineView, CapturedFileSetView, FileSyncSettingsPatch, SettingsPatch,
+};
+
+use crate::commands::app_session::{build_app_session, refuse_if_daemon_running, CliAppSession};
+use crate::{exit_codes, output, ui};
+
+pub struct CaptureFilesArgs {
+    pub paths: Vec<PathBuf>,
+    pub max_members: Option<u64>,
+    pub max_bytes: Option<u64>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CaptureFilesOutput {
+    entry_id: String,
+    deduplicated: bool,
+    directory_structure: bool,
+    content_digest_count: usize,
+    lines: Vec<CaptureFilesLineOutput>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CaptureFilesLineOutput {
+    line_index: i64,
+    root_index: Option<i64>,
+    relative_path: Option<String>,
+    member_kind: Option<String>,
+    line_kind: String,
+    exclude_reason: Option<String>,
+}
+
+impl From<CapturedFileSetView> for CaptureFilesOutput {
+    fn from(value: CapturedFileSetView) -> Self {
+        Self {
+            entry_id: value.entry.entry_id,
+            deduplicated: value.entry.deduplicated,
+            directory_structure: value.directory_structure,
+            content_digest_count: value.content_digest_count,
+            lines: value.lines.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl From<CapturedFileSetLineView> for CaptureFilesLineOutput {
+    fn from(value: CapturedFileSetLineView) -> Self {
+        Self {
+            line_index: value.line_index,
+            root_index: value.root_index,
+            relative_path: value.relative_path,
+            member_kind: value.member_kind,
+            line_kind: value.line_kind,
+            exclude_reason: value.exclude_reason,
+        }
+    }
+}
+
+pub async fn run(args: CaptureFilesArgs, json: bool, verbose: bool) -> i32 {
+    if !json {
+        ui::header("Capture file set");
+    }
+    if let Err(code) = refuse_if_daemon_running().await {
+        return code;
+    }
+
+    let bundle = match build_app_session(verbose).await {
+        Ok(bundle) => bundle,
+        Err(code) => return code,
+    };
+    if let Err(code) = resume_session(&bundle).await {
+        bundle.shutdown().await;
+        return code;
+    }
+
+    let original_caps = match bundle.app_facade().settings.get().await {
+        Ok(settings) => (
+            settings.file_sync.max_file_set_member_count,
+            settings.file_sync.max_file_set_total_bytes,
+        ),
+        Err(err) => {
+            ui::error(&format!("Failed to load file-set caps: {err}"));
+            bundle.shutdown().await;
+            return exit_codes::EXIT_ERROR;
+        }
+    };
+    let overrides_requested = args.max_members.is_some() || args.max_bytes.is_some();
+    if overrides_requested {
+        let patch = SettingsPatch {
+            file_sync: Some(FileSyncSettingsPatch {
+                max_file_set_member_count: args.max_members,
+                max_file_set_total_bytes: args.max_bytes,
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        if let Err(err) = bundle.app_facade().settings.update(patch).await {
+            ui::error(&format!("Failed to apply temporary file-set caps: {err}"));
+            bundle.shutdown().await;
+            return exit_codes::EXIT_ERROR;
+        }
+    }
+
+    let capture = bundle
+        .app_facade()
+        .clipboard_capture
+        .capture_file_paths_for_diagnostics(args.paths)
+        .await;
+    let restore = if overrides_requested {
+        bundle
+            .app_facade()
+            .settings
+            .update(SettingsPatch {
+                file_sync: Some(FileSyncSettingsPatch {
+                    max_file_set_member_count: Some(original_caps.0),
+                    max_file_set_total_bytes: Some(original_caps.1),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            })
+            .await
+            .map(|_| ())
+    } else {
+        Ok(())
+    };
+
+    let result = match capture {
+        Ok(result) => result,
+        Err(err) => {
+            ui::error(&format!("Failed to capture file set: {err}"));
+            if let Err(restore_err) = restore {
+                ui::error(&format!("Failed to restore file-set caps: {restore_err}"));
+            }
+            bundle.shutdown().await;
+            return exit_codes::EXIT_ERROR;
+        }
+    };
+    if let Err(err) = restore {
+        ui::error(&format!("Failed to restore file-set caps: {err}"));
+        bundle.shutdown().await;
+        return exit_codes::EXIT_ERROR;
+    }
+
+    let output_view = CaptureFilesOutput::from(result);
+    let exit = if json {
+        output::emit_json(&output_view, "captured file set")
+    } else {
+        ui::info("entry_id", &output_view.entry_id);
+        ui::info("line_count", &output_view.lines.len().to_string());
+        ui::info(
+            "directory_structure",
+            &output_view.directory_structure.to_string(),
+        );
+        for line in &output_view.lines {
+            ui::info("member", line.relative_path.as_deref().unwrap_or("-"));
+        }
+        exit_codes::EXIT_SUCCESS
+    };
+
+    bundle.shutdown().await;
+    exit
+}
+
+async fn resume_session(bundle: &CliAppSession) -> Result<(), i32> {
+    match bundle.app_facade().try_resume_session().await {
+        Ok(true) => Ok(()),
+        Ok(false) => {
+            ui::error("This device is not set up yet. Use `uniclip init` or `uniclip join` first.");
+            Err(exit_codes::EXIT_ERROR)
+        }
+        Err(TryResumeSessionError::CorruptedKeyMaterial) => {
+            ui::error("Key material is corrupted - consider resetting this profile.");
+            Err(exit_codes::EXIT_ERROR)
+        }
+        Err(TryResumeSessionError::KeyringMiss) => {
+            ui::error("Secure storage cannot silently unlock this space.");
+            Err(exit_codes::EXIT_ERROR)
+        }
+        Err(TryResumeSessionError::Internal(message)) => {
+            ui::error(&format!("Resume failed: {message}"));
+            Err(exit_codes::EXIT_ERROR)
+        }
+    }
+}

--- a/apps/cli/src/commands/dev.rs
+++ b/apps/cli/src/commands/dev.rs
@@ -2,13 +2,14 @@
 
 use std::fmt;
 use std::net::IpAddr;
+use std::path::PathBuf;
 
 use clap::Subcommand;
 use serde::Serialize;
 use uc_application::facade::{IssuePairingInvitationError, PairingInvitationAddressCandidate};
 
 use crate::commands::app_session::{build_app_session, refuse_if_daemon_running};
-use crate::commands::{dump_clipboard, invite, seed_clipboard};
+use crate::commands::{capture_files, dump_clipboard, invite, seed_clipboard};
 use crate::exit_codes;
 use crate::output;
 use crate::ui;
@@ -35,6 +36,18 @@ pub enum DevCommands {
         /// Maximum number of entries to print (default 10).
         #[arg(long, default_value_t = 10)]
         limit: usize,
+    },
+    /// Capture files or directories through the real local capture pipeline.
+    CaptureFiles {
+        /// Top-level file or directory path. Repeat for mixed selections.
+        #[arg(long = "path", required = true)]
+        paths: Vec<PathBuf>,
+        /// Temporarily override the whole-set member cap for this capture.
+        #[arg(long)]
+        max_members: Option<u64>,
+        /// Temporarily override the whole-set byte cap for this capture.
+        #[arg(long)]
+        max_bytes: Option<u64>,
     },
 }
 
@@ -94,6 +107,22 @@ pub async fn run(command: DevCommands, json: bool, verbose: bool) -> i32 {
         }
         DevCommands::DumpClipboard { limit } => {
             dump_clipboard::run(dump_clipboard::DumpClipboardArgs { limit }, json, verbose).await
+        }
+        DevCommands::CaptureFiles {
+            paths,
+            max_members,
+            max_bytes,
+        } => {
+            capture_files::run(
+                capture_files::CaptureFilesArgs {
+                    paths,
+                    max_members,
+                    max_bytes,
+                },
+                json,
+                verbose,
+            )
+            .await
         }
     }
 }

--- a/apps/cli/src/commands/mod.rs
+++ b/apps/cli/src/commands/mod.rs
@@ -1,6 +1,8 @@
 pub mod app_session;
 #[cfg(feature = "dev-tools")]
 pub mod blob;
+#[cfg(feature = "dev-tools")]
+pub mod capture_files;
 pub mod debug;
 #[cfg(feature = "dev-tools")]
 pub mod dev;

--- a/apps/cli/src/commands/send.rs
+++ b/apps/cli/src/commands/send.rs
@@ -401,6 +401,7 @@ async fn run_send_file(path: PathBuf, json: bool, verbose: bool) -> i32 {
             uri_bytes,
         )],
         file_content_digests: Vec::new(),
+        file_set_v1_component: None,
     };
     let blob_refs = vec![V3BlobRef {
         ticket: publish_result.ticket,

--- a/apps/cli/src/commands/watch.rs
+++ b/apps/cli/src/commands/watch.rs
@@ -230,5 +230,6 @@ fn decode_v3_envelope(bytes: &[u8]) -> anyhow::Result<SystemClipboardSnapshot> {
         ts_ms: payload.ts_ms,
         representations,
         file_content_digests: Vec::new(),
+        file_set_v1_component: None,
     })
 }

--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -662,6 +662,40 @@ mod tests {
         assert!(probe);
     }
 
+    #[cfg(feature = "dev-tools")]
+    #[test]
+    fn dev_capture_files_parses_repeated_paths_and_cap_overrides() {
+        let parsed = Cli::try_parse_from([
+            "uniclip",
+            "dev",
+            "capture-files",
+            "--path",
+            "/tmp/a",
+            "--path",
+            "/tmp/b",
+            "--max-members",
+            "2",
+            "--max-bytes",
+            "1024",
+        ])
+        .expect("capture-files args parse");
+
+        let Some(Commands::Dev {
+            subcommand:
+                commands::dev::DevCommands::CaptureFiles {
+                    paths,
+                    max_members,
+                    max_bytes,
+                },
+        }) = parsed.command
+        else {
+            panic!("expected dev capture-files")
+        };
+        assert_eq!(paths.len(), 2);
+        assert_eq!(max_members, Some(2));
+        assert_eq!(max_bytes, Some(1024));
+    }
+
     #[test]
     fn devices_is_an_alias_for_members() {
         // The former `devices` command is now a hidden alias of `members`.

--- a/apps/cli/tests/directory_capture_e2e.rs
+++ b/apps/cli/tests/directory_capture_e2e.rs
@@ -127,6 +127,11 @@ fn cli_captures_directory_members_and_deduplicates_repeat_capture() {
     assert_eq!(first["directoryStructure"], true);
     assert_eq!(first["contentDigestCount"], 0);
     assert_eq!(first["deduplicated"], false);
+    assert!(first["lines"]
+        .as_array()
+        .expect("lines array")
+        .iter()
+        .all(|line| line["rootName"] == "root"));
     let members = member_pairs(&first);
     assert!(members.contains(&(".hidden", "f")));
     assert!(members.contains(&("visible.txt", "f")));

--- a/apps/cli/tests/directory_capture_e2e.rs
+++ b/apps/cli/tests/directory_capture_e2e.rs
@@ -1,0 +1,278 @@
+#![cfg(feature = "dev-tools")]
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde_json::Value;
+
+struct CliProfile {
+    name: String,
+    data_dir: PathBuf,
+    cache_dir: PathBuf,
+    log_dir: PathBuf,
+}
+
+impl CliProfile {
+    fn new(label: &str) -> Self {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock after epoch")
+            .as_nanos();
+        let name = format!("cli-dir-{label}-{}-{nonce}", std::process::id());
+        Self {
+            data_dir: profile_data_dir(&name),
+            cache_dir: profile_cache_dir(&name),
+            log_dir: profile_log_dir(&name),
+            name,
+        }
+    }
+
+    fn run(&self, args: &[String]) -> Output {
+        Command::new(env!("CARGO_BIN_EXE_uniclip"))
+            .args(["--dev", "--profile", self.name.as_str()])
+            .args(args)
+            .output()
+            .expect("run uniclip")
+    }
+
+    fn init(&self) {
+        let output = self.run(&[
+            "init".to_string(),
+            "--passphrase".to_string(),
+            "directory-e2e-passphrase".to_string(),
+            "--device-name".to_string(),
+            "directory-e2e".to_string(),
+        ]);
+        assert_success(&output, "init");
+
+        let stop = self.run(&["stop".to_string()]);
+        assert_success(&stop, "stop transient daemon");
+    }
+
+    fn capture(&self, paths: &[&Path], extra: &[&str]) -> Value {
+        let mut args = vec![
+            "--json".to_string(),
+            "dev".to_string(),
+            "capture-files".to_string(),
+        ];
+        for path in paths {
+            args.push("--path".to_string());
+            args.push(path.to_string_lossy().into_owned());
+        }
+        args.extend(extra.iter().map(|value| (*value).to_string()));
+        let output = self.run(&args);
+        assert_success(&output, "capture-files");
+        serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+            panic!(
+                "capture-files returned invalid JSON: {error}; stdout={}; stderr={}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            )
+        })
+    }
+}
+
+impl Drop for CliProfile {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.data_dir);
+        let _ = std::fs::remove_dir_all(&self.cache_dir);
+        let _ = std::fs::remove_dir_all(&self.log_dir);
+    }
+}
+
+fn assert_success(output: &Output, action: &str) {
+    assert!(
+        output.status.success(),
+        "{action} failed: exit={:?}; stdout={}; stderr={}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn member_pairs(value: &Value) -> Vec<(&str, &str)> {
+    value["lines"]
+        .as_array()
+        .expect("lines array")
+        .iter()
+        .filter_map(|line| Some((line["relativePath"].as_str()?, line["memberKind"].as_str()?)))
+        .collect()
+}
+
+#[test]
+#[ignore = "requires a prebuilt uniclipd sibling"]
+fn cli_captures_directory_members_and_deduplicates_repeat_capture() {
+    let profile = CliProfile::new("tree");
+    profile.init();
+    let fixture = tempfile::tempdir().expect("fixture dir");
+    let root = fixture.path().join("root");
+    std::fs::create_dir_all(root.join("nested")).unwrap();
+    std::fs::create_dir(root.join("empty")).unwrap();
+    std::fs::write(root.join("visible.txt"), b"visible").unwrap();
+    std::fs::write(root.join(".hidden"), b"hidden").unwrap();
+    std::fs::write(root.join("e\u{301}.txt"), b"unicode").unwrap();
+    let executable = root.join("nested/run.sh");
+    std::fs::write(&executable, b"#!/bin/sh\n").unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&executable, std::fs::Permissions::from_mode(0o755)).unwrap();
+    }
+
+    let first = profile.capture(&[&root], &[]);
+    assert!(!first
+        .to_string()
+        .contains(&root.to_string_lossy().to_string()));
+    assert_eq!(first["directoryStructure"], true);
+    assert_eq!(first["contentDigestCount"], 0);
+    assert_eq!(first["deduplicated"], false);
+    let members = member_pairs(&first);
+    assert!(members.contains(&(".hidden", "f")));
+    assert!(members.contains(&("visible.txt", "f")));
+    assert!(members.contains(&("empty", "d")));
+    assert!(members.contains(&("\u{e9}.txt", "f")));
+    #[cfg(unix)]
+    assert!(members.contains(&("nested/run.sh", "x")));
+
+    let second = profile.capture(&[&root], &[]);
+    assert_eq!(second["deduplicated"], true);
+    assert_eq!(second["entryId"], first["entryId"]);
+}
+
+#[test]
+#[ignore = "requires a prebuilt uniclipd sibling"]
+fn cli_captures_mixed_roots_and_applies_member_cap() {
+    let profile = CliProfile::new("mixed-cap");
+    profile.init();
+    let fixture = tempfile::tempdir().expect("fixture dir");
+    let loose = fixture.path().join("loose.txt");
+    std::fs::write(&loose, b"loose").unwrap();
+    let root = fixture.path().join("root");
+    std::fs::create_dir(&root).unwrap();
+    std::fs::write(root.join("child.txt"), b"child").unwrap();
+
+    let mixed = profile.capture(&[&loose, &root], &[]);
+    let lines = mixed["lines"].as_array().expect("lines array");
+    assert!(lines
+        .iter()
+        .any(|line| { line["rootIndex"] == 0 && line["relativePath"] == "loose.txt" }));
+    assert!(lines
+        .iter()
+        .any(|line| { line["rootIndex"] == 1 && line["relativePath"] == "child.txt" }));
+
+    let capped_root = fixture.path().join("capped");
+    std::fs::create_dir(&capped_root).unwrap();
+    for name in ["a", "b", "c"] {
+        std::fs::write(capped_root.join(name), name.as_bytes()).unwrap();
+    }
+    let capped = profile.capture(&[&capped_root], &["--max-members", "2"]);
+    assert!(capped["lines"]
+        .as_array()
+        .expect("lines array")
+        .iter()
+        .all(|line| {
+            line["lineKind"] == "excluded" && line["excludeReason"] == "size_cap_exceeded"
+        }));
+
+    let byte_capped = fixture.path().join("byte-capped");
+    std::fs::create_dir(&byte_capped).unwrap();
+    std::fs::write(byte_capped.join("large"), b"four").unwrap();
+    let byte_result = profile.capture(&[&byte_capped], &["--max-bytes", "1"]);
+    assert!(byte_result["lines"]
+        .as_array()
+        .expect("lines array")
+        .iter()
+        .all(|line| line["excludeReason"] == "size_cap_exceeded"));
+
+    let after_override = fixture.path().join("after-override.txt");
+    std::fs::write(&after_override, b"normal").unwrap();
+    let restored = profile.capture(&[&after_override], &[]);
+    assert_eq!(restored["lines"][0]["lineKind"], "file");
+    assert_eq!(restored["contentDigestCount"], 1);
+}
+
+#[cfg(unix)]
+#[test]
+#[ignore = "requires a prebuilt uniclipd sibling"]
+fn cli_rejects_symlink_and_socket_members() {
+    use std::os::unix::fs::symlink;
+    use std::os::unix::net::UnixListener;
+
+    let profile = CliProfile::new("unsupported");
+    profile.init();
+    for kind in ["symlink", "socket"] {
+        let fixture = tempfile::tempdir().expect("fixture dir");
+        let root = fixture.path().join("root");
+        std::fs::create_dir(&root).unwrap();
+        std::fs::write(root.join("target.txt"), b"target").unwrap();
+        let _socket = if kind == "symlink" {
+            symlink(root.join("target.txt"), root.join("forbidden")).unwrap();
+            None
+        } else {
+            Some(UnixListener::bind(root.join("forbidden")).unwrap())
+        };
+
+        let result = profile.capture(&[&root], &[]);
+        assert!(result["lines"]
+            .as_array()
+            .expect("lines array")
+            .iter()
+            .any(|line| line["excludeReason"] == "unsupported_member"));
+    }
+}
+
+fn profile_data_dir(profile: &str) -> PathBuf {
+    #[cfg(target_os = "macos")]
+    return home_dir()
+        .join("Library/Application Support")
+        .join(format!("app.uniclipboard.desktop-{profile}"));
+    #[cfg(target_os = "linux")]
+    return std::env::var_os("XDG_DATA_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| home_dir().join(".local/share"))
+        .join(format!("app.uniclipboard.desktop-{profile}"));
+    #[cfg(target_os = "windows")]
+    return std::env::var_os("LOCALAPPDATA")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from(r"C:\Temp"))
+        .join(format!("app.uniclipboard.desktop-{profile}"));
+}
+
+fn profile_cache_dir(profile: &str) -> PathBuf {
+    #[cfg(target_os = "macos")]
+    return home_dir()
+        .join("Library/Caches")
+        .join(format!("app.uniclipboard.desktop-{profile}"));
+    #[cfg(target_os = "linux")]
+    return std::env::var_os("XDG_CACHE_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| home_dir().join(".cache"))
+        .join(format!("app.uniclipboard.desktop-{profile}"));
+    #[cfg(target_os = "windows")]
+    return profile_data_dir(profile).join("cache");
+}
+
+fn profile_log_dir(profile: &str) -> PathBuf {
+    #[cfg(target_os = "macos")]
+    return home_dir()
+        .join("Library/Logs")
+        .join(format!("app.uniclipboard.desktop-{profile}"));
+    #[cfg(target_os = "linux")]
+    return std::env::var_os("XDG_STATE_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| home_dir().join(".local/state"))
+        .join(format!("app.uniclipboard.desktop-{profile}"));
+    #[cfg(target_os = "windows")]
+    return std::env::var_os("LOCALAPPDATA")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from(r"C:\Temp"))
+        .join(format!("app.uniclipboard.desktop-{profile}"))
+        .join("logs");
+}
+
+fn home_dir() -> PathBuf {
+    std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .expect("HOME is set")
+}

--- a/crates/uc-application/Cargo.toml
+++ b/crates/uc-application/Cargo.toml
@@ -46,6 +46,7 @@ hex = "0.4"
 # boundaries without extra clones. Matches uc-core + uc-infra.
 bytes = "1.7"
 url = "2"
+unicode-normalization = "0.1"
 # Base64 — Basic Auth credential parsing (mobile sync auth use case).
 base64 = "0.22"
 # QR code rendering for SyncClipboard install URL (mobile sync register use case).

--- a/crates/uc-application/src/clipboard_capture/usecase.rs
+++ b/crates/uc-application/src/clipboard_capture/usecase.rs
@@ -28,11 +28,13 @@ use uc_observability::analytics::{
     AnalyticsPort, CaptureOrigin, Event, PayloadSizeBucket, PayloadType,
 };
 use uc_observability::{stages, FlowId};
+use unicode_normalization::UnicodeNormalization;
 
 use uc_core::blob::ports::BlobContentIngestPort;
 use uc_core::clipboard::{
     is_file_mime_or_format, ClipboardPayloadSource, EntryFileSet, EntryFileSetExcludeReason,
-    EntryFileSetLine, EntryFileSetLineKind, PersistedClipboardRepresentation,
+    EntryFileSetLine, EntryFileSetLineKind, FileSetMemberKind, FileSetMemberLocation,
+    PersistedClipboardRepresentation,
 };
 
 use crate::facade::clipboard_outbound::{parse_uri_list_line, UriListLineKind};
@@ -804,21 +806,16 @@ impl FileSetCaps {
 ///
 /// # Whole-set caps (ADR-010)
 ///
-/// Before hashing, a millisecond-scale metadata pre-check sums member sizes
-/// and counts members (`metadata()` only — no content read). If either
-/// `caps` dimension is exceeded, every file line is marked
+/// Before hashing, a metadata-only traversal expands directory leaves while
+/// summing member sizes and counts. If either `caps` dimension is exceeded,
+/// traversal stops immediately and every discovered file line is marked
 /// `Excluded { SizeCapExceeded }` and hashing is skipped entirely: an
 /// over-budget set's identity falls back to path text anyway, so streaming
-/// gigabytes just to discard the digests would be pure waste (and, once
-/// directory capture lands, unbounded). The set is still admitted to local
-/// history; only sync is suppressed (the outbound path skips any manifest with
-/// excluded lines). The check is all-or-nothing to match
-/// [`EntryFileSet::content_digest_contribution`]. `LocalFile` reps carry their
-/// size, so their byte cap needs no filesystem access; inline uri-list members
-/// are `stat`ed. If an unmeasurable member is reached while still under budget
-/// the verdict stays `false` and the per-line hashing below marks it
-/// `IngestFailed`, which already forces the same path-text fallback, so the
-/// size verdict is moot.
+/// gigabytes just to discard the digests would be pure waste. The set is still
+/// admitted to local history; only sync is suppressed (the outbound path skips
+/// any manifest with excluded lines). The check is all-or-nothing to match
+/// [`EntryFileSet::content_digest_contribution`]. Symlinks and non-regular
+/// special files stop the same traversal without being dereferenced.
 ///
 /// Each file line's content hash comes from the fallible
 /// [`BlobContentIngestPort::hash_path`] (never a rep's `content_hash()`,
@@ -840,34 +837,38 @@ async fn build_entry_file_set(
     blob_ingest: &dyn BlobContentIngestPort,
     caps: FileSetCaps,
 ) -> Option<EntryFileSet> {
-    // LocalFile reps already carry the member size (captured with the rep), so
-    // the byte-cap pre-check can sum sizes without any `metadata()` round-trip.
-    let local_file_members: Vec<CapMember> = snapshot
+    let local_file_members: Vec<TopLevelFileMember> = snapshot
         .representations
         .iter()
-        .filter_map(|r| match r.source() {
-            ClipboardPayloadSource::LocalFile { path, size_bytes } => Some(CapMember {
-                path: path.clone(),
-                known_size: Some(*size_bytes),
-            }),
+        .filter_map(|rep| match rep.source() {
+            ClipboardPayloadSource::LocalFile { path, size_bytes } => {
+                Some((path.clone(), *size_bytes))
+            }
             ClipboardPayloadSource::Inline(_) => None,
+        })
+        .enumerate()
+        .map(|(idx, (path, size_bytes))| TopLevelFileMember {
+            line_index: idx as i64,
+            root_index: idx as i64,
+            original_text: path.display().to_string(),
+            path,
+            known_size: Some(size_bytes),
         })
         .collect();
 
     if !local_file_members.is_empty() {
-        let over_cap = file_set_exceeds_caps(&local_file_members, caps).await;
-        let mut lines = Vec::with_capacity(local_file_members.len());
-        for (idx, member) in local_file_members.iter().enumerate() {
-            let kind = classify_file_path(&member.path, blob_ingest, over_cap).await;
-            lines.push(EntryFileSetLine {
-                line_index: idx as i64,
-                original_text: member.path.display().to_string(),
-                kind,
-            });
-        }
+        let top_level_count = local_file_members.len() as i64;
+        let lines = build_file_member_lines(
+            local_file_members,
+            Vec::new(),
+            top_level_count,
+            blob_ingest,
+            caps,
+        )
+        .await;
         debug!(
             line_count = lines.len(),
-            over_cap, "capture: built file-set manifest from LocalFile reps"
+            "capture: built file-set manifest from LocalFile reps"
         );
         return Some(EntryFileSet { lines });
     }
@@ -881,86 +882,407 @@ async fn build_entry_file_set(
             .map(str::to_string)
     })?;
 
-    let parsed: Vec<UriListLineKind> = uri_list_text.lines().map(parse_uri_list_line).collect();
-    // Inline uri-list only yields path strings, so sizes are unknown here and
-    // the byte-cap pre-check must `stat` each member.
-    let file_members: Vec<CapMember> = parsed
-        .iter()
-        .filter_map(|kind| match kind {
-            UriListLineKind::File(path) => Some(CapMember {
-                path: path.clone(),
+    let mut file_members = Vec::new();
+    let mut non_file_lines = Vec::new();
+    let mut root_index = 0i64;
+    let top_level_count = uri_list_text.lines().count() as i64;
+    for (idx, raw_line) in uri_list_text.lines().enumerate() {
+        match parse_uri_list_line(raw_line) {
+            UriListLineKind::File(path) => file_members.push(TopLevelFileMember {
+                line_index: idx as i64,
+                root_index: {
+                    let current = root_index;
+                    root_index = root_index.saturating_add(1);
+                    current
+                },
+                original_text: raw_line.to_string(),
+                path,
                 known_size: None,
             }),
-            UriListLineKind::NonFile => None,
-        })
-        .collect();
-    let over_cap = file_set_exceeds_caps(&file_members, caps).await;
-
-    let mut lines = Vec::with_capacity(parsed.len());
-    for (idx, (raw_line, parsed_kind)) in uri_list_text.lines().zip(parsed).enumerate() {
-        let kind = match parsed_kind {
-            UriListLineKind::NonFile => EntryFileSetLineKind::NonFile,
-            UriListLineKind::File(path) => classify_file_path(&path, blob_ingest, over_cap).await,
-        };
-        lines.push(EntryFileSetLine {
-            line_index: idx as i64,
-            original_text: raw_line.to_string(),
-            kind,
-        });
+            UriListLineKind::NonFile => non_file_lines.push(EntryFileSetLine {
+                line_index: idx as i64,
+                original_text: raw_line.to_string(),
+                member_location: None,
+                kind: EntryFileSetLineKind::NonFile,
+            }),
+        }
     }
+    let lines = build_file_member_lines(
+        file_members,
+        non_file_lines,
+        top_level_count,
+        blob_ingest,
+        caps,
+    )
+    .await;
     debug!(
         line_count = lines.len(),
-        over_cap, "capture: built file-set manifest from inline uri-list text"
+        "capture: built file-set manifest from inline uri-list text"
     );
     Some(EntryFileSet { lines })
 }
 
-/// A file-set member for the whole-set cap pre-check.
-struct CapMember {
+struct TopLevelFileMember {
+    line_index: i64,
+    root_index: i64,
+    original_text: String,
     path: std::path::PathBuf,
-    /// Size already known from the capture rep (`LocalFile` carries it), so the
-    /// byte cap can be evaluated without a `metadata()` round-trip. `None` means
-    /// "measure it" — inline uri-list only gives a path string.
     known_size: Option<u64>,
 }
 
-/// Millisecond-scale pre-check: does this file set exceed either whole-set
-/// cap? Reads `metadata()` only for members whose size isn't already known
-/// (never content); the member-count cap short-circuits before any filesystem
-/// access.
-///
-/// The byte verdict flips to `true` as soon as the running total exceeds the
-/// cap, so a member that can't be measured *after* the cap is already blown
-/// doesn't change the outcome. It only aborts to `false` when an unmeasurable
-/// member (missing / directory / stat error) is reached while still under
-/// budget — then the caller's per-line hashing marks that member
-/// `IngestFailed`, which forces the same path-text fallback, so the size
-/// verdict is moot anyway.
-async fn file_set_exceeds_caps(members: &[CapMember], caps: FileSetCaps) -> bool {
-    if caps.max_member_count > 0 && members.len() as u64 > caps.max_member_count {
-        return true;
-    }
-    if caps.max_total_bytes == 0 {
-        return false;
-    }
-    let mut total: u64 = 0;
-    for member in members {
-        let size = match member.known_size {
-            Some(size) => size,
-            None => match tokio::fs::metadata(&member.path).await {
-                Ok(meta) if meta.is_file() => meta.len(),
-                // Non-regular or unreadable member, still under budget: can't
-                // confirm over-budget. Per-line hashing will mark it
-                // IngestFailed → path-text identity.
-                _ => return false,
-            },
-        };
-        total = total.saturating_add(size);
-        if total > caps.max_total_bytes {
-            return true;
+struct PendingFileSetLine {
+    line_index: i64,
+    original_text: String,
+    member_location: FileSetMemberLocation,
+    file_path: Option<std::path::PathBuf>,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum ExpansionFailure {
+    SizeCapExceeded,
+    UnsupportedMember,
+    IngestFailed,
+}
+
+impl ExpansionFailure {
+    fn exclude_reason(self) -> EntryFileSetExcludeReason {
+        match self {
+            Self::SizeCapExceeded => EntryFileSetExcludeReason::SizeCapExceeded,
+            Self::UnsupportedMember => EntryFileSetExcludeReason::UnsupportedMember,
+            Self::IngestFailed => EntryFileSetExcludeReason::IngestFailed,
         }
     }
-    false
+}
+
+#[derive(Default)]
+struct TraversalBudget {
+    member_count: u64,
+    total_bytes: u64,
+}
+
+impl TraversalBudget {
+    fn admit(&mut self, size_bytes: u64, caps: FileSetCaps) -> bool {
+        self.member_count = self.member_count.saturating_add(1);
+        self.total_bytes = self.total_bytes.saturating_add(size_bytes);
+        (caps.max_member_count > 0 && self.member_count > caps.max_member_count)
+            || (caps.max_total_bytes > 0 && self.total_bytes > caps.max_total_bytes)
+    }
+}
+
+async fn build_file_member_lines(
+    roots: Vec<TopLevelFileMember>,
+    mut lines: Vec<EntryFileSetLine>,
+    top_level_count: i64,
+    blob_ingest: &dyn BlobContentIngestPort,
+    caps: FileSetCaps,
+) -> Vec<EntryFileSetLine> {
+    if caps.max_member_count > 0 && roots.len() as u64 > caps.max_member_count {
+        lines.extend(
+            roots
+                .into_iter()
+                .map(|root| excluded_root_line(root, EntryFileSetExcludeReason::SizeCapExceeded)),
+        );
+        lines.sort_by_key(|line| line.line_index);
+        return lines;
+    }
+
+    let mut budget = TraversalBudget::default();
+    let mut pending = Vec::new();
+    let mut next_directory_line = top_level_count;
+    let mut failure = None;
+
+    let mut roots = roots.into_iter();
+    while let Some(root) = roots.next() {
+        let metadata = tokio::fs::symlink_metadata(&root.path).await;
+        match metadata {
+            Ok(metadata) if metadata.file_type().is_symlink() => {
+                pending.push(pending_root_marker(root, next_directory_line));
+                failure = Some(ExpansionFailure::UnsupportedMember);
+                break;
+            }
+            Ok(metadata) if metadata.is_dir() => {
+                match expand_directory(&root, &mut next_directory_line, &mut budget, caps).await {
+                    Ok(mut members) => pending.append(&mut members),
+                    Err((reason, marker)) => {
+                        pending.push(marker);
+                        failure = Some(reason);
+                        break;
+                    }
+                }
+            }
+            Ok(metadata) if metadata.is_file() => {
+                let size = root.known_size.unwrap_or_else(|| metadata.len());
+                if budget.admit(size, caps) {
+                    pending.push(pending_flat_file(root, metadata));
+                    failure = Some(ExpansionFailure::SizeCapExceeded);
+                    break;
+                }
+                pending.push(pending_flat_file(root, metadata));
+            }
+            Ok(_) => {
+                pending.push(pending_root_marker(root, next_directory_line));
+                failure = Some(ExpansionFailure::UnsupportedMember);
+                break;
+            }
+            Err(_) => {
+                let size = root.known_size.unwrap_or(0);
+                if budget.admit(size, caps) {
+                    pending.push(pending_missing_file(root));
+                    failure = Some(ExpansionFailure::SizeCapExceeded);
+                    break;
+                }
+                pending.push(pending_missing_file(root));
+            }
+        }
+    }
+
+    if let Some(failure) = failure {
+        let reason = failure.exclude_reason();
+        pending.extend(roots.map(|root| PendingFileSetLine {
+            line_index: root.line_index,
+            original_text: root.original_text,
+            member_location: FileSetMemberLocation {
+                root_index: root.root_index,
+                relative_path: normalized_basename(&root.path),
+                kind: FileSetMemberKind::File,
+            },
+            file_path: None,
+        }));
+        warn!(
+            reason = ?reason,
+            "capture: file-set traversal stopped; the whole set is ineligible"
+        );
+        lines.extend(pending.into_iter().map(|line| EntryFileSetLine {
+            line_index: line.line_index,
+            original_text: line.original_text,
+            member_location: Some(line.member_location),
+            kind: EntryFileSetLineKind::Excluded { reason },
+        }));
+    } else {
+        for line in pending {
+            let kind = match line.file_path {
+                Some(path) => classify_file_path(&path, blob_ingest, false).await,
+                None => EntryFileSetLineKind::NonFile,
+            };
+            lines.push(EntryFileSetLine {
+                line_index: line.line_index,
+                original_text: line.original_text,
+                member_location: Some(line.member_location),
+                kind,
+            });
+        }
+    }
+    lines.sort_by_key(|line| line.line_index);
+    lines
+}
+
+fn pending_flat_file(root: TopLevelFileMember, metadata: std::fs::Metadata) -> PendingFileSetLine {
+    let relative_path = normalized_basename(&root.path);
+    PendingFileSetLine {
+        line_index: root.line_index,
+        original_text: root.original_text,
+        member_location: FileSetMemberLocation {
+            root_index: root.root_index,
+            relative_path,
+            kind: member_kind(&metadata),
+        },
+        file_path: Some(root.path),
+    }
+}
+
+fn pending_missing_file(root: TopLevelFileMember) -> PendingFileSetLine {
+    let relative_path = normalized_basename(&root.path);
+    PendingFileSetLine {
+        line_index: root.line_index,
+        original_text: root.original_text,
+        member_location: FileSetMemberLocation {
+            root_index: root.root_index,
+            relative_path,
+            kind: FileSetMemberKind::File,
+        },
+        file_path: Some(root.path),
+    }
+}
+
+fn pending_root_marker(root: TopLevelFileMember, line_index: i64) -> PendingFileSetLine {
+    PendingFileSetLine {
+        line_index,
+        original_text: root.original_text,
+        member_location: FileSetMemberLocation {
+            root_index: root.root_index,
+            relative_path: ".".to_string(),
+            kind: FileSetMemberKind::File,
+        },
+        file_path: None,
+    }
+}
+
+fn excluded_root_line(
+    root: TopLevelFileMember,
+    reason: EntryFileSetExcludeReason,
+) -> EntryFileSetLine {
+    EntryFileSetLine {
+        line_index: root.line_index,
+        original_text: root.original_text,
+        member_location: Some(FileSetMemberLocation {
+            root_index: root.root_index,
+            relative_path: normalized_basename(&root.path),
+            kind: FileSetMemberKind::File,
+        }),
+        kind: EntryFileSetLineKind::Excluded { reason },
+    }
+}
+
+async fn expand_directory(
+    root: &TopLevelFileMember,
+    next_line_index: &mut i64,
+    budget: &mut TraversalBudget,
+    caps: FileSetCaps,
+) -> std::result::Result<Vec<PendingFileSetLine>, (ExpansionFailure, PendingFileSetLine)> {
+    use std::collections::VecDeque;
+
+    let mut pending = Vec::new();
+    let mut queue = VecDeque::from([(root.path.clone(), String::new())]);
+    while let Some((directory, relative_directory)) = queue.pop_front() {
+        let mut read_dir = tokio::fs::read_dir(&directory).await.map_err(|_| {
+            (
+                ExpansionFailure::IngestFailed,
+                directory_marker(root, next_line_index, &relative_directory),
+            )
+        })?;
+        let mut entries = Vec::new();
+        while let Some(entry) = read_dir.next_entry().await.map_err(|_| {
+            (
+                ExpansionFailure::IngestFailed,
+                directory_marker(root, next_line_index, &relative_directory),
+            )
+        })? {
+            entries.push(entry);
+        }
+        entries.sort_by_key(|entry| entry.file_name());
+
+        if entries.is_empty() {
+            let relative_path = if relative_directory.is_empty() {
+                ".".to_string()
+            } else {
+                relative_directory.clone()
+            };
+            let marker = PendingFileSetLine {
+                line_index: take_line_index(next_line_index),
+                original_text: root.original_text.clone(),
+                member_location: FileSetMemberLocation {
+                    root_index: root.root_index,
+                    relative_path,
+                    kind: FileSetMemberKind::EmptyDirectory,
+                },
+                file_path: None,
+            };
+            if budget.admit(0, caps) {
+                return Err((ExpansionFailure::SizeCapExceeded, marker));
+            }
+            pending.push(marker);
+            continue;
+        }
+
+        for entry in entries {
+            let name = entry.file_name();
+            let Some(name) = name.to_str() else {
+                return Err((
+                    ExpansionFailure::UnsupportedMember,
+                    directory_marker(root, next_line_index, &relative_directory),
+                ));
+            };
+            let name = name.nfc().collect::<String>();
+            let relative_path = if relative_directory.is_empty() {
+                name
+            } else {
+                format!("{relative_directory}/{name}")
+            };
+            let path = entry.path();
+            let metadata = tokio::fs::symlink_metadata(&path).await.map_err(|_| {
+                (
+                    ExpansionFailure::IngestFailed,
+                    directory_marker(root, next_line_index, &relative_path),
+                )
+            })?;
+            if metadata.file_type().is_symlink() {
+                return Err((
+                    ExpansionFailure::UnsupportedMember,
+                    directory_marker(root, next_line_index, &relative_path),
+                ));
+            }
+            if metadata.is_dir() {
+                queue.push_back((path, relative_path));
+                continue;
+            }
+            if !metadata.is_file() {
+                return Err((
+                    ExpansionFailure::UnsupportedMember,
+                    directory_marker(root, next_line_index, &relative_path),
+                ));
+            }
+
+            let member = PendingFileSetLine {
+                line_index: take_line_index(next_line_index),
+                original_text: root.original_text.clone(),
+                member_location: FileSetMemberLocation {
+                    root_index: root.root_index,
+                    relative_path,
+                    kind: member_kind(&metadata),
+                },
+                file_path: Some(path),
+            };
+            if budget.admit(metadata.len(), caps) {
+                return Err((ExpansionFailure::SizeCapExceeded, member));
+            }
+            pending.push(member);
+        }
+    }
+    Ok(pending)
+}
+
+fn directory_marker(
+    root: &TopLevelFileMember,
+    next_line_index: &mut i64,
+    relative_path: &str,
+) -> PendingFileSetLine {
+    PendingFileSetLine {
+        line_index: take_line_index(next_line_index),
+        original_text: root.original_text.clone(),
+        member_location: FileSetMemberLocation {
+            root_index: root.root_index,
+            relative_path: if relative_path.is_empty() {
+                ".".to_string()
+            } else {
+                relative_path.to_string()
+            },
+            kind: FileSetMemberKind::File,
+        },
+        file_path: None,
+    }
+}
+
+fn take_line_index(next_line_index: &mut i64) -> i64 {
+    let current = *next_line_index;
+    *next_line_index = (*next_line_index).saturating_add(1);
+    current
+}
+
+fn normalized_basename(path: &std::path::Path) -> String {
+    path.file_name()
+        .map(|name| name.to_string_lossy().nfc().collect())
+        .unwrap_or_else(|| ".".to_string())
+}
+
+fn member_kind(metadata: &std::fs::Metadata) -> FileSetMemberKind {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if metadata.permissions().mode() & 0o111 != 0 {
+            return FileSetMemberKind::Executable;
+        }
+    }
+    FileSetMemberKind::File
 }
 
 /// Classify one resolved file path into a manifest line's kind.
@@ -1079,6 +1401,193 @@ mod tests {
             representations: reps,
             file_content_digests: Vec::new(),
         }
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn directory_capture_expands_members_and_preserves_member_semantics() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let parent = tempfile::tempdir().unwrap();
+        let root = parent.path().join("root");
+        std::fs::create_dir(&root).unwrap();
+        std::fs::write(root.join("visible.txt"), b"visible").unwrap();
+        std::fs::write(root.join(".hidden"), b"hidden").unwrap();
+        std::fs::create_dir(root.join("nested")).unwrap();
+        let executable = root.join("nested/run.sh");
+        std::fs::write(&executable, b"#!/bin/sh\n").unwrap();
+        std::fs::set_permissions(&executable, std::fs::Permissions::from_mode(0o755)).unwrap();
+        std::fs::create_dir(root.join("empty")).unwrap();
+        std::fs::write(root.join("e\u{301}.txt"), b"unicode").unwrap();
+
+        let uri_list = format!("file://{}", root.display());
+        let snapshot = snapshot_with(vec![rep(
+            "public.file-url",
+            Some("text/uri-list"),
+            uri_list.as_bytes(),
+        )]);
+        let set = build_entry_file_set(&snapshot, &FakeIngestByName, FileSetCaps::unbounded())
+            .await
+            .expect("directory should produce a manifest");
+
+        let members: Vec<_> = set
+            .lines
+            .iter()
+            .map(|line| {
+                let location = line
+                    .member_location
+                    .as_ref()
+                    .expect("directory member location");
+                (location.relative_path.as_str(), location.kind)
+            })
+            .collect();
+        assert!(members.contains(&(".hidden", FileSetMemberKind::File)));
+        assert!(members.contains(&("visible.txt", FileSetMemberKind::File)));
+        assert!(members.contains(&("nested/run.sh", FileSetMemberKind::Executable)));
+        assert!(members.contains(&("empty", FileSetMemberKind::EmptyDirectory)));
+        assert!(members.contains(&("\u{e9}.txt", FileSetMemberKind::File)));
+        assert!(set.has_directory_structure());
+        assert!(set.content_digest_contribution().is_empty());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn directory_capture_rejects_symlinks_and_special_files() {
+        use std::os::unix::fs::symlink;
+        use std::os::unix::net::UnixListener;
+
+        for forbidden in ["symlink", "socket"] {
+            let parent = tempfile::tempdir().unwrap();
+            let root = parent.path().join("root");
+            std::fs::create_dir(&root).unwrap();
+            std::fs::write(root.join("target.txt"), b"target").unwrap();
+            let _socket = if forbidden == "symlink" {
+                symlink(root.join("target.txt"), root.join("forbidden")).unwrap();
+                None
+            } else {
+                Some(UnixListener::bind(root.join("forbidden")).unwrap())
+            };
+            let uri_list = format!("file://{}", root.display());
+            let snapshot = snapshot_with(vec![rep(
+                "public.file-url",
+                Some("text/uri-list"),
+                uri_list.as_bytes(),
+            )]);
+
+            let set = build_entry_file_set(&snapshot, &PanicOnHash, FileSetCaps::unbounded())
+                .await
+                .expect("ineligible directory should still produce a manifest");
+            assert!(set.lines.iter().any(|line| matches!(
+                line.kind,
+                EntryFileSetLineKind::Excluded {
+                    reason: EntryFileSetExcludeReason::UnsupportedMember
+                }
+            )));
+            assert_eq!(set.file_lines().count(), 0);
+        }
+    }
+
+    #[tokio::test]
+    async fn directory_member_count_cap_stops_before_hashing() {
+        let parent = tempfile::tempdir().unwrap();
+        let root = parent.path().join("root");
+        std::fs::create_dir(&root).unwrap();
+        for name in ["a", "b", "c"] {
+            std::fs::write(root.join(name), name.as_bytes()).unwrap();
+        }
+        let uri_list = format!("file://{}", root.display());
+        let snapshot = snapshot_with(vec![rep(
+            "public.file-url",
+            Some("text/uri-list"),
+            uri_list.as_bytes(),
+        )]);
+
+        let set = build_entry_file_set(&snapshot, &PanicOnHash, caps(0, 2))
+            .await
+            .expect("over-cap directory should produce a manifest");
+        assert!(set.lines.iter().all(|line| matches!(
+            line.kind,
+            EntryFileSetLineKind::Excluded {
+                reason: EntryFileSetExcludeReason::SizeCapExceeded
+            }
+        )));
+    }
+
+    #[tokio::test]
+    async fn traversal_failure_keeps_remaining_top_level_roots() {
+        let parent = tempfile::tempdir().unwrap();
+        let paths: Vec<_> = ["a", "b", "c"]
+            .into_iter()
+            .map(|name| {
+                let path = parent.path().join(name);
+                std::fs::write(&path, b"xx").unwrap();
+                path
+            })
+            .collect();
+        let uri_list = paths
+            .iter()
+            .map(|path| format!("file://{}", path.display()))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let snapshot = snapshot_with(vec![rep(
+            "public.file-url",
+            Some("text/uri-list"),
+            uri_list.as_bytes(),
+        )]);
+
+        let set = build_entry_file_set(&snapshot, &PanicOnHash, caps(1, 0))
+            .await
+            .expect("over-cap selection should produce a manifest");
+        assert_eq!(set.lines.len(), 3);
+        assert!(set.lines.iter().all(|line| matches!(
+            line.kind,
+            EntryFileSetLineKind::Excluded {
+                reason: EntryFileSetExcludeReason::SizeCapExceeded
+            }
+        )));
+    }
+
+    #[tokio::test]
+    async fn mixed_file_and_directory_keep_stable_root_indexes() {
+        let parent = tempfile::tempdir().unwrap();
+        let loose = parent.path().join("loose.txt");
+        std::fs::write(&loose, b"loose").unwrap();
+        let root = parent.path().join("root");
+        std::fs::create_dir(&root).unwrap();
+        std::fs::write(root.join("child.txt"), b"child").unwrap();
+        let uri_list = format!("file://{}\nfile://{}", loose.display(), root.display());
+        let snapshot = snapshot_with(vec![rep(
+            "public.file-url",
+            Some("text/uri-list"),
+            uri_list.as_bytes(),
+        )]);
+
+        let set = build_entry_file_set(&snapshot, &FakeIngestByName, FileSetCaps::unbounded())
+            .await
+            .expect("mixed selection should produce a manifest");
+        let flat = set
+            .lines
+            .iter()
+            .find(|line| line.line_index == 0)
+            .unwrap()
+            .member_location
+            .as_ref()
+            .unwrap();
+        assert_eq!(
+            (flat.root_index, flat.relative_path.as_str()),
+            (0, "loose.txt")
+        );
+        let child = set
+            .lines
+            .iter()
+            .find(|line| {
+                line.member_location
+                    .as_ref()
+                    .is_some_and(|location| location.relative_path == "child.txt")
+            })
+            .unwrap();
+        assert_eq!(child.member_location.as_ref().unwrap().root_index, 1);
+        assert!(child.line_index >= 2);
     }
 
     /// Fake ingest whose content hash is keyed on the file *name*, so two

--- a/crates/uc-application/src/clipboard_capture/usecase.rs
+++ b/crates/uc-application/src/clipboard_capture/usecase.rs
@@ -299,17 +299,18 @@ impl CaptureClipboardUseCase {
                 && is_file_class
             {
                 // Read the file-set caps for this capture. A load failure must
-                // not drop the capture — fall back to no cap (behaviour before
-                // the gate existed) so a transient settings error can't silently
-                // stop file sync.
+                // not drop the capture, but it must stay bounded — fall back to
+                // the conservative ADR-010 default ceiling rather than no cap,
+                // so a transient settings error can't let a directory capture
+                // traverse and hash an entire tree unbounded.
                 let caps = match self.settings.load().await {
                     Ok(s) => FileSetCaps {
                         max_total_bytes: s.file_sync.max_file_set_total_bytes,
                         max_member_count: s.file_sync.max_file_set_member_count,
                     },
                     Err(err) => {
-                        warn!(error = %err, "capture: settings load failed; file-set caps disabled for this capture");
-                        FileSetCaps::unbounded()
+                        warn!(error = %err, "capture: settings load failed; using fallback file-set caps for this capture");
+                        FileSetCaps::fallback()
                     }
                 };
                 if let Some(built) =
@@ -788,8 +789,23 @@ struct FileSetCaps {
 }
 
 impl FileSetCaps {
-    /// No cap on either dimension — used when the settings load fails so a
-    /// transient error never silently stops file sync.
+    /// Conservative fallback caps for when the settings load fails: a transient
+    /// error must not silently stop file sync, but it also must not disable the
+    /// caps entirely — with directory capture, unbounded caps would let one
+    /// settings hiccup traverse and hash an entire directory tree. Mirror the
+    /// ADR-010 defaults (`uc-core` `Settings::default`: 1 GiB / 2000 members)
+    /// so the fallback stays bounded without dropping the capture.
+    fn fallback() -> Self {
+        Self {
+            max_total_bytes: 1024 * 1024 * 1024, // 1 GiB
+            max_member_count: 2000,
+        }
+    }
+
+    /// No cap on either dimension. Test-only: exercises the manifest builder
+    /// without cap interference. Production never disables the caps — a
+    /// settings-load failure uses [`Self::fallback`], not this.
+    #[cfg(test)]
     fn unbounded() -> Self {
         Self {
             max_total_bytes: 0,

--- a/crates/uc-application/src/clipboard_capture/usecase.rs
+++ b/crates/uc-application/src/clipboard_capture/usecase.rs
@@ -276,12 +276,16 @@ impl CaptureClipboardUseCase {
             };
             // Build this capture's file-set manifest (line-level: kept for
             // persistence below) and use it to populate `file_content_digests`
-            // so `snapshot_hash()` is based on device-independent file
-            // *content* rather than the text/uri-list path text (device-
-            // specific). Skipped when already populated (RemotePush: the
-            // inbound materializer fills these from the wire before this
-            // capture runs; it does not yet build a manifest — out of this
-            // phase's scope).
+            // / `file_set_v1_component` so `snapshot_hash()` is based on
+            // device-independent file *content* rather than the text/uri-list
+            // path text (device-specific). Skipped when either is already
+            // populated (RemotePush: the inbound materializer fills these
+            // from the wire before this capture runs; it does not yet build
+            // a manifest — out of this phase's scope). No current snapshot
+            // constructor pre-populates `file_set_v1_component`, so that half
+            // of the guard is a no-op today; it exists for parity with
+            // `file_content_digests` and to cover a future wire path that
+            // carries the component directly.
             let mut file_set: Option<EntryFileSet> = None;
             // Only file-class captures build a manifest, so keep the text/image
             // hot path off the settings port (see the `settings` field doc).
@@ -290,7 +294,10 @@ impl CaptureClipboardUseCase {
                 matches!(rep.source(), ClipboardPayloadSource::LocalFile { .. })
                     || is_file_mime_or_format(rep.mime.as_ref(), &rep.format_id)
             });
-            if snapshot.file_content_digests.is_empty() && is_file_class {
+            if snapshot.file_content_digests.is_empty()
+                && snapshot.file_set_v1_component.is_none()
+                && is_file_class
+            {
                 // Read the file-set caps for this capture. A load failure must
                 // not drop the capture — fall back to no cap (behaviour before
                 // the gate existed) so a transient settings error can't silently
@@ -308,9 +315,13 @@ impl CaptureClipboardUseCase {
                 if let Some(built) =
                     build_entry_file_set(&snapshot, self.blob_ingest.as_ref(), caps).await
                 {
-                    let digests = built.content_digest_contribution();
-                    if !digests.is_empty() {
-                        snapshot.file_content_digests = digests;
+                    if let Some(component) = built.file_set_v1_component() {
+                        snapshot.file_set_v1_component = Some(component);
+                    } else {
+                        let digests = built.content_digest_contribution();
+                        if !digests.is_empty() {
+                            snapshot.file_content_digests = digests;
+                        }
                     }
                     file_set = Some(built);
                 }
@@ -851,6 +862,7 @@ async fn build_entry_file_set(
             line_index: idx as i64,
             root_index: idx as i64,
             original_text: path.display().to_string(),
+            root_name: normalized_basename(&path),
             path,
             known_size: Some(size_bytes),
         })
@@ -896,6 +908,7 @@ async fn build_entry_file_set(
                     current
                 },
                 original_text: raw_line.to_string(),
+                root_name: normalized_basename(&path),
                 path,
                 known_size: None,
             }),
@@ -926,6 +939,7 @@ struct TopLevelFileMember {
     line_index: i64,
     root_index: i64,
     original_text: String,
+    root_name: String,
     path: std::path::PathBuf,
     known_size: Option<u64>,
 }
@@ -1043,6 +1057,7 @@ async fn build_file_member_lines(
             original_text: root.original_text,
             member_location: FileSetMemberLocation {
                 root_index: root.root_index,
+                root_name: root.root_name,
                 relative_path: normalized_basename(&root.path),
                 kind: FileSetMemberKind::File,
             },
@@ -1083,6 +1098,7 @@ fn pending_flat_file(root: TopLevelFileMember, metadata: std::fs::Metadata) -> P
         original_text: root.original_text,
         member_location: FileSetMemberLocation {
             root_index: root.root_index,
+            root_name: root.root_name,
             relative_path,
             kind: member_kind(&metadata),
         },
@@ -1097,6 +1113,7 @@ fn pending_missing_file(root: TopLevelFileMember) -> PendingFileSetLine {
         original_text: root.original_text,
         member_location: FileSetMemberLocation {
             root_index: root.root_index,
+            root_name: root.root_name,
             relative_path,
             kind: FileSetMemberKind::File,
         },
@@ -1110,6 +1127,7 @@ fn pending_root_marker(root: TopLevelFileMember, line_index: i64) -> PendingFile
         original_text: root.original_text,
         member_location: FileSetMemberLocation {
             root_index: root.root_index,
+            root_name: root.root_name,
             relative_path: ".".to_string(),
             kind: FileSetMemberKind::File,
         },
@@ -1126,6 +1144,7 @@ fn excluded_root_line(
         original_text: root.original_text,
         member_location: Some(FileSetMemberLocation {
             root_index: root.root_index,
+            root_name: root.root_name,
             relative_path: normalized_basename(&root.path),
             kind: FileSetMemberKind::File,
         }),
@@ -1172,6 +1191,7 @@ async fn expand_directory(
                 original_text: root.original_text.clone(),
                 member_location: FileSetMemberLocation {
                     root_index: root.root_index,
+                    root_name: root.root_name.clone(),
                     relative_path,
                     kind: FileSetMemberKind::EmptyDirectory,
                 },
@@ -1227,6 +1247,7 @@ async fn expand_directory(
                 original_text: root.original_text.clone(),
                 member_location: FileSetMemberLocation {
                     root_index: root.root_index,
+                    root_name: root.root_name.clone(),
                     relative_path,
                     kind: member_kind(&metadata),
                 },
@@ -1251,6 +1272,7 @@ fn directory_marker(
         original_text: root.original_text.clone(),
         member_location: FileSetMemberLocation {
             root_index: root.root_index,
+            root_name: root.root_name.clone(),
             relative_path: if relative_path.is_empty() {
                 ".".to_string()
             } else {
@@ -1400,6 +1422,7 @@ mod tests {
             ts_ms: 1_700_000_000_000,
             representations: reps,
             file_content_digests: Vec::new(),
+            file_set_v1_component: None,
         }
     }
 
@@ -1409,7 +1432,7 @@ mod tests {
         use std::os::unix::fs::PermissionsExt;
 
         let parent = tempfile::tempdir().unwrap();
-        let root = parent.path().join("root");
+        let root = parent.path().join("roote\u{301}");
         std::fs::create_dir(&root).unwrap();
         std::fs::write(root.join("visible.txt"), b"visible").unwrap();
         std::fs::write(root.join(".hidden"), b"hidden").unwrap();
@@ -1438,16 +1461,21 @@ mod tests {
                     .member_location
                     .as_ref()
                     .expect("directory member location");
-                (location.relative_path.as_str(), location.kind)
+                (
+                    location.root_name.as_str(),
+                    location.relative_path.as_str(),
+                    location.kind,
+                )
             })
             .collect();
-        assert!(members.contains(&(".hidden", FileSetMemberKind::File)));
-        assert!(members.contains(&("visible.txt", FileSetMemberKind::File)));
-        assert!(members.contains(&("nested/run.sh", FileSetMemberKind::Executable)));
-        assert!(members.contains(&("empty", FileSetMemberKind::EmptyDirectory)));
-        assert!(members.contains(&("\u{e9}.txt", FileSetMemberKind::File)));
+        assert!(members.contains(&("root\u{e9}", ".hidden", FileSetMemberKind::File)));
+        assert!(members.contains(&("root\u{e9}", "visible.txt", FileSetMemberKind::File)));
+        assert!(members.contains(&("root\u{e9}", "nested/run.sh", FileSetMemberKind::Executable)));
+        assert!(members.contains(&("root\u{e9}", "empty", FileSetMemberKind::EmptyDirectory)));
+        assert!(members.contains(&("root\u{e9}", "\u{e9}.txt", FileSetMemberKind::File)));
         assert!(set.has_directory_structure());
         assert!(set.content_digest_contribution().is_empty());
+        assert!(set.file_set_v1_component().is_some());
     }
 
     #[cfg(unix)]
@@ -1574,8 +1602,12 @@ mod tests {
             .as_ref()
             .unwrap();
         assert_eq!(
-            (flat.root_index, flat.relative_path.as_str()),
-            (0, "loose.txt")
+            (
+                flat.root_index,
+                flat.root_name.as_str(),
+                flat.relative_path.as_str()
+            ),
+            (0, "loose.txt", "loose.txt")
         );
         let child = set
             .lines
@@ -1586,7 +1618,13 @@ mod tests {
                     .is_some_and(|location| location.relative_path == "child.txt")
             })
             .unwrap();
-        assert_eq!(child.member_location.as_ref().unwrap().root_index, 1);
+        assert_eq!(
+            (
+                child.member_location.as_ref().unwrap().root_index,
+                child.member_location.as_ref().unwrap().root_name.as_str()
+            ),
+            (1, "root")
+        );
         assert!(child.line_index >= 2);
     }
 
@@ -1689,6 +1727,54 @@ mod tests {
             snap_a.snapshot_hash(),
             "filling content digests must move identity off the path-text hash"
         );
+    }
+
+    #[tokio::test]
+    async fn directory_identity_is_stable_across_devices_and_distinct_from_flat_files() {
+        let fixture = tempfile::tempdir().unwrap();
+        let device_a = fixture.path().join("device-a/root");
+        let device_b = fixture.path().join("device-b/root");
+        for root in [&device_a, &device_b] {
+            std::fs::create_dir_all(root).unwrap();
+            std::fs::write(root.join("1.txt"), b"one").unwrap();
+            std::fs::write(root.join("2.txt"), b"two").unwrap();
+        }
+
+        let make_directory_snapshot = |root: &std::path::Path| {
+            snapshot_with(vec![rep(
+                "files",
+                Some("text/uri-list"),
+                format!("file://{}", root.display()).as_bytes(),
+            )])
+        };
+        let mut directory_a = make_directory_snapshot(&device_a);
+        let mut directory_b = make_directory_snapshot(&device_b);
+        for snapshot in [&mut directory_a, &mut directory_b] {
+            let set = build_entry_file_set(snapshot, &FakeIngestByName, FileSetCaps::unbounded())
+                .await
+                .expect("directory manifest");
+            snapshot.file_set_v1_component = set.file_set_v1_component();
+        }
+        assert_eq!(directory_a.snapshot_hash(), directory_b.snapshot_hash());
+
+        let flat_a = fixture.path().join("flat-a/1.txt");
+        let flat_b = fixture.path().join("flat-b/2.txt");
+        std::fs::create_dir_all(flat_a.parent().unwrap()).unwrap();
+        std::fs::create_dir_all(flat_b.parent().unwrap()).unwrap();
+        std::fs::write(&flat_a, b"one").unwrap();
+        std::fs::write(&flat_b, b"two").unwrap();
+        let mut flat = snapshot_with(vec![rep(
+            "files",
+            Some("text/uri-list"),
+            format!("file://{}\nfile://{}", flat_a.display(), flat_b.display()).as_bytes(),
+        )]);
+        flat.file_content_digests =
+            build_entry_file_set(&flat, &FakeIngestByName, FileSetCaps::unbounded())
+                .await
+                .expect("flat manifest")
+                .content_digest_contribution();
+
+        assert_ne!(directory_a.snapshot_hash(), flat.snapshot_hash());
     }
 
     /// A per-file ingest failure must be skipped (not abort the capture); when

--- a/crates/uc-application/src/clipboard_write/coordinator.rs
+++ b/crates/uc-application/src/clipboard_write/coordinator.rs
@@ -423,6 +423,7 @@ mod tests {
                 b"x".to_vec(),
             )],
             file_content_digests: Vec::new(),
+            file_set_v1_component: None,
         }
     }
 

--- a/crates/uc-application/src/clipboard_write/primary_rep_selector.rs
+++ b/crates/uc-application/src/clipboard_write/primary_rep_selector.rs
@@ -67,6 +67,7 @@ pub fn narrow_to_primary(
         ts_ms,
         representations: vec![chosen],
         file_content_digests: Vec::new(),
+        file_set_v1_component: None,
     })
 }
 
@@ -94,6 +95,8 @@ mod tests {
             representations: vec![],
 
             file_content_digests: Vec::new(),
+
+            file_set_v1_component: None,
         };
         let policy = SelectRepresentationPolicyV1::default();
         match narrow_to_primary(snapshot, &policy) {
@@ -109,6 +112,8 @@ mod tests {
             representations: vec![rep("text", Some("text/plain"), b"hello")],
 
             file_content_digests: Vec::new(),
+
+            file_set_v1_component: None,
         };
         let original_id = snapshot.representations[0].id.clone();
         let policy = SelectRepresentationPolicyV1::default();
@@ -135,6 +140,8 @@ mod tests {
             representations: vec![plain, html, image],
 
             file_content_digests: Vec::new(),
+
+            file_set_v1_component: None,
         };
         let policy = SelectRepresentationPolicyV1::default();
         let narrowed = narrow_to_primary(snapshot, &policy).expect("policy narrow ok");
@@ -151,6 +158,7 @@ mod tests {
                 rep("html", Some("text/html"), b"<p>a</p>"),
             ],
             file_content_digests: Vec::new(),
+            file_set_v1_component: None,
         };
         let policy = SelectRepresentationPolicyV1::default();
         let narrowed = narrow_to_primary(snapshot, &policy).expect("ok");

--- a/crates/uc-application/src/facade/clipboard/facade.rs
+++ b/crates/uc-application/src/facade/clipboard/facade.rs
@@ -1145,6 +1145,7 @@ mod tests {
                 b"hello phase3".to_vec(),
             )],
             file_content_digests: Vec::new(),
+            file_set_v1_component: None,
         };
         let outcome = facade
             .dispatch_snapshot(

--- a/crates/uc-application/src/facade/clipboard_capture/mod.rs
+++ b/crates/uc-application/src/facade/clipboard_capture/mod.rs
@@ -34,6 +34,7 @@ pub struct CapturedClipboardEntryView {
 pub struct CapturedFileSetLineView {
     pub line_index: i64,
     pub root_index: Option<i64>,
+    pub root_name: Option<String>,
     pub relative_path: Option<String>,
     pub member_kind: Option<String>,
     pub line_kind: String,
@@ -183,6 +184,7 @@ impl ClipboardCaptureFacade {
                 uris.join("\n").into_bytes(),
             )],
             file_content_digests: Vec::new(),
+            file_set_v1_component: None,
         };
         let entry = self
             .capture(snapshot, ClipboardChangeOrigin::LocalCapture, None)
@@ -213,17 +215,18 @@ impl ClipboardCaptureFacade {
             .lines
             .iter()
             .map(|line| {
-                let (root_index, relative_path, member_kind) = line
+                let (root_index, root_name, relative_path, member_kind) = line
                     .member_location
                     .as_ref()
                     .map(|location| {
                         (
                             Some(location.root_index),
+                            Some(location.root_name.clone()),
                             Some(location.relative_path.clone()),
                             Some(location.kind.as_tag().to_string()),
                         )
                     })
-                    .unwrap_or((None, None, None));
+                    .unwrap_or((None, None, None, None));
                 let (line_kind, exclude_reason) = match line.kind {
                     EntryFileSetLineKind::File { .. } => ("file", None),
                     EntryFileSetLineKind::NonFile => ("non_file", None),
@@ -234,6 +237,7 @@ impl ClipboardCaptureFacade {
                 CapturedFileSetLineView {
                     line_index: line.line_index,
                     root_index,
+                    root_name,
                     relative_path,
                     member_kind,
                     line_kind: line_kind.to_string(),
@@ -303,6 +307,7 @@ mod tests {
             representations: Vec::new(),
             ts_ms: 0,
             file_content_digests: Vec::new(),
+            file_set_v1_component: None,
         }
     }
 
@@ -375,6 +380,7 @@ mod tests {
                     original_text: "file:///private/root".to_string(),
                     member_location: Some(FileSetMemberLocation {
                         root_index: 0,
+                        root_name: "root".to_string(),
                         relative_path: "child.txt".to_string(),
                         kind: FileSetMemberKind::File,
                     }),
@@ -409,6 +415,7 @@ mod tests {
             vec![CapturedFileSetLineView {
                 line_index: 1,
                 root_index: Some(0),
+                root_name: Some("root".to_string()),
                 relative_path: Some("child.txt".to_string()),
                 member_kind: Some("f".to_string()),
                 line_kind: "file".to_string(),

--- a/crates/uc-application/src/facade/clipboard_capture/mod.rs
+++ b/crates/uc-application/src/facade/clipboard_capture/mod.rs
@@ -1,11 +1,15 @@
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use anyhow::Result;
 use async_trait::async_trait;
 use thiserror::Error;
-use uc_core::ids::EntryId;
-use uc_core::ports::clipboard::PlatformClipboardPort;
-use uc_core::{ClipboardChangeOrigin, SystemClipboardSnapshot};
+use uc_core::clipboard::{EntryFileSetExcludeReason, EntryFileSetLineKind};
+use uc_core::ids::{EntryId, FormatId, RepresentationId};
+use uc_core::ports::clipboard::{EntryFileSetRepositoryPort, PlatformClipboardPort};
+use uc_core::{
+    ClipboardChangeOrigin, MimeType, ObservedClipboardRepresentation, SystemClipboardSnapshot,
+};
 
 use crate::clipboard_capture::CaptureClipboardUseCase;
 
@@ -24,6 +28,24 @@ pub struct CapturedClipboardEntryView {
     /// advertised identity diverges from its dispatch identity and the receiver
     /// dedups into two entries.
     pub snapshot_hash: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CapturedFileSetLineView {
+    pub line_index: i64,
+    pub root_index: Option<i64>,
+    pub relative_path: Option<String>,
+    pub member_kind: Option<String>,
+    pub line_kind: String,
+    pub exclude_reason: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CapturedFileSetView {
+    pub entry: CapturedClipboardEntryView,
+    pub directory_structure: bool,
+    pub content_digest_count: usize,
+    pub lines: Vec<CapturedFileSetLineView>,
 }
 
 #[derive(Debug, Error)]
@@ -74,6 +96,7 @@ impl ClipboardCapturePort for CaptureClipboardUseCase {
 pub struct ClipboardCaptureFacade {
     capture: Arc<dyn ClipboardCapturePort>,
     current_clipboard: Arc<dyn PlatformClipboardPort>,
+    entry_file_set_repo: Option<Arc<dyn EntryFileSetRepositoryPort>>,
 }
 
 impl ClipboardCaptureFacade {
@@ -84,7 +107,16 @@ impl ClipboardCaptureFacade {
         Self {
             capture,
             current_clipboard,
+            entry_file_set_repo: None,
         }
+    }
+
+    pub fn with_entry_file_set_repository(
+        mut self,
+        repository: Arc<dyn EntryFileSetRepositoryPort>,
+    ) -> Self {
+        self.entry_file_set_repo = Some(repository);
+        self
     }
 
     pub async fn capture(
@@ -111,12 +143,131 @@ impl ClipboardCaptureFacade {
         self.capture(snapshot, ClipboardChangeOrigin::LocalCapture, None)
             .await
     }
+
+    /// Capture explicit local paths through the normal file capture pipeline
+    /// and return the persisted manifest without exposing absolute source
+    /// paths. This is reserved for hidden CLI diagnostics and E2E tests.
+    pub async fn capture_file_paths_for_diagnostics(
+        &self,
+        paths: Vec<PathBuf>,
+    ) -> Result<CapturedFileSetView, ClipboardCaptureFacadeError> {
+        if paths.is_empty() {
+            return Err(ClipboardCaptureFacadeError::Internal(
+                "at least one file path is required".to_string(),
+            ));
+        }
+
+        let current_dir = std::env::current_dir()
+            .map_err(|err| ClipboardCaptureFacadeError::Internal(err.to_string()))?;
+        let mut uris = Vec::with_capacity(paths.len());
+        for path in paths {
+            let absolute = if path.is_absolute() {
+                path
+            } else {
+                current_dir.join(path)
+            };
+            let uri = url::Url::from_file_path(absolute).map_err(|()| {
+                ClipboardCaptureFacadeError::Internal(
+                    "a path could not be represented as a file URL".to_string(),
+                )
+            })?;
+            uris.push(uri.to_string());
+        }
+
+        let snapshot = SystemClipboardSnapshot {
+            ts_ms: chrono::Utc::now().timestamp_millis(),
+            representations: vec![ObservedClipboardRepresentation::new(
+                RepresentationId::new(),
+                FormatId::from("files"),
+                Some(MimeType("text/uri-list".to_string())),
+                uris.join("\n").into_bytes(),
+            )],
+            file_content_digests: Vec::new(),
+        };
+        let entry = self
+            .capture(snapshot, ClipboardChangeOrigin::LocalCapture, None)
+            .await?
+            .ok_or_else(|| {
+                ClipboardCaptureFacadeError::Internal(
+                    "file capture did not produce an entry".to_string(),
+                )
+            })?;
+        let repository = self.entry_file_set_repo.as_ref().ok_or_else(|| {
+            ClipboardCaptureFacadeError::Internal(
+                "file-set diagnostics are unavailable in this runtime".to_string(),
+            )
+        })?;
+        let file_set = repository
+            .load(&EntryId::from(entry.entry_id.as_str()))
+            .await
+            .map_err(|err| ClipboardCaptureFacadeError::Internal(err.to_string()))?
+            .ok_or_else(|| {
+                ClipboardCaptureFacadeError::Internal(
+                    "captured entry has no file-set manifest".to_string(),
+                )
+            })?;
+
+        let directory_structure = file_set.has_directory_structure();
+        let content_digest_count = file_set.content_digest_contribution().len();
+        let lines = file_set
+            .lines
+            .iter()
+            .map(|line| {
+                let (root_index, relative_path, member_kind) = line
+                    .member_location
+                    .as_ref()
+                    .map(|location| {
+                        (
+                            Some(location.root_index),
+                            Some(location.relative_path.clone()),
+                            Some(location.kind.as_tag().to_string()),
+                        )
+                    })
+                    .unwrap_or((None, None, None));
+                let (line_kind, exclude_reason) = match line.kind {
+                    EntryFileSetLineKind::File { .. } => ("file", None),
+                    EntryFileSetLineKind::NonFile => ("non_file", None),
+                    EntryFileSetLineKind::Excluded { reason } => {
+                        ("excluded", Some(exclude_reason_tag(reason).to_string()))
+                    }
+                };
+                CapturedFileSetLineView {
+                    line_index: line.line_index,
+                    root_index,
+                    relative_path,
+                    member_kind,
+                    line_kind: line_kind.to_string(),
+                    exclude_reason,
+                }
+            })
+            .collect();
+
+        Ok(CapturedFileSetView {
+            entry,
+            directory_structure,
+            content_digest_count,
+            lines,
+        })
+    }
+}
+
+fn exclude_reason_tag(reason: EntryFileSetExcludeReason) -> &'static str {
+    match reason {
+        EntryFileSetExcludeReason::SizeCapExceeded => "size_cap_exceeded",
+        EntryFileSetExcludeReason::IngestFailed => "ingest_failed",
+        EntryFileSetExcludeReason::UnsupportedMember => "unsupported_member",
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    use uc_core::clipboard::{
+        ContentHash, EntryFileSet, EntryFileSetError, EntryFileSetLine, EntryFileSetLineKind,
+        FileSetMemberKind, FileSetMemberLocation, HashAlgorithm,
+    };
+    use uc_core::ports::clipboard::EntryFileSetRepositoryPort;
     use uc_core::SystemClipboardSnapshot;
 
     struct FakeCapture;
@@ -198,6 +349,71 @@ mod tests {
                 deduplicated: false,
                 snapshot_hash: "blake3v1:test".to_string(),
             })
+        );
+    }
+
+    struct FakeFileSetRepo;
+
+    #[async_trait]
+    impl EntryFileSetRepositoryPort for FakeFileSetRepo {
+        async fn save(
+            &self,
+            _entry_id: &EntryId,
+            _file_set: &EntryFileSet,
+        ) -> Result<(), EntryFileSetError> {
+            panic!("diagnostic capture must not save through its readback dependency")
+        }
+
+        async fn load(
+            &self,
+            entry_id: &EntryId,
+        ) -> Result<Option<EntryFileSet>, EntryFileSetError> {
+            assert_eq!(entry_id.as_str(), "entry-a");
+            Ok(Some(EntryFileSet {
+                lines: vec![EntryFileSetLine {
+                    line_index: 1,
+                    original_text: "file:///private/root".to_string(),
+                    member_location: Some(FileSetMemberLocation {
+                        root_index: 0,
+                        relative_path: "child.txt".to_string(),
+                        kind: FileSetMemberKind::File,
+                    }),
+                    kind: EntryFileSetLineKind::File {
+                        content_hash: ContentHash {
+                            alg: HashAlgorithm::Blake3V1,
+                            bytes: [7; 32],
+                        },
+                        blob_id: None,
+                        size_bytes: None,
+                    },
+                }],
+            }))
+        }
+    }
+
+    #[tokio::test]
+    async fn diagnostic_file_capture_returns_persisted_path_safe_manifest() {
+        let facade = facade_with_fakes()
+            .with_entry_file_set_repository(std::sync::Arc::new(FakeFileSetRepo));
+
+        let result = facade
+            .capture_file_paths_for_diagnostics(vec![std::path::PathBuf::from("/private/root")])
+            .await
+            .expect("diagnostic capture");
+
+        assert_eq!(result.entry.entry_id, "entry-a");
+        assert!(result.directory_structure);
+        assert_eq!(result.content_digest_count, 0);
+        assert_eq!(
+            result.lines,
+            vec![CapturedFileSetLineView {
+                line_index: 1,
+                root_index: Some(0),
+                relative_path: Some("child.txt".to_string()),
+                member_kind: Some("f".to_string()),
+                line_kind: "file".to_string(),
+                exclude_reason: None,
+            }]
         );
     }
 }

--- a/crates/uc-application/src/facade/clipboard_history/mod.rs
+++ b/crates/uc-application/src/facade/clipboard_history/mod.rs
@@ -396,6 +396,7 @@ impl ClipboardHistoryFacade {
                 bytes.clone(),
             )],
             file_content_digests: Vec::new(),
+            file_set_v1_component: None,
         };
         let snapshot_hash = snapshot.snapshot_hash();
 

--- a/crates/uc-application/src/facade/clipboard_live_index/mod.rs
+++ b/crates/uc-application/src/facade/clipboard_live_index/mod.rs
@@ -201,6 +201,8 @@ mod tests {
                     ts_ms: 0,
 
                     file_content_digests: Vec::new(),
+
+                    file_set_v1_component: None,
                 }),
             })
             .await

--- a/crates/uc-application/src/facade/clipboard_outbound/mod.rs
+++ b/crates/uc-application/src/facade/clipboard_outbound/mod.rs
@@ -237,9 +237,19 @@ impl ClipboardOutboundPort for ClipboardOutboundDispatcher {
                 expected_digests,
             } => (paths, true, expected_digests),
             OutboundFileSetResolution::Fallback { paths } => (paths, false, Vec::new()),
+            OutboundFileSetResolution::DirectoryNotYetSyncable => {
+                info!(
+                    entry_id = %entry_id_str,
+                    "outbound: directory manifest retained locally; skipping dispatch"
+                );
+                return Ok(ClipboardOutboundOutcome::Skipped {
+                    reason: "directory_not_yet_syncable".to_string(),
+                });
+            }
             OutboundFileSetResolution::Excluded {
                 ingest_failed,
                 size_cap_exceeded,
+                unsupported_member,
             } => {
                 // All-or-nothing: the manifest says at least one member never
                 // got a content identity, so this entry is keyed on path text.
@@ -250,6 +260,7 @@ impl ClipboardOutboundPort for ClipboardOutboundDispatcher {
                     entry_id = %entry_id_str,
                     ingest_failed,
                     size_cap_exceeded,
+                    unsupported_member,
                     "outbound: file-set manifest has excluded lines; skipping dispatch (all-or-nothing)"
                 );
                 return Ok(ClipboardOutboundOutcome::Skipped {
@@ -560,6 +571,9 @@ pub(crate) enum OutboundFileSetResolution {
     /// best-effort save at capture, or an unreadable manifest row) — fall
     /// back to re-parsing the snapshot's reps.
     Fallback { paths: Vec<PathBuf> },
+    /// Directory members are captured locally but the current wire protocol
+    /// cannot reconstruct their tree yet.
+    DirectoryNotYetSyncable,
     /// The manifest exists but contains excluded lines: at least one member
     /// never got a content identity, so the entry's identity fell back to
     /// path text at capture. All-or-nothing — callers must not publish the
@@ -568,6 +582,7 @@ pub(crate) enum OutboundFileSetResolution {
     Excluded {
         ingest_failed: usize,
         size_cap_exceeded: usize,
+        unsupported_member: usize,
     },
 }
 
@@ -617,20 +632,27 @@ pub(crate) async fn resolve_outbound_file_set(
         }
     };
 
+    if file_set.has_directory_structure() {
+        return OutboundFileSetResolution::DirectoryNotYetSyncable;
+    }
+
     let mut ingest_failed = 0usize;
     let mut size_cap_exceeded = 0usize;
+    let mut unsupported_member = 0usize;
     for line in &file_set.lines {
         if let EntryFileSetLineKind::Excluded { reason } = &line.kind {
             match reason {
                 EntryFileSetExcludeReason::IngestFailed => ingest_failed += 1,
                 EntryFileSetExcludeReason::SizeCapExceeded => size_cap_exceeded += 1,
+                EntryFileSetExcludeReason::UnsupportedMember => unsupported_member += 1,
             }
         }
     }
-    if ingest_failed + size_cap_exceeded > 0 {
+    if ingest_failed + size_cap_exceeded + unsupported_member > 0 {
         return OutboundFileSetResolution::Excluded {
             ingest_failed,
             size_cap_exceeded,
+            unsupported_member,
         };
     }
 
@@ -831,8 +853,8 @@ mod tests {
     use super::*;
     use std::sync::Mutex;
     use uc_core::clipboard::{
-        ContentHash, EntryFileSet, EntryFileSetError, EntryFileSetLine, HashAlgorithm, MimeType,
-        ObservedClipboardRepresentation,
+        ContentHash, EntryFileSet, EntryFileSetError, EntryFileSetLine, FileSetMemberKind,
+        FileSetMemberLocation, HashAlgorithm, MimeType, ObservedClipboardRepresentation,
     };
     use uc_core::ids::{EntryId, FormatId, RepresentationId};
 
@@ -956,6 +978,7 @@ mod tests {
         EntryFileSetLine {
             line_index: index,
             original_text: original_text.to_string(),
+            member_location: None,
             kind: EntryFileSetLineKind::File {
                 content_hash: ContentHash {
                     alg: HashAlgorithm::Blake3V1,
@@ -971,8 +994,30 @@ mod tests {
         EntryFileSetLine {
             line_index: index,
             original_text: "file:///excluded".to_string(),
+            member_location: None,
             kind: EntryFileSetLineKind::Excluded { reason },
         }
+    }
+
+    #[tokio::test]
+    async fn resolver_blocks_directory_manifest_before_path_publication() {
+        let mut line = file_line(1, "file:///tmp/root", 1);
+        line.member_location = Some(FileSetMemberLocation {
+            root_index: 0,
+            relative_path: "child.txt".to_string(),
+            kind: FileSetMemberKind::File,
+        });
+        let resolution = resolve_outbound_file_set(
+            &FakeFileSetRepo::Found(EntryFileSet { lines: vec![line] }),
+            &EntryId::from("e1"),
+            &uri_list_snapshot("file:///tmp/root\n"),
+        )
+        .await;
+
+        assert_eq!(
+            resolution,
+            OutboundFileSetResolution::DirectoryNotYetSyncable
+        );
     }
 
     #[tokio::test]
@@ -1001,6 +1046,7 @@ mod tests {
                 EntryFileSetLine {
                     line_index: 3,
                     original_text: "# comment".to_string(),
+                    member_location: None,
                     kind: EntryFileSetLineKind::NonFile,
                 },
             ],
@@ -1065,6 +1111,7 @@ mod tests {
             OutboundFileSetResolution::Excluded {
                 ingest_failed: 1,
                 size_cap_exceeded: 1,
+                unsupported_member: 0,
             }
         );
     }

--- a/crates/uc-application/src/facade/clipboard_outbound/mod.rs
+++ b/crates/uc-application/src/facade/clipboard_outbound/mod.rs
@@ -958,6 +958,7 @@ mod tests {
                 text.as_bytes().to_vec(),
             )],
             file_content_digests: Vec::new(),
+            file_set_v1_component: None,
         }
     }
 
@@ -971,6 +972,7 @@ mod tests {
                 b"hello".to_vec(),
             )],
             file_content_digests: Vec::new(),
+            file_set_v1_component: None,
         }
     }
 
@@ -1004,6 +1006,7 @@ mod tests {
         let mut line = file_line(1, "file:///tmp/root", 1);
         line.member_location = Some(FileSetMemberLocation {
             root_index: 0,
+            root_name: "root".to_string(),
             relative_path: "child.txt".to_string(),
             kind: FileSetMemberKind::File,
         });
@@ -1155,6 +1158,8 @@ mod tests {
                     ts_ms: 0,
 
                     file_content_digests: Vec::new(),
+
+                    file_set_v1_component: None,
                 },
                 origin: ClipboardChangeOrigin::LocalCapture,
             })

--- a/crates/uc-application/src/facade/mobile_sync/activation_announce_adapter.rs
+++ b/crates/uc-application/src/facade/mobile_sync/activation_announce_adapter.rs
@@ -235,6 +235,7 @@ mod tests {
                 b"hi".to_vec(),
             )],
             file_content_digests: Vec::new(),
+            file_set_v1_component: None,
         }
     }
 

--- a/crates/uc-application/src/facade/mod.rs
+++ b/crates/uc-application/src/facade/mod.rs
@@ -63,8 +63,8 @@ pub use crate::usecases::clipboard_sync::{
     decode_v3_bytes_to_snapshot, decode_v3_bytes_to_snapshot_and_blob_refs, V3BlobRef,
 };
 pub use clipboard_capture::{
-    CapturedClipboardEntryView, ClipboardCaptureFacade, ClipboardCaptureFacadeError,
-    ClipboardCapturePort,
+    CapturedClipboardEntryView, CapturedFileSetLineView, CapturedFileSetView,
+    ClipboardCaptureFacade, ClipboardCaptureFacadeError, ClipboardCapturePort,
 };
 pub use clipboard_history::{
     CleanupResultView as ClipboardCleanupResultView,

--- a/crates/uc-application/src/facade/search/projection.rs
+++ b/crates/uc-application/src/facade/search/projection.rs
@@ -351,6 +351,7 @@ mod tests {
             ts_ms: 1,
             representations: vec![r],
             file_content_digests: Vec::new(),
+            file_set_v1_component: None,
         };
         let selection = ClipboardSelection {
             primary_rep_id: id.clone(),
@@ -382,6 +383,7 @@ mod tests {
             ts_ms: 1,
             representations: vec![plain, html],
             file_content_digests: Vec::new(),
+            file_set_v1_component: None,
         };
         let selection = ClipboardSelection {
             primary_rep_id: html_id.clone(),
@@ -423,6 +425,7 @@ mod tests {
             ts_ms: 1,
             representations: vec![plain],
             file_content_digests: Vec::new(),
+            file_set_v1_component: None,
         };
         let selection = ClipboardSelection {
             primary_rep_id: plain_id.clone(),
@@ -465,6 +468,7 @@ mod tests {
             ts_ms: 1,
             representations: vec![image, html, plain],
             file_content_digests: Vec::new(),
+            file_set_v1_component: None,
         };
         // The selection policy ranks the rich-text (html) rep as the paste rep.
         let selection = ClipboardSelection {
@@ -525,6 +529,7 @@ mod tests {
             ts_ms: 1,
             representations: vec![image, files],
             file_content_digests: Vec::new(),
+            file_set_v1_component: None,
         };
         let selection = ClipboardSelection {
             primary_rep_id: files_id.clone(),
@@ -573,6 +578,7 @@ mod tests {
             ts_ms: 1,
             representations: vec![image, files],
             file_content_digests: Vec::new(),
+            file_set_v1_component: None,
         };
         let selection = ClipboardSelection {
             primary_rep_id: files_id.clone(),
@@ -709,6 +715,7 @@ mod tests {
             ts_ms: 1,
             representations: vec![r],
             file_content_digests: Vec::new(),
+            file_set_v1_component: None,
         };
         let selection = ClipboardSelection {
             primary_rep_id: id.clone(),
@@ -885,6 +892,7 @@ mod tests {
             ts_ms: 1,
             representations: vec![observed],
             file_content_digests: Vec::new(),
+            file_set_v1_component: None,
         };
         let live = SearchProjectionBuilder::build_from_capture(
             &e,

--- a/crates/uc-application/src/facade/settings/models.rs
+++ b/crates/uc-application/src/facade/settings/models.rs
@@ -148,6 +148,8 @@ pub struct FileSyncSettingsView {
     pub file_cache_quota_per_device: u64,
     pub file_retention_hours: u32,
     pub file_auto_cleanup: bool,
+    pub max_file_set_total_bytes: u64,
+    pub max_file_set_member_count: u64,
     /// Directory where inbound files are saved, or `None` for managed storage.
     pub auto_save_dir: Option<String>,
 }
@@ -285,6 +287,8 @@ pub struct FileSyncSettingsPatch {
     pub file_cache_quota_per_device: Option<u64>,
     pub file_retention_hours: Option<u32>,
     pub file_auto_cleanup: Option<bool>,
+    pub max_file_set_total_bytes: Option<u64>,
+    pub max_file_set_member_count: Option<u64>,
     /// `None` = leave unchanged. `Some("")` (blank) = clear (managed storage).
     /// `Some(dir)` = save inbound files to `dir`.
     pub auto_save_dir: Option<String>,
@@ -583,6 +587,8 @@ impl From<core::Settings> for SettingsView {
                 file_cache_quota_per_device: value.file_sync.file_cache_quota_per_device,
                 file_retention_hours: value.file_sync.file_retention_hours,
                 file_auto_cleanup: value.file_sync.file_auto_cleanup,
+                max_file_set_total_bytes: value.file_sync.max_file_set_total_bytes,
+                max_file_set_member_count: value.file_sync.max_file_set_member_count,
                 auto_save_dir: value.file_sync.auto_save_dir,
             },
             network: NetworkSettingsView {
@@ -742,6 +748,12 @@ pub(crate) fn apply_settings_patch(
         }
         if let Some(v) = file_sync.file_auto_cleanup {
             existing.file_sync.file_auto_cleanup = v;
+        }
+        if let Some(v) = file_sync.max_file_set_total_bytes {
+            existing.file_sync.max_file_set_total_bytes = v;
+        }
+        if let Some(v) = file_sync.max_file_set_member_count {
+            existing.file_sync.max_file_set_member_count = v;
         }
         if let Some(dir) = file_sync.auto_save_dir {
             // Blank clears the setting (managed storage); a path sets it.
@@ -1092,6 +1104,28 @@ mod file_sync_auto_save_dir_apply_patch_tests {
             result.file_sync.auto_save_dir.as_deref(),
             Some("/Users/me/Downloads")
         );
+    }
+
+    #[test]
+    fn file_set_caps_round_trip_through_patch_and_view() {
+        let existing = Settings::default();
+        let result = apply_settings_patch(
+            existing,
+            SettingsPatch {
+                file_sync: Some(FileSyncSettingsPatch {
+                    max_file_set_total_bytes: Some(123),
+                    max_file_set_member_count: Some(7),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+        );
+        assert_eq!(result.file_sync.max_file_set_total_bytes, 123);
+        assert_eq!(result.file_sync.max_file_set_member_count, 7);
+
+        let view = SettingsView::from(result);
+        assert_eq!(view.file_sync.max_file_set_total_bytes, 123);
+        assert_eq!(view.file_sync.max_file_set_member_count, 7);
     }
 
     /// A blank string clears the directory (back to managed storage).

--- a/crates/uc-application/src/sync_planner/planner.rs
+++ b/crates/uc-application/src/sync_planner/planner.rs
@@ -221,6 +221,7 @@ mod tests {
                 b"hi".to_vec(),
             )],
             file_content_digests: Vec::new(),
+            file_set_v1_component: None,
         }
     }
 

--- a/crates/uc-application/src/usecases/clipboard_restore/file_snapshot.rs
+++ b/crates/uc-application/src/usecases/clipboard_restore/file_snapshot.rs
@@ -32,5 +32,6 @@ pub(crate) fn build_file_snapshot(uri_list: &str) -> SystemClipboardSnapshot {
             uri_list.as_bytes().to_vec(),
         )],
         file_content_digests: Vec::new(),
+        file_set_v1_component: None,
     }
 }

--- a/crates/uc-application/src/usecases/clipboard_restore/restore_as_plain_text.rs
+++ b/crates/uc-application/src/usecases/clipboard_restore/restore_as_plain_text.rs
@@ -263,6 +263,7 @@ impl RestoreClipboardEntryAsPlainTextUseCase {
                 ts_ms: chrono::Utc::now().timestamp_millis(),
                 representations: vec![observed],
                 file_content_digests: Vec::new(),
+                file_set_v1_component: None,
             });
         }
 
@@ -397,6 +398,7 @@ impl RestoreClipboardEntryAsPlainTextUseCase {
                         ts_ms: chrono::Utc::now().timestamp_millis(),
                         representations: vec![observed],
                         file_content_digests: Vec::new(),
+                        file_set_v1_component: None,
                     }));
                 }
                 Err(err) => {

--- a/crates/uc-application/src/usecases/clipboard_sync/active_state/reconcile.rs
+++ b/crates/uc-application/src/usecases/clipboard_sync/active_state/reconcile.rs
@@ -215,6 +215,7 @@ mod tests {
                 text.as_bytes().to_vec(),
             )],
             file_content_digests: Vec::new(),
+            file_set_v1_component: None,
         }
     }
 
@@ -234,6 +235,8 @@ mod tests {
                     representations: vec![],
 
                     file_content_digests: Vec::new(),
+
+                    file_set_v1_component: None,
                 }),
                 FakeClipboard::ReadError => Err(anyhow::anyhow!("clipboard unreadable")),
             }

--- a/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/tests.rs
+++ b/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/tests.rs
@@ -146,6 +146,7 @@ fn fixture_input(text: &str) -> (ApplyInboundInput, String) {
             text.as_bytes().to_vec(),
         )],
         file_content_digests: Vec::new(),
+        file_set_v1_component: None,
     };
     let (plaintext, snapshot_hash) = encode_snapshot_to_v3_bytes(&snapshot).unwrap();
     (
@@ -378,6 +379,7 @@ async fn visible_duplicate_skipped_across_channel_representation_expansion() {
             visible_text.clone(),
         )],
         file_content_digests: Vec::new(),
+        file_set_v1_component: None,
     };
     let second_snapshot = SystemClipboardSnapshot {
         ts_ms: 1_700_000_000_250,
@@ -402,6 +404,7 @@ async fn visible_duplicate_skipped_across_channel_representation_expansion() {
             ),
         ],
         file_content_digests: Vec::new(),
+        file_set_v1_component: None,
     };
     let (first_input, first_hash) = fixture_input_from_snapshot(first_snapshot);
     let (second_input, second_hash) = fixture_input_from_snapshot(second_snapshot);
@@ -459,6 +462,7 @@ async fn visible_duplicate_window_expires() {
             b"expires".to_vec(),
         )],
         file_content_digests: Vec::new(),
+        file_set_v1_component: None,
     };
     let second_snapshot = SystemClipboardSnapshot {
         ts_ms: 1_700_000_003_000,
@@ -469,6 +473,7 @@ async fn visible_duplicate_window_expires() {
             b"expires".to_vec(),
         )],
         file_content_digests: Vec::new(),
+        file_set_v1_component: None,
     };
     let (first_input, _) = fixture_input_from_snapshot(first_snapshot);
     let (second_input, _) = fixture_input_from_snapshot(second_snapshot);
@@ -703,6 +708,7 @@ async fn materializes_blob_refs_before_capture_and_write() {
             b"file:///sender/original.txt\n".to_vec(),
         )],
         file_content_digests: Vec::new(),
+        file_set_v1_component: None,
     };
     let blob_ref = V3BlobRef {
         ticket: BlobTicket::from_bytes(vec![9, 8, 7]),
@@ -787,6 +793,7 @@ async fn partial_materialize_persists_entry_but_skips_os_write() {
             b"file:///sender/big.iso\n".to_vec(),
         )],
         file_content_digests: Vec::new(),
+        file_set_v1_component: None,
     };
     let blob_ref = V3BlobRef {
         ticket: BlobTicket::from_bytes(vec![5, 5, 5]),
@@ -871,6 +878,7 @@ async fn partial_materialize_does_not_register_dedup_entry() {
             b"file:///sender/retry.iso\n".to_vec(),
         )],
         file_content_digests: Vec::new(),
+        file_set_v1_component: None,
     };
     let blob_ref = V3BlobRef {
         ticket: BlobTicket::from_bytes(vec![7, 7, 7]),
@@ -979,6 +987,7 @@ async fn file_cache_blob_materializer_writes_file_and_rewrites_file_uri_list() {
             b"file:///sender/report.txt\n".to_vec(),
         )],
         file_content_digests: Vec::new(),
+        file_set_v1_component: None,
     };
 
     let mut fetcher = MockBlobFetcher::new();
@@ -1077,6 +1086,7 @@ async fn file_cache_blob_materializer_redirects_to_reserved_user_dir() {
             b"file:///sender/report.txt\n".to_vec(),
         )],
         file_content_digests: Vec::new(),
+        file_set_v1_component: None,
     };
 
     let mut fetcher = MockBlobFetcher::new();
@@ -1159,6 +1169,7 @@ async fn file_cache_blob_materializer_removes_reserved_placeholder_on_fetch_erro
             b"file:///sender/report.txt\n".to_vec(),
         )],
         file_content_digests: Vec::new(),
+        file_set_v1_component: None,
     };
 
     let mut fetcher = MockBlobFetcher::new();
@@ -1225,6 +1236,7 @@ async fn file_cache_blob_materializer_inlines_representation_bound_blob_into_rep
             Vec::new(),
         )],
         file_content_digests: Vec::new(),
+        file_set_v1_component: None,
     };
 
     let mut fetcher = MockBlobFetcher::new();
@@ -1296,6 +1308,7 @@ async fn file_cache_blob_materializer_rejects_out_of_bounds_representation_index
             Vec::new(),
         )],
         file_content_digests: Vec::new(),
+        file_set_v1_component: None,
     };
 
     let mut fetcher = MockBlobFetcher::new();
@@ -1362,6 +1375,7 @@ async fn file_cache_blob_materializer_partial_on_cancel_mid_batch() {
             b"file:///sender/first.txt\r\nfile:///sender/second.iso\r\n".to_vec(),
         )],
         file_content_digests: Vec::new(),
+        file_set_v1_component: None,
     };
 
     let mut fetcher = MockBlobFetcher::new();
@@ -1445,6 +1459,7 @@ async fn file_cache_blob_materializer_partial_on_cancel_first_file() {
             b"file:///sender/nothing.iso\r\n".to_vec(),
         )],
         file_content_digests: Vec::new(),
+        file_set_v1_component: None,
     };
 
     let mut fetcher = MockBlobFetcher::new();
@@ -1500,6 +1515,7 @@ async fn file_cache_blob_materializer_partial_on_rep_cancel_no_files() {
             Vec::new(),
         )],
         file_content_digests: Vec::new(),
+        file_set_v1_component: None,
     };
 
     let mut fetcher = MockBlobFetcher::new();
@@ -1634,6 +1650,7 @@ fn file_blob_input() -> ApplyInboundInput {
             b"file:///sender/payload.bin\n".to_vec(),
         )],
         file_content_digests: Vec::new(),
+        file_set_v1_component: None,
     };
     let blob_ref = V3BlobRef {
         ticket: BlobTicket::from_bytes(vec![1, 2, 3]),

--- a/crates/uc-application/src/usecases/clipboard_sync/ingest_inbound.rs
+++ b/crates/uc-application/src/usecases/clipboard_sync/ingest_inbound.rs
@@ -659,6 +659,7 @@ mod tests {
                 b"hello text".to_vec(),
             )],
             file_content_digests: Vec::new(),
+            file_set_v1_component: None,
         };
         let (envelope_bytes, _hash) =
             super::super::payload_codec::encode_snapshot_to_v3_bytes(&snapshot)

--- a/crates/uc-application/src/usecases/clipboard_sync/payload_codec.rs
+++ b/crates/uc-application/src/usecases/clipboard_sync/payload_codec.rs
@@ -166,6 +166,7 @@ pub fn decode_v3_bytes_to_snapshot_and_blob_refs(
             ts_ms: payload.ts_ms,
             representations,
             file_content_digests: Vec::new(),
+            file_set_v1_component: None,
         },
         blob_refs,
     ))
@@ -407,6 +408,7 @@ mod tests {
                 text.as_bytes().to_vec(),
             )],
             file_content_digests: Vec::new(),
+            file_set_v1_component: None,
         }
     }
 
@@ -453,6 +455,7 @@ mod tests {
                 ),
             ],
             file_content_digests: Vec::new(),
+            file_set_v1_component: None,
         };
         let (bytes, _) = encode_snapshot_to_v3_bytes(&original).expect("encode should succeed");
         let decoded = decode_v3_bytes_to_snapshot(&bytes).expect("decode should succeed");

--- a/crates/uc-application/src/usecases/clipboard_sync/resend_entry.rs
+++ b/crates/uc-application/src/usecases/clipboard_sync/resend_entry.rs
@@ -394,14 +394,23 @@ impl ResendEntryUseCase {
             OutboundFileSetResolution::NotFileClass => (Vec::new(), false),
             OutboundFileSetResolution::Manifest { paths, .. } => (paths, true),
             OutboundFileSetResolution::Fallback { paths } => (paths, false),
+            OutboundFileSetResolution::DirectoryNotYetSyncable => {
+                // TODO(ADR-010 phase 4): remove this gate once the wire format
+                // carries directory member locations and receivers rebuild trees.
+                return Err(ResendEntryError::Dispatch(
+                    "directory_not_yet_syncable".to_string(),
+                ));
+            }
             OutboundFileSetResolution::Excluded {
                 ingest_failed,
                 size_cap_exceeded,
+                unsupported_member,
             } => {
                 warn!(
                     entry_id = %cmd.entry_id,
                     ingest_failed,
                     size_cap_exceeded,
+                    unsupported_member,
                     "resend: file-set manifest has excluded lines; entry not resendable (all-or-nothing)"
                 );
                 return Err(ResendEntryError::EntryNotResendable {
@@ -1399,6 +1408,7 @@ mod tests {
             lines: vec![uc_core::clipboard::EntryFileSetLine {
                 line_index: 0,
                 original_text: "file:///tmp/gone.txt".to_string(),
+                member_location: None,
                 kind: uc_core::clipboard::EntryFileSetLineKind::Excluded {
                     reason: uc_core::clipboard::EntryFileSetExcludeReason::IngestFailed,
                 },
@@ -1432,6 +1442,7 @@ mod tests {
             lines: vec![uc_core::clipboard::EntryFileSetLine {
                 line_index: 0,
                 original_text: missing.to_string(),
+                member_location: None,
                 kind: uc_core::clipboard::EntryFileSetLineKind::File {
                     content_hash: uc_core::clipboard::ContentHash {
                         alg: uc_core::clipboard::HashAlgorithm::Blake3V1,

--- a/crates/uc-application/src/usecases/clipboard_sync/snapshot_from_entry.rs
+++ b/crates/uc-application/src/usecases/clipboard_sync/snapshot_from_entry.rs
@@ -272,6 +272,7 @@ pub(crate) async fn reconstruct_snapshot_from_entry(
         ts_ms: entry.created_at_ms,
         representations,
         file_content_digests: Vec::new(),
+        file_set_v1_component: None,
     })
 }
 

--- a/crates/uc-application/src/usecases/mobile_sync/apply_incoming.rs
+++ b/crates/uc-application/src/usecases/mobile_sync/apply_incoming.rs
@@ -772,6 +772,7 @@ impl ApplyIncomingMobileClipUseCase {
                 ts_ms: self.clock.now_ms(),
                 representations: vec![rep],
                 file_content_digests: Vec::new(),
+                file_set_v1_component: None,
             },
             transfer_id: None,
         })
@@ -819,6 +820,7 @@ impl ApplyIncomingMobileClipUseCase {
                 ts_ms: self.clock.now_ms(),
                 representations: vec![rep],
                 file_content_digests: Vec::new(),
+                file_set_v1_component: None,
             },
             transfer_id: Some(transfer_id),
         })
@@ -863,6 +865,7 @@ impl ApplyIncomingMobileClipUseCase {
                 ts_ms: self.clock.now_ms(),
                 representations: vec![rep],
                 file_content_digests: Vec::new(),
+                file_set_v1_component: None,
             },
             transfer_id: Some(transfer_id),
         })

--- a/crates/uc-bootstrap/src/entrypoint/non_gui.rs
+++ b/crates/uc-bootstrap/src/entrypoint/non_gui.rs
@@ -189,10 +189,10 @@ fn build_clipboard_capture_facade(deps: &AppDeps) -> Arc<ClipboardCaptureFacade>
         )
         .with_entry_identity_coordinator(deps.clipboard.entry_identity_coordinator.clone()),
     );
-    Arc::new(ClipboardCaptureFacade::new(
-        capture_uc,
-        deps.clipboard.clipboard.clone(),
-    ))
+    Arc::new(
+        ClipboardCaptureFacade::new(capture_uc, deps.clipboard.clipboard.clone())
+            .with_entry_file_set_repository(deps.storage.entry_file_set_repo.clone()),
+    )
 }
 
 /// `InboundWrite` 的 NoOp 实装。

--- a/crates/uc-bootstrap/src/wiring/wire.rs
+++ b/crates/uc-bootstrap/src/wiring/wire.rs
@@ -93,8 +93,10 @@ struct InfraLayer {
     /// 投递结果仓储,由 `DispatchClipboardEntryUseCase` 写、由
     /// `GetEntryDeliveryViewUseCase` 读。
     entry_delivery_repo: Arc<dyn uc_core::ports::EntryDeliveryRepositoryPort>,
-    /// File-class entry line-level manifest, built and persisted by capture.
-    entry_file_set_repo: Arc<dyn uc_core::ports::clipboard::EntryFileSetRepositoryPort>,
+    /// Shared Diesel executor. Exposed so repos that also need a post-`platform`
+    /// dependency (e.g. the entry-file-set repo's per-session path cipher) can be
+    /// constructed after space access is wired, over the same connection pool.
+    db_executor: Arc<DieselSqliteExecutor>,
     representation_repo: Arc<dyn ClipboardRepresentationStore>,
     selection_repo: Arc<dyn ClipboardSelectionRepositoryPort>,
 
@@ -568,10 +570,10 @@ fn create_infra_layer(
         uc_infra::db::repositories::DieselEntryDeliveryRepository::new(Arc::clone(&db_executor)),
     );
 
-    let entry_file_set_repo: Arc<dyn uc_core::ports::clipboard::EntryFileSetRepositoryPort> =
-        Arc::new(
-            uc_infra::db::repositories::DieselEntryFileSetRepository::new(Arc::clone(&db_executor)),
-        );
+    // NOTE: the entry-file-set repo seals its path columns with a per-session
+    // subkey, which needs `current_profile` + space access — both wired after
+    // `platform`. It is therefore constructed at the orchestrator level once
+    // those exist (mirroring the search index), over `infra.db_executor`.
 
     let member_repo_impl =
         DieselSpaceMemberRepository::new(Arc::clone(&db_executor), SpaceMemberRowMapper);
@@ -725,7 +727,7 @@ fn create_infra_layer(
         clipboard_event_repo,
         clipboard_event_reader_repo,
         entry_delivery_repo,
-        entry_file_set_repo,
+        db_executor,
         representation_repo,
         selection_repo,
         active_clipboard_register,
@@ -828,6 +830,17 @@ pub fn wire_dependencies(
         &platform.current_profile,
         &platform.session,
     );
+
+    // File-class entry line-level manifest. Its path columns are sealed with a
+    // per-session subkey derived from space access, so it is constructed here
+    // (after space access + profile exist) rather than in `create_infra_layer`,
+    // reusing the shared executor.
+    let entry_file_set_repo: Arc<dyn uc_core::ports::clipboard::EntryFileSetRepositoryPort> =
+        Arc::new(uc_infra::db::repositories::DieselEntryFileSetRepository::new(
+            infra.db_executor.clone(),
+            space_access_ports.derive_subkey.clone(),
+            platform.current_profile.clone(),
+        ));
 
     // Wire the search bundle (Phase 92). Search only derives a subkey.
     let SearchAssembly {
@@ -964,7 +977,7 @@ pub fn wire_dependencies(
             blob_store: platform.blob_store,
             blob_writer: platform.blob_writer,
             blob_content_ingest: platform.blob_content_ingest,
-            entry_file_set_repo: infra.entry_file_set_repo,
+            entry_file_set_repo,
             thumbnail_repo: infra.thumbnail_repo,
             thumbnail_generator: infra.thumbnail_generator,
             file_transfer: infra.file_transfer,

--- a/crates/uc-bootstrap/src/wiring/wire.rs
+++ b/crates/uc-bootstrap/src/wiring/wire.rs
@@ -836,11 +836,13 @@ pub fn wire_dependencies(
     // (after space access + profile exist) rather than in `create_infra_layer`,
     // reusing the shared executor.
     let entry_file_set_repo: Arc<dyn uc_core::ports::clipboard::EntryFileSetRepositoryPort> =
-        Arc::new(uc_infra::db::repositories::DieselEntryFileSetRepository::new(
-            infra.db_executor.clone(),
-            space_access_ports.derive_subkey.clone(),
-            platform.current_profile.clone(),
-        ));
+        Arc::new(
+            uc_infra::db::repositories::DieselEntryFileSetRepository::new(
+                infra.db_executor.clone(),
+                space_access_ports.derive_subkey.clone(),
+                platform.current_profile.clone(),
+            ),
+        );
 
     // Wire the search bundle (Phase 92). Search only derives a subkey.
     let SearchAssembly {

--- a/crates/uc-bootstrap/tests/slice2_phase2_clipboard_e2e.rs
+++ b/crates/uc-bootstrap/tests/slice2_phase2_clipboard_e2e.rs
@@ -676,6 +676,7 @@ async fn sponsor_dispatch_lands_on_joiner_within_2s() {
             text.as_bytes().to_vec(),
         )],
         file_content_digests: Vec::new(),
+        file_set_v1_component: None,
     };
     let expected_hash = snapshot.snapshot_hash().to_string();
     let outcome = sponsor
@@ -777,6 +778,7 @@ async fn repeat_dispatch_lands_twice_phase2_no_dedup() {
             fixture_text.as_bytes().to_vec(),
         )],
         file_content_digests: Vec::new(),
+        file_set_v1_component: None,
     };
     let canonical_hash = build_snapshot().snapshot_hash().to_string();
     for attempt in 0..2 {

--- a/crates/uc-content-hash/src/lib.rs
+++ b/crates/uc-content-hash/src/lib.rs
@@ -30,6 +30,12 @@ const STREAM_CHUNK_SIZE: usize = 64 * 1024;
 /// Domain-separation prefix for [`file_content_wrapper`].
 const FILE_CONTENT_PREFIX: &[u8] = b"file-content|";
 
+/// Domain-separation prefix for a structured file-set member leaf.
+const FILE_SET_MEMBER_V1_PREFIX: &[u8] = b"file-set-member-v1|";
+
+/// Domain-separation prefix for a structured file-set component.
+const FILE_SET_V1_PREFIX: &[u8] = b"file-set-v1|";
+
 /// Domain-separation prefix for [`snapshot_hash`].
 const SNAPSHOT_HASH_PREFIX: &[u8] = b"snapshot-hash-v1|";
 
@@ -66,6 +72,39 @@ pub fn file_content_wrapper(digests: &[[u8; 32]]) -> [u8; 32] {
     hasher.update(FILE_CONTENT_PREFIX);
     for d in &sorted {
         hasher.update(d);
+    }
+    *hasher.finalize().as_bytes()
+}
+
+/// Hash one structured file-set member using the ADR-010 v1 formula.
+pub fn file_set_member_v1(
+    root_name: &str,
+    relative_path: &str,
+    kind_tag: &str,
+    file_digest: Option<&[u8; 32]>,
+) -> [u8; 32] {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(FILE_SET_MEMBER_V1_PREFIX);
+    hasher.update(root_name.as_bytes());
+    hasher.update(&[0]);
+    hasher.update(relative_path.as_bytes());
+    hasher.update(&[0]);
+    hasher.update(kind_tag.as_bytes());
+    hasher.update(&[0]);
+    if let Some(file_digest) = file_digest {
+        hasher.update(file_digest);
+    }
+    *hasher.finalize().as_bytes()
+}
+
+/// Aggregate structured member leaves into an ADR-010 v1 file-set component.
+pub fn file_set_v1_wrapper(leaves: &[[u8; 32]]) -> [u8; 32] {
+    let mut sorted = leaves.to_vec();
+    sorted.sort_unstable();
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(FILE_SET_V1_PREFIX);
+    for leaf in &sorted {
+        hasher.update(leaf);
     }
     *hasher.finalize().as_bytes()
 }
@@ -164,6 +203,62 @@ mod tests {
         assert_eq!(
             file_content_wrapper(&[d1, d2]),
             file_content_wrapper(&[d2, d1])
+        );
+    }
+
+    #[test]
+    fn file_set_member_v1_matches_manual_formula() {
+        let digest = content_hash(b"member bytes");
+        let mut expected_hasher = blake3::Hasher::new();
+        expected_hasher.update(b"file-set-member-v1|");
+        expected_hasher.update("资料".as_bytes());
+        expected_hasher.update(&[0]);
+        expected_hasher.update(b"nested/file.txt");
+        expected_hasher.update(&[0]);
+        expected_hasher.update(b"x");
+        expected_hasher.update(&[0]);
+        expected_hasher.update(&digest);
+
+        assert_eq!(
+            file_set_member_v1("资料", "nested/file.txt", "x", Some(&digest)),
+            *expected_hasher.finalize().as_bytes()
+        );
+    }
+
+    #[test]
+    fn empty_directory_member_has_no_file_digest_bytes() {
+        let mut expected_hasher = blake3::Hasher::new();
+        expected_hasher.update(b"file-set-member-v1|");
+        expected_hasher.update(b"folder");
+        expected_hasher.update(&[0]);
+        expected_hasher.update(b"empty");
+        expected_hasher.update(&[0]);
+        expected_hasher.update(b"d");
+        expected_hasher.update(&[0]);
+
+        assert_eq!(
+            file_set_member_v1("folder", "empty", "d", None),
+            *expected_hasher.finalize().as_bytes()
+        );
+    }
+
+    #[test]
+    fn file_set_v1_wrapper_sorts_leaves() {
+        let first = content_hash(b"first leaf");
+        let second = content_hash(b"second leaf");
+        let mut sorted = [first, second];
+        sorted.sort_unstable();
+        let mut expected_hasher = blake3::Hasher::new();
+        expected_hasher.update(b"file-set-v1|");
+        for leaf in &sorted {
+            expected_hasher.update(leaf);
+        }
+
+        let expected = *expected_hasher.finalize().as_bytes();
+        assert_eq!(file_set_v1_wrapper(&[first, second]), expected);
+        assert_eq!(
+            file_set_v1_wrapper(&[first, second]),
+            file_set_v1_wrapper(&[second, first])
         );
     }
 

--- a/crates/uc-core/src/clipboard/category.rs
+++ b/crates/uc-core/src/clipboard/category.rs
@@ -346,6 +346,7 @@ mod tests {
             ts_ms: 0,
             representations: reps,
             file_content_digests: Vec::new(),
+            file_set_v1_component: None,
         }
     }
 

--- a/crates/uc-core/src/clipboard/file_set.rs
+++ b/crates/uc-core/src/clipboard/file_set.rs
@@ -27,7 +27,47 @@ pub struct EntryFileSetLine {
     pub line_index: i64,
     /// 原始行文本,未经解析/归一化。
     pub original_text: String,
+    /// Structured member location for file-set rows written by phase 3.
+    pub member_location: Option<FileSetMemberLocation>,
     pub kind: EntryFileSetLineKind,
+}
+
+/// Stable location of a selected file or a member expanded from a directory.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FileSetMemberLocation {
+    /// Zero-based position of the selected top-level root.
+    pub root_index: i64,
+    /// NFC-normalized path relative to the selected root, using `/` separators.
+    pub relative_path: String,
+    /// Member classification needed to reconstruct the selected tree.
+    pub kind: FileSetMemberKind,
+}
+
+/// Persisted classification tag for a file-set member.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FileSetMemberKind {
+    File,
+    Executable,
+    EmptyDirectory,
+}
+
+impl FileSetMemberKind {
+    pub fn as_tag(self) -> &'static str {
+        match self {
+            Self::File => "f",
+            Self::Executable => "x",
+            Self::EmptyDirectory => "d",
+        }
+    }
+
+    pub fn from_tag(tag: &str) -> Option<Self> {
+        match tag {
+            "f" => Some(Self::File),
+            "x" => Some(Self::Executable),
+            "d" => Some(Self::EmptyDirectory),
+            _ => None,
+        }
+    }
 }
 
 /// 一行清单条目的分类结果。
@@ -43,7 +83,8 @@ pub enum EntryFileSetLineKind {
         blob_id: Option<BlobId>,
         size_bytes: Option<i64>,
     },
-    /// 该行不表示文件(空行、注释、无法识别的条目)。
+    /// A line without file content, including uri-list comments and empty
+    /// directory markers distinguished by `member_location.kind`.
     NonFile,
     /// 该行本可以是文件,但因故未纳入这条 entry 的身份/传输范围。
     Excluded { reason: EntryFileSetExcludeReason },
@@ -52,18 +93,12 @@ pub enum EntryFileSetLineKind {
 /// 一行被排除在外的原因。
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum EntryFileSetExcludeReason {
-    /// 超出体积/数量上限策略。
-    ///
-    /// Reserved for the capture-time size-cap gate (ADR-010: per-set total-
-    /// size and member-count caps). The capture path does not yet produce
-    /// this variant; the persistence codec and identity rules already handle
-    /// it so the gate can be added without a schema/format change. Both
-    /// exclude reasons are treated identically by
-    /// [`EntryFileSet::content_digest_contribution`] (any exclusion → path-
-    /// text identity fallback).
+    /// The whole set exceeded its member-count or total-byte cap.
     SizeCapExceeded,
     /// 尝试确定其内容身份时失败(如文件不可读)。
     IngestFailed,
+    /// The file set contains a symlink or non-regular special file.
+    UnsupportedMember,
 }
 
 /// 仓储端口可能返回的领域错误。具体实现侧的底层错误必须被翻译为本枚举,
@@ -79,6 +114,24 @@ pub enum EntryFileSetError {
 }
 
 impl EntryFileSet {
+    /// Whether this manifest contains members expanded from a directory root.
+    ///
+    /// Directory members are assigned line indexes after the top-level input
+    /// range. At least the final expanded member therefore sits outside the
+    /// persisted row count, which distinguishes even a one-member directory
+    /// without confusing flat files preceded by uri-list comments. The path
+    /// and empty-directory checks defend the same invariant for decoded data.
+    pub fn has_directory_structure(&self) -> bool {
+        let row_count = self.lines.len() as i64;
+        self.lines.iter().any(|line| {
+            line.member_location.as_ref().is_some_and(|location| {
+                location.kind == FileSetMemberKind::EmptyDirectory
+                    || location.relative_path.contains('/')
+                    || line.line_index >= row_count
+            })
+        })
+    }
+
     /// 该清单中 `File` 行的内容 hash,已排序。
     ///
     /// 排序是有意为之:身份计算只关心"这条 entry 含有哪些文件内容",不
@@ -100,7 +153,7 @@ impl EntryFileSet {
             .lines
             .iter()
             .any(|line| matches!(line.kind, EntryFileSetLineKind::Excluded { .. }));
-        if has_excluded {
+        if has_excluded || self.has_directory_structure() {
             return Vec::new();
         }
 
@@ -140,12 +193,65 @@ mod tests {
         EntryFileSetLine {
             line_index: index,
             original_text: format!("file:///f{index}"),
+            member_location: None,
             kind: EntryFileSetLineKind::File {
                 content_hash: hash(byte),
                 blob_id: Some(BlobId::from(format!("blob-{index}"))),
                 size_bytes: Some(10),
             },
         }
+    }
+
+    #[test]
+    fn directory_structure_suppresses_content_digest_contribution() {
+        let mut line = file_line(1, 7);
+        line.member_location = Some(FileSetMemberLocation {
+            root_index: 0,
+            relative_path: "child.txt".to_string(),
+            kind: FileSetMemberKind::File,
+        });
+        let set = EntryFileSet { lines: vec![line] };
+
+        assert!(set.has_directory_structure());
+        assert!(set.content_digest_contribution().is_empty());
+    }
+
+    #[test]
+    fn flat_member_location_keeps_content_digest_contribution() {
+        let mut line = file_line(0, 7);
+        line.member_location = Some(FileSetMemberLocation {
+            root_index: 0,
+            relative_path: "f0".to_string(),
+            kind: FileSetMemberKind::File,
+        });
+        let set = EntryFileSet { lines: vec![line] };
+
+        assert!(!set.has_directory_structure());
+        assert_eq!(set.content_digest_contribution(), vec![[7; 32]]);
+    }
+
+    #[test]
+    fn comment_before_flat_file_does_not_look_like_directory_structure() {
+        let mut line = file_line(1, 7);
+        line.member_location = Some(FileSetMemberLocation {
+            root_index: 0,
+            relative_path: "f1".to_string(),
+            kind: FileSetMemberKind::File,
+        });
+        let set = EntryFileSet {
+            lines: vec![
+                EntryFileSetLine {
+                    line_index: 0,
+                    original_text: "# comment".to_string(),
+                    member_location: None,
+                    kind: EntryFileSetLineKind::NonFile,
+                },
+                line,
+            ],
+        };
+
+        assert!(!set.has_directory_structure());
+        assert_eq!(set.content_digest_contribution(), vec![[7; 32]]);
     }
 
     #[test]
@@ -156,6 +262,7 @@ mod tests {
                 EntryFileSetLine {
                     line_index: 1,
                     original_text: "# a comment".into(),
+                    member_location: None,
                     kind: EntryFileSetLineKind::NonFile,
                 },
                 file_line(2, 1),
@@ -183,6 +290,7 @@ mod tests {
                     EntryFileSetLine {
                         line_index: 2,
                         original_text: "file:///excluded".into(),
+                        member_location: None,
                         kind: EntryFileSetLineKind::Excluded { reason },
                     },
                 ],
@@ -203,6 +311,7 @@ mod tests {
                 EntryFileSetLine {
                     line_index: 1,
                     original_text: String::new(),
+                    member_location: None,
                     kind: EntryFileSetLineKind::NonFile,
                 },
             ],

--- a/crates/uc-core/src/clipboard/file_set.rs
+++ b/crates/uc-core/src/clipboard/file_set.rs
@@ -37,6 +37,8 @@ pub struct EntryFileSetLine {
 pub struct FileSetMemberLocation {
     /// Zero-based position of the selected top-level root.
     pub root_index: i64,
+    /// NFC-normalized basename of the selected top-level root.
+    pub root_name: String,
     /// NFC-normalized path relative to the selected root, using `/` separators.
     pub relative_path: String,
     /// Member classification needed to reconstruct the selected tree.
@@ -169,6 +171,43 @@ impl EntryFileSet {
         digests
     }
 
+    /// Return the structured identity component for a complete directory set.
+    pub fn file_set_v1_component(&self) -> Option<[u8; 32]> {
+        if !self.has_directory_structure()
+            || self
+                .lines
+                .iter()
+                .any(|line| matches!(line.kind, EntryFileSetLineKind::Excluded { .. }))
+        {
+            return None;
+        }
+
+        let mut leaves = Vec::new();
+        for line in &self.lines {
+            let location = match (&line.member_location, &line.kind) {
+                (Some(location), _) => location,
+                (None, EntryFileSetLineKind::NonFile) => continue,
+                (None, _) => return None,
+            };
+            let digest = match (&line.kind, location.kind) {
+                (
+                    EntryFileSetLineKind::File { content_hash, .. },
+                    FileSetMemberKind::File | FileSetMemberKind::Executable,
+                ) => Some(&content_hash.bytes),
+                (EntryFileSetLineKind::NonFile, FileSetMemberKind::EmptyDirectory) => None,
+                _ => return None,
+            };
+            leaves.push(uc_content_hash::file_set_member_v1(
+                &location.root_name,
+                &location.relative_path,
+                location.kind.as_tag(),
+                digest,
+            ));
+        }
+
+        (!leaves.is_empty()).then(|| uc_content_hash::file_set_v1_wrapper(&leaves))
+    }
+
     /// 迭代所有 `File` 行。
     pub fn file_lines(&self) -> impl Iterator<Item = &EntryFileSetLine> {
         self.lines
@@ -207,6 +246,7 @@ mod tests {
         let mut line = file_line(1, 7);
         line.member_location = Some(FileSetMemberLocation {
             root_index: 0,
+            root_name: "root".to_string(),
             relative_path: "child.txt".to_string(),
             kind: FileSetMemberKind::File,
         });
@@ -217,10 +257,87 @@ mod tests {
     }
 
     #[test]
+    fn directory_structure_produces_versioned_component() {
+        let mut file = file_line(2, 7);
+        file.member_location = Some(FileSetMemberLocation {
+            root_index: 0,
+            root_name: "folder".to_string(),
+            relative_path: "nested/file.txt".to_string(),
+            kind: FileSetMemberKind::File,
+        });
+        let empty = EntryFileSetLine {
+            line_index: 3,
+            original_text: "file:///folder/empty".to_string(),
+            member_location: Some(FileSetMemberLocation {
+                root_index: 0,
+                root_name: "folder".to_string(),
+                relative_path: "empty".to_string(),
+                kind: FileSetMemberKind::EmptyDirectory,
+            }),
+            kind: EntryFileSetLineKind::NonFile,
+        };
+        let set = EntryFileSet {
+            lines: vec![file, empty],
+        };
+
+        let file_leaf =
+            uc_content_hash::file_set_member_v1("folder", "nested/file.txt", "f", Some(&[7; 32]));
+        let empty_leaf = uc_content_hash::file_set_member_v1("folder", "empty", "d", None);
+        assert_eq!(
+            set.file_set_v1_component(),
+            Some(uc_content_hash::file_set_v1_wrapper(&[
+                file_leaf, empty_leaf
+            ]))
+        );
+    }
+
+    #[test]
+    fn executable_kind_changes_directory_component() {
+        let mut regular = file_line(1, 7);
+        regular.member_location = Some(FileSetMemberLocation {
+            root_index: 0,
+            root_name: "folder".to_string(),
+            relative_path: "run".to_string(),
+            kind: FileSetMemberKind::File,
+        });
+        let mut executable = regular.clone();
+        executable.member_location.as_mut().unwrap().kind = FileSetMemberKind::Executable;
+
+        assert_ne!(
+            EntryFileSet {
+                lines: vec![regular]
+            }
+            .file_set_v1_component(),
+            EntryFileSet {
+                lines: vec![executable]
+            }
+            .file_set_v1_component()
+        );
+    }
+
+    #[test]
+    fn directory_component_rejects_file_without_member_location() {
+        let mut directory_file = file_line(2, 7);
+        directory_file.member_location = Some(FileSetMemberLocation {
+            root_index: 0,
+            root_name: "folder".to_string(),
+            relative_path: "nested/file.txt".to_string(),
+            kind: FileSetMemberKind::File,
+        });
+        let missing_location = file_line(0, 8);
+        let set = EntryFileSet {
+            lines: vec![missing_location, directory_file],
+        };
+
+        assert_eq!(set.file_set_v1_component(), None);
+    }
+
+    #[test]
     fn flat_member_location_keeps_content_digest_contribution() {
         let mut line = file_line(0, 7);
         line.member_location = Some(FileSetMemberLocation {
             root_index: 0,
+            root_name: "f0".to_string(),
             relative_path: "f0".to_string(),
             kind: FileSetMemberKind::File,
         });
@@ -235,6 +352,7 @@ mod tests {
         let mut line = file_line(1, 7);
         line.member_location = Some(FileSetMemberLocation {
             root_index: 0,
+            root_name: "f1".to_string(),
             relative_path: "f1".to_string(),
             kind: FileSetMemberKind::File,
         });

--- a/crates/uc-core/src/clipboard/mod.rs
+++ b/crates/uc-core/src/clipboard/mod.rs
@@ -33,7 +33,7 @@ pub use entry::*;
 pub use event::*;
 pub use file_set::{
     EntryFileSet, EntryFileSetError, EntryFileSetExcludeReason, EntryFileSetLine,
-    EntryFileSetLineKind,
+    EntryFileSetLineKind, FileSetMemberKind, FileSetMemberLocation,
 };
 pub use policy::ClipboardSelection;
 pub use policy::*;

--- a/crates/uc-core/src/clipboard/policy/v1.rs
+++ b/crates/uc-core/src/clipboard/policy/v1.rs
@@ -341,6 +341,7 @@ mod tests {
             ts_ms: 0,
             representations: vec![large_image, files],
             file_content_digests: Vec::new(),
+            file_set_v1_component: None,
         };
 
         let policy = SelectRepresentationPolicyV1::new();
@@ -375,6 +376,7 @@ mod tests {
             ts_ms: 0,
             representations: vec![large_image, files],
             file_content_digests: Vec::new(),
+            file_set_v1_component: None,
         };
 
         let policy = SelectRepresentationPolicyV1::new();
@@ -407,6 +409,7 @@ mod tests {
             ts_ms: 0,
             representations: vec![small_image, files],
             file_content_digests: Vec::new(),
+            file_set_v1_component: None,
         };
 
         let policy = SelectRepresentationPolicyV1::new();
@@ -444,6 +447,7 @@ mod tests {
             ts_ms: 0,
             representations: vec![html, image],
             file_content_digests: Vec::new(),
+            file_set_v1_component: None,
         };
 
         let policy = SelectRepresentationPolicyV1::new();

--- a/crates/uc-core/src/clipboard/system.rs
+++ b/crates/uc-core/src/clipboard/system.rs
@@ -33,6 +33,11 @@ pub struct SystemClipboardSnapshot {
     /// Empty for text-only / image-only snapshots (no file-list rep).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub file_content_digests: Vec<[u8; 32]>,
+    /// Precomputed ADR-010 `file-set-v1` component for a structured directory
+    /// manifest. This replaces the file-list representation directly and must
+    /// not be wrapped again with the legacy `file-content|` prefix.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub file_set_v1_component: Option<[u8; 32]>,
 }
 
 /// 表示一条 rep 的负载来源。
@@ -532,14 +537,15 @@ impl SystemClipboardSnapshot {
         // When file_content_digests are available, use them as the hash
         // contribution for file-list reps instead of hashing the
         // text/uri-list inline bytes (which contain device-local paths).
+        let has_file_component = self.file_set_v1_component.is_some();
         let has_file_digests = !self.file_content_digests.is_empty();
 
         let mut rep_hashes: Vec<[u8; 32]> = self
             .representations
             .iter()
             .filter_map(|r| {
-                if has_file_digests && is_file_representation(r) {
-                    // Skip — file-list rep hash replaced by file_content_digests below
+                if (has_file_component || has_file_digests) && is_file_representation(r) {
+                    // Skip — the file-list rep is replaced by a stable file component below.
                     None
                 } else {
                     Some(r.content_hash().bytes)
@@ -547,7 +553,9 @@ impl SystemClipboardSnapshot {
             })
             .collect();
 
-        if has_file_digests {
+        if let Some(component) = self.file_set_v1_component {
+            rep_hashes.push(component);
+        } else if has_file_digests {
             rep_hashes.push(uc_content_hash::file_content_wrapper(
                 &self.file_content_digests,
             ));
@@ -602,6 +610,48 @@ impl SystemClipboardSnapshot {
 #[cfg(test)]
 mod snapshot_hash_tests {
     use super::*;
+
+    fn uri_list_rep(bytes: &[u8]) -> ObservedClipboardRepresentation {
+        ObservedClipboardRepresentation::new(
+            RepresentationId::from("files"),
+            FormatId::from("text/uri-list"),
+            Some(MimeType::uri_list()),
+            bytes.to_vec(),
+        )
+    }
+
+    #[test]
+    fn structured_file_set_component_replaces_uri_list_hash_directly() {
+        let component = uc_content_hash::content_hash(b"file-set-v1 component");
+        let snapshot = SystemClipboardSnapshot {
+            ts_ms: 0,
+            representations: vec![uri_list_rep(b"file:///device-local/folder")],
+            file_content_digests: Vec::new(),
+            file_set_v1_component: Some(component),
+        };
+
+        assert_eq!(
+            snapshot.snapshot_hash().bytes,
+            uc_content_hash::snapshot_hash([component])
+        );
+    }
+
+    #[test]
+    fn flat_file_digest_identity_remains_byte_for_byte_unchanged() {
+        let digests = vec![[2; 32], [1; 32]];
+        let snapshot = SystemClipboardSnapshot {
+            ts_ms: 0,
+            representations: vec![uri_list_rep(b"file:///device-local/file.txt")],
+            file_content_digests: digests.clone(),
+            file_set_v1_component: None,
+        };
+
+        let legacy_component = uc_content_hash::file_content_wrapper(&digests);
+        assert_eq!(
+            snapshot.snapshot_hash().bytes,
+            uc_content_hash::snapshot_hash([legacy_component])
+        );
+    }
 
     #[test]
     fn parse_round_trips_display_form() {

--- a/crates/uc-core/src/crypto/aad.rs
+++ b/crates/uc-core/src/crypto/aad.rs
@@ -154,6 +154,34 @@ pub fn for_search_render(entry_id: &EntryId) -> Vec<u8> {
     .into_bytes()
 }
 
+/// Generates AAD for a per-line entry-file-set path column encryption.
+///
+/// # Format
+///
+/// `uc:file_set_line:v1|{entry_id}|{line_index}`
+///
+/// Binds a sealed path column (`original_text` / `relative_path`) to its exact
+/// manifest row so a ciphertext cannot be transplanted onto a different entry
+/// or a different line within the same entry.
+///
+/// # Examples
+///
+/// ```rust
+/// use uc_core::crypto::aad::for_file_set_line;
+/// use uc_core::ids::EntryId;
+///
+/// let entry_id = EntryId::from("test-entry");
+/// let aad = for_file_set_line(&entry_id, 3);
+/// assert_eq!(aad, b"uc:file_set_line:v1|test-entry|3".to_vec());
+/// ```
+pub fn for_file_set_line(entry_id: &EntryId, line_index: i64) -> Vec<u8> {
+    format!(
+        "{AAD_NAMESPACE}:file_set_line:{AAD_VERSION}|{}|{line_index}",
+        entry_id.as_ref()
+    )
+    .into_bytes()
+}
+
 pub fn for_network_clipboard(message_id: &str) -> Vec<u8> {
     format!("{AAD_NAMESPACE}:net_clipboard:{AAD_VERSION}|{message_id}").into_bytes()
 }

--- a/crates/uc-infra/migrations/2026-07-10-000001_encrypt_entry_file_set_paths/down.sql
+++ b/crates/uc-infra/migrations/2026-07-10-000001_encrypt_entry_file_set_paths/down.sql
@@ -1,0 +1,11 @@
+-- Intentionally irreversible (see up.sql).
+--
+-- Sealed path columns cannot be decrypted inside a migration context, so a
+-- rollback would recreate an empty plaintext original_text column and silently
+-- drop the manifest data. Failing loudly is safer than persisting broken
+-- manifests. To go back to an older binary, delete the entry_file_set rows and
+-- let capture rebuild them (dispatch falls back to snapshot re-parse meanwhile).
+--
+-- The quoted identifier is not a real table; SQLite reports it as the error
+-- message so the intent is visible in logs.
+SELECT 1 FROM "cannot downgrade: entry_file_set path encryption is irreversible; clear the manifest to rebuild on the older version";

--- a/crates/uc-infra/migrations/2026-07-10-000001_encrypt_entry_file_set_paths/up.sql
+++ b/crates/uc-infra/migrations/2026-07-10-000001_encrypt_entry_file_set_paths/up.sql
@@ -1,0 +1,25 @@
+-- Encrypt the file-path columns of entry_file_set (ADR-010 phase 3 PR-A).
+--
+-- `original_text` stored device-local file paths (user content — filenames and
+-- directory structure) as plaintext TEXT, leaking to disk against the
+-- persist-as-ciphertext bedrock rule. Reseal it as an AEAD BLOB (UCFS
+-- envelope). Also add the directory-member location columns that ADR-010 phase
+-- 3 directory capture needs: root_index / relative_path (encrypted) / kind_tag.
+-- These stay NULL until directory capture populates them in a later PR.
+--
+-- The manifest capture-write path only merged 2026-07-10, so existing rows are
+-- negligible dev data and cannot be re-encrypted here (the MasterKey is
+-- unavailable in a migration context). Drop them: the manifest rebuilds on the
+-- next capture, and dispatch falls back to snapshot re-parse for any entry that
+-- lacks one.
+--
+-- Requires SQLite >= 3.35 for ALTER TABLE ... DROP COLUMN. The dropped column
+-- carries no index/view/trigger dependency (the composite PK covers entry_id).
+DELETE FROM entry_file_set;
+
+ALTER TABLE entry_file_set ADD COLUMN original_text_ct BLOB;
+ALTER TABLE entry_file_set DROP COLUMN original_text;
+
+ALTER TABLE entry_file_set ADD COLUMN root_index BIGINT;
+ALTER TABLE entry_file_set ADD COLUMN relative_path_ct BLOB;
+ALTER TABLE entry_file_set ADD COLUMN kind_tag TEXT;

--- a/crates/uc-infra/migrations/2026-07-11-000001_add_entry_file_set_root_name/down.sql
+++ b/crates/uc-infra/migrations/2026-07-11-000001_add_entry_file_set_root_name/down.sql
@@ -1,0 +1,4 @@
+-- The manifest is rebuildable; older binaries do not consume root names.
+DELETE FROM entry_file_set;
+
+ALTER TABLE entry_file_set DROP COLUMN root_name_ct;

--- a/crates/uc-infra/migrations/2026-07-11-000001_add_entry_file_set_root_name/up.sql
+++ b/crates/uc-infra/migrations/2026-07-11-000001_add_entry_file_set_root_name/up.sql
@@ -1,0 +1,15 @@
+-- Persist the selected top-level root basename needed by ADR-010 file-set-v1.
+-- Root names are user content and therefore use the existing UCFS AEAD
+-- envelope. Existing manifests are a rebuildable cache and predate root-name
+-- modeling, so clear them rather than retain structurally incomplete rows.
+--
+-- This DELETE also covers an unrelated cipher hardening landing alongside
+-- root-name support: `original_text_ct` / `relative_path_ct` now bind a
+-- column-specific AAD suffix (previously they shared one AAD per row, which
+-- let a ciphertext be transplanted between the two columns undetected).
+-- Rows sealed before this change use the old AAD and cannot be decrypted
+-- under the new scheme — clearing here means no row written before this
+-- migration survives into a build that expects column-bound AAD.
+DELETE FROM entry_file_set;
+
+ALTER TABLE entry_file_set ADD COLUMN root_name_ct BLOB;

--- a/crates/uc-infra/src/db/models/entry_file_set.rs
+++ b/crates/uc-infra/src/db/models/entry_file_set.rs
@@ -1,17 +1,32 @@
 use crate::db::schema::entry_file_set;
 use diesel::prelude::*;
 
+// Field order MUST match the `table!` column order in `schema.rs` (and thus the
+// physical DDL order the encrypt migration produces, added columns last):
+// `#[derive(Queryable)]` maps positionally, so a reorder silently mismaps
+// columns. Keep both in sync with `diesel print-schema`.
 #[derive(Queryable)]
 #[diesel(table_name = entry_file_set)]
 pub struct EntryFileSetRow {
     pub entry_id: String,
     pub line_index: i64,
-    pub original_text: String,
     pub kind: String,
     pub content_hash: Option<String>,
     pub blob_id: Option<String>,
     pub size_bytes: Option<i64>,
     pub exclude_reason: Option<String>,
+    /// AEAD-sealed `original_text` (UCFS envelope). NULL only on rows written by
+    /// an older schema (none survive the phase-3 encrypt migration, which clears
+    /// the table); a NULL here is treated as a decode failure.
+    pub original_text_ct: Option<Vec<u8>>,
+    /// Directory-member location (ADR-010 phase 3). NULL for flat file-set lines;
+    /// populated by directory capture in a later PR.
+    pub root_index: Option<i64>,
+    /// AEAD-sealed `relative_path` (UCFS envelope). NULL for flat file-set lines.
+    pub relative_path_ct: Option<Vec<u8>>,
+    /// Member kind tag (`f`/`x`/`d`); classification enum, kept plaintext. NULL
+    /// for flat file-set lines.
+    pub kind_tag: Option<String>,
 }
 
 #[derive(Insertable)]
@@ -19,10 +34,13 @@ pub struct EntryFileSetRow {
 pub struct NewEntryFileSetRow {
     pub entry_id: String,
     pub line_index: i64,
-    pub original_text: String,
     pub kind: String,
     pub content_hash: Option<String>,
     pub blob_id: Option<String>,
     pub size_bytes: Option<i64>,
     pub exclude_reason: Option<String>,
+    pub original_text_ct: Option<Vec<u8>>,
+    pub root_index: Option<i64>,
+    pub relative_path_ct: Option<Vec<u8>>,
+    pub kind_tag: Option<String>,
 }

--- a/crates/uc-infra/src/db/models/entry_file_set.rs
+++ b/crates/uc-infra/src/db/models/entry_file_set.rs
@@ -26,6 +26,8 @@ pub struct EntryFileSetRow {
     /// Member kind tag (`f`/`x`/`d`); classification enum, kept plaintext. NULL
     /// for legacy rows.
     pub kind_tag: Option<String>,
+    /// AEAD-sealed selected root basename. NULL only for legacy rows.
+    pub root_name_ct: Option<Vec<u8>>,
 }
 
 #[derive(Insertable)]
@@ -42,4 +44,5 @@ pub struct NewEntryFileSetRow {
     pub root_index: Option<i64>,
     pub relative_path_ct: Option<Vec<u8>>,
     pub kind_tag: Option<String>,
+    pub root_name_ct: Option<Vec<u8>>,
 }

--- a/crates/uc-infra/src/db/models/entry_file_set.rs
+++ b/crates/uc-infra/src/db/models/entry_file_set.rs
@@ -19,13 +19,12 @@ pub struct EntryFileSetRow {
     /// an older schema (none survive the phase-3 encrypt migration, which clears
     /// the table); a NULL here is treated as a decode failure.
     pub original_text_ct: Option<Vec<u8>>,
-    /// Directory-member location (ADR-010 phase 3). NULL for flat file-set lines;
-    /// populated by directory capture in a later PR.
+    /// Directory-member root position. NULL for rows written before phase 3.
     pub root_index: Option<i64>,
-    /// AEAD-sealed `relative_path` (UCFS envelope). NULL for flat file-set lines.
+    /// AEAD-sealed `relative_path` (UCFS envelope). NULL for legacy rows.
     pub relative_path_ct: Option<Vec<u8>>,
     /// Member kind tag (`f`/`x`/`d`); classification enum, kept plaintext. NULL
-    /// for flat file-set lines.
+    /// for legacy rows.
     pub kind_tag: Option<String>,
 }
 

--- a/crates/uc-infra/src/db/repositories/entry_file_set_cipher.rs
+++ b/crates/uc-infra/src/db/repositories/entry_file_set_cipher.rs
@@ -1,0 +1,226 @@
+//! `EntryFileSetPathCipher` — AEAD codec for the sealed path columns of
+//! `entry_file_set` (`original_text`, and later `relative_path`).
+//!
+//! A file path is user content — it exposes filenames and directory structure —
+//! so it must never hit disk in plaintext (the persist-as-ciphertext rule). Each
+//! path string is sealed with XChaCha20-Poly1305 under a per-session subkey,
+//! bound to its exact manifest row via `aad::for_file_set_line(entry_id,
+//! line_index)` so a ciphertext cannot be transplanted onto a different entry or
+//! line.
+//!
+//! On-disk envelope (fixed binary header, mirroring the UCSR search-render
+//! header):
+//!
+//! ```text
+//! [magic "UCFS" 4B][format_version 1B = 0x01][nonce 24B][ciphertext+tag]
+//! ```
+
+use uc_core::crypto::aad;
+use uc_core::ids::EntryId;
+
+use crate::security::v1_aead::{decrypt_xchacha_raw, encrypt_xchacha_raw};
+
+/// UCFS envelope magic — "UCFS" (UniClipboard File Set).
+const FILE_SET_MAGIC: [u8; 4] = [0x55, 0x43, 0x46, 0x53];
+/// Current UCFS envelope format version.
+const FILE_SET_FORMAT_VERSION: u8 = 0x01;
+/// Fixed nonce length (XChaCha20-Poly1305).
+const NONCE_LEN: usize = 24;
+/// Header = magic(4) + version(1) + nonce(24).
+const HEADER_LEN: usize = 4 + 1 + NONCE_LEN;
+
+/// Failure while sealing or opening a file-set path column.
+///
+/// The repository maps every variant to `EntryFileSetError::Storage`: a decode
+/// failure on a path column means the manifest row is unreadable, which the
+/// dispatch reader already handles by falling back to snapshot re-parse.
+#[derive(Debug, thiserror::Error)]
+pub enum FileSetCipherError {
+    #[error("file-set path envelope too short: {0} bytes")]
+    Truncated(usize),
+    #[error("file-set path envelope magic mismatch")]
+    BadMagic,
+    #[error("unsupported file-set path envelope version: {0:#x}")]
+    UnsupportedVersion(u8),
+    #[error("file-set path AEAD encryption failed")]
+    EncryptFailed,
+    #[error("file-set path AEAD verification failed")]
+    DecryptFailed,
+    // Deliberately content-free: the decrypted plaintext is a device-local path,
+    // so the underlying utf-8 error must not carry it into logs.
+    #[error("file-set path plaintext is not valid UTF-8")]
+    InvalidUtf8,
+}
+
+/// AEAD codec holding a per-session 32-byte subkey.
+///
+/// One codec is constructed per repository operation (save / load) after the
+/// subkey is derived, then reused for every row in that operation. Holds no
+/// database handle — pure seal/open. `Clone` is cheap (32 key bytes).
+#[derive(Clone)]
+pub struct EntryFileSetPathCipher {
+    key: [u8; 32],
+}
+
+impl EntryFileSetPathCipher {
+    pub fn new(key: [u8; 32]) -> Self {
+        Self { key }
+    }
+
+    /// Seal `plaintext` into a UCFS envelope bound to `(entry_id, line_index)`.
+    pub fn seal(
+        &self,
+        entry_id: &EntryId,
+        line_index: i64,
+        plaintext: &str,
+    ) -> Result<Vec<u8>, FileSetCipherError> {
+        let ad = aad::for_file_set_line(entry_id, line_index);
+        let (nonce, ciphertext) = encrypt_xchacha_raw(&self.key, plaintext.as_bytes(), &ad)
+            .map_err(|_| FileSetCipherError::EncryptFailed)?;
+
+        let mut buf = Vec::with_capacity(HEADER_LEN + ciphertext.len());
+        buf.extend_from_slice(&FILE_SET_MAGIC);
+        buf.push(FILE_SET_FORMAT_VERSION);
+        buf.extend_from_slice(&nonce);
+        buf.extend_from_slice(&ciphertext);
+        Ok(buf)
+    }
+
+    /// Open a UCFS envelope, verifying it is bound to `(entry_id, line_index)`.
+    pub fn open(
+        &self,
+        entry_id: &EntryId,
+        line_index: i64,
+        bytes: &[u8],
+    ) -> Result<String, FileSetCipherError> {
+        if bytes.len() < HEADER_LEN {
+            return Err(FileSetCipherError::Truncated(bytes.len()));
+        }
+        if bytes[0..4] != FILE_SET_MAGIC {
+            return Err(FileSetCipherError::BadMagic);
+        }
+        let version = bytes[4];
+        if version != FILE_SET_FORMAT_VERSION {
+            return Err(FileSetCipherError::UnsupportedVersion(version));
+        }
+        let nonce = &bytes[5..HEADER_LEN];
+        let ciphertext = &bytes[HEADER_LEN..];
+        let ad = aad::for_file_set_line(entry_id, line_index);
+        let plaintext = decrypt_xchacha_raw(&self.key, nonce, ciphertext, &ad)
+            .map_err(|_| FileSetCipherError::DecryptFailed)?;
+        String::from_utf8(plaintext).map_err(|_| FileSetCipherError::InvalidUtf8)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cipher(seed: u8) -> EntryFileSetPathCipher {
+        EntryFileSetPathCipher::new([seed; 32])
+    }
+
+    #[test]
+    fn roundtrip() {
+        let c = cipher(0xA1);
+        let id = EntryId::from("entry-1");
+        let env = c.seal(&id, 0, "file:///Users/mark/secret.pdf").unwrap();
+        assert_eq!(&env[0..4], &FILE_SET_MAGIC);
+        assert_eq!(env[4], FILE_SET_FORMAT_VERSION);
+        assert_eq!(c.open(&id, 0, &env).unwrap(), "file:///Users/mark/secret.pdf");
+    }
+
+    #[test]
+    fn ciphertext_does_not_contain_plaintext() {
+        let c = cipher(0xB2);
+        let id = EntryId::from("entry-1");
+        let path = "file:///Users/mark/budget/salaries.xlsx";
+        let env = c.seal(&id, 0, path).unwrap();
+        assert!(
+            !env.windows(path.len()).any(|w| w == path.as_bytes()),
+            "sealed envelope must not carry the plaintext path"
+        );
+    }
+
+    #[test]
+    fn wrong_entry_id_fails_aad() {
+        let c = cipher(0xC3);
+        let env = c.seal(&EntryId::from("entry-a"), 0, "/tmp/a").unwrap();
+        assert!(matches!(
+            c.open(&EntryId::from("entry-b"), 0, &env).unwrap_err(),
+            FileSetCipherError::DecryptFailed
+        ));
+    }
+
+    #[test]
+    fn wrong_line_index_fails_aad() {
+        let c = cipher(0xC4);
+        let id = EntryId::from("entry-1");
+        let env = c.seal(&id, 0, "/tmp/a").unwrap();
+        assert!(matches!(
+            c.open(&id, 1, &env).unwrap_err(),
+            FileSetCipherError::DecryptFailed
+        ));
+    }
+
+    #[test]
+    fn wrong_key_fails() {
+        let a = cipher(0x01);
+        let b = cipher(0x02);
+        let id = EntryId::from("entry-1");
+        let env = a.seal(&id, 0, "/tmp/a").unwrap();
+        assert!(matches!(
+            b.open(&id, 0, &env).unwrap_err(),
+            FileSetCipherError::DecryptFailed
+        ));
+    }
+
+    #[test]
+    fn bad_magic_rejected() {
+        let c = cipher(0xD4);
+        let id = EntryId::from("entry-1");
+        let mut env = c.seal(&id, 0, "/tmp/a").unwrap();
+        env[0] ^= 0xFF;
+        assert!(matches!(
+            c.open(&id, 0, &env).unwrap_err(),
+            FileSetCipherError::BadMagic
+        ));
+    }
+
+    #[test]
+    fn unknown_version_rejected() {
+        let c = cipher(0xE5);
+        let id = EntryId::from("entry-1");
+        let mut env = c.seal(&id, 0, "/tmp/a").unwrap();
+        env[4] = 0x02;
+        assert!(matches!(
+            c.open(&id, 0, &env).unwrap_err(),
+            FileSetCipherError::UnsupportedVersion(0x02)
+        ));
+    }
+
+    #[test]
+    fn truncated_rejected() {
+        let c = cipher(0xF6);
+        let id = EntryId::from("entry-1");
+        let env = c.seal(&id, 0, "/tmp/a").unwrap();
+        let short = &env[0..HEADER_LEN - 1];
+        assert!(matches!(
+            c.open(&id, 0, short).unwrap_err(),
+            FileSetCipherError::Truncated(_)
+        ));
+    }
+
+    #[test]
+    fn tampered_ciphertext_rejected() {
+        let c = cipher(0x28);
+        let id = EntryId::from("entry-1");
+        let mut env = c.seal(&id, 0, "/tmp/a").unwrap();
+        let last = env.len() - 1;
+        env[last] ^= 0x01;
+        assert!(matches!(
+            c.open(&id, 0, &env).unwrap_err(),
+            FileSetCipherError::DecryptFailed
+        ));
+    }
+}

--- a/crates/uc-infra/src/db/repositories/entry_file_set_cipher.rs
+++ b/crates/uc-infra/src/db/repositories/entry_file_set_cipher.rs
@@ -1,12 +1,14 @@
 //! `EntryFileSetPathCipher` — AEAD codec for the sealed path columns of
-//! `entry_file_set` (`original_text`, and later `relative_path`).
+//! `entry_file_set` (`original_text`, `relative_path`, `root_name`).
 //!
 //! A file path is user content — it exposes filenames and directory structure —
 //! so it must never hit disk in plaintext (the persist-as-ciphertext rule). Each
 //! path string is sealed with XChaCha20-Poly1305 under a per-session subkey,
 //! bound to its exact manifest row via `aad::for_file_set_line(entry_id,
-//! line_index)` so a ciphertext cannot be transplanted onto a different entry or
-//! line.
+//! line_index)` plus a column-specific suffix, so a ciphertext cannot be
+//! transplanted onto a different entry, line, *or column* — without the suffix,
+//! two columns sealed for the same row would share one AAD and a ciphertext
+//! swap between them would decrypt "successfully".
 //!
 //! On-disk envelope (fixed binary header, mirroring the UCSR search-render
 //! header):
@@ -28,6 +30,22 @@ const FILE_SET_FORMAT_VERSION: u8 = 0x01;
 const NONCE_LEN: usize = 24;
 /// Header = magic(4) + version(1) + nonce(24).
 const HEADER_LEN: usize = 4 + 1 + NONCE_LEN;
+
+/// AAD suffix for the `original_text` column.
+const ORIGINAL_TEXT_AAD_SUFFIX: &[u8] = b"|original-text";
+/// AAD suffix for the `relative_path` column.
+const RELATIVE_PATH_AAD_SUFFIX: &[u8] = b"|relative-path";
+/// AAD suffix for the `root_name` column.
+const ROOT_NAME_AAD_SUFFIX: &[u8] = b"|root-name";
+
+/// Bind an AAD to `(entry_id, line_index)` and one column, so a ciphertext
+/// sealed for one column of a row can never be opened as another column of
+/// the same row.
+fn column_aad(entry_id: &EntryId, line_index: i64, column_suffix: &[u8]) -> Vec<u8> {
+    let mut ad = aad::for_file_set_line(entry_id, line_index);
+    ad.extend_from_slice(column_suffix);
+    ad
+}
 
 /// Failure while sealing or opening a file-set path column.
 ///
@@ -67,15 +85,47 @@ impl EntryFileSetPathCipher {
         Self { key }
     }
 
-    /// Seal `plaintext` into a UCFS envelope bound to `(entry_id, line_index)`.
-    pub fn seal(
+    /// Seal `original_text` bound to `(entry_id, line_index)` and its column.
+    pub fn seal_original_text(
         &self,
         entry_id: &EntryId,
         line_index: i64,
         plaintext: &str,
     ) -> Result<Vec<u8>, FileSetCipherError> {
-        let ad = aad::for_file_set_line(entry_id, line_index);
-        let (nonce, ciphertext) = encrypt_xchacha_raw(&self.key, plaintext.as_bytes(), &ad)
+        self.seal_with_aad(
+            plaintext,
+            &column_aad(entry_id, line_index, ORIGINAL_TEXT_AAD_SUFFIX),
+        )
+    }
+
+    /// Seal `relative_path` bound to `(entry_id, line_index)` and its column.
+    pub fn seal_relative_path(
+        &self,
+        entry_id: &EntryId,
+        line_index: i64,
+        plaintext: &str,
+    ) -> Result<Vec<u8>, FileSetCipherError> {
+        self.seal_with_aad(
+            plaintext,
+            &column_aad(entry_id, line_index, RELATIVE_PATH_AAD_SUFFIX),
+        )
+    }
+
+    /// Seal `root_name` bound to `(entry_id, line_index)` and its column.
+    pub fn seal_root_name(
+        &self,
+        entry_id: &EntryId,
+        line_index: i64,
+        plaintext: &str,
+    ) -> Result<Vec<u8>, FileSetCipherError> {
+        self.seal_with_aad(
+            plaintext,
+            &column_aad(entry_id, line_index, ROOT_NAME_AAD_SUFFIX),
+        )
+    }
+
+    fn seal_with_aad(&self, plaintext: &str, ad: &[u8]) -> Result<Vec<u8>, FileSetCipherError> {
+        let (nonce, ciphertext) = encrypt_xchacha_raw(&self.key, plaintext.as_bytes(), ad)
             .map_err(|_| FileSetCipherError::EncryptFailed)?;
 
         let mut buf = Vec::with_capacity(HEADER_LEN + ciphertext.len());
@@ -86,13 +136,46 @@ impl EntryFileSetPathCipher {
         Ok(buf)
     }
 
-    /// Open a UCFS envelope, verifying it is bound to `(entry_id, line_index)`.
-    pub fn open(
+    /// Open an `original_text` envelope, enforcing its column-specific AAD.
+    pub fn open_original_text(
         &self,
         entry_id: &EntryId,
         line_index: i64,
         bytes: &[u8],
     ) -> Result<String, FileSetCipherError> {
+        self.open_with_aad(
+            bytes,
+            &column_aad(entry_id, line_index, ORIGINAL_TEXT_AAD_SUFFIX),
+        )
+    }
+
+    /// Open a `relative_path` envelope, enforcing its column-specific AAD.
+    pub fn open_relative_path(
+        &self,
+        entry_id: &EntryId,
+        line_index: i64,
+        bytes: &[u8],
+    ) -> Result<String, FileSetCipherError> {
+        self.open_with_aad(
+            bytes,
+            &column_aad(entry_id, line_index, RELATIVE_PATH_AAD_SUFFIX),
+        )
+    }
+
+    /// Open a `root_name` envelope, enforcing its column-specific AAD.
+    pub fn open_root_name(
+        &self,
+        entry_id: &EntryId,
+        line_index: i64,
+        bytes: &[u8],
+    ) -> Result<String, FileSetCipherError> {
+        self.open_with_aad(
+            bytes,
+            &column_aad(entry_id, line_index, ROOT_NAME_AAD_SUFFIX),
+        )
+    }
+
+    fn open_with_aad(&self, bytes: &[u8], ad: &[u8]) -> Result<String, FileSetCipherError> {
         if bytes.len() < HEADER_LEN {
             return Err(FileSetCipherError::Truncated(bytes.len()));
         }
@@ -105,8 +188,7 @@ impl EntryFileSetPathCipher {
         }
         let nonce = &bytes[5..HEADER_LEN];
         let ciphertext = &bytes[HEADER_LEN..];
-        let ad = aad::for_file_set_line(entry_id, line_index);
-        let plaintext = decrypt_xchacha_raw(&self.key, nonce, ciphertext, &ad)
+        let plaintext = decrypt_xchacha_raw(&self.key, nonce, ciphertext, ad)
             .map_err(|_| FileSetCipherError::DecryptFailed)?;
         String::from_utf8(plaintext).map_err(|_| FileSetCipherError::InvalidUtf8)
     }
@@ -124,10 +206,15 @@ mod tests {
     fn roundtrip() {
         let c = cipher(0xA1);
         let id = EntryId::from("entry-1");
-        let env = c.seal(&id, 0, "file:///Users/mark/secret.pdf").unwrap();
+        let env = c
+            .seal_original_text(&id, 0, "file:///Users/mark/secret.pdf")
+            .unwrap();
         assert_eq!(&env[0..4], &FILE_SET_MAGIC);
         assert_eq!(env[4], FILE_SET_FORMAT_VERSION);
-        assert_eq!(c.open(&id, 0, &env).unwrap(), "file:///Users/mark/secret.pdf");
+        assert_eq!(
+            c.open_original_text(&id, 0, &env).unwrap(),
+            "file:///Users/mark/secret.pdf"
+        );
     }
 
     #[test]
@@ -135,7 +222,7 @@ mod tests {
         let c = cipher(0xB2);
         let id = EntryId::from("entry-1");
         let path = "file:///Users/mark/budget/salaries.xlsx";
-        let env = c.seal(&id, 0, path).unwrap();
+        let env = c.seal_original_text(&id, 0, path).unwrap();
         assert!(
             !env.windows(path.len()).any(|w| w == path.as_bytes()),
             "sealed envelope must not carry the plaintext path"
@@ -145,9 +232,12 @@ mod tests {
     #[test]
     fn wrong_entry_id_fails_aad() {
         let c = cipher(0xC3);
-        let env = c.seal(&EntryId::from("entry-a"), 0, "/tmp/a").unwrap();
+        let env = c
+            .seal_original_text(&EntryId::from("entry-a"), 0, "/tmp/a")
+            .unwrap();
         assert!(matches!(
-            c.open(&EntryId::from("entry-b"), 0, &env).unwrap_err(),
+            c.open_original_text(&EntryId::from("entry-b"), 0, &env)
+                .unwrap_err(),
             FileSetCipherError::DecryptFailed
         ));
     }
@@ -156,9 +246,63 @@ mod tests {
     fn wrong_line_index_fails_aad() {
         let c = cipher(0xC4);
         let id = EntryId::from("entry-1");
-        let env = c.seal(&id, 0, "/tmp/a").unwrap();
+        let env = c.seal_original_text(&id, 0, "/tmp/a").unwrap();
         assert!(matches!(
-            c.open(&id, 1, &env).unwrap_err(),
+            c.open_original_text(&id, 1, &env).unwrap_err(),
+            FileSetCipherError::DecryptFailed
+        ));
+    }
+
+    #[test]
+    fn column_ciphertext_cannot_be_opened_as_another_column_of_the_same_row() {
+        let c = cipher(0xC5);
+        let id = EntryId::from("entry-1");
+
+        let original_text_env = c.seal_original_text(&id, 0, "shared-plaintext").unwrap();
+        let relative_path_env = c.seal_relative_path(&id, 0, "shared-plaintext").unwrap();
+        let root_name_env = c.seal_root_name(&id, 0, "shared-plaintext").unwrap();
+
+        assert_eq!(
+            c.open_original_text(&id, 0, &original_text_env).unwrap(),
+            "shared-plaintext"
+        );
+        assert_eq!(
+            c.open_relative_path(&id, 0, &relative_path_env).unwrap(),
+            "shared-plaintext"
+        );
+        assert_eq!(
+            c.open_root_name(&id, 0, &root_name_env).unwrap(),
+            "shared-plaintext"
+        );
+
+        // Every cross-column open of a same-row envelope must fail: each
+        // column binds a distinct AAD suffix, so a ciphertext transplanted
+        // from one column to another cannot be decrypted even with the
+        // correct key, entry_id, and line_index.
+        assert!(matches!(
+            c.open_relative_path(&id, 0, &original_text_env)
+                .unwrap_err(),
+            FileSetCipherError::DecryptFailed
+        ));
+        assert!(matches!(
+            c.open_root_name(&id, 0, &original_text_env).unwrap_err(),
+            FileSetCipherError::DecryptFailed
+        ));
+        assert!(matches!(
+            c.open_original_text(&id, 0, &relative_path_env)
+                .unwrap_err(),
+            FileSetCipherError::DecryptFailed
+        ));
+        assert!(matches!(
+            c.open_root_name(&id, 0, &relative_path_env).unwrap_err(),
+            FileSetCipherError::DecryptFailed
+        ));
+        assert!(matches!(
+            c.open_original_text(&id, 0, &root_name_env).unwrap_err(),
+            FileSetCipherError::DecryptFailed
+        ));
+        assert!(matches!(
+            c.open_relative_path(&id, 0, &root_name_env).unwrap_err(),
             FileSetCipherError::DecryptFailed
         ));
     }
@@ -168,9 +312,9 @@ mod tests {
         let a = cipher(0x01);
         let b = cipher(0x02);
         let id = EntryId::from("entry-1");
-        let env = a.seal(&id, 0, "/tmp/a").unwrap();
+        let env = a.seal_original_text(&id, 0, "/tmp/a").unwrap();
         assert!(matches!(
-            b.open(&id, 0, &env).unwrap_err(),
+            b.open_original_text(&id, 0, &env).unwrap_err(),
             FileSetCipherError::DecryptFailed
         ));
     }
@@ -179,10 +323,10 @@ mod tests {
     fn bad_magic_rejected() {
         let c = cipher(0xD4);
         let id = EntryId::from("entry-1");
-        let mut env = c.seal(&id, 0, "/tmp/a").unwrap();
+        let mut env = c.seal_original_text(&id, 0, "/tmp/a").unwrap();
         env[0] ^= 0xFF;
         assert!(matches!(
-            c.open(&id, 0, &env).unwrap_err(),
+            c.open_original_text(&id, 0, &env).unwrap_err(),
             FileSetCipherError::BadMagic
         ));
     }
@@ -191,10 +335,10 @@ mod tests {
     fn unknown_version_rejected() {
         let c = cipher(0xE5);
         let id = EntryId::from("entry-1");
-        let mut env = c.seal(&id, 0, "/tmp/a").unwrap();
+        let mut env = c.seal_original_text(&id, 0, "/tmp/a").unwrap();
         env[4] = 0x02;
         assert!(matches!(
-            c.open(&id, 0, &env).unwrap_err(),
+            c.open_original_text(&id, 0, &env).unwrap_err(),
             FileSetCipherError::UnsupportedVersion(0x02)
         ));
     }
@@ -203,10 +347,10 @@ mod tests {
     fn truncated_rejected() {
         let c = cipher(0xF6);
         let id = EntryId::from("entry-1");
-        let env = c.seal(&id, 0, "/tmp/a").unwrap();
+        let env = c.seal_original_text(&id, 0, "/tmp/a").unwrap();
         let short = &env[0..HEADER_LEN - 1];
         assert!(matches!(
-            c.open(&id, 0, short).unwrap_err(),
+            c.open_original_text(&id, 0, short).unwrap_err(),
             FileSetCipherError::Truncated(_)
         ));
     }
@@ -215,11 +359,11 @@ mod tests {
     fn tampered_ciphertext_rejected() {
         let c = cipher(0x28);
         let id = EntryId::from("entry-1");
-        let mut env = c.seal(&id, 0, "/tmp/a").unwrap();
+        let mut env = c.seal_original_text(&id, 0, "/tmp/a").unwrap();
         let last = env.len() - 1;
         env[last] ^= 0x01;
         assert!(matches!(
-            c.open(&id, 0, &env).unwrap_err(),
+            c.open_original_text(&id, 0, &env).unwrap_err(),
             FileSetCipherError::DecryptFailed
         ));
     }

--- a/crates/uc-infra/src/db/repositories/entry_file_set_repo.rs
+++ b/crates/uc-infra/src/db/repositories/entry_file_set_repo.rs
@@ -308,7 +308,7 @@ where
                     // members (ADR-010 caps the set at ~2000), so a multi-row
                     // insert beats per-row round-trips. Chunk so a single
                     // statement stays well under SQLite's bound-parameter limit
-                    // (8 columns × CHUNK params); the whole loop is inside the
+                    // (12 columns × CHUNK params); the whole loop is inside the
                     // surrounding transaction, so it's still all-or-nothing.
                     for chunk in new_rows.chunks(ENTRY_FILE_SET_INSERT_CHUNK) {
                         diesel::insert_into(entry_file_set::table)

--- a/crates/uc-infra/src/db/repositories/entry_file_set_repo.rs
+++ b/crates/uc-infra/src/db/repositories/entry_file_set_repo.rs
@@ -32,8 +32,8 @@ use crate::db::models::entry_file_set::{EntryFileSetRow, NewEntryFileSetRow};
 use crate::db::ports::DbExecutor;
 use crate::db::schema::entry_file_set;
 
-/// Rows per multi-row INSERT statement. `NewEntryFileSetRow` binds 11 columns,
-/// so 80 rows = 880 bound params — safely under SQLite's historical
+/// Rows per multi-row INSERT statement. `NewEntryFileSetRow` binds 12 columns,
+/// so 80 rows = 960 bound params — safely under SQLite's historical
 /// 999-parameter-per-statement limit (older bundled builds), while still
 /// collapsing a ~2000-member insert into ~25 statements instead of 2000.
 const ENTRY_FILE_SET_INSERT_CHUNK: usize = 80;
@@ -137,20 +137,24 @@ fn encode_line(
     };
 
     let original_text_ct = cipher
-        .seal(entry_id, line.line_index, &line.original_text)
+        .seal_original_text(entry_id, line.line_index, &line.original_text)
         .map_err(|e| EntryFileSetError::Storage(format!("seal original_text: {e}")))?;
-    let (root_index, relative_path_ct, kind_tag) = match &line.member_location {
+    let (root_index, relative_path_ct, kind_tag, root_name_ct) = match &line.member_location {
         Some(location) => {
             let relative_path_ct = cipher
-                .seal(entry_id, line.line_index, &location.relative_path)
+                .seal_relative_path(entry_id, line.line_index, &location.relative_path)
                 .map_err(|e| EntryFileSetError::Storage(format!("seal relative_path: {e}")))?;
+            let root_name_ct = cipher
+                .seal_root_name(entry_id, line.line_index, &location.root_name)
+                .map_err(|e| EntryFileSetError::Storage(format!("seal root_name: {e}")))?;
             (
                 Some(location.root_index),
                 Some(relative_path_ct),
                 Some(location.kind.as_tag().to_string()),
+                Some(root_name_ct),
             )
         }
-        None => (None, None, None),
+        None => (None, None, None, None),
     };
 
     Ok(NewEntryFileSetRow {
@@ -165,6 +169,7 @@ fn encode_line(
         root_index,
         relative_path_ct,
         kind_tag,
+        root_name_ct,
     })
 }
 
@@ -177,19 +182,28 @@ fn decode_row(
         EntryFileSetError::Storage("file-set row missing sealed original_text".into())
     })?;
     let original_text = cipher
-        .open(entry_id, row.line_index, &original_text_ct)
+        .open_original_text(entry_id, row.line_index, &original_text_ct)
         .map_err(|e| EntryFileSetError::Storage(format!("open original_text: {e}")))?;
-    let member_location = match (row.root_index, row.relative_path_ct, row.kind_tag) {
-        (None, None, None) => None,
-        (Some(root_index), Some(relative_path_ct), Some(kind_tag)) => {
+    let member_location = match (
+        row.root_index,
+        row.relative_path_ct,
+        row.kind_tag,
+        row.root_name_ct,
+    ) {
+        (None, None, None, None) => None,
+        (Some(root_index), Some(relative_path_ct), Some(kind_tag), Some(root_name_ct)) => {
             let relative_path = cipher
-                .open(entry_id, row.line_index, &relative_path_ct)
+                .open_relative_path(entry_id, row.line_index, &relative_path_ct)
                 .map_err(|e| EntryFileSetError::Storage(format!("open relative_path: {e}")))?;
             let kind = FileSetMemberKind::from_tag(&kind_tag).ok_or_else(|| {
                 EntryFileSetError::Storage(format!("unknown member kind tag: {kind_tag}"))
             })?;
+            let root_name = cipher
+                .open_root_name(entry_id, row.line_index, &root_name_ct)
+                .map_err(|e| EntryFileSetError::Storage(format!("open root_name: {e}")))?;
             Some(FileSetMemberLocation {
                 root_index,
+                root_name,
                 relative_path,
                 kind,
             })
@@ -470,6 +484,7 @@ mod tests {
                     original_text: "file:///a.txt".into(),
                     member_location: Some(FileSetMemberLocation {
                         root_index: 0,
+                        root_name: "a.txt".into(),
                         relative_path: "a.txt".into(),
                         kind: FileSetMemberKind::File,
                     }),
@@ -501,6 +516,7 @@ mod tests {
                     original_text: "file:///root/run.sh".into(),
                     member_location: Some(FileSetMemberLocation {
                         root_index: 1,
+                        root_name: "root".into(),
                         relative_path: "run.sh".into(),
                         kind: FileSetMemberKind::Executable,
                     }),
@@ -518,6 +534,7 @@ mod tests {
                     original_text: "file:///root".into(),
                     member_location: Some(FileSetMemberLocation {
                         root_index: 1,
+                        root_name: "root".into(),
                         relative_path: "empty".into(),
                         kind: FileSetMemberKind::EmptyDirectory,
                     }),
@@ -528,6 +545,7 @@ mod tests {
                     original_text: "file:///root/link".into(),
                     member_location: Some(FileSetMemberLocation {
                         root_index: 1,
+                        root_name: "root".into(),
                         relative_path: "link".into(),
                         kind: FileSetMemberKind::File,
                     }),
@@ -673,6 +691,24 @@ mod tests {
             assert!(
                 !ct.windows(needle.len()).any(|window| window == needle),
                 "sealed relative_path must not carry plaintext path bytes"
+            );
+        }
+
+        let root_name_cts: Vec<Option<Vec<u8>>> = seed_exec
+            .run(move |conn| {
+                Ok(entry_file_set::table
+                    .filter(entry_file_set::entry_id.eq("entry-1"))
+                    .order(entry_file_set::line_index.asc())
+                    .select(entry_file_set::root_name_ct)
+                    .load::<Option<Vec<u8>>>(conn)?)
+            })
+            .unwrap();
+        let root_name = b"root";
+        for ct in root_name_cts.iter().flatten() {
+            assert!(
+                !ct.windows(root_name.len())
+                    .any(|window| window == root_name),
+                "sealed root_name must not carry plaintext path bytes"
             );
         }
     }

--- a/crates/uc-infra/src/db/repositories/entry_file_set_repo.rs
+++ b/crates/uc-infra/src/db/repositories/entry_file_set_repo.rs
@@ -9,9 +9,9 @@
 
 use std::sync::Arc;
 
-use diesel::query_dsl::methods::{FilterDsl, OrderDsl};
 #[cfg(test)]
 use diesel::query_dsl::methods::SelectDsl;
+use diesel::query_dsl::methods::{FilterDsl, OrderDsl};
 use diesel::Connection;
 use diesel::ExpressionMethods;
 use diesel::RunQueryDsl;
@@ -20,7 +20,7 @@ use async_trait::async_trait;
 use tracing::instrument;
 use uc_core::clipboard::{
     ContentHash, EntryFileSet, EntryFileSetError, EntryFileSetExcludeReason, EntryFileSetLine,
-    EntryFileSetLineKind,
+    EntryFileSetLineKind, FileSetMemberKind, FileSetMemberLocation,
 };
 use uc_core::ids::{BlobId, EntryId};
 use uc_core::ports::clipboard::EntryFileSetRepositoryPort;
@@ -72,11 +72,10 @@ impl<E> DieselEntryFileSetRepository<E> {
     /// unlocked, and the dispatch reader treats a load error as "no manifest"
     /// and falls back to snapshot re-parse.
     async fn cipher(&self) -> Result<EntryFileSetPathCipher, EntryFileSetError> {
-        let profile = self
-            .current_profile
-            .current_profile()
-            .await
-            .map_err(|e| EntryFileSetError::Storage(format!("current profile unavailable: {e}")))?;
+        let profile =
+            self.current_profile.current_profile().await.map_err(|e| {
+                EntryFileSetError::Storage(format!("current profile unavailable: {e}"))
+            })?;
         let key = self
             .derive_subkey
             .derive_subkey(profile.as_ref().as_bytes(), FILE_SET_KEY_INFO)
@@ -102,6 +101,7 @@ mod kind_codec {
 mod exclude_reason_codec {
     pub const SIZE_CAP_EXCEEDED: &str = "size_cap_exceeded";
     pub const INGEST_FAILED: &str = "ingest_failed";
+    pub const UNSUPPORTED_MEMBER: &str = "unsupported_member";
 }
 
 fn encode_line(
@@ -128,6 +128,9 @@ fn encode_line(
                     exclude_reason_codec::SIZE_CAP_EXCEEDED
                 }
                 EntryFileSetExcludeReason::IngestFailed => exclude_reason_codec::INGEST_FAILED,
+                EntryFileSetExcludeReason::UnsupportedMember => {
+                    exclude_reason_codec::UNSUPPORTED_MEMBER
+                }
             };
             (kind_codec::EXCLUDED, None, None, None, Some(reason_str))
         }
@@ -136,6 +139,19 @@ fn encode_line(
     let original_text_ct = cipher
         .seal(entry_id, line.line_index, &line.original_text)
         .map_err(|e| EntryFileSetError::Storage(format!("seal original_text: {e}")))?;
+    let (root_index, relative_path_ct, kind_tag) = match &line.member_location {
+        Some(location) => {
+            let relative_path_ct = cipher
+                .seal(entry_id, line.line_index, &location.relative_path)
+                .map_err(|e| EntryFileSetError::Storage(format!("seal relative_path: {e}")))?;
+            (
+                Some(location.root_index),
+                Some(relative_path_ct),
+                Some(location.kind.as_tag().to_string()),
+            )
+        }
+        None => (None, None, None),
+    };
 
     Ok(NewEntryFileSetRow {
         entry_id: entry_id.to_string(),
@@ -146,11 +162,9 @@ fn encode_line(
         blob_id,
         size_bytes,
         exclude_reason: exclude_reason.map(str::to_string),
-        // Directory-member location columns are unwritten in this PR (ADR-010
-        // phase 3 PR-A opens the schema; directory capture populates them later).
-        root_index: None,
-        relative_path_ct: None,
-        kind_tag: None,
+        root_index,
+        relative_path_ct,
+        kind_tag,
     })
 }
 
@@ -165,6 +179,27 @@ fn decode_row(
     let original_text = cipher
         .open(entry_id, row.line_index, &original_text_ct)
         .map_err(|e| EntryFileSetError::Storage(format!("open original_text: {e}")))?;
+    let member_location = match (row.root_index, row.relative_path_ct, row.kind_tag) {
+        (None, None, None) => None,
+        (Some(root_index), Some(relative_path_ct), Some(kind_tag)) => {
+            let relative_path = cipher
+                .open(entry_id, row.line_index, &relative_path_ct)
+                .map_err(|e| EntryFileSetError::Storage(format!("open relative_path: {e}")))?;
+            let kind = FileSetMemberKind::from_tag(&kind_tag).ok_or_else(|| {
+                EntryFileSetError::Storage(format!("unknown member kind tag: {kind_tag}"))
+            })?;
+            Some(FileSetMemberLocation {
+                root_index,
+                relative_path,
+                kind,
+            })
+        }
+        _ => {
+            return Err(EntryFileSetError::Storage(
+                "file-set row has incomplete member location".into(),
+            ))
+        }
+    };
 
     let kind = match row.kind.as_str() {
         kind_codec::FILE => {
@@ -187,6 +222,9 @@ fn decode_row(
                     EntryFileSetExcludeReason::SizeCapExceeded
                 }
                 exclude_reason_codec::INGEST_FAILED => EntryFileSetExcludeReason::IngestFailed,
+                exclude_reason_codec::UNSUPPORTED_MEMBER => {
+                    EntryFileSetExcludeReason::UnsupportedMember
+                }
                 other => {
                     return Err(EntryFileSetError::Storage(format!(
                         "unknown exclude_reason code: {other}"
@@ -205,6 +243,7 @@ fn decode_row(
     Ok(EntryFileSetLine {
         line_index: row.line_index,
         original_text,
+        member_location,
         kind,
     })
 }
@@ -429,6 +468,11 @@ mod tests {
                 EntryFileSetLine {
                     line_index: 0,
                     original_text: "file:///a.txt".into(),
+                    member_location: Some(FileSetMemberLocation {
+                        root_index: 0,
+                        relative_path: "a.txt".into(),
+                        kind: FileSetMemberKind::File,
+                    }),
                     kind: EntryFileSetLineKind::File {
                         content_hash: ContentHash {
                             alg: HashAlgorithm::Blake3V1,
@@ -441,13 +485,54 @@ mod tests {
                 EntryFileSetLine {
                     line_index: 1,
                     original_text: "# comment".into(),
+                    member_location: None,
                     kind: EntryFileSetLineKind::NonFile,
                 },
                 EntryFileSetLine {
                     line_index: 2,
                     original_text: "file:///too-big.bin".into(),
+                    member_location: None,
                     kind: EntryFileSetLineKind::Excluded {
                         reason: EntryFileSetExcludeReason::SizeCapExceeded,
+                    },
+                },
+                EntryFileSetLine {
+                    line_index: 3,
+                    original_text: "file:///root/run.sh".into(),
+                    member_location: Some(FileSetMemberLocation {
+                        root_index: 1,
+                        relative_path: "run.sh".into(),
+                        kind: FileSetMemberKind::Executable,
+                    }),
+                    kind: EntryFileSetLineKind::File {
+                        content_hash: ContentHash {
+                            alg: HashAlgorithm::Blake3V1,
+                            bytes: [2u8; 32],
+                        },
+                        blob_id: None,
+                        size_bytes: Some(20),
+                    },
+                },
+                EntryFileSetLine {
+                    line_index: 4,
+                    original_text: "file:///root".into(),
+                    member_location: Some(FileSetMemberLocation {
+                        root_index: 1,
+                        relative_path: "empty".into(),
+                        kind: FileSetMemberKind::EmptyDirectory,
+                    }),
+                    kind: EntryFileSetLineKind::NonFile,
+                },
+                EntryFileSetLine {
+                    line_index: 5,
+                    original_text: "file:///root/link".into(),
+                    member_location: Some(FileSetMemberLocation {
+                        root_index: 1,
+                        relative_path: "link".into(),
+                        kind: FileSetMemberKind::File,
+                    }),
+                    kind: EntryFileSetLineKind::Excluded {
+                        reason: EntryFileSetExcludeReason::UnsupportedMember,
                     },
                 },
             ],
@@ -485,6 +570,7 @@ mod tests {
             lines: vec![EntryFileSetLine {
                 line_index: 0,
                 original_text: "file:///only.txt".into(),
+                member_location: None,
                 kind: EntryFileSetLineKind::File {
                     content_hash: ContentHash {
                         alg: HashAlgorithm::Blake3V1,
@@ -528,6 +614,7 @@ mod tests {
                 .map(|idx| EntryFileSetLine {
                     line_index: idx,
                     original_text: format!("file:///f{idx}.txt"),
+                    member_location: None,
                     kind: EntryFileSetLineKind::File {
                         content_hash: ContentHash {
                             alg: HashAlgorithm::Blake3V1,
@@ -572,6 +659,22 @@ mod tests {
                 "sealed original_text must not carry plaintext path bytes"
             );
         }
+
+        let relative_cts: Vec<Option<Vec<u8>>> = seed_exec
+            .run(move |conn| {
+                Ok(entry_file_set::table
+                    .filter(entry_file_set::entry_id.eq("entry-1"))
+                    .order(entry_file_set::line_index.asc())
+                    .select(entry_file_set::relative_path_ct)
+                    .load::<Option<Vec<u8>>>(conn)?)
+            })
+            .unwrap();
+        for ct in relative_cts.iter().flatten() {
+            assert!(
+                !ct.windows(needle.len()).any(|window| window == needle),
+                "sealed relative_path must not carry plaintext path bytes"
+            );
+        }
     }
 
     #[tokio::test]
@@ -591,7 +694,9 @@ mod tests {
     async fn save_fails_when_session_locked() {
         let (repo, seed_exec, _tempdir) = make_repo_with_subkey(Arc::new(LockedSubkey));
         seed_entry(&seed_exec, "entry-1");
-        let result = repo.save(&EntryId::from("entry-1"), &sample_file_set()).await;
+        let result = repo
+            .save(&EntryId::from("entry-1"), &sample_file_set())
+            .await;
         assert!(
             matches!(result, Err(EntryFileSetError::Storage(_))),
             "locked session must surface a Storage error, got {result:?}"

--- a/crates/uc-infra/src/db/repositories/entry_file_set_repo.rs
+++ b/crates/uc-infra/src/db/repositories/entry_file_set_repo.rs
@@ -7,7 +7,11 @@
 //! CASCADE)。本文件把 wire 中性的 kind/排除原因枚举与 SQL 字符串做双向
 //! 映射,保持表结构稳定。
 
+use std::sync::Arc;
+
 use diesel::query_dsl::methods::{FilterDsl, OrderDsl};
+#[cfg(test)]
+use diesel::query_dsl::methods::SelectDsl;
 use diesel::Connection;
 use diesel::ExpressionMethods;
 use diesel::RunQueryDsl;
@@ -20,24 +24,70 @@ use uc_core::clipboard::{
 };
 use uc_core::ids::{BlobId, EntryId};
 use uc_core::ports::clipboard::EntryFileSetRepositoryPort;
+use uc_core::ports::security::current_profile::CurrentProfilePort;
+use uc_core::ports::space::{DeriveSpaceSubkeyPort, SpaceAccessError};
 
+use super::entry_file_set_cipher::EntryFileSetPathCipher;
 use crate::db::models::entry_file_set::{EntryFileSetRow, NewEntryFileSetRow};
 use crate::db::ports::DbExecutor;
 use crate::db::schema::entry_file_set;
 
-/// Rows per multi-row INSERT statement. `NewEntryFileSetRow` binds 8 columns,
-/// so 100 rows = 800 bound params — safely under SQLite's historical
+/// Rows per multi-row INSERT statement. `NewEntryFileSetRow` binds 11 columns,
+/// so 80 rows = 880 bound params — safely under SQLite's historical
 /// 999-parameter-per-statement limit (older bundled builds), while still
-/// collapsing a ~2000-member insert into ~20 statements instead of 2000.
-const ENTRY_FILE_SET_INSERT_CHUNK: usize = 100;
+/// collapsing a ~2000-member insert into ~25 statements instead of 2000.
+const ENTRY_FILE_SET_INSERT_CHUNK: usize = 80;
+
+/// HKDF `info` label for the entry-file-set path-column AEAD subkey. Distinct
+/// from every other subkey label so this key never doubles for another purpose.
+const FILE_SET_KEY_INFO: &[u8] = b"uniclipboard-file-set/v1";
 
 pub struct DieselEntryFileSetRepository<E> {
     executor: E,
+    /// Derives the per-session subkey that seals the path columns. Held rather
+    /// than a fixed key so a lock/unlock or profile switch always re-derives.
+    derive_subkey: Arc<dyn DeriveSpaceSubkeyPort>,
+    /// Salts the subkey by the active profile (defense-in-depth alongside the
+    /// per-profile database file).
+    current_profile: Arc<dyn CurrentProfilePort>,
 }
 
 impl<E> DieselEntryFileSetRepository<E> {
-    pub fn new(executor: E) -> Self {
-        Self { executor }
+    pub fn new(
+        executor: E,
+        derive_subkey: Arc<dyn DeriveSpaceSubkeyPort>,
+        current_profile: Arc<dyn CurrentProfilePort>,
+    ) -> Self {
+        Self {
+            executor,
+            derive_subkey,
+            current_profile,
+        }
+    }
+
+    /// Derive the path-column cipher for the currently unlocked session.
+    ///
+    /// Returns `EntryFileSetError::Storage` when the session is locked or the
+    /// profile is unavailable — the manifest is only read/written while
+    /// unlocked, and the dispatch reader treats a load error as "no manifest"
+    /// and falls back to snapshot re-parse.
+    async fn cipher(&self) -> Result<EntryFileSetPathCipher, EntryFileSetError> {
+        let profile = self
+            .current_profile
+            .current_profile()
+            .await
+            .map_err(|e| EntryFileSetError::Storage(format!("current profile unavailable: {e}")))?;
+        let key = self
+            .derive_subkey
+            .derive_subkey(profile.as_ref().as_bytes(), FILE_SET_KEY_INFO)
+            .await
+            .map_err(|e| match e {
+                SpaceAccessError::NotUnlocked => {
+                    EntryFileSetError::Storage("session locked: cannot derive file-set key".into())
+                }
+                other => EntryFileSetError::Storage(format!("derive file-set key: {other}")),
+            })?;
+        Ok(EntryFileSetPathCipher::new(key))
     }
 }
 
@@ -54,7 +104,11 @@ mod exclude_reason_codec {
     pub const INGEST_FAILED: &str = "ingest_failed";
 }
 
-fn encode_line(entry_id: &str, line: &EntryFileSetLine) -> NewEntryFileSetRow {
+fn encode_line(
+    cipher: &EntryFileSetPathCipher,
+    entry_id: &EntryId,
+    line: &EntryFileSetLine,
+) -> Result<NewEntryFileSetRow, EntryFileSetError> {
     let (kind, content_hash, blob_id, size_bytes, exclude_reason) = match &line.kind {
         EntryFileSetLineKind::File {
             content_hash,
@@ -79,19 +133,39 @@ fn encode_line(entry_id: &str, line: &EntryFileSetLine) -> NewEntryFileSetRow {
         }
     };
 
-    NewEntryFileSetRow {
+    let original_text_ct = cipher
+        .seal(entry_id, line.line_index, &line.original_text)
+        .map_err(|e| EntryFileSetError::Storage(format!("seal original_text: {e}")))?;
+
+    Ok(NewEntryFileSetRow {
         entry_id: entry_id.to_string(),
         line_index: line.line_index,
-        original_text: line.original_text.clone(),
+        original_text_ct: Some(original_text_ct),
         kind: kind.to_string(),
         content_hash,
         blob_id,
         size_bytes,
         exclude_reason: exclude_reason.map(str::to_string),
-    }
+        // Directory-member location columns are unwritten in this PR (ADR-010
+        // phase 3 PR-A opens the schema; directory capture populates them later).
+        root_index: None,
+        relative_path_ct: None,
+        kind_tag: None,
+    })
 }
 
-fn decode_row(row: EntryFileSetRow) -> Result<EntryFileSetLine, EntryFileSetError> {
+fn decode_row(
+    cipher: &EntryFileSetPathCipher,
+    entry_id: &EntryId,
+    row: EntryFileSetRow,
+) -> Result<EntryFileSetLine, EntryFileSetError> {
+    let original_text_ct = row.original_text_ct.ok_or_else(|| {
+        EntryFileSetError::Storage("file-set row missing sealed original_text".into())
+    })?;
+    let original_text = cipher
+        .open(entry_id, row.line_index, &original_text_ct)
+        .map_err(|e| EntryFileSetError::Storage(format!("open original_text: {e}")))?;
+
     let kind = match row.kind.as_str() {
         kind_codec::FILE => {
             let content_hash = row.content_hash.ok_or_else(|| {
@@ -130,7 +204,7 @@ fn decode_row(row: EntryFileSetRow) -> Result<EntryFileSetLine, EntryFileSetErro
 
     Ok(EntryFileSetLine {
         line_index: row.line_index,
-        original_text: row.original_text,
+        original_text,
         kind,
     })
 }
@@ -155,13 +229,20 @@ where
         entry_id: &EntryId,
         file_set: &EntryFileSet,
     ) -> Result<(), EntryFileSetError> {
-        let entry_id_str = entry_id.to_string();
-        let new_rows: Vec<NewEntryFileSetRow> = file_set
-            .lines
-            .iter()
-            .map(|line| encode_line(&entry_id_str, line))
-            .collect();
+        // An empty manifest is a pure DELETE, so it needs no key — deriving one
+        // would fail an otherwise-valid replace when the session is locked.
+        let new_rows: Vec<NewEntryFileSetRow> = if file_set.lines.is_empty() {
+            Vec::new()
+        } else {
+            let cipher = self.cipher().await?;
+            file_set
+                .lines
+                .iter()
+                .map(|line| encode_line(&cipher, entry_id, line))
+                .collect::<Result<Vec<_>, _>>()?
+        };
 
+        let entry_id_str = entry_id.to_string();
         let entry_id_for_err = entry_id_str.clone();
         self.executor
             .run(move |conn| {
@@ -214,9 +295,10 @@ where
             return Ok(None);
         }
 
+        let cipher = self.cipher().await?;
         let lines = rows
             .into_iter()
-            .map(decode_row)
+            .map(|row| decode_row(&cipher, entry_id, row))
             .collect::<Result<Vec<_>, _>>()?;
         Ok(Some(EntryFileSet { lines }))
     }
@@ -249,16 +331,63 @@ mod tests {
     use crate::db::schema::{clipboard_entry, clipboard_event};
     use tempfile::{tempdir, TempDir};
     use uc_core::clipboard::HashAlgorithm;
+    use uc_core::ids::ProfileId;
+    use uc_core::ports::security::current_profile::CurrentProfileError;
 
     type Repo = DieselEntryFileSetRepository<DieselSqliteExecutor>;
 
+    /// Fixed-key subkey derivation: returns a constant regardless of salt/info,
+    /// so the repo round-trips deterministically without a real unlocked session.
+    struct FixedSubkey([u8; 32]);
+    #[async_trait]
+    impl DeriveSpaceSubkeyPort for FixedSubkey {
+        async fn derive_subkey(
+            &self,
+            _salt: &[u8],
+            _info: &[u8],
+        ) -> Result<[u8; 32], SpaceAccessError> {
+            Ok(self.0)
+        }
+    }
+
+    /// Subkey derivation that always reports a locked session.
+    struct LockedSubkey;
+    #[async_trait]
+    impl DeriveSpaceSubkeyPort for LockedSubkey {
+        async fn derive_subkey(
+            &self,
+            _salt: &[u8],
+            _info: &[u8],
+        ) -> Result<[u8; 32], SpaceAccessError> {
+            Err(SpaceAccessError::NotUnlocked)
+        }
+    }
+
+    struct FixedProfile;
+    #[async_trait]
+    impl CurrentProfilePort for FixedProfile {
+        async fn current_profile(&self) -> Result<ProfileId, CurrentProfileError> {
+            Ok(ProfileId::from("default"))
+        }
+    }
+
     fn make_repo() -> (Repo, DieselSqliteExecutor, TempDir) {
+        make_repo_with_subkey(Arc::new(FixedSubkey([7u8; 32])))
+    }
+
+    fn make_repo_with_subkey(
+        derive_subkey: Arc<dyn DeriveSpaceSubkeyPort>,
+    ) -> (Repo, DieselSqliteExecutor, TempDir) {
         let tempdir = tempdir().unwrap();
         let path = tempdir.path().join("file-set-repo.sqlite");
         let path_str = path.to_str().unwrap();
         let pool_for_repo = init_db_pool(path_str).unwrap();
         let pool_for_seed = init_db_pool(path_str).unwrap();
-        let repo = DieselEntryFileSetRepository::new(DieselSqliteExecutor::new(pool_for_repo));
+        let repo = DieselEntryFileSetRepository::new(
+            DieselSqliteExecutor::new(pool_for_repo),
+            derive_subkey,
+            Arc::new(FixedProfile),
+        );
         (repo, DieselSqliteExecutor::new(pool_for_seed), tempdir)
     }
 
@@ -414,6 +543,81 @@ mod tests {
         repo.save(&entry_id, &big).await.unwrap();
         let loaded = repo.load(&entry_id).await.unwrap().expect("should exist");
         assert_eq!(loaded, big, "跨 insert chunk 边界应完整、保序地回读");
+    }
+
+    #[tokio::test]
+    async fn sealed_path_column_is_not_plaintext_on_disk() {
+        let (repo, seed_exec, _tempdir) = make_repo();
+        seed_entry(&seed_exec, "entry-1");
+        let entry_id = EntryId::from("entry-1");
+        repo.save(&entry_id, &sample_file_set()).await.unwrap();
+
+        // Read the raw sealed column back out and assert the device-local path
+        // never appears as plaintext bytes on disk.
+        let cts: Vec<Option<Vec<u8>>> = seed_exec
+            .run(move |conn| {
+                Ok(entry_file_set::table
+                    .filter(entry_file_set::entry_id.eq("entry-1"))
+                    .order(entry_file_set::line_index.asc())
+                    .select(entry_file_set::original_text_ct)
+                    .load::<Option<Vec<u8>>>(conn)?)
+            })
+            .unwrap();
+
+        let needle = b"a.txt";
+        for ct in &cts {
+            let bytes = ct.as_ref().expect("sealed column must be present");
+            assert!(
+                !bytes.windows(needle.len()).any(|w| w == needle),
+                "sealed original_text must not carry plaintext path bytes"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn empty_manifest_save_succeeds_even_when_locked() {
+        // An empty manifest is a pure DELETE and needs no key, so it must not be
+        // blocked by a locked session (no path bytes to seal).
+        let (repo, seed_exec, _tempdir) = make_repo_with_subkey(Arc::new(LockedSubkey));
+        seed_entry(&seed_exec, "entry-1");
+        let entry_id = EntryId::from("entry-1");
+        repo.save(&entry_id, &EntryFileSet { lines: vec![] })
+            .await
+            .expect("empty manifest save must not require a key");
+        assert!(repo.load(&entry_id).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn save_fails_when_session_locked() {
+        let (repo, seed_exec, _tempdir) = make_repo_with_subkey(Arc::new(LockedSubkey));
+        seed_entry(&seed_exec, "entry-1");
+        let result = repo.save(&EntryId::from("entry-1"), &sample_file_set()).await;
+        assert!(
+            matches!(result, Err(EntryFileSetError::Storage(_))),
+            "locked session must surface a Storage error, got {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn load_fails_when_session_locked() {
+        // Seed a row with a working key, then attempt to read it with a locked
+        // session — the load must error rather than return garbage.
+        let (repo, seed_exec, tempdir) = make_repo();
+        seed_entry(&seed_exec, "entry-1");
+        let entry_id = EntryId::from("entry-1");
+        repo.save(&entry_id, &sample_file_set()).await.unwrap();
+
+        let path = tempdir.path().join("file-set-repo.sqlite");
+        let locked_repo = DieselEntryFileSetRepository::new(
+            DieselSqliteExecutor::new(init_db_pool(path.to_str().unwrap()).unwrap()),
+            Arc::new(LockedSubkey),
+            Arc::new(FixedProfile),
+        );
+        let result = locked_repo.load(&entry_id).await;
+        assert!(
+            matches!(result, Err(EntryFileSetError::Storage(_))),
+            "locked session must surface a Storage error on load, got {result:?}"
+        );
     }
 
     #[tokio::test]

--- a/crates/uc-infra/src/db/repositories/mod.rs
+++ b/crates/uc-infra/src/db/repositories/mod.rs
@@ -6,6 +6,7 @@ mod clipboard_event_repo;
 mod clipboard_selection_repo;
 mod entry_availability_repo;
 mod entry_delivery_repo;
+mod entry_file_set_cipher;
 mod entry_file_set_repo;
 mod entry_replace_repo;
 mod file_transfer_repo;

--- a/crates/uc-infra/src/db/schema.rs
+++ b/crates/uc-infra/src/db/schema.rs
@@ -96,12 +96,15 @@ diesel::table! {
     entry_file_set (entry_id, line_index) {
         entry_id -> Text,
         line_index -> BigInt,
-        original_text -> Text,
         kind -> Text,
         content_hash -> Nullable<Text>,
         blob_id -> Nullable<Text>,
         size_bytes -> Nullable<BigInt>,
         exclude_reason -> Nullable<Text>,
+        original_text_ct -> Nullable<Binary>,
+        root_index -> Nullable<BigInt>,
+        relative_path_ct -> Nullable<Binary>,
+        kind_tag -> Nullable<Text>,
     }
 }
 

--- a/crates/uc-infra/src/db/schema.rs
+++ b/crates/uc-infra/src/db/schema.rs
@@ -105,6 +105,7 @@ diesel::table! {
         root_index -> Nullable<BigInt>,
         relative_path_ct -> Nullable<Binary>,
         kind_tag -> Nullable<Text>,
+        root_name_ct -> Nullable<Binary>,
     }
 }
 

--- a/crates/uc-infra/src/search/sqlite_index.rs
+++ b/crates/uc-infra/src/search/sqlite_index.rs
@@ -2471,26 +2471,36 @@ mod tests {
         );
     }
 
-    /// The render-column encryption migration is intentionally irreversible: its
-    /// `down.sql` fails rather than recreate empty plaintext columns (which would
-    /// silently lose the encrypted render data).
+    /// Encryption/sealing migrations (render-column encryption, entry-file-set
+    /// path encryption, …) are intentionally irreversible: their `down.sql`
+    /// fails loudly rather than recreate empty plaintext columns and silently
+    /// drop the sealed data. Unwinding migrations from the top must therefore
+    /// hit at least one such refusal before reaching the base. Reverting one at
+    /// a time (instead of hard-coding a fixed migration on top) keeps this
+    /// robust as new migrations — reversible or not — land above them.
     #[tokio::test]
-    async fn encrypt_render_migration_down_is_irreversible() {
+    async fn encryption_migration_downs_are_irreversible() {
         use crate::db::pool::MIGRATIONS;
         use diesel_migrations::MigrationHarness;
 
         let (_index, pool, _dir) = make_index();
         let mut conn = pool.get().unwrap();
-        // The later `drop_clipboard_entry_title` migration sits on top of the
-        // render-column encryption one and is intentionally reversible (it re-adds
-        // an empty `title` column so an older binary still finds it). Revert it
-        // first to expose the encryption migration underneath.
-        conn.revert_last_migration(MIGRATIONS)
-            .expect("drop-title migration is reversible");
-        let result = conn.revert_last_migration(MIGRATIONS);
+        // Bound the unwind by the number of applied migrations so a failing
+        // revert can only mean "this migration's down.sql refused" — never "no
+        // migrations left" (which also errors). Reversible migrations on top
+        // unwind cleanly; the first irreversible encryption migration's down.sql
+        // fails, which is the behavior under test.
+        let applied = conn.applied_migrations().expect("list applied migrations");
+        let mut hit_irreversible = false;
+        for _ in 0..applied.len() {
+            if conn.revert_last_migration(MIGRATIONS).is_err() {
+                hit_irreversible = true;
+                break;
+            }
+        }
         assert!(
-            result.is_err(),
-            "down.sql must fail loudly; encryption migration is irreversible"
+            hit_irreversible,
+            "an encryption migration down must fail loudly (irreversible)"
         );
     }
 

--- a/crates/uc-platform/examples/wayland_clipboard_test.rs
+++ b/crates/uc-platform/examples/wayland_clipboard_test.rs
@@ -55,6 +55,7 @@ fn main() -> anyhow::Result<()> {
             payload.clone().into_bytes(),
         )],
         file_content_digests: Vec::new(),
+        file_set_v1_component: None,
     };
     eprintln!("[1/3] writing via WaylandClipboard: {payload:?}");
     clipboard.write_snapshot(write_snap)?;

--- a/crates/uc-platform/examples/x11_clipboard_test.rs
+++ b/crates/uc-platform/examples/x11_clipboard_test.rs
@@ -56,6 +56,7 @@ fn main() -> anyhow::Result<()> {
             payload.clone().into_bytes(),
         )],
         file_content_digests: Vec::new(),
+        file_set_v1_component: None,
     };
     eprintln!("[1/3] writing via X11Clipboard: {payload:?}");
     clipboard.write_snapshot(write_snap)?;

--- a/crates/uc-platform/src/clipboard/common.rs
+++ b/crates/uc-platform/src/clipboard/common.rs
@@ -752,6 +752,7 @@ impl CommonClipboardImpl {
                 ts_ms: chrono::Utc::now().timestamp_millis(),
                 representations: reps,
                 file_content_digests: Vec::new(),
+                file_set_v1_component: None,
             },
             had_unreadable_format,
         ))
@@ -1030,6 +1031,7 @@ impl CommonClipboardImpl {
                 ts_ms,
                 representations: vec![chosen],
                 file_content_digests: Vec::new(),
+                file_set_v1_component: None,
             };
             return Self::write_snapshot(ctx, reduced);
         }

--- a/crates/uc-platform/src/clipboard/noop.rs
+++ b/crates/uc-platform/src/clipboard/noop.rs
@@ -28,6 +28,7 @@ impl SystemClipboardPort for NoopSystemClipboard {
             ts_ms: 0,
             representations: Vec::new(),
             file_content_digests: Vec::new(),
+            file_set_v1_component: None,
         })
     }
 

--- a/crates/uc-platform/src/clipboard/platform/linux/wayland/protocol/ext.rs
+++ b/crates/uc-platform/src/clipboard/platform/linux/wayland/protocol/ext.rs
@@ -636,6 +636,7 @@ fn empty_snapshot() -> SystemClipboardSnapshot {
         ts_ms: chrono::Utc::now().timestamp_millis(),
         representations: Vec::new(),
         file_content_digests: Vec::new(),
+        file_set_v1_component: None,
     }
 }
 

--- a/crates/uc-platform/src/clipboard/platform/linux/wayland/protocol/wlr.rs
+++ b/crates/uc-platform/src/clipboard/platform/linux/wayland/protocol/wlr.rs
@@ -648,6 +648,7 @@ fn empty_snapshot() -> SystemClipboardSnapshot {
         ts_ms: chrono::Utc::now().timestamp_millis(),
         representations: Vec::new(),
         file_content_digests: Vec::new(),
+        file_set_v1_component: None,
     }
 }
 

--- a/crates/uc-platform/src/clipboard/platform/linux/wayland/snapshot.rs
+++ b/crates/uc-platform/src/clipboard/platform/linux/wayland/snapshot.rs
@@ -110,5 +110,6 @@ pub(super) fn build_from_offer<O: OfferLike>(
         ts_ms: chrono::Utc::now().timestamp_millis(),
         representations: reps,
         file_content_digests: Vec::new(),
+        file_set_v1_component: None,
     })
 }

--- a/crates/uc-platform/src/clipboard/platform/linux/x11/reader.rs
+++ b/crates/uc-platform/src/clipboard/platform/linux/x11/reader.rs
@@ -189,6 +189,7 @@ pub(super) fn read_snapshot(
         ts_ms: chrono::Utc::now().timestamp_millis(),
         representations: reps,
         file_content_digests: Vec::new(),
+        file_set_v1_component: None,
     })
 }
 
@@ -197,6 +198,7 @@ fn empty_snapshot() -> SystemClipboardSnapshot {
         ts_ms: chrono::Utc::now().timestamp_millis(),
         representations: Vec::new(),
         file_content_digests: Vec::new(),
+        file_set_v1_component: None,
     }
 }
 

--- a/crates/uc-platform/src/clipboard/watcher.rs
+++ b/crates/uc-platform/src/clipboard/watcher.rs
@@ -499,6 +499,7 @@ mod tests {
                 ts_ms: 0,
                 representations: vec![],
                 file_content_digests: Vec::new(),
+                file_set_v1_component: None,
             })
         }
         fn write_snapshot(&self, _snapshot: SystemClipboardSnapshot) -> anyhow::Result<()> {
@@ -526,6 +527,7 @@ mod tests {
             ts_ms: 0,
             representations: vec![rep],
             file_content_digests: Vec::new(),
+            file_set_v1_component: None,
         }
     }
 
@@ -555,6 +557,7 @@ mod tests {
             ts_ms: 0,
             representations: vec![primary, secondary],
             file_content_digests: Vec::new(),
+            file_set_v1_component: None,
         }
     }
 
@@ -571,6 +574,7 @@ mod tests {
             ts_ms: 0,
             representations: vec![rep],
             file_content_digests: Vec::new(),
+            file_set_v1_component: None,
         }
     }
 
@@ -611,6 +615,7 @@ mod tests {
             ts_ms: 0,
             representations: vec![rep],
             file_content_digests: Vec::new(),
+            file_set_v1_component: None,
         }
     }
 

--- a/crates/uc-webserver/src/api/clipboard.rs
+++ b/crates/uc-webserver/src/api/clipboard.rs
@@ -381,6 +381,7 @@ async fn dispatch_text(
             req.text.into_bytes(),
         )],
         file_content_digests: Vec::new(),
+        file_set_v1_component: None,
     };
 
     let outcome = app

--- a/crates/uc-webserver/src/api/projection/settings.rs
+++ b/crates/uc-webserver/src/api/projection/settings.rs
@@ -85,6 +85,10 @@ impl IntoDomain<app_settings::SettingsPatch> for SettingsPatchDto {
                     file_retention_hours: file_sync.file_retention_hours,
                     file_auto_cleanup: file_sync.file_auto_cleanup,
                     auto_save_dir: file_sync.auto_save_dir,
+                    // File-set cap overrides are diagnostic-only for now and
+                    // are not part of the public daemon settings contract.
+                    max_file_set_total_bytes: None,
+                    max_file_set_member_count: None,
                 }),
             network: self
                 .network

--- a/docs-site/content/docs/en/cli/reference.mdx
+++ b/docs-site/content/docs/en/cli/reference.mdx
@@ -248,6 +248,12 @@ The following commands exist but are deliberately hidden from
   switch-space data-integrity tests.
 - `uniclip dev dump-clipboard --limit <N>` — debug printing of decrypted
   history.
+- `uniclip dev capture-files --path <PATH>` — captures one or more files
+  or directories through the real local-capture pipeline and prints the
+  persisted file-set manifest. Repeat `--path` for mixed selections.
+  `--max-members` and `--max-bytes` temporarily override the file-set
+  caps for this capture only; the override is not written back to the
+  profile's settings.
 - `uniclip dev pairing ...` — pairing-invitation diagnostics: `addrs`
   lists candidate addresses after the product filter has run, and
   `issue --addr <IP>` issues an invitation constrained to one local

--- a/docs-site/content/docs/zh/cli/reference.mdx
+++ b/docs-site/content/docs/zh/cli/reference.mdx
@@ -212,6 +212,7 @@ uniclip upgrade ack        # 把游标推进到当前构建版本
   CLI 中 **唯一** 写系统剪贴板的入口（仅限 `probe restore`），仅供开发与 E2E 调试。
 - `uniclip dev seed-clipboard --text <TEXT>` —— switch-space 数据完整性测试用的种子写入。
 - `uniclip dev dump-clipboard --limit <N>` —— 调试用，打印解密后的历史。
+- `uniclip dev capture-files --path <PATH>` —— 通过真实的本地捕获流程捕获一个或多个文件/目录，并打印落盘的文件集清单。可重复传入 `--path` 以混合选择多个路径。`--max-members` 和 `--max-bytes` 只临时覆盖本次捕获的文件集上限，不会写回 profile 的持久化设置。
 - `uniclip dev pairing ...` —— 配对邀请的诊断子命令组：`addrs` 列出经过产品过滤后的候选地址，`issue --addr <IP>` 把邀请约束在某一个本机 IP 上。daemon 跑着时会被拒绝；仅供开发与排查 [配对在虚拟网卡环境下打不通](../help/troubleshooting#配对失败) 这类问题使用。
 - `uniclipd` —— 后台 daemon，现在是**独立的二进制**（不再是 `uniclip daemon` 子命令）。`uniclip start` 和桌面应用会自动拉起它；你会在 `ps` 中看到它，但不要直接运行。
 


### PR DESCRIPTION
## Summary

- Encrypt `entry_file_set`'s path columns (`original_text`, `relative_path`, `root_name`) with a per-row, per-column AEAD-bound envelope so directory/file paths — user content — never hit SQLite in plaintext (6f9f125, ADR-010 file-set-v1).
- Capture directory members locally: traverse a directory root under the existing whole-set member/byte caps, building a manifest that preserves relative paths and per-member kind, with traversal stopping early (and the set falling back to path-text identity) on cap overrun, symlinks, or unsupported members (88a70c2, f9139f5).
- Bind directory members to their root name so nested files resolve correctly regardless of capture origin (3fa5749).
- Add a hidden `uniclip dev capture-files` diagnostic command to drive the real local-capture pipeline from the CLI and print the persisted manifest, with an e2e test exercising directory capture end to end (0b789c3, apps/cli).
- The outbound dispatcher now recognizes directory manifests (`DirectoryNotYetSyncable`) and skips dispatch rather than publishing an incomplete tree — the wire protocol for directory sync itself is out of scope for this phase.

This is phase 3 of directory-copy support tracked in #875; it lands local capture + storage only. Outbound sync of directory trees over the wire is a follow-up phase.

## Test plan

- [x] `cargo test -p uc-cli`, `cargo test -p uc-application`, `cargo test -p uc-infra` (unit + integration, including the new cipher AEAD round-trip / tamper / cross-column tests and the file-set repo save/load tests)
- [x] `apps/cli/tests/directory_capture_e2e.rs` — real daemon + CLI process e2e covering directory capture end to end
- [x] Reviewed the diff against `docs/guides/tracing.md` and confirmed the new capture/outbound code paths already have correct-level breadcrumbs (no new gaps)
- [ ] Reviewer: manually exercise `uniclip --dev --json dev capture-files --path <dir>` against a real directory tree with nested files and confirm the printed manifest matches disk structure

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the hidden `dev capture-files` command for capturing files/directories and printing a persisted file-set manifest (JSON or readable output).
  * Supports repeating `--path` and temporary `--max-members` / `--max-bytes` overrides for the current capture.
  * Directory captures now emit structured metadata with deduplication and per-line exclusion reasons (including support for files, executables, and empty directories).
* **Bug Fixes**
  * Improved handling of unsupported directory members and captures that exceed cap limits (clear exclusion reasons).
* **Documentation**
  * Updated the CLI hidden-command reference and end-to-end test instructions.
* **Security**
  * File-set manifest paths are now encrypted when stored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->