### PR TITLE
feat(ui): integrate beUI motion components (theme toggle, switch)

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build": "tsc && vite build",
     "preview": "vite preview",
     "version:bump": "node scripts/bump-version.js",
+    "add:beui": "node scripts/add-beui.mjs",
     "gen:openapi": "cargo run -p uc-webserver --bin gen-openapi",
     "gen:client": "openapi-ts",
     "gen:api": "bun run gen:openapi && bun run gen:client",

--- a/scripts/add-beui.mjs
+++ b/scripts/add-beui.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+// Pull beUI components (https://beui.dev) into src/.
+//
+// beUI is a copy-paste component registry, not a standard shadcn registry, so
+// the shadcn CLI cannot add its items. This script fetches a component's JSON
+// from the registry, writes each file under src/ (beUI paths are src-relative
+// and its `@/...` imports already match our `@ -> src` alias), and rewrites the
+// `motion/react` imports to `framer-motion` (the package this project uses).
+//
+// Usage:
+//   node scripts/add-beui.mjs <slug> [<slug>...] [--no-install]
+//   bun run add:beui <slug> [<slug>...]
+//
+// Browse available slugs at https://beui.dev/r
+//
+// Safety: existing files are never overwritten (skipped). This protects
+// src/lib/utils.ts — beUI ships its own cn() as lib/utils.ts, but ours also
+// holds project helpers like formatPeerIdForDisplay. Shared beUI utils
+// (lib/ease.ts, ...) are written once by the first component and skipped after.
+
+import { mkdir, writeFile, readFile, access } from 'node:fs/promises'
+import { dirname, resolve, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { execFileSync } from 'node:child_process'
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const SRC = join(ROOT, 'src')
+const REGISTRY = 'https://beui.dev/r'
+
+// beUI lists `motion` as a dependency, but we rewrite its imports to
+// framer-motion, so the motion package is never actually needed.
+const IGNORED_DEPS = new Set(['motion'])
+
+const args = process.argv.slice(2)
+const noInstall = args.includes('--no-install')
+const slugs = args.filter((a) => !a.startsWith('-'))
+
+if (slugs.length === 0) {
+  console.error('Usage: node scripts/add-beui.mjs <slug> [<slug>...] [--no-install]')
+  console.error('Browse slugs at https://beui.dev/r')
+  process.exit(1)
+}
+
+const pkg = JSON.parse(await readFile(join(ROOT, 'package.json'), 'utf8'))
+const owned = new Set([
+  ...Object.keys(pkg.dependencies ?? {}),
+  ...Object.keys(pkg.devDependencies ?? {}),
+])
+
+const exists = (p) => access(p).then(() => true, () => false)
+
+const rewriteMotion = (content) =>
+  content
+    .replace(/(["'])motion\/react\1/g, '$1framer-motion$1')
+    .replace(/(from\s+["'])motion(["'])/g, '$1framer-motion$2')
+
+const missingDeps = new Set()
+const written = []
+const skipped = []
+
+for (const slug of slugs) {
+  const url = `${REGISTRY}/${slug}`
+  const res = await fetch(url)
+  if (!res.ok) {
+    console.error(`✗ ${slug}: ${res.status} ${res.statusText} (${url})`)
+    process.exitCode = 1
+    continue
+  }
+  const item = await res.json()
+  console.log(`\n▸ ${item.name} — ${item.description ?? ''}`)
+
+  for (const file of item.files ?? []) {
+    if (file.type === 'preview') {
+      skipped.push(`${file.path} (preview/example)`)
+      continue
+    }
+    const target = join(SRC, file.path)
+    if (await exists(target)) {
+      skipped.push(`${file.path} (already exists)`)
+      continue
+    }
+    await mkdir(dirname(target), { recursive: true })
+    await writeFile(target, rewriteMotion(file.content))
+    written.push(`src/${file.path}`)
+  }
+
+  for (const dep of item.dependencies ?? []) {
+    if (!owned.has(dep) && !IGNORED_DEPS.has(dep)) missingDeps.add(dep)
+  }
+}
+
+console.log('\n── summary ──')
+if (written.length === 0) console.log('  (no new files written)')
+written.forEach((p) => console.log(`  + ${p}`))
+skipped.forEach((p) => console.log(`  · skipped ${p}`))
+
+if (missingDeps.size === 0) {
+  console.log('\nNo new dependencies needed.')
+} else if (noInstall) {
+  console.log(`\nMissing deps — install manually:\n  bun add ${[...missingDeps].join(' ')}`)
+} else {
+  const list = [...missingDeps]
+  console.log(`\nInstalling missing deps: ${list.join(' ')}`)
+  execFileSync('bun', ['add', ...list], { cwd: ROOT, stdio: 'inherit' })
+}
+
+console.log('\nDone. Import from "@/components/motion/...".')

--- a/scripts/add-beui.mjs
+++ b/scripts/add-beui.mjs
@@ -21,7 +21,7 @@
 // (lib/ease.ts, ...) are written once by the first component and skipped after.
 
 import { mkdir, writeFile, readFile, access } from 'node:fs/promises'
-import { dirname, resolve, join } from 'node:path'
+import { dirname, resolve, join, sep } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { execFileSync } from 'node:child_process'
 
@@ -99,6 +99,12 @@ for (const slug of slugs) {
       continue
     }
     const target = join(SRC, file.path)
+    // Sandbox: registry data is untrusted; reject paths that escape src/.
+    if (!resolve(target).startsWith(SRC + sep)) {
+      console.error(`✗ ${file.path}: resolves outside src/, skipping`)
+      process.exitCode = 1
+      continue
+    }
     if (await exists(target)) {
       skipped.push(`${file.path} (already exists)`)
       continue

--- a/scripts/add-beui.mjs
+++ b/scripts/add-beui.mjs
@@ -35,7 +35,7 @@ const IGNORED_DEPS = new Set(['motion'])
 
 const args = process.argv.slice(2)
 const noInstall = args.includes('--no-install')
-const slugs = args.filter((a) => !a.startsWith('-'))
+const slugs = args.filter(a => !a.startsWith('-'))
 
 if (slugs.length === 0) {
   console.error('Usage: node scripts/add-beui.mjs <slug> [<slug>...] [--no-install]')
@@ -49,9 +49,13 @@ const owned = new Set([
   ...Object.keys(pkg.devDependencies ?? {}),
 ])
 
-const exists = (p) => access(p).then(() => true, () => false)
+const exists = p =>
+  access(p).then(
+    () => true,
+    () => false
+  )
 
-const rewriteMotion = (content) => {
+const rewriteMotion = content => {
   // 1. Module path: beUI imports from "motion/react"; this project ships framer-motion.
   let out = content
     .replace(/(["'])motion\/react\1/g, '$1framer-motion$1')
@@ -111,8 +115,8 @@ for (const slug of slugs) {
 
 console.log('\n── summary ──')
 if (written.length === 0) console.log('  (no new files written)')
-written.forEach((p) => console.log(`  + ${p}`))
-skipped.forEach((p) => console.log(`  · skipped ${p}`))
+written.forEach(p => console.log(`  + ${p}`))
+skipped.forEach(p => console.log(`  · skipped ${p}`))
 
 if (missingDeps.size === 0) {
   console.log('\nNo new dependencies needed.')

--- a/scripts/add-beui.mjs
+++ b/scripts/add-beui.mjs
@@ -4,8 +4,10 @@
 // beUI is a copy-paste component registry, not a standard shadcn registry, so
 // the shadcn CLI cannot add its items. This script fetches a component's JSON
 // from the registry, writes each file under src/ (beUI paths are src-relative
-// and its `@/...` imports already match our `@ -> src` alias), and rewrites the
-// `motion/react` imports to `framer-motion` (the package this project uses).
+// and its `@/...` imports already match our `@ -> src` alias), and rewrites its
+// motion imports for this project: `motion/react` -> `framer-motion` (the package
+// we ship), and the full `motion` component -> the lightweight `m` component
+// (required because every React root here runs under <LazyMotion strict>).
 //
 // Usage:
 //   node scripts/add-beui.mjs <slug> [<slug>...] [--no-install]
@@ -49,10 +51,28 @@ const owned = new Set([
 
 const exists = (p) => access(p).then(() => true, () => false)
 
-const rewriteMotion = (content) =>
-  content
+const rewriteMotion = (content) => {
+  // 1. Module path: beUI imports from "motion/react"; this project ships framer-motion.
+  let out = content
     .replace(/(["'])motion\/react\1/g, '$1framer-motion$1')
     .replace(/(from\s+["'])motion(["'])/g, '$1framer-motion$2')
+
+  // 2. Every React root in this project renders under <LazyMotion strict>, which
+  //    forbids the full `motion` component (it throws at runtime) — the
+  //    lightweight `m` component must be used instead. Rewrite the `motion` named
+  //    import from framer-motion and every `motion.<tag>` usage to `m`. This
+  //    leaves useReducedMotion / MotionConfig / HTMLMotionProps / AnimatePresence
+  //    and the "framer-motion" string untouched. (This step is only valid because
+  //    this project guarantees a LazyMotion ancestor; it is not generally safe.)
+  out = out.replace(
+    /import\s*\{([\s\S]*?)\}\s*from\s*(["'])framer-motion\2/g,
+    (_full, names, q) =>
+      `import {${names.replace(/(^|[,\s])motion(\s*(?:,|$))/g, '$1m$2')}} from ${q}framer-motion${q}`
+  )
+  out = out.replace(/\bmotion\.(?=[a-zA-Z])/g, 'm.')
+
+  return out
+}
 
 const missingDeps = new Set()
 const written = []

--- a/src/components/motion/action-swap.tsx
+++ b/src/components/motion/action-swap.tsx
@@ -2,7 +2,7 @@
 
 import {
   AnimatePresence,
-  motion,
+  m,
   useReducedMotion,
   type HTMLMotionProps,
   type Variants,
@@ -202,7 +202,7 @@ export function ActionSwapText({
           {/* Letters are decorative fragments; readers get the whole label. */}
           <span className="sr-only">{label}</span>
           <AnimatePresence initial={false}>
-            <motion.span
+            <m.span
               key={`cascade-${value}`}
               aria-hidden
               initial="initial"
@@ -211,7 +211,7 @@ export function ActionSwapText({
               className="absolute left-0 top-0 inline-block whitespace-pre"
             >
               {label.split('').map((char, i) => (
-                <motion.span
+                <m.span
                   // biome-ignore lint/suspicious/noArrayIndexKey: position is the slot identity — the letter at a position is exactly what rolls.
                   key={i}
                   custom={i * CASCADE_STAGGER}
@@ -219,14 +219,14 @@ export function ActionSwapText({
                   className="inline-block whitespace-pre will-change-[opacity,filter,transform]"
                 >
                   {char}
-                </motion.span>
+                </m.span>
               ))}
-            </motion.span>
+            </m.span>
           </AnimatePresence>
         </>
       ) : (
         <AnimatePresence initial={false}>
-          <motion.span
+          <m.span
             key={`${animation}-${value}`}
             variants={TEXT_VARIANTS[coreAnimation]}
             initial={reduce ? false : 'initial'}
@@ -235,7 +235,7 @@ export function ActionSwapText({
             className="absolute left-0 top-0 inline-block will-change-[opacity,filter,transform]"
           >
             {children}
-          </motion.span>
+          </m.span>
         </AnimatePresence>
       )}
     </span>
@@ -257,7 +257,7 @@ export function ActionSwapIcon({
       className={cn('relative inline-grid shrink-0 place-items-center overflow-hidden', className)}
     >
       <AnimatePresence mode="popLayout" initial={false}>
-        <motion.span
+        <m.span
           key={`${animation}-${value}`}
           aria-hidden
           variants={ICON_VARIANTS[coreAnimation]}
@@ -267,7 +267,7 @@ export function ActionSwapIcon({
           className="col-start-1 row-start-1 inline-flex items-center justify-center will-change-[opacity,filter,transform]"
         >
           {children}
-        </motion.span>
+        </m.span>
       </AnimatePresence>
     </span>
   )
@@ -306,7 +306,7 @@ export function ActionSwapButton({
     (iconOnly && typeof activeItem.label === 'string' ? activeItem.label : undefined)
 
   return (
-    <motion.button
+    <m.button
       type="button"
       disabled={disabled}
       whileTap={reduce || disabled ? undefined : { scale: 0.97 }}
@@ -337,6 +337,6 @@ export function ActionSwapButton({
           {activeItem.label}
         </ActionSwapText>
       ) : null}
-    </motion.button>
+    </m.button>
   )
 }

--- a/src/components/motion/action-swap.tsx
+++ b/src/components/motion/action-swap.tsx
@@ -1,0 +1,342 @@
+'use client'
+
+import {
+  AnimatePresence,
+  motion,
+  useReducedMotion,
+  type HTMLMotionProps,
+  type Variants,
+} from 'framer-motion'
+import { useLayoutEffect, useRef, useState, type ReactNode } from 'react'
+import { EASE_OUT, EASE_OUT_CSS, SPRING_PRESS, SPRING_SWAP } from '@/lib/ease'
+import { cn } from '@/lib/utils'
+
+export type ActionSwapItem = {
+  id: string
+  label: ReactNode
+  icon?: ReactNode
+  ariaLabel?: string
+}
+
+export type ActionSwapButtonVariant = 'primary' | 'secondary' | 'outline' | 'ghost'
+export type ActionSwapButtonSize = 'sm' | 'md' | 'lg' | 'icon'
+export type ActionSwapAnimation = 'blur' | 'roll' | 'cascade'
+
+/** Animations with a single-element variant set (cascade animates per letter). */
+type CoreAnimation = 'blur' | 'roll'
+
+export interface ActionSwapButtonProps extends Omit<
+  HTMLMotionProps<'button'>,
+  'children' | 'onChange'
+> {
+  items: ActionSwapItem[]
+  value?: string
+  defaultValue?: string
+  onValueChange?: (value: string, item: ActionSwapItem) => void
+  variant?: ActionSwapButtonVariant
+  size?: ActionSwapButtonSize
+  animation?: ActionSwapAnimation
+  iconOnly?: boolean
+  cycle?: boolean
+}
+
+export interface ActionSwapTextProps {
+  value: string
+  children: ReactNode
+  animation?: ActionSwapAnimation
+  className?: string
+}
+
+export interface ActionSwapIconProps {
+  value: string
+  children: ReactNode
+  animation?: ActionSwapAnimation
+  className?: string
+}
+
+const BLUR_TRANSITION = { duration: 0.2, ease: 'easeInOut' } as const
+const ROLL_TRANSITION = { duration: 0.24, ease: EASE_OUT } as const
+const SWAP_BLUR = 'blur(8px)'
+const ROLL_BLUR = 'blur(6px)'
+
+// Cascade rolls the label one letter at a time, left to right. The leaving
+// and landing strings overlap as independent layers (no shared cells), so
+// proportional glyph widths never jitter. Exits cascade at half the enter
+// stagger so the tail of the old label lingers briefly.
+const CASCADE_STAGGER = 0.025
+
+const CASCADE_LETTER_VARIANTS: Variants = {
+  initial: { opacity: 0, y: '105%', filter: ROLL_BLUR },
+  animate: (delay: number = 0) => ({
+    opacity: 1,
+    y: '0%',
+    filter: 'blur(0px)',
+    transition: { ...SPRING_SWAP, delay },
+  }),
+  exit: (delay: number = 0) => ({
+    opacity: 0,
+    y: '-105%',
+    filter: ROLL_BLUR,
+    transition: { duration: 0.16, ease: EASE_OUT, delay: delay * 0.5 },
+  }),
+}
+
+const TEXT_VARIANTS: Record<CoreAnimation, Variants> = {
+  blur: {
+    initial: { opacity: 0, scale: 0.94, filter: SWAP_BLUR },
+    animate: {
+      opacity: 1,
+      scale: 1,
+      filter: 'blur(0px)',
+      transition: BLUR_TRANSITION,
+    },
+    exit: {
+      opacity: 0,
+      scale: 0.94,
+      filter: SWAP_BLUR,
+      transition: BLUR_TRANSITION,
+    },
+  },
+  roll: {
+    initial: { opacity: 0, y: '115%', filter: ROLL_BLUR },
+    animate: {
+      opacity: 1,
+      y: '0%',
+      filter: 'blur(0px)',
+      transition: ROLL_TRANSITION,
+    },
+    exit: {
+      opacity: 0,
+      y: '-115%',
+      filter: ROLL_BLUR,
+      transition: { duration: 0.18, ease: 'easeInOut' },
+    },
+  },
+}
+
+const ICON_VARIANTS: Record<CoreAnimation, Variants> = {
+  blur: {
+    initial: { opacity: 0, scale: 0.25, filter: SWAP_BLUR },
+    animate: {
+      opacity: 1,
+      scale: 1,
+      filter: 'blur(0px)',
+      transition: BLUR_TRANSITION,
+    },
+    exit: {
+      opacity: 0,
+      scale: 0.25,
+      filter: SWAP_BLUR,
+      transition: BLUR_TRANSITION,
+    },
+  },
+  roll: {
+    initial: { opacity: 0, y: 16, filter: ROLL_BLUR },
+    animate: {
+      opacity: 1,
+      y: 0,
+      filter: 'blur(0px)',
+      transition: ROLL_TRANSITION,
+    },
+    exit: {
+      opacity: 0,
+      y: -16,
+      filter: ROLL_BLUR,
+      transition: { duration: 0.18, ease: 'easeInOut' },
+    },
+  },
+}
+
+const VARIANT_CLASS: Record<ActionSwapButtonVariant, string> = {
+  primary: 'bg-primary text-primary-foreground hover:bg-primary/90',
+  secondary: 'border border-border bg-card text-foreground hover:border-border',
+  outline: 'border border-border bg-transparent text-foreground hover:bg-primary/5',
+  ghost: 'text-muted-foreground hover:bg-primary/5 hover:text-foreground',
+}
+
+const SIZE_CLASS: Record<ActionSwapButtonSize, string> = {
+  sm: 'h-8 gap-1.5 rounded-full px-3 text-xs',
+  md: 'h-10 gap-2 rounded-full px-4 text-sm',
+  lg: 'h-12 gap-2.5 rounded-full px-5 text-base',
+  icon: 'h-10 w-10 rounded-full',
+}
+
+export function ActionSwapText({
+  value,
+  children,
+  animation = 'blur',
+  className,
+}: ActionSwapTextProps) {
+  const reduce = useReducedMotion()
+  const measureRef = useRef<HTMLSpanElement>(null)
+  const [width, setWidth] = useState<number>()
+
+  useLayoutEffect(() => {
+    const nextWidth = measureRef.current?.offsetWidth
+    if (!nextWidth) return
+    setWidth(currentWidth => (currentWidth === nextWidth ? currentWidth : nextWidth))
+  })
+
+  // Cascade needs a plain string to split into letters; non-string content
+  // and reduced motion fall back to the closest single-element animation.
+  const label = typeof children === 'string' ? children : null
+  const cascade = animation === 'cascade' && label !== null && !reduce
+  const coreAnimation: CoreAnimation = animation === 'cascade' ? 'roll' : animation
+
+  return (
+    <span
+      className={cn(
+        'relative inline-block overflow-hidden whitespace-nowrap align-bottom',
+        className
+      )}
+      style={{
+        width,
+        transition: reduce ? undefined : `width 220ms ${EASE_OUT_CSS}`,
+      }}
+    >
+      <span ref={measureRef} aria-hidden className="invisible inline-block whitespace-nowrap">
+        {children}
+      </span>
+      {cascade ? (
+        <>
+          {/* Letters are decorative fragments; readers get the whole label. */}
+          <span className="sr-only">{label}</span>
+          <AnimatePresence initial={false}>
+            <motion.span
+              key={`cascade-${value}`}
+              aria-hidden
+              initial="initial"
+              animate="animate"
+              exit="exit"
+              className="absolute left-0 top-0 inline-block whitespace-pre"
+            >
+              {label.split('').map((char, i) => (
+                <motion.span
+                  // biome-ignore lint/suspicious/noArrayIndexKey: position is the slot identity — the letter at a position is exactly what rolls.
+                  key={i}
+                  custom={i * CASCADE_STAGGER}
+                  variants={CASCADE_LETTER_VARIANTS}
+                  className="inline-block whitespace-pre will-change-[opacity,filter,transform]"
+                >
+                  {char}
+                </motion.span>
+              ))}
+            </motion.span>
+          </AnimatePresence>
+        </>
+      ) : (
+        <AnimatePresence initial={false}>
+          <motion.span
+            key={`${animation}-${value}`}
+            variants={TEXT_VARIANTS[coreAnimation]}
+            initial={reduce ? false : 'initial'}
+            animate={reduce ? { opacity: 1, filter: 'blur(0px)', scale: 1, y: 0 } : 'animate'}
+            exit={reduce ? undefined : 'exit'}
+            className="absolute left-0 top-0 inline-block will-change-[opacity,filter,transform]"
+          >
+            {children}
+          </motion.span>
+        </AnimatePresence>
+      )}
+    </span>
+  )
+}
+
+export function ActionSwapIcon({
+  value,
+  children,
+  animation = 'blur',
+  className,
+}: ActionSwapIconProps) {
+  const reduce = useReducedMotion()
+  // Icons are single elements — cascade maps to its closest motion, roll.
+  const coreAnimation: CoreAnimation = animation === 'cascade' ? 'roll' : animation
+
+  return (
+    <span
+      className={cn('relative inline-grid shrink-0 place-items-center overflow-hidden', className)}
+    >
+      <AnimatePresence mode="popLayout" initial={false}>
+        <motion.span
+          key={`${animation}-${value}`}
+          aria-hidden
+          variants={ICON_VARIANTS[coreAnimation]}
+          initial={reduce ? false : 'initial'}
+          animate={reduce ? { opacity: 1, filter: 'blur(0px)', scale: 1, y: 0 } : 'animate'}
+          exit={reduce ? undefined : 'exit'}
+          className="col-start-1 row-start-1 inline-flex items-center justify-center will-change-[opacity,filter,transform]"
+        >
+          {children}
+        </motion.span>
+      </AnimatePresence>
+    </span>
+  )
+}
+
+export function ActionSwapButton({
+  items,
+  value,
+  defaultValue,
+  onValueChange,
+  variant = 'secondary',
+  size = 'md',
+  animation = 'blur',
+  iconOnly = size === 'icon',
+  cycle = true,
+  className,
+  disabled,
+  onClick,
+  ...rest
+}: ActionSwapButtonProps) {
+  const reduce = useReducedMotion()
+  const [internalValue, setInternalValue] = useState(defaultValue ?? items[0]?.id)
+  const currentValue = value ?? internalValue
+  const activeIndex = Math.max(
+    0,
+    items.findIndex(item => item.id === currentValue)
+  )
+  const activeItem = items[activeIndex] ?? items[0]
+  const hasIcon = items.some(item => item.icon)
+  const nextItem = cycle && items.length > 0 ? items[(activeIndex + 1) % items.length] : undefined
+
+  if (!activeItem) return null
+
+  const accessibleLabel =
+    activeItem.ariaLabel ??
+    (iconOnly && typeof activeItem.label === 'string' ? activeItem.label : undefined)
+
+  return (
+    <motion.button
+      type="button"
+      disabled={disabled}
+      whileTap={reduce || disabled ? undefined : { scale: 0.97 }}
+      transition={SPRING_PRESS}
+      className={cn(
+        'inline-flex items-center justify-center overflow-hidden font-medium transition-colors',
+        'disabled:pointer-events-none disabled:opacity-50',
+        VARIANT_CLASS[variant],
+        SIZE_CLASS[size],
+        className
+      )}
+      aria-label={accessibleLabel}
+      onClick={event => {
+        onClick?.(event)
+        if (event.defaultPrevented || disabled || !cycle || !nextItem) return
+        if (value === undefined) setInternalValue(nextItem.id)
+        onValueChange?.(nextItem.id, nextItem)
+      }}
+      {...rest}
+    >
+      {hasIcon ? (
+        <ActionSwapIcon value={activeItem.id} animation={animation} className="h-4 w-4">
+          {activeItem.icon ?? null}
+        </ActionSwapIcon>
+      ) : null}
+      {!iconOnly ? (
+        <ActionSwapText value={activeItem.id} animation={animation}>
+          {activeItem.label}
+        </ActionSwapText>
+      ) : null}
+    </motion.button>
+  )
+}

--- a/src/components/motion/theme-toggle.tsx
+++ b/src/components/motion/theme-toggle.tsx
@@ -1,0 +1,74 @@
+// Adapted from beui.dev/components/motion/theme-toggle.
+//
+// The original drives next-themes and wraps the switch in its own View
+// Transition. This project keeps theme in daemon-persisted settings
+// (SettingContext / theme-engine) and already runs a centralized circle-blur
+// reveal in `@/lib/theme-transition` whenever `setting.general.theme` changes.
+// So here we only trigger the setting change (recording the click origin for
+// the reveal) and keep beUI's ActionSwapIcon icon-swap visual.
+
+import { Moon, Sun } from 'lucide-react'
+import { useEffect, useState, type ComponentPropsWithoutRef } from 'react'
+import { ActionSwapIcon } from '@/components/motion/action-swap'
+import { useSetting } from '@/hooks/useSetting'
+import { createLogger } from '@/lib/logger'
+import { setTransitionOrigin } from '@/lib/theme-transition'
+import { cn } from '@/lib/utils'
+
+const log = createLogger('theme-toggle')
+
+export interface ThemeToggleProps extends Omit<
+  ComponentPropsWithoutRef<'button'>,
+  'children' | 'onClick'
+> {
+  iconClassName?: string
+}
+
+/**
+ * Read the resolved light/dark mode straight from the `dark` class that
+ * SettingContext maintains on <html>. Staying on the root class keeps this in
+ * sync with every path that changes the theme (settings page, system change),
+ * without duplicating theme-engine's resolve logic.
+ */
+function useResolvedDark(): boolean {
+  const [isDark, setIsDark] = useState(() => document.documentElement.classList.contains('dark'))
+
+  useEffect(() => {
+    const root = document.documentElement
+    const sync = () => setIsDark(root.classList.contains('dark'))
+    sync()
+    const observer = new MutationObserver(sync)
+    observer.observe(root, { attributes: true, attributeFilter: ['class'] })
+    return () => observer.disconnect()
+  }, [])
+
+  return isDark
+}
+
+export function ThemeToggle({ className, iconClassName, ...rest }: ThemeToggleProps) {
+  const { updateGeneralSetting } = useSetting()
+  const isDark = useResolvedDark()
+
+  const toggle = (e: React.MouseEvent<HTMLButtonElement>) => {
+    // Record the click point so theme-transition's circle-blur reveal expands
+    // from the button; SettingContext runs the transition on the setting change.
+    setTransitionOrigin(e.clientX, e.clientY)
+    updateGeneralSetting({ theme: isDark ? 'light' : 'dark' }).catch(err => {
+      log.error({ err }, 'Failed to toggle theme')
+    })
+  }
+
+  return (
+    <button
+      type="button"
+      aria-label={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
+      onClick={toggle}
+      className={cn('flex items-center justify-center', className)}
+      {...rest}
+    >
+      <ActionSwapIcon value={isDark ? 'dark' : 'light'} animation="blur" className={iconClassName}>
+        {isDark ? <Sun className={iconClassName} /> : <Moon className={iconClassName} />}
+      </ActionSwapIcon>
+    </button>
+  )
+}

--- a/src/components/setting/NetworkSection.tsx
+++ b/src/components/setting/NetworkSection.tsx
@@ -1,6 +1,13 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Switch } from '@/components/ui'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
 import { useDebounce } from '@/hooks/useDebounce'
 import { useSetting } from '@/hooks/useSetting'
 import { commands } from '@/lib/ipc'
@@ -221,9 +228,8 @@ const NetworkSection: React.FC = () => {
   }
 
   // ── Select 切换 handler（Congestion Controller） ───────────────
-  const handleCongestionControllerChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    const value = e.target.value as CongestionController
-    setCongestionController(value)
+  const handleCongestionControllerChange = (value: string) => {
+    setCongestionController(value as CongestionController)
     setPending(true)
     setSaveError(null)
     setRestartError(null)
@@ -295,18 +301,22 @@ const NetworkSection: React.FC = () => {
         description={t('settings.sections.network.congestionController.description')}
         experimentalKey="network.congestionController"
       >
-        <select
-          id="congestion-controller-select"
-          aria-label={t('settings.sections.network.congestionController.label')}
-          value={congestionController}
-          onChange={handleCongestionControllerChange}
-          className="rounded-md border border-input bg-background px-3 py-1.5 text-sm"
-        >
-          <option value="cubic">
-            CUBIC ({t('settings.sections.network.congestionController.recommended')})
-          </option>
-          <option value="bbr3">BBR3</option>
-        </select>
+        <Select value={congestionController} onValueChange={handleCongestionControllerChange}>
+          <SelectTrigger
+            id="congestion-controller-select"
+            size="sm"
+            aria-label={t('settings.sections.network.congestionController.label')}
+            className="w-[180px]"
+          >
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="cubic">
+              CUBIC ({t('settings.sections.network.congestionController.recommended')})
+            </SelectItem>
+            <SelectItem value="bbr3">BBR3</SelectItem>
+          </SelectContent>
+        </Select>
       </SettingRow>
       <CustomRelayUrlsField value={customRelayUrls} onChange={handleCustomRelayUrlsChange} />
       {saveError && (

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -1,30 +1,107 @@
-import { Switch as SwitchPrimitive } from 'radix-ui'
+import { MotionConfig, animate, m, useReducedMotion } from 'framer-motion'
 import * as React from 'react'
 import { cn } from '@/lib/utils'
 
-function Switch({
-  className,
-  size = 'default',
-  ...props
-}: React.ComponentProps<typeof SwitchPrimitive.Root> & {
+// Motion feel ported from beui.dev/components/motion/switch: a heavy, deliberate
+// thumb (high mass, no wobble) that springs across on toggle, squishes on press,
+// and shakes when a disabled switch is pressed. The public API stays identical to
+// the previous Radix-based switch (controlled checked/onCheckedChange + size +
+// arbitrary button props like id/aria-label), so no call site changes.
+const THUMB_SPRING = { type: 'spring', stiffness: 800, damping: 80, mass: 4 } as const
+
+const SIZES = {
+  default: { track: 'h-[18.4px] w-[32px] px-[2px]', thumb: 'size-4' },
+  sm: { track: 'h-[14px] w-[24px] px-[1px]', thumb: 'size-3' },
+} as const
+
+// Drag/animation handlers collide with framer-motion's same-named props, so drop
+// them from the public surface (no call site uses them on a switch).
+type MotionConflictingProps =
+  | 'onDrag'
+  | 'onDragStart'
+  | 'onDragEnd'
+  | 'onDragEnter'
+  | 'onDragExit'
+  | 'onDragLeave'
+  | 'onDragOver'
+  | 'onAnimationStart'
+  | 'onAnimationEnd'
+  | 'onAnimationIteration'
+
+export interface SwitchProps extends Omit<
+  React.ComponentProps<'button'>,
+  'onChange' | 'children' | MotionConflictingProps
+> {
+  checked: boolean
+  onCheckedChange?: (checked: boolean) => void
   size?: 'sm' | 'default'
-}) {
+}
+
+function Switch({
+  checked,
+  onCheckedChange,
+  disabled,
+  size = 'default',
+  className,
+  ...props
+}: SwitchProps) {
+  const thumbRef = React.useRef<HTMLDivElement>(null)
+  const reduce = useReducedMotion()
+  const [isPressed, setIsPressed] = React.useState(false)
+  const [isPointer, setIsPointer] = React.useState(false)
+
+  // Disabled shake feedback when pressed.
+  React.useEffect(() => {
+    if (!thumbRef.current || reduce) return
+    if (disabled && isPressed) {
+      animate(thumbRef.current, { x: [0, -2, 2, -1, 0] }, { delay: 0.2, duration: 0.6 })
+    }
+  }, [disabled, isPressed, reduce])
+
+  const squish = !disabled && isPointer && isPressed && !reduce
+  const dims = SIZES[size]
+
   return (
-    <SwitchPrimitive.Root
-      data-slot="switch"
-      data-size={size}
-      data-cuelume-toggle=""
-      className={cn(
-        'peer group/switch relative inline-flex shrink-0 items-center rounded-full border border-transparent transition-all outline-none after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-[size=default]:h-[18.4px] data-[size=default]:w-[32px] data-[size=sm]:h-[14px] data-[size=sm]:w-[24px] dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:bg-primary data-unchecked:bg-input dark:data-unchecked:bg-input/80 cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-50',
-        className
-      )}
-      {...props}
-    >
-      <SwitchPrimitive.Thumb
-        data-slot="switch-thumb"
-        className="pointer-events-none block rounded-full bg-background ring-0 transition-transform group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 group-data-[size=default]/switch:data-checked:translate-x-[calc(100%-2px)] group-data-[size=sm]/switch:data-checked:translate-x-[calc(100%-2px)] dark:data-checked:bg-primary-foreground group-data-[size=default]/switch:data-unchecked:translate-x-0 group-data-[size=sm]/switch:data-unchecked:translate-x-0 dark:data-unchecked:bg-foreground"
-      />
-    </SwitchPrimitive.Root>
+    <MotionConfig transition={reduce ? { duration: 0 } : THUMB_SPRING}>
+      <m.button
+        {...props}
+        type="button"
+        role="switch"
+        aria-checked={checked}
+        disabled={disabled}
+        data-slot="switch"
+        data-size={size}
+        data-state={checked ? 'checked' : 'unchecked'}
+        // cuelume plays a toggle sound on click of [data-cuelume-toggle] (see lib/ui-sound.ts).
+        data-cuelume-toggle=""
+        onClick={() => !disabled && onCheckedChange?.(!checked)}
+        onPointerDown={e => {
+          setIsPressed(true)
+          setIsPointer(e.type.startsWith('pointer'))
+        }}
+        onPointerUp={() => setIsPressed(false)}
+        onPointerLeave={() => setIsPressed(false)}
+        initial={false}
+        className={cn(
+          'peer inline-flex shrink-0 cursor-pointer items-center rounded-full outline-none transition-colors duration-200',
+          'focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+          'disabled:cursor-not-allowed disabled:opacity-50',
+          dims.track,
+          checked ? 'justify-end bg-primary' : 'justify-start bg-input dark:bg-input/80',
+          className
+        )}
+      >
+        <m.div
+          ref={thumbRef}
+          layout
+          animate={{ scale: squish ? 0.9 : 1 }}
+          className={cn(
+            'pointer-events-none block rounded-full bg-background shadow-sm dark:bg-foreground',
+            dims.thumb
+          )}
+        />
+      </m.button>
+    </MotionConfig>
   )
 }
 

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -1,12 +1,12 @@
-import { MotionConfig, animate, m, useReducedMotion } from 'framer-motion'
+import { MotionConfig, m, useReducedMotion } from 'framer-motion'
 import * as React from 'react'
 import { cn } from '@/lib/utils'
 
 // Motion feel ported from beui.dev/components/motion/switch: a heavy, deliberate
-// thumb (high mass, no wobble) that springs across on toggle, squishes on press,
-// and shakes when a disabled switch is pressed. The public API stays identical to
-// the previous Radix-based switch (controlled checked/onCheckedChange + size +
-// arbitrary button props like id/aria-label), so no call site changes.
+// thumb (high mass, no wobble) that springs across on toggle and squishes on
+// press. The public API stays identical to the previous Radix-based switch
+// (controlled checked/onCheckedChange + size + arbitrary button props like
+// id/aria-label), so no call site changes.
 const THUMB_SPRING = { type: 'spring', stiffness: 800, damping: 80, mass: 4 } as const
 
 const SIZES = {
@@ -45,18 +45,9 @@ function Switch({
   className,
   ...props
 }: SwitchProps) {
-  const thumbRef = React.useRef<HTMLDivElement>(null)
   const reduce = useReducedMotion()
   const [isPressed, setIsPressed] = React.useState(false)
   const [isPointer, setIsPointer] = React.useState(false)
-
-  // Disabled shake feedback when pressed.
-  React.useEffect(() => {
-    if (!thumbRef.current || reduce) return
-    if (disabled && isPressed) {
-      animate(thumbRef.current, { x: [0, -2, 2, -1, 0] }, { delay: 0.2, duration: 0.6 })
-    }
-  }, [disabled, isPressed, reduce])
 
   const squish = !disabled && isPointer && isPressed && !reduce
   const dims = SIZES[size]
@@ -93,7 +84,6 @@ function Switch({
         )}
       >
         <m.div
-          ref={thumbRef}
           layout
           animate={{ scale: squish ? 0.9 : 1 }}
           className={cn(

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -30,7 +30,7 @@ type MotionConflictingProps =
 
 export interface SwitchProps extends Omit<
   React.ComponentProps<'button'>,
-  'onChange' | 'children' | MotionConflictingProps
+  'onChange' | 'onClick' | 'children' | MotionConflictingProps
 > {
   checked: boolean
   onCheckedChange?: (checked: boolean) => void
@@ -81,6 +81,7 @@ function Switch({
         }}
         onPointerUp={() => setIsPressed(false)}
         onPointerLeave={() => setIsPressed(false)}
+        onPointerCancel={() => setIsPressed(false)}
         initial={false}
         className={cn(
           'peer inline-flex shrink-0 cursor-pointer items-center rounded-full outline-none transition-colors duration-200',

--- a/src/lib/ease.ts
+++ b/src/lib/ease.ts
@@ -1,0 +1,49 @@
+// Shared motion tokens. Easing curves mirror the CSS custom properties in
+// globals.css; springs are the canonical physics used across components.
+// Strong custom variants — defaults like `ease-in`/`ease-out` feel weak.
+
+export const EASE_OUT = [0.16, 1, 0.3, 1] as const
+export const EASE_IN_OUT = [0.77, 0, 0.175, 1] as const
+export const EASE_DRAWER = [0.32, 0.72, 0, 1] as const
+
+/** CSS string form of EASE_OUT for inline style transitions. */
+export const EASE_OUT_CSS = 'cubic-bezier(0.16, 1, 0.3, 1)'
+
+/** Press feedback on buttons and other tappable surfaces. */
+export const SPRING_PRESS = {
+  type: 'spring',
+  stiffness: 500,
+  damping: 30,
+  mass: 0.6,
+} as const
+
+/** Content swaps — label/icon slots trading places inside a control. */
+export const SPRING_SWAP = {
+  type: 'spring',
+  stiffness: 460,
+  damping: 30,
+  mass: 0.55,
+} as const
+
+/** Overlay panel entrances — modals and sheets summoned by pointer. */
+export const SPRING_PANEL = {
+  type: 'spring',
+  stiffness: 420,
+  damping: 40,
+  mass: 0.5,
+} as const
+
+/** Shared-layout glides — pills, indicators and panels morphing between positions. */
+export const SPRING_LAYOUT = {
+  type: 'spring',
+  stiffness: 360,
+  damping: 32,
+  mass: 0.6,
+} as const
+
+/** Cursor-follow physics for decorative mouse tracking (magnetic, tilt, dock). */
+export const SPRING_MOUSE = {
+  stiffness: 200,
+  damping: 15,
+  mass: 0.3,
+} as const

--- a/src/lib/theme-transition.ts
+++ b/src/lib/theme-transition.ts
@@ -1,6 +1,7 @@
 /**
  * View Transition utility using the View Transition API.
- * Creates circular reveal animations from a given origin point (used for theme switching).
+ * Creates a circle-blur reveal animation from a given origin point (used for
+ * theme switching): an expanding circular clip-path paired with a deblur.
  */
 
 import { flushSync } from 'react-dom'
@@ -37,13 +38,18 @@ function startCircularReveal(x: number | null, y: number | null, updateDOM: () =
   })
 
   transition.ready.then(() => {
+    // "circle-blur" reveal (ported from beui.dev/components/motion/theme-toggle):
+    // the new snapshot clips in as an expanding circle from the click point while
+    // deblurring 8px -> 0px. globals.css already pins the old snapshot underneath
+    // (animation: none, z-index) so only this reveal is visible.
     document.documentElement.animate(
       {
         clipPath: [`circle(0px at ${x}px ${y}px)`, `circle(${endRadius}px at ${x}px ${y}px)`],
+        filter: ['blur(8px)', 'blur(0px)'],
       },
       {
-        duration: 500,
-        easing: 'ease-in-out',
+        duration: 700,
+        easing: 'cubic-bezier(0.4, 0, 0.2, 1)',
         pseudoElement: '::view-transition-new(root)',
       }
     )

--- a/src/updater/main.tsx
+++ b/src/updater/main.tsx
@@ -1,3 +1,4 @@
+import { LazyMotion, domMax } from 'framer-motion'
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import '@/i18n'
@@ -7,8 +8,14 @@ import UpdaterWindow from './UpdaterWindow'
 
 initializeWindowUi()
 
+// This window has its own React root (separate from App.tsx), so it needs its
+// own LazyMotion provider for the `m` components used inside (e.g. <Switch>).
+// domMax matches App.tsx and supplies the layout animation feature the switch
+// thumb relies on.
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
-    <UpdaterWindow />
+    <LazyMotion features={domMax} strict>
+      <UpdaterWindow />
+    </LazyMotion>
   </React.StrictMode>
 )


### PR DESCRIPTION
## Summary

- **beUI pull script** (`a321c295`, `403aeae1`): add `scripts/add-beui.mjs` + `bun run add:beui <slug>` — beUI is a copy-paste registry with a custom schema (not shadcn-CLI-compatible), so this fetches a component's JSON, writes files under `src/`, rewrites `motion/react` → `framer-motion`, and rewrites the full `motion` component → the lightweight `m` (required by this repo's `<LazyMotion strict>` roots). Skips existing files (protects `src/lib/utils.ts`).
- **Theme toggle + circle-blur reveal** (`058a4569`): port beUI's circle-blur View Transition into the centralized `theme-transition.ts` (expanding circular clip-path + 8px→0 deblur), so every theme change (incl. the settings page) uses it. Adapt beUI's `ThemeToggle` to drive the daemon-persisted theme-engine instead of next-themes (records click origin, calls `updateGeneralSetting`; avoids nesting a second View Transition). Button is not wired into any surface yet.
- **Switch spring motion** (`e05cee56`): replace the Radix switch internals with beUI's spring thumb / press squish / disabled shake, keeping the exact public API (controlled `checked`/`onCheckedChange` + `size` + `id`/`aria-label` passthrough) so no call site changes. Preserves the upstream `data-cuelume-toggle` so the toggle sound cue still fires. Adds a LazyMotion provider to the updater window (its own React root).
- **Congestion controller dropdown** (`8117edbb`): replace the raw native `<select>` in NetworkSection with the project's Radix `Select`, matching the convention used elsewhere. Same options (`cubic`/`bbr3`), default, label, and `UC_CONGESTION_CONTROLLER` env var — no user-facing contract change.

## Test plan

- [x] `tsc --noEmit` clean across the branch
- [x] `eslint` clean on all touched files
- [x] Vitest: NetworkSection (25), DevicesPage (4), UpdaterWindow — all green after the changes
- [ ] Manual: verify Switch animates (spring/squish) in the main app AND the updater window, and does NOT crash under `<LazyMotion strict>`
- [ ] Manual: toggle theme and confirm the circle-blur reveal + that switching plays the cuelume sound cue
- [ ] Manual: open the congestion-controller Select in NetworkSection and confirm cubic/bbr3 selection persists

## Notes

- docs-site: scanned — the congestion controller is documented but nothing about its contract changed, so no docs edits. Telemetry/tracing: N/A (no `uc-application` or `.rs` changes).
- `ThemeToggle` is intentionally not placed in any UI surface yet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a CLI command to pull beUI registry components into the project.
  - Introduced animated “action swap” UI elements (text, icon, button).
  - Added a theme toggle with an enhanced circle-blur transition reveal.
- **Enhancements**
  - Added shared easing and spring presets for consistent motion.
  - Updated the network congestion controller to use the app’s custom Select UI.
  - Reworked the Switch to use animated, controlled behavior for clearer interaction and accessibility.
- **Performance / UX**
  - Improved motion loading inside the updater window for smoother animations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->