### PR TITLE
feat(file-sync): serve directory manifests on active-clipboard pull

### DIFF
--- a/crates/uc-application/src/facade/active_clipboard/mod.rs
+++ b/crates/uc-application/src/facade/active_clipboard/mod.rs
@@ -26,9 +26,9 @@ use uc_core::ids::{DeviceId, EntryId};
 use uc_core::ports::clipboard::{
     ActiveClipboardDispatchPort, ActiveClipboardPullClientPort, ActiveClipboardPullServePort,
     ActiveClipboardReceiverPort, AdvanceActiveClipboardPort, CheckEntryAvailabilityPort,
-    ClipboardPayloadResolverPort, ClipboardSelectionRepositoryPort, FindEntryIdBySnapshotHashPort,
-    GetClipboardEntryPort, GetRepresentationPort, LoadActiveClipboardPort, TouchClipboardEntryPort,
-    UpdateRepresentationProcessingResultPort,
+    ClipboardPayloadResolverPort, ClipboardSelectionRepositoryPort, EntryFileSetRepositoryPort,
+    FindEntryIdBySnapshotHashPort, GetClipboardEntryPort, GetRepresentationPort,
+    LoadActiveClipboardPort, TouchClipboardEntryPort, UpdateRepresentationProcessingResultPort,
 };
 use uc_core::ports::security::TransferCipherPort;
 use uc_core::ports::space::IsSpaceUnlockedPort;
@@ -160,6 +160,11 @@ pub struct ActiveClipboardPullServeFacadeDeps {
     /// free-standing files into this device's blob store through it, re-issuing
     /// tickets pinned to this device (D3) before encoding the V3 envelope.
     pub blob_publisher: Arc<BlobTransferFacade>,
+    /// File-set manifest store — the single source of truth for a file-class
+    /// entry's member list on every outbound path (dispatch / resend / pull
+    /// serve, issue #1327). The serve side resolves directory entries through
+    /// it so pulled payloads carry the same UCDS manifest as dispatched ones.
+    pub entry_file_set_repo: Arc<dyn EntryFileSetRepositoryPort>,
     /// Snapshot reconstruction ports (shared with restore / resend), folded
     /// into a `SnapshotReconstructor` at construction.
     pub snapshot: ClipboardSnapshotDeps,
@@ -182,6 +187,7 @@ pub fn build_active_clipboard_pull_serve_port(
             reconstructor,
             settings: deps.settings,
             blob_publisher,
+            entry_file_set_repo: deps.entry_file_set_repo,
             cipher: deps.transfer_cipher,
         },
     ))

--- a/crates/uc-application/src/facade/clipboard_outbound/mod.rs
+++ b/crates/uc-application/src/facade/clipboard_outbound/mod.rs
@@ -44,6 +44,9 @@ pub use crate::usecases::clipboard_sync::resend_entry::{
 mod file_uri_line;
 pub(crate) use file_uri_line::{parse_uri_list_line, UriListLineKind};
 
+mod payload_prep;
+pub(crate) use payload_prep::{assemble_outbound_payload, OutboundPayload, OutboundPayloadError};
+
 /// Crate-internal adapter trait over [`BlobTransferFacade`]'s publish surface.
 ///
 /// 抽出这层只为单测 ergonomics:[`publish_file_blob_refs`] /
@@ -351,8 +354,11 @@ impl ClipboardOutboundPort for ClipboardOutboundDispatcher {
         // identity this entry was persisted under; the publish digests are
         // what actually went on the wire. Only comparable when the planner
         // kept every member (a per-file `max_file_size` exclusion legitimately
-        // shrinks the publish set).
-        if from_manifest && plan.files.len() == extracted_paths_count {
+        // shrinks the publish set) and the manifest carries a flat digest
+        // contribution at all — directory sets contribute none
+        // (`content_digest_contribution` is empty for them), so comparing
+        // would false-positive on every directory dispatch.
+        if !expected_digests.is_empty() && plan.files.len() == extracted_paths_count {
             let mut wire_digests = file_content_digests.clone();
             wire_digests.sort_unstable();
             wire_digests.dedup();

--- a/crates/uc-application/src/facade/clipboard_outbound/payload_prep.rs
+++ b/crates/uc-application/src/facade/clipboard_outbound/payload_prep.rs
@@ -147,6 +147,21 @@ pub(crate) async fn assemble_outbound_payload(
         return Err(OutboundPayloadError::Unavailable);
     };
 
+    // All-or-nothing for every manifest-backed set (flat AND directory): a
+    // planner-dropped member (e.g. file sync disabled → zero files planned)
+    // means the wire payload cannot carry the contents the entry's persisted
+    // identity covers. Serving the remainder would ship path text under a
+    // content-keyed identity — refuse instead.
+    if from_manifest && plan.files.len() != extracted_paths_count {
+        warn!(
+            entry_id = %entry_id,
+            published = plan.files.len(),
+            expected = extracted_paths_count,
+            "outbound payload: planner excluded manifest members; not reproducible (all-or-nothing)"
+        );
+        return Err(OutboundPayloadError::Unavailable);
+    }
+
     // 4. Publish file blobs (re-issues tickets pinned to this device).
     let (mut blob_refs, file_content_digests) =
         publish_file_blob_refs(blob_publisher, &plan.files, entry_id)
@@ -156,9 +171,9 @@ pub(crate) async fn assemble_outbound_payload(
     // Capture→send drift observability (flat manifests only — directory sets
     // carry no flat digest contribution): the manifest digests are the
     // identity the entry was persisted under; the publish digests are what
-    // actually goes on the wire. Only comparable when the planner kept every
-    // member.
-    if !expected_digests.is_empty() && plan.files.len() == extracted_paths_count {
+    // actually goes on the wire. The all-or-nothing guard above already
+    // ensured the planner kept every member.
+    if !expected_digests.is_empty() {
         let mut wire_digests = file_content_digests.clone();
         wire_digests.sort_unstable();
         wire_digests.dedup();
@@ -172,25 +187,14 @@ pub(crate) async fn assemble_outbound_payload(
         }
     }
 
-    // 5. Directory sets: all members must have survived planning, then the
-    //    transfer manifest + structured identity component replace the flat
-    //    digest contribution.
+    // 5. Directory sets: the transfer manifest + structured identity component
+    //    replace the flat digest contribution (member completeness is already
+    //    guaranteed by the all-or-nothing guard above).
     let file_set_manifest = match directory_members {
-        Some(members) => {
-            if plan.files.len() != extracted_paths_count {
-                warn!(
-                    entry_id = %entry_id,
-                    published = plan.files.len(),
-                    expected = extracted_paths_count,
-                    "outbound payload: planner excluded directory members; not reproducible (all-or-nothing)"
-                );
-                return Err(OutboundPayloadError::Unavailable);
-            }
-            Some(
-                build_transfer_manifest(&members, &plan.files)
-                    .map_err(|err| OutboundPayloadError::Internal(err.to_string()))?,
-            )
-        }
+        Some(members) => Some(
+            build_transfer_manifest(&members, &plan.files)
+                .map_err(|err| OutboundPayloadError::Internal(err.to_string()))?,
+        ),
         None => None,
     };
     if let Some(manifest) = &file_set_manifest {

--- a/crates/uc-application/src/facade/clipboard_outbound/payload_prep.rs
+++ b/crates/uc-application/src/facade/clipboard_outbound/payload_prep.rs
@@ -1,0 +1,226 @@
+//! Shared assembly of an outbound clipboard payload for the user/peer-initiated
+//! send paths (resend + active-clipboard pull serve).
+//!
+//! Both paths run the identical "resolve file set → read metadata → plan →
+//! publish blobs → build directory manifest → stamp identity → publish
+//! oversized inline reps" sequence and differ only in how they map the failure
+//! modes onto their own error surfaces. Keeping the sequence here (next to
+//! [`resolve_outbound_file_set`]) prevents the parallel-logic drift that let
+//! the pull-serve path leak flat directory frames in the first place (issue
+//! #1327).
+//!
+//! The `dispatch_capture` path intentionally does NOT go through this helper:
+//! its orchestration is genuinely different (LocalCapture origin gating,
+//! per-phase latency instrumentation for GH#487, `Skipped { reason }`
+//! outcomes), and folding it in would turn this into a leaky mega-helper.
+
+use std::sync::Arc;
+
+use tracing::warn;
+
+use uc_core::ids::EntryId;
+use uc_core::ports::clipboard::EntryFileSetRepositoryPort;
+use uc_core::ports::SettingsPort;
+use uc_core::{ClipboardChangeOrigin, SystemClipboardSnapshot};
+
+use crate::sync_planner::{FileCandidate, OutboundSyncPlanner};
+use crate::usecases::clipboard_sync::apply_inbound::{
+    compute_file_set_component, InboundFileSetManifest,
+};
+use crate::usecases::clipboard_sync::V3BlobRef;
+
+use super::{
+    build_transfer_manifest, publish_file_blob_refs, publish_oversized_inline_blob_refs,
+    resolve_outbound_file_set, ClipboardOutboundError, OutboundBlobPublishGateway,
+    OutboundFileSetResolution,
+};
+
+/// The assembled outbound payload: the (possibly mutated) snapshot with its
+/// identity fields stamped, the published blob refs, and the directory
+/// manifest when the entry is a directory set (`None` for flat/text entries —
+/// the caller picks the matching V3 encoder from its presence).
+pub(crate) struct OutboundPayload {
+    pub snapshot: SystemClipboardSnapshot,
+    pub blob_refs: Vec<V3BlobRef>,
+    pub file_set_manifest: Option<InboundFileSetManifest>,
+}
+
+/// Failure surface of [`assemble_outbound_payload`]. Details are logged at the
+/// failure site; callers only map the class onto their own error enums.
+pub(crate) enum OutboundPayloadError {
+    /// This device cannot reproduce the payload in full: the manifest has
+    /// excluded lines, a manifest member is unreadable, the planner dropped a
+    /// directory member, or every referenced file is gone (all-or-nothing).
+    Unavailable,
+    /// A blob publish step failed.
+    Publish(ClipboardOutboundError),
+    /// Manifest construction or identity-component computation failed.
+    Internal(String),
+}
+
+/// Assemble the outbound payload for a user/peer-initiated send of `entry_id`.
+///
+/// Plans with [`ClipboardChangeOrigin::Resend`] — both callers serve content
+/// the user already holds, bypassing the `max_file_size` capture guard.
+/// Manifest-backed file sets are all-or-nothing: any member this device cannot
+/// publish fails the whole payload ([`OutboundPayloadError::Unavailable`])
+/// instead of shipping a subset with a diverged identity.
+pub(crate) async fn assemble_outbound_payload(
+    entry_file_set_repo: &dyn EntryFileSetRepositoryPort,
+    blob_publisher: &dyn OutboundBlobPublishGateway,
+    settings: Arc<dyn SettingsPort>,
+    entry_id: &EntryId,
+    snapshot: SystemClipboardSnapshot,
+) -> Result<OutboundPayload, OutboundPayloadError> {
+    // 1. Member path list from the persisted file-set manifest — the single
+    //    source of truth shared with the dispatch path.
+    let resolution = resolve_outbound_file_set(entry_file_set_repo, entry_id, &snapshot).await;
+    let (resolved_paths, from_manifest, expected_digests, directory_members) = match resolution {
+        OutboundFileSetResolution::NotFileClass => (Vec::new(), false, Vec::new(), None),
+        OutboundFileSetResolution::Manifest {
+            paths,
+            expected_digests,
+        } => (paths, true, expected_digests, None),
+        OutboundFileSetResolution::Fallback { paths } => (paths, false, Vec::new(), None),
+        OutboundFileSetResolution::DirectorySyncable { paths, members } => {
+            (paths, true, Vec::new(), Some(members))
+        }
+        OutboundFileSetResolution::Excluded {
+            ingest_failed,
+            size_cap_exceeded,
+            unsupported_member,
+        } => {
+            warn!(
+                entry_id = %entry_id,
+                ingest_failed,
+                size_cap_exceeded,
+                unsupported_member,
+                "outbound payload: file-set manifest has excluded lines; not reproducible (all-or-nothing)"
+            );
+            return Err(OutboundPayloadError::Unavailable);
+        }
+    };
+
+    // 2. Read metadata. A manifest member unreadable now means this device can
+    //    no longer reproduce the set the entry's identity covers; legacy
+    //    (fallback) sets keep the lenient warn-and-skip semantics.
+    let extracted_paths_count = resolved_paths.len();
+    let mut file_candidates = Vec::with_capacity(resolved_paths.len());
+    for path in resolved_paths {
+        match tokio::fs::metadata(&path).await {
+            Ok(meta) => file_candidates.push(FileCandidate {
+                path,
+                size: meta.len(),
+            }),
+            Err(err) if from_manifest => {
+                warn!(
+                    error = %err,
+                    entry_id = %entry_id,
+                    "outbound payload: file-set member unreadable; not reproducible (all-or-nothing)"
+                );
+                return Err(OutboundPayloadError::Unavailable);
+            }
+            Err(err) => warn!(
+                error = %err,
+                entry_id = %entry_id,
+                "outbound payload: excluding clipboard file whose metadata could not be read"
+            ),
+        }
+    }
+
+    // 3. Plan. The only branch that drops `clipboard` for a Resend-origin plan
+    //    is `all_files_excluded` (every referenced file gone / over caps).
+    let planner = OutboundSyncPlanner::new(settings);
+    let plan = planner
+        .plan(
+            snapshot,
+            ClipboardChangeOrigin::Resend,
+            file_candidates,
+            extracted_paths_count,
+        )
+        .await;
+    let Some(mut clipboard_intent) = plan.clipboard else {
+        warn!(
+            entry_id = %entry_id,
+            "outbound payload: planner excluded every referenced file; not reproducible"
+        );
+        return Err(OutboundPayloadError::Unavailable);
+    };
+
+    // 4. Publish file blobs (re-issues tickets pinned to this device).
+    let (mut blob_refs, file_content_digests) =
+        publish_file_blob_refs(blob_publisher, &plan.files, entry_id)
+            .await
+            .map_err(OutboundPayloadError::Publish)?;
+
+    // Capture→send drift observability (flat manifests only — directory sets
+    // carry no flat digest contribution): the manifest digests are the
+    // identity the entry was persisted under; the publish digests are what
+    // actually goes on the wire. Only comparable when the planner kept every
+    // member.
+    if !expected_digests.is_empty() && plan.files.len() == extracted_paths_count {
+        let mut wire_digests = file_content_digests.clone();
+        wire_digests.sort_unstable();
+        wire_digests.dedup();
+        let mut capture_digests = expected_digests;
+        capture_digests.dedup();
+        if wire_digests != capture_digests {
+            warn!(
+                entry_id = %entry_id,
+                "outbound payload: file content drifted between capture and send; wire identity keyed on current bytes"
+            );
+        }
+    }
+
+    // 5. Directory sets: all members must have survived planning, then the
+    //    transfer manifest + structured identity component replace the flat
+    //    digest contribution.
+    let file_set_manifest = match directory_members {
+        Some(members) => {
+            if plan.files.len() != extracted_paths_count {
+                warn!(
+                    entry_id = %entry_id,
+                    published = plan.files.len(),
+                    expected = extracted_paths_count,
+                    "outbound payload: planner excluded directory members; not reproducible (all-or-nothing)"
+                );
+                return Err(OutboundPayloadError::Unavailable);
+            }
+            Some(
+                build_transfer_manifest(&members, &plan.files)
+                    .map_err(|err| OutboundPayloadError::Internal(err.to_string()))?,
+            )
+        }
+        None => None,
+    };
+    if let Some(manifest) = &file_set_manifest {
+        let digests = file_content_digests
+            .iter()
+            .enumerate()
+            .map(|(index, digest)| (index as u32, *digest))
+            .collect();
+        clipboard_intent.snapshot.file_content_digests.clear();
+        clipboard_intent.snapshot.file_set_v1_component = Some(
+            compute_file_set_component(manifest, &digests)
+                .map_err(|err| OutboundPayloadError::Internal(err.to_string()))?,
+        );
+    } else if !file_content_digests.is_empty() {
+        clipboard_intent.snapshot.file_content_digests = file_content_digests;
+    }
+
+    // 6. Publish oversized inline (image) reps.
+    let mut image_blob_refs = publish_oversized_inline_blob_refs(
+        blob_publisher,
+        &mut clipboard_intent.snapshot,
+        entry_id,
+    )
+    .await
+    .map_err(OutboundPayloadError::Publish)?;
+    blob_refs.append(&mut image_blob_refs);
+
+    Ok(OutboundPayload {
+        snapshot: clipboard_intent.snapshot,
+        blob_refs,
+        file_set_manifest,
+    })
+}

--- a/crates/uc-application/src/usecases/clipboard_sync/active_state/serve_pull.rs
+++ b/crates/uc-application/src/usecases/clipboard_sync/active_state/serve_pull.rs
@@ -413,6 +413,21 @@ mod tests {
         }
     }
 
+    /// Settings with file sync turned off — the planner then plans zero files
+    /// even though the manifest lists members.
+    struct FileSyncDisabledSettings;
+    #[async_trait]
+    impl SettingsPort for FileSyncDisabledSettings {
+        async fn load(&self) -> anyhow::Result<Settings> {
+            let mut settings = Settings::default();
+            settings.file_sync.file_sync_enabled = false;
+            Ok(settings)
+        }
+        async fn save(&self, _s: &Settings) -> anyhow::Result<()> {
+            unimplemented!()
+        }
+    }
+
     struct UnusedPublishGateway;
     #[async_trait]
     impl OutboundBlobPublishGateway for UnusedPublishGateway {
@@ -602,6 +617,22 @@ mod tests {
         gateway: Arc<dyn OutboundBlobPublishGateway>,
         cipher: Arc<dyn TransferCipherPort>,
     ) -> ActiveClipboardPullServeUseCase {
+        build_uc_for_file_with_manifest_and_settings(
+            file_uri,
+            manifest,
+            gateway,
+            cipher,
+            Arc::new(StubSettings),
+        )
+    }
+
+    fn build_uc_for_file_with_manifest_and_settings(
+        file_uri: &str,
+        manifest: Option<EntryFileSet>,
+        gateway: Arc<dyn OutboundBlobPublishGateway>,
+        cipher: Arc<dyn TransferCipherPort>,
+        settings: Arc<dyn SettingsPort>,
+    ) -> ActiveClipboardPullServeUseCase {
         let entry_id = EntryId::from("entry-1");
         let event_id = EventId::from("evt-1");
         let reconstructor = SnapshotReconstructor::new(
@@ -625,7 +656,7 @@ mod tests {
         ActiveClipboardPullServeUseCase::new(ActiveClipboardPullServeDeps {
             entry_lookup: Arc::new(FixedLookup(Some(entry_id))),
             reconstructor,
-            settings: Arc::new(StubSettings),
+            settings,
             blob_publisher: gateway,
             entry_file_set_repo: Arc::new(FakeFileSetRepo(manifest)),
             cipher,
@@ -1070,6 +1101,52 @@ mod tests {
             .serve("blake3v1:whatever")
             .await
             .expect_err("a flat manifest with an unreadable member must not serve a subset");
+        assert!(matches!(err, ActiveClipboardPullServeError::NotAvailable));
+        assert!(cipher.seen_plaintext.lock().unwrap().is_none());
+    }
+
+    /// V11 (issue #1327, CodeRabbit round 1) — file sync disabled: the planner
+    /// plans zero files, so a manifest-backed flat entry cannot carry the
+    /// contents its persisted identity covers. Serve must answer NotAvailable
+    /// instead of shipping path text under a content-keyed identity.
+    #[tokio::test]
+    async fn flat_manifest_with_file_sync_disabled_is_not_available() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let file_path = dir.path().join("present.bin");
+        std::fs::write(&file_path, b"bytes").expect("write temp file");
+        let file_uri = url::Url::from_file_path(&file_path)
+            .expect("file path to file:// URI")
+            .to_string();
+
+        let flat_manifest = EntryFileSet {
+            lines: vec![EntryFileSetLine {
+                line_index: 0,
+                original_text: file_uri.clone(),
+                member_location: None,
+                kind: EntryFileSetLineKind::File {
+                    content_hash: ContentHash {
+                        alg: HashAlgorithm::Blake3V1,
+                        bytes: [4u8; 32],
+                    },
+                    blob_id: None,
+                    size_bytes: Some(5),
+                },
+            }],
+        };
+
+        let cipher = StubCipher::new(Ok(b"unused".to_vec()));
+        let uc = build_uc_for_file_with_manifest_and_settings(
+            &file_uri,
+            Some(flat_manifest),
+            Arc::new(UnusedPublishGateway),
+            Arc::clone(&cipher) as _,
+            Arc::new(FileSyncDisabledSettings),
+        );
+
+        let err = uc
+            .serve("blake3v1:whatever")
+            .await
+            .expect_err("file sync disabled must not serve a manifest-backed file entry");
         assert!(matches!(err, ActiveClipboardPullServeError::NotAvailable));
         assert!(cipher.seen_plaintext.lock().unwrap().is_none());
     }

--- a/crates/uc-application/src/usecases/clipboard_sync/active_state/serve_pull.rs
+++ b/crates/uc-application/src/usecases/clipboard_sync/active_state/serve_pull.rs
@@ -17,7 +17,10 @@
 //!    published into **this device's** blob store, which issues a fresh
 //!    ticket **pinned to this device** (D3: the relay re-signs the ticket so a
 //!    downstream fetch dials the holder, not the original provider);
-//! 4. [`encode_snapshot_with_blob_refs_to_v3_bytes`] — frame the V3 envelope;
+//! 4. [`encode_snapshot_with_blob_refs_to_v3_bytes`] — frame the V3 envelope
+//!    (directory entries resolved via `resolve_outbound_file_set` are framed
+//!    with [`encode_snapshot_with_blob_refs_and_file_set_to_v3_bytes`] so the
+//!    UCDS manifest travels, same as dispatch/resend — issue #1327);
 //! 5. [`TransferCipherPort::encrypt`] — wrap it with a fresh transfer identity.
 //!
 //! A locked session cannot decrypt at step 2, so it cannot serve: the use case
@@ -35,20 +38,21 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use tracing::{debug, info, instrument, warn};
 
-use uc_core::clipboard::ClipboardChangeOrigin;
 use uc_core::ids::EntryId;
 use uc_core::ports::clipboard::{
-    ActiveClipboardPullServeError, ActiveClipboardPullServePort, FindEntryIdBySnapshotHashPort,
+    ActiveClipboardPullServeError, ActiveClipboardPullServePort, EntryFileSetRepositoryPort,
+    FindEntryIdBySnapshotHashPort,
 };
 use uc_core::ports::security::{TransferCipherError, TransferCipherPort};
 use uc_core::ports::SettingsPort;
 
 use crate::facade::clipboard_outbound::{
-    extract_file_paths_from_snapshot, publish_file_blob_refs, publish_oversized_inline_blob_refs,
-    OutboundBlobPublishGateway,
+    assemble_outbound_payload, OutboundBlobPublishGateway, OutboundPayload, OutboundPayloadError,
 };
-use crate::sync_planner::{FileCandidate, OutboundSyncPlanner};
-use crate::usecases::clipboard_sync::payload_codec::encode_snapshot_with_blob_refs_to_v3_bytes;
+use crate::usecases::clipboard_sync::payload_codec::{
+    encode_snapshot_with_blob_refs_and_file_set_to_v3_bytes,
+    encode_snapshot_with_blob_refs_to_v3_bytes,
+};
 use crate::usecases::clipboard_sync::snapshot_from_entry::{
     BuildSnapshotError, SnapshotReconstructor,
 };
@@ -61,6 +65,7 @@ pub(crate) struct ActiveClipboardPullServeUseCase {
     reconstructor: SnapshotReconstructor,
     settings: Arc<dyn SettingsPort>,
     blob_publisher: Arc<dyn OutboundBlobPublishGateway>,
+    entry_file_set_repo: Arc<dyn EntryFileSetRepositoryPort>,
     cipher: Arc<dyn TransferCipherPort>,
 }
 
@@ -70,6 +75,7 @@ pub(crate) struct ActiveClipboardPullServeDeps {
     pub reconstructor: SnapshotReconstructor,
     pub settings: Arc<dyn SettingsPort>,
     pub blob_publisher: Arc<dyn OutboundBlobPublishGateway>,
+    pub entry_file_set_repo: Arc<dyn EntryFileSetRepositoryPort>,
     pub cipher: Arc<dyn TransferCipherPort>,
 }
 
@@ -80,6 +86,7 @@ impl ActiveClipboardPullServeUseCase {
             reconstructor: deps.reconstructor,
             settings: deps.settings,
             blob_publisher: deps.blob_publisher,
+            entry_file_set_repo: deps.entry_file_set_repo,
             cipher: deps.cipher,
         }
     }
@@ -123,83 +130,55 @@ impl ActiveClipboardPullServeUseCase {
             Err(err) => return Err(map_reconstruct_error(err, &entry_id)),
         };
 
-        // 3. Plan + publish blobs. Planning with `Resend` origin treats this as
-        //    a user-initiated outbound (bypassing the `max_file_size` capture
-        //    guard, like resend). Publishing re-issues blob tickets pinned to
-        //    THIS device (D3) so a downstream fetch dials the holder.
-        let resolved_paths = extract_file_paths_from_snapshot(&snapshot);
-        let extracted_paths_count = resolved_paths.len();
-        let mut file_candidates = Vec::with_capacity(resolved_paths.len());
-        for path in resolved_paths {
-            match tokio::fs::metadata(&path).await {
-                Ok(meta) => file_candidates.push(FileCandidate {
-                    path,
-                    size: meta.len(),
-                }),
-                Err(err) => warn!(
-                    error = %err,
-                    "pull serve: excluding clipboard file whose metadata could not be read"
-                ),
-            }
-        }
-
-        let planner = OutboundSyncPlanner::new(Arc::clone(&self.settings));
-        let plan = planner
-            .plan(
-                snapshot,
-                ClipboardChangeOrigin::Resend,
-                file_candidates,
-                extracted_paths_count,
-            )
-            .await;
-        let Some(mut clipboard_intent) = plan.clipboard else {
-            // The only branch that drops `clipboard` for a Resend-origin plan
-            // is `all_files_excluded` (every referenced file gone). Treat as
-            // not available.
-            debug!("pull serve: all referenced files excluded; content not available");
-            return Err(ActiveClipboardPullServeError::NotAvailable);
-        };
-
-        let (mut blob_refs, file_content_digests) = match publish_file_blob_refs(
+        // 3. Assemble the payload via the shared outbound chain (issue #1327:
+        //    same single source of truth as resend — file-set resolution,
+        //    all-or-nothing member checks, blob publish re-issuing tickets
+        //    pinned to THIS device (D3), directory manifest + identity stamp).
+        //    `Unavailable` covers every "this holder cannot reproduce the set"
+        //    case → the requester should ask another holder.
+        let payload = assemble_outbound_payload(
+            self.entry_file_set_repo.as_ref(),
             self.blob_publisher.as_ref(),
-            &plan.files,
+            Arc::clone(&self.settings),
             &entry_id,
+            snapshot,
         )
-        .await
-        {
-            Ok(result) => result,
-            Err(err) => {
-                warn!(error = %err, "pull serve: file blob publish failed");
+        .await;
+        let OutboundPayload {
+            snapshot,
+            blob_refs,
+            file_set_manifest,
+        } = match payload {
+            Ok(parts) => parts,
+            Err(OutboundPayloadError::Unavailable) => {
+                debug!("pull serve: payload not reproducible on this holder; not available");
+                return Err(ActiveClipboardPullServeError::NotAvailable);
+            }
+            Err(OutboundPayloadError::Publish(err)) => {
+                warn!(error = %err, "pull serve: blob publish failed");
                 return Err(ActiveClipboardPullServeError::Internal(format!(
-                    "publish file blobs: {err}"
+                    "publish blobs: {err}"
                 )));
             }
-        };
-        if !file_content_digests.is_empty() {
-            clipboard_intent.snapshot.file_content_digests = file_content_digests;
-        }
-        let mut image_blob_refs = match publish_oversized_inline_blob_refs(
-            self.blob_publisher.as_ref(),
-            &mut clipboard_intent.snapshot,
-            &entry_id,
-        )
-        .await
-        {
-            Ok(refs) => refs,
-            Err(err) => {
-                warn!(error = %err, "pull serve: inline blob publish failed");
-                return Err(ActiveClipboardPullServeError::Internal(format!(
-                    "publish inline blobs: {err}"
-                )));
+            Err(OutboundPayloadError::Internal(msg)) => {
+                warn!(error = %msg, "pull serve: payload assembly failed");
+                return Err(ActiveClipboardPullServeError::Internal(msg));
             }
         };
-        blob_refs.append(&mut image_blob_refs);
 
-        // 4. Encode the V3 envelope (snapshot + blob refs trailer).
-        let (plaintext, _snapshot_hash) = match encode_snapshot_with_blob_refs_to_v3_bytes(
-            &clipboard_intent.snapshot,
-            &blob_refs,
-        ) {
+        // 4. Encode the V3 envelope (snapshot + blob refs trailer; directory
+        //    entries additionally carry the UCDS file-set manifest trailer,
+        //    same as the dispatch/resend paths). The pull channel has no
+        //    header version gate — an old puller's strict trailing-byte check
+        //    fails loudly on the UCDS trailer, which is the intended failure
+        //    shape (issue #1327 §4.2: no pull-side version negotiation).
+        let encoded = match &file_set_manifest {
+            Some(manifest) => encode_snapshot_with_blob_refs_and_file_set_to_v3_bytes(
+                &snapshot, &blob_refs, manifest,
+            ),
+            None => encode_snapshot_with_blob_refs_to_v3_bytes(&snapshot, &blob_refs),
+        };
+        let (plaintext, _snapshot_hash) = match encoded {
             Ok(encoded) => encoded,
             Err(err) => {
                 warn!(error = %err, "pull serve: V3 envelope encode failed");
@@ -272,7 +251,9 @@ mod tests {
     use uc_core::blob::ports::BlobReaderPort;
     use uc_core::clipboard::{
         ClipboardEntry, ClipboardRepositoryError, ClipboardSelection, ClipboardSelectionDecision,
-        MimeType, PayloadAvailability, PersistedClipboardRepresentation, SelectionPolicyVersion,
+        ContentHash, EntryFileSet, EntryFileSetError, EntryFileSetExcludeReason, EntryFileSetLine,
+        EntryFileSetLineKind, FileSetMemberKind, FileSetMemberLocation, HashAlgorithm, MimeType,
+        PayloadAvailability, PersistedClipboardRepresentation, SelectionPolicyVersion,
     };
     use uc_core::ids::{EventId, FormatId, RepresentationId};
     use uc_core::ports::blob::{BlobDigest, BlobTicket, PlaintextHash};
@@ -298,6 +279,27 @@ mod tests {
             &self,
             _hash: &str,
         ) -> Result<Option<EntryId>, ClipboardRepositoryError> {
+            Ok(self.0.clone())
+        }
+    }
+
+    /// File-set manifest fake. `None` models a pre-manifest (legacy) entry —
+    /// the serve chain falls back to rep parsing, i.e. the pre-#1327 behavior
+    /// every flat/text verdict below exercises.
+    struct FakeFileSetRepo(Option<EntryFileSet>);
+    #[async_trait]
+    impl EntryFileSetRepositoryPort for FakeFileSetRepo {
+        async fn save(
+            &self,
+            _entry_id: &EntryId,
+            _file_set: &EntryFileSet,
+        ) -> Result<(), EntryFileSetError> {
+            unreachable!("serve never writes the manifest")
+        }
+        async fn load(
+            &self,
+            _entry_id: &EntryId,
+        ) -> Result<Option<EntryFileSet>, EntryFileSetError> {
             Ok(self.0.clone())
         }
     }
@@ -583,16 +585,20 @@ mod tests {
             reconstructor,
             settings: Arc::new(StubSettings),
             blob_publisher: Arc::new(UnusedPublishGateway),
+            entry_file_set_repo: Arc::new(FakeFileSetRepo(None)),
             cipher,
         })
     }
 
     /// Build a serve use case whose local entry resolves to a single-file
     /// `text/uri-list` snapshot pointing at `file_uri`, with an injectable
-    /// blob publish gateway. Drives the blob (file) sub-path: reconstruct →
-    /// extract path → plan(Resend) → `publish_blob_path` → V3 blob ref trailer.
-    fn build_uc_for_file(
+    /// blob publish gateway and file-set manifest. Drives the blob (file)
+    /// sub-path: reconstruct → resolve file set → plan(Resend) →
+    /// `publish_blob_path` → V3 blob ref trailer (+ UCDS manifest trailer for
+    /// directory manifests).
+    fn build_uc_for_file_with_manifest(
         file_uri: &str,
+        manifest: Option<EntryFileSet>,
         gateway: Arc<dyn OutboundBlobPublishGateway>,
         cipher: Arc<dyn TransferCipherPort>,
     ) -> ActiveClipboardPullServeUseCase {
@@ -621,8 +627,47 @@ mod tests {
             reconstructor,
             settings: Arc::new(StubSettings),
             blob_publisher: gateway,
+            entry_file_set_repo: Arc::new(FakeFileSetRepo(manifest)),
             cipher,
         })
+    }
+
+    /// Legacy single-file builder — no persisted manifest (rep-parsing
+    /// fallback), matching every pre-#1327 flat-file verdict.
+    fn build_uc_for_file(
+        file_uri: &str,
+        gateway: Arc<dyn OutboundBlobPublishGateway>,
+        cipher: Arc<dyn TransferCipherPort>,
+    ) -> ActiveClipboardPullServeUseCase {
+        build_uc_for_file_with_manifest(file_uri, None, gateway, cipher)
+    }
+
+    /// A directory-shaped file-set manifest with a single member
+    /// `<root>/nested/file.txt` under top-level root `root_name`. The line's
+    /// `original_text` carries the ROOT uri (the outbound resolver joins
+    /// `relative_path` onto it), and `relative_path` containing `/` is what
+    /// flips `has_directory_structure()`.
+    fn directory_manifest(root_uri: &str, root_name: &str) -> EntryFileSet {
+        EntryFileSet {
+            lines: vec![EntryFileSetLine {
+                line_index: 0,
+                original_text: root_uri.to_string(),
+                member_location: Some(FileSetMemberLocation {
+                    root_index: 0,
+                    root_name: root_name.to_string(),
+                    relative_path: "nested/file.txt".to_string(),
+                    kind: FileSetMemberKind::File,
+                }),
+                kind: EntryFileSetLineKind::File {
+                    content_hash: ContentHash {
+                        alg: HashAlgorithm::Blake3V1,
+                        bytes: [7u8; 32],
+                    },
+                    blob_id: None,
+                    size_bytes: Some(10),
+                },
+            }],
+        }
     }
 
     // ── verdicts ─────────────────────────────────────────────────────────
@@ -787,5 +832,245 @@ mod tests {
         // File blob refs are independent files (not inline image reps), so the
         // ref must not claim a representation slot.
         assert_eq!(blob_refs[0].representation_index, None);
+    }
+
+    /// V6 (issue #1327) — serving a directory entry resolves the member list
+    /// through the persisted file-set manifest (same single source of truth as
+    /// dispatch/resend) and frames the V3 envelope WITH the UCDS manifest
+    /// trailer, so a pulling peer reconstructs the tree instead of receiving a
+    /// flat frame. Also proves the intended old-puller failure shape: the
+    /// pre-directory strict decoder rejects the payload loudly (§4.2 — no
+    /// pull-side version negotiation).
+    #[tokio::test]
+    async fn serves_directory_entry_with_file_set_manifest() {
+        // Real on-disk tree: <root>/nested/file.txt — the resolver joins the
+        // manifest's relative_path onto the root and reads its metadata.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root_path = dir.path().join("folder");
+        std::fs::create_dir_all(root_path.join("nested")).expect("mkdir");
+        let member_path = root_path.join("nested/file.txt");
+        std::fs::write(&member_path, b"directory member bytes").expect("write member");
+        let root_uri = url::Url::from_file_path(&root_path)
+            .expect("root path to file:// URI")
+            .to_string();
+
+        let resigned_ticket = BlobTicket::from_bytes(b"DIR-MEMBER-TICKET".to_vec());
+        let gateway =
+            RecordingPublishGateway::new(resigned_ticket.clone(), EntryId::from("entry-1"));
+        let cipher = StubCipher::new(Ok(b"CIPHERTEXT".to_vec()));
+        let uc = build_uc_for_file_with_manifest(
+            &root_uri,
+            Some(directory_manifest(&root_uri, "folder")),
+            Arc::clone(&gateway) as _,
+            Arc::clone(&cipher) as _,
+        );
+
+        let envelope = uc.serve("blake3v1:whatever").await.expect("serve ok");
+        assert_eq!(envelope, b"CIPHERTEXT");
+
+        // The publish set is the manifest-resolved member, not the raw rep's
+        // root path — proof the resolution came from the manifest.
+        let published = gateway.published_paths.lock().unwrap().clone();
+        assert_eq!(published, vec![member_path]);
+
+        // The plaintext carries the UCDS trailer with the directory shape.
+        let seen = cipher.seen_plaintext.lock().unwrap().clone().unwrap();
+        let (snapshot, blob_refs, manifest) =
+            crate::usecases::clipboard_sync::payload_codec::decode_v3_bytes_to_snapshot_blob_refs_and_file_set(&seen)
+                .expect("plaintext must be a V3 envelope with a UCDS trailer");
+        let manifest = manifest.expect("directory serve must carry the file-set manifest");
+        assert_eq!(manifest.members.len(), 1);
+        assert_eq!(manifest.members[0].root_name, "folder");
+        assert!(!manifest.members[0].root_is_file);
+        assert_eq!(manifest.members[0].relative_path, "nested/file.txt");
+        assert_eq!(manifest.members[0].blob_ref_index, Some(0));
+        assert_eq!(blob_refs.len(), 1);
+        assert_eq!(blob_refs[0].ticket.as_bytes(), resigned_ticket.as_bytes());
+        // Directory identity never travels as flat per-file digests — the
+        // receiver recomputes the structured component from the UCDS manifest
+        // (the wire does not carry `file_set_v1_component` itself).
+        assert!(snapshot.file_content_digests.is_empty());
+
+        // Old-puller simulation: the pre-directory decoder (any bytes after
+        // the UCBS section are an error) must reject this payload loudly —
+        // the legacy peer fails the pull instead of persisting a corrupted
+        // flat entry (issue #1327 §4.2: no pull-side version negotiation).
+        let err =
+            crate::usecases::clipboard_sync::payload_codec::decode_v3_bytes_as_legacy_peer(&seen)
+                .expect_err("legacy decoder must hard-fail on the UCDS trailer");
+        assert!(err.to_string().contains("trailing byte"));
+    }
+
+    /// V7 (issue #1327 regression) — a FLAT (no directory structure) manifest
+    /// keeps the pre-directory wire shape: no UCDS trailer, so existing peers
+    /// decode it unchanged.
+    #[tokio::test]
+    async fn flat_manifest_entry_serves_without_file_set_trailer() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let file_path = dir.path().join("flat.bin");
+        std::fs::write(&file_path, b"flat payload").expect("write temp file");
+        let file_uri = url::Url::from_file_path(&file_path)
+            .expect("file path to file:// URI")
+            .to_string();
+
+        let flat_manifest = EntryFileSet {
+            lines: vec![EntryFileSetLine {
+                line_index: 0,
+                original_text: file_uri.clone(),
+                member_location: None,
+                kind: EntryFileSetLineKind::File {
+                    content_hash: ContentHash {
+                        alg: HashAlgorithm::Blake3V1,
+                        bytes: [9u8; 32],
+                    },
+                    blob_id: None,
+                    size_bytes: Some(12),
+                },
+            }],
+        };
+
+        let gateway = RecordingPublishGateway::new(
+            BlobTicket::from_bytes(b"FLAT-TICKET".to_vec()),
+            EntryId::from("entry-1"),
+        );
+        let cipher = StubCipher::new(Ok(b"CIPHERTEXT".to_vec()));
+        let uc = build_uc_for_file_with_manifest(
+            &file_uri,
+            Some(flat_manifest),
+            Arc::clone(&gateway) as _,
+            Arc::clone(&cipher) as _,
+        );
+
+        uc.serve("blake3v1:whatever").await.expect("serve ok");
+
+        // The legacy-peer decoder (hard-errors on any bytes after the UCBS
+        // section) accepts the plaintext — i.e. no UCDS trailer traveled for
+        // a flat set, so old peers keep decoding flat pulls unchanged.
+        let seen = cipher.seen_plaintext.lock().unwrap().clone().unwrap();
+        let (snapshot, blob_refs) =
+            crate::usecases::clipboard_sync::payload_codec::decode_v3_bytes_as_legacy_peer(&seen)
+                .expect("no UCDS trailer expected");
+        assert_eq!(blob_refs.len(), 1);
+        assert!(snapshot.file_set_v1_component.is_none());
+    }
+
+    /// V8 (issue #1327) — an excluded manifest (a member never got a content
+    /// identity at capture) is a true not-syncable state: serve answers
+    /// NotAvailable without publishing or encrypting anything.
+    #[tokio::test]
+    async fn excluded_manifest_is_not_available() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let file_path = dir.path().join("excluded.bin");
+        std::fs::write(&file_path, b"bytes").expect("write temp file");
+        let file_uri = url::Url::from_file_path(&file_path)
+            .expect("file path to file:// URI")
+            .to_string();
+
+        let excluded_manifest = EntryFileSet {
+            lines: vec![EntryFileSetLine {
+                line_index: 0,
+                original_text: file_uri.clone(),
+                member_location: None,
+                kind: EntryFileSetLineKind::Excluded {
+                    reason: EntryFileSetExcludeReason::UnsupportedMember,
+                },
+            }],
+        };
+
+        let cipher = StubCipher::new(Ok(b"unused".to_vec()));
+        let uc = build_uc_for_file_with_manifest(
+            &file_uri,
+            Some(excluded_manifest),
+            Arc::new(UnusedPublishGateway),
+            Arc::clone(&cipher) as _,
+        );
+
+        let err = uc
+            .serve("blake3v1:whatever")
+            .await
+            .expect_err("excluded manifest must not serve");
+        assert!(matches!(err, ActiveClipboardPullServeError::NotAvailable));
+        assert!(cipher.seen_plaintext.lock().unwrap().is_none());
+    }
+
+    /// V9 (issue #1327) — all-or-nothing: a directory member unreadable at
+    /// serve time means this holder cannot reproduce the set → NotAvailable,
+    /// never a subset.
+    #[tokio::test]
+    async fn unreadable_directory_member_is_not_available() {
+        // Root exists but the manifest's member path does not.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root_path = dir.path().join("folder");
+        std::fs::create_dir_all(&root_path).expect("mkdir");
+        let root_uri = url::Url::from_file_path(&root_path)
+            .expect("root path to file:// URI")
+            .to_string();
+
+        let cipher = StubCipher::new(Ok(b"unused".to_vec()));
+        let uc = build_uc_for_file_with_manifest(
+            &root_uri,
+            Some(directory_manifest(&root_uri, "folder")),
+            Arc::new(UnusedPublishGateway),
+            Arc::clone(&cipher) as _,
+        );
+
+        let err = uc
+            .serve("blake3v1:whatever")
+            .await
+            .expect_err("unreadable member must not serve");
+        assert!(matches!(err, ActiveClipboardPullServeError::NotAvailable));
+        assert!(cipher.seen_plaintext.lock().unwrap().is_none());
+    }
+
+    /// V10 (issue #1327) — all-or-nothing also applies to FLAT manifest sets:
+    /// a manifest member unreadable at serve time → NotAvailable, never the
+    /// readable subset. This pins an intentional tightening: pre-#1327 the
+    /// serve path warned and published the surviving subset, which would key
+    /// the pulled copy on a diverged identity (the manifest covers ALL
+    /// members). Aligns pull with the dispatch/resend semantics.
+    #[tokio::test]
+    async fn unreadable_flat_manifest_member_is_not_available() {
+        // Two-member flat manifest; only the first file exists on disk.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let present_path = dir.path().join("present.bin");
+        std::fs::write(&present_path, b"still here").expect("write temp file");
+        let present_uri = url::Url::from_file_path(&present_path)
+            .expect("file path to file:// URI")
+            .to_string();
+        let missing_uri = url::Url::from_file_path(dir.path().join("gone.bin"))
+            .expect("file path to file:// URI")
+            .to_string();
+
+        let flat_line = |index: i64, uri: &str, byte: u8| EntryFileSetLine {
+            line_index: index,
+            original_text: uri.to_string(),
+            member_location: None,
+            kind: EntryFileSetLineKind::File {
+                content_hash: ContentHash {
+                    alg: HashAlgorithm::Blake3V1,
+                    bytes: [byte; 32],
+                },
+                blob_id: None,
+                size_bytes: Some(10),
+            },
+        };
+        let flat_manifest = EntryFileSet {
+            lines: vec![flat_line(0, &present_uri, 1), flat_line(1, &missing_uri, 2)],
+        };
+
+        let cipher = StubCipher::new(Ok(b"unused".to_vec()));
+        let uc = build_uc_for_file_with_manifest(
+            &present_uri,
+            Some(flat_manifest),
+            Arc::new(UnusedPublishGateway),
+            Arc::clone(&cipher) as _,
+        );
+
+        let err = uc
+            .serve("blake3v1:whatever")
+            .await
+            .expect_err("a flat manifest with an unreadable member must not serve a subset");
+        assert!(matches!(err, ActiveClipboardPullServeError::NotAvailable));
+        assert!(cipher.seen_plaintext.lock().unwrap().is_none());
     }
 }

--- a/crates/uc-application/src/usecases/clipboard_sync/payload_codec.rs
+++ b/crates/uc-application/src/usecases/clipboard_sync/payload_codec.rs
@@ -203,6 +203,31 @@ pub fn decode_v3_bytes_to_snapshot_blob_refs_and_file_set(
     ))
 }
 
+/// Test-only replica of the pre-directory-sync decoder as shipped before
+/// ADR-010 phase 4: it read the UCBS blob-refs extension and hard-errored on
+/// any remaining bytes. Kept as an executable spec of the legacy-peer failure
+/// shape — a payload carrying the UCDS directory trailer must fail loudly on
+/// old peers (no silent corruption, no pull-side version negotiation; issue
+/// #1327 §4.2).
+#[cfg(test)]
+pub(crate) fn decode_v3_bytes_as_legacy_peer(
+    bytes: &[u8],
+) -> Result<(SystemClipboardSnapshot, Vec<V3BlobRef>)> {
+    let mut cursor = bytes;
+    let _ = ClipboardBinaryPayload::decode_from(&mut cursor)
+        .map_err(|e| anyhow!("decode V3 envelope: {e}"))?;
+    let (_, trailing) = read_blob_refs_extension_with_remainder(cursor)?;
+    if !trailing.is_empty() {
+        // Verbatim legacy error: `read_blob_refs_extension` rejected any
+        // bytes left after the UCBS section.
+        return Err(anyhow!(
+            "V3 blob refs extension has {} trailing byte(s)",
+            trailing.len()
+        ));
+    }
+    decode_v3_bytes_to_snapshot_and_blob_refs(bytes)
+}
+
 fn write_blob_refs_extension<W: Write>(
     writer: &mut W,
     blob_refs: &[V3BlobRef],

--- a/crates/uc-application/src/usecases/clipboard_sync/resend_entry.rs
+++ b/crates/uc-application/src/usecases/clipboard_sync/resend_entry.rs
@@ -20,11 +20,10 @@
 //! 但下游(plan → publish → encode → dispatch)100% 复用既有路径:
 //!
 //! - [`reconstruct_snapshot_from_entry`] —— commit B2 抽出的共享 helper;
-//! - [`OutboundSyncPlanner::plan`] —— commit B3 让 `Resend` 与 `LocalCapture`
-//!   共享文件分支条件;
-//! - [`publish_file_blob_refs`] / [`publish_oversized_inline_blob_refs`] ——
-//!   commit B3 提升为 `pub(crate)` + 抽出 [`OutboundBlobPublishGateway`]
-//!   trait 让本用例可单测;
+//! - [`assemble_outbound_payload`] —— resolve file set → plan → publish →
+//!   directory manifest → identity stamp 的共享出站组装链,与
+//!   active-clipboard pull serve 同源(issue #1327);其内部的 planner
+//!   bypass 语义见下文 `max_file_size` 契约;
 //! - [`encode_snapshot_with_blob_refs_to_v3_bytes`] —— payload codec;
 //! - [`DispatchEntryRunner`] —— commit A 的 `target_filter` 字段 + 本 commit
 //!   抽出的内部 trait,让 fan-out / delivery 落盘 / host event emit 全部复用。
@@ -43,9 +42,10 @@
 //!
 //! Resend 路径**不**受 `settings.file_sync.max_file_size` 限制 —— 该 setting
 //! 是 LocalCapture 自动出站的带宽护栏(用户没主动表态时不想偷偷送大文件),
-//! 而 resend 是用户显式动作,理应越过此护栏自行承担后果。bypass 在
-//! [`OutboundSyncPlanner::plan`] 内实现(origin-aware),`file_sync_enabled`
-//! 不在 bypass 范围内 —— "关闭文件同步"是更强的用户意图,resend 仍尊重。
+//! 而 resend 是用户显式动作,理应越过此护栏自行承担后果。bypass 在 planner
+//! 内实现(origin-aware,[`assemble_outbound_payload`] 以 `Resend` origin
+//! 规划),`file_sync_enabled` 不在 bypass 范围内 —— "关闭文件同步"是更强
+//! 的用户意图,resend 仍尊重。
 //!
 //! 这条契约让 [`NotResendableReason::PayloadLost`] 的语义严格收窄到"本机
 //! 不持有 plaintext / blob",不再混入"持有但超用户上限"的歧义,前端
@@ -55,7 +55,7 @@ use std::collections::HashSet;
 use std::sync::Arc;
 
 use thiserror::Error;
-use tracing::{info, warn};
+use tracing::info;
 
 use uc_core::blob::ports::BlobReaderPort;
 use uc_core::clipboard::ClipboardContentCategorySet;
@@ -70,15 +70,11 @@ use uc_core::ports::{
     EntryDeliveryRepositoryPort, SettingsPort,
 };
 use uc_core::trusted_peer::TrustedPeerRepositoryPort;
-use uc_core::ClipboardChangeOrigin;
 
 use crate::facade::clipboard_outbound::{
-    build_transfer_manifest, publish_file_blob_refs, publish_oversized_inline_blob_refs,
-    resolve_outbound_file_set, ClipboardOutboundError, OutboundBlobPublishGateway,
-    OutboundFileSetResolution,
+    assemble_outbound_payload, ClipboardOutboundError, OutboundBlobPublishGateway, OutboundPayload,
+    OutboundPayloadError,
 };
-use crate::sync_planner::{FileCandidate, OutboundSyncPlanner};
-use crate::usecases::clipboard_sync::apply_inbound::compute_file_set_component;
 use crate::usecases::clipboard_sync::dispatch_entry::{
     DispatchClipboardEntryInput, DispatchEntryRunner, DispatchSyncError,
 };
@@ -263,8 +259,8 @@ impl ResendEntryUseCase {
     /// 2. `event_repo.get_source_device` — 非本机则 `RemoteOrigin`。
     /// 3. `reconstruct_snapshot_from_entry` — 任一必要 rep 不可解则 `PayloadLost`。
     /// 4. 派生目标集合(filter 校验 / 差集派生)。
-    /// 5. `OutboundSyncPlanner.plan(Resend)` + `publish_*` — 文件全缺失或
-    ///    publish 失败映射到对应 error。
+    /// 5. `assemble_outbound_payload` — resolve file set → plan(Resend) →
+    ///    publish;文件集不可复现 / publish 失败映射到对应 error。
     /// 6. V3 envelope 编码。
     /// 7. `dispatch_runner.execute` with `target_filter = Some(targets)`。
     ///
@@ -378,144 +374,48 @@ impl ResendEntryUseCase {
             }
         };
 
-        // 5. Plan + publish blobs.
-        //
-        // The member path list comes from the persisted file-set manifest
-        // (single source of truth, shared with the LocalCapture dispatch
-        // path); pre-manifest entries fall back to re-parsing the
-        // reconstructed snapshot's `text/uri-list` rep.
-        //
-        // Manifest-backed sets are all-or-nothing: an excluded manifest line
-        // (a member that never got a content identity at capture) or a member
-        // unreadable now both mean this machine cannot reproduce the set the
-        // entry's identity covers → `PayloadLost`. Fallback (legacy) sets keep
-        // the older lenient semantics: a lost member is warned and skipped;
-        // if all members are lost, the planner returns `clipboard: None`
-        // below, which also maps to `PayloadLost`.
-        let resolution =
-            resolve_outbound_file_set(self.entry_file_set_repo.as_ref(), &cmd.entry_id, &snapshot)
-                .await;
-        let (resolved_paths, from_manifest, directory_members) = match resolution {
-            OutboundFileSetResolution::NotFileClass => (Vec::new(), false, None),
-            OutboundFileSetResolution::Manifest { paths, .. } => (paths, true, None),
-            OutboundFileSetResolution::Fallback { paths } => (paths, false, None),
-            OutboundFileSetResolution::DirectorySyncable { paths, members } => {
-                (paths, true, Some(members))
-            }
-            OutboundFileSetResolution::Excluded {
-                ingest_failed,
-                size_cap_exceeded,
-                unsupported_member,
-            } => {
-                warn!(
-                    entry_id = %cmd.entry_id,
-                    ingest_failed,
-                    size_cap_exceeded,
-                    unsupported_member,
-                    "resend: file-set manifest has excluded lines; entry not resendable (all-or-nothing)"
-                );
+        // 5. Assemble the payload via the shared outbound chain (file-set
+        //    resolution from the persisted manifest, all-or-nothing member
+        //    checks, blob publish, directory manifest + identity stamp; shared
+        //    with the pull-serve path — issue #1327). `Unavailable` covers
+        //    every "this machine cannot reproduce the set" case (excluded
+        //    manifest lines, a member unreadable now, planner exclusions) →
+        //    `PayloadLost`.
+        let payload = assemble_outbound_payload(
+            self.entry_file_set_repo.as_ref(),
+            self.blob_publisher.as_ref(),
+            Arc::clone(&self.settings),
+            &cmd.entry_id,
+            snapshot,
+        )
+        .await;
+        let OutboundPayload {
+            snapshot,
+            blob_refs,
+            file_set_manifest,
+        } = match payload {
+            Ok(parts) => parts,
+            Err(OutboundPayloadError::Unavailable) => {
                 return Err(ResendEntryError::EntryNotResendable {
                     entry_id: cmd.entry_id.clone(),
                     reason: NotResendableReason::PayloadLost,
                 });
             }
-        };
-        let extracted_paths_count = resolved_paths.len();
-        let mut file_candidates = Vec::with_capacity(resolved_paths.len());
-        for path in resolved_paths {
-            match tokio::fs::metadata(&path).await {
-                Ok(meta) => file_candidates.push(FileCandidate {
-                    path,
-                    size: meta.len(),
-                }),
-                Err(err) if from_manifest => {
-                    warn!(
-                        error = %err,
-                        entry_id = %cmd.entry_id,
-                        "resend: file-set member unreadable; entry not resendable (all-or-nothing)"
-                    );
-                    return Err(ResendEntryError::EntryNotResendable {
-                        entry_id: cmd.entry_id.clone(),
-                        reason: NotResendableReason::PayloadLost,
-                    });
-                }
-                Err(err) => warn!(
-                    error = %err,
-                    "resend: 排除无法读取元数据的剪贴板文件(本机可能已不持有)"
-                ),
+            Err(OutboundPayloadError::Publish(err)) => {
+                return Err(map_outbound_publish_error(err));
             }
-        }
-
-        let planner = OutboundSyncPlanner::new(Arc::clone(&self.settings));
-        let plan = planner
-            .plan(
-                snapshot,
-                ClipboardChangeOrigin::Resend,
-                file_candidates,
-                extracted_paths_count,
-            )
-            .await;
-        let Some(mut clipboard_intent) = plan.clipboard else {
-            // resend 路径下唯一让 `clipboard` 落空的分支是 planner 的
-            // `all_files_excluded` —— 即 extracted_paths_count > 0 但所有
-            // candidate 都被 metadata 失败 / size 上限排除。视为 PayloadLost。
-            return Err(ResendEntryError::EntryNotResendable {
-                entry_id: cmd.entry_id.clone(),
-                reason: NotResendableReason::PayloadLost,
-            });
-        };
-
-        let (mut blob_refs, file_content_digests) =
-            publish_file_blob_refs(self.blob_publisher.as_ref(), &plan.files, &cmd.entry_id)
-                .await
-                .map_err(map_outbound_publish_error)?;
-        let file_set_manifest = match directory_members {
-            Some(members) => {
-                if plan.files.len() != extracted_paths_count {
-                    return Err(ResendEntryError::EntryNotResendable {
-                        entry_id: cmd.entry_id.clone(),
-                        reason: NotResendableReason::PayloadLost,
-                    });
-                }
-                Some(
-                    build_transfer_manifest(&members, &plan.files)
-                        .map_err(map_outbound_publish_error)?,
-                )
+            Err(OutboundPayloadError::Internal(msg)) => {
+                return Err(ResendEntryError::Dispatch(msg));
             }
-            None => None,
         };
-        if let Some(manifest) = &file_set_manifest {
-            let digests = file_content_digests
-                .iter()
-                .enumerate()
-                .map(|(index, digest)| (index as u32, *digest))
-                .collect();
-            clipboard_intent.snapshot.file_content_digests.clear();
-            clipboard_intent.snapshot.file_set_v1_component = Some(
-                compute_file_set_component(manifest, &digests)
-                    .map_err(|err| ResendEntryError::Dispatch(err.to_string()))?,
-            );
-        } else if !file_content_digests.is_empty() {
-            clipboard_intent.snapshot.file_content_digests = file_content_digests;
-        }
-        let mut image_blob_refs = publish_oversized_inline_blob_refs(
-            self.blob_publisher.as_ref(),
-            &mut clipboard_intent.snapshot,
-            &cmd.entry_id,
-        )
-        .await
-        .map_err(map_outbound_publish_error)?;
-        blob_refs.append(&mut image_blob_refs);
 
         // 6. Encode V3 envelope.
-        let categories = ClipboardContentCategorySet::from_snapshot(&clipboard_intent.snapshot);
+        let categories = ClipboardContentCategorySet::from_snapshot(&snapshot);
         let (plaintext, snapshot_hash, wire_version) = match file_set_manifest {
             Some(manifest) => {
                 let (plaintext, snapshot_hash) =
                     encode_snapshot_with_blob_refs_and_file_set_to_v3_bytes(
-                        &clipboard_intent.snapshot,
-                        &blob_refs,
-                        &manifest,
+                        &snapshot, &blob_refs, &manifest,
                     )
                     .map_err(|e| ResendEntryError::Dispatch(format!("payload encode: {e}")))?;
                 (
@@ -525,11 +425,9 @@ impl ResendEntryUseCase {
                 )
             }
             None => {
-                let (plaintext, snapshot_hash) = encode_snapshot_with_blob_refs_to_v3_bytes(
-                    &clipboard_intent.snapshot,
-                    &blob_refs,
-                )
-                .map_err(|e| ResendEntryError::Dispatch(format!("payload encode: {e}")))?;
+                let (plaintext, snapshot_hash) =
+                    encode_snapshot_with_blob_refs_to_v3_bytes(&snapshot, &blob_refs)
+                        .map_err(|e| ResendEntryError::Dispatch(format!("payload encode: {e}")))?;
                 (
                     plaintext,
                     snapshot_hash,

--- a/crates/uc-bootstrap/src/subsystem/sync_engine.rs
+++ b/crates/uc-bootstrap/src/subsystem/sync_engine.rs
@@ -505,6 +505,7 @@ pub(crate) async fn build_sync_engine_assembly(
             settings: Arc::clone(&deps.settings),
             transfer_cipher: Arc::clone(&deps.security.transfer_cipher),
             blob_publisher: Arc::clone(&blob),
+            entry_file_set_repo: Arc::clone(&deps.storage.entry_file_set_repo),
             snapshot: ClipboardSnapshotDeps {
                 entry_repo: Arc::clone(&deps.clipboard.entry_ports.get),
                 selection_repo: Arc::clone(&deps.clipboard.selection_repo),


### PR DESCRIPTION
## Summary

- **Close the third directory-leak entry point** (ADR-010 phase 5 P0-B, plan §4): the active-clipboard pull-serve path bypassed the phase-4 directory-aware outbound resolution, so a desktop peer pulling a directory entry by hash received a tree-less flat frame. `serve_pull` now resolves through the persisted file-set manifest and frames the V3 envelope with the UCDS trailer — byte-identical semantics to dispatch/resend (2292948).
- **Single source of truth enforced structurally**: the shared "resolve file set → all-or-nothing member checks → plan → publish → directory manifest + identity stamp" chain is extracted into `assemble_outbound_payload`, consumed by both resend and pull serve; callers only map failure classes onto their own error surfaces (1721cb7). `dispatch_capture` intentionally keeps its own orchestration (origin gating, per-phase latency instrumentation, `Skipped` reasons).
- **Truly unsyncable stays `NotAvailable`**: excluded manifest lines, members unreadable at serve time, and planner-dropped members all refuse to serve rather than shipping a subset with a diverged identity. This intentionally tightens flat-manifest pulls too (previously served the readable subset) — pinned by a dedicated regression test.
- **Legacy pullers fail loudly, no pull-side version negotiation** (plan §4.2): a pre-directory decoder hard-errors on the UCDS trailing bytes and drops the pull. Since the current decoder tolerates the trailer, `decode_v3_bytes_as_legacy_peer` (test-only) preserves the shipped legacy behavior as an executable spec.
- **Drive-by fix**: the capture→send digest drift warn false-positived on every successful directory dispatch (`DirectorySyncable` resolves with empty `expected_digests`); the check is now gated on a non-empty flat digest contribution (1721cb7).

The puller side needs no change — pulled envelopes flow through the shared inbound apply path, which decodes UCDS and rebuilds directories all-or-nothing since phase 4 (#1323).

Closes #1327.

## Test plan

- [x] `cargo test -p uc-application --lib` — 787 passed, including 5 new pull-serve verdicts: directory serve carries UCDS manifest + legacy decoder hard-fails on it; flat-manifest serve has no trailer (legacy decoder accepts); excluded manifest → NotAvailable; unreadable directory member → NotAvailable; unreadable flat-manifest member → NotAvailable (regression pin for the intentional tightening).
- [x] Existing flat/text pull verdicts (V1–V5) unchanged and green.
- [x] `cargo check` clean for uc-application / uc-bootstrap / uc-webserver / uc-daemon; each commit compiles independently; clippy warning count unchanged vs `main`.
- [ ] Dual-desktop manual verification: activate a directory on machine A while machine B is offline on that hash; B's 0xC3 convergence pull should rebuild the full tree (covered structurally by shared inbound-apply tests, worth one real-machine pass).

## Notes for review

- Docs-site untouched by design: the user-facing folder-sync page is T9 (#1334) and depends on the T3–T5 UI work.
- No telemetry added: the pull channel has no events in the frozen catalog today; instrumenting it is new schema work, out of this P0's scope.
- Tracing conforms: work runs under the existing `active_state.serve_pull` use-case span; new logs are `warn` on recoverable unavailability, no paths/content in fields.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced clipboard sharing for directory-based file sets during active-clipboard pull and user resend flows.
  * Outbound transfers now preserve and use an optional persisted file-set manifest to frame directory-member content.
  * Directory-based transfers follow all-or-nothing behavior when manifest members are unavailable or unreadable.

* **Bug Fixes**
  * Reduced false-positive transfer consistency/digest drift warnings.
  * Improved compatibility with legacy clipboard receivers.
  * Standardized “not available” failure handling for unreproducible payloads, including correct behavior when file sync is disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->