### PR TITLE
feat: add directory search tag

### DIFF
--- a/apps/daemon/src/daemon/runtime_assembly.rs
+++ b/apps/daemon/src/daemon/runtime_assembly.rs
@@ -139,6 +139,7 @@ pub fn build_daemon_runtime_workers(
             search_pipeline: input.deps.search.search_pipeline.clone(),
             search_index: input.deps.search.search_index.clone(),
             event_repo: input.clipboard_event_reader_repo.clone(),
+            entry_file_set_repo: input.deps.storage.entry_file_set_repo.clone(),
         }));
     let apply_inbound_uc = Arc::new(
         ApplyInboundClipboardUseCase::new(

--- a/apps/daemon/src/daemon/search_assembly.rs
+++ b/apps/daemon/src/daemon/search_assembly.rs
@@ -30,6 +30,7 @@ pub fn build_daemon_search_assembly(
         deps.clipboard.representation_ports.list_for_event.clone(),
         deps.clipboard.selection_repo.clone(),
         deps.clipboard.clipboard_event_reader_repo.clone(),
+        deps.storage.entry_file_set_repo.clone(),
     )));
 
     let service = Arc::new(SearchCoordinatorService::new(

--- a/crates/uc-application/src/content_tags.rs
+++ b/crates/uc-application/src/content_tags.rs
@@ -57,6 +57,29 @@ impl TagRule for ImageRule {
     }
 }
 
+/// A [`TagRule`] that marks file entries containing a copied directory root.
+struct DirectoryRule {
+    tag_id: TagId,
+}
+
+impl DirectoryRule {
+    fn new() -> Self {
+        Self {
+            tag_id: TagId::directory(),
+        }
+    }
+}
+
+impl TagRule for DirectoryRule {
+    fn tag_id(&self) -> &TagId {
+        &self.tag_id
+    }
+
+    fn evaluate(&self, content: &TaggableContent<'_>) -> bool {
+        content.has_directory
+    }
+}
+
 /// A [`TagRule`] that marks plain-text snippets that look like source code with
 /// the builtin `code` tag.
 struct CodeRule {
@@ -142,12 +165,14 @@ fn looks_like_code(text: Option<&str>) -> bool {
 }
 
 /// The builtin tag rules evaluated for every entry: [`LinkRule`] (web URLs),
-/// [`ImageRule`] (image content), and [`CodeRule`] (source-like text).
+/// [`ImageRule`] (image content), [`DirectoryRule`] (directory roots), and
+/// [`CodeRule`] (source-like text).
 /// User-defined rules are a later extension point.
 fn builtin_rules() -> Vec<Box<dyn TagRule>> {
     vec![
         Box::new(LinkRule::new()),
         Box::new(ImageRule::new()),
+        Box::new(DirectoryRule::new()),
         Box::new(CodeRule::new()),
     ]
 }
@@ -166,19 +191,25 @@ mod tests {
     use super::*;
     use uc_core::search::document::ContentType;
 
-    fn tags_for(plain_text: Option<&str>, uri_list: &[String], has_image: bool) -> Vec<TagId> {
+    fn tags_for(
+        plain_text: Option<&str>,
+        uri_list: &[String],
+        has_image: bool,
+        has_directory: bool,
+    ) -> Vec<TagId> {
         evaluate_builtin_content_tags(&TaggableContent {
             content_type: ContentType::Text,
             uri_list,
             plain_text,
             has_image,
+            has_directory,
         })
     }
 
     #[test]
     fn plain_text_url_gets_link_tag() {
         assert_eq!(
-            tags_for(Some("https://example.com"), &[], false),
+            tags_for(Some("https://example.com"), &[], false, false),
             vec![TagId::link()]
         );
     }
@@ -188,6 +219,7 @@ mod tests {
         let tags = tags_for(
             Some("function greet(name) {\n  return `hello ${name}`;\n}"),
             &[],
+            false,
             false,
         );
         assert!(tags.contains(&TagId::code()));
@@ -199,13 +231,20 @@ mod tests {
             Some("Notes from today: please return the signed form after the meeting."),
             &[],
             false,
+            false,
         );
         assert!(!tags.contains(&TagId::code()));
     }
 
     #[test]
     fn image_content_gets_image_tag() {
-        let tags = tags_for(None, &[], true);
+        let tags = tags_for(None, &[], true, false);
         assert_eq!(tags, vec![TagId::image()]);
+    }
+
+    #[test]
+    fn directory_content_gets_directory_tag() {
+        let tags = tags_for(None, &[], false, true);
+        assert_eq!(tags, vec![TagId::directory()]);
     }
 }

--- a/crates/uc-application/src/facade/clipboard_live_index/mod.rs
+++ b/crates/uc-application/src/facade/clipboard_live_index/mod.rs
@@ -4,7 +4,9 @@ use async_trait::async_trait;
 use thiserror::Error;
 use tracing::debug;
 use uc_core::ids::EntryId;
-use uc_core::ports::clipboard::{ClipboardEventRepositoryPort, GetClipboardEntryPort};
+use uc_core::ports::clipboard::{
+    ClipboardEventRepositoryPort, EntryFileSetRepositoryPort, GetClipboardEntryPort,
+};
 use uc_core::ports::search::SearchPipelinePort;
 use uc_core::ports::{SearchIndexPort, SearchKeyDerivationPort, SelectRepresentationPolicyPort};
 use uc_core::SystemClipboardSnapshot;
@@ -50,6 +52,9 @@ pub struct ClipboardLiveIndexDeps {
     /// Resolves the originating device of a capture's event for the
     /// `source_device` render column (live/rebuild use the same lookup).
     pub event_repo: Arc<dyn ClipboardEventRepositoryPort>,
+    /// Loads the persisted file manifest so live and rebuild indexing use the
+    /// same directory-structure authority.
+    pub entry_file_set_repo: Arc<dyn EntryFileSetRepositoryPort>,
 }
 
 pub struct ClipboardLiveIndexer {
@@ -110,11 +115,25 @@ impl ClipboardLiveIndexPort for ClipboardLiveIndexer {
             }
         };
 
+        let has_directory = match self.deps.entry_file_set_repo.load(&entry_id).await {
+            Ok(Some(file_set)) => file_set.has_directory_structure(),
+            Ok(None) => false,
+            Err(err) => {
+                debug!(
+                    error = %err,
+                    entry_id = %entry_id,
+                    "search: failed to load file set, indexing without directory tag"
+                );
+                false
+            }
+        };
+
         let Some(pipeline_input) = SearchProjectionBuilder::build_from_capture(
             &entry,
             input.snapshot.as_ref(),
             &selection,
             source_device,
+            has_directory,
         ) else {
             return Ok(ClipboardLiveIndexOutcome::Skipped {
                 reason: "no_searchable_content".to_string(),

--- a/crates/uc-application/src/facade/search/coordinator.rs
+++ b/crates/uc-application/src/facade/search/coordinator.rs
@@ -10,8 +10,8 @@ use tracing::{debug, info, info_span, instrument, warn, Instrument};
 use uc_core::clipboard::ClipboardEntry;
 use uc_core::ids::EntryId;
 use uc_core::ports::clipboard::{
-    ClipboardEventRepositoryPort, GetClipboardEntryPort, ListClipboardEntriesPort,
-    ListRepresentationsForEventPort,
+    ClipboardEventRepositoryPort, EntryFileSetRepositoryPort, GetClipboardEntryPort,
+    ListClipboardEntriesPort, ListRepresentationsForEventPort,
 };
 use uc_core::ports::search::{SearchIndexMaintenancePort, SearchPipelinePort};
 use uc_core::ports::{ClipboardSelectionRepositoryPort, SearchIndexPort, SearchKeyDerivationPort};
@@ -85,6 +85,8 @@ pub struct SearchCoordinatorDeps {
     /// Resolves the originating device of each entry's event for the
     /// `source_device` render column (same lookup as the live index path).
     pub event_repo: Arc<dyn ClipboardEventRepositoryPort>,
+    /// Loads the persisted file manifest used by the directory tag rule.
+    pub entry_file_set_repo: Arc<dyn EntryFileSetRepositoryPort>,
     pub current_index_version: String,
 }
 
@@ -100,6 +102,7 @@ impl SearchCoordinatorDeps {
         representation_repo: Arc<dyn ListRepresentationsForEventPort>,
         selection_repo: Arc<dyn ClipboardSelectionRepositoryPort>,
         event_repo: Arc<dyn ClipboardEventRepositoryPort>,
+        entry_file_set_repo: Arc<dyn EntryFileSetRepositoryPort>,
     ) -> Self {
         Self {
             search_index,
@@ -111,6 +114,7 @@ impl SearchCoordinatorDeps {
             representation_repo,
             selection_repo,
             event_repo,
+            entry_file_set_repo,
             current_index_version: CURRENT_INDEX_VERSION.to_string(),
         }
     }
@@ -206,6 +210,7 @@ impl SearchCoordinator {
             self.deps.representation_repo.as_ref(),
             self.deps.selection_repo.as_ref(),
             self.deps.event_repo.as_ref(),
+            self.deps.entry_file_set_repo.as_ref(),
             limit,
             offset,
         )
@@ -469,6 +474,7 @@ impl SearchCoordinator {
                     deps.representation_repo.as_ref(),
                     deps.selection_repo.as_ref(),
                     deps.event_repo.as_ref(),
+                    deps.entry_file_set_repo.as_ref(),
                     entry,
                 )
                 .await
@@ -610,6 +616,7 @@ async fn project_persisted_entry(
     representation_repo: &dyn ListRepresentationsForEventPort,
     selection_repo: &dyn ClipboardSelectionRepositoryPort,
     event_repo: &dyn ClipboardEventRepositoryPort,
+    entry_file_set_repo: &dyn EntryFileSetRepositoryPort,
     entry: &ClipboardEntry,
 ) -> Option<SearchPipelineInput> {
     let reps = match representation_repo
@@ -660,7 +667,26 @@ async fn project_persisted_entry(
         }
     };
 
-    SearchProjectionBuilder::build_from_persisted(entry, &selection, &reps, source_device)
+    let has_directory = match entry_file_set_repo.load(&entry.entry_id).await {
+        Ok(Some(file_set)) => file_set.has_directory_structure(),
+        Ok(None) => false,
+        Err(e) => {
+            debug!(
+                error = %e,
+                entry_id = %entry.entry_id,
+                "search projection: failed to load file set, projecting without directory tag"
+            );
+            false
+        }
+    };
+
+    SearchProjectionBuilder::build_from_persisted(
+        entry,
+        &selection,
+        &reps,
+        source_device,
+        has_directory,
+    )
 }
 
 /// Build a degraded browse page (§4.7) directly from the main store. Extracted
@@ -671,6 +697,7 @@ async fn project_browse_page(
     representation_repo: &dyn ListRepresentationsForEventPort,
     selection_repo: &dyn ClipboardSelectionRepositoryPort,
     event_repo: &dyn ClipboardEventRepositoryPort,
+    entry_file_set_repo: &dyn EntryFileSetRepositoryPort,
     limit: usize,
     offset: usize,
 ) -> Result<SearchResultsPage, SearchError> {
@@ -685,8 +712,14 @@ async fn project_browse_page(
 
     let mut items = Vec::with_capacity(entries.len());
     for entry in &entries {
-        if let Some(input) =
-            project_persisted_entry(representation_repo, selection_repo, event_repo, entry).await
+        if let Some(input) = project_persisted_entry(
+            representation_repo,
+            selection_repo,
+            event_repo,
+            entry_file_set_repo,
+            entry,
+        )
+        .await
         {
             items.push(pipeline_input_to_search_result(input));
         }
@@ -752,6 +785,7 @@ async fn repair_entry(deps: &SearchCoordinatorDeps, entry_id: &EntryId) {
         deps.representation_repo.as_ref(),
         deps.selection_repo.as_ref(),
         deps.event_repo.as_ref(),
+        deps.entry_file_set_repo.as_ref(),
         &entry,
     )
     .await
@@ -916,6 +950,27 @@ mod tests {
         }
     }
 
+    struct FakeFileSetRepo;
+
+    #[async_trait::async_trait]
+    impl EntryFileSetRepositoryPort for FakeFileSetRepo {
+        async fn save(
+            &self,
+            _entry_id: &EntryId,
+            _file_set: &uc_core::clipboard::EntryFileSet,
+        ) -> Result<(), uc_core::clipboard::EntryFileSetError> {
+            unimplemented!("not used by search projection tests")
+        }
+
+        async fn load(
+            &self,
+            _entry_id: &EntryId,
+        ) -> Result<Option<uc_core::clipboard::EntryFileSet>, uc_core::clipboard::EntryFileSetError>
+        {
+            Ok(None)
+        }
+    }
+
     fn entry(favorited: bool) -> ClipboardEntry {
         let e = ClipboardEntry::new(EntryId::new(), EventId::new(), 0, 0)
             .with_content_category(ClipboardEntryContentCategory::Text);
@@ -945,9 +1000,17 @@ mod tests {
         let event_repo = FakeEventRepo;
 
         // limit 5 over 2 entries => no further page.
-        let page = project_browse_page(&entry_repo, &rep_repo, &sel_repo, &event_repo, 5, 0)
-            .await
-            .expect("degraded browse projects without error");
+        let page = project_browse_page(
+            &entry_repo,
+            &rep_repo,
+            &sel_repo,
+            &event_repo,
+            &FakeFileSetRepo,
+            5,
+            0,
+        )
+        .await
+        .expect("degraded browse projects without error");
 
         assert_eq!(page.items.len(), 2);
         assert!(!page.has_more, "2 of 2 entries fit in a page of 5");
@@ -981,9 +1044,17 @@ mod tests {
         };
         let event_repo = FakeEventRepo;
 
-        let page = project_browse_page(&entry_repo, &rep_repo, &sel_repo, &event_repo, 2, 0)
-            .await
-            .expect("degraded browse projects without error");
+        let page = project_browse_page(
+            &entry_repo,
+            &rep_repo,
+            &sel_repo,
+            &event_repo,
+            &FakeFileSetRepo,
+            2,
+            0,
+        )
+        .await
+        .expect("degraded browse projects without error");
 
         assert_eq!(page.items.len(), 2);
         assert!(page.has_more, "page of 2 over 3 entries has a next page");
@@ -1130,6 +1201,7 @@ mod tests {
             }),
             Arc::new(FakeSelectionRepo { rep_id }),
             Arc::new(FakeEventRepo),
+            Arc::new(FakeFileSetRepo),
         );
         let coordinator = SearchCoordinator::new(deps);
 
@@ -1213,6 +1285,7 @@ mod tests {
             }),
             Arc::new(FakeSelectionRepo { rep_id }),
             Arc::new(FakeEventRepo),
+            Arc::new(FakeFileSetRepo),
         );
         let coordinator = SearchCoordinator::new(deps);
 

--- a/crates/uc-application/src/facade/search/projection.rs
+++ b/crates/uc-application/src/facade/search/projection.rs
@@ -164,6 +164,7 @@ impl SearchableContent {
         mime_type: String,
         source_device: Option<String>,
         payload_state: Option<String>,
+        has_directory: bool,
     ) -> Option<SearchPipelineInput> {
         if self.is_empty() {
             return None;
@@ -175,6 +176,7 @@ impl SearchableContent {
             uri_list: &self.uri_list,
             plain_text: self.plain_text.as_deref(),
             has_image: self.has_image,
+            has_directory,
         });
         // `favorited` is user-state, not a content rule, so it cannot come from
         // `builtin_rules`. Mirror the entry's persisted favorite flag into the
@@ -244,6 +246,7 @@ impl SearchProjectionBuilder {
         snapshot: &SystemClipboardSnapshot,
         selection: &ClipboardSelection,
         source_device: Option<String>,
+        has_directory: bool,
     ) -> Option<SearchPipelineInput> {
         let preview_rep_id = &selection.preview_rep_id;
 
@@ -265,7 +268,7 @@ impl SearchProjectionBuilder {
             .map(|m| m.as_str().to_string())
             .unwrap_or_else(|| "application/octet-stream".to_string());
 
-        content.into_pipeline_input(entry, mime_type, source_device, None)
+        content.into_pipeline_input(entry, mime_type, source_device, None, has_directory)
     }
 
     /// Build a `SearchPipelineInput` from persisted clipboard data.
@@ -283,6 +286,7 @@ impl SearchProjectionBuilder {
         selection: &ClipboardSelectionDecision,
         reps: &[PersistedClipboardRepresentation],
         source_device: Option<String>,
+        has_directory: bool,
     ) -> Option<SearchPipelineInput> {
         let preview_rep_id = &selection.selection.preview_rep_id;
 
@@ -308,7 +312,13 @@ impl SearchProjectionBuilder {
             .unwrap_or_else(|| "application/octet-stream".to_string());
         let payload_state = paste_rep.and_then(|r| payload_state_marker(&r.payload_state));
 
-        content.into_pipeline_input(entry, mime_type, source_device, payload_state)
+        content.into_pipeline_input(
+            entry,
+            mime_type,
+            source_device,
+            payload_state,
+            has_directory,
+        )
     }
 }
 
@@ -365,6 +375,7 @@ mod tests {
             &snapshot,
             &selection,
             None,
+            false,
         )
         .expect("snapshot has searchable content")
     }
@@ -398,6 +409,7 @@ mod tests {
             &snapshot,
             &selection,
             None,
+            false,
         )
         .expect("snapshot has searchable content");
 
@@ -440,6 +452,7 @@ mod tests {
             &snapshot,
             &selection,
             None,
+            false,
         )
         .expect("snapshot has searchable content");
 
@@ -484,6 +497,7 @@ mod tests {
             &snapshot,
             &selection,
             None,
+            false,
         )
         .expect("snapshot has searchable content");
 
@@ -544,6 +558,7 @@ mod tests {
             &snapshot,
             &selection,
             None,
+            false,
         )
         .expect("snapshot has searchable content");
 
@@ -593,6 +608,7 @@ mod tests {
             &snapshot,
             &selection,
             None,
+            false,
         )
         .expect("snapshot has searchable content");
 
@@ -730,6 +746,7 @@ mod tests {
             &snapshot,
             &selection,
             Some("dev-x".to_string()),
+            false,
         )
         .expect("snapshot has searchable content");
 
@@ -787,9 +804,14 @@ mod tests {
             },
         );
 
-        let input =
-            SearchProjectionBuilder::build_from_persisted(&e, &decision, &[preview, paste], None)
-                .expect("preview supplies searchable content");
+        let input = SearchProjectionBuilder::build_from_persisted(
+            &e,
+            &decision,
+            &[preview, paste],
+            None,
+            false,
+        )
+        .expect("preview supplies searchable content");
 
         assert_eq!(input.payload_state.as_deref(), Some("Lost"));
         assert_eq!(input.content_type, ContentType::Html);
@@ -812,7 +834,7 @@ mod tests {
             },
         );
 
-        let input = SearchProjectionBuilder::build_from_persisted(&e, &decision, &[r], None)
+        let input = SearchProjectionBuilder::build_from_persisted(&e, &decision, &[r], None, false)
             .expect("inline text is searchable");
 
         assert_eq!(input.payload_state, None);
@@ -836,9 +858,14 @@ mod tests {
                 policy_version: SelectionPolicyVersion::V1,
             },
         );
-        let fav_input =
-            SearchProjectionBuilder::build_from_persisted(&favorited, &fav_dec, &[fav_rep], None)
-                .expect("inline text is searchable");
+        let fav_input = SearchProjectionBuilder::build_from_persisted(
+            &favorited,
+            &fav_dec,
+            &[fav_rep],
+            None,
+            false,
+        )
+        .expect("inline text is searchable");
         assert!(
             fav_input.tags.contains(&TagId::favorited()),
             "a persisted favorited entry carries the favorited tag"
@@ -857,9 +884,14 @@ mod tests {
                 policy_version: SelectionPolicyVersion::V1,
             },
         );
-        let plain_input =
-            SearchProjectionBuilder::build_from_persisted(&plain, &plain_dec, &[plain_rep], None)
-                .expect("inline text is searchable");
+        let plain_input = SearchProjectionBuilder::build_from_persisted(
+            &plain,
+            &plain_dec,
+            &[plain_rep],
+            None,
+            false,
+        )
+        .expect("inline text is searchable");
         assert!(
             !plain_input.tags.contains(&TagId::favorited()),
             "an unfavorited entry carries no favorited tag"
@@ -873,7 +905,7 @@ mod tests {
     fn live_and_rebuild_render_parity() {
         let bytes = b"file:///home/u/a.txt\nhttps://example.com\n";
         let rep_id = RepresentationId::new();
-        let e = entry();
+        let e = entry_with_category(ClipboardEntryContentCategory::File);
         let make_selection = || ClipboardSelection {
             primary_rep_id: rep_id.clone(),
             secondary_rep_ids: Vec::new(),
@@ -899,6 +931,7 @@ mod tests {
             &snapshot,
             &make_selection(),
             Some("dev-1".to_string()),
+            true,
         )
         .expect("live snapshot is searchable");
 
@@ -909,6 +942,7 @@ mod tests {
             &decision,
             &[stored],
             Some("dev-1".to_string()),
+            true,
         )
         .expect("persisted reps are searchable");
 
@@ -916,5 +950,8 @@ mod tests {
         assert_eq!(live.link_urls, rebuilt.link_urls);
         assert_eq!(live.source_device, rebuilt.source_device);
         assert_eq!(live.content_type, rebuilt.content_type);
+        assert_eq!(live.content_type, ContentType::File);
+        assert_eq!(live.tags, rebuilt.tags);
+        assert!(live.tags.contains(&TagId::directory()));
     }
 }

--- a/crates/uc-application/src/usecases/clipboard_history/list_entry_projections.rs
+++ b/crates/uc-application/src/usecases/clipboard_history/list_entry_projections.rs
@@ -228,6 +228,7 @@ fn content_tags_for_projection(
         uri_list: &uri_list,
         plain_text,
         has_image,
+        has_directory: false,
     })
     .into_iter()
     .map(|tag| tag.to_string())

--- a/crates/uc-bootstrap/src/entrypoint/non_gui.rs
+++ b/crates/uc-bootstrap/src/entrypoint/non_gui.rs
@@ -605,6 +605,7 @@ pub async fn build_cli_app_runtime(
         deps.clipboard.representation_ports.list_for_event.clone(),
         deps.clipboard.selection_repo.clone(),
         deps.clipboard.clipboard_event_reader_repo.clone(),
+        deps.storage.entry_file_set_repo.clone(),
     )));
 
     // CLI 不接 LAN listener,但仍需 `mobile_sync` facade 跑查询命令

--- a/crates/uc-bootstrap/src/subsystem/sync_engine.rs
+++ b/crates/uc-bootstrap/src/subsystem/sync_engine.rs
@@ -670,6 +670,7 @@ pub(crate) async fn build_sync_engine_assembly(
             search_pipeline: Arc::clone(&deps.search.search_pipeline),
             search_index: Arc::clone(&deps.search.search_index),
             event_repo: Arc::clone(&shared.clipboard_event_reader_repo),
+            entry_file_set_repo: Arc::clone(&deps.storage.entry_file_set_repo),
         }));
     let pull_store_apply: Arc<dyn InboundClipboardApplyPort> = Arc::new(
         ApplyInboundClipboardUseCase::new(

--- a/crates/uc-core/src/search/tag.rs
+++ b/crates/uc-core/src/search/tag.rs
@@ -30,6 +30,8 @@ pub mod builtin {
     pub const IMAGE: &str = "image";
     /// Code/rich-text tag: the entry carries rich text / HTML content.
     pub const CODE: &str = "code";
+    /// Directory tag: the entry contains a top-level root copied as a directory.
+    pub const DIRECTORY: &str = "directory";
 }
 
 /// Stable identifier of a search tag.
@@ -65,6 +67,11 @@ impl TagId {
         Self::new(builtin::CODE)
     }
 
+    /// The builtin `directory` tag id.
+    pub fn directory() -> Self {
+        Self::new(builtin::DIRECTORY)
+    }
+
     /// Borrow the id as a string slice.
     pub fn as_str(&self) -> &str {
         &self.0
@@ -74,7 +81,11 @@ impl TagId {
     pub fn is_builtin(&self) -> bool {
         matches!(
             self.0.as_str(),
-            builtin::LINK | builtin::FAVORITED | builtin::IMAGE | builtin::CODE
+            builtin::LINK
+                | builtin::FAVORITED
+                | builtin::IMAGE
+                | builtin::CODE
+                | builtin::DIRECTORY
         )
     }
 }
@@ -128,6 +139,10 @@ pub struct TaggableContent<'a> {
     /// an image file. Drives the builtin `image` tag, which is orthogonal to
     /// `content_type` (a copied image file is physically a `File`).
     pub has_image: bool,
+    /// True when the entry contains a top-level root copied as a directory.
+    /// Drives the builtin `directory` tag and remains orthogonal to
+    /// `content_type` (directory copies are physically `File`).
+    pub has_directory: bool,
 }
 
 /// A producer of exactly one tag: given content, decides whether the tag
@@ -162,10 +177,12 @@ mod tests {
         assert_eq!(TagId::favorited().as_str(), builtin::FAVORITED);
         assert_eq!(TagId::image().as_str(), builtin::IMAGE);
         assert_eq!(TagId::code().as_str(), builtin::CODE);
+        assert_eq!(TagId::directory().as_str(), builtin::DIRECTORY);
         assert!(TagId::link().is_builtin());
         assert!(TagId::favorited().is_builtin());
         assert!(TagId::image().is_builtin());
         assert!(TagId::code().is_builtin());
+        assert!(TagId::directory().is_builtin());
     }
 
     #[test]

--- a/crates/uc-infra/src/search/constants.rs
+++ b/crates/uc-infra/src/search/constants.rs
@@ -1,12 +1,13 @@
 //! Authoritative search schema and tokenizer constants for `uc-infra`.
 //!
-//! `CURRENT_INDEX_VERSION` must be bumped whenever normalization rules change
-//! (NFKC, separator splitting, camelCase, CJK bigram). A version mismatch
-//! triggers a full index rebuild in Phase 91.
+//! `CURRENT_INDEX_VERSION` must be bumped whenever normalization or derived
+//! projection rules change. A version mismatch triggers a full index rebuild in
+//! Phase 91.
 
 /// Current tokenizer/normalization schema version.
 ///
-/// Bump this whenever the tokenization rules change to trigger a full rebuild.
+/// Bump this whenever tokenization or derived projection rules change to trigger
+/// a full rebuild.
 ///
 /// History:
 /// - `search-v2`: per-field prefix expansion (body/html unexpanded).
@@ -46,7 +47,10 @@
 ///   `render_payload` BLOB. The rebuild backfills the encrypted payload from the
 ///   decrypted representations (see the `encrypt_search_render_columns`
 ///   migration). `source_device` and `payload_state` stay plaintext by design.
-pub const CURRENT_INDEX_VERSION: &str = "search-v10";
+/// - `search-v11`: adds the derived `directory` tag for file entries whose
+///   persisted file manifest contains a copied directory root. The rebuild
+///   backfills this tag for existing directory entries.
+pub const CURRENT_INDEX_VERSION: &str = "search-v11";
 
 /// Field-mask bit: term was extracted from the plain-text body.
 pub const SEARCH_FIELD_BODY: u8 = 0b0000_0001;

--- a/src/components/history/composite-search/__tests__/composite-search-model.test.ts
+++ b/src/components/history/composite-search/__tests__/composite-search-model.test.ts
@@ -1,3 +1,4 @@
+import { Folder } from 'lucide-react'
 import { describe, expect, it } from 'vitest'
 import { Filter } from '@/api/clipboardItems'
 import {
@@ -64,6 +65,20 @@ describe('composite search model', () => {
       tagOptions,
     }).map(c => c.value)
 
-    expect(values).toEqual(['link', 'code', 'favorited', 'image'])
+    expect(values).toEqual(['link', 'code', 'favorited', 'image', 'directory'])
+  })
+
+  it('offers the builtin directory tag as a folder', () => {
+    const tagOptions = searchableTagsToOptions([])
+    const [candidate] = buildCandidates('tag', 'directory', {
+      t: key => (key === 'history.type.directory' ? '文件夹' : key),
+      sourceOptions: [],
+      current,
+      tagOptions,
+    })
+
+    expect(candidate.value).toBe('directory')
+    expect(candidate.label).toBe('文件夹')
+    expect(candidate.icon).toBe(Folder)
   })
 })

--- a/src/components/history/composite-search/composite-search-model.ts
+++ b/src/components/history/composite-search/composite-search-model.ts
@@ -18,6 +18,7 @@ import {
   File,
   FileCode,
   FileText,
+  Folder,
   Hash,
   Image as ImageIcon,
   Laptop,
@@ -83,6 +84,7 @@ const TYPE_ICONS: Record<string, LucideIcon> = {
   [Filter.Link]: ExternalLink,
   [Filter.Image]: ImageIcon,
   [Filter.File]: File,
+  directory: Folder,
 }
 
 /** Default ("cleared") value of each dimension — clearing a chip resets to this. */

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -750,6 +750,7 @@
       "link": "Link",
       "favorited": "Favorites",
       "image": "Image",
+      "directory": "Folder",
       "file": "File",
       "unknown": "Unknown"
     },

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -740,6 +740,7 @@
       "link": "链接",
       "favorited": "收藏",
       "image": "图片",
+      "directory": "文件夹",
       "file": "文件",
       "unknown": "未知"
     },

--- a/src/lib/search-tags.ts
+++ b/src/lib/search-tags.ts
@@ -7,13 +7,14 @@ export interface SearchTagOption {
 }
 
 // Mirror the backend's reserved builtin tag set (`link`/`code`/`favorited`/
-// `image`) so fallback options and builtin-first ordering stay consistent with
+// `image`/`directory`) so fallback options and builtin-first ordering stay consistent with
 // what the server returns.
 const BUILTIN_SEARCH_TAGS: SearchTagOption[] = [
   { id: 'link', count: 0, isBuiltin: true },
   { id: 'code', count: 0, isBuiltin: true },
   { id: 'favorited', count: 0, isBuiltin: true },
   { id: 'image', count: 0, isBuiltin: true },
+  { id: 'directory', count: 0, isBuiltin: true },
 ]
 
 export function defaultSearchTagOptions(): SearchTagOption[] {


### PR DESCRIPTION
## Summary

- add a builtin `directory` tag derived from the persisted file-set directory predicate
- keep live indexing, rebuilds, degraded browsing, and repaired entries in parity
- rebuild existing search data and expose the folder filter in the desktop UI

## Verification

- `cargo test -p uc-core -p uc-application --lib`
- `cargo test -p uc-infra --lib`
- `cargo check --workspace`
- `npx vitest run`
- `bun run build`
- `cargo fmt --all -- --check`
- focused ESLint checks

## Known unrelated failure

`cargo test --workspace --lib` reaches one existing `uc-platform` failure: `parameterized_text_plain_classifies_as_text_plain` constructs a representation with the non-RFC MIME value `public.utf8-plain-text`, which the current core constructor rejects. The test fails unchanged when run alone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a **Folder** type and `directory` search tag for clipboard history entries containing directory structures.
  * Directory entries are now automatically tagged and searchable.
  * Added folder icons and localized labels in English and Chinese.
  * Existing entries are updated to support the new directory classification.

* **Bug Fixes**
  * Improved consistency between live indexing and rebuilt search results for directory entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->