### PR TITLE
fix(desktop): surface early daemon spawn failures

### DIFF
--- a/crates/uc-daemon-process/src/contract.rs
+++ b/crates/uc-daemon-process/src/contract.rs
@@ -32,10 +32,63 @@ pub enum DaemonBootstrapError {
     RefusedNewerDaemon { observed: String, expected: String },
     #[error("failed to spawn uniclipboard-daemon: {0}")]
     Spawn(anyhow::Error),
+    /// The daemon binary launched but its process exited BEFORE it could serve
+    /// `/health` — a hard launch failure, NOT a slow start. On Windows this is
+    /// how a missing dependency surfaces: `CreateProcess` (hence
+    /// `Command::spawn`) returns `Ok`, then the image loader fails and the
+    /// process dies within milliseconds with an NTSTATUS exit code (e.g.
+    /// `0xC0000135` STATUS_DLL_NOT_FOUND when `vcruntime140.dll` is absent). A
+    /// naive `/health` timeout cannot tell this apart from "the daemon is just
+    /// slow to start"; watching the child's exit lets us fail fast with an
+    /// actionable message. `code` is the process exit code if the OS reported
+    /// one (issue #1259).
+    #[error("daemon process exited immediately after spawn{}", describe_spawn_exit(.code))]
+    SpawnExitedEarly { code: Option<i32> },
     #[error("daemon startup timed out after {timeout_ms}ms")]
     StartupTimeout { timeout_ms: u64 },
     #[error("failed to load daemon connection info: {0}")]
     ConnectionInfo(anyhow::Error),
+}
+
+/// Render the actionable suffix for [`DaemonBootstrapError::SpawnExitedEarly`].
+///
+/// A handful of Windows loader NTSTATUS codes are recognizable enough to name
+/// the likely fix (a missing/incompatible runtime library). Everything else
+/// just reports the raw exit code. NTSTATUS error codes have the high bit set,
+/// so they read as negative `i32`s — those are rendered as unsigned hex
+/// (`0xC0000135`, the conventional form); ordinary small exit codes (a Rust
+/// panic is 101, a clean-ish crash may be 1) render as decimal.
+fn describe_spawn_exit(code: &Option<i32>) -> String {
+    let Some(code) = *code else {
+        return String::new();
+    };
+    if code >= 0 {
+        return format!(" (exit code {code})");
+    }
+    let ntstatus = code as u32;
+    let hint = match ntstatus {
+        // STATUS_DLL_NOT_FOUND: a required DLL could not be located. On a clean
+        // Windows install the usual culprit is the absent Visual C++ Runtime
+        // (`vcruntime140.dll`) — the proximate trigger in issue #1259.
+        0xC000_0135 => {
+            " - a required system library is missing (for example the Visual C++ Runtime). \
+             Install the Microsoft Visual C++ 2015-2022 Redistributable (x64) and try again."
+        }
+        // STATUS_ENTRYPOINT_NOT_FOUND: a DLL was found but lacks an expected
+        // entry point — typically a version mismatch of that same runtime.
+        0xC000_0139 => {
+            " - a required system library is present but incompatible. \
+             Reinstall the Microsoft Visual C++ 2015-2022 Redistributable (x64) and try again."
+        }
+        // STATUS_DLL_INIT_FAILED: a dependent DLL's initialization routine
+        // failed. Not always the VC++ runtime, so keep the advice generic.
+        0xC000_0142 => {
+            " - a required system library failed to initialize. \
+             Reinstall the app's runtime dependencies and try again."
+        }
+        _ => "",
+    };
+    format!(" (exit code {ntstatus:#010X}){hint}")
 }
 
 /// `terminate_local_daemon_pid` 的返回错误，仅承载一个 detail string。
@@ -277,6 +330,59 @@ mod tests {
             msg.contains("0.15.0") && msg.contains("0.14.0") && msg.contains("refusing"),
             "refusal display must surface observed + expected versions; got: {err}"
         );
+    }
+
+    #[test]
+    fn spawn_exited_early_names_missing_dll_and_the_fix() {
+        // The signature case (issue #1259): a Windows missing-DLL crash exits
+        // with STATUS_DLL_NOT_FOUND (0xC0000135, negative as i32). The message
+        // must render the code as unsigned hex AND point at the likely fix so
+        // the frontend error screen is actionable, not just "it timed out".
+        let err = DaemonBootstrapError::SpawnExitedEarly {
+            code: Some(0xC000_0135u32 as i32),
+        };
+        let msg = err.to_string();
+        assert!(
+            msg.contains("0xC0000135"),
+            "must render the NTSTATUS as unsigned hex; got: {msg}"
+        );
+        assert!(
+            msg.contains("Visual C++"),
+            "must name the actionable fix for a missing runtime; got: {msg}"
+        );
+        assert!(
+            msg.contains("exited immediately"),
+            "must distinguish an immediate crash from a slow start; got: {msg}"
+        );
+    }
+
+    #[test]
+    fn spawn_exited_early_renders_plain_codes_in_decimal() {
+        // A non-NTSTATUS exit (e.g. a Rust panic aborts with 101) has no
+        // loader-specific hint — report the raw code in decimal, not hex.
+        let err = DaemonBootstrapError::SpawnExitedEarly { code: Some(101) };
+        let msg = err.to_string();
+        assert!(
+            msg.contains("101"),
+            "plain exit code must appear; got: {msg}"
+        );
+        assert!(
+            !msg.contains("0x"),
+            "a plain positive code must not be hex-rendered; got: {msg}"
+        );
+    }
+
+    #[test]
+    fn spawn_exited_early_tolerates_unknown_exit_code() {
+        // No OS-reported code: still a distinct, non-panicking message.
+        let err = DaemonBootstrapError::SpawnExitedEarly { code: None };
+        assert!(err.to_string().contains("exited immediately"));
+
+        // An unrecognized NTSTATUS still renders as hex, just without a hint.
+        let err = DaemonBootstrapError::SpawnExitedEarly {
+            code: Some(0xC000_00FDu32 as i32), // STATUS_STACK_OVERFLOW
+        };
+        assert!(err.to_string().contains("0xC00000FD"));
     }
 
     #[test]

--- a/crates/uc-daemon-process/src/health_wait.rs
+++ b/crates/uc-daemon-process/src/health_wait.rs
@@ -9,6 +9,24 @@ use std::time::Duration;
 
 use crate::contract::{DaemonBootstrapError, ProbeOutcome};
 
+/// Liveness of a freshly-spawned daemon child process, as observed by
+/// [`wait_for_daemon_health_watching_child`].
+///
+/// Transport-neutral by design — it carries no `std::process` types — so the
+/// wait loop stays decoupled from the spawn primitive and can be unit-tested
+/// with a scripted poller. The bridge from a real [`std::process::Child`] lives
+/// in [`crate::spawn::poll_child_liveness`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChildLiveness {
+    /// The child is still running, or its liveness could not be determined
+    /// (treated as "keep waiting" — the health timeout still bounds the loop).
+    Running,
+    /// The child has exited with the given process exit code, if the OS
+    /// reported one. On Windows this surfaces the NTSTATUS (e.g. `0xC0000135`
+    /// STATUS_DLL_NOT_FOUND for a missing dependency — issue #1259).
+    Exited { code: Option<i32> },
+}
+
 /// 轮询 daemon 健康端点，直到 daemon 报告兼容、或超时、或观测到不兼容。
 ///
 /// - `Compatible` → 返回 `Ok(())`
@@ -31,6 +49,60 @@ where
             ProbeOutcome::Incompatible { details, .. } => {
                 return Err(DaemonBootstrapError::IncompatibleDaemon { details });
             }
+        }
+
+        if tokio::time::Instant::now() >= deadline {
+            return Err(DaemonBootstrapError::StartupTimeout {
+                timeout_ms: timeout.as_millis() as u64,
+            });
+        }
+
+        tokio::time::sleep(poll_interval).await;
+    }
+}
+
+/// Like [`wait_for_daemon_health`] but ALSO watches the freshly-spawned child
+/// process: if it exits before `/health` reports healthy, fail fast with
+/// [`DaemonBootstrapError::SpawnExitedEarly`] instead of spinning until the
+/// (long) startup timeout.
+///
+/// This is what distinguishes "the daemon binary crashed on launch" (e.g. a
+/// missing `vcruntime140.dll` on Windows, where `Command::spawn` still returns
+/// `Ok` — issue #1259) from "the daemon is merely slow to start". `poll_child`
+/// reports the child's [`ChildLiveness`]; production wraps
+/// [`crate::spawn::poll_child_liveness`], tests script it.
+///
+/// Ordering within each iteration is **probe first, then liveness**: a daemon
+/// that has genuinely come up wins even in the rare race where our spawned
+/// child has exited but a healthy daemon is reachable (e.g. another actor's).
+/// Connection-refused probes return `Absent` immediately, so probe-first adds
+/// no latency to detecting a crash — the exit is caught on the next iteration.
+pub async fn wait_for_daemon_health_watching_child<Probe, ProbeFuture, ChildPoll>(
+    probe: &mut Probe,
+    poll_child: &mut ChildPoll,
+    timeout: Duration,
+    poll_interval: Duration,
+) -> Result<(), DaemonBootstrapError>
+where
+    Probe: FnMut() -> ProbeFuture,
+    ProbeFuture: Future<Output = Result<ProbeOutcome, DaemonBootstrapError>>,
+    ChildPoll: FnMut() -> ChildLiveness,
+{
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        match probe().await? {
+            ProbeOutcome::Compatible(_) => return Ok(()),
+            ProbeOutcome::Absent => {}
+            ProbeOutcome::Incompatible { details, .. } => {
+                return Err(DaemonBootstrapError::IncompatibleDaemon { details });
+            }
+        }
+
+        // The child exited before serving `/health` — a dead process can never
+        // turn healthy, so surface the crash (with its exit code) now rather
+        // than after the full startup timeout.
+        if let ChildLiveness::Exited { code } = poll_child() {
+            return Err(DaemonBootstrapError::SpawnExitedEarly { code });
         }
 
         if tokio::time::Instant::now() >= deadline {
@@ -290,5 +362,113 @@ mod tests {
             1,
             "must not retry through probe errors"
         );
+    }
+
+    // ---- wait_for_daemon_health_watching_child: early-exit detection ----
+
+    /// A scripted child poller mirroring `scripted_probe`: returns successive
+    /// `ChildLiveness` values, then repeats the last one forever.
+    fn scripted_child(script: Vec<ChildLiveness>) -> impl FnMut() -> ChildLiveness {
+        let mut n = 0usize;
+        move || {
+            let idx = n.min(script.len().saturating_sub(1));
+            n += 1;
+            script[idx]
+        }
+    }
+
+    #[tokio::test]
+    async fn watching_child_fails_fast_when_child_exits_before_health() {
+        // The issue #1259 case: the daemon binary launches but its process
+        // dies before `/health` ever comes up. We must surface the exit code,
+        // not wait out the full startup timeout.
+        let (mut probe, probe_calls) = scripted_probe(vec![ProbeOutcome::Absent]);
+        // First poll: still starting; second poll: dead with a DLL-load code.
+        let mut poll_child = scripted_child(vec![
+            ChildLiveness::Running,
+            ChildLiveness::Exited {
+                code: Some(0xC000_0135u32 as i32),
+            },
+        ]);
+
+        let err = wait_for_daemon_health_watching_child(
+            &mut probe,
+            &mut poll_child,
+            Duration::from_secs(30),
+            Duration::from_millis(1),
+        )
+        .await
+        .expect_err("a child that exits before health must fail fast");
+
+        match err {
+            DaemonBootstrapError::SpawnExitedEarly { code } => {
+                assert_eq!(code, Some(0xC000_0135u32 as i32));
+            }
+            other => panic!("expected SpawnExitedEarly, got: {other}"),
+        }
+        // Must NOT have spun for the full timeout — a couple of polls, no more.
+        assert!(
+            probe_calls.load(Ordering::SeqCst) <= 2,
+            "must fail on the exit, not exhaust the startup budget"
+        );
+    }
+
+    #[tokio::test]
+    async fn watching_child_succeeds_when_daemon_becomes_healthy() {
+        // Child stays alive and the daemon eventually serves `/health`.
+        let (mut probe, _) = scripted_probe(vec![
+            ProbeOutcome::Absent,
+            ProbeOutcome::Compatible(ok_health()),
+        ]);
+        let mut poll_child = scripted_child(vec![ChildLiveness::Running]);
+
+        wait_for_daemon_health_watching_child(
+            &mut probe,
+            &mut poll_child,
+            Duration::from_secs(5),
+            Duration::from_millis(1),
+        )
+        .await
+        .expect("a live child that becomes healthy must resolve Ok");
+    }
+
+    #[tokio::test]
+    async fn watching_child_prefers_compatible_over_a_racing_exit() {
+        // Probe-first ordering: if `/health` is already healthy, a same-tick
+        // child exit (e.g. a different, healthy daemon owns the port) must not
+        // mask success.
+        let (mut probe, _) = scripted_probe(vec![ProbeOutcome::Compatible(ok_health())]);
+        let mut poll_child = scripted_child(vec![ChildLiveness::Exited { code: Some(1) }]);
+
+        wait_for_daemon_health_watching_child(
+            &mut probe,
+            &mut poll_child,
+            Duration::from_secs(5),
+            Duration::from_millis(1),
+        )
+        .await
+        .expect("a healthy probe must win over a racing child exit");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn watching_child_still_times_out_when_child_lingers_unhealthy() {
+        // A child that stays alive but never serves `/health` must still hit
+        // the startup timeout — liveness watching only shortcuts a real crash.
+        let (mut probe, _) = scripted_probe(vec![ProbeOutcome::Absent]);
+        let mut poll_child = scripted_child(vec![ChildLiveness::Running]);
+
+        let err = wait_for_daemon_health_watching_child(
+            &mut probe,
+            &mut poll_child,
+            Duration::from_millis(100),
+            Duration::from_millis(10),
+        )
+        .await
+        .expect_err("a lingering-but-unhealthy child must time out");
+
+        assert!(matches!(
+            err,
+            DaemonBootstrapError::StartupTimeout { timeout_ms: 100 }
+        ));
     }
 }

--- a/crates/uc-daemon-process/src/spawn.rs
+++ b/crates/uc-daemon-process/src/spawn.rs
@@ -80,6 +80,36 @@ pub fn spawn_detached_daemon(
     origin: DaemonSpawnOrigin,
     handover_dir_override: Option<std::path::PathBuf>,
 ) -> Result<(), SpawnDaemonError> {
+    // Drop the handle deliberately (see fn doc): fire-and-forget detach. This
+    // is the historical contract for callers that only care that the spawn
+    // syscall succeeded and then prove liveness by polling `/health`.
+    let child = spawn_detached_daemon_returning_child(origin, handover_dir_override)?;
+    drop(child);
+    Ok(())
+}
+
+/// Like [`spawn_detached_daemon`], but hands back the spawned [`Child`] so the
+/// caller can watch for an **early exit** while it waits for `/health`.
+///
+/// This exists because `Command::spawn` returning `Ok` does NOT prove the
+/// daemon is running: on Windows `CreateProcess` succeeds even when the image
+/// loader later fails to resolve a dependency (e.g. a missing `vcruntime140.dll`
+/// — issue #1259), so the process is created and then dies within
+/// milliseconds. A caller that only polls `/health` cannot distinguish that
+/// hard crash from a slow start until the (long) startup timeout elapses.
+/// Holding the `Child` lets it observe the exit and its code via
+/// [`poll_child_liveness`] / [`std::process::Child::try_wait`] and fail fast.
+///
+/// The parent may `try_wait`/`wait` the returned handle regardless of the
+/// detach flags: `DETACHED_PROCESS` / `setsid` only govern console and session
+/// membership, not the parent↔child handle. The caller MUST drop the handle
+/// once the daemon is confirmed healthy — dropping detaches cleanly (it neither
+/// kills the process nor, on Unix, reaps it; the child is reparented to PID 1
+/// when the spawner exits), preserving the daemon's independent lifetime.
+pub fn spawn_detached_daemon_returning_child(
+    origin: DaemonSpawnOrigin,
+    handover_dir_override: Option<std::path::PathBuf>,
+) -> Result<std::process::Child, SpawnDaemonError> {
     let daemon_exe = resolve_daemon_exe_path()?;
 
     let mut command = Command::new(&daemon_exe);
@@ -120,10 +150,28 @@ pub fn spawn_detached_daemon(
         )))
     })?;
 
-    // Drop the handle deliberately — see fn doc. The detached child runs on its
-    // own; the spawner's responsibility ends here.
-    drop(child);
-    Ok(())
+    // Hand the live handle back — the caller decides whether to watch it for an
+    // early exit or drop it for fire-and-forget detach (see fn doc).
+    Ok(child)
+}
+
+/// Non-blocking check of whether a freshly-spawned daemon [`Child`] has already
+/// exited, mapped into the transport-neutral [`ChildLiveness`] the health-wait
+/// loop consumes (so `health_wait` need not know about `std::process`).
+///
+/// A `try_wait` error (rare — e.g. the handle was already reaped) maps to
+/// [`ChildLiveness::Running`]: we cannot *prove* the child is dead, so we let
+/// the `/health` startup timeout bound the wait rather than misreport a crash
+/// that may not have happened.
+pub fn poll_child_liveness(child: &mut std::process::Child) -> crate::health_wait::ChildLiveness {
+    use crate::health_wait::ChildLiveness;
+    match child.try_wait() {
+        Ok(Some(status)) => ChildLiveness::Exited {
+            code: status.code(),
+        },
+        Ok(None) => ChildLiveness::Running,
+        Err(_) => ChildLiveness::Running,
+    }
 }
 
 /// Resolve the directory to read the pending handover record from.

--- a/crates/uc-desktop/src/daemon_probe.rs
+++ b/crates/uc-desktop/src/daemon_probe.rs
@@ -22,12 +22,14 @@ use uc_daemon_contract::probe::{
 use uc_daemon_process::contract::{
     terminate_local_daemon_pid, DaemonBootstrapError, TerminateDaemonError,
 };
-use uc_daemon_process::health_wait::{wait_for_daemon_health, wait_for_endpoint_absent};
+use uc_daemon_process::health_wait::{
+    wait_for_daemon_health_watching_child, wait_for_endpoint_absent,
+};
 use uc_daemon_process::process_metadata::{
     find_pid_by_port, read_pid_metadata, DaemonPidMetadata, DaemonProcessMode, DaemonSpawnOrigin,
 };
 use uc_daemon_process::socket::try_resolve_daemon_http_addr;
-use uc_daemon_process::spawn::spawn_detached_daemon;
+use uc_daemon_process::spawn::{poll_child_liveness, spawn_detached_daemon_returning_child};
 
 use crate::daemon::{DaemonLaunchOrigin, DaemonOwnership};
 
@@ -122,7 +124,7 @@ pub fn load_daemon_connection_info() -> Result<DaemonConnectionInfo, DaemonBoots
 ///
 /// ADR-008 P3-3 (B2'-3): GUI 是外部 `uniclipd` 的纯客户端。不再有 in-process
 /// daemon —— 没有 daemon 时拉起的是一个 **detached 外部进程**
-/// ([`spawn_detached_daemon`])。
+/// ([`spawn_detached_daemon_returning_child`])。
 ///
 /// 行为：
 /// 1. 探测本机 daemon HTTP 端点；
@@ -248,17 +250,40 @@ async fn spawn_external_and_wait_health(
 ) -> Result<(), DaemonBootstrapError> {
     // ADR-008 D3: tag the spawn as GUI-owned so its PID file records
     // `spawned_by = gui` — this (or another) GUI may stop it on full quit.
-    spawn_detached_daemon(DaemonSpawnOrigin::Gui, None).map_err(|error| {
-        DaemonBootstrapError::Spawn(
-            anyhow::Error::new(error).context("detached daemon spawn failed"),
-        )
-    })?;
+    //
+    // Keep the child handle so the wait loop can watch for an early exit: on
+    // Windows `Command::spawn` returns `Ok` even when the image loader later
+    // fails to resolve a dependency DLL (e.g. a missing `vcruntime140.dll`,
+    // issue #1259) and the process dies within milliseconds. Without watching
+    // the child, that hard crash is indistinguishable from a slow start until
+    // the (long) `health_check_timeout` elapses.
+    let mut child =
+        spawn_detached_daemon_returning_child(DaemonSpawnOrigin::Gui, None).map_err(|error| {
+            DaemonBootstrapError::Spawn(
+                anyhow::Error::new(error).context("detached daemon spawn failed"),
+            )
+        })?;
     ownership.set_external();
     // This launch spawned the daemon — a genuine cold start (issue #1169).
     launch_origin.mark_spawned();
 
     let mut probe_fn = || async { probe_daemon_health(client, expected_package_version).await };
-    wait_for_daemon_health(&mut probe_fn, health_check_timeout, health_poll_interval).await
+    let mut poll_child = || poll_child_liveness(&mut child);
+    let result = wait_for_daemon_health_watching_child(
+        &mut probe_fn,
+        &mut poll_child,
+        health_check_timeout,
+        health_poll_interval,
+    )
+    .await;
+
+    // Drop the handle now the outcome is known: on success this detaches the
+    // healthy daemon (it keeps running independently); on failure the process
+    // is already gone. Dropping neither kills nor reaps it — see
+    // `spawn_detached_daemon_returning_child`.
+    drop(poll_child);
+    drop(child);
+    result
 }
 
 /// 终止 PID 文件指向的不兼容 daemon——但**绝不**对 in-process daemon 动手。
@@ -628,16 +653,32 @@ pub async fn restart_local_daemon(
     }
 
     // ── 4. spawn 新 daemon ────────────────────────────────────────
+    // Hold the child handle so step 5 can fail fast if the freshly-spawned
+    // daemon exits on launch (e.g. a broken build with a missing dependency
+    // DLL) instead of waiting out the full startup timeout — issue #1259.
     tracing::info!("restart_local_daemon: spawning new daemon");
-    spawn_detached_daemon(DaemonSpawnOrigin::Gui, None).map_err(|e| {
-        DaemonBootstrapError::Spawn(
-            anyhow::Error::new(e).context("restart_local_daemon: failed to spawn new daemon"),
-        )
-    })?;
+    let mut child =
+        spawn_detached_daemon_returning_child(DaemonSpawnOrigin::Gui, None).map_err(|e| {
+            DaemonBootstrapError::Spawn(
+                anyhow::Error::new(e).context("restart_local_daemon: failed to spawn new daemon"),
+            )
+        })?;
 
     // ── 5. 等待新 daemon 就绪 ────────────────────────────────────
     let mut probe_fn = || async { probe_daemon_health(&client, expected_package_version).await };
-    wait_for_daemon_health(&mut probe_fn, HEALTH_CHECK_TIMEOUT, HEALTH_POLL_INTERVAL).await?;
+    let mut poll_child = || poll_child_liveness(&mut child);
+    let wait_result = wait_for_daemon_health_watching_child(
+        &mut probe_fn,
+        &mut poll_child,
+        HEALTH_CHECK_TIMEOUT,
+        HEALTH_POLL_INTERVAL,
+    )
+    .await;
+    // Detach the healthy daemon (or release the handle of a crashed one) before
+    // returning — dropping neither kills nor reaps it.
+    drop(poll_child);
+    drop(child);
+    wait_result?;
 
     // ── 6. 返回新连接信息 ────────────────────────────────────────
     let info = load_daemon_connection_info()?;


### PR DESCRIPTION
## Summary

- retain the detached daemon child handle while waiting for `/health`
- detect an early child exit and report it separately from a startup timeout
- render Windows loader NTSTATUS codes with actionable runtime guidance
- preserve the existing fire-and-forget spawn API for callers that do not watch the child

## Root cause

On Windows, `CreateProcess` can succeed before the image loader discovers a missing runtime DLL. The GUI therefore saw a successful spawn, dropped the child handle, and eventually reported only a generic health timeout. Watching `Child::try_wait()` during health polling preserves the process exit code and distinguishes a hard launch failure from a slow startup.

Fixes #1259.

## Verification

- `cargo check -p uc-daemon-process --quiet`
- `cargo test -p uc-daemon-process --lib --quiet` (54 passed)
- `cargo test -p uc-desktop daemon_probe --quiet` (14 passed)
- LSP diagnostics on the four affected Rust files: no errors or warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved daemon startup monitoring to detect processes that exit immediately.
  - Startup failures now surface promptly instead of waiting for the full health-check timeout.
  - Error messages provide clearer exit-code details, including helpful hints for recognized missing or incompatible runtime issues.
  - Daemon restarts now monitor process health and report early failures consistently.
- **Reliability**
  - Improved handling of daemon startup timeouts and health-check races for more predictable launch behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->