### PR TITLE
feat(file-sync): ADR-010 phase 4 — cross-device directory sync

### DIFF
--- a/.planning/2026-07-11-adr010-directory-sync-phase4-plan.md
+++ b/.planning/2026-07-11-adr010-directory-sync-phase4-plan.md
@@ -1,0 +1,377 @@
+# ADR-010 目录同步 · 第四阶段规划（传输与接收）
+
+Status: draft (2026-07-11)
+Issue: #875 · Map: #1315（子 ticket #1316 #1317 #1318 #1319 #1320）
+ADR: `docs/architecture/adr-010-directory-sync-as-file-set-manifest.md`
+前序规划：`.planning/2026-07-10-adr010-directory-sync-phase2-plan.md` ·
+`.planning/2026-07-10-adr010-directory-sync-phase3-plan.md`
+基线假设：**阶段 3a 已合并**（PR-A `6f9f12526`、PR-B `88a70c2d4`+`f9139f53c`、
+PR-C `3fa5749be`）。本文所有行号锚点相对阶段 3a 基线。
+
+> 本阶段目标：**跨设备目录粘贴可用**（#875 核心验收）。阶段 5（UX / 进度 / 取消 /
+> Sync-ineligible 展示 / `file_sync` 设置 UI / 移动端 register 兼容修复 / 文档）不在本文，
+> 见 §8 Out of scope。
+
+---
+
+## 1. 现状盘点（阶段 3a 落地后，阶段 4 的起点）
+
+调研已在 map #1315 charting 阶段完成，下列锚点直接引用，勿重复调研。
+
+### 1.1 领域模型：目录结构已建，仅服务本地身份
+
+- `crates/uc-core/src/clipboard/file_set.rs`
+  - `FileSetMemberLocation { root_index, root_name, relative_path, kind }`（`:36-46`）——
+    `root_name`/`relative_path` 已 NFC 归一、`/` 分隔。
+  - `FileSetMemberKind { File, Executable, EmptyDirectory }`（`:49-73`），`as_tag()` → `f`/`x`/`d`。
+  - `EntryFileSet::has_directory_structure()`（`:126-135`）：任一成员 `kind==EmptyDirectory`
+    ‖ `relative_path.contains('/')` ‖ `line_index >= row_count`。
+  - `file_set_v1_component()`（`:175-209`）：含目录时按成员逐 leaf
+    (`uc_content_hash::file_set_member_v1` → `file_set_v1_wrapper`) 算结构化身份；否则 `None`。
+  - `content_digest_contribution()`（`:150-172`）：含目录或含 `Excluded` → 空贡献
+    （回退路径文本身份）。
+- **关键事实**：以上结构 **从不上 wire**。它只喂 `SystemClipboardSnapshot.file_set_v1_component`
+  参与本地 `snapshot_hash`。传输层对目录结构一无所知。
+
+### 1.2 wire 与 header：无目录定位，且尾部扩展对旧端「静默」
+
+- app 层 payload（`crates/uc-application/src/usecases/clipboard_sync/payload_codec.rs`）：
+  - `V3BlobRef { ticket, entry_id, filename, mime, size_bytes, representation_index }`
+    （`:55-63`）——**无 `root_index`/`relative_path`/`kind_tag`**。
+  - `UCBS` 尾部扩展（`:41`）：`encode_snapshot_with_blob_refs_to_v3_bytes` 追加，
+    `ClipboardBinaryPayload` 本体之后。**旧 envelope decoder 忽略尾部**（前向兼容），
+    但 **`UCBS` decoder 自身严格**：未知 magic → `unknown V3 trailing extension`（`:212-214`），
+    读完 `count` 条后仍有剩字节 → `V3 blob refs extension has N trailing byte(s)`（`:241-246`）。
+  - **推论**：若在 ref 内新增字段，阶段 3a 接收端读完旧布局后撞到多余字节 → 硬报错 → **丢整帧**
+    （连平铺文件都拿不到）。「加尾部字段旧端静默降级为平铺」这条前向兼容 trick 在 `UCBS` 层 **不成立**。
+- infra 层 header（`crates/uc-infra/src/network/iroh/clipboard_wire.rs`）：
+  - `ClipboardHeader::CURRENT_VERSION = 2`（`sync_dispatch.rs:61`）；`decode_header` 按首字节
+    版本分派 `{1,2}`，其余 → `UnsupportedVersion`（`:248-252`）。`encode_header` 恒发 v2。
+  - 另有 `payload_version`（=3）字段，但 `decode_header` **不校验它**——版本门在 `version` 字节。
+- **ack 时机（#1316 命门）**：`crates/uc-infra/src/network/iroh/clipboard_receiver_adapter.rs`
+  - `read_frame`（含 `decode_header`）失败 → `emit_ack(Rejected)`（`:160-172`）→ 发送端
+    `send_and_ack` 得 `ClipboardDispatchError::PeerRejected`（`clipboard_dispatch_adapter.rs:244`）。
+  - 成功后 `emit_ack(Accepted)`（`:195`）**先于** 上层 `ApplyInboundClipboardUseCase` 解 `UCBS` trailer。
+  - **推论**：**header 层拒绝 → 发送端可知（PeerRejected）；trailer 层失败 → ack 已 Accepted → 对发送端静默。**
+    这决定了「非静默门控」必须落在 **header 版本**，而非 trailer。
+
+### 1.3 出站：两处目录门控
+
+- `crates/uc-application/src/facade/clipboard_outbound/mod.rs`
+  - `resolve_outbound_file_set`（`:596-685`）：`file_set.has_directory_structure()` → 返回
+    `OutboundFileSetResolution::DirectoryNotYetSyncable`（`:635-637`）。
+  - dispatch 消费（`:240-248`）→ `Skipped { reason: "directory_not_yet_syncable" }`。
+  - `publish_file_blob_refs`（`:808-849`）：逐 `FileSyncIntent` → `publish_blob_path` → 产
+    `V3BlobRef`（无目录字段）+ `file_content_digests`。
+- `crates/uc-application/src/usecases/clipboard_sync/resend_entry.rs`
+  - `DirectoryNotYetSyncable` → `Err(Dispatch("directory_not_yet_syncable"))`（`:397-403`），
+    带 `TODO(ADR-010 phase 4)` 标记。
+  - resend 恒 **全量重发**（`reconstruct_snapshot_from_entry` → `plan` → `publish_file_blob_refs`），
+    无「只补缺失成员」路径；选择性只在 target/peer 粒度。
+
+### 1.4 接收：平铺落盘，无树，partial 贴占位
+
+- `crates/uc-application/src/usecases/clipboard_sync/apply_inbound/materializer.rs`
+  - `FileCacheBlobMaterializer::materialize(from_device, receiver_entry_id, snapshot, blob_refs)`
+    （`:170-614`）：**只吃 `Vec<V3BlobRef>`，无 manifest，无树概念**。
+  - 落盘两模式：用户保存目录（`ReserveInboundFileTargetPort` 预留占位，adapter 加后缀）或
+    受管缓存 `cache_dir/iroh-blobs/<entry_id>/<unique_filename>`。`unique_filename` 冲突 → `N-{base}`。
+  - `MaterializeResult { snapshot, missing: Vec<MissingFileRef>, partial: bool }`（`:64-73`）——
+    中间态 **从未持久化**、未与 `EntryDeliveryRecord` 打通。
+  - `finalize_partial`（`:626-717`）：混合 `file://` 与 `uniclip-missing:///…?reason=cancelled`
+    占位 URI 拼 `text/uri-list`——**平铺文件的宽松半成品路径**。
+  - 成功路径不设 `snapshot.file_set_v1_component`（保持 `None`）。
+- 解码入口 `decode_v3_bytes_to_snapshot_and_blob_refs`（`payload_codec.rs:140-173`）：产
+  `file_content_digests: Vec::new()` + `file_set_v1_component: None`。接收侧 **从不重建 EntryFileSet**。
+
+### 1.5 已存在的 entry 级聚合（#1317 复用地基）
+
+- `crates/uc-core/src/ports/file_transfer.rs`
+  - `EntryTransferSummary { entry_id, aggregate_status, failure_reason, transfer_ids }`（`:80-87`）。
+  - `compute_aggregate_status(&[TrackedFileTransferStatus])`（`:200-220`）：优先级
+    failed > transferring > pending > cancelled > completed。
+  - `GetEntryTransferSummaryPort`（`:140-147`）、`RecordReceiverTransferPort`
+    （`upsert_pending_transfer` / `link_transfer_to_entry`）、`FindEntryIdForTransferPort` 等。
+- `file_transfer` 表（`2026-03-15-000002_upgrade_file_transfer_tracking`）：`transfer_id` PK、
+  `entry_id NOT NULL`、`status`、`failure_reason`、`content_hash`、`cached_path` …
+  **receiver 侧按 `entry_id` 汇总 per-file 状态的投影已就位**——「哪些成员缺失」天然可查。
+- `crates/uc-core/src/clipboard/delivery.rs`：`EntryDeliveryStatus { Delivered, Duplicate,
+  Unreachable, Failed{reason} }`（`:21-33`）是 **出站 per-target 结果**，不含 entry 内成员级聚合。
+
+### 1.6 移动端（#1318 调研结论）
+
+- `mobile_sync` 全模块不引用 `EntryFileSet`/`FileSetMemberKind`，inbound 硬编码
+  `file_set_v1_component: None`（`apply_incoming.rs:775/823/868` 等）——「移动端不产出文件集」成立。
+- **缺口**：出站（mobile GET）降级 **未实现**。`announce_local_activation`
+  （`facade/active_clipboard/mod.rs:287-306`）无条件把 register 推进到 file-set entry；
+  mobile GET（`latest_snapshot_adapter.rs:112-152`）只读 register 当前指针、无「上一个可消费值」
+  概念、无 file-set 检测（`MobileSyncSnapshotPorts` 未含 `EntryFileSetRepositoryPort`）。
+  目录 entry 经 `classify_for_sync`（`is_file_mime_or_format`）被判为 **File** →
+  以伪 File（`data_name` = 目录路径段，`/file/{name}` 返回 uri-list 而非文件）泄漏给手机。
+  这与 ADR 声明「保持上一个可消费值」不符。
+
+---
+
+## 2. 五张 ticket 的决策落地
+
+| ticket | 类型 | 决策 | 依据 |
+| --- | --- | --- | --- |
+| #1316 协议门控 | grilling | **Header 版本门控**（§3） | §1.2 ack 时机：只有 header 版本能让旧端拒绝且发送端可知 |
+| #1317 失败聚合 | grilling | **复用现有聚合**（§4） | §1.5 `EntryTransferSummary`/`file_transfer` 已能按 entry 汇总 |
+| #1319 树重建 | grilling | **暂存 + 原子提升 + root 加后缀**（§5） | ADR 连带决策 2；依赖 #1316 #1317 |
+| #1320 重发 | grilling | **全量重发，靠 iroh 内容寻址去重**（§6） | §1.3 现状 + iroh 字节级去重，应用层无需新代码 |
+| #1318 移动端 | research | **记录缺口，修复留阶段 5**（§7） | 阶段 2 计划已把「移动端 register 兼容」列阶段 5 |
+
+---
+
+## 3. #1316 协议门控：Header 版本门控
+
+### 3.1 决策
+
+**含目录结构的帧把 `ClipboardHeader.version` 从 2 bump 到 3**；目录成员定位走 **app 层新增的自描述
+尾部段**（不改动 `V3BlobRef`）。**不新建能力协商 handshake**。
+
+理由（见 §1.2）：header decode 失败会让接收端在 ack 前回 `Rejected` → 发送端得 `PeerRejected`
+→ 记 `EntryDeliveryStatus::Failed(PeerRejected)`。这满足 ADR 连带决策 2「不静默丢失（准数据丢失比
+失败更糟）」，且复用现有版本分派 + ack 通道，零新增协商基础设施。trailer 层的失败发生在 ack 之后，
+对发送端静默，故门控 **必须** 在 header 版本。
+
+### 3.2 wire 格式设计
+
+**两层，各司其职**：
+
+1. **门控层（infra header）**：`clipboard_wire.rs`
+   - `WireHeaderV3`：字段与 `WireHeaderV2` 相同（`version` 置 3 即可，无需新增字段）。`version=3`
+     的语义 = 「本帧 payload 携带目录成员定位尾部段，需阶段 4 接收端」。
+   - `encode_header`：dispatch 传入「是否目录帧」信号时发 v3，否则维持 v2。**纯平铺/文本/图片帧
+     继续 v2，与旧端零影响**。
+   - `decode_header`：接受 `{1,2,3}`；`version=3` 落 `ClipboardHeader`（新增只读标志或由上层据
+     trailer 自描述判定，见下）。旧端（仅认 `{1,2}`）：v3 → `UnsupportedVersion` → `Rejected` ack。
+   - `ClipboardHeader`（`sync_dispatch.rs`）：`CURRENT_VERSION` **保持 2**（默认帧仍 v2）；新增一个
+     构造侧信号（如 `carries_directory: bool` 或 `min_wire_version: u8`）驱动 `encode_header` 选版。
+
+2. **数据层（app 尾部段）**：`payload_codec.rs`，在 `UCBS` blob-refs 段 **之后** 追加 **新自描述段**
+   `UCDS`（directory-set manifest v1），布局：
+   ```text
+   magic  "UCDS" (4B)
+   count  u16 LE                       // 成员总数（含空目录）
+   repeat count 次：
+     kind_tag        u8               // b'f' | b'x' | b'd'
+     root_index      u32 LE
+     root_name       u16-len + UTF-8   // NFC
+     relative_path   u16-len + UTF-8   // NFC, '/' 分隔
+     blob_ref_index  optional-u32      // f/x: Some(该成员内容在 UCBS 列表中的下标); d: None
+   ```
+   - `f`/`x` 成员经 `blob_ref_index` 指回同帧 `UCBS` 里的 `V3BlobRef`（内容 blob）；`d`（空目录）
+     无 blob。这样一条帧完整描述「哪些 blob 属于哪个 root 的哪个相对路径 + 空目录骨架」。
+   - **自描述**：v3 接收端读完 `UCBS` 后探测是否跟 `UCDS`；有则解成 `InboundFileSetManifest`。
+     v2 接收端永远收不到 v3 帧（header 已门控），故 `UCDS` 不会撞上 §1.2 的严格拒绝。
+   - 复用现有 `write_string_u16` / `read_string_u16` / `write_optional_u32` 等原语，长度上限沿用
+     `MAX_BLOB_REF_STRING_LEN`；`count` 上限沿用 `MAX_BLOB_REFS`（成员数已受阶段 2 caps=2000 约束）。
+
+### 3.3 出站开闸
+
+- `resolve_outbound_file_set`：新增结果变体 `DirectorySyncable { paths, members: Vec<FileSetMemberLocation> }`
+  取代对目录的 `DirectoryNotYetSyncable`（保留该变体给「密钥未解锁读不到 manifest」等真正不可同步态）。
+- dispatch：`DirectorySyncable` → 走 `publish_file_blob_refs` 得 blob refs → 生成 `UCDS` 成员段
+  （成员→blob_ref_index 映射）→ `encode_header` 发 v3 → `dispatch_snapshot_with_blob_refs`（+ UCDS）。
+- resend 同源接线（§6）。
+- 旧端拒绝：dispatch 得 `PeerRejected` → 现有 delivery 记录路径落 `Failed(PeerRejected)`。
+  **不静默**。（可后续记忆「某 peer 拒 v3」以抑制重试，属优化，非阶段 4 必需。）
+
+---
+
+## 4. #1317 entry 级全有或全无失败聚合：复用现有聚合
+
+### 4.1 决策
+
+**复用 `EntryTransferSummary` / `compute_aggregate_status` / `file_transfer` 表**，不新建目录专属
+持久化聚合状态。**目录 entry 的落盘走严格全有或全无**（区别于平铺文件的宽松半成品路径）。
+
+### 4.2 谁判定 Failed、缺失成员是否持久化
+
+- **判定方**：materializer 在 **落盘阶段** 做全有或全无判定（§5 暂存 + 原子提升）。目录 entry 任一成员
+  fetch 失败 → **不重建树、不提升、不提交半成品快照**；已存在的 `file_transfer` 逐成员行经
+  `RecordReceiverTransferPort` 标 `Failed`，`GetEntryTransferSummaryPort` 用 `compute_aggregate_status`
+  滚成 entry 级 `Failed`（failed 优先级最高）。
+- **缺失成员持久化**：**不新建**。`file_transfer` 行已按 `entry_id` 记 per-file 状态（pending/failed/
+  completed），「缺哪些成员」直接从该投影查（`FindEntryIdForTransferPort` 反查 + 按 status 过滤）。
+  这也正好喂 #1320——但 #1320 决策是全量重发（§6），故此处只需「可查」不需「可选择性驱动」。
+- **与平铺文件的关系**：**同一套机制的加强版**，非新路径。差异是一个策略开关：
+  - 目录 entry（`InboundFileSetManifest` 存在）→ 严格全有或全无，**禁止** `finalize_partial` 的
+    占位 URI 半成品（ADR 连带决策 2）。
+  - 平铺文件集（无 manifest）→ 维持现有宽松路径（`finalize_partial` 贴 `uniclip-missing` 占位）不变。
+
+### 4.3 落点
+
+- `materializer.rs`：`materialize` 接受可选 `InboundFileSetManifest`；present 时进入目录分支
+  （§5）。目录分支 partial → 返回一个显式「entry 失败」信号（如 `MaterializeResult::failed(...)`
+  或 `Err` 语义），`ApplyInboundClipboardUseCase` 据此 **不 commit 快照**、只更新 `file_transfer`
+  聚合 → entry 呈 `Failed`。
+- **不碰** `EntryDeliveryStatus`（那是出站 per-target 模型，§1.5）。接收侧 entry 级结果走
+  `EntryTransferSummary` 投影。
+
+---
+
+## 5. #1319 接收侧目录树重建：暂存 + 原子提升 + root 加后缀
+
+依赖 #1316（拿到 `InboundFileSetManifest`）与 #1317（何时算失败要回滚 / 成功可提交）。
+
+### 5.1 落盘策略：暂存目录 + 原子提升
+
+1. 为本次 entry 在缓存下开 **唯一暂存目录** `cache_dir/iroh-blobs/staging/<receiver_entry_id>/`。
+2. 逐成员 fetch → 按 `root_index` 分组、按 `relative_path`（`/` 拆分）在暂存目录内建子目录树；
+   `d` 成员建空目录；`f`/`x` 成员写文件内容（blob）。
+3. **全部成员就绪后**，把每个 root 从暂存目录 **原子改名（`rename`）** 到最终目标目录下的落点；
+   跨卷 rename 失败则回退「复制 + 校验 + 删暂存」，仍保持「全有才可见」。
+4. 任一成员失败 → 删整个暂存目录、不提升 → entry 判 `Failed`（§4）。**永不把半成品目录暴露到最终位置。**
+
+最终目标目录：沿用现有 `ReserveInboundFileTargetPort` 语义决定的用户保存目录；无 reserver 时落
+受管缓存布局（与现状一致，只是从「平铺」变「带树」）。
+
+### 5.2 root 冲突：加后缀 `folder (2)`
+
+- **决策**：目标目录下已存在同名 root → 生成 `名字 (2)`、`名字 (3)`… 递增，直至无冲突。
+- **冲突检测作用域**：**目标目录既有内容** ∪ **本次粘贴内多个 root 之间**（先在暂存内解决 root 间
+  同名，再对目标目录既有内容解决）。
+- **永不覆盖、永不合并进已有目录**（与项目安全底线一致）。后缀只作用于 **root 名**；root 内部相对
+  路径保持原样。
+- 实现建议：抽 `resolve_nonconflicting_root_name(target_dir, desired, reserved_in_this_paste)`，
+  在提升前一次性算好所有 root 落点。
+
+### 5.3 uri-list 改写
+
+- 重建后，entry 的 `text/uri-list` representation 从「扁平文件 URI 列表」改写为**指向重建后各 root
+  的 `file://` URI**（每个被选中的顶层 root 一条；混合选择时顶层文件走自身 URI、目录 root 走目录 URI）。
+- 落点：materializer 成功路径构建 `local_file_uri_list` 时，改用 **root 落点** 而非逐叶子路径；
+  复用 `is_file_list_representation` 就地改写、无则合成 `text/uri-list`（FormatId `"files"`）。
+
+### 5.4 跨平台 exec bit
+
+- `kind_tag = x` 成员：
+  - **Unix**（macOS/Linux）：落盘后 `set_permissions` 加可执行位（`0o755` 或在原 mode 上 `|= 0o111`）。
+  - **Windows**：无 unix exec 概念 → **忽略 exec bit**（文件正常写，不做特殊处理）。
+- 身份一致性不受影响：`kind_tag` 已入 `file-set-v1` 身份（ADR 连带决策 1），跨设备身份稳定；仅**物理
+  粘贴产物**按平台不同（Windows 无可执行位），此为平台本质差异，不可消除。
+
+### 5.5 接收侧 file-set-v1 身份复校（可选加固，见开放问题 §9.1）
+
+拿到全部 blob + `UCDS` manifest 后，接收端 **有能力** 重算 `file_set_v1_component`（逐成员
+`file_set_member_v1` leaf → `file_set_v1_wrapper`）并与 wire `snapshot_hash` 的文件内容组件比对，
+mismatch → 判损坏 → `Failed`。**默认放 PR-C 作可选加固**，不阻塞主线。
+
+---
+
+## 6. #1320 目录 entry 重发：全量重发，靠 iroh 内容寻址去重
+
+### 6.1 决策
+
+**应用层无需新代码**：现状 resend 全量重发（§1.3），iroh-blobs 内容寻址在 **字节层面** 去重——已在
+接收端存在的 blob 传输被跳过，事实上实现了增量补缺；应用层语义仍是「全量重发」，但传输代价 ≈ 只补缺失。
+
+这与 #1317 的全有或全无接收语义相容：resend 恒携带 **全部成员**（重建完整快照），接收端照常跑全有或
+全无重建（§5），已存在 blob 秒级去重、缺失 blob 补传，全齐后原子提升。**接收端无需区分「本次重发只带
+部分成员」**——因为重发从不只带部分。
+
+### 6.2 落点
+
+- 移除 `resend_entry.rs:397-403` 的 `DirectoryNotYetSyncable` gate（连同 `TODO(ADR-010 phase 4)`），
+  改走 §3.3 的 `DirectorySyncable` 分支（与 dispatch 同源，禁止两套文件列表推导逻辑）。
+- resend 走同一 `UCDS` 编码 + v3 header 路径。
+- **不引入**「只发缺失成员」的选择性应用层逻辑（YAGNI；iroh 去重已覆盖，选择性会引入「接收端需
+  区分部分重发」的复杂度，与全有或全无相冲）。
+
+---
+
+## 7. #1318 移动端降级缺口：记录缺口，修复留阶段 5
+
+- **结论**：ADR 声明的「register 指向 file-set entry 时 mobile GET 保持上一个可消费值」**当前未实现**
+  （§1.6）。目录 entry 会以伪 File 泄漏给手机。
+- **本阶段动作**：仅 **记录**。实际修复按既定阶段划分留 **阶段 5**（阶段 2 计划 §2 表已把「移动端
+  register 兼容确认」列在阶段 5）。阶段 4 聚焦桌面传输/接收主线。
+- **阶段 5 修复方向备忘**（不在本阶段实现）：
+  - 方案 A：register 推进侧排除——`announce_local_activation` 不把 file-set/目录 entry 推进为
+    mobile 可消费指针（单一收口，但需确认不影响桌面 pull 路径 `ACTIVE_CLIPBOARD_PULL_ALPN`）。
+  - 方案 B：mobile 出站 adapter 检测——`latest_snapshot_adapter` 引入 file-set 识别
+    （`MobileSyncSnapshotPorts` 补 `EntryFileSetRepositoryPort` 或 `ClipboardEntry` 加标记）+
+    「上一个可消费值」回退源（当前不存在，需新建）。
+  - 倾向阶段 5 拍板；阶段 4 不预设。
+
+---
+
+## 8. PR 拆分（三个 PR，尊重 ticket DAG）
+
+ticket DAG：#1316 #1317 为 frontier；#1319 依赖 #1316+#1317；#1320 依赖 #1317。三个 PR 在 **同一发布**
+落地，故 PR 间无「已发布旧端」兼容问题（§3 的 header 门控针对的是 **真正已发布的历史版本**）。
+
+### PR-A：接收侧全有或全无地基（#1317 + #1319 树重建核心）
+
+纯 app（receiver 侧），不改 infra、不开出站闸。
+
+1. 定义 `InboundFileSetManifest`（成员定位的接收侧值对象，独立于 wire codec，供测试直接构造）。
+2. `materializer.rs`：`materialize` 增可选 manifest 参数；present → 目录分支：
+   - 暂存目录 + 逐成员建树（`d` 建空目录、`f`/`x` 写内容）（§5.1）。
+   - 全有或全无：任一失败 → 删暂存、不提升、返回「entry 失败」信号；成功 → 原子提升 + `text/uri-list`
+     改写为 root 落点（§5.3）。
+   - **禁止** 目录分支走 `finalize_partial` 占位 URI（§4.2）。
+3. `ApplyInboundClipboardUseCase`：目录分支失败 → 不 commit 快照 + 更新 `file_transfer` 聚合
+   → entry `Failed`（复用 `RecordReceiverTransferPort` + `EntryTransferSummary`，§4）。
+4. 测试（port mock + tempfile）：单 root 目录重建（树形/空目录/嵌套 relative_path）/ 混合选择
+   （文件 + 目录）/ 任一成员失败 → 暂存清理 + 无半成品 + entry Failed / uri-list 指向 root 落点 /
+   平铺文件宽松路径回归不变（`finalize_partial` 仍走占位）。
+
+> 说明：本 PR 出站仍门控（目录不发），目录分支靠单测喂合成 manifest 验证，属受控引入；PR-B 紧随开闸，
+> 分支不在中途发布，不构成「未验证基础设施长期悬空」。
+
+### PR-B：wire 格式 + header 版本门控 + 出站开闸（#1316）
+
+跨 infra（header）+ app（codec + 出站）。提交按层拆（infra 一提交、app 一提交）。
+
+1. infra `clipboard_wire.rs`：`WireHeaderV3`（复用 v2 字段，`version=3`）；`encode_header` 按
+   `ClipboardHeader` 的 `carries_directory` 信号选版；`decode_header` 接受 `{1,2,3}`。
+   `sync_dispatch.rs`：`ClipboardHeader` 加构造信号；`CURRENT_VERSION` 保持 2。
+2. app `payload_codec.rs`：`UCDS` 目录成员段的 `write_*`/`read_*`（§3.2）+ 自描述探测；
+   `encode_snapshot_with_dir_manifest_*` / decode 侧产 `InboundFileSetManifest`（PR-A 消费）。
+   roundtrip + 向后兼容测试（v2 帧无 `UCDS`；v3 帧 `UCDS` 往返；成员→blob_ref_index 映射）。
+3. app 出站 `clipboard_outbound/mod.rs`：`OutboundFileSetResolution::DirectorySyncable`；dispatch
+   编 `UCDS` + 发 v3；旧端 `PeerRejected` → `Failed`（现有 delivery 路径，无新代码）。
+4. 端到端测试：新 sender ↔ 新 receiver 目录粘贴可用；新 sender → 模拟 v2 receiver → `Rejected` ack
+   → 发送端 `Failed(PeerRejected)`（非静默回归）；纯平铺帧仍 v2（旧端不受影响回归）。
+
+### PR-C：边界 + 重发（#1319 剩余 + #1320）
+
+1. root 冲突加后缀 `folder (2)`（§5.2，目标目录既有 ∪ 本次多 root 作用域）。
+2. 跨平台 exec bit（§5.4，Unix 加位 / Windows 忽略）。
+3. 移除 resend `DirectoryNotYetSyncable` gate（§6.2），同源走 `DirectorySyncable`；
+   iroh 去重「事实增量」测试（重发已部分到达的目录 → 只补缺失 blob → 全齐提升）。
+4. （可选）接收侧 `file_set_v1_component` 复校（§5.5 / 开放问题 §9.1）。
+5. 测试：root 同名冲突（既有 + 本次多 root）/ Windows 忽略 exec / Unix 加 exec / resend 全量→去重
+   增量 / 复校 mismatch → Failed（若做）。
+
+---
+
+## 9. 待拍板的开放问题
+
+1. **接收侧 file-set-v1 身份复校去留**（§5.5）：收齐 blob + `UCDS` 后重算结构化身份、比对广播值，
+   是纵深防御（防中间人/损坏 blob 冒充）还是过度设计？倾向 PR-C 作 **可选加固**（默认做，成本低：
+   重算一次 `file_set_v1_wrapper` 比对 header hash）。若体量或时延不划算可外移。
+2. **v3 拒绝的记忆/抑制**（§3.3）：首次向旧 peer 发目录 → `Failed(PeerRejected)`；是否持久化「该
+   peer 不支持 v3」以抑制后续每条目录都试→Failed 的噪声？倾向阶段 5（UX 层，与 Sync-ineligible
+   展示一并做），阶段 4 接受「每条 Failed」。
+3. **`ClipboardHeader` 门控信号形态**（§3.2）：`carries_directory: bool` vs `min_wire_version: u8`？
+   前者语义直白、后者可扩展（未来更多 wire 特性）。倾向 `min_wire_version`（可扩展，decode 侧统一按
+   版本分派），PR-B 定稿。
+4. **暂存目录与用户保存目录的卷关系**（§5.1）：暂存置于缓存卷、最终落用户保存目录，跨卷 rename 需
+   复制回退。是否改为「暂存直接开在目标目录下的隐藏临时子目录」以保证同卷原子 rename？倾向后者（同卷
+   原子性更强），但需处理目标目录不可写/权限场景，PR-A 定稿。
+
+---
+
+## 10. 明确不在阶段 4（Out of scope）
+
+- **阶段 5**：进度/取消 UI、Sync-ineligible 原因展示、`file_sync` 设置界面、**移动端 register 降级
+  修复**（§7）、面向用户文档。
+- **阶段 3b**：延迟身份就绪（捕获流水线异步化）+ 摄取毕 `(mtime,size)` 漂移复核——与阶段 4 正交，
+  独立往后排。
+- **移动端完整参与文件集同步**：ADR 范围外（桌面三平台专属）。
+- **归档 blob 方案**：ADR 已否（`docs/architecture/adr-010-…`「被否掉的方案」）。

--- a/.planning/2026-07-11-adr010-directory-sync-phase4-plan.md
+++ b/.planning/2026-07-11-adr010-directory-sync-phase4-plan.md
@@ -1,6 +1,6 @@
 # ADR-010 目录同步 · 第四阶段规划（传输与接收）
 
-Status: draft (2026-07-11)
+Status: completed (2026-07-12)
 Issue: #875 · Map: #1315（子 ticket #1316 #1317 #1318 #1319 #1320）
 ADR: `docs/architecture/adr-010-directory-sync-as-file-set-manifest.md`
 前序规划：`.planning/2026-07-10-adr010-directory-sync-phase2-plan.md` ·
@@ -11,6 +11,28 @@ PR-C `3fa5749be`）。本文所有行号锚点相对阶段 3a 基线。
 > 本阶段目标：**跨设备目录粘贴可用**（#875 核心验收）。阶段 5（UX / 进度 / 取消 /
 > Sync-ineligible 展示 / `file_sync` 设置 UI / 移动端 register 兼容修复 / 文档）不在本文，
 > 见 §8 Out of scope。
+
+## 0. 实施结果（2026-07-12）
+
+阶段 4 已完成。实现按以下提交分阶段落地：
+
+- `a756e3a25`：接收侧目录树暂存、全有或全无重建与原子提升。
+- `eeba764ae`：目录帧使用 wire version 3，旧接收端可在确认前明确拒绝。
+- `bebda9ecf`：传输目录成员清单。
+- `cc46e322a`：冲突后缀、权限、身份复校与目录重发。
+- `6238461c9`：按目录成员独立记录传输结果与失败原因。
+- `9eb100b3e`：混合选择中的顶层文件与目录保持原始形态。
+- `c4f9681e2`：完整接收流程与旧版本拒绝流程验证。
+- `99a9e8516`：跨卷复制回退与 Windows 权限行为验证。
+- `d58ac2abe`：部分内容已到达时，重发只通过网络补齐缺失内容。
+
+最终验证：
+
+- `uc-application`：773 个单元测试与 10 个集成测试通过。
+- `uc-core`：165 个单元测试与 19 个文档测试通过。
+- `uc-infra`：556 个单元测试、12 个独立网络测试与 16 个文档测试通过；6 个既有手动/性能测试按声明跳过。
+- Windows 目标的 `uc-application` 测试代码编译通过。
+- `cargo check --workspace` 通过。
 
 ---
 
@@ -157,6 +179,7 @@ PR-C `3fa5749be`）。本文所有行号锚点相对阶段 3a 基线。
    count  u16 LE                       // 成员总数（含空目录）
    repeat count 次：
      kind_tag        u8               // b'f' | b'x' | b'd'
+     root_is_file    u8               // 0 = 目录 root，1 = 顶层独立文件 root
      root_index      u32 LE
      root_name       u16-len + UTF-8   // NFC
      relative_path   u16-len + UTF-8   // NFC, '/' 分隔

--- a/.planning/2026-07-11-adr010-directory-sync-phase4-plan.md
+++ b/.planning/2026-07-11-adr010-directory-sync-phase4-plan.md
@@ -394,6 +394,11 @@ ticket DAG：#1316 #1317 为 frontier；#1319 依赖 #1316+#1317；#1320 依赖 
 
 - **阶段 5**：进度/取消 UI、Sync-ineligible 原因展示、`file_sync` 设置界面、**移动端 register 降级
   修复**（§7）、面向用户文档。
+- **阶段 5**：目录 root 提升的预留竞态（CodeRabbit PR #1323 Finding 2）。接收侧目录提升复用了面向
+  文件的 `ReserveInboundFileTargetPort`：`reserve_target()` 只预留一个文件占位，promote 前先
+  `remove_file` 再把目录树 `rename` 就位，中间存在一段预留路径不受保护的 TOCTOU 窗口（Minor，窗口
+  极小）。正确修法是给该端口增加目录感知的预留（或让占位在提升全程保持），属跨 crate 端口设计决策，
+  与阶段 5 的 reserver/UX 工作一并处理。
 - **阶段 3b**：延迟身份就绪（捕获流水线异步化）+ 摄取毕 `(mtime,size)` 漂移复核——与阶段 4 正交，
   独立往后排。
 - **移动端完整参与文件集同步**：ADR 范围外（桌面三平台专属）。

--- a/crates/uc-application/src/facade/blob_transfer/facade.rs
+++ b/crates/uc-application/src/facade/blob_transfer/facade.rs
@@ -119,6 +119,9 @@ pub struct PublishBlobResult {
 #[derive(Debug, Clone)]
 pub struct FetchTransferContext {
     pub transfer_id: String,
+    /// Clipboard entry that owns this transfer. Directory members use a
+    /// distinct `transfer_id` while sharing this entry id for aggregation.
+    pub entry_id: String,
     pub peer_id: String,
     pub total_bytes: Option<u64>,
     pub filename: String,
@@ -134,6 +137,9 @@ pub struct FetchTransferContext {
     /// 单 blob 调用者(CLI `uniclip recv`、子 facade 内部转发)保留默认
     /// `Only`,行为与改造前完全一致。
     pub batch_position: BatchPosition,
+    /// Track this fetch as its own receiver-side lifecycle row even when it
+    /// belongs to a larger outbound progress batch.
+    pub individual_lifecycle: bool,
 }
 
 /// 位置标志:在一个共享 `transfer_id` 的 fetch batch 里,本次 fetch 处在哪个位置。
@@ -329,7 +335,7 @@ impl BlobTransferFacade {
     ) {
         self.emit_host_event(HostEvent::Transfer(TransferHostEvent::Progress {
             transfer_id: ctx.transfer_id.clone(),
-            entry_id: Some(ctx.transfer_id.clone()),
+            entry_id: Some(ctx.entry_id.clone()),
             peer_id: ctx.peer_id.clone(),
             direction: FileTransferDirection::Receiving,
             bytes_transferred,
@@ -350,7 +356,7 @@ impl BlobTransferFacade {
         };
         let input = SeedReceiverContext {
             transfer_id: ctx.transfer_id.clone(),
-            entry_id: ctx.transfer_id.clone(),
+            entry_id: ctx.entry_id.clone(),
             origin_device_id: ctx.peer_id.clone(),
             filename: ctx.filename.clone(),
             cached_path,
@@ -435,6 +441,12 @@ impl BlobTransferFacade {
                 );
             }
         }
+    }
+
+    pub async fn record_unfetched_failure(&self, ctx: FetchTransferContext, detail: String) {
+        self.seed_lifecycle(&ctx, String::new()).await;
+        self.start_lifecycle(&ctx).await;
+        self.fail_lifecycle(&ctx, detail).await;
     }
 
     /// 取消一次进行中的 inbound fetch。
@@ -617,6 +629,7 @@ impl BlobTransferFacade {
                 let sink: Arc<dyn BlobProgressSink> = Arc::new(HostEventProgressSink {
                     bus: self.host_event_emitter.clone().unwrap(),
                     transfer_id: ctx.transfer_id.clone(),
+                    entry_id: ctx.entry_id.clone(),
                     peer_id: ctx.peer_id.clone(),
                     fallback_total: ctx.total_bytes,
                     outbound: outbound_ctx.clone(),
@@ -629,7 +642,7 @@ impl BlobTransferFacade {
         // receiver projection 行已经 `transferring`/`completed`,upsert
         // 会 fail-soft 但 warn 流满天飞。
         if let Some(ctx) = command.transfer_context.as_ref() {
-            if ctx.batch_position.is_first() {
+            if ctx.individual_lifecycle || ctx.batch_position.is_first() {
                 self.seed_lifecycle(ctx, String::new()).await;
                 self.start_lifecycle(ctx).await;
                 self.emit_progress(ctx, 0, ctx.total_bytes);
@@ -654,8 +667,13 @@ impl BlobTransferFacade {
                     // 但 complete lifecycle + outbound terminal Completed
                     // 只在 batch 收尾时发,避免提前告诉 sender"完成了"。
                     self.emit_progress(ctx, final_size, total);
-                    if ctx.batch_position.is_last() {
+                    if ctx.individual_lifecycle {
                         self.complete_lifecycle(ctx).await;
+                    }
+                    if ctx.batch_position.is_last() {
+                        if !ctx.individual_lifecycle {
+                            self.complete_lifecycle(ctx).await;
+                        }
                         self.report_outbound_terminal(
                             ctx,
                             final_size,
@@ -708,6 +726,7 @@ impl BlobTransferFacade {
                 let sink: Arc<dyn BlobProgressSink> = Arc::new(HostEventProgressSink {
                     bus: self.host_event_emitter.clone().unwrap(),
                     transfer_id: ctx.transfer_id.clone(),
+                    entry_id: ctx.entry_id.clone(),
                     peer_id: ctx.peer_id.clone(),
                     fallback_total: ctx.total_bytes,
                     outbound: outbound_ctx.clone(),
@@ -719,7 +738,7 @@ impl BlobTransferFacade {
         // dashboard `cached_path` 字段直接显示为本地副本路径。
         // 仅 batch 首帧时 seed/start,见 `BatchPosition` doc。
         if let Some(ctx) = command.transfer_context.as_ref() {
-            if ctx.batch_position.is_first() {
+            if ctx.individual_lifecycle || ctx.batch_position.is_first() {
                 let cached_path = command.target_path.to_string_lossy().into_owned();
                 self.seed_lifecycle(ctx, cached_path).await;
                 self.start_lifecycle(ctx).await;
@@ -779,8 +798,13 @@ impl BlobTransferFacade {
                     let final_size = outcome.bytes_written;
                     let total = ctx.total_bytes.or(Some(final_size));
                     self.emit_progress(ctx, final_size, total);
-                    if ctx.batch_position.is_last() {
+                    if ctx.individual_lifecycle {
                         self.complete_lifecycle(ctx).await;
+                    }
+                    if ctx.batch_position.is_last() {
+                        if !ctx.individual_lifecycle {
+                            self.complete_lifecycle(ctx).await;
+                        }
                         self.report_outbound_terminal(
                             ctx,
                             final_size,
@@ -892,8 +916,8 @@ fn flip_cancel_reason_perspective(
 ///
 /// adapter 已经做了字节阈值/时间窗节流,这里只负责把每次回调翻译成
 /// `TransferHostEvent::Progress`,并填充上下文字段(transfer_id /
-/// peer_id / direction)。`entry_id` 字段直接复用 `transfer_id`(协议
-/// 约定 == receiver_entry_id)。`fallback_total` 用于补全 adapter 不知
+/// peer_id / direction)。`entry_id` identifies the owning clipboard entry;
+/// directory members may use distinct transfer ids. `fallback_total` 用于补全 adapter 不知
 /// 道总大小(`total_bytes == None`)的场景——iroh 拉取过程中 size 通
 /// 常要等到 PartComplete 才已知,所以前端的进度百分比依赖这个 fallback。
 ///
@@ -903,6 +927,7 @@ fn flip_cancel_reason_perspective(
 struct HostEventProgressSink {
     bus: SharedHostEventEmitter,
     transfer_id: String,
+    entry_id: String,
     peer_id: String,
     fallback_total: Option<u64>,
     outbound: Option<OutboundReportContext>,
@@ -914,7 +939,7 @@ impl BlobProgressSink for HostEventProgressSink {
         let total = total_bytes.or(self.fallback_total);
         let event = HostEvent::Transfer(TransferHostEvent::Progress {
             transfer_id: self.transfer_id.clone(),
-            entry_id: Some(self.transfer_id.clone()),
+            entry_id: Some(self.entry_id.clone()),
             peer_id: self.peer_id.clone(),
             direction: FileTransferDirection::Receiving,
             bytes_transferred,

--- a/crates/uc-application/src/facade/clipboard/facade.rs
+++ b/crates/uc-application/src/facade/clipboard/facade.rs
@@ -249,6 +249,12 @@ pub struct ClipboardSyncFacade {
     view_uc: Arc<GetEntryDeliveryViewUseCase>,
 }
 
+#[derive(Clone, Copy)]
+struct DispatchVersions {
+    payload: u8,
+    wire: u8,
+}
+
 impl ClipboardSyncFacade {
     pub fn new(deps: ClipboardSyncDeps) -> Self {
         let dispatch_uc = Arc::new(DispatchClipboardEntryUseCase::new(
@@ -335,8 +341,7 @@ impl ClipboardSyncFacade {
         &self,
         plaintext: Bytes,
         snapshot_hash: String,
-        payload_version: u8,
-        wire_version: u8,
+        versions: DispatchVersions,
         categories: ClipboardContentCategorySet,
         entry_id: Option<EntryId>,
         target_filter: Option<Vec<DeviceId>>,
@@ -346,8 +351,8 @@ impl ClipboardSyncFacade {
             .execute(DispatchClipboardEntryInput {
                 plaintext,
                 snapshot_hash,
-                payload_version,
-                wire_version,
+                payload_version: versions.payload,
+                wire_version: versions.wire,
                 categories,
                 entry_id,
                 target_filter,
@@ -382,8 +387,10 @@ impl ClipboardSyncFacade {
         self.dispatch_internal(
             plaintext,
             snapshot_hash,
-            3,
-            ClipboardHeader::CURRENT_VERSION,
+            DispatchVersions {
+                payload: 3,
+                wire: ClipboardHeader::CURRENT_VERSION,
+            },
             categories,
             entry_id,
             target_filter,
@@ -412,8 +419,10 @@ impl ClipboardSyncFacade {
         self.dispatch_internal(
             plaintext,
             snapshot_hash,
-            3,
-            ClipboardHeader::CURRENT_VERSION,
+            DispatchVersions {
+                payload: 3,
+                wire: ClipboardHeader::CURRENT_VERSION,
+            },
             categories,
             entry_id,
             target_filter,
@@ -442,8 +451,10 @@ impl ClipboardSyncFacade {
         self.dispatch_internal(
             plaintext,
             snapshot_hash,
-            3,
-            ClipboardHeader::DIRECTORY_VERSION,
+            DispatchVersions {
+                payload: 3,
+                wire: ClipboardHeader::DIRECTORY_VERSION,
+            },
             categories,
             entry_id,
             target_filter,

--- a/crates/uc-application/src/facade/clipboard/facade.rs
+++ b/crates/uc-application/src/facade/clipboard/facade.rs
@@ -430,6 +430,11 @@ impl ClipboardSyncFacade {
         .await
     }
 
+    /// 编码并发送带目录成员清单的剪贴板快照。
+    ///
+    /// 与 [`Self::dispatch_snapshot_with_blob_refs`] 相同,但额外携带
+    /// `manifest` 让接收端能原子重建目录树,因此走 `DIRECTORY_VERSION` wire。
+    #[instrument(skip_all, fields(rep_count = snapshot.representations.len(), blob_ref_count = blob_refs.len(), member_count = manifest.members.len(), origin = ?origin))]
     pub async fn dispatch_snapshot_with_blob_refs_and_file_set(
         &self,
         snapshot: SystemClipboardSnapshot,
@@ -439,7 +444,7 @@ impl ClipboardSyncFacade {
         entry_id: Option<EntryId>,
         target_filter: Option<Vec<DeviceId>>,
     ) -> Result<DispatchEntryOutcome, ClipboardSyncError> {
-        let _ = origin;
+        let _ = origin; // span metadata only (see sibling dispatch methods)
         let categories = ClipboardContentCategorySet::from_snapshot(&snapshot);
         let (plaintext, snapshot_hash) =
             crate::usecases::clipboard_sync::payload_codec::encode_snapshot_with_blob_refs_and_file_set_to_v3_bytes(

--- a/crates/uc-application/src/facade/clipboard/facade.rs
+++ b/crates/uc-application/src/facade/clipboard/facade.rs
@@ -20,9 +20,9 @@ use tracing::instrument;
 use uc_core::ids::{DeviceId, EntryId};
 use uc_core::ports::security::TransferCipherPort;
 use uc_core::ports::{
-    ClipboardDispatchPort, ClipboardReceiverPort, ClockPort, DeviceIdentityPort, DispatchAck,
-    EntryDeliveryRepositoryPort, FindMobileDeviceByIdPort, FirstSyncStatePort, LocalIdentityPort,
-    PeerAddressRepositoryPort, PresencePort, SettingsPort,
+    ClipboardDispatchPort, ClipboardHeader, ClipboardReceiverPort, ClockPort, DeviceIdentityPort,
+    DispatchAck, EntryDeliveryRepositoryPort, FindMobileDeviceByIdPort, FirstSyncStatePort,
+    LocalIdentityPort, PeerAddressRepositoryPort, PresencePort, SettingsPort,
 };
 use uc_core::MemberRepositoryPort;
 use uc_core::{ClipboardChangeOrigin, SystemClipboardSnapshot};
@@ -317,6 +317,7 @@ impl ClipboardSyncFacade {
                 plaintext: input.plaintext,
                 snapshot_hash: input.snapshot_hash.clone(),
                 payload_version: input.payload_version,
+                wire_version: ClipboardHeader::CURRENT_VERSION,
                 categories: ClipboardContentCategorySet::empty(),
                 // raw-bytes 路径不与某条 entry 绑定,跳过 delivery 落盘。
                 entry_id: None,
@@ -335,6 +336,7 @@ impl ClipboardSyncFacade {
         plaintext: Bytes,
         snapshot_hash: String,
         payload_version: u8,
+        wire_version: u8,
         categories: ClipboardContentCategorySet,
         entry_id: Option<EntryId>,
         target_filter: Option<Vec<DeviceId>>,
@@ -345,6 +347,7 @@ impl ClipboardSyncFacade {
                 plaintext,
                 snapshot_hash,
                 payload_version,
+                wire_version,
                 categories,
                 entry_id,
                 target_filter,
@@ -380,6 +383,7 @@ impl ClipboardSyncFacade {
             plaintext,
             snapshot_hash,
             3,
+            ClipboardHeader::CURRENT_VERSION,
             categories,
             entry_id,
             target_filter,
@@ -409,6 +413,37 @@ impl ClipboardSyncFacade {
             plaintext,
             snapshot_hash,
             3,
+            ClipboardHeader::CURRENT_VERSION,
+            categories,
+            entry_id,
+            target_filter,
+        )
+        .await
+    }
+
+    pub async fn dispatch_snapshot_with_blob_refs_and_file_set(
+        &self,
+        snapshot: SystemClipboardSnapshot,
+        blob_refs: Vec<V3BlobRef>,
+        manifest: crate::usecases::clipboard_sync::apply_inbound::InboundFileSetManifest,
+        origin: ClipboardChangeOrigin,
+        entry_id: Option<EntryId>,
+        target_filter: Option<Vec<DeviceId>>,
+    ) -> Result<DispatchEntryOutcome, ClipboardSyncError> {
+        let _ = origin;
+        let categories = ClipboardContentCategorySet::from_snapshot(&snapshot);
+        let (plaintext, snapshot_hash) =
+            crate::usecases::clipboard_sync::payload_codec::encode_snapshot_with_blob_refs_and_file_set_to_v3_bytes(
+                &snapshot,
+                &blob_refs,
+                &manifest,
+            )
+            .map_err(|e| ClipboardSyncError::CipherFailure(format!("payload encode: {e}")))?;
+        self.dispatch_internal(
+            plaintext,
+            snapshot_hash,
+            3,
+            ClipboardHeader::DIRECTORY_VERSION,
             categories,
             entry_id,
             target_filter,

--- a/crates/uc-application/src/facade/clipboard_outbound/mod.rs
+++ b/crates/uc-application/src/facade/clipboard_outbound/mod.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Instant;
@@ -8,7 +9,8 @@ use thiserror::Error;
 use tracing::{debug, info, warn};
 use uc_core::blob::ports::BlobReaderPort;
 use uc_core::clipboard::{
-    is_file_mime_or_format, ClipboardPayloadSource, EntryFileSetExcludeReason, EntryFileSetLineKind,
+    is_file_mime_or_format, ClipboardPayloadSource, EntryFileSetExcludeReason,
+    EntryFileSetLineKind, FileSetMemberKind, FileSetMemberLocation,
 };
 use uc_core::ids::EntryId;
 use uc_core::ports::clipboard::{
@@ -27,6 +29,9 @@ use crate::facade::{
     PublishBlobPathCommand, PublishBlobResult,
 };
 use crate::sync_planner::{FileCandidate, FileSyncIntent, OutboundSyncPlanner};
+use crate::usecases::clipboard_sync::apply_inbound::{
+    InboundFileSetManifest, InboundFileSetMember,
+};
 use crate::usecases::clipboard_sync::resend_entry::{
     ResendEntryDeps, ResendEntryRunner, ResendEntryUseCase,
 };
@@ -230,22 +235,17 @@ impl ClipboardOutboundPort for ClipboardOutboundDispatcher {
         } else {
             OutboundFileSetResolution::NotFileClass
         };
-        let (resolved_paths, from_manifest, expected_digests) = match resolution {
-            OutboundFileSetResolution::NotFileClass => (Vec::new(), false, Vec::new()),
+        let (resolved_paths, from_manifest, expected_digests, directory_members) = match resolution
+        {
+            OutboundFileSetResolution::NotFileClass => (Vec::new(), false, Vec::new(), None),
             OutboundFileSetResolution::Manifest {
                 paths,
                 expected_digests,
-            } => (paths, true, expected_digests),
-            OutboundFileSetResolution::Fallback { paths } => (paths, false, Vec::new()),
-            OutboundFileSetResolution::DirectoryNotYetSyncable => {
-                info!(
-                    entry_id = %entry_id_str,
-                    "outbound: directory manifest retained locally; skipping dispatch"
-                );
-                return Ok(ClipboardOutboundOutcome::Skipped {
-                    reason: "directory_not_yet_syncable".to_string(),
-                });
+            } => (paths, true, expected_digests, None),
+            OutboundFileSetResolution::DirectorySyncable { paths, members } => {
+                (paths, true, Vec::new(), Some(members))
             }
+            OutboundFileSetResolution::Fallback { paths } => (paths, false, Vec::new(), None),
             OutboundFileSetResolution::Excluded {
                 ingest_failed,
                 size_cap_exceeded,
@@ -382,10 +382,33 @@ impl ClipboardOutboundPort for ClipboardOutboundDispatcher {
         blob_refs.append(&mut image_blob_refs);
         let blob_ref_count = blob_refs.len();
 
+        let file_set_manifest = match directory_members {
+            Some(members) => {
+                if plan.files.len() != extracted_paths_count {
+                    return Ok(ClipboardOutboundOutcome::Skipped {
+                        reason: "file_set_member_unavailable".to_string(),
+                    });
+                }
+                Some(build_transfer_manifest(&members, &plan.files)?)
+            }
+            None => None,
+        };
+
         let dispatch_phase_start = Instant::now();
         // LocalCapture 路径:把 entry_id 透传给 dispatch,fan-out 完成后落盘
         // 每个对端的投递结果(供视图层追踪"这条 entry 同步到了哪些设备")。
-        let dispatch_result = if blob_refs.is_empty() {
+        let dispatch_result = if let Some(manifest) = file_set_manifest {
+            self.clipboard_sync
+                .dispatch_snapshot_with_blob_refs_and_file_set(
+                    clipboard_intent.snapshot,
+                    blob_refs,
+                    manifest,
+                    input.origin,
+                    Some(entry_id.clone()),
+                    None,
+                )
+                .await
+        } else if blob_refs.is_empty() {
             self.clipboard_sync
                 .dispatch_snapshot(
                     clipboard_intent.snapshot,
@@ -571,9 +594,10 @@ pub(crate) enum OutboundFileSetResolution {
     /// best-effort save at capture, or an unreadable manifest row) — fall
     /// back to re-parsing the snapshot's reps.
     Fallback { paths: Vec<PathBuf> },
-    /// Directory members are captured locally but the current wire protocol
-    /// cannot reconstruct their tree yet.
-    DirectoryNotYetSyncable,
+    DirectorySyncable {
+        paths: Vec<PathBuf>,
+        members: Vec<DirectoryMemberSource>,
+    },
     /// The manifest exists but contains excluded lines: at least one member
     /// never got a content identity, so the entry's identity fell back to
     /// path text at capture. All-or-nothing — callers must not publish the
@@ -584,6 +608,12 @@ pub(crate) enum OutboundFileSetResolution {
         size_cap_exceeded: usize,
         unsupported_member: usize,
     },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DirectoryMemberSource {
+    pub location: FileSetMemberLocation,
+    pub path: Option<PathBuf>,
 }
 
 /// Resolve the member path list for an outbound file-class send, preferring
@@ -632,10 +662,6 @@ pub(crate) async fn resolve_outbound_file_set(
         }
     };
 
-    if file_set.has_directory_structure() {
-        return OutboundFileSetResolution::DirectoryNotYetSyncable;
-    }
-
     let mut ingest_failed = 0usize;
     let mut size_cap_exceeded = 0usize;
     let mut unsupported_member = 0usize;
@@ -654,6 +680,47 @@ pub(crate) async fn resolve_outbound_file_set(
             size_cap_exceeded,
             unsupported_member,
         };
+    }
+
+    if file_set.has_directory_structure() {
+        let mut paths = Vec::new();
+        let mut members = Vec::new();
+        for line in &file_set.lines {
+            let Some(location) = line.member_location.clone() else {
+                if matches!(line.kind, EntryFileSetLineKind::NonFile) {
+                    continue;
+                }
+                return OutboundFileSetResolution::Fallback {
+                    paths: extract_file_paths_from_snapshot(snapshot),
+                };
+            };
+            let path = match (&line.kind, location.kind) {
+                (
+                    EntryFileSetLineKind::File { .. },
+                    FileSetMemberKind::File | FileSetMemberKind::Executable,
+                ) => match manifest_line_path(&line.original_text) {
+                    Some(path) => {
+                        paths.push(path.clone());
+                        Some(path)
+                    }
+                    None => {
+                        return OutboundFileSetResolution::Fallback {
+                            paths: extract_file_paths_from_snapshot(snapshot),
+                        };
+                    }
+                },
+                (EntryFileSetLineKind::NonFile, FileSetMemberKind::EmptyDirectory) => None,
+                _ => {
+                    return OutboundFileSetResolution::Fallback {
+                        paths: extract_file_paths_from_snapshot(snapshot),
+                    };
+                }
+            };
+            members.push(DirectoryMemberSource { location, path });
+        }
+        paths.sort();
+        paths.dedup();
+        return OutboundFileSetResolution::DirectorySyncable { paths, members };
     }
 
     let mut paths = Vec::new();
@@ -682,6 +749,46 @@ pub(crate) async fn resolve_outbound_file_set(
         expected_digests: file_set.content_digest_contribution(),
         paths,
     }
+}
+
+fn build_transfer_manifest(
+    members: &[DirectoryMemberSource],
+    files: &[FileSyncIntent],
+) -> Result<InboundFileSetManifest, ClipboardOutboundError> {
+    let indexes: HashMap<&std::path::Path, u32> = files
+        .iter()
+        .enumerate()
+        .map(|(index, file)| {
+            let index = u32::try_from(index).map_err(|_| {
+                ClipboardOutboundError::Internal("file-set index cannot fit u32".to_string())
+            })?;
+            Ok((file.path.as_path(), index))
+        })
+        .collect::<Result<_, ClipboardOutboundError>>()?;
+    let members = members
+        .iter()
+        .map(|member| {
+            let blob_ref_index = match &member.path {
+                Some(path) => Some(*indexes.get(path.as_path()).ok_or_else(|| {
+                    ClipboardOutboundError::Internal(format!(
+                        "directory member was not published: {}",
+                        path.display()
+                    ))
+                })?),
+                None => None,
+            };
+            Ok(InboundFileSetMember {
+                root_index: u32::try_from(member.location.root_index).map_err(|_| {
+                    ClipboardOutboundError::Internal("negative directory root index".to_string())
+                })?,
+                root_name: member.location.root_name.clone(),
+                relative_path: member.location.relative_path.clone(),
+                kind: member.location.kind,
+                blob_ref_index,
+            })
+        })
+        .collect::<Result<Vec<_>, ClipboardOutboundError>>()?;
+    Ok(InboundFileSetManifest { members })
 }
 
 /// Recover the local path of a manifest `File` line. Capture writes
@@ -1002,7 +1109,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn resolver_blocks_directory_manifest_before_path_publication() {
+    async fn resolver_exposes_directory_members_for_wire_publication() {
         let mut line = file_line(1, "file:///tmp/root", 1);
         line.member_location = Some(FileSetMemberLocation {
             root_index: 0,
@@ -1017,10 +1124,15 @@ mod tests {
         )
         .await;
 
-        assert_eq!(
-            resolution,
-            OutboundFileSetResolution::DirectoryNotYetSyncable
-        );
+        match resolution {
+            OutboundFileSetResolution::DirectorySyncable { paths, members } => {
+                assert_eq!(paths, vec![PathBuf::from("/tmp/root")]);
+                assert_eq!(members.len(), 1);
+                assert_eq!(members[0].location.root_name, "root");
+                assert_eq!(members[0].path, Some(PathBuf::from("/tmp/root")));
+            }
+            other => panic!("expected directory syncable resolution, got {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/crates/uc-application/src/facade/clipboard_outbound/mod.rs
+++ b/crates/uc-application/src/facade/clipboard_outbound/mod.rs
@@ -30,7 +30,7 @@ use crate::facade::{
 };
 use crate::sync_planner::{FileCandidate, FileSyncIntent, OutboundSyncPlanner};
 use crate::usecases::clipboard_sync::apply_inbound::{
-    InboundFileSetManifest, InboundFileSetMember,
+    compute_file_set_component, InboundFileSetManifest, InboundFileSetMember,
 };
 use crate::usecases::clipboard_sync::resend_entry::{
     ResendEntryDeps, ResendEntryRunner, ResendEntryUseCase,
@@ -366,10 +366,6 @@ impl ClipboardOutboundPort for ClipboardOutboundDispatcher {
             }
         }
 
-        if !file_content_digests.is_empty() {
-            clipboard_intent.snapshot.file_content_digests = file_content_digests;
-        }
-
         let publish_inline_start = Instant::now();
         let mut image_blob_refs = publish_oversized_inline_blob_refs(
             self.blob_transfer.as_ref(),
@@ -393,6 +389,20 @@ impl ClipboardOutboundPort for ClipboardOutboundDispatcher {
             }
             None => None,
         };
+        if let Some(manifest) = &file_set_manifest {
+            let digests = file_content_digests
+                .iter()
+                .enumerate()
+                .map(|(index, digest)| (index as u32, *digest))
+                .collect();
+            clipboard_intent.snapshot.file_content_digests.clear();
+            clipboard_intent.snapshot.file_set_v1_component = Some(
+                compute_file_set_component(manifest, &digests)
+                    .map_err(|err| ClipboardOutboundError::Internal(err.to_string()))?,
+            );
+        } else if !file_content_digests.is_empty() {
+            clipboard_intent.snapshot.file_content_digests = file_content_digests;
+        }
 
         let dispatch_phase_start = Instant::now();
         // LocalCapture 路径:把 entry_id 透传给 dispatch,fan-out 完成后落盘
@@ -751,7 +761,7 @@ pub(crate) async fn resolve_outbound_file_set(
     }
 }
 
-fn build_transfer_manifest(
+pub(crate) fn build_transfer_manifest(
     members: &[DirectoryMemberSource],
     files: &[FileSyncIntent],
 ) -> Result<InboundFileSetManifest, ClipboardOutboundError> {

--- a/crates/uc-application/src/facade/clipboard_outbound/mod.rs
+++ b/crates/uc-application/src/facade/clipboard_outbound/mod.rs
@@ -698,13 +698,11 @@ pub(crate) async fn resolve_outbound_file_set(
         let directory_roots: std::collections::HashSet<i64> = file_set
             .lines
             .iter()
+            .filter(|line| line.indicates_directory_root(row_count))
             .filter_map(|line| {
-                line.member_location.as_ref().and_then(|location| {
-                    (location.kind == FileSetMemberKind::EmptyDirectory
-                        || location.relative_path.contains('/')
-                        || line.line_index >= row_count)
-                        .then_some(location.root_index)
-                })
+                line.member_location
+                    .as_ref()
+                    .map(|location| location.root_index)
             })
             .collect();
         let mut paths = Vec::new();

--- a/crates/uc-application/src/facade/clipboard_outbound/mod.rs
+++ b/crates/uc-application/src/facade/clipboard_outbound/mod.rs
@@ -624,6 +624,7 @@ pub(crate) enum OutboundFileSetResolution {
 pub(crate) struct DirectoryMemberSource {
     pub location: FileSetMemberLocation,
     pub path: Option<PathBuf>,
+    pub root_is_file: bool,
 }
 
 /// Resolve the member path list for an outbound file-class send, preferring
@@ -693,6 +694,19 @@ pub(crate) async fn resolve_outbound_file_set(
     }
 
     if file_set.has_directory_structure() {
+        let row_count = file_set.lines.len() as i64;
+        let directory_roots: std::collections::HashSet<i64> = file_set
+            .lines
+            .iter()
+            .filter_map(|line| {
+                line.member_location.as_ref().and_then(|location| {
+                    (location.kind == FileSetMemberKind::EmptyDirectory
+                        || location.relative_path.contains('/')
+                        || line.line_index >= row_count)
+                        .then_some(location.root_index)
+                })
+            })
+            .collect();
         let mut paths = Vec::new();
         let mut members = Vec::new();
         for line in &file_set.lines {
@@ -726,7 +740,12 @@ pub(crate) async fn resolve_outbound_file_set(
                     };
                 }
             };
-            members.push(DirectoryMemberSource { location, path });
+            let root_is_file = !directory_roots.contains(&location.root_index);
+            members.push(DirectoryMemberSource {
+                location,
+                path,
+                root_is_file,
+            });
         }
         paths.sort();
         paths.dedup();
@@ -792,6 +811,7 @@ pub(crate) fn build_transfer_manifest(
                     ClipboardOutboundError::Internal("negative directory root index".to_string())
                 })?,
                 root_name: member.location.root_name.clone(),
+                root_is_file: member.root_is_file,
                 relative_path: member.location.relative_path.clone(),
                 kind: member.location.kind,
                 blob_ref_index,
@@ -1140,9 +1160,43 @@ mod tests {
                 assert_eq!(members.len(), 1);
                 assert_eq!(members[0].location.root_name, "root");
                 assert_eq!(members[0].path, Some(PathBuf::from("/tmp/root")));
+                assert!(!members[0].root_is_file);
             }
             other => panic!("expected directory syncable resolution, got {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn resolver_distinguishes_file_roots_in_mixed_selection() {
+        let mut loose_file = file_line(0, "file:///tmp/loose.txt", 1);
+        loose_file.member_location = Some(FileSetMemberLocation {
+            root_index: 0,
+            root_name: "loose.txt".to_string(),
+            relative_path: "loose.txt".to_string(),
+            kind: FileSetMemberKind::File,
+        });
+        let mut directory_member = file_line(2, "file:///tmp/folder", 2);
+        directory_member.member_location = Some(FileSetMemberLocation {
+            root_index: 1,
+            root_name: "folder".to_string(),
+            relative_path: "child.txt".to_string(),
+            kind: FileSetMemberKind::File,
+        });
+
+        let resolution = resolve_outbound_file_set(
+            &FakeFileSetRepo::Found(EntryFileSet {
+                lines: vec![loose_file, directory_member],
+            }),
+            &EntryId::from("e1"),
+            &uri_list_snapshot("file:///tmp/loose.txt\nfile:///tmp/folder\n"),
+        )
+        .await;
+
+        let OutboundFileSetResolution::DirectorySyncable { members, .. } = resolution else {
+            panic!("expected directory syncable resolution");
+        };
+        assert!(members[0].root_is_file);
+        assert!(!members[1].root_is_file);
     }
 
     #[tokio::test]

--- a/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/materializer.rs
+++ b/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/materializer.rs
@@ -18,7 +18,10 @@ use async_trait::async_trait;
 use tracing::{debug, info, warn};
 use url::Url;
 
-use uc_core::clipboard::FileSetMemberKind;
+use uc_core::clipboard::{
+    ContentHash, EntryFileSet, EntryFileSetLine, EntryFileSetLineKind, FileSetMemberKind,
+    FileSetMemberLocation, HashAlgorithm,
+};
 use uc_core::ids::{DeviceId, EntryId, FormatId, RepresentationId};
 use uc_core::ports::inbound_file_target::ReserveInboundFileTargetPort;
 use uc_core::{MimeType, ObservedClipboardRepresentation, SystemClipboardSnapshot};
@@ -193,7 +196,7 @@ impl InboundBlobMaterializer for FileCacheBlobMaterializer {
         blob_refs: Vec<V3BlobRef>,
         file_set_manifest: Option<InboundFileSetManifest>,
     ) -> Result<MaterializeResult> {
-        if blob_refs.is_empty() {
+        if blob_refs.is_empty() && file_set_manifest.is_none() {
             return Ok(MaterializeResult::complete(snapshot));
         }
 
@@ -670,7 +673,7 @@ impl FileCacheBlobMaterializer {
             .join("iroh-blobs")
             .join("staging")
             .join(sanitize_path_segment(receiver_entry_id.as_ref()));
-        if tokio::fs::try_exists(&staging_base).await.unwrap_or(false) {
+        if tokio::fs::try_exists(&staging_base).await? {
             tokio::fs::remove_dir_all(&staging_base).await?;
         }
         tokio::fs::create_dir_all(&staging_base).await?;
@@ -688,9 +691,11 @@ impl FileCacheBlobMaterializer {
             .await;
 
         match result {
-            Ok((root_paths, file_content_digests)) => {
+            Ok((root_paths, member_digests)) => {
                 remove_directory_and_empty_parents(&staging_base, &self.cache_dir).await;
-                snapshot.file_content_digests = file_content_digests;
+                snapshot.file_content_digests.clear();
+                snapshot.file_set_v1_component =
+                    Some(compute_file_set_component(&manifest, &member_digests)?);
                 let uri_list = local_file_uri_list(&root_paths)?;
                 rewrite_file_list(&mut snapshot, uri_list, root_paths.len())?;
                 Ok(MaterializeResult::complete(snapshot))
@@ -711,7 +716,7 @@ impl FileCacheBlobMaterializer {
         staging_base: &std::path::Path,
         batch_idx: &mut usize,
         batch_total: usize,
-    ) -> Result<(Vec<PathBuf>, Vec<[u8; 32]>)> {
+    ) -> Result<(Vec<PathBuf>, BTreeMap<u32, [u8; 32]>)> {
         let mut roots = BTreeMap::<u32, String>::new();
         for member in &manifest.members {
             validate_manifest_member(member)?;
@@ -732,7 +737,7 @@ impl FileCacheBlobMaterializer {
             tokio::fs::create_dir_all(staging_root(staging_base, *root_index, root_name)).await?;
         }
 
-        let mut file_content_digests = Vec::new();
+        let mut member_digests = BTreeMap::new();
         for member in &manifest.members {
             let root = staging_root(staging_base, member.root_index, &member.root_name);
             let target = join_relative_path(&root, &member.relative_path)?;
@@ -772,11 +777,14 @@ impl FileCacheBlobMaterializer {
                         .fetch_blob_to_path(FetchBlobToPathCommand {
                             ticket: blob_ref.ticket.clone(),
                             entry_id: blob_ref.entry_id.clone(),
-                            target_path: target,
+                            target_path: target.clone(),
                             transfer_context: Some(context),
                         })
                         .await?;
-                    file_content_digests.push(*fetched.plaintext_hash.as_bytes());
+                    if member.kind == FileSetMemberKind::Executable {
+                        restore_executable_permission(&target).await?;
+                    }
+                    member_digests.insert(index as u32, *fetched.plaintext_hash.as_bytes());
                 }
             }
         }
@@ -787,27 +795,195 @@ impl FileCacheBlobMaterializer {
             .join(sanitize_path_segment(receiver_entry_id.as_ref()));
         tokio::fs::create_dir_all(&managed_parent).await?;
         let mut destinations = Vec::new();
+        let mut reserved_destinations = HashSet::new();
         for (root_index, root_name) in &roots {
             let reserved = match &self.target_reserver {
                 Some(reserver) => reserver.reserve_target(root_name).await,
                 None => None,
             };
-            let destination = reserved.unwrap_or_else(|| managed_parent.join(root_name));
-            if destination.is_file() {
-                tokio::fs::remove_file(&destination).await?;
+            let destination = match reserved {
+                Some(path) => path,
+                None => resolve_nonconflicting_root_path(
+                    &managed_parent,
+                    root_name,
+                    &reserved_destinations,
+                )?,
+            };
+            if !reserved_destinations.insert(destination.clone()) {
+                return Err(anyhow!(
+                    "directory target reserver returned a duplicate path: {}",
+                    destination.display()
+                ));
             }
-            if tokio::fs::try_exists(&destination).await? {
+            destinations.push((*root_index, root_name.clone(), destination));
+        }
+
+        for (_, _, destination) in &destinations {
+            if destination.is_file() {
+                tokio::fs::remove_file(destination).await?;
+            }
+            if tokio::fs::try_exists(destination).await? {
                 return Err(anyhow!(
                     "directory destination already exists: {}",
                     destination.display()
                 ));
             }
-            let source = staging_root(staging_base, *root_index, root_name);
-            tokio::fs::rename(&source, &destination).await?;
-            destinations.push(destination);
         }
-        Ok((destinations, file_content_digests))
+
+        let mut promoted = Vec::new();
+        for (root_index, root_name, destination) in &destinations {
+            let source = staging_root(staging_base, *root_index, root_name);
+            if let Err(err) = promote_directory(&source, destination).await {
+                for path in promoted.iter().rev() {
+                    let _ = tokio::fs::remove_dir_all(path).await;
+                }
+                return Err(err);
+            }
+            promoted.push(destination.clone());
+        }
+        Ok((promoted, member_digests))
     }
+}
+
+pub(crate) fn compute_file_set_component(
+    manifest: &InboundFileSetManifest,
+    member_digests: &BTreeMap<u32, [u8; 32]>,
+) -> Result<[u8; 32]> {
+    let row_count = i64::try_from(manifest.members.len())?;
+    let mut lines = Vec::with_capacity(manifest.members.len());
+    for (index, member) in manifest.members.iter().enumerate() {
+        let location = FileSetMemberLocation {
+            root_index: i64::from(member.root_index),
+            root_name: member.root_name.clone(),
+            relative_path: member.relative_path.clone(),
+            kind: member.kind,
+        };
+        let kind = match member.kind {
+            FileSetMemberKind::File | FileSetMemberKind::Executable => {
+                let blob_ref_index = member
+                    .blob_ref_index
+                    .ok_or_else(|| anyhow!("file member is missing its blob reference"))?;
+                let bytes = member_digests
+                    .get(&blob_ref_index)
+                    .ok_or_else(|| anyhow!("file member is missing its fetched content digest"))?;
+                EntryFileSetLineKind::File {
+                    content_hash: ContentHash {
+                        alg: HashAlgorithm::Blake3V1,
+                        bytes: *bytes,
+                    },
+                    blob_id: None,
+                    size_bytes: None,
+                }
+            }
+            FileSetMemberKind::EmptyDirectory => EntryFileSetLineKind::NonFile,
+        };
+        lines.push(EntryFileSetLine {
+            line_index: row_count + i64::try_from(index)?,
+            original_text: String::new(),
+            member_location: Some(location),
+            kind,
+        });
+    }
+    EntryFileSet { lines }
+        .file_set_v1_component()
+        .ok_or_else(|| anyhow!("directory manifest cannot produce a file-set identity"))
+}
+
+fn resolve_nonconflicting_root_path(
+    parent: &std::path::Path,
+    desired_name: &str,
+    reserved: &HashSet<PathBuf>,
+) -> Result<PathBuf> {
+    let desired = parent.join(desired_name);
+    if !desired.exists() && !reserved.contains(&desired) {
+        return Ok(desired);
+    }
+    let mut suffix = 2u32;
+    loop {
+        let candidate = parent.join(format!("{desired_name} ({suffix})"));
+        if !candidate.exists() && !reserved.contains(&candidate) {
+            return Ok(candidate);
+        }
+        suffix = suffix
+            .checked_add(1)
+            .ok_or_else(|| anyhow!("directory collision suffix space exhausted"))?;
+    }
+}
+
+async fn promote_directory(source: &std::path::Path, destination: &std::path::Path) -> Result<()> {
+    match tokio::fs::rename(source, destination).await {
+        Ok(()) => Ok(()),
+        Err(rename_error) => {
+            let parent = destination
+                .parent()
+                .ok_or_else(|| anyhow!("directory destination has no parent"))?;
+            let file_name = destination
+                .file_name()
+                .and_then(|name| name.to_str())
+                .ok_or_else(|| anyhow!("directory destination name is not valid UTF-8"))?;
+            let hidden = parent.join(format!(".uniclip-staging-{file_name}"));
+            if tokio::fs::try_exists(&hidden).await? {
+                tokio::fs::remove_dir_all(&hidden).await?;
+            }
+            let source = source.to_path_buf();
+            let source_copy = source.clone();
+            let hidden_copy = hidden.clone();
+            tokio::task::spawn_blocking(move || copy_directory_tree(&source_copy, &hidden_copy))
+                .await
+                .map_err(|err| anyhow!("directory copy task failed: {err}"))??;
+            if let Err(err) = tokio::fs::rename(&hidden, destination).await {
+                let _ = tokio::fs::remove_dir_all(&hidden).await;
+                return Err(anyhow!(
+                    "directory promotion failed after rename error ({rename_error}): {err}"
+                ));
+            }
+            tokio::fs::remove_dir_all(source).await?;
+            Ok(())
+        }
+    }
+}
+
+fn copy_directory_tree(source: &std::path::Path, destination: &std::path::Path) -> Result<()> {
+    std::fs::create_dir_all(destination)?;
+    for entry in std::fs::read_dir(source)? {
+        let entry = entry?;
+        let source_path = entry.path();
+        let destination_path = destination.join(entry.file_name());
+        let metadata = entry.metadata()?;
+        if metadata.is_dir() {
+            copy_directory_tree(&source_path, &destination_path)?;
+        } else if metadata.is_file() {
+            let copied = std::fs::copy(&source_path, &destination_path)?;
+            if copied != metadata.len() {
+                return Err(anyhow!(
+                    "copied byte count mismatch for {}",
+                    source_path.display()
+                ));
+            }
+            std::fs::set_permissions(&destination_path, metadata.permissions())?;
+        } else {
+            return Err(anyhow!(
+                "staging tree contains an unsupported member: {}",
+                source_path.display()
+            ));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+async fn restore_executable_permission(path: &std::path::Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let mut permissions = tokio::fs::metadata(path).await?.permissions();
+    permissions.set_mode(permissions.mode() | 0o111);
+    tokio::fs::set_permissions(path, permissions).await?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+async fn restore_executable_permission(_path: &std::path::Path) -> Result<()> {
+    Ok(())
 }
 
 fn validate_manifest_member(member: &InboundFileSetMember) -> Result<()> {

--- a/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/materializer.rs
+++ b/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/materializer.rs
@@ -138,6 +138,8 @@ pub trait InboundBlobFetcher: Send + Sync {
         &self,
         command: FetchBlobToPathCommand,
     ) -> Result<FetchBlobToPathResult>;
+
+    async fn record_unfetched_failure(&self, _context: FetchTransferContext, _detail: String) {}
 }
 
 #[async_trait]
@@ -157,6 +159,10 @@ impl InboundBlobFetcher for BlobTransferFacade {
         BlobTransferFacade::fetch_blob_to_path(self, command)
             .await
             .map_err(anyhow::Error::from)
+    }
+
+    async fn record_unfetched_failure(&self, context: FetchTransferContext, detail: String) {
+        BlobTransferFacade::record_unfetched_failure(self, context, detail).await;
     }
 }
 
@@ -273,12 +279,14 @@ impl InboundBlobMaterializer for FileCacheBlobMaterializer {
             // 两者让 sender UI 能定位本地 entry 并接收实时字节进度。
             let transfer_context = FetchTransferContext {
                 transfer_id: receiver_entry_id.as_ref().to_string(),
+                entry_id: receiver_entry_id.as_ref().to_string(),
                 peer_id: from_device.as_str().to_string(),
                 total_bytes: Some(advertised_size),
                 filename: String::new(),
                 outbound_transfer_id: Some(blob_ref.entry_id.as_ref().to_string()),
                 outbound_target: Some(from_device.clone()),
                 batch_position: position_in_batch(batch_idx, batch_total),
+                individual_lifecycle: false,
             };
             batch_idx += 1;
             let fetched = match self
@@ -416,12 +424,14 @@ impl InboundBlobMaterializer for FileCacheBlobMaterializer {
             // 让 sender UI 定位本地 entry,target 是消息来源 device。
             let transfer_context = FetchTransferContext {
                 transfer_id: receiver_entry_id.as_ref().to_string(),
+                entry_id: receiver_entry_id.as_ref().to_string(),
                 peer_id: from_device.as_str().to_string(),
                 total_bytes: Some(advertised_size),
                 filename: declared_name.clone().unwrap_or_default(),
                 outbound_transfer_id: Some(blob_ref.entry_id.as_ref().to_string()),
                 outbound_target: Some(from_device.clone()),
                 batch_position: position_in_batch(batch_idx, batch_total),
+                individual_lifecycle: false,
             };
             batch_idx += 1;
 
@@ -738,7 +748,7 @@ impl FileCacheBlobMaterializer {
         }
 
         let mut member_digests = BTreeMap::new();
-        for member in &manifest.members {
+        for (member_index, member) in manifest.members.iter().enumerate() {
             let root = staging_root(staging_base, member.root_index, &member.root_name);
             let target = join_relative_path(&root, &member.relative_path)?;
             match member.kind {
@@ -763,16 +773,18 @@ impl FileCacheBlobMaterializer {
                         tokio::fs::create_dir_all(parent).await?;
                     }
                     let context = FetchTransferContext {
-                        transfer_id: receiver_entry_id.as_ref().to_string(),
+                        transfer_id: directory_member_transfer_id(receiver_entry_id, member_index),
+                        entry_id: receiver_entry_id.as_ref().to_string(),
                         peer_id: from_device.as_str().to_string(),
                         total_bytes: Some(blob_ref.size_bytes),
                         filename: blob_ref.filename.clone().unwrap_or_default(),
                         outbound_transfer_id: Some(blob_ref.entry_id.as_ref().to_string()),
                         outbound_target: Some(from_device.clone()),
                         batch_position: position_in_batch(*batch_idx, batch_total),
+                        individual_lifecycle: true,
                     };
                     *batch_idx += 1;
-                    let fetched = self
+                    let fetched = match self
                         .fetcher
                         .fetch_blob_to_path(FetchBlobToPathCommand {
                             ticket: blob_ref.ticket.clone(),
@@ -780,7 +792,52 @@ impl FileCacheBlobMaterializer {
                             target_path: target.clone(),
                             transfer_context: Some(context),
                         })
-                        .await?;
+                        .await
+                    {
+                        Ok(fetched) => fetched,
+                        Err(err) => {
+                            let detail = err.to_string();
+                            for (remaining_index, remaining) in
+                                manifest.members.iter().enumerate().skip(member_index + 1)
+                            {
+                                if remaining.kind == FileSetMemberKind::EmptyDirectory {
+                                    continue;
+                                }
+                                let remaining_blob_index =
+                                    remaining.blob_ref_index.ok_or_else(|| {
+                                        anyhow!("file member is missing its blob reference")
+                                    })? as usize;
+                                let remaining_blob = blob_refs.get(remaining_blob_index).ok_or_else(|| {
+                                    anyhow!("directory blob reference index {remaining_blob_index} is out of bounds")
+                                })?;
+                                self.fetcher
+                                    .record_unfetched_failure(
+                                        FetchTransferContext {
+                                            transfer_id: directory_member_transfer_id(
+                                                receiver_entry_id,
+                                                remaining_index,
+                                            ),
+                                            entry_id: receiver_entry_id.as_ref().to_string(),
+                                            peer_id: from_device.as_str().to_string(),
+                                            total_bytes: Some(remaining_blob.size_bytes),
+                                            filename: remaining_blob
+                                                .filename
+                                                .clone()
+                                                .unwrap_or_default(),
+                                            outbound_transfer_id: Some(
+                                                remaining_blob.entry_id.as_ref().to_string(),
+                                            ),
+                                            outbound_target: Some(*from_device),
+                                            batch_position: BatchPosition::Middle,
+                                            individual_lifecycle: true,
+                                        },
+                                        format!("not fetched after another directory member failed: {detail}"),
+                                    )
+                                    .await;
+                            }
+                            return Err(err);
+                        }
+                    };
                     if member.kind == FileSetMemberKind::Executable {
                         restore_executable_permission(&target).await?;
                     }
@@ -843,6 +900,10 @@ impl FileCacheBlobMaterializer {
         }
         Ok((promoted, member_digests))
     }
+}
+
+fn directory_member_transfer_id(receiver_entry_id: &EntryId, member_index: usize) -> String {
+    format!("{}:member:{member_index}", receiver_entry_id.as_ref())
 }
 
 pub(crate) fn compute_file_set_component(

--- a/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/materializer.rs
+++ b/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/materializer.rs
@@ -62,6 +62,7 @@ pub struct InboundFileSetManifest {
 pub struct InboundFileSetMember {
     pub root_index: u32,
     pub root_name: String,
+    pub root_is_file: bool,
     pub relative_path: String,
     pub kind: FileSetMemberKind,
     pub blob_ref_index: Option<u32>,
@@ -727,30 +728,50 @@ impl FileCacheBlobMaterializer {
         batch_idx: &mut usize,
         batch_total: usize,
     ) -> Result<(Vec<PathBuf>, BTreeMap<u32, [u8; 32]>)> {
-        let mut roots = BTreeMap::<u32, String>::new();
+        let mut roots = BTreeMap::<u32, (String, bool)>::new();
+        let mut root_member_counts = BTreeMap::<u32, usize>::new();
         for member in &manifest.members {
             validate_manifest_member(member)?;
+            *root_member_counts.entry(member.root_index).or_default() += 1;
             match roots.get(&member.root_index) {
-                Some(existing) if existing != &member.root_name => {
+                Some((existing_name, existing_is_file))
+                    if existing_name != &member.root_name
+                        || *existing_is_file != member.root_is_file =>
+                {
                     return Err(anyhow!(
                         "directory root {} has conflicting names",
                         member.root_index
                     ));
                 }
                 _ => {
-                    roots.insert(member.root_index, member.root_name.clone());
+                    roots.insert(
+                        member.root_index,
+                        (member.root_name.clone(), member.root_is_file),
+                    );
                 }
             }
         }
+        for (root_index, (_, root_is_file)) in &roots {
+            if *root_is_file && root_member_counts.get(root_index) != Some(&1) {
+                return Err(anyhow!("top-level file root must have exactly one member"));
+            }
+        }
 
-        for (root_index, root_name) in &roots {
-            tokio::fs::create_dir_all(staging_root(staging_base, *root_index, root_name)).await?;
+        for (root_index, (root_name, root_is_file)) in &roots {
+            if !root_is_file {
+                tokio::fs::create_dir_all(staging_root(staging_base, *root_index, root_name))
+                    .await?;
+            }
         }
 
         let mut member_digests = BTreeMap::new();
         for (member_index, member) in manifest.members.iter().enumerate() {
             let root = staging_root(staging_base, member.root_index, &member.root_name);
-            let target = join_relative_path(&root, &member.relative_path)?;
+            let target = if member.root_is_file {
+                root.clone()
+            } else {
+                join_relative_path(&root, &member.relative_path)?
+            };
             match member.kind {
                 FileSetMemberKind::EmptyDirectory => {
                     if member.blob_ref_index.is_some() {
@@ -853,7 +874,7 @@ impl FileCacheBlobMaterializer {
         tokio::fs::create_dir_all(&managed_parent).await?;
         let mut destinations = Vec::new();
         let mut reserved_destinations = HashSet::new();
-        for (root_index, root_name) in &roots {
+        for (root_index, (root_name, _)) in &roots {
             let reserved = match &self.target_reserver {
                 Some(reserver) => reserver.reserve_target(root_name).await,
                 None => None,
@@ -887,12 +908,12 @@ impl FileCacheBlobMaterializer {
             }
         }
 
-        let mut promoted = Vec::new();
+        let mut promoted: Vec<PathBuf> = Vec::new();
         for (root_index, root_name, destination) in &destinations {
             let source = staging_root(staging_base, *root_index, root_name);
-            if let Err(err) = promote_directory(&source, destination).await {
+            if let Err(err) = promote_root(&source, destination).await {
                 for path in promoted.iter().rev() {
-                    let _ = tokio::fs::remove_dir_all(path).await;
+                    remove_path(path).await?;
                 }
                 return Err(err);
             }
@@ -971,7 +992,7 @@ fn resolve_nonconflicting_root_path(
     }
 }
 
-async fn promote_directory(source: &std::path::Path, destination: &std::path::Path) -> Result<()> {
+async fn promote_root(source: &std::path::Path, destination: &std::path::Path) -> Result<()> {
     match tokio::fs::rename(source, destination).await {
         Ok(()) => Ok(()),
         Err(rename_error) => {
@@ -984,24 +1005,60 @@ async fn promote_directory(source: &std::path::Path, destination: &std::path::Pa
                 .ok_or_else(|| anyhow!("directory destination name is not valid UTF-8"))?;
             let hidden = parent.join(format!(".uniclip-staging-{file_name}"));
             if tokio::fs::try_exists(&hidden).await? {
-                tokio::fs::remove_dir_all(&hidden).await?;
+                remove_path(&hidden).await?;
             }
             let source = source.to_path_buf();
             let source_copy = source.clone();
             let hidden_copy = hidden.clone();
-            tokio::task::spawn_blocking(move || copy_directory_tree(&source_copy, &hidden_copy))
+            tokio::task::spawn_blocking(move || copy_root(&source_copy, &hidden_copy))
                 .await
                 .map_err(|err| anyhow!("directory copy task failed: {err}"))??;
             if let Err(err) = tokio::fs::rename(&hidden, destination).await {
-                let _ = tokio::fs::remove_dir_all(&hidden).await;
+                let cleanup_error = remove_path(&hidden).await.err();
                 return Err(anyhow!(
-                    "directory promotion failed after rename error ({rename_error}): {err}"
+                    "directory promotion failed after rename error ({rename_error}): {err}; cleanup error: {cleanup_error:?}"
                 ));
             }
-            tokio::fs::remove_dir_all(source).await?;
+            remove_path(&source).await?;
             Ok(())
         }
     }
+}
+
+fn copy_root(source: &std::path::Path, destination: &std::path::Path) -> Result<()> {
+    let metadata = std::fs::metadata(source)?;
+    if metadata.is_dir() {
+        return copy_directory_tree(source, destination);
+    }
+    if metadata.is_file() {
+        let copied = std::fs::copy(source, destination)?;
+        if copied != metadata.len() {
+            return Err(anyhow!(
+                "copied byte count mismatch for {}",
+                source.display()
+            ));
+        }
+        std::fs::set_permissions(destination, metadata.permissions())?;
+        return Ok(());
+    }
+    Err(anyhow!(
+        "staging root has an unsupported type: {}",
+        source.display()
+    ))
+}
+
+async fn remove_path(path: &std::path::Path) -> Result<()> {
+    match tokio::fs::metadata(path).await {
+        Ok(metadata) if metadata.is_dir() => {
+            tokio::fs::remove_dir_all(path).await?;
+        }
+        Ok(_) => {
+            tokio::fs::remove_file(path).await?;
+        }
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+        Err(err) => return Err(err.into()),
+    }
+    Ok(())
 }
 
 fn copy_directory_tree(source: &std::path::Path, destination: &std::path::Path) -> Result<()> {
@@ -1057,6 +1114,12 @@ fn validate_manifest_member(member: &InboundFileSetMember) -> Result<()> {
     }
     if member.relative_path.is_empty() {
         return Err(anyhow!("directory member has an empty relative path"));
+    }
+    if member.root_is_file
+        && (member.relative_path != member.root_name
+            || member.kind == FileSetMemberKind::EmptyDirectory)
+    {
+        return Err(anyhow!("invalid top-level file member"));
     }
     Ok(())
 }

--- a/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/materializer.rs
+++ b/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/materializer.rs
@@ -144,6 +144,28 @@ pub trait InboundBlobFetcher: Send + Sync {
 }
 
 #[async_trait]
+pub(crate) trait RootRenamer: Send + Sync {
+    async fn rename(
+        &self,
+        source: &std::path::Path,
+        destination: &std::path::Path,
+    ) -> std::io::Result<()>;
+}
+
+struct TokioRootRenamer;
+
+#[async_trait]
+impl RootRenamer for TokioRootRenamer {
+    async fn rename(
+        &self,
+        source: &std::path::Path,
+        destination: &std::path::Path,
+    ) -> std::io::Result<()> {
+        tokio::fs::rename(source, destination).await
+    }
+}
+
+#[async_trait]
 impl InboundBlobFetcher for BlobTransferFacade {
     async fn fetch_blob(&self, command: FetchBlobCommand) -> Result<FetchBlobResult> {
         // 保留 thiserror 类型链:materializer 用 `is_cancel_error` downcast
@@ -171,6 +193,7 @@ pub struct FileCacheBlobMaterializer {
     fetcher: Arc<dyn InboundBlobFetcher>,
     cache_dir: PathBuf,
     target_reserver: Option<Arc<dyn ReserveInboundFileTargetPort>>,
+    root_renamer: Arc<dyn RootRenamer>,
 }
 
 impl FileCacheBlobMaterializer {
@@ -179,6 +202,7 @@ impl FileCacheBlobMaterializer {
             fetcher,
             cache_dir,
             target_reserver: None,
+            root_renamer: Arc::new(TokioRootRenamer),
         }
     }
 
@@ -189,6 +213,12 @@ impl FileCacheBlobMaterializer {
     /// `cache_dir/iroh-blobs/<entry_id>/` layout is used.
     pub fn with_target_reserver(mut self, reserver: Arc<dyn ReserveInboundFileTargetPort>) -> Self {
         self.target_reserver = Some(reserver);
+        self
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_root_renamer(mut self, renamer: Arc<dyn RootRenamer>) -> Self {
+        self.root_renamer = renamer;
         self
     }
 }
@@ -911,7 +941,7 @@ impl FileCacheBlobMaterializer {
         let mut promoted: Vec<PathBuf> = Vec::new();
         for (root_index, root_name, destination) in &destinations {
             let source = staging_root(staging_base, *root_index, root_name);
-            if let Err(err) = promote_root(&source, destination).await {
+            if let Err(err) = promote_root(&source, destination, self.root_renamer.as_ref()).await {
                 for path in promoted.iter().rev() {
                     remove_path(path).await?;
                 }
@@ -992,8 +1022,12 @@ fn resolve_nonconflicting_root_path(
     }
 }
 
-async fn promote_root(source: &std::path::Path, destination: &std::path::Path) -> Result<()> {
-    match tokio::fs::rename(source, destination).await {
+async fn promote_root(
+    source: &std::path::Path,
+    destination: &std::path::Path,
+    renamer: &dyn RootRenamer,
+) -> Result<()> {
+    match renamer.rename(source, destination).await {
         Ok(()) => Ok(()),
         Err(rename_error) => {
             let parent = destination
@@ -1013,7 +1047,7 @@ async fn promote_root(source: &std::path::Path, destination: &std::path::Path) -
             tokio::task::spawn_blocking(move || copy_root(&source_copy, &hidden_copy))
                 .await
                 .map_err(|err| anyhow!("directory copy task failed: {err}"))??;
-            if let Err(err) = tokio::fs::rename(&hidden, destination).await {
+            if let Err(err) = renamer.rename(&hidden, destination).await {
                 let cleanup_error = remove_path(&hidden).await.err();
                 return Err(anyhow!(
                     "directory promotion failed after rename error ({rename_error}): {err}; cleanup error: {cleanup_error:?}"

--- a/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/materializer.rs
+++ b/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/materializer.rs
@@ -911,11 +911,14 @@ impl FileCacheBlobMaterializer {
             };
             let destination = match reserved {
                 Some(path) => path,
-                None => resolve_nonconflicting_root_path(
-                    &managed_parent,
-                    root_name,
-                    &reserved_destinations,
-                )?,
+                None => {
+                    resolve_nonconflicting_root_path(
+                        &managed_parent,
+                        root_name,
+                        &reserved_destinations,
+                    )
+                    .await?
+                }
             };
             if !reserved_destinations.insert(destination.clone()) {
                 return Err(anyhow!(
@@ -927,8 +930,10 @@ impl FileCacheBlobMaterializer {
         }
 
         for (_, _, destination) in &destinations {
-            if destination.is_file() {
-                tokio::fs::remove_file(destination).await?;
+            if let Ok(metadata) = tokio::fs::metadata(destination).await {
+                if metadata.is_file() {
+                    tokio::fs::remove_file(destination).await?;
+                }
             }
             if tokio::fs::try_exists(destination).await? {
                 return Err(anyhow!(
@@ -1001,19 +1006,19 @@ pub(crate) fn compute_file_set_component(
         .ok_or_else(|| anyhow!("directory manifest cannot produce a file-set identity"))
 }
 
-fn resolve_nonconflicting_root_path(
+async fn resolve_nonconflicting_root_path(
     parent: &std::path::Path,
     desired_name: &str,
     reserved: &HashSet<PathBuf>,
 ) -> Result<PathBuf> {
     let desired = parent.join(desired_name);
-    if !desired.exists() && !reserved.contains(&desired) {
+    if !reserved.contains(&desired) && !tokio::fs::try_exists(&desired).await? {
         return Ok(desired);
     }
     let mut suffix = 2u32;
     loop {
         let candidate = parent.join(format!("{desired_name} ({suffix})"));
-        if !candidate.exists() && !reserved.contains(&candidate) {
+        if !reserved.contains(&candidate) && !tokio::fs::try_exists(&candidate).await? {
             return Ok(candidate);
         }
         suffix = suffix

--- a/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/materializer.rs
+++ b/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/materializer.rs
@@ -9,7 +9,7 @@
 //! `InboundBlobFetcher` 是 facade 适配层,生产环境就是 `BlobTransferFacade`,
 //! 测试用 mockall 替身。
 
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -18,6 +18,7 @@ use async_trait::async_trait;
 use tracing::{debug, info, warn};
 use url::Url;
 
+use uc_core::clipboard::FileSetMemberKind;
 use uc_core::ids::{DeviceId, EntryId, FormatId, RepresentationId};
 use uc_core::ports::inbound_file_target::ReserveInboundFileTargetPort;
 use uc_core::{MimeType, ObservedClipboardRepresentation, SystemClipboardSnapshot};
@@ -47,6 +48,20 @@ pub fn is_cancel_error(err: &anyhow::Error) -> bool {
 pub struct MissingFileRef {
     pub filename: String,
     pub size_bytes: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InboundFileSetManifest {
+    pub members: Vec<InboundFileSetMember>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InboundFileSetMember {
+    pub root_index: u32,
+    pub root_name: String,
+    pub relative_path: String,
+    pub kind: FileSetMemberKind,
+    pub blob_ref_index: Option<u32>,
 }
 
 /// `InboundBlobMaterializer::materialize` 的返回值。
@@ -102,6 +117,7 @@ pub trait InboundBlobMaterializer: Send + Sync {
         receiver_entry_id: EntryId,
         snapshot: SystemClipboardSnapshot,
         blob_refs: Vec<V3BlobRef>,
+        file_set_manifest: Option<InboundFileSetManifest>,
     ) -> Result<MaterializeResult>;
 }
 
@@ -175,6 +191,7 @@ impl InboundBlobMaterializer for FileCacheBlobMaterializer {
         receiver_entry_id: EntryId,
         mut snapshot: SystemClipboardSnapshot,
         blob_refs: Vec<V3BlobRef>,
+        file_set_manifest: Option<InboundFileSetManifest>,
     ) -> Result<MaterializeResult> {
         if blob_refs.is_empty() {
             return Ok(MaterializeResult::complete(snapshot));
@@ -188,6 +205,7 @@ impl InboundBlobMaterializer for FileCacheBlobMaterializer {
         //   - `representation_index = None`: free-standing file (legacy
         //     file-URI path). Fetched bytes go to cache_dir, file-list rep is
         //     rewritten with local `file://` URIs.
+        let manifest_blob_refs = file_set_manifest.as_ref().map(|_| blob_refs.clone());
         let (rep_refs, file_refs): (Vec<V3BlobRef>, Vec<V3BlobRef>) = blob_refs
             .into_iter()
             .partition(|r| r.representation_index.is_some());
@@ -317,6 +335,9 @@ impl InboundBlobMaterializer for FileCacheBlobMaterializer {
         // Rep-refs stage partial (cancel or error): skip all file_refs fetches,
         // mark them missing, finalize via the partial path.
         if partial {
+            if file_set_manifest.is_some() {
+                return Err(anyhow!("directory representation blob fetch failed"));
+            }
             for blob_ref in file_refs.iter() {
                 missing_files.push(MissingFileRef {
                     filename: blob_ref
@@ -336,7 +357,23 @@ impl InboundBlobMaterializer for FileCacheBlobMaterializer {
         }
 
         if file_refs.is_empty() {
-            return Ok(MaterializeResult::complete(snapshot));
+            if file_set_manifest.is_none() {
+                return Ok(MaterializeResult::complete(snapshot));
+            }
+        }
+
+        if let Some(manifest) = file_set_manifest {
+            return self
+                .materialize_directory(
+                    from_device,
+                    receiver_entry_id,
+                    snapshot,
+                    manifest_blob_refs.unwrap_or_default(),
+                    manifest,
+                    batch_idx,
+                    batch_total,
+                )
+                .await;
         }
 
         // 2. Free-standing files: existing cache_dir + file-list rewrite path.
@@ -611,6 +648,240 @@ impl InboundBlobMaterializer for FileCacheBlobMaterializer {
 
         Ok(MaterializeResult::complete(snapshot))
     }
+}
+
+impl FileCacheBlobMaterializer {
+    async fn materialize_directory(
+        &self,
+        from_device: DeviceId,
+        receiver_entry_id: EntryId,
+        mut snapshot: SystemClipboardSnapshot,
+        blob_refs: Vec<V3BlobRef>,
+        manifest: InboundFileSetManifest,
+        mut batch_idx: usize,
+        batch_total: usize,
+    ) -> Result<MaterializeResult> {
+        if manifest.members.is_empty() {
+            return Err(anyhow!("directory manifest has no members"));
+        }
+
+        let staging_base = self
+            .cache_dir
+            .join("iroh-blobs")
+            .join("staging")
+            .join(sanitize_path_segment(receiver_entry_id.as_ref()));
+        if tokio::fs::try_exists(&staging_base).await.unwrap_or(false) {
+            tokio::fs::remove_dir_all(&staging_base).await?;
+        }
+        tokio::fs::create_dir_all(&staging_base).await?;
+
+        let result = self
+            .build_and_promote_directory(
+                &from_device,
+                &receiver_entry_id,
+                &blob_refs,
+                &manifest,
+                &staging_base,
+                &mut batch_idx,
+                batch_total,
+            )
+            .await;
+
+        match result {
+            Ok((root_paths, file_content_digests)) => {
+                remove_directory_and_empty_parents(&staging_base, &self.cache_dir).await;
+                snapshot.file_content_digests = file_content_digests;
+                let uri_list = local_file_uri_list(&root_paths)?;
+                rewrite_file_list(&mut snapshot, uri_list, root_paths.len())?;
+                Ok(MaterializeResult::complete(snapshot))
+            }
+            Err(err) => {
+                remove_directory_and_empty_parents(&staging_base, &self.cache_dir).await;
+                Err(err)
+            }
+        }
+    }
+
+    async fn build_and_promote_directory(
+        &self,
+        from_device: &DeviceId,
+        receiver_entry_id: &EntryId,
+        blob_refs: &[V3BlobRef],
+        manifest: &InboundFileSetManifest,
+        staging_base: &std::path::Path,
+        batch_idx: &mut usize,
+        batch_total: usize,
+    ) -> Result<(Vec<PathBuf>, Vec<[u8; 32]>)> {
+        let mut roots = BTreeMap::<u32, String>::new();
+        for member in &manifest.members {
+            validate_manifest_member(member)?;
+            match roots.get(&member.root_index) {
+                Some(existing) if existing != &member.root_name => {
+                    return Err(anyhow!(
+                        "directory root {} has conflicting names",
+                        member.root_index
+                    ));
+                }
+                _ => {
+                    roots.insert(member.root_index, member.root_name.clone());
+                }
+            }
+        }
+
+        for (root_index, root_name) in &roots {
+            tokio::fs::create_dir_all(staging_root(staging_base, *root_index, root_name)).await?;
+        }
+
+        let mut file_content_digests = Vec::new();
+        for member in &manifest.members {
+            let root = staging_root(staging_base, member.root_index, &member.root_name);
+            let target = join_relative_path(&root, &member.relative_path)?;
+            match member.kind {
+                FileSetMemberKind::EmptyDirectory => {
+                    if member.blob_ref_index.is_some() {
+                        return Err(anyhow!("empty directory member references a blob"));
+                    }
+                    tokio::fs::create_dir_all(&target).await?;
+                }
+                FileSetMemberKind::File | FileSetMemberKind::Executable => {
+                    let index = member
+                        .blob_ref_index
+                        .ok_or_else(|| anyhow!("file member is missing its blob reference"))?
+                        as usize;
+                    let blob_ref = blob_refs.get(index).ok_or_else(|| {
+                        anyhow!("directory blob reference index {index} is out of bounds")
+                    })?;
+                    if blob_ref.representation_index.is_some() {
+                        return Err(anyhow!("directory member references a representation blob"));
+                    }
+                    if let Some(parent) = target.parent() {
+                        tokio::fs::create_dir_all(parent).await?;
+                    }
+                    let context = FetchTransferContext {
+                        transfer_id: receiver_entry_id.as_ref().to_string(),
+                        peer_id: from_device.as_str().to_string(),
+                        total_bytes: Some(blob_ref.size_bytes),
+                        filename: blob_ref.filename.clone().unwrap_or_default(),
+                        outbound_transfer_id: Some(blob_ref.entry_id.as_ref().to_string()),
+                        outbound_target: Some(from_device.clone()),
+                        batch_position: position_in_batch(*batch_idx, batch_total),
+                    };
+                    *batch_idx += 1;
+                    let fetched = self
+                        .fetcher
+                        .fetch_blob_to_path(FetchBlobToPathCommand {
+                            ticket: blob_ref.ticket.clone(),
+                            entry_id: blob_ref.entry_id.clone(),
+                            target_path: target,
+                            transfer_context: Some(context),
+                        })
+                        .await?;
+                    file_content_digests.push(*fetched.plaintext_hash.as_bytes());
+                }
+            }
+        }
+
+        let managed_parent = self
+            .cache_dir
+            .join("iroh-blobs")
+            .join(sanitize_path_segment(receiver_entry_id.as_ref()));
+        tokio::fs::create_dir_all(&managed_parent).await?;
+        let mut destinations = Vec::new();
+        for (root_index, root_name) in &roots {
+            let reserved = match &self.target_reserver {
+                Some(reserver) => reserver.reserve_target(root_name).await,
+                None => None,
+            };
+            let destination = reserved.unwrap_or_else(|| managed_parent.join(root_name));
+            if destination.is_file() {
+                tokio::fs::remove_file(&destination).await?;
+            }
+            if tokio::fs::try_exists(&destination).await? {
+                return Err(anyhow!(
+                    "directory destination already exists: {}",
+                    destination.display()
+                ));
+            }
+            let source = staging_root(staging_base, *root_index, root_name);
+            tokio::fs::rename(&source, &destination).await?;
+            destinations.push(destination);
+        }
+        Ok((destinations, file_content_digests))
+    }
+}
+
+fn validate_manifest_member(member: &InboundFileSetMember) -> Result<()> {
+    if member.root_name.is_empty()
+        || member.root_name == "."
+        || member.root_name == ".."
+        || member.root_name.contains(['/', '\\'])
+    {
+        return Err(anyhow!("invalid directory root name"));
+    }
+    if member.relative_path.is_empty() {
+        return Err(anyhow!("directory member has an empty relative path"));
+    }
+    Ok(())
+}
+
+fn staging_root(base: &std::path::Path, root_index: u32, root_name: &str) -> PathBuf {
+    base.join(format!("{root_index}-{}", sanitize_path_segment(root_name)))
+}
+
+fn join_relative_path(root: &std::path::Path, relative_path: &str) -> Result<PathBuf> {
+    let mut result = root.to_path_buf();
+    for component in relative_path.split('/') {
+        if component.is_empty() || component == "." || component == ".." || component.contains('\\')
+        {
+            return Err(anyhow!("invalid directory member relative path"));
+        }
+        result.push(component);
+    }
+    Ok(result)
+}
+
+async fn remove_directory_and_empty_parents(path: &std::path::Path, stop: &std::path::Path) {
+    let _ = tokio::fs::remove_dir_all(path).await;
+    let mut current = path.parent();
+    while let Some(parent) = current {
+        if parent == stop {
+            break;
+        }
+        if tokio::fs::remove_dir(parent).await.is_err() {
+            break;
+        }
+        current = parent.parent();
+    }
+}
+
+fn rewrite_file_list(
+    snapshot: &mut SystemClipboardSnapshot,
+    uri_list: String,
+    local_path_count: usize,
+) -> Result<()> {
+    let mut rewritten = 0usize;
+    for rep in &mut snapshot.representations {
+        if is_file_list_representation(rep) {
+            rep.set_inline_bytes(uri_list.as_bytes().to_vec())
+                .map_err(|err| anyhow!("materialize: failed to rewrite files rep: {err}"))?;
+            rewritten += 1;
+        }
+    }
+    if rewritten == 0 {
+        snapshot
+            .representations
+            .push(ObservedClipboardRepresentation::new(
+                RepresentationId::new(),
+                FormatId::from("files"),
+                Some(MimeType("text/uri-list".to_string())),
+                uri_list.into_bytes(),
+            ));
+    }
+    debug!(
+        rewritten,
+        local_path_count, "materialize: rewrote directory roots"
+    );
+    Ok(())
 }
 
 /// 把 partial cancel 的中间状态收口为 [`MaterializeResult`]:

--- a/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/mod.rs
+++ b/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/mod.rs
@@ -67,7 +67,10 @@ mod usecase;
 #[cfg(test)]
 mod tests;
 
-pub use materializer::{FileCacheBlobMaterializer, InboundBlobFetcher, InboundBlobMaterializer};
+pub use materializer::{
+    FileCacheBlobMaterializer, InboundBlobFetcher, InboundBlobMaterializer, InboundFileSetManifest,
+    InboundFileSetMember,
+};
 pub use ports::{InboundCapture, InboundWrite};
 pub use usecase::ApplyInboundClipboardUseCase;
 

--- a/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/mod.rs
+++ b/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/mod.rs
@@ -67,6 +67,7 @@ mod usecase;
 #[cfg(test)]
 mod tests;
 
+pub(crate) use materializer::compute_file_set_component;
 pub use materializer::{
     FileCacheBlobMaterializer, InboundBlobFetcher, InboundBlobMaterializer, InboundFileSetManifest,
     InboundFileSetMember,

--- a/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/tests.rs
+++ b/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/tests.rs
@@ -27,7 +27,8 @@ use crate::usecases::clipboard_sync::payload_codec::{
 };
 
 use super::materializer::{
-    FileCacheBlobMaterializer, InboundBlobFetcher, InboundBlobMaterializer, MaterializeResult,
+    FileCacheBlobMaterializer, InboundBlobFetcher, InboundBlobMaterializer, InboundFileSetManifest,
+    InboundFileSetMember, MaterializeResult,
 };
 use super::ports::{InboundCapture, InboundWrite};
 use super::usecase::ApplyInboundClipboardUseCase;
@@ -114,6 +115,7 @@ mockall::mock! {
             receiver_entry_id: EntryId,
             snapshot: SystemClipboardSnapshot,
             blob_refs: Vec<V3BlobRef>,
+            file_set_manifest: Option<InboundFileSetManifest>,
         ) -> Result<MaterializeResult>;
     }
 }
@@ -737,11 +739,15 @@ async fn materializes_blob_refs_before_capture_and_write() {
     materializer
         .expect_materialize()
         .times(1)
-        .withf(move |_from_device, _receiver_entry_id, snapshot, refs| {
-            snapshot.representations[0].expect_inline_bytes() == b"file:///sender/original.txt\n"
-                && refs == &vec![blob_ref.clone()]
-        })
-        .returning(|_from_device, _receiver_entry_id, mut snapshot, _| {
+        .withf(
+            move |_from_device, _receiver_entry_id, snapshot, refs, manifest| {
+                assert!(manifest.is_none());
+                snapshot.representations[0].expect_inline_bytes()
+                    == b"file:///sender/original.txt\n"
+                    && refs == &vec![blob_ref.clone()]
+            },
+        )
+        .returning(|_from_device, _receiver_entry_id, mut snapshot, _, _| {
             snapshot.representations[0]
                 .set_inline_bytes(b"file:///local/cache/original.txt\n".to_vec())
                 .unwrap();
@@ -821,7 +827,7 @@ async fn partial_materialize_persists_entry_but_skips_os_write() {
     // 已被重写为带 uniclip-missing:// 占位,missing 列表非空。
     let mut materializer = MockBlobMaterializer::new();
     materializer.expect_materialize().times(1).returning(
-        |_from_device, _receiver_entry_id, mut snapshot, _| {
+        |_from_device, _receiver_entry_id, mut snapshot, _, _| {
             snapshot.representations[0]
                 .set_inline_bytes(
                     b"uniclip-missing:///big.iso?size=950000000&reason=cancelled".to_vec(),
@@ -912,7 +918,7 @@ async fn partial_materialize_does_not_register_dedup_entry() {
     let mut materializer = MockBlobMaterializer::new();
     let call_count = std::sync::atomic::AtomicUsize::new(0);
     materializer.expect_materialize().times(2).returning(
-        move |_from_device, _receiver_entry_id, mut snapshot, _| {
+        move |_from_device, _receiver_entry_id, mut snapshot, _, _| {
             let n = call_count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
             if n == 0 {
                 snapshot.representations[0]
@@ -1020,6 +1026,7 @@ async fn file_cache_blob_materializer_writes_file_and_rewrites_file_uri_list() {
             EntryId::from("entry-receiver"),
             snapshot,
             vec![blob_ref],
+            None,
         )
         .await
         .expect("materialize should succeed");
@@ -1041,6 +1048,184 @@ async fn file_cache_blob_materializer_writes_file_and_rewrites_file_uri_list() {
         .await
         .expect("materialized file should exist");
     assert_eq!(bytes, b"hello world");
+}
+
+#[tokio::test]
+async fn directory_materializer_rebuilds_nested_tree_and_empty_directory() {
+    use uc_core::clipboard::FileSetMemberKind;
+
+    let cache_dir = tempfile::tempdir().expect("cache dir");
+    let sender_entry_id = EntryId::from("entry-directory");
+    let receiver_entry_id = EntryId::from("receiver-directory");
+    let blob_ref = V3BlobRef {
+        ticket: BlobTicket::from_bytes(vec![4, 5, 6]),
+        entry_id: sender_entry_id,
+        filename: Some("notes.txt".to_string()),
+        mime: Some("text/plain".to_string()),
+        size_bytes: 5,
+        representation_index: None,
+    };
+    let manifest = InboundFileSetManifest {
+        members: vec![
+            InboundFileSetMember {
+                root_index: 0,
+                root_name: "project".to_string(),
+                relative_path: "docs/notes.txt".to_string(),
+                kind: FileSetMemberKind::File,
+                blob_ref_index: Some(0),
+            },
+            InboundFileSetMember {
+                root_index: 0,
+                root_name: "project".to_string(),
+                relative_path: "empty".to_string(),
+                kind: FileSetMemberKind::EmptyDirectory,
+                blob_ref_index: None,
+            },
+        ],
+    };
+    let snapshot = SystemClipboardSnapshot {
+        ts_ms: 1,
+        representations: vec![ObservedClipboardRepresentation::new(
+            RepresentationId::new(),
+            FormatId::from("files"),
+            Some(MimeType("text/uri-list".to_string())),
+            b"file:///sender/project\n".to_vec(),
+        )],
+        file_content_digests: Vec::new(),
+        file_set_v1_component: None,
+    };
+
+    let mut fetcher = MockBlobFetcher::new();
+    fetcher
+        .expect_fetch_blob_to_path()
+        .times(1)
+        .returning(|command| {
+            std::fs::write(&command.target_path, b"hello").expect("write nested file");
+            Ok(crate::facade::blob_transfer::FetchBlobToPathResult {
+                entry_id: command.entry_id,
+                plaintext_hash: PlaintextHash::from_bytes([7; 32]),
+                digest: BlobDigest::from_bytes([8; 32]),
+                bytes_written: 5,
+            })
+        });
+
+    let materializer =
+        FileCacheBlobMaterializer::new(Arc::new(fetcher), cache_dir.path().to_path_buf());
+    let result = materializer
+        .materialize(
+            DeviceId::new("peer-x"),
+            receiver_entry_id.clone(),
+            snapshot,
+            vec![blob_ref],
+            Some(manifest),
+        )
+        .await
+        .expect("directory materialize");
+
+    let root = cache_dir
+        .path()
+        .join("iroh-blobs")
+        .join(receiver_entry_id.as_ref())
+        .join("project");
+    assert_eq!(
+        std::fs::read(root.join("docs/notes.txt")).unwrap(),
+        b"hello"
+    );
+    assert!(root.join("empty").is_dir());
+    let uri_list = String::from_utf8(
+        result.snapshot.representations[0]
+            .expect_inline_bytes()
+            .to_vec(),
+    )
+    .unwrap();
+    assert_eq!(
+        url::Url::parse(uri_list.trim())
+            .unwrap()
+            .to_file_path()
+            .unwrap(),
+        root
+    );
+    assert!(!cache_dir.path().join("iroh-blobs/staging").exists());
+}
+
+#[tokio::test]
+async fn directory_materializer_removes_staging_and_exposes_nothing_on_failure() {
+    use uc_core::clipboard::FileSetMemberKind;
+
+    let cache_dir = tempfile::tempdir().expect("cache dir");
+    let receiver_entry_id = EntryId::from("receiver-failed-directory");
+    let blob_refs = ["first.txt", "second.txt"]
+        .into_iter()
+        .enumerate()
+        .map(|(index, name)| V3BlobRef {
+            ticket: BlobTicket::from_bytes(vec![index as u8 + 1]),
+            entry_id: EntryId::from(format!("sender-{index}")),
+            filename: Some(name.to_string()),
+            mime: None,
+            size_bytes: 1,
+            representation_index: None,
+        })
+        .collect::<Vec<_>>();
+    let manifest = InboundFileSetManifest {
+        members: blob_refs
+            .iter()
+            .enumerate()
+            .map(|(index, blob_ref)| InboundFileSetMember {
+                root_index: 0,
+                root_name: "folder".to_string(),
+                relative_path: blob_ref.filename.clone().unwrap(),
+                kind: FileSetMemberKind::File,
+                blob_ref_index: Some(index as u32),
+            })
+            .collect(),
+    };
+    let snapshot = SystemClipboardSnapshot {
+        ts_ms: 1,
+        representations: Vec::new(),
+        file_content_digests: Vec::new(),
+        file_set_v1_component: None,
+    };
+
+    let mut fetcher = MockBlobFetcher::new();
+    let mut call = 0usize;
+    fetcher
+        .expect_fetch_blob_to_path()
+        .times(2)
+        .returning(move |command| {
+            call += 1;
+            if call == 2 {
+                anyhow::bail!("network failed");
+            }
+            std::fs::write(&command.target_path, b"a").expect("write first staged file");
+            Ok(crate::facade::blob_transfer::FetchBlobToPathResult {
+                entry_id: command.entry_id,
+                plaintext_hash: PlaintextHash::from_bytes([1; 32]),
+                digest: BlobDigest::from_bytes([2; 32]),
+                bytes_written: 1,
+            })
+        });
+
+    let materializer =
+        FileCacheBlobMaterializer::new(Arc::new(fetcher), cache_dir.path().to_path_buf());
+    let error = materializer
+        .materialize(
+            DeviceId::new("peer-x"),
+            receiver_entry_id.clone(),
+            snapshot,
+            blob_refs,
+            Some(manifest),
+        )
+        .await
+        .expect_err("directory failure must fail the whole entry");
+
+    assert!(error.to_string().contains("network failed"));
+    assert!(!cache_dir
+        .path()
+        .join("iroh-blobs")
+        .join(receiver_entry_id.as_ref())
+        .join("folder")
+        .exists());
+    assert!(!cache_dir.path().join("iroh-blobs/staging").exists());
 }
 
 /// Fake reserver: redirects every inbound file flat into `dir`.
@@ -1116,6 +1301,7 @@ async fn file_cache_blob_materializer_redirects_to_reserved_user_dir() {
             EntryId::from("entry-receiver"),
             snapshot,
             vec![blob_ref],
+            None,
         )
         .await
         .expect("materialize should succeed");
@@ -1194,6 +1380,7 @@ async fn file_cache_blob_materializer_removes_reserved_placeholder_on_fetch_erro
             EntryId::from("entry-receiver"),
             snapshot,
             vec![blob_ref],
+            None,
         )
         .await
         .expect("partial materialize should succeed (fetch error is soft)");
@@ -1261,6 +1448,7 @@ async fn file_cache_blob_materializer_inlines_representation_bound_blob_into_rep
             EntryId::from("entry-receiver"),
             snapshot,
             vec![blob_ref],
+            None,
         )
         .await
         .expect("representation-bound materialize should succeed");
@@ -1329,6 +1517,7 @@ async fn file_cache_blob_materializer_rejects_out_of_bounds_representation_index
             EntryId::from("entry-receiver"),
             snapshot,
             vec![blob_ref],
+            None,
         )
         .await
         .expect_err("out-of-bounds index should fail");
@@ -1405,6 +1594,7 @@ async fn file_cache_blob_materializer_partial_on_cancel_mid_batch() {
             EntryId::from("entry-receiver"),
             snapshot,
             vec![blob_ref_ok, blob_ref_cancel],
+            None,
         )
         .await
         .expect("partial materialize should succeed (no real error)");
@@ -1476,6 +1666,7 @@ async fn file_cache_blob_materializer_partial_on_cancel_first_file() {
             EntryId::from("entry-receiver"),
             snapshot,
             vec![blob_ref],
+            None,
         )
         .await
         .expect("first-file cancel still yields Ok(partial)");
@@ -1532,6 +1723,7 @@ async fn file_cache_blob_materializer_partial_on_rep_cancel_no_files() {
             EntryId::from("entry-receiver"),
             snapshot,
             vec![blob_ref],
+            None,
         )
         .await
         .expect("rep-only cancel yields Ok(partial)");
@@ -1688,7 +1880,7 @@ async fn partial_match_is_upgraded_in_place_by_complete_delivery() {
 
     let mut materializer = MockBlobMaterializer::new();
     materializer.expect_materialize().times(1).returning(
-        |_from_device, _receiver_entry_id, mut snapshot, _| {
+        |_from_device, _receiver_entry_id, mut snapshot, _, _| {
             snapshot.representations[0]
                 .set_inline_bytes(b"file:///local/cache/payload.bin\n".to_vec())
                 .unwrap();
@@ -1775,7 +1967,7 @@ async fn partial_delivery_does_not_replace_existing_partial() {
 
     let mut materializer = MockBlobMaterializer::new();
     materializer.expect_materialize().times(1).returning(
-        |_from_device, _receiver_entry_id, mut snapshot, _| {
+        |_from_device, _receiver_entry_id, mut snapshot, _, _| {
             snapshot.representations[0]
                 .set_inline_bytes(
                     b"uniclip-missing:///payload.bin?size=10&reason=cancelled".to_vec(),

--- a/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/tests.rs
+++ b/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/tests.rs
@@ -31,6 +31,7 @@ use super::materializer::{
     InboundFileSetMember, MaterializeResult,
 };
 use super::ports::{InboundCapture, InboundWrite};
+use super::usecase::verify_file_set_identity;
 use super::usecase::ApplyInboundClipboardUseCase;
 use super::{ApplyInboundError, ApplyInboundInput, ApplyOutcome};
 
@@ -160,6 +161,20 @@ fn fixture_input(text: &str) -> (ApplyInboundInput, String) {
         },
         snapshot_hash,
     )
+}
+
+#[test]
+fn directory_identity_verification_rejects_mismatched_snapshot_hash() {
+    let snapshot = SystemClipboardSnapshot {
+        ts_ms: 1,
+        representations: Vec::new(),
+        file_content_digests: Vec::new(),
+        file_set_v1_component: Some([1; 32]),
+    };
+
+    let error = verify_file_set_identity(&snapshot, "blake3v1:deadbeef")
+        .expect_err("mismatched directory identity must fail");
+    assert!(error.to_string().contains("identity mismatch"));
 }
 
 fn fixture_input_from_snapshot(snapshot: SystemClipboardSnapshot) -> (ApplyInboundInput, String) {
@@ -1132,6 +1147,7 @@ async fn directory_materializer_rebuilds_nested_tree_and_empty_directory() {
         b"hello"
     );
     assert!(root.join("empty").is_dir());
+    assert!(result.snapshot.file_set_v1_component.is_some());
     let uri_list = String::from_utf8(
         result.snapshot.representations[0]
             .expect_inline_bytes()
@@ -1226,6 +1242,139 @@ async fn directory_materializer_removes_staging_and_exposes_nothing_on_failure()
         .join("folder")
         .exists());
     assert!(!cache_dir.path().join("iroh-blobs/staging").exists());
+}
+
+#[tokio::test]
+async fn directory_materializer_suffixes_existing_and_same_paste_root_names() {
+    use uc_core::clipboard::FileSetMemberKind;
+
+    let cache_dir = tempfile::tempdir().expect("cache dir");
+    let receiver_entry_id = EntryId::from("receiver-collisions");
+    let destination = cache_dir
+        .path()
+        .join("iroh-blobs")
+        .join(receiver_entry_id.as_ref());
+    std::fs::create_dir_all(destination.join("folder")).unwrap();
+    let manifest = InboundFileSetManifest {
+        members: vec![
+            InboundFileSetMember {
+                root_index: 0,
+                root_name: "folder".to_string(),
+                relative_path: "empty-a".to_string(),
+                kind: FileSetMemberKind::EmptyDirectory,
+                blob_ref_index: None,
+            },
+            InboundFileSetMember {
+                root_index: 1,
+                root_name: "folder".to_string(),
+                relative_path: "empty-b".to_string(),
+                kind: FileSetMemberKind::EmptyDirectory,
+                blob_ref_index: None,
+            },
+        ],
+    };
+    let snapshot = SystemClipboardSnapshot {
+        ts_ms: 1,
+        representations: Vec::new(),
+        file_content_digests: Vec::new(),
+        file_set_v1_component: None,
+    };
+
+    let materializer = FileCacheBlobMaterializer::new(
+        Arc::new(MockBlobFetcher::new()),
+        cache_dir.path().to_path_buf(),
+    );
+    let result = materializer
+        .materialize(
+            DeviceId::new("peer-x"),
+            receiver_entry_id,
+            snapshot,
+            Vec::new(),
+            Some(manifest),
+        )
+        .await
+        .expect("empty directory set should materialize");
+
+    assert!(destination.join("folder (2)/empty-a").is_dir());
+    assert!(destination.join("folder (3)/empty-b").is_dir());
+    let uri_list = String::from_utf8(
+        result.snapshot.representations[0]
+            .expect_inline_bytes()
+            .to_vec(),
+    )
+    .unwrap();
+    assert_eq!(uri_list.lines().count(), 2);
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn directory_materializer_restores_executable_permission() {
+    use std::os::unix::fs::PermissionsExt;
+    use uc_core::clipboard::FileSetMemberKind;
+
+    let cache_dir = tempfile::tempdir().expect("cache dir");
+    let receiver_entry_id = EntryId::from("receiver-executable");
+    let blob_ref = V3BlobRef {
+        ticket: BlobTicket::from_bytes(vec![3]),
+        entry_id: EntryId::from("sender-executable"),
+        filename: Some("run.sh".to_string()),
+        mime: None,
+        size_bytes: 9,
+        representation_index: None,
+    };
+    let manifest = InboundFileSetManifest {
+        members: vec![InboundFileSetMember {
+            root_index: 0,
+            root_name: "scripts".to_string(),
+            relative_path: "run.sh".to_string(),
+            kind: FileSetMemberKind::Executable,
+            blob_ref_index: Some(0),
+        }],
+    };
+    let snapshot = SystemClipboardSnapshot {
+        ts_ms: 1,
+        representations: Vec::new(),
+        file_content_digests: Vec::new(),
+        file_set_v1_component: None,
+    };
+    let mut fetcher = MockBlobFetcher::new();
+    fetcher
+        .expect_fetch_blob_to_path()
+        .times(1)
+        .returning(|command| {
+            std::fs::write(&command.target_path, b"#!/bin/sh").unwrap();
+            Ok(crate::facade::blob_transfer::FetchBlobToPathResult {
+                entry_id: command.entry_id,
+                plaintext_hash: PlaintextHash::from_bytes([3; 32]),
+                digest: BlobDigest::from_bytes([4; 32]),
+                bytes_written: 9,
+            })
+        });
+
+    let materializer =
+        FileCacheBlobMaterializer::new(Arc::new(fetcher), cache_dir.path().to_path_buf());
+    materializer
+        .materialize(
+            DeviceId::new("peer-x"),
+            receiver_entry_id.clone(),
+            snapshot,
+            vec![blob_ref],
+            Some(manifest),
+        )
+        .await
+        .unwrap();
+
+    let mode = std::fs::metadata(
+        cache_dir
+            .path()
+            .join("iroh-blobs")
+            .join(receiver_entry_id.as_ref())
+            .join("scripts/run.sh"),
+    )
+    .unwrap()
+    .permissions()
+    .mode();
+    assert_ne!(mode & 0o111, 0);
 }
 
 /// Fake reserver: redirects every inbound file flat into `dir`.

--- a/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/tests.rs
+++ b/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/tests.rs
@@ -1091,6 +1091,7 @@ async fn directory_materializer_rebuilds_nested_tree_and_empty_directory() {
             InboundFileSetMember {
                 root_index: 0,
                 root_name: "project".to_string(),
+                root_is_file: false,
                 relative_path: "docs/notes.txt".to_string(),
                 kind: FileSetMemberKind::File,
                 blob_ref_index: Some(0),
@@ -1098,6 +1099,7 @@ async fn directory_materializer_rebuilds_nested_tree_and_empty_directory() {
             InboundFileSetMember {
                 root_index: 0,
                 root_name: "project".to_string(),
+                root_is_file: false,
                 relative_path: "empty".to_string(),
                 kind: FileSetMemberKind::EmptyDirectory,
                 blob_ref_index: None,
@@ -1171,6 +1173,88 @@ async fn directory_materializer_rebuilds_nested_tree_and_empty_directory() {
 }
 
 #[tokio::test]
+async fn directory_materializer_preserves_mixed_top_level_file_and_directory() {
+    use uc_core::clipboard::FileSetMemberKind;
+
+    let cache_dir = tempfile::tempdir().expect("cache dir");
+    let receiver_entry_id = EntryId::from("receiver-mixed-roots");
+    let blob_refs = ["loose.txt", "child.txt"]
+        .into_iter()
+        .enumerate()
+        .map(|(index, filename)| V3BlobRef {
+            ticket: BlobTicket::from_bytes(vec![index as u8 + 1]),
+            entry_id: EntryId::from(format!("sender-mixed-{index}")),
+            filename: Some(filename.to_string()),
+            mime: None,
+            size_bytes: 5,
+            representation_index: None,
+        })
+        .collect::<Vec<_>>();
+    let manifest = InboundFileSetManifest {
+        members: vec![
+            InboundFileSetMember {
+                root_index: 0,
+                root_name: "loose.txt".to_string(),
+                root_is_file: true,
+                relative_path: "loose.txt".to_string(),
+                kind: FileSetMemberKind::File,
+                blob_ref_index: Some(0),
+            },
+            InboundFileSetMember {
+                root_index: 1,
+                root_name: "folder".to_string(),
+                root_is_file: false,
+                relative_path: "child.txt".to_string(),
+                kind: FileSetMemberKind::File,
+                blob_ref_index: Some(1),
+            },
+        ],
+    };
+    let snapshot = SystemClipboardSnapshot {
+        ts_ms: 1,
+        representations: Vec::new(),
+        file_content_digests: Vec::new(),
+        file_set_v1_component: None,
+    };
+    let mut fetcher = MockBlobFetcher::new();
+    fetcher
+        .expect_fetch_blob_to_path()
+        .times(2)
+        .returning(|command| {
+            std::fs::write(&command.target_path, b"hello").unwrap();
+            Ok(crate::facade::blob_transfer::FetchBlobToPathResult {
+                entry_id: command.entry_id,
+                plaintext_hash: PlaintextHash::from_bytes([5; 32]),
+                digest: BlobDigest::from_bytes([6; 32]),
+                bytes_written: 5,
+            })
+        });
+    let materializer =
+        FileCacheBlobMaterializer::new(Arc::new(fetcher), cache_dir.path().to_path_buf());
+
+    materializer
+        .materialize(
+            DeviceId::new("peer-x"),
+            receiver_entry_id.clone(),
+            snapshot,
+            blob_refs,
+            Some(manifest),
+        )
+        .await
+        .expect("mixed roots should materialize");
+
+    let target = cache_dir
+        .path()
+        .join("iroh-blobs")
+        .join(receiver_entry_id.as_ref());
+    assert_eq!(std::fs::read(target.join("loose.txt")).unwrap(), b"hello");
+    assert_eq!(
+        std::fs::read(target.join("folder/child.txt")).unwrap(),
+        b"hello"
+    );
+}
+
+#[tokio::test]
 async fn directory_materializer_removes_staging_and_exposes_nothing_on_failure() {
     use uc_core::clipboard::FileSetMemberKind;
 
@@ -1195,6 +1279,7 @@ async fn directory_materializer_removes_staging_and_exposes_nothing_on_failure()
             .map(|(index, blob_ref)| InboundFileSetMember {
                 root_index: 0,
                 root_name: "folder".to_string(),
+                root_is_file: false,
                 relative_path: blob_ref.filename.clone().unwrap(),
                 kind: FileSetMemberKind::File,
                 blob_ref_index: Some(index as u32),
@@ -1288,6 +1373,7 @@ async fn directory_materializer_suffixes_existing_and_same_paste_root_names() {
             InboundFileSetMember {
                 root_index: 0,
                 root_name: "folder".to_string(),
+                root_is_file: false,
                 relative_path: "empty-a".to_string(),
                 kind: FileSetMemberKind::EmptyDirectory,
                 blob_ref_index: None,
@@ -1295,6 +1381,7 @@ async fn directory_materializer_suffixes_existing_and_same_paste_root_names() {
             InboundFileSetMember {
                 root_index: 1,
                 root_name: "folder".to_string(),
+                root_is_file: false,
                 relative_path: "empty-b".to_string(),
                 kind: FileSetMemberKind::EmptyDirectory,
                 blob_ref_index: None,
@@ -1354,6 +1441,7 @@ async fn directory_materializer_restores_executable_permission() {
         members: vec![InboundFileSetMember {
             root_index: 0,
             root_name: "scripts".to_string(),
+            root_is_file: false,
             relative_path: "run.sh".to_string(),
             kind: FileSetMemberKind::Executable,
             blob_ref_index: Some(0),

--- a/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/tests.rs
+++ b/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/tests.rs
@@ -30,6 +30,7 @@ use crate::usecases::clipboard_sync::payload_codec::{
 use super::materializer::{
     compute_file_set_component, FileCacheBlobMaterializer, InboundBlobFetcher,
     InboundBlobMaterializer, InboundFileSetManifest, InboundFileSetMember, MaterializeResult,
+    RootRenamer,
 };
 use super::ports::{InboundCapture, InboundWrite};
 use super::usecase::verify_file_set_identity;
@@ -83,6 +84,28 @@ mockall::mock! {
             &self,
             snapshot_hash: &str,
         ) -> std::result::Result<Option<EntryId>, ClipboardRepositoryError>;
+    }
+}
+
+#[derive(Default)]
+struct FailFirstRootRenamer {
+    calls: std::sync::atomic::AtomicUsize,
+}
+
+#[async_trait]
+impl RootRenamer for FailFirstRootRenamer {
+    async fn rename(
+        &self,
+        source: &std::path::Path,
+        destination: &std::path::Path,
+    ) -> std::io::Result<()> {
+        if self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst) == 0 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::CrossesDevices,
+                "forced cross-device rename",
+            ));
+        }
+        tokio::fs::rename(source, destination).await
     }
 }
 
@@ -1174,6 +1197,78 @@ async fn directory_materializer_rebuilds_nested_tree_and_empty_directory() {
 }
 
 #[tokio::test]
+async fn directory_materializer_copies_complete_tree_when_direct_rename_crosses_devices() {
+    use uc_core::clipboard::FileSetMemberKind;
+
+    let cache_dir = tempfile::tempdir().expect("cache dir");
+    let receiver_entry_id = EntryId::from("receiver-cross-volume");
+    let manifest = InboundFileSetManifest {
+        members: vec![InboundFileSetMember {
+            root_index: 0,
+            root_name: "project".to_string(),
+            root_is_file: false,
+            relative_path: "nested/notes.txt".to_string(),
+            kind: FileSetMemberKind::File,
+            blob_ref_index: Some(0),
+        }],
+    };
+    let blob_ref = V3BlobRef {
+        ticket: BlobTicket::from_bytes(vec![9]),
+        entry_id: EntryId::from("sender-cross-volume"),
+        filename: Some("notes.txt".to_string()),
+        mime: Some("text/plain".to_string()),
+        size_bytes: 5,
+        representation_index: None,
+    };
+    let snapshot = SystemClipboardSnapshot {
+        ts_ms: 1,
+        representations: Vec::new(),
+        file_content_digests: Vec::new(),
+        file_set_v1_component: None,
+    };
+    let mut fetcher = MockBlobFetcher::new();
+    fetcher
+        .expect_fetch_blob_to_path()
+        .times(1)
+        .returning(|command| {
+            std::fs::write(&command.target_path, b"hello").expect("write staged member");
+            Ok(crate::facade::blob_transfer::FetchBlobToPathResult {
+                entry_id: command.entry_id,
+                plaintext_hash: PlaintextHash::from_bytes([3; 32]),
+                digest: BlobDigest::from_bytes([4; 32]),
+                bytes_written: 5,
+            })
+        });
+    let renamer = Arc::new(FailFirstRootRenamer::default());
+    let materializer =
+        FileCacheBlobMaterializer::new(Arc::new(fetcher), cache_dir.path().to_path_buf())
+            .with_root_renamer(renamer.clone());
+
+    materializer
+        .materialize(
+            DeviceId::new("peer-x"),
+            receiver_entry_id.clone(),
+            snapshot,
+            vec![blob_ref],
+            Some(manifest),
+        )
+        .await
+        .expect("copy fallback should materialize");
+
+    let entry_root = cache_dir
+        .path()
+        .join("iroh-blobs")
+        .join(receiver_entry_id.as_ref());
+    assert_eq!(
+        std::fs::read(entry_root.join("project/nested/notes.txt")).unwrap(),
+        b"hello"
+    );
+    assert!(!entry_root.join(".uniclip-staging-project").exists());
+    assert!(!cache_dir.path().join("iroh-blobs/staging").exists());
+    assert_eq!(renamer.calls.load(std::sync::atomic::Ordering::SeqCst), 2);
+}
+
+#[tokio::test]
 async fn directory_materializer_preserves_mixed_top_level_file_and_directory() {
     use uc_core::clipboard::FileSetMemberKind;
 
@@ -1638,6 +1733,71 @@ async fn directory_materializer_restores_executable_permission() {
     .permissions()
     .mode();
     assert_ne!(mode & 0o111, 0);
+}
+
+#[cfg(windows)]
+#[tokio::test]
+async fn directory_materializer_keeps_executable_member_as_regular_windows_file() {
+    use uc_core::clipboard::FileSetMemberKind;
+
+    let cache_dir = tempfile::tempdir().expect("cache dir");
+    let receiver_entry_id = EntryId::from("receiver-windows-executable");
+    let blob_ref = V3BlobRef {
+        ticket: BlobTicket::from_bytes(vec![3]),
+        entry_id: EntryId::from("sender-windows-executable"),
+        filename: Some("run.cmd".to_string()),
+        mime: None,
+        size_bytes: 7,
+        representation_index: None,
+    };
+    let manifest = InboundFileSetManifest {
+        members: vec![InboundFileSetMember {
+            root_index: 0,
+            root_name: "scripts".to_string(),
+            root_is_file: false,
+            relative_path: "run.cmd".to_string(),
+            kind: FileSetMemberKind::Executable,
+            blob_ref_index: Some(0),
+        }],
+    };
+    let snapshot = SystemClipboardSnapshot {
+        ts_ms: 1,
+        representations: Vec::new(),
+        file_content_digests: Vec::new(),
+        file_set_v1_component: None,
+    };
+    let mut fetcher = MockBlobFetcher::new();
+    fetcher
+        .expect_fetch_blob_to_path()
+        .times(1)
+        .returning(|command| {
+            std::fs::write(&command.target_path, b"echo ok").unwrap();
+            Ok(crate::facade::blob_transfer::FetchBlobToPathResult {
+                entry_id: command.entry_id,
+                plaintext_hash: PlaintextHash::from_bytes([3; 32]),
+                digest: BlobDigest::from_bytes([4; 32]),
+                bytes_written: 7,
+            })
+        });
+
+    FileCacheBlobMaterializer::new(Arc::new(fetcher), cache_dir.path().to_path_buf())
+        .materialize(
+            DeviceId::new("peer-x"),
+            receiver_entry_id.clone(),
+            snapshot,
+            vec![blob_ref],
+            Some(manifest),
+        )
+        .await
+        .unwrap();
+
+    let path = cache_dir
+        .path()
+        .join("iroh-blobs")
+        .join(receiver_entry_id.as_ref())
+        .join("scripts/run.cmd");
+    assert_eq!(std::fs::read(&path).unwrap(), b"echo ok");
+    assert!(!std::fs::metadata(path).unwrap().permissions().readonly());
 }
 
 /// Fake reserver: redirects every inbound file flat into `dir`.

--- a/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/tests.rs
+++ b/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/tests.rs
@@ -134,6 +134,12 @@ mockall::mock! {
             &self,
             command: crate::facade::blob_transfer::FetchBlobToPathCommand,
         ) -> Result<crate::facade::blob_transfer::FetchBlobToPathResult>;
+
+        async fn record_unfetched_failure(
+            &self,
+            context: crate::facade::blob_transfer::FetchTransferContext,
+            detail: String,
+        );
     }
 }
 
@@ -1170,7 +1176,7 @@ async fn directory_materializer_removes_staging_and_exposes_nothing_on_failure()
 
     let cache_dir = tempfile::tempdir().expect("cache dir");
     let receiver_entry_id = EntryId::from("receiver-failed-directory");
-    let blob_refs = ["first.txt", "second.txt"]
+    let blob_refs = ["first.txt", "second.txt", "third.txt"]
         .into_iter()
         .enumerate()
         .map(|(index, name)| V3BlobRef {
@@ -1204,10 +1210,19 @@ async fn directory_materializer_removes_staging_and_exposes_nothing_on_failure()
 
     let mut fetcher = MockBlobFetcher::new();
     let mut call = 0usize;
+    let transfer_ids = Arc::new(Mutex::new(Vec::new()));
+    let recorded_ids = Arc::clone(&transfer_ids);
     fetcher
         .expect_fetch_blob_to_path()
         .times(2)
         .returning(move |command| {
+            let context = command.transfer_context.as_ref().expect("transfer context");
+            assert_eq!(context.entry_id, "receiver-failed-directory");
+            assert!(context.individual_lifecycle);
+            recorded_ids
+                .lock()
+                .unwrap()
+                .push(context.transfer_id.clone());
             call += 1;
             if call == 2 {
                 anyhow::bail!("network failed");
@@ -1220,6 +1235,16 @@ async fn directory_materializer_removes_staging_and_exposes_nothing_on_failure()
                 bytes_written: 1,
             })
         });
+    fetcher
+        .expect_record_unfetched_failure()
+        .times(1)
+        .withf(|context, detail| {
+            context.entry_id == "receiver-failed-directory"
+                && context.filename == "third.txt"
+                && context.individual_lifecycle
+                && detail.contains("network failed")
+        })
+        .return_const(());
 
     let materializer =
         FileCacheBlobMaterializer::new(Arc::new(fetcher), cache_dir.path().to_path_buf());
@@ -1235,6 +1260,9 @@ async fn directory_materializer_removes_staging_and_exposes_nothing_on_failure()
         .expect_err("directory failure must fail the whole entry");
 
     assert!(error.to_string().contains("network failed"));
+    let transfer_ids = transfer_ids.lock().unwrap();
+    assert_eq!(transfer_ids.len(), 2);
+    assert_ne!(transfer_ids[0], transfer_ids[1]);
     assert!(!cache_dir
         .path()
         .join("iroh-blobs")

--- a/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/tests.rs
+++ b/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/tests.rs
@@ -23,12 +23,13 @@ use uc_core::{MimeType, ObservedClipboardRepresentation, SystemClipboardSnapshot
 use uc_observability::FlowId;
 
 use crate::usecases::clipboard_sync::payload_codec::{
-    encode_snapshot_to_v3_bytes, encode_snapshot_with_blob_refs_to_v3_bytes, V3BlobRef,
+    encode_snapshot_to_v3_bytes, encode_snapshot_with_blob_refs_and_file_set_to_v3_bytes,
+    encode_snapshot_with_blob_refs_to_v3_bytes, V3BlobRef,
 };
 
 use super::materializer::{
-    FileCacheBlobMaterializer, InboundBlobFetcher, InboundBlobMaterializer, InboundFileSetManifest,
-    InboundFileSetMember, MaterializeResult,
+    compute_file_set_component, FileCacheBlobMaterializer, InboundBlobFetcher,
+    InboundBlobMaterializer, InboundFileSetManifest, InboundFileSetMember, MaterializeResult,
 };
 use super::ports::{InboundCapture, InboundWrite};
 use super::usecase::verify_file_set_identity;
@@ -1252,6 +1253,152 @@ async fn directory_materializer_preserves_mixed_top_level_file_and_directory() {
         std::fs::read(target.join("folder/child.txt")).unwrap(),
         b"hello"
     );
+}
+
+#[tokio::test]
+async fn apply_inbound_materializes_and_commits_mixed_directory_payload() {
+    use std::collections::BTreeMap;
+
+    use uc_core::clipboard::FileSetMemberKind;
+
+    let cache_dir = tempfile::tempdir().expect("cache dir");
+    let blob_refs = ["loose.txt", "child.txt"]
+        .into_iter()
+        .enumerate()
+        .map(|(index, filename)| V3BlobRef {
+            ticket: BlobTicket::from_bytes(vec![index as u8 + 1]),
+            entry_id: EntryId::from(format!("sender-full-flow-{index}")),
+            filename: Some(filename.to_string()),
+            mime: Some("text/plain".to_string()),
+            size_bytes: 5,
+            representation_index: None,
+        })
+        .collect::<Vec<_>>();
+    let manifest = InboundFileSetManifest {
+        members: vec![
+            InboundFileSetMember {
+                root_index: 0,
+                root_name: "loose.txt".to_string(),
+                root_is_file: true,
+                relative_path: "loose.txt".to_string(),
+                kind: FileSetMemberKind::File,
+                blob_ref_index: Some(0),
+            },
+            InboundFileSetMember {
+                root_index: 1,
+                root_name: "folder".to_string(),
+                root_is_file: false,
+                relative_path: "child.txt".to_string(),
+                kind: FileSetMemberKind::File,
+                blob_ref_index: Some(1),
+            },
+        ],
+    };
+    let member_digests = BTreeMap::from([(0, [5; 32]), (1, [6; 32])]);
+    let snapshot = SystemClipboardSnapshot {
+        ts_ms: 1,
+        representations: vec![ObservedClipboardRepresentation::new(
+            RepresentationId::new(),
+            FormatId::from("files"),
+            Some(MimeType("text/uri-list".to_string())),
+            b"file:///sender/loose.txt\r\nfile:///sender/folder\r\n".to_vec(),
+        )],
+        file_content_digests: Vec::new(),
+        file_set_v1_component: Some(
+            compute_file_set_component(&manifest, &member_digests).expect("file-set component"),
+        ),
+    };
+    let (plaintext, snapshot_hash) =
+        encode_snapshot_with_blob_refs_and_file_set_to_v3_bytes(&snapshot, &blob_refs, &manifest)
+            .expect("encode directory payload");
+
+    let mut repo = MockEntryRepo::new();
+    repo.expect_find_entry_id_by_snapshot_hash()
+        .with(eq(snapshot_hash.clone()))
+        .times(1)
+        .returning(|_| Ok(None));
+
+    let mut fetcher = MockBlobFetcher::new();
+    fetcher
+        .expect_fetch_blob_to_path()
+        .times(2)
+        .returning(|command| {
+            let index = usize::from(command.ticket.as_bytes()[0] - 1);
+            std::fs::write(&command.target_path, b"hello").expect("write fetched member");
+            Ok(crate::facade::blob_transfer::FetchBlobToPathResult {
+                entry_id: command.entry_id,
+                plaintext_hash: PlaintextHash::from_bytes(if index == 0 {
+                    [5; 32]
+                } else {
+                    [6; 32]
+                }),
+                digest: BlobDigest::from_bytes([7; 32]),
+                bytes_written: 5,
+            })
+        });
+
+    let mut capture = MockCapture::new();
+    capture
+        .expect_capture()
+        .times(1)
+        .withf(|_, _, snapshot| snapshot_paths_exist(snapshot))
+        .returning(|entry_id, _, _| Ok(Some(entry_id)));
+
+    let write_completed = Arc::new(tokio::sync::Notify::new());
+    let mut write = MockWrite::new();
+    write
+        .expect_write()
+        .times(1)
+        .withf(snapshot_paths_exist)
+        .returning({
+            let write_completed = Arc::clone(&write_completed);
+            move |_| {
+                write_completed.notify_one();
+                Ok(())
+            }
+        });
+
+    let materializer =
+        FileCacheBlobMaterializer::new(Arc::new(fetcher), cache_dir.path().to_path_buf());
+    let uc = ApplyInboundClipboardUseCase::new(Arc::new(repo), Arc::new(capture), Arc::new(write))
+        .with_blob_materializer(Arc::new(materializer));
+    let outcome = uc
+        .execute(ApplyInboundInput {
+            from_device: DeviceId::new("peer-full-flow"),
+            snapshot_hash,
+            plaintext,
+            flow_id: None,
+        })
+        .await
+        .expect("directory payload should apply");
+    assert!(matches!(outcome, ApplyOutcome::Applied { .. }));
+    tokio::time::timeout(
+        std::time::Duration::from_secs(1),
+        write_completed.notified(),
+    )
+    .await
+    .expect("clipboard write should complete");
+}
+
+fn snapshot_paths_exist(snapshot: &SystemClipboardSnapshot) -> bool {
+    let Some(rep) = snapshot.representations.iter().find(|rep| {
+        rep.mime
+            .as_ref()
+            .is_some_and(|mime| mime.0 == "text/uri-list")
+    }) else {
+        return false;
+    };
+    let Ok(uri_list) = std::str::from_utf8(rep.expect_inline_bytes()) else {
+        return false;
+    };
+    let paths = uri_list
+        .lines()
+        .filter_map(|line| url::Url::parse(line).ok())
+        .filter_map(|url| url.to_file_path().ok())
+        .collect::<Vec<_>>();
+    paths.len() == 2
+        && paths.iter().any(|path| path.is_file())
+        && paths.iter().any(|path| path.join("child.txt").is_file())
 }
 
 #[tokio::test]

--- a/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/usecase.rs
+++ b/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/usecase.rs
@@ -373,6 +373,7 @@ impl ApplyInboundClipboardUseCase {
                         receiver_entry_id.clone(),
                         snapshot,
                         blob_refs,
+                        None,
                     )
                     .await
                     .map_err(|e| {

--- a/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/usecase.rs
+++ b/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/usecase.rs
@@ -22,7 +22,7 @@ use crate::facade::clipboard_live_index::{
 use crate::facade::host_event::{
     ClipboardHostEvent, ClipboardOriginKind, HostEvent, TransferHostEvent,
 };
-use crate::usecases::clipboard_sync::payload_codec::decode_v3_bytes_to_snapshot_and_blob_refs;
+use crate::usecases::clipboard_sync::payload_codec::decode_v3_bytes_to_snapshot_blob_refs_and_file_set;
 
 use super::materializer::InboundBlobMaterializer;
 use super::ports::{InboundCapture, InboundWrite};
@@ -282,8 +282,8 @@ impl ApplyInboundClipboardUseCase {
         tracing::Span::current().record("flow.id", tracing::field::display(&flow_id));
         // 1. Decode V3 envelope. Decode failure is non-fatal — drop the
         // frame, keep the loop alive (peer may be on a newer wire).
-        let (snapshot, blob_refs) =
-            match decode_v3_bytes_to_snapshot_and_blob_refs(input.plaintext.as_ref()) {
+        let (snapshot, blob_refs, file_set_manifest) =
+            match decode_v3_bytes_to_snapshot_blob_refs_and_file_set(input.plaintext.as_ref()) {
                 Ok(decoded) => decoded,
                 Err(e) => {
                     let reason = e.to_string();
@@ -363,9 +363,10 @@ impl ApplyInboundClipboardUseCase {
             filenames: advertised_filenames,
         }));
 
-        let (snapshot, is_partial) = match (blob_refs.is_empty(), &self.blob_materializer) {
-            (true, _) => (snapshot, false),
-            (false, Some(materializer)) => {
+        let requires_materialize = !blob_refs.is_empty() || file_set_manifest.is_some();
+        let (snapshot, is_partial) = match (requires_materialize, &self.blob_materializer) {
+            (false, _) => (snapshot, false),
+            (true, Some(materializer)) => {
                 let count = blob_refs.len();
                 let result = materializer
                     .materialize(
@@ -373,7 +374,7 @@ impl ApplyInboundClipboardUseCase {
                         receiver_entry_id.clone(),
                         snapshot,
                         blob_refs,
-                        None,
+                        file_set_manifest,
                     )
                     .await
                     .map_err(|e| {
@@ -401,7 +402,7 @@ impl ApplyInboundClipboardUseCase {
                 );
                 (result.snapshot, partial)
             }
-            (false, None) => {
+            (true, None) => {
                 let reason =
                     "payload contains blob refs but no blob materializer is wired".to_string();
                 warn!(reason, "inbound dropped: blob materializer missing");

--- a/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/usecase.rs
+++ b/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/usecase.rs
@@ -364,6 +364,7 @@ impl ApplyInboundClipboardUseCase {
         }));
 
         let requires_materialize = !blob_refs.is_empty() || file_set_manifest.is_some();
+        let verify_directory_identity = file_set_manifest.is_some();
         let (snapshot, is_partial) = match (requires_materialize, &self.blob_materializer) {
             (false, _) => (snapshot, false),
             (true, Some(materializer)) => {
@@ -392,6 +393,21 @@ impl ApplyInboundClipboardUseCase {
                         ApplyInboundError::Internal(format!("blob materialize: {e}"))
                     })?;
                 let partial = result.is_partial();
+                if verify_directory_identity {
+                    verify_file_set_identity(&result.snapshot, &input.snapshot_hash).map_err(
+                        |err| {
+                            self.emit_host_event(HostEvent::Transfer(
+                                TransferHostEvent::StatusChanged {
+                                    transfer_id: receiver_entry_id.as_ref().to_string(),
+                                    entry_id: receiver_entry_id.as_ref().to_string(),
+                                    status: "failed".to_string(),
+                                    reason: Some(err.to_string()),
+                                },
+                            ));
+                            ApplyInboundError::Internal(err.to_string())
+                        },
+                    )?;
+                }
                 info!(
                     blob_ref_count = count,
                     rep_count = result.snapshot.representations.len(),
@@ -638,6 +654,19 @@ impl ApplyInboundClipboardUseCase {
 
         Ok(ApplyOutcome::Applied { entry_id })
     }
+}
+
+pub(crate) fn verify_file_set_identity(
+    snapshot: &SystemClipboardSnapshot,
+    expected_snapshot_hash: &str,
+) -> anyhow::Result<()> {
+    let actual = snapshot.snapshot_hash().to_string();
+    if actual != expected_snapshot_hash {
+        anyhow::bail!(
+            "directory file-set identity mismatch: expected {expected_snapshot_hash}, got {actual}"
+        );
+    }
+    Ok(())
 }
 
 /// Compact summary of the snapshot's representations for tracing.

--- a/crates/uc-application/src/usecases/clipboard_sync/dispatch_entry/header.rs
+++ b/crates/uc-application/src/usecases/clipboard_sync/dispatch_entry/header.rs
@@ -41,7 +41,7 @@ impl OutboundHeaderFactory {
     ) -> ClipboardHeader {
         let origin_device_name = self.load_origin_device_name().await;
         ClipboardHeader {
-            version: ClipboardHeader::CURRENT_VERSION,
+            version: input.wire_version,
             snapshot_hash: input.snapshot_hash.clone(),
             captured_at_ms: self.clock.now_ms(),
             origin_device_id: local_device.as_str().to_string(),
@@ -114,6 +114,23 @@ mod tests {
         assert_eq!(header.origin_device_id, "self-device");
         assert_eq!(header.origin_device_name, "Alice Laptop");
         assert_eq!(header.flow_id, Some(flow.to_string()));
+    }
+
+    #[tokio::test]
+    async fn build_preserves_directory_wire_requirement() {
+        let mut settings = MockSettings_::new();
+        settings
+            .expect_load()
+            .returning(|| Ok(settings_with_device_name("Alice Laptop")));
+        let factory = factory(settings, MockLocalIdentity::new());
+        let mut input = dispatch_input();
+        input.wire_version = ClipboardHeader::DIRECTORY_VERSION;
+
+        let header = factory
+            .build(&input, &FlowId::generate(), &dev("self-device"))
+            .await;
+
+        assert_eq!(header.version, ClipboardHeader::DIRECTORY_VERSION);
     }
 
     /// No usable settings name (absent) ⇒ fall back to the fingerprint

--- a/crates/uc-application/src/usecases/clipboard_sync/dispatch_entry/mod.rs
+++ b/crates/uc-application/src/usecases/clipboard_sync/dispatch_entry/mod.rs
@@ -193,6 +193,8 @@ pub(crate) struct DispatchClipboardEntryInput {
     pub snapshot_hash: String,
     /// Payload codec tag, e.g. `3` for the V3 `ClipboardBinaryPayload`.
     pub payload_version: u8,
+    /// Minimum wire version required to preserve this payload's semantics.
+    pub wire_version: u8,
     /// Set of content categories present in the snapshot, used to gate
     /// against each peer's `send_content_types` toggle. Caller (facade
     /// `dispatch_snapshot*`) computes via
@@ -1006,6 +1008,7 @@ mod tests {
             plaintext: Bytes::from_static(b"hello world"),
             snapshot_hash: "9".repeat(64),
             payload_version: 3,
+            wire_version: ClipboardHeader::CURRENT_VERSION,
             // Existing verdicts predate the content-type filter; default
             // to an empty set so they always pass the gate (fail open).
             categories: ClipboardContentCategorySet::empty(),
@@ -1542,6 +1545,7 @@ mod tests {
             plaintext: Bytes::from_static(b"hello world"),
             snapshot_hash: "9".repeat(64),
             payload_version: 3,
+            wire_version: ClipboardHeader::CURRENT_VERSION,
             categories,
             entry_id: None,
             target_filter: None,
@@ -1873,6 +1877,7 @@ mod tests {
             plaintext: Bytes::from_static(b"hello world"),
             snapshot_hash: "9".repeat(64),
             payload_version: 3,
+            wire_version: ClipboardHeader::CURRENT_VERSION,
             categories,
             entry_id: None,
             target_filter: None,

--- a/crates/uc-application/src/usecases/clipboard_sync/dispatch_entry/mod.rs
+++ b/crates/uc-application/src/usecases/clipboard_sync/dispatch_entry/mod.rs
@@ -2100,6 +2100,70 @@ mod tests {
         }
     }
 
+    #[tokio::test]
+    async fn directory_send_to_v2_receiver_records_explicit_rejection() {
+        let mut repo = MockPeerAddrRepo::new();
+        repo.expect_list()
+            .times(1)
+            .returning(|| Ok(vec![record("peer-v2")]));
+
+        let mut cipher = MockCipher::new();
+        cipher
+            .expect_encrypt()
+            .times(1)
+            .returning(|plaintext| Ok(plaintext.to_vec()));
+
+        let mut dispatch = MockDispatch::new();
+        dispatch
+            .expect_dispatch()
+            .withf(|device_id, header, _| {
+                device_id == &DeviceId::new("peer-v2")
+                    && header.version == ClipboardHeader::DIRECTORY_VERSION
+            })
+            .times(1)
+            .returning(|_, _, _| {
+                dispatch_report(Err(ClipboardDispatchError::PeerRejected(
+                    "unsupported clipboard wire version 3".to_string(),
+                )))
+            });
+
+        let spy = Arc::new(SpyEntryDeliveryRepo::default());
+        let uc = DispatchClipboardEntryUseCase::new(
+            Arc::new(repo),
+            Arc::new(make_member_repo_all_enabled()),
+            Arc::new(StaticPresence(ReachabilityState::Unknown)),
+            Arc::new(cipher),
+            Arc::new(dispatch),
+            Arc::new(make_device_identity("self-device")),
+            Arc::new(make_local_identity_stub()),
+            Arc::new(make_settings_stub()),
+            Arc::new(FixedClock(1_700_000_000_000)),
+            Arc::new(uc_observability::analytics::NoopAnalyticsSink),
+            Arc::new(AllMarkedFirstSyncState),
+            Arc::clone(&spy) as Arc<dyn EntryDeliveryRepositoryPort>,
+            Arc::new(crate::facade::host_event::HostEventBus::new()),
+        );
+
+        let mut input = input();
+        input.entry_id = Some(EntryId::from("entry-directory"));
+        input.wire_version = ClipboardHeader::DIRECTORY_VERSION;
+        let outcome = uc.execute(input).await.expect("dispatch should settle");
+        assert_eq!(outcome.total_errored, 1);
+
+        let attempts = spy.snapshot().await;
+        assert_eq!(attempts.len(), 1);
+        assert!(matches!(
+            attempts[0].status,
+            EntryDeliveryStatus::Failed {
+                reason: DeliveryFailureReason::PeerRejected
+            }
+        ));
+        assert_eq!(
+            attempts[0].reason_detail.as_deref(),
+            Some("unsupported clipboard wire version 3")
+        );
+    }
+
     /// entry_id=None 路径(CLI raw-bytes / 测试)永不触发落盘:dispatch
     /// 自身不与某条 entry 绑定,落盘对应 entry_id 无处可写。
     #[tokio::test]

--- a/crates/uc-application/src/usecases/clipboard_sync/dispatch_entry/test_support.rs
+++ b/crates/uc-application/src/usecases/clipboard_sync/dispatch_entry/test_support.rs
@@ -244,6 +244,7 @@ pub(crate) fn dispatch_input() -> DispatchClipboardEntryInput {
         plaintext: Bytes::from_static(b"hello world"),
         snapshot_hash: "9".repeat(64),
         payload_version: 3,
+        wire_version: ClipboardHeader::CURRENT_VERSION,
         categories: ClipboardContentCategorySet::empty(),
         entry_id: None,
         target_filter: None,

--- a/crates/uc-application/src/usecases/clipboard_sync/payload_codec.rs
+++ b/crates/uc-application/src/usecases/clipboard_sync/payload_codec.rs
@@ -29,6 +29,7 @@ use anyhow::{anyhow, Result};
 use bytes::Bytes;
 
 use uc_core::clipboard::normalize_wire_mime;
+use uc_core::clipboard::FileSetMemberKind;
 use uc_core::ids::{EntryId, FormatId, RepresentationId};
 use uc_core::network::protocol::{BinaryRepresentation, ClipboardBinaryPayload};
 use uc_core::ports::blob::BlobTicket;
@@ -36,9 +37,12 @@ use uc_core::ports::blob::BlobTicket;
 use uc_core::MimeType;
 use uc_core::{ObservedClipboardRepresentation, SystemClipboardSnapshot};
 
+use super::apply_inbound::{InboundFileSetManifest, InboundFileSetMember};
+
 /// V3 blob refs trailer magic. Each ref carries 6 fields:
 /// `ticket / entry_id / filename / mime / size_bytes / representation_index`.
 const BLOB_REFS_MAGIC: &[u8; 4] = b"UCBS";
+const FILE_SET_MAGIC: &[u8; 4] = b"UCDS";
 const NONE_STRING_LEN: u16 = u16::MAX;
 const NONE_U32_MARKER: u8 = 0;
 const SOME_U32_MARKER: u8 = 1;
@@ -121,6 +125,20 @@ pub fn encode_snapshot_with_blob_refs_to_v3_bytes(
     Ok((Bytes::from(out), snapshot_hash))
 }
 
+pub fn encode_snapshot_with_blob_refs_and_file_set_to_v3_bytes(
+    snapshot: &SystemClipboardSnapshot,
+    blob_refs: &[V3BlobRef],
+    manifest: &InboundFileSetManifest,
+) -> Result<(Bytes, String)> {
+    let (bytes, snapshot_hash) = encode_snapshot_to_v3_bytes(snapshot)?;
+    let mut out = bytes.to_vec();
+    write_blob_refs_extension(&mut out, blob_refs)
+        .map_err(|e| anyhow!("encode V3 blob refs extension: {e}"))?;
+    write_file_set_extension(&mut out, manifest)
+        .map_err(|e| anyhow!("encode directory file-set extension: {e}"))?;
+    Ok((Bytes::from(out), snapshot_hash))
+}
+
 /// Decode V3 envelope bytes back into a `SystemClipboardSnapshot`.
 ///
 /// Each `BinaryRepresentation` becomes an
@@ -140,6 +158,17 @@ pub fn decode_v3_bytes_to_snapshot(bytes: &[u8]) -> Result<SystemClipboardSnapsh
 pub fn decode_v3_bytes_to_snapshot_and_blob_refs(
     bytes: &[u8],
 ) -> Result<(SystemClipboardSnapshot, Vec<V3BlobRef>)> {
+    let (snapshot, blob_refs, _) = decode_v3_bytes_to_snapshot_blob_refs_and_file_set(bytes)?;
+    Ok((snapshot, blob_refs))
+}
+
+pub fn decode_v3_bytes_to_snapshot_blob_refs_and_file_set(
+    bytes: &[u8],
+) -> Result<(
+    SystemClipboardSnapshot,
+    Vec<V3BlobRef>,
+    Option<InboundFileSetManifest>,
+)> {
     let mut cursor = bytes;
     let payload = ClipboardBinaryPayload::decode_from(&mut cursor)
         .map_err(|e| anyhow!("decode V3 envelope: {e}"))?;
@@ -160,7 +189,8 @@ pub fn decode_v3_bytes_to_snapshot_and_blob_refs(
         })
         .collect();
 
-    let blob_refs = read_blob_refs_extension(cursor)?;
+    let (blob_refs, trailing) = read_blob_refs_extension_with_remainder(cursor)?;
+    let file_set_manifest = read_file_set_extension(trailing)?;
     Ok((
         SystemClipboardSnapshot {
             ts_ms: payload.ts_ms,
@@ -169,6 +199,7 @@ pub fn decode_v3_bytes_to_snapshot_and_blob_refs(
             file_set_v1_component: None,
         },
         blob_refs,
+        file_set_manifest,
     ))
 }
 
@@ -200,9 +231,9 @@ fn write_blob_refs_extension<W: Write>(
     Ok(())
 }
 
-fn read_blob_refs_extension(mut bytes: &[u8]) -> Result<Vec<V3BlobRef>> {
+fn read_blob_refs_extension_with_remainder(mut bytes: &[u8]) -> Result<(Vec<V3BlobRef>, &[u8])> {
     if bytes.is_empty() {
-        return Ok(Vec::new());
+        return Ok((Vec::new(), bytes));
     }
 
     let mut magic = [0u8; 4];
@@ -238,13 +269,83 @@ fn read_blob_refs_extension(mut bytes: &[u8]) -> Result<Vec<V3BlobRef>> {
         });
     }
 
+    Ok((refs, bytes))
+}
+
+fn write_file_set_extension<W: Write>(
+    writer: &mut W,
+    manifest: &InboundFileSetManifest,
+) -> std::io::Result<()> {
+    if manifest.members.is_empty() || manifest.members.len() > MAX_BLOB_REFS {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!(
+                "directory member count {} is outside 1..={MAX_BLOB_REFS}",
+                manifest.members.len()
+            ),
+        ));
+    }
+    writer.write_all(FILE_SET_MAGIC)?;
+    writer.write_all(&(manifest.members.len() as u16).to_le_bytes())?;
+    for member in &manifest.members {
+        let kind = match member.kind {
+            FileSetMemberKind::File => b'f',
+            FileSetMemberKind::Executable => b'x',
+            FileSetMemberKind::EmptyDirectory => b'd',
+        };
+        writer.write_all(&[kind])?;
+        writer.write_all(&member.root_index.to_le_bytes())?;
+        write_string_u16(writer, &member.root_name, "root_name")?;
+        write_string_u16(writer, &member.relative_path, "relative_path")?;
+        write_optional_u32(writer, member.blob_ref_index)?;
+    }
+    Ok(())
+}
+
+fn read_file_set_extension(mut bytes: &[u8]) -> Result<Option<InboundFileSetManifest>> {
+    if bytes.is_empty() {
+        return Ok(None);
+    }
+    let mut magic = [0u8; 4];
+    bytes
+        .read_exact(&mut magic)
+        .map_err(|e| anyhow!("read directory file-set magic: {e}"))?;
+    if &magic != FILE_SET_MAGIC {
+        return Err(anyhow!("unknown V3 trailing extension"));
+    }
+    let count = read_u16(&mut bytes, "directory_member_count")? as usize;
+    if count == 0 || count > MAX_BLOB_REFS {
+        return Err(anyhow!(
+            "directory_member_count {count} is outside 1..={MAX_BLOB_REFS}"
+        ));
+    }
+    let mut members = Vec::with_capacity(count);
+    for _ in 0..count {
+        let mut kind = [0u8; 1];
+        bytes
+            .read_exact(&mut kind)
+            .map_err(|e| anyhow!("read directory member kind: {e}"))?;
+        let kind = match kind[0] {
+            b'f' => FileSetMemberKind::File,
+            b'x' => FileSetMemberKind::Executable,
+            b'd' => FileSetMemberKind::EmptyDirectory,
+            other => return Err(anyhow!("invalid directory member kind byte: {other}")),
+        };
+        members.push(InboundFileSetMember {
+            kind,
+            root_index: read_u32(&mut bytes, "root_index")?,
+            root_name: read_string_u16(&mut bytes, "root_name")?,
+            relative_path: read_string_u16(&mut bytes, "relative_path")?,
+            blob_ref_index: read_optional_u32(&mut bytes, "blob_ref_index")?,
+        });
+    }
     if !bytes.is_empty() {
         return Err(anyhow!(
-            "V3 blob refs extension has {} trailing byte(s)",
+            "directory file-set extension has {} trailing byte(s)",
             bytes.len()
         ));
     }
-    Ok(refs)
+    Ok(Some(InboundFileSetManifest { members }))
 }
 
 fn write_bytes_u32<W: Write>(writer: &mut W, value: &[u8], label: &str) -> std::io::Result<()> {
@@ -568,6 +669,55 @@ mod tests {
         assert_eq!(refs.len(), 1);
         assert_eq!(refs[0], blob_ref);
         assert_eq!(refs[0].representation_index, Some(0));
+    }
+
+    #[test]
+    fn directory_manifest_round_trip_preserves_member_locations() {
+        use crate::usecases::clipboard_sync::apply_inbound::{
+            InboundFileSetManifest, InboundFileSetMember,
+        };
+        use uc_core::clipboard::FileSetMemberKind;
+
+        let original = fixture_snapshot("directory placeholder");
+        let blob_ref = V3BlobRef {
+            ticket: BlobTicket::from_bytes(vec![9, 8, 7]),
+            entry_id: EntryId::from("directory-entry"),
+            filename: Some("run.sh".to_string()),
+            mime: None,
+            size_bytes: 12,
+            representation_index: None,
+        };
+        let manifest = InboundFileSetManifest {
+            members: vec![
+                InboundFileSetMember {
+                    root_index: 0,
+                    root_name: "project".to_string(),
+                    relative_path: "bin/run.sh".to_string(),
+                    kind: FileSetMemberKind::Executable,
+                    blob_ref_index: Some(0),
+                },
+                InboundFileSetMember {
+                    root_index: 0,
+                    root_name: "project".to_string(),
+                    relative_path: "empty".to_string(),
+                    kind: FileSetMemberKind::EmptyDirectory,
+                    blob_ref_index: None,
+                },
+            ],
+        };
+
+        let (bytes, _) = encode_snapshot_with_blob_refs_and_file_set_to_v3_bytes(
+            &original,
+            &[blob_ref.clone()],
+            &manifest,
+        )
+        .unwrap();
+        let (decoded, refs, decoded_manifest) =
+            decode_v3_bytes_to_snapshot_blob_refs_and_file_set(&bytes).unwrap();
+
+        assert_eq!(decoded.ts_ms, original.ts_ms);
+        assert_eq!(refs, vec![blob_ref]);
+        assert_eq!(decoded_manifest, Some(manifest));
     }
 
     /// Verdict 6 —— 不带扩展时新 decoder 返回空 blob 引用,保持普通文本

--- a/crates/uc-application/src/usecases/clipboard_sync/payload_codec.rs
+++ b/crates/uc-application/src/usecases/clipboard_sync/payload_codec.rs
@@ -708,7 +708,7 @@ mod tests {
 
         let (bytes, _) = encode_snapshot_with_blob_refs_and_file_set_to_v3_bytes(
             &original,
-            &[blob_ref.clone()],
+            std::slice::from_ref(&blob_ref),
             &manifest,
         )
         .unwrap();

--- a/crates/uc-application/src/usecases/clipboard_sync/payload_codec.rs
+++ b/crates/uc-application/src/usecases/clipboard_sync/payload_codec.rs
@@ -294,6 +294,7 @@ fn write_file_set_extension<W: Write>(
             FileSetMemberKind::EmptyDirectory => b'd',
         };
         writer.write_all(&[kind])?;
+        writer.write_all(&[u8::from(member.root_is_file)])?;
         writer.write_all(&member.root_index.to_le_bytes())?;
         write_string_u16(writer, &member.root_name, "root_name")?;
         write_string_u16(writer, &member.relative_path, "relative_path")?;
@@ -331,8 +332,18 @@ fn read_file_set_extension(mut bytes: &[u8]) -> Result<Option<InboundFileSetMani
             b'd' => FileSetMemberKind::EmptyDirectory,
             other => return Err(anyhow!("invalid directory member kind byte: {other}")),
         };
+        let mut root_is_file = [0u8; 1];
+        bytes
+            .read_exact(&mut root_is_file)
+            .map_err(|e| anyhow!("read directory root kind: {e}"))?;
+        let root_is_file = match root_is_file[0] {
+            0 => false,
+            1 => true,
+            other => return Err(anyhow!("invalid directory root kind byte: {other}")),
+        };
         members.push(InboundFileSetMember {
             kind,
+            root_is_file,
             root_index: read_u32(&mut bytes, "root_index")?,
             root_name: read_string_u16(&mut bytes, "root_name")?,
             relative_path: read_string_u16(&mut bytes, "relative_path")?,
@@ -692,6 +703,7 @@ mod tests {
                 InboundFileSetMember {
                     root_index: 0,
                     root_name: "project".to_string(),
+                    root_is_file: false,
                     relative_path: "bin/run.sh".to_string(),
                     kind: FileSetMemberKind::Executable,
                     blob_ref_index: Some(0),
@@ -699,6 +711,7 @@ mod tests {
                 InboundFileSetMember {
                     root_index: 0,
                     root_name: "project".to_string(),
+                    root_is_file: false,
                     relative_path: "empty".to_string(),
                     kind: FileSetMemberKind::EmptyDirectory,
                     blob_ref_index: None,

--- a/crates/uc-application/src/usecases/clipboard_sync/resend_entry.rs
+++ b/crates/uc-application/src/usecases/clipboard_sync/resend_entry.rs
@@ -73,14 +73,19 @@ use uc_core::trusted_peer::TrustedPeerRepositoryPort;
 use uc_core::ClipboardChangeOrigin;
 
 use crate::facade::clipboard_outbound::{
-    publish_file_blob_refs, publish_oversized_inline_blob_refs, resolve_outbound_file_set,
-    ClipboardOutboundError, OutboundBlobPublishGateway, OutboundFileSetResolution,
+    build_transfer_manifest, publish_file_blob_refs, publish_oversized_inline_blob_refs,
+    resolve_outbound_file_set, ClipboardOutboundError, OutboundBlobPublishGateway,
+    OutboundFileSetResolution,
 };
 use crate::sync_planner::{FileCandidate, OutboundSyncPlanner};
+use crate::usecases::clipboard_sync::apply_inbound::compute_file_set_component;
 use crate::usecases::clipboard_sync::dispatch_entry::{
     DispatchClipboardEntryInput, DispatchEntryRunner, DispatchSyncError,
 };
-use crate::usecases::clipboard_sync::payload_codec::encode_snapshot_with_blob_refs_to_v3_bytes;
+use crate::usecases::clipboard_sync::payload_codec::{
+    encode_snapshot_with_blob_refs_and_file_set_to_v3_bytes,
+    encode_snapshot_with_blob_refs_to_v3_bytes,
+};
 use crate::usecases::clipboard_sync::snapshot_from_entry::{
     reconstruct_snapshot_from_entry, BuildSnapshotError,
 };
@@ -390,16 +395,12 @@ impl ResendEntryUseCase {
         let resolution =
             resolve_outbound_file_set(self.entry_file_set_repo.as_ref(), &cmd.entry_id, &snapshot)
                 .await;
-        let (resolved_paths, from_manifest) = match resolution {
-            OutboundFileSetResolution::NotFileClass => (Vec::new(), false),
-            OutboundFileSetResolution::Manifest { paths, .. } => (paths, true),
-            OutboundFileSetResolution::Fallback { paths } => (paths, false),
-            OutboundFileSetResolution::DirectorySyncable { .. } => {
-                // TODO(ADR-010 phase 4): remove this gate once the wire format
-                // carries directory member locations and receivers rebuild trees.
-                return Err(ResendEntryError::Dispatch(
-                    "directory_not_yet_syncable".to_string(),
-                ));
+        let (resolved_paths, from_manifest, directory_members) = match resolution {
+            OutboundFileSetResolution::NotFileClass => (Vec::new(), false, None),
+            OutboundFileSetResolution::Manifest { paths, .. } => (paths, true, None),
+            OutboundFileSetResolution::Fallback { paths } => (paths, false, None),
+            OutboundFileSetResolution::DirectorySyncable { paths, members } => {
+                (paths, true, Some(members))
             }
             OutboundFileSetResolution::Excluded {
                 ingest_failed,
@@ -468,7 +469,33 @@ impl ResendEntryUseCase {
             publish_file_blob_refs(self.blob_publisher.as_ref(), &plan.files, &cmd.entry_id)
                 .await
                 .map_err(map_outbound_publish_error)?;
-        if !file_content_digests.is_empty() {
+        let file_set_manifest = match directory_members {
+            Some(members) => {
+                if plan.files.len() != extracted_paths_count {
+                    return Err(ResendEntryError::EntryNotResendable {
+                        entry_id: cmd.entry_id.clone(),
+                        reason: NotResendableReason::PayloadLost,
+                    });
+                }
+                Some(
+                    build_transfer_manifest(&members, &plan.files)
+                        .map_err(map_outbound_publish_error)?,
+                )
+            }
+            None => None,
+        };
+        if let Some(manifest) = &file_set_manifest {
+            let digests = file_content_digests
+                .iter()
+                .enumerate()
+                .map(|(index, digest)| (index as u32, *digest))
+                .collect();
+            clipboard_intent.snapshot.file_content_digests.clear();
+            clipboard_intent.snapshot.file_set_v1_component = Some(
+                compute_file_set_component(manifest, &digests)
+                    .map_err(|err| ResendEntryError::Dispatch(err.to_string()))?,
+            );
+        } else if !file_content_digests.is_empty() {
             clipboard_intent.snapshot.file_content_digests = file_content_digests;
         }
         let mut image_blob_refs = publish_oversized_inline_blob_refs(
@@ -482,9 +509,34 @@ impl ResendEntryUseCase {
 
         // 6. Encode V3 envelope.
         let categories = ClipboardContentCategorySet::from_snapshot(&clipboard_intent.snapshot);
-        let (plaintext, snapshot_hash) =
-            encode_snapshot_with_blob_refs_to_v3_bytes(&clipboard_intent.snapshot, &blob_refs)
+        let (plaintext, snapshot_hash, wire_version) = match file_set_manifest {
+            Some(manifest) => {
+                let (plaintext, snapshot_hash) =
+                    encode_snapshot_with_blob_refs_and_file_set_to_v3_bytes(
+                        &clipboard_intent.snapshot,
+                        &blob_refs,
+                        &manifest,
+                    )
+                    .map_err(|e| ResendEntryError::Dispatch(format!("payload encode: {e}")))?;
+                (
+                    plaintext,
+                    snapshot_hash,
+                    uc_core::ports::ClipboardHeader::DIRECTORY_VERSION,
+                )
+            }
+            None => {
+                let (plaintext, snapshot_hash) = encode_snapshot_with_blob_refs_to_v3_bytes(
+                    &clipboard_intent.snapshot,
+                    &blob_refs,
+                )
                 .map_err(|e| ResendEntryError::Dispatch(format!("payload encode: {e}")))?;
+                (
+                    plaintext,
+                    snapshot_hash,
+                    uc_core::ports::ClipboardHeader::CURRENT_VERSION,
+                )
+            }
+        };
 
         // 7. Dispatch. fan-out 的 delivery 落盘 + host event emit 在
         //    `DispatchClipboardEntryUseCase::execute` 内串行完成,本用例只
@@ -497,7 +549,7 @@ impl ResendEntryUseCase {
                 plaintext,
                 snapshot_hash,
                 payload_version: 3,
-                wire_version: uc_core::ports::ClipboardHeader::CURRENT_VERSION,
+                wire_version,
                 categories,
                 entry_id: Some(cmd.entry_id.clone()),
                 target_filter: Some(targets),
@@ -832,6 +884,30 @@ mod tests {
             _command: PublishBlobPathCommand,
         ) -> Result<PublishBlobResult, BlobTransferError> {
             unreachable!("UnusedPublishGateway: publish_blob_path must not be called for text-only snapshots")
+        }
+    }
+
+    struct FilePublishGateway;
+    #[async_trait]
+    impl OutboundBlobPublishGateway for FilePublishGateway {
+        async fn publish_blob(
+            &self,
+            _command: PublishBlobCommand,
+        ) -> Result<PublishBlobResult, BlobTransferError> {
+            unreachable!("directory resend test has no oversized inline blob")
+        }
+
+        async fn publish_blob_path(
+            &self,
+            command: PublishBlobPathCommand,
+        ) -> Result<PublishBlobResult, BlobTransferError> {
+            Ok(PublishBlobResult {
+                ticket: uc_core::ports::blob::BlobTicket::from_bytes(vec![1, 2, 3]),
+                entry_id: command.entry_id.unwrap(),
+                plaintext_hash: uc_core::ports::blob::PlaintextHash::from_bytes([5; 32]),
+                digest: uc_core::ports::blob::BlobDigest::from_bytes([6; 32]),
+                reused_existing: false,
+            })
         }
     }
 
@@ -1370,7 +1446,7 @@ mod tests {
                 entry: Some(entry_with_event(&entry_id, &event_id)),
             }),
             event_repo: Arc::new(FakeEventRepo {
-                source: Some(local.clone()),
+                source: Some(local),
             }),
             selection_repo: Arc::new(FakeSelectionRepo {
                 selection: Some(selection_for(&entry_id, "rep-files")),
@@ -1470,5 +1546,94 @@ mod tests {
             }
             other => panic!("expected EntryNotResendable, got {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn resend_directory_uses_full_manifest_and_directory_wire_version() {
+        use uc_core::clipboard::{
+            ContentHash, EntryFileSet, EntryFileSetLine, EntryFileSetLineKind, FileSetMemberKind,
+            FileSetMemberLocation, HashAlgorithm,
+        };
+
+        let temp = tempfile::tempdir().unwrap();
+        let file = temp.path().join("child.txt");
+        std::fs::write(&file, b"hello").unwrap();
+        let uri = url::Url::from_file_path(&file).unwrap().to_string();
+        let entry_id = EntryId::from("entry-directory-resend");
+        let event_id = EventId::from("event-directory-resend");
+        let local = DeviceId::new("self");
+        let file_set = EntryFileSet {
+            lines: vec![EntryFileSetLine {
+                line_index: 1,
+                original_text: uri.clone(),
+                member_location: Some(FileSetMemberLocation {
+                    root_index: 0,
+                    root_name: "folder".to_string(),
+                    relative_path: "child.txt".to_string(),
+                    kind: FileSetMemberKind::File,
+                }),
+                kind: EntryFileSetLineKind::File {
+                    content_hash: ContentHash {
+                        alg: HashAlgorithm::Blake3V1,
+                        bytes: [5; 32],
+                    },
+                    blob_id: None,
+                    size_bytes: Some(5),
+                },
+            }],
+        };
+        let runner = Arc::new(RecordingDispatchRunner::new(|input| {
+            Ok(happy_outcome(input))
+        }));
+        let uc = ResendEntryUseCase::new(ResendEntryDeps {
+            entry_repo: Arc::new(FakeEntryRepo {
+                entry: Some(entry_with_event(&entry_id, &event_id)),
+            }),
+            event_repo: Arc::new(FakeEventRepo {
+                source: Some(local.clone()),
+            }),
+            selection_repo: Arc::new(FakeSelectionRepo {
+                selection: Some(selection_for(&entry_id, "rep-files")),
+            }),
+            representation_repo: Arc::new(StaticRepRepo {
+                reps: vec![uri_list_rep("rep-files", &format!("{uri}\r\n"))],
+            }),
+            rep_processing_repo: Arc::new(StubProcessingRepo),
+            payload_resolver: Arc::new(StubResolver(ResolveBehavior::Inline(
+                format!("{uri}\r\n").into_bytes(),
+            ))),
+            blob_store: Arc::new(UnusedBlobStore),
+            entry_delivery_repo: Arc::new(StubDeliveryRepo { records: vec![] }),
+            trusted_peer_repo: Arc::new(StubTrustedPeerRepo {
+                peers: vec![trusted(&local, "peer-a", 1)],
+            }),
+            device_identity: Arc::new(StubDeviceIdentity(local)),
+            settings: Arc::new(StubSettings),
+            entry_file_set_repo: Arc::new(StubFileSetRepo {
+                file_set: Some(file_set),
+            }),
+            blob_publisher: Arc::new(FilePublishGateway),
+            dispatch_runner: runner.clone(),
+        });
+
+        uc.execute(ResendEntryCommand {
+            entry_id,
+            target_filter: Some(vec![DeviceId::new("peer-a")]),
+        })
+        .await
+        .expect("directory resend should dispatch");
+
+        let captured = runner.captured();
+        assert_eq!(
+            captured[0].wire_version,
+            uc_core::ports::ClipboardHeader::DIRECTORY_VERSION
+        );
+        let (_, refs, manifest) =
+            crate::usecases::clipboard_sync::payload_codec::decode_v3_bytes_to_snapshot_blob_refs_and_file_set(
+                &captured[0].plaintext,
+            )
+            .unwrap();
+        assert_eq!(refs.len(), 1);
+        assert_eq!(manifest.unwrap().members[0].relative_path, "child.txt");
     }
 }

--- a/crates/uc-application/src/usecases/clipboard_sync/resend_entry.rs
+++ b/crates/uc-application/src/usecases/clipboard_sync/resend_entry.rs
@@ -394,7 +394,7 @@ impl ResendEntryUseCase {
             OutboundFileSetResolution::NotFileClass => (Vec::new(), false),
             OutboundFileSetResolution::Manifest { paths, .. } => (paths, true),
             OutboundFileSetResolution::Fallback { paths } => (paths, false),
-            OutboundFileSetResolution::DirectoryNotYetSyncable => {
+            OutboundFileSetResolution::DirectorySyncable { .. } => {
                 // TODO(ADR-010 phase 4): remove this gate once the wire format
                 // carries directory member locations and receivers rebuild trees.
                 return Err(ResendEntryError::Dispatch(
@@ -497,6 +497,7 @@ impl ResendEntryUseCase {
                 plaintext,
                 snapshot_hash,
                 payload_version: 3,
+                wire_version: uc_core::ports::ClipboardHeader::CURRENT_VERSION,
                 categories,
                 entry_id: Some(cmd.entry_id.clone()),
                 target_filter: Some(targets),

--- a/crates/uc-core/src/clipboard/file_set.rs
+++ b/crates/uc-core/src/clipboard/file_set.rs
@@ -32,6 +32,30 @@ pub struct EntryFileSetLine {
     pub kind: EntryFileSetLineKind,
 }
 
+impl EntryFileSetLine {
+    /// Whether this line marks its selected root as an expanded directory
+    /// rather than a loose top-level file.
+    ///
+    /// Directory members are assigned line indexes after the top-level input
+    /// range, so at least the final expanded member sits at or beyond the
+    /// persisted `row_count` (pass `EntryFileSet::lines.len()`). That threshold
+    /// recognizes even a one-member directory without confusing flat files
+    /// preceded by uri-list comments. The empty-directory and nested-path
+    /// checks defend the same invariant for data decoded off the wire, where
+    /// line indexes are re-derived.
+    ///
+    /// This predicate is the single source of truth for directory-root
+    /// detection; callers deriving per-root state must go through it rather
+    /// than re-inlining the condition.
+    pub fn indicates_directory_root(&self, row_count: i64) -> bool {
+        self.member_location.as_ref().is_some_and(|location| {
+            location.kind == FileSetMemberKind::EmptyDirectory
+                || location.relative_path.contains('/')
+                || self.line_index >= row_count
+        })
+    }
+}
+
 /// Stable location of a selected file or a member expanded from a directory.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FileSetMemberLocation {
@@ -118,20 +142,14 @@ pub enum EntryFileSetError {
 impl EntryFileSet {
     /// Whether this manifest contains members expanded from a directory root.
     ///
-    /// Directory members are assigned line indexes after the top-level input
-    /// range. At least the final expanded member therefore sits outside the
-    /// persisted row count, which distinguishes even a one-member directory
-    /// without confusing flat files preceded by uri-list comments. The path
-    /// and empty-directory checks defend the same invariant for decoded data.
+    /// Delegates the per-line decision to
+    /// [`EntryFileSetLine::indicates_directory_root`] so the detection rule
+    /// lives in exactly one place.
     pub fn has_directory_structure(&self) -> bool {
         let row_count = self.lines.len() as i64;
-        self.lines.iter().any(|line| {
-            line.member_location.as_ref().is_some_and(|location| {
-                location.kind == FileSetMemberKind::EmptyDirectory
-                    || location.relative_path.contains('/')
-                    || line.line_index >= row_count
-            })
-        })
+        self.lines
+            .iter()
+            .any(|line| line.indicates_directory_root(row_count))
     }
 
     /// 该清单中 `File` 行的内容 hash,已排序。

--- a/crates/uc-core/src/ports/clipboard/sync_dispatch.rs
+++ b/crates/uc-core/src/ports/clipboard/sync_dispatch.rs
@@ -59,6 +59,9 @@ impl ClipboardHeader {
     /// - v1: initial Slice 2 Phase 2 format (no `flow_id`)
     /// - v2: adds `flow_id` for cross-device trace correlation
     pub const CURRENT_VERSION: u8 = 2;
+    /// Frames carrying a directory member manifest require a receiver that
+    /// understands the all-or-nothing directory reconstruction contract.
+    pub const DIRECTORY_VERSION: u8 = 3;
 }
 
 /// Opaque ciphertext already sealed by the application layer. Phase 2 keeps

--- a/crates/uc-core/src/ports/file_transfer.rs
+++ b/crates/uc-core/src/ports/file_transfer.rs
@@ -84,6 +84,16 @@ pub struct EntryTransferSummary {
     pub failure_reason: Option<String>,
     /// Transfer IDs belonging to this entry.
     pub transfer_ids: Vec<String>,
+    /// Per-member state, ordered by transfer id for deterministic reads.
+    pub members: Vec<EntryTransferMemberSummary>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EntryTransferMemberSummary {
+    pub transfer_id: String,
+    pub filename: String,
+    pub status: TrackedFileTransferStatus,
+    pub failure_reason: Option<String>,
 }
 
 /// Expired in-flight record with cleanup target.

--- a/crates/uc-core/src/ports/file_transfer.rs
+++ b/crates/uc-core/src/ports/file_transfer.rs
@@ -82,18 +82,8 @@ pub struct EntryTransferSummary {
     pub aggregate_status: TrackedFileTransferStatus,
     /// Human-readable reason when aggregate is `Failed`.
     pub failure_reason: Option<String>,
-    /// Transfer IDs belonging to this entry.
+    /// Transfer IDs belonging to this entry, sorted for deterministic reads.
     pub transfer_ids: Vec<String>,
-    /// Per-member state, ordered by transfer id for deterministic reads.
-    pub members: Vec<EntryTransferMemberSummary>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct EntryTransferMemberSummary {
-    pub transfer_id: String,
-    pub filename: String,
-    pub status: TrackedFileTransferStatus,
-    pub failure_reason: Option<String>,
 }
 
 /// Expired in-flight record with cleanup target.

--- a/crates/uc-infra/src/db/repositories/file_transfer_repo.rs
+++ b/crates/uc-infra/src/db/repositories/file_transfer_repo.rs
@@ -7,10 +7,10 @@ use crate::db::models::{FileTransferRow, NewFileTransferRow};
 use crate::db::ports::DbExecutor;
 use crate::db::schema::file_transfer;
 use uc_core::ports::file_transfer::{
-    compute_aggregate_status, EntryTransferSummary, ExpiredInflightTransfer,
-    FailInflightTransfersPort, FileTransferProjectionError, FindEntryIdForTransferPort,
-    GetEntryTransferSummaryPort, ListExpiredInflightTransfersPort, PendingInboundTransfer,
-    RecordReceiverTransferPort, TrackedFileTransferStatus,
+    compute_aggregate_status, EntryTransferMemberSummary, EntryTransferSummary,
+    ExpiredInflightTransfer, FailInflightTransfersPort, FileTransferProjectionError,
+    FindEntryIdForTransferPort, GetEntryTransferSummaryPort, ListExpiredInflightTransfersPort,
+    PendingInboundTransfer, RecordReceiverTransferPort, TrackedFileTransferStatus,
 };
 
 /// SQLite adapter for the receiver-side file-transfer projection ports.
@@ -173,13 +173,28 @@ impl<E: DbExecutor> GetEntryTransferSummaryPort for DieselFileTransferRepository
                     None
                 };
 
-                let transfer_ids = rows.iter().map(|r| r.transfer_id.clone()).collect();
+                let mut members: Vec<EntryTransferMemberSummary> = rows
+                    .iter()
+                    .map(|row| EntryTransferMemberSummary {
+                        transfer_id: row.transfer_id.clone(),
+                        filename: row.filename.clone(),
+                        status: TrackedFileTransferStatus::from_str_value(&row.status)
+                            .unwrap_or(TrackedFileTransferStatus::Pending),
+                        failure_reason: row.failure_reason.clone(),
+                    })
+                    .collect();
+                members.sort_by(|left, right| left.transfer_id.cmp(&right.transfer_id));
+                let transfer_ids = members
+                    .iter()
+                    .map(|member| member.transfer_id.clone())
+                    .collect();
 
                 Ok(Some(EntryTransferSummary {
                     entry_id: eid,
                     aggregate_status,
                     failure_reason,
                     transfer_ids,
+                    members,
                 }))
             })
             .map_err(backend)
@@ -297,5 +312,85 @@ impl<E: DbExecutor> FailInflightTransfersPort for DieselFileTransferRepository<E
                 Ok(targets)
             })
             .map_err(backend)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::executor::DieselSqliteExecutor;
+    use crate::db::pool::init_db_pool;
+    use crate::db::ports::DbExecutor;
+    use tempfile::{tempdir, TempDir};
+
+    type Repo = DieselFileTransferRepository<DieselSqliteExecutor>;
+
+    fn make_repo() -> (Repo, DieselSqliteExecutor, TempDir) {
+        let tempdir = tempdir().unwrap();
+        let path = tempdir.path().join("file-transfer-repo.sqlite");
+        let path_str = path.to_str().unwrap();
+        let repo = Repo::new(DieselSqliteExecutor::new(init_db_pool(path_str).unwrap()));
+        let writer = DieselSqliteExecutor::new(init_db_pool(path_str).unwrap());
+        (repo, writer, tempdir)
+    }
+
+    async fn seed(repo: &Repo, transfer_id: &str, filename: &str) {
+        repo.upsert_pending_transfer(&PendingInboundTransfer {
+            transfer_id: transfer_id.to_string(),
+            entry_id: "entry-directory".to_string(),
+            origin_device_id: "peer-a".to_string(),
+            filename: filename.to_string(),
+            cached_path: String::new(),
+            created_at_ms: 1,
+        })
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn entry_summary_lists_each_directory_member_and_aggregates_failure() {
+        let (repo, writer, _tempdir) = make_repo();
+        seed(&repo, "transfer-a", "a.txt").await;
+        seed(&repo, "transfer-b", "b.txt").await;
+        seed(&repo, "transfer-c", "c.txt").await;
+        writer
+            .run(|conn| {
+                diesel::update(
+                    file_transfer::table.filter(file_transfer::transfer_id.eq("transfer-a")),
+                )
+                .set(file_transfer::status.eq(TrackedFileTransferStatus::Completed.as_str()))
+                .execute(conn)?;
+                diesel::update(
+                    file_transfer::table.filter(file_transfer::transfer_id.eq("transfer-b")),
+                )
+                .set((
+                    file_transfer::status.eq(TrackedFileTransferStatus::Failed.as_str()),
+                    file_transfer::failure_reason.eq(Some("network")),
+                ))
+                .execute(conn)?;
+                Ok(())
+            })
+            .unwrap();
+
+        let summary = repo
+            .get_entry_transfer_summary("entry-directory")
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(summary.aggregate_status, TrackedFileTransferStatus::Failed);
+        assert_eq!(summary.members.len(), 3);
+        assert_eq!(summary.members[0].filename, "a.txt");
+        assert_eq!(
+            summary.members[0].status,
+            TrackedFileTransferStatus::Completed
+        );
+        assert_eq!(summary.members[1].filename, "b.txt");
+        assert_eq!(summary.members[1].status, TrackedFileTransferStatus::Failed);
+        assert_eq!(summary.members[2].filename, "c.txt");
+        assert_eq!(
+            summary.members[2].status,
+            TrackedFileTransferStatus::Pending
+        );
     }
 }

--- a/crates/uc-infra/src/db/repositories/file_transfer_repo.rs
+++ b/crates/uc-infra/src/db/repositories/file_transfer_repo.rs
@@ -7,10 +7,10 @@ use crate::db::models::{FileTransferRow, NewFileTransferRow};
 use crate::db::ports::DbExecutor;
 use crate::db::schema::file_transfer;
 use uc_core::ports::file_transfer::{
-    compute_aggregate_status, EntryTransferMemberSummary, EntryTransferSummary,
-    ExpiredInflightTransfer, FailInflightTransfersPort, FileTransferProjectionError,
-    FindEntryIdForTransferPort, GetEntryTransferSummaryPort, ListExpiredInflightTransfersPort,
-    PendingInboundTransfer, RecordReceiverTransferPort, TrackedFileTransferStatus,
+    compute_aggregate_status, EntryTransferSummary, ExpiredInflightTransfer,
+    FailInflightTransfersPort, FileTransferProjectionError, FindEntryIdForTransferPort,
+    GetEntryTransferSummaryPort, ListExpiredInflightTransfersPort, PendingInboundTransfer,
+    RecordReceiverTransferPort, TrackedFileTransferStatus,
 };
 
 /// SQLite adapter for the receiver-side file-transfer projection ports.
@@ -173,28 +173,15 @@ impl<E: DbExecutor> GetEntryTransferSummaryPort for DieselFileTransferRepository
                     None
                 };
 
-                let mut members: Vec<EntryTransferMemberSummary> = rows
-                    .iter()
-                    .map(|row| EntryTransferMemberSummary {
-                        transfer_id: row.transfer_id.clone(),
-                        filename: row.filename.clone(),
-                        status: TrackedFileTransferStatus::from_str_value(&row.status)
-                            .unwrap_or(TrackedFileTransferStatus::Pending),
-                        failure_reason: row.failure_reason.clone(),
-                    })
-                    .collect();
-                members.sort_by(|left, right| left.transfer_id.cmp(&right.transfer_id));
-                let transfer_ids = members
-                    .iter()
-                    .map(|member| member.transfer_id.clone())
-                    .collect();
+                let mut transfer_ids: Vec<String> =
+                    rows.iter().map(|row| row.transfer_id.clone()).collect();
+                transfer_ids.sort();
 
                 Ok(Some(EntryTransferSummary {
                     entry_id: eid,
                     aggregate_status,
                     failure_reason,
                     transfer_ids,
-                    members,
                 }))
             })
             .map_err(backend)
@@ -348,11 +335,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn entry_summary_lists_each_directory_member_and_aggregates_failure() {
+    async fn entry_summary_sorts_transfer_ids_and_aggregates_failure() {
         let (repo, writer, _tempdir) = make_repo();
+        // Seed out of order to prove the summary sorts deterministically.
+        seed(&repo, "transfer-c", "c.txt").await;
         seed(&repo, "transfer-a", "a.txt").await;
         seed(&repo, "transfer-b", "b.txt").await;
-        seed(&repo, "transfer-c", "c.txt").await;
         writer
             .run(|conn| {
                 diesel::update(
@@ -379,18 +367,14 @@ mod tests {
             .unwrap();
 
         assert_eq!(summary.aggregate_status, TrackedFileTransferStatus::Failed);
-        assert_eq!(summary.members.len(), 3);
-        assert_eq!(summary.members[0].filename, "a.txt");
+        assert_eq!(summary.failure_reason.as_deref(), Some("network"));
         assert_eq!(
-            summary.members[0].status,
-            TrackedFileTransferStatus::Completed
-        );
-        assert_eq!(summary.members[1].filename, "b.txt");
-        assert_eq!(summary.members[1].status, TrackedFileTransferStatus::Failed);
-        assert_eq!(summary.members[2].filename, "c.txt");
-        assert_eq!(
-            summary.members[2].status,
-            TrackedFileTransferStatus::Pending
+            summary.transfer_ids,
+            vec![
+                "transfer-a".to_string(),
+                "transfer-b".to_string(),
+                "transfer-c".to_string()
+            ]
         );
     }
 }

--- a/crates/uc-infra/src/network/iroh/blobs.rs
+++ b/crates/uc-infra/src/network/iroh/blobs.rs
@@ -742,6 +742,7 @@ mod tests {
     use super::*;
 
     use std::path::PathBuf;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::time::Duration;
 
     use iroh::{protocol::Router, RelayMode};
@@ -810,6 +811,18 @@ mod tests {
     /// 断言无影响。
     fn dummy_reason(name: &str) -> TagReason {
         TagReason::ClipboardEntry(EntryId::from_str(name))
+    }
+
+    #[derive(Default)]
+    struct CountingProgressSink {
+        reports: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl BlobProgressSink for CountingProgressSink {
+        async fn report(&self, _bytes_transferred: u64, _total_bytes: Option<u64>) {
+            self.reports.fetch_add(1, Ordering::SeqCst);
+        }
     }
 
     #[tokio::test]
@@ -1173,6 +1186,67 @@ mod tests {
         let fetched = receiver.adapter.fetch(&ticket, None).await?;
 
         assert_eq!(fetched, payload);
+        receiver.shutdown().await?;
+        provider.shutdown().await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn partially_cached_directory_batch_downloads_only_missing_member() -> anyhow::Result<()>
+    {
+        let provider = Fixture::bind().await?;
+        let receiver = Fixture::bind().await?;
+        provider.wait_for_direct_addr().await?;
+        receiver.wait_for_direct_addr().await?;
+
+        let cached_payload = vec![0x31; 64 * 1024];
+        let missing_payload = vec![0x72; 64 * 1024];
+        let cached_digest = provider
+            .adapter
+            .publish(
+                Bytes::from(cached_payload.clone()),
+                dummy_reason("resend-provider-cached"),
+            )
+            .await?;
+        let missing_digest = provider
+            .adapter
+            .publish(
+                Bytes::from(missing_payload.clone()),
+                dummy_reason("resend-provider-missing"),
+            )
+            .await?;
+        let cached_ticket = provider.adapter.issue_ticket(&cached_digest).await?;
+        let missing_ticket = provider.adapter.issue_ticket(&missing_digest).await?;
+
+        let receiver_cached_digest = receiver
+            .adapter
+            .publish(
+                Bytes::from(cached_payload.clone()),
+                dummy_reason("resend-receiver-preloaded"),
+            )
+            .await?;
+        assert_eq!(receiver_cached_digest, cached_digest);
+
+        let target_dir = tempdir()?;
+        let cached_target = target_dir.path().join("cached-member.bin");
+        let missing_target = target_dir.path().join("missing-member.bin");
+        let cached_progress = CountingProgressSink::default();
+        let missing_progress = CountingProgressSink::default();
+
+        receiver
+            .adapter
+            .fetch_to_path(&cached_ticket, &cached_target, Some(&cached_progress))
+            .await?;
+        receiver
+            .adapter
+            .fetch_to_path(&missing_ticket, &missing_target, Some(&missing_progress))
+            .await?;
+
+        assert_eq!(std::fs::read(cached_target)?, cached_payload);
+        assert_eq!(std::fs::read(missing_target)?, missing_payload);
+        assert_eq!(cached_progress.reports.load(Ordering::SeqCst), 0);
+        assert!(missing_progress.reports.load(Ordering::SeqCst) > 0);
+
         receiver.shutdown().await?;
         provider.shutdown().await?;
         Ok(())

--- a/crates/uc-infra/src/network/iroh/clipboard_dispatch_adapter.rs
+++ b/crates/uc-infra/src/network/iroh/clipboard_dispatch_adapter.rs
@@ -358,6 +358,9 @@ fn map_encode_err(err: WireEncodeError) -> ClipboardDispatchError {
         WireEncodeError::Postcard(err) => {
             ClipboardDispatchError::Internal(format!("header encode: {err}"))
         }
+        WireEncodeError::UnsupportedVersion(version) => {
+            ClipboardDispatchError::Internal(format!("unsupported outbound wire version {version}"))
+        }
     }
 }
 

--- a/crates/uc-infra/src/network/iroh/clipboard_wire.rs
+++ b/crates/uc-infra/src/network/iroh/clipboard_wire.rs
@@ -147,6 +147,17 @@ struct WireHeaderV2 {
     flow_id: Option<String>,
 }
 
+#[derive(Serialize, Deserialize, Debug)]
+struct WireHeaderV3 {
+    version: u8,
+    snapshot_hash: String,
+    captured_at_ms: i64,
+    origin_device_id: String,
+    origin_device_name: String,
+    payload_version: u8,
+    flow_id: Option<String>,
+}
+
 // ============================================================================
 // Errors
 // ============================================================================
@@ -161,6 +172,8 @@ pub enum WireEncodeError {
     PayloadTooLarge { size: usize, max: u32 },
     #[error("stream io: {0}")]
     Io(std::io::Error),
+    #[error("unsupported outbound clipboard wire version {0}")]
+    UnsupportedVersion(u8),
 }
 
 #[derive(Debug, Error)]
@@ -190,16 +203,27 @@ pub enum WireDecodeError {
 /// 永远以 v2 schema 编码;v1 仅作为兼容老对端的*解码*入口存在(见
 /// [`decode_header`])。
 pub fn encode_header(header: &ClipboardHeader) -> Result<Vec<u8>, WireEncodeError> {
-    let wire = WireHeaderV2 {
-        version: ClipboardHeader::CURRENT_VERSION,
-        snapshot_hash: header.snapshot_hash.clone(),
-        captured_at_ms: header.captured_at_ms,
-        origin_device_id: header.origin_device_id.clone(),
-        origin_device_name: header.origin_device_name.clone(),
-        payload_version: header.payload_version,
-        flow_id: header.flow_id.clone(),
+    let bytes = match header.version {
+        ClipboardHeader::CURRENT_VERSION => postcard::to_allocvec(&WireHeaderV2 {
+            version: header.version,
+            snapshot_hash: header.snapshot_hash.clone(),
+            captured_at_ms: header.captured_at_ms,
+            origin_device_id: header.origin_device_id.clone(),
+            origin_device_name: header.origin_device_name.clone(),
+            payload_version: header.payload_version,
+            flow_id: header.flow_id.clone(),
+        })?,
+        ClipboardHeader::DIRECTORY_VERSION => postcard::to_allocvec(&WireHeaderV3 {
+            version: header.version,
+            snapshot_hash: header.snapshot_hash.clone(),
+            captured_at_ms: header.captured_at_ms,
+            origin_device_id: header.origin_device_id.clone(),
+            origin_device_name: header.origin_device_name.clone(),
+            payload_version: header.payload_version,
+            flow_id: header.flow_id.clone(),
+        })?,
+        other => return Err(WireEncodeError::UnsupportedVersion(other)),
     };
-    let bytes = postcard::to_allocvec(&wire)?;
     if bytes.len() > MAX_HEADER_SIZE as usize {
         return Err(WireEncodeError::HeaderTooLarge {
             size: bytes.len(),
@@ -245,9 +269,21 @@ pub fn decode_header(bytes: &[u8]) -> Result<ClipboardHeader, WireDecodeError> {
                 flow_id: wire.flow_id,
             })
         }
+        3 => {
+            let wire: WireHeaderV3 = postcard::from_bytes(bytes)?;
+            Ok(ClipboardHeader {
+                version: wire.version,
+                snapshot_hash: wire.snapshot_hash,
+                captured_at_ms: wire.captured_at_ms,
+                origin_device_id: wire.origin_device_id,
+                origin_device_name: wire.origin_device_name,
+                payload_version: wire.payload_version,
+                flow_id: wire.flow_id,
+            })
+        }
         other => Err(WireDecodeError::UnsupportedVersion {
             got: other,
-            expected: ClipboardHeader::CURRENT_VERSION,
+            expected: ClipboardHeader::DIRECTORY_VERSION,
         }),
     }
 }
@@ -508,8 +544,8 @@ mod tests {
     /// as the current schema.
     #[tokio::test]
     async fn decode_rejects_future_header_version() {
-        let future = WireHeaderV2 {
-            version: ClipboardHeader::CURRENT_VERSION + 1,
+        let future = WireHeaderV3 {
+            version: ClipboardHeader::DIRECTORY_VERSION + 1,
             snapshot_hash: "stub".to_string(),
             captured_at_ms: 0,
             origin_device_id: "d".to_string(),
@@ -521,8 +557,8 @@ mod tests {
 
         match decode_header(&bytes) {
             Err(WireDecodeError::UnsupportedVersion { got, expected }) => {
-                assert_eq!(got, ClipboardHeader::CURRENT_VERSION + 1);
-                assert_eq!(expected, ClipboardHeader::CURRENT_VERSION);
+                assert_eq!(got, ClipboardHeader::DIRECTORY_VERSION + 1);
+                assert_eq!(expected, ClipboardHeader::DIRECTORY_VERSION);
             }
             other => panic!("expected UnsupportedVersion, got {other:?}"),
         }
@@ -566,6 +602,19 @@ mod tests {
         let decoded = decode_header(&bytes).unwrap();
         assert_eq!(decoded.flow_id, header.flow_id);
         assert_eq!(decoded.version, ClipboardHeader::CURRENT_VERSION);
+    }
+
+    #[tokio::test]
+    async fn directory_header_round_trip_uses_v3_without_changing_default_version() {
+        let mut header = sample_header();
+        header.version = ClipboardHeader::DIRECTORY_VERSION;
+
+        let bytes = encode_header(&header).unwrap();
+        let decoded = decode_header(&bytes).unwrap();
+
+        assert_eq!(decoded.version, ClipboardHeader::DIRECTORY_VERSION);
+        assert_eq!(decoded.flow_id, header.flow_id);
+        assert_eq!(ClipboardHeader::CURRENT_VERSION, 2);
     }
 
     /// Ack codec sanity — the three defined variants round-trip through

--- a/crates/uc-infra/src/network/iroh/clipboard_wire.rs
+++ b/crates/uc-infra/src/network/iroh/clipboard_wire.rs
@@ -133,6 +133,10 @@ struct WireHeaderV1 {
     payload_version: u8,
 }
 
+/// Postcard schema shared by wire versions v2 and v3. The two versions are
+/// byte-identical; the leading `version` byte alone gates receiver
+/// compatibility — v3 signals that a directory member manifest travels in the
+/// payload trailer and must only be sent to peers that can rebuild the tree.
 #[derive(Serialize, Deserialize, Debug)]
 struct WireHeaderV2 {
     version: u8,
@@ -144,17 +148,6 @@ struct WireHeaderV2 {
     /// Cross-device trace correlation id (UUIDv7 as string). `None` only
     /// during construction from older in-memory paths; encoded as the
     /// postcard `Option` discriminant (single byte `0x00` when None).
-    flow_id: Option<String>,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-struct WireHeaderV3 {
-    version: u8,
-    snapshot_hash: String,
-    captured_at_ms: i64,
-    origin_device_id: String,
-    origin_device_name: String,
-    payload_version: u8,
     flow_id: Option<String>,
 }
 
@@ -200,30 +193,24 @@ pub enum WireDecodeError {
 /// magic byte or length prefix — callers typically run this once and hand
 /// the bytes (plus the payload) to [`write_frame`].
 ///
-/// 永远以 v2 schema 编码;v1 仅作为兼容老对端的*解码*入口存在(见
-/// [`decode_header`])。
+/// v2 与 v3 共用同一份 postcard schema([`WireHeaderV2`]),仅版本号不同;
+/// v1 仅作为兼容老对端的*解码*入口存在(见 [`decode_header`])。
 pub fn encode_header(header: &ClipboardHeader) -> Result<Vec<u8>, WireEncodeError> {
-    let bytes = match header.version {
-        ClipboardHeader::CURRENT_VERSION => postcard::to_allocvec(&WireHeaderV2 {
-            version: header.version,
-            snapshot_hash: header.snapshot_hash.clone(),
-            captured_at_ms: header.captured_at_ms,
-            origin_device_id: header.origin_device_id.clone(),
-            origin_device_name: header.origin_device_name.clone(),
-            payload_version: header.payload_version,
-            flow_id: header.flow_id.clone(),
-        })?,
-        ClipboardHeader::DIRECTORY_VERSION => postcard::to_allocvec(&WireHeaderV3 {
-            version: header.version,
-            snapshot_hash: header.snapshot_hash.clone(),
-            captured_at_ms: header.captured_at_ms,
-            origin_device_id: header.origin_device_id.clone(),
-            origin_device_name: header.origin_device_name.clone(),
-            payload_version: header.payload_version,
-            flow_id: header.flow_id.clone(),
-        })?,
-        other => return Err(WireEncodeError::UnsupportedVersion(other)),
-    };
+    if !matches!(
+        header.version,
+        ClipboardHeader::CURRENT_VERSION | ClipboardHeader::DIRECTORY_VERSION
+    ) {
+        return Err(WireEncodeError::UnsupportedVersion(header.version));
+    }
+    let bytes = postcard::to_allocvec(&WireHeaderV2 {
+        version: header.version,
+        snapshot_hash: header.snapshot_hash.clone(),
+        captured_at_ms: header.captured_at_ms,
+        origin_device_id: header.origin_device_id.clone(),
+        origin_device_name: header.origin_device_name.clone(),
+        payload_version: header.payload_version,
+        flow_id: header.flow_id.clone(),
+    })?;
     if bytes.len() > MAX_HEADER_SIZE as usize {
         return Err(WireEncodeError::HeaderTooLarge {
             size: bytes.len(),
@@ -257,20 +244,10 @@ pub fn decode_header(bytes: &[u8]) -> Result<ClipboardHeader, WireDecodeError> {
                 flow_id: None,
             })
         }
-        2 => {
+        // v2 and v3 share the same schema; the version byte gates the payload
+        // trailer, not the header layout.
+        2 | 3 => {
             let wire: WireHeaderV2 = postcard::from_bytes(bytes)?;
-            Ok(ClipboardHeader {
-                version: wire.version,
-                snapshot_hash: wire.snapshot_hash,
-                captured_at_ms: wire.captured_at_ms,
-                origin_device_id: wire.origin_device_id,
-                origin_device_name: wire.origin_device_name,
-                payload_version: wire.payload_version,
-                flow_id: wire.flow_id,
-            })
-        }
-        3 => {
-            let wire: WireHeaderV3 = postcard::from_bytes(bytes)?;
             Ok(ClipboardHeader {
                 version: wire.version,
                 snapshot_hash: wire.snapshot_hash,
@@ -544,7 +521,7 @@ mod tests {
     /// as the current schema.
     #[tokio::test]
     async fn decode_rejects_future_header_version() {
-        let future = WireHeaderV3 {
+        let future = WireHeaderV2 {
             version: ClipboardHeader::DIRECTORY_VERSION + 1,
             snapshot_hash: "stub".to_string(),
             captured_at_ms: 0,


### PR DESCRIPTION
## Summary

Completes ADR-010 phase 4: a copied directory now syncs across devices
end-to-end. The receiver rebuilds the selected tree atomically (all-or-nothing),
old peers reject directory frames before acknowledging them, entry-level
transfer status aggregates across members, and directory entries can be resent.

Planned as PR-A/B/C in the phase 4 map; landed on one branch since the receive
geobase, wire gating, and resend paths are interdependent and ship in the same
release. Reviewed under `/review-strict`; the follow-up cleanup is the final
commit.

## 协议门控 — wire version gating (#1316)

- Directory frames travel on wire version `DIRECTORY_VERSION` (3). A peer that
  only understands v2 rejects the frame **before** acknowledging it, so the
  sender learns via `PeerRejected` instead of silently losing the paste.
- v2 and v3 share one postcard header schema (`WireHeaderV2`); the version byte
  alone gates receiver compatibility. Default sends stay on v2 — only payloads
  that carry a directory member manifest bump to v3.

## 失败聚合 — entry-level all-or-nothing status (#1317)

- Reuses the existing `EntryTransferSummary` / `compute_aggregate_status`
  aggregation; no parallel status model added. `transfer_ids` is now sorted for
  deterministic reads.
- A mid-tree fetch failure records the remaining members as failed and rolls the
  whole entry back — the receiver never surfaces a half-materialized directory.
- Per-member display (progress rows, member breakdown) is deliberately left to
  the phase 5 UX layer.

## 树重建 — inbound tree reconstruction (#1319)

- Members are fetched into a per-entry staging dir, then each root is promoted
  by an atomic `rename` into the user's save dir; on cross-device rename the
  promotion falls back to a verified copy. Any failure removes staging and
  exposes nothing.
- Root name collisions (against both existing targets and other roots in the
  same paste) get `name (2)`, `name (3)`, … suffixes.
- The file-list rep is rewritten to local `file://` URIs; the receiver
  recomputes the file-set identity from fetched content and verifies it against
  the header's snapshot hash. Executable bit is restored on Unix and treated as
  a plain file on Windows.
- Path-traversal hardening: member relative paths reject empty / `.` / `..` /
  separator components.

## 重发 — directory resend (#1320)

- Resend always carries the full member set (a complete snapshot); iroh
  content-addressing dedupes bytes the receiver already holds, so a partially
  cached directory only pulls the missing members over the wire.

## Review 优化 — post-review cleanup (final commit)

Behavior-preserving cleanup from the strict review:

- Directory-root detection extracted into
  `EntryFileSetLine::indicates_directory_root` (single source of truth; was
  inlined in three places).
- Removed the unused `EntryTransferSummary.members` /
  `EntryTransferMemberSummary` dead data (kept the deterministic sort).
- Instrumented the directory dispatch method so it records `origin` in its span,
  matching sibling methods.
- Collapsed the byte-identical `WireHeaderV3` into `WireHeaderV2`.
- Replaced blocking `Path::exists`/`is_file` in the async promotion path with
  `tokio::fs` (the `spawn_blocking` copy helpers stay synchronous by design).

## Testing

- `cargo check -p uc-core -p uc-application -p uc-infra --tests` — clean, no warnings.
- Targeted suites green: `uc-core` file_set (12), `uc-infra` clipboard_wire (10)
  + file_transfer_repo (1), `uc-application` apply_inbound directory
  materializer (35) + clipboard_outbound resolver (13).
- **Not yet run in this review:** full `cargo test --workspace`, `clippy`, and a
  real two-device end-to-end directory paste. Recommend all three before merge.

## Closes

Closes #1316
Closes #1317
Closes #1319
Closes #1320

## Not closed here

- **#1318** (research: mobile register/GET degradation for file-set entries) —
  the gap is recorded (plan §7); the mobile fix is scoped to phase 5. Close it
  only if the research deliverable is considered done.
- **#1315** (phase 4 map) — close once its child tickets are all resolved.
- **#875** (feat: support copying directories) — keep open until a real
  cross-device paste is verified and the phase 5 UX (progress / cancel /
  sync-ineligible display / `file_sync` settings / mobile / docs) lands.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for synchronizing directory-based clipboard entries, including nested files, empty directories, and mixed file structures.
  * Added directory-aware transfer manifests and wire-format handling.
  * Added safeguards to verify reconstructed directory contents before completion.
* **Bug Fixes**
  * Improved transfer progress and lifecycle tracking for grouped and individual downloads.
  * Ensured deterministic transfer summary ordering.
  * Improved handling of unsupported clipboard versions and transfer failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->