### PR TITLE
docs(docs-site): extract Tailscale cross-network sync into its own guide

### DIFF
--- a/docs-site/content/docs/en/core-features/mobile-sync.mdx
+++ b/docs-site/content/docs/en/core-features/mobile-sync.mdx
@@ -343,132 +343,24 @@ public internet. The `--ip <IP>` form instead produces the LAN
 
 ## Cross-network sync via Tailscale
 
-Tailscale is one of two ways to use mobile sync across networks; the
-other is a [headless server node](../guides/self-host-server-node) that
-exposes the gateway as a public HTTPS endpoint. Tailscale is the
-lighter-weight option when you control both the desktop and the phone
-and don't want to run a VPS.
+Put the desktop and phone on the same Tailscale network (tailnet) and each gets
+a `100.x.x.x` address — the phone can reach the desktop from cellular or a
+remote Wi-Fi exactly as if they shared a LAN, with no VPS and no domain. Since
+**0.12** the **Bind IP** dropdown also lists `100.64.0.0/10` (Tailscale's CGNAT
+range).
 
-By default, **the desktop listener is only reachable on the same Wi-Fi**
-— once the phone moves to cellular (4G/5G) or to a different Wi-Fi, it
-can't reach the listener. Since **0.12**, the **Bind IP** dropdown also
-lists addresses in `100.64.0.0/10` (the CGNAT block Tailscale assigns
-to its virtual interfaces). If both the desktop and the phone are
-signed in to the same Tailscale network (tailnet), you can pair them
-exactly like on a LAN, with the **whole path carried over the
-Tailscale / WireGuard tunnel**.
-
-Typical setup:
-
-- Desktop sits at home on Ethernet / Wi-Fi;
-- Phone is out on 4G/5G cellular, or on someone else's Wi-Fi;
-- Both signed in to the same Tailscale account → reachable over the
-  tailnet directly.
+For the full walkthrough, caveats, and troubleshooting see
+**[Cross-network sync with Tailscale](../guides/tailscale)**. The other
+cross-network path is a self-hosted [server node](../guides/self-host-server-node),
+which exposes the gateway as a public HTTPS endpoint; that page also compares
+the two.
 
 <Callout type="info">
   **This only changes _reachability_, not the v1 HTTP wire format.** The listener still speaks plain
-  HTTP + Basic Auth; confidentiality is provided by the Tailscale / WireGuard tunnel you trust. If
-  you don't trust Tailscale as a network layer, keep using the LAN-only setup.
+  HTTP + Basic Auth; confidentiality is provided by the Tailscale / WireGuard tunnel you trust. It
+  also does **not** close the listener on your LAN — the socket always binds `0.0.0.0`, and "Bind IP"
+  only picks which address is advertised to the phone.
 </Callout>
-
-<Steps>
-
-<Step>
-
-### Install Tailscale on the desktop and phone, sign in to the same account
-
-- **Desktop** — install the official client
-  ([tailscale.com/download](https://tailscale.com/download)) and stay
-  **Connected**. On Linux run `tailscale up` after the daemon is up;
-  on macOS / Windows, hit **Connect** from the menu bar / system tray.
-- **Phone** — install **Tailscale** from the App Store / Google Play,
-  sign in to the **same account**, and flip the VPN toggle on. iOS
-  will ask permission to add a VPN configuration — accept it.
-
-Once both ends are **Connected**, you'll see each other in the
-Tailscale client's **Machines** list, each with a `100.x.x.x` tailnet
-IPv4.
-
-</Step>
-
-<Step>
-
-### Pick the Tailscale interface in the desktop **Configure** dialog
-
-Go back to **Devices → Mobile sync → Configure**. In the **Bind IP**
-dropdown, pick the `100.x.x.x` entry (the Tailscale CGNAT one). The
-**current listening address** row immediately switches to
-`http://100.x.x.x:42720`, and any credentials minted from now on will
-embed that address.
-
-No daemon restart is needed — the listener hot-swaps. The actual
-socket still binds on `0.0.0.0`; **the "Bind IP" picker only controls
-which address is advertised to the phone.**
-
-<Callout type="info">
-  This is **independent** of the **Settings → Network → Allow overlay network addrs** toggle. That
-  toggle gates desktop-↔-desktop P2P path candidates; mobile sync is a manual pick of an address
-  that gets handed to the phone, so the Tailscale CGNAT range is always listed here.
-</Callout>
-
-</Step>
-
-<Step>
-
-### Click **Add device** and scan from the phone
-
-Run the normal **Add device** flow from
-[Enable mobile sync](#enable-mobile-sync-one-shot). The connect-URI
-QR at the top of the credentials modal now encodes the tailnet
-`http://100.x.x.x:42720` address.
-
-If you've already paired a device on a LAN interface, you don't have
-to re-add it: open the device card's dialog (or the credentials
-modal) and switch the **baseUrl dropdown** to the Tailscale entry —
-the QR refreshes in place with a new connect URI. No trip back to
-Configure required.
-
-</Step>
-
-<Step>
-
-### Scan from the phone and keep Tailscale connected
-
-Scan the top QR from the UniClipboard iOS / Android app; all fields
-auto-fill. **As long as the phone's Tailscale VPN stays Connected**,
-sync works the same way it would on the home LAN, whether the phone
-is on cellular or some unrelated Wi-Fi.
-
-</Step>
-
-</Steps>
-
-### Caveats and limits
-
-- **Both ends must stay Connected on Tailscale.** If the phone's
-  Tailscale drops (manual disconnect, OS background-killed, or
-  carrier idle-timeout), you're back to "unreachable from off-LAN"
-  and requests will hang / fail.
-- **MagicDNS hostnames aren't used.** The credentials URL embeds the
-  raw `100.x.x.x` IP; even if you've given the desktop a Tailscale
-  alias (e.g. `desktop.tail-XXXX.ts.net`), we **don't** write that
-  name into the connect URI. Stick with the numeric IP.
-- **Mobile background restrictions still apply.** iOS clipboard reads
-  are gated on lock / background, and Android 10+ has similar limits.
-  Tailscale doesn't change OS behaviour here. For predictable
-  "background sync," keep the app foregrounded or whitelisted.
-- **This is not v2 TLS.** Tailscale gives you _network-layer_
-  confidentiality. If your threat model needs end-to-end semantics
-  (e.g. you can't trust the desktop machine itself), this path
-  doesn't fix that — wait for v2 TLS.
-
-Troubleshooting: if the phone can ping `100.x.x.x` but the app times
-out, the desktop's Tailscale is usually the problem — either it
-isn't Connected, or you're going through a DERP relay with throttled
-throughput (Tailscale free plan caps relays around ~50 KB/s, which
-makes large images / files crawl). Check both ends are **Online** in
-the Tailscale "Machines" list and confirm a **direct** connection
-(rather than a DERP relay) between them.
 
 ## Manage paired devices
 

--- a/docs-site/content/docs/en/core-features/sync.mdx
+++ b/docs-site/content/docs/en/core-features/sync.mdx
@@ -107,7 +107,8 @@ Known limits compared to desktop ↔ desktop sync:
   NAT hole-punching, or relay — it's a plain HTTP client. On the same
   LAN it works out of the box; to reach it across networks, run a
   [headless server node](../guides/self-host-server-node) (a public
-  HTTPS endpoint) or put both ends on a Tailscale / VPN overlay.
+  HTTPS endpoint) or put both ends on a
+  [Tailscale / VPN overlay](../guides/tailscale).
 - **No mobile-to-mobile sync.** Two phones don't talk directly to
   each other; both talk to the desktop.
 - **No per-direction or per-content-type gates yet** for mobile

--- a/docs-site/content/docs/en/guides/meta.json
+++ b/docs-site/content/docs/en/guides/meta.json
@@ -2,5 +2,12 @@
   "title": "Guides",
   "icon": "BookOpen",
   "defaultOpen": true,
-  "pages": ["pairing", "config-migration", "settings", "self-host-relay", "self-host-server-node"]
+  "pages": [
+    "pairing",
+    "config-migration",
+    "settings",
+    "tailscale",
+    "self-host-relay",
+    "self-host-server-node"
+  ]
 }

--- a/docs-site/content/docs/en/guides/pairing.mdx
+++ b/docs-site/content/docs/en/guides/pairing.mdx
@@ -146,8 +146,9 @@ an iroh peer. "Cross-network," then, means reaching the gateway from
 another network rather than P2P: run a
 [headless server node](./self-host-server-node) that exposes the gateway
 as a public HTTPS endpoint, or put the desktop and phone on the same
-Tailscale / VPN overlay. See
-[Mobile sync](../core-features/mobile-sync) for both paths.
+[Tailscale / VPN overlay](./tailscale). See
+[Cross-network sync with Tailscale](./tailscale) for a comparison of both
+paths.
 
 ### Pairing a mobile device
 

--- a/docs-site/content/docs/en/guides/tailscale.mdx
+++ b/docs-site/content/docs/en/guides/tailscale.mdx
@@ -1,0 +1,347 @@
+---
+title: Cross-network sync with Tailscale
+description: No VPS, no domain, no certificates — put your phone and desktop on the same tailnet and sync from any network.
+---
+
+import { Step, Steps } from 'fumadocs-ui/components/steps'
+import { Tab, Tabs } from 'fumadocs-ui/components/tabs'
+
+UniClipboard's mobile client is an **HTTP companion** — it doesn't join your
+space's trust mesh and doesn't run a P2P node. It just talks to the small HTTP
+gateway the desktop exposes, using a base URL + Basic Auth. By default that
+gateway is **only reachable on the same Wi-Fi**: once the phone moves to
+cellular or someone else's Wi-Fi, it can't reach it.
+
+Put the desktop and the phone on the same **Tailscale network (tailnet)** and
+each gets a `100.x.x.x` address — the phone can then reach the desktop exactly
+as if they shared a LAN, with the whole path carried over the Tailscale /
+WireGuard tunnel. No VPS, no domain, no certificates.
+
+This page covers:
+
+- what this does and — importantly — what it does **not** do (it does not close
+  your gateway off)
+- how to configure the desktop and phone (GUI and CLI)
+- why one QR scan gives you both a LAN and a tailnet address
+- advanced: routing desktop-↔-desktop P2P over the tailnet too
+- how to choose between this and a [self-hosted server node](./self-host-server-node)
+
+## What it solves, and what it doesn't
+
+It changes **reachability** only — the wire protocol is untouched:
+
+- **Solves**: the phone can reach the desktop gateway from any network.
+  Confidentiality comes from the Tailscale / WireGuard tunnel you trust.
+- **Doesn't solve**: the gateway still speaks **plain HTTP + Basic Auth**. This
+  path gives you no end-to-end TLS semantics — if your threat model needs that,
+  see [self-hosted server node](./self-host-server-node) (real HTTPS certs).
+- **Doesn't solve**: when the desktop sleeps or shuts down, the phone can't
+  reach it either. A tailnet won't keep your desktop online. If you need sync to
+  stay up while every desktop sleeps, that's the server-node scenario.
+
+<Callout type="warn">
+  **Tailscale does not close the listener on your LAN.** The gateway socket
+  **always binds `0.0.0.0`** — this is not configurable. The **Bind IP** picker
+  used below is **advertisement-only**: it decides which address goes into the
+  install URL / QR handed to the phone, and **nothing else**. Even after you
+  pick `100.x.x.x`, the gateway **is still listening in cleartext on your
+  physical LAN**. Tailscale gets your phone *in* from outside; it does not keep
+  anyone else *out*. On untrusted networks (public Wi-Fi), turn it off.
+</Callout>
+
+## How the path works
+
+```mermaid
+flowchart LR
+  subgraph net1[Phone's network · cellular / remote Wi-Fi]
+    P[📱 Mobile client<br/>Tailscale VPN connected]
+  end
+  subgraph ts[tailnet · WireGuard-encrypted]
+    R[Direct hole-punch<br/>DERP relay on failure]
+  end
+  subgraph net2[Desktop's network · home / office]
+    D[💻 Desktop daemon<br/>gateway binds 0.0.0.0:42720<br/>tailnet addr 100.x.x.x]
+  end
+  P -->|HTTP · GET pull / PUT push| R
+  R --> D
+```
+
+Compared to the [server node](./self-host-server-node) path: there's **no VPS,
+no Caddy, no certificate issuance** — one fewer machine in the chain. The
+trade-off is that the desktop has to stay awake.
+
+## Prerequisites
+
+- A Tailscale account both the desktop and phone can sign in to.
+- UniClipboard desktop **0.12 or newer** (the Bind IP dropdown only lists the
+  CGNAT range from 0.12 on).
+- The desktop stays **awake** while you sync — asleep means unreachable.
+- The [UniClipboard mobile app](https://github.com/UniClipboard/UniClip) on your phone.
+
+## Setup
+
+<Steps>
+
+<Step>
+
+### Install Tailscale on both ends, sign in to the same account
+
+Install Tailscale on both the desktop and the phone, and **sign in to the same
+account**. The official page [tailscale.com/download](https://tailscale.com/download)
+is authoritative; the common platforms:
+
+<Tabs items={['Linux', 'macOS', 'Windows', 'iOS', 'Android']}>
+
+<Tab value="Linux">
+
+Official one-line installer (detects your distro, installs the `tailscaled`
+service, and enables it on boot):
+
+```bash
+curl -fsSL https://tailscale.com/install.sh | sh
+```
+
+Then sign in and connect (it prints an auth link to open in a browser):
+
+```bash
+sudo tailscale up
+```
+
+`tailscale status` should list this machine and the others on your tailnet.
+
+</Tab>
+
+<Tab value="macOS">
+
+Pick one:
+
+- **App Store** — search **Tailscale** (includes the menu-bar GUI, easiest).
+- **Standalone** — grab the `.pkg` from [tailscale.com/download/macos](https://tailscale.com/download/macos).
+- **Homebrew (CLI / headless)**:
+
+  ```bash
+  brew install tailscale
+  sudo tailscale up
+  ```
+
+With the GUI build, click **Connect** in the menu bar and sign in.
+
+</Tab>
+
+<Tab value="Windows">
+
+Download the installer from [tailscale.com/download/windows](https://tailscale.com/download/windows),
+or use winget:
+
+```powershell
+winget install tailscale.tailscale
+```
+
+Then click the Tailscale tray icon → **Log in / Connect** and sign in.
+
+</Tab>
+
+<Tab value="iOS">
+
+Install **Tailscale** from the App Store
+([App Store link](https://apps.apple.com/app/tailscale/id1470499037)), sign in,
+and flip the VPN toggle on. iOS asks permission to add a VPN configuration —
+accept it.
+
+</Tab>
+
+<Tab value="Android">
+
+Install **Tailscale** from Google Play
+([Google Play link](https://play.google.com/store/apps/details?id=com.tailscale.ipn)),
+sign in, and flip the VPN toggle on. On devices without Google Play, grab the
+APK from the official site.
+
+</Tab>
+
+</Tabs>
+
+Keep the desktop **Connected** and turn the phone's VPN toggle on. Once both are
+up, each should see the other in the Tailscale client's **Machines** list, each
+with a `100.x.x.x` tailnet IPv4. **Confirm this before moving on** — nine out of
+ten problems later trace back to this step.
+
+</Step>
+
+<Step>
+
+### Point the advertised address at the tailnet
+
+<Tabs items={['GUI', 'CLI']}>
+
+<Tab value="GUI">
+
+Go to **Devices → Mobile sync → Configure** and pick the `100.x.x.x` (Tailscale)
+entry in the **Bind IP** dropdown. The **current listening address** row switches
+to `http://100.x.x.x:42720` immediately, and every credential minted from now on
+embeds that address.
+
+No daemon restart needed — the listener hot-swaps.
+
+</Tab>
+
+<Tab value="CLI">
+
+List the eligible interfaces and find the one starting with `100.`:
+
+```bash
+uniclip mobile network interfaces
+```
+
+Then point the advertised address at it (`--ip` renders as `http://<IP>:42720`):
+
+```bash
+uniclip mobile network set --ip 100.101.102.103 --accept-network-risk
+```
+
+<Callout type="info">
+  `--accept-network-risk` only skips the interactive y/N confirmation — it
+  **changes no technical behavior**, and is required for non-interactive use
+  (scripts / CI). The warning text it prints is hardcoded for the LAN case and
+  prints verbatim on the tailnet path too — defer to the warn callout above.
+</Callout>
+
+</Tab>
+
+</Tabs>
+
+<Callout type="info">
+  This is **independent** of the **Settings → Network → Allow overlay network
+  addrs** toggle. That toggle gates desktop-↔-desktop P2P path candidates (see
+  [below](#advanced-desktop-to-desktop-p2p-over-the-tailnet)); mobile sync is a manual pick of an address handed to the
+  phone, so the Tailscale range is **always listed** here. The two mechanisms are
+  deliberately separate.
+</Callout>
+
+</Step>
+
+<Step>
+
+### Add a device and scan from the phone
+
+Run the normal [Mobile sync → Add device](../core-features/mobile-sync#enable-mobile-sync-one-shot) flow:
+
+```bash
+uniclip mobile add --label "My iPhone"
+```
+
+The QR in the modal / terminal now encodes the tailnet address. **The one-time
+password is shown once** — copy it now.
+
+Already paired on a LAN interface? You don't need to re-add the device — switch
+to the Tailscale interface in the **baseUrl dropdown** of the credentials modal /
+device card dialog and the QR refreshes in place.
+
+</Step>
+
+<Step>
+
+### Scan from the phone, and keep Tailscale connected
+
+Scan with the UniClipboard app — every field fills in automatically. From then
+on, **as long as the phone's Tailscale VPN is Connected**, sync works both ways
+on cellular or any external Wi-Fi.
+
+</Step>
+
+</Steps>
+
+## You don't need to enter two addresses
+
+The QR encodes **a candidate list, not a single address**: when minting
+credentials the desktop puts *every* eligible interface — LAN (`192.168.x` /
+`10.x`) and tailnet (`100.x`) — into the connect URI, and the client probes them
+in turn.
+
+So one scan gets you both paths: **direct LAN at home** (fast, no WireGuard
+detour) and **automatic tailnet fallback when you're out**. The app re-picks
+after a network change and labels which address it **will use** — no manual
+switching.
+
+The CGNAT range sorts **last** in the dropdown (order: `10/8 → 172.16/12 →
+192.168/16 → 100.64/10`), so real LAN interfaces win. The tailnet address is
+only auto-selected when **no RFC1918 interface** is available.
+
+## Advanced: desktop-to-desktop P2P over the tailnet
+
+Everything above is **phone ↔ desktop**. Desktops talk to each other over iroh
+P2P, which treats Tailscale addresses the **opposite** way by default:
+
+| | Default for Tailscale `100.x` | Why |
+| --- | --- | --- |
+| Mobile sync (advertised addr) | **Included** | you pick the address by hand — no path-probing cost |
+| Desktop P2P (dial candidates) | **Filtered out** | automatic path racing would burn its budget on dead paths |
+
+This asymmetry is deliberate, and it's the easiest thing on this page to
+conflate. Only when **both desktops are on the same tailnet** and you want iroh
+to use that path do you need: **Settings → Network → Allow overlay network addrs**.
+
+Once on, Tailscale CGNAT (`100.64.0.0/10`) and the IPv6 ULA
+(`fd7a:115c:a1e0::/48`) are published as direct candidates and written into
+pairing invites.
+
+<Callout type="warn">
+  **Restart the daemon after changing this.** The address filter is fixed at iroh
+  endpoint **bind time** — the toggle does not take effect hot.
+</Callout>
+
+<Callout type="info">
+  Clash TUN fake-ip (`198.18.0.0/15`) and IPv4 link-local (`169.254.0.0/16`) are
+  **always filtered, with no toggle** — those interfaces can't carry a real dial
+  anyway.
+</Callout>
+
+Typical symptom: the sponsor runs Tailscale, the joiner's invite contains only
+unreachable LAN addresses, and pairing never connects — see
+[pairing failures](../help/troubleshooting#pairing-failures).
+
+## Caveats and limits
+
+- **Both ends must stay connected to Tailscale.** Once the phone disconnects
+  (manual Disconnect, killed in the background, or suspended after a long idle),
+  you're back to "unreachable outside the LAN" and requests time out.
+- **MagicDNS hostnames are not supported.** The connect URI always carries the
+  numeric `100.x.x.x` IP; even if you've given the desktop an alias like
+  `desktop.tail-XXXX.ts.net`, we **won't** write it in.
+- **DERP fallback is noticeably slower.** When hole-punching fails, traffic goes
+  through Tailscale's DERP relays at far lower bandwidth than a direct path —
+  large images and files will struggle. Check whether your two machines are
+  **direct** or **DERP** in the Tailscale client.
+- **Mobile background limits still apply.** iOS on lock/background and Android
+  10+ restrict clipboard access — unrelated to Tailscale, it's OS behavior. Keep
+  the app in the foreground for reliable background sync.
+- **The gateway still listens on your LAN** (see the warn callout at the top).
+
+## Troubleshooting
+
+| Symptom | Where to look |
+| --- | --- |
+| App reports a connection timeout | First confirm **both machines are online** in the Tailscale **Machines** list on both ends. Nine out of ten issues are here. |
+| Phone can ping `100.x` but the app times out | The desktop gateway is off or on a different port. Run `uniclip mobile status` to see the current listening URL. |
+| Sync is slow, large files stall | You're probably on DERP relays. Check direct vs DERP in the Tailscale client. |
+| Auth failure / 401 | Wrong username or password. Rotate on the desktop and re-enter on the phone. |
+| Can't connect after returning to home Wi-Fi | Check which address the app says it **will use**; confirm the LAN entry is in the candidate list. |
+| Desktop-↔-desktop pairing won't connect | Turn on **Allow overlay network addrs** on the sponsor and **restart the daemon** so Tailscale addresses reach the invite. |
+
+## Choosing: Tailscale or a server node
+
+| | Tailscale | [Server node](./self-host-server-node) |
+| --- | --- | --- |
+| Needs a VPS / domain | ❌ No | ✅ Yes |
+| Syncs while the desktop sleeps | ❌ No | ✅ Yes |
+| Extra app on the phone | ✅ Yes (Tailscale) | ❌ No |
+| Transport confidentiality | 🔒 WireGuard tunnel (network layer) | 🔒 Real HTTPS certs |
+| Large-file speed | ⚡ Fast when direct; slow on DERP | 🌐 Bounded by VPS bandwidth |
+| Operational cost | 🟢 Almost none | 🟡 Container, certs, backups to maintain |
+
+Both ends are yours and you'd rather not run a VPS — pick Tailscale. You need
+the phone to work while every desktop is off, or you want a stable public HTTPS
+endpoint — pick the server node.
+
+The two **aren't mutually exclusive**: configure both and the phone's candidate
+list can carry the tailnet address *and* the public gateway.

--- a/docs-site/content/docs/en/help/faq.mdx
+++ b/docs-site/content/docs/en/help/faq.mdx
@@ -251,7 +251,8 @@ What "companion" means in practice:
   P2P, no NAT hole-punching, and no encrypted relay** on the mobile
   side. It works on the LAN out of the box; for cross-network reach,
   run a [headless server node](../guides/self-host-server-node) (a
-  public HTTPS endpoint) or use a Tailscale / VPN overlay.
+  public HTTPS endpoint) or use a
+  [Tailscale / VPN overlay](../guides/tailscale).
 - **Mobile is not a peer.** Mobile devices don't join the space's
   trust mesh and don't sync between each other; they exchange
   clipboard with whichever desktop they're paired to.

--- a/docs-site/content/docs/en/mobile/connect.mdx
+++ b/docs-site/content/docs/en/mobile/connect.mdx
@@ -30,6 +30,7 @@ Open the UniClipboard desktop app on your computer and go to
   [Pairing & Sync](../guides/pairing).
 - Your phone and computer need to be on the **same Wi-Fi**, or both on the same
   Tailscale / VPN. For access across networks, see
+  [Cross-network sync with Tailscale](../guides/tailscale) or
   [Self-Hosted Server Node](../guides/self-host-server-node).
 
 The **plaintext password is usually shown only once**. If the scan or entry

--- a/docs-site/content/docs/zh/core-features/mobile-sync.mdx
+++ b/docs-site/content/docs/zh/core-features/mobile-sync.mdx
@@ -304,116 +304,20 @@ uniclip mobile network set \
 
 ## 跨网络同步：搭配 Tailscale
 
-Tailscale 是移动端跨网络同步的两条路径之一；另一条是自建
-[无头 server 节点](../guides/self-host-server-node)，把网关暴露成公网
-HTTPS 端点。当你自己同时掌握桌面与手机、又不想跑 VPS 时，Tailscale
-是更轻量的选择。
+把桌面与手机接进同一个 Tailscale 网络（tailnet），两端各拿一个 `100.x.x.x`
+地址，手机在蜂窝 / 异地 Wi-Fi 下也能像同 LAN 一样直连桌面 —— 不需要 VPS、
+不需要域名。从 **0.12** 起，「监听 IP」下拉会一并列出 `100.64.0.0/10`
+（Tailscale 的 CGNAT 段）。
 
-默认情况下，**桌面那个监听器只在同一个 Wi-Fi 下可达** —— 手机走
-4G/5G、或人在外面接别人的 Wi-Fi 时，是 **拨不通** 它的。从
-**0.12** 起，「监听 IP」下拉额外把 `100.64.0.0/10` 这一段 CGNAT
-地址（Tailscale 默认给虚拟网卡用的 IPv4 区段）也列了出来，所以只要
-桌面与手机都接入同一个 Tailscale 网络（tailnet），就能像在同一个
-LAN 里一样直接配对，**整条通道由 Tailscale / WireGuard 加密承载**。
-
-典型使用场景：
-
-- 电脑在家走有线 / 公司 Wi-Fi；
-- 手机在外走 4G / 5G 蜂窝网络，或者接的是另一个咖啡馆 Wi-Fi；
-- 两端都登录同一个 Tailscale 账号 → 走 tailnet 直接互通。
+完整步骤、注意事项与排错见 **[用 Tailscale 打通手机与桌面](../guides/tailscale)**。
+另一条跨网络路径是自建 [server 节点](../guides/self-host-server-node)，把网关
+暴露成公网 HTTPS 端点；两者的取舍对照也在那篇里。
 
 <Callout type="info">
-  **这条路径只换了「可达性」，没换 v1 的 HTTP 协议本身。** 监听器对外 依然是明文 HTTP + Basic
-  Auth；机密性由你信任的 Tailscale / WireGuard 隧道托底。如果你只把 Tailscale
-  当工具，不把它视作可信网络，请 暂时保持原本的「仅限同 LAN」做法。
+  **这条路径只换了「可达性」，没换 v1 的 HTTP 协议本身。** 监听器对外依然是明文 HTTP + Basic
+  Auth，机密性由你信任的 Tailscale / WireGuard 隧道托底；而且它**不会**帮你关掉 LAN 上的监听 ——
+  socket 始终 bind 在 `0.0.0.0`，「监听 IP」只决定广告给手机的地址。
 </Callout>
-
-<Steps>
-
-<Step>
-
-### 在桌面与手机上分别安装 Tailscale 并登录同一账号
-
-- **桌面端** —— 装官方客户端（[tailscale.com/download](https://tailscale.com/download)），
-  登录后保持「连接」状态。Linux 上启动 `tailscaled` 后执行
-  `tailscale up`；macOS / Windows 直接在状态栏 / 系统托盘里点
-  **Connect**。
-- **手机端** —— 在 App Store / Google Play 安装 **Tailscale** App，
-  登录 **同一个账号**，把 VPN 开关打开。iOS 上系统会要求授权
-  添加 VPN 配置，确认即可。
-
-两端都 **Connect** 之后，可以在桌面 / 手机的 Tailscale 客户端里看到
-对方设备出现在「Machines」列表中，每台机器都拿到一个 `100.x.x.x`
-的 tailnet IPv4。
-
-</Step>
-
-<Step>
-
-### 在桌面 **配置** modal 选 Tailscale 网卡
-
-回到 **设备 → 移动端同步 → 配置**。在 **监听 IP** 下拉里，找到形如
-`100.x.x.x`（Tailscale 段）的那一项选中。**当前监听地址** 行立即切到
-对应的 `http://100.x.x.x:42720`，所有后续签发的设备凭据 URL 都会
-带上这个地址。
-
-不需要重启 daemon —— 监听器是热切换的，实际 socket 还是 bind 在
-`0.0.0.0`，**「监听 IP」这个选项只决定对外宣告哪一个地址**。
-
-<Callout type="info">
-  这与 **设置 → 网络 → 允许覆盖网络地址** 开关 **无关**。后者控制的是 桌面 ↔ 桌面 P2P
-  的路径候选，移动端同步是手动挑一个地址给手机扫码， 所以 Tailscale CGNAT 在这里始终可见。
-</Callout>
-
-</Step>
-
-<Step>
-
-### 点 **添加设备**，让手机扫码
-
-照常走 [一键启用](#一键启用) 里的 **添加设备** 流程。凭据弹窗顶部
-那张 connect URI 二维码现在编码的就是 `http://100.x.x.x:42720` 的
-tailnet 地址。
-
-如果已经把设备加好，但当时选的是 LAN 网卡，可以直接在凭据弹窗 / 设备卡片 dialog 的
-**baseUrl 下拉** 里切到 Tailscale 网卡，二维码会原地刷新成新的 connect URI，
-不需要回到「配置」modal、也不用重新添加设备。
-
-</Step>
-
-<Step>
-
-### 手机端扫码并保持 Tailscale 在线
-
-用 UniClipboard iOS / Android App 扫顶部那张大码，所有字段自动填好。
-**之后只要手机端的 Tailscale VPN 处于「Connected」状态**，无论手机
-走 4G/5G 还是任意一个外部 Wi-Fi，都能像在家里同 LAN 一样跟桌面双向
-同步。
-
-</Step>
-
-</Steps>
-
-### 注意事项与限制
-
-- **两端都要保持 Tailscale 在线。** 手机端 Tailscale 一旦断开（手动
-  Disconnect、被系统杀后台、或长时间没流量被运营商挂起），就回到「LAN
-  外不可达」的状态，请求会超时或拨号失败。
-- **不支持 MagicDNS 主机名。** 凭据 URL 用的是 `100.x.x.x` 形式的
-  数字 IP；如果你给桌面在 Tailscale 上配了别名（如 `desktop.tail-XXXX.ts.net`），
-  我们 **不会** 把这个名字写进 connect URI。固定走 `100.x.x.x` 即可。
-- **跨网络场景手机后台限制更明显。** iOS 在锁屏 / 切后台后会限制
-  剪贴板读写，Android 10+ 也有类似限制；这与 Tailscale 无关，是
-  系统行为。需要稳定的"后台同步"请把 App 留在前台或加进系统的
-  "始终允许"白名单。
-- **它不是 v2 TLS。** Tailscale 给的是 **网络层** 的机密性。如果
-  你的威胁模型要求"端到端"语义（例如担心桌面机器本身被攻破），这条
-  路径不解决该问题，等 v2 的 TLS 即可。
-
-故障排查：手机端能 ping 通 `100.x.x.x` 但 App 报连接超时，多半是
-桌面端那台 Tailscale 没接入 / 退到了 DERP 中继的限速档（个人版限速
-约 50KB/s，跑大图大文件会很慢）；先确认两端在 Tailscale 客户端的
-「Machines」列表里都显示在线，再确认两台机器的连接类型（直连 vs DERP）。
 
 ## 管理已配对设备
 

--- a/docs-site/content/docs/zh/core-features/sync.mdx
+++ b/docs-site/content/docs/zh/core-features/sync.mdx
@@ -81,7 +81,7 @@ SyncClipboard 协议的 Android 客户端通过这个接口读写。
 - **移动端这边不走 P2P。** 移动客户端不走 iroh、不打洞、也不走中继 ——
   它就是个普通 HTTP 客户端。同一 LAN 下开箱即用；需要跨网络时，自建
   [无头 server 节点](../guides/self-host-server-node)（公网 HTTPS 端点）
-  或让两端接入同一个 Tailscale / VPN overlay 即可。
+  或让两端接入同一个 [Tailscale / VPN overlay](../guides/tailscale) 即可。
 - **移动端之间不会互相同步。** 两部手机不会直连，它们都与桌面通信。
 - **暂无按方向 / 按内容类型的开关** 适用于移动端配对。
 - **不参与空间的加密历史网络。** 移动客户端通过 HTTP 读取与推送最新一条剪贴，

--- a/docs-site/content/docs/zh/guides/meta.json
+++ b/docs-site/content/docs/zh/guides/meta.json
@@ -2,5 +2,12 @@
   "title": "指南",
   "icon": "BookOpen",
   "defaultOpen": true,
-  "pages": ["pairing", "config-migration", "settings", "self-host-relay", "self-host-server-node"]
+  "pages": [
+    "pairing",
+    "config-migration",
+    "settings",
+    "tailscale",
+    "self-host-relay",
+    "self-host-server-node"
+  ]
 }

--- a/docs-site/content/docs/zh/guides/pairing.mdx
+++ b/docs-site/content/docs/zh/guides/pairing.mdx
@@ -111,8 +111,8 @@ flowchart LR
 手机端始终只是个 SyncClipboard HTTP 客户端，永远不会成为 iroh 对端。
 所谓「跨网络」指的是 **从另一个网络访问到这个网关**，而非 P2P：可以自建
 [无头 server 节点](./self-host-server-node) 把网关暴露成公网 HTTPS 端点，
-或让桌面与手机接入同一个 Tailscale / VPN overlay。两条路径详见
-[移动端同步](../core-features/mobile-sync)。
+或让桌面与手机接入同一个 [Tailscale / VPN overlay](./tailscale)。两条路径的取舍
+对照见 [用 Tailscale 打通手机与桌面](./tailscale)。
 
 ### 配对移动设备
 

--- a/docs-site/content/docs/zh/guides/tailscale.mdx
+++ b/docs-site/content/docs/zh/guides/tailscale.mdx
@@ -1,0 +1,313 @@
+---
+title: 用 Tailscale 打通手机与桌面
+description: 不用 VPS、不用域名，把手机与桌面接进同一个 tailnet，手机在任何网络下都能跟桌面同步。
+---
+
+import { Step, Steps } from 'fumadocs-ui/components/steps'
+import { Tab, Tabs } from 'fumadocs-ui/components/tabs'
+
+UniClipboard 的手机端是一个 **HTTP 伴侣** —— 它不加入空间的信任网络、也不跑
+P2P 节点，只是拿 base URL + Basic Auth 去读写桌面端暴露的那个小型 HTTP 网关。
+默认情况下这个网关**只在同一个 Wi-Fi 下可达**：手机一旦走 4G/5G、或接了别人的
+Wi-Fi，就拨不通它。
+
+把桌面与手机都接进同一个 **Tailscale 网络（tailnet）**，两端就各自拿到一个
+`100.x.x.x` 地址，手机可以像在同一个 LAN 里一样直接连桌面 —— 整条通道由
+Tailscale / WireGuard 加密承载。不需要 VPS、不需要域名、不需要证书。
+
+这篇文档解答：
+
+- 这条路解决什么、**不**解决什么（尤其是它并没有帮你把网关关起来）
+- 桌面与手机分别怎么配（GUI 与 CLI 两条路径）
+- 为什么扫一次码就同时拿到 LAN 与 tailnet 两条地址
+- 进阶：让桌面 ↔ 桌面的 P2P 也走 tailnet
+- 它与[自建 server 节点](./self-host-server-node)该怎么选
+
+## 它解决什么、不解决什么
+
+它换的只是**可达性**，没有换掉协议本身：
+
+- **解决**：手机在任意网络下都能拨通桌面的网关。机密性由你信任的
+  Tailscale / WireGuard 隧道托底。
+- **不解决**：网关对外**依然是明文 HTTP + Basic Auth**。这条路不提供端到端
+  TLS 语义 —— 如果你的威胁模型要求这个，看 [自建 server 节点](./self-host-server-node)
+  （真证书 HTTPS）。
+- **不解决**：桌面休眠 / 关机时，手机同样拨不通。tailnet 不会替你把桌面留在线上。
+  需要「桌面全休眠时同步仍然在线」，那是 server 节点的场景。
+
+<Callout type="warn">
+  **Tailscale 不会帮你关掉 LAN 上的监听。** 网关的 socket **永远 bind 在 `0.0.0.0`**，
+  这一点不可配置。下面要用到的「监听 IP」下拉是**纯广告语义** —— 它只决定发给手机的安装
+  URL / 二维码里写哪个地址，**不改变 socket 监听在哪**。所以即使你选了 `100.x.x.x`，
+  网关**仍然在你的物理 LAN 上明文监听**。Tailscale 给你的是「手机能从外面连进来」，
+  **不是**「别人连不进来」。在不可信网络（公共 Wi-Fi）下，该关就关。
+</Callout>
+
+## 跨网络是怎么走的
+
+```mermaid
+flowchart LR
+  subgraph net1[手机所在网络 · 蜂窝 / 异地 Wi-Fi]
+    P[📱 手机客户端<br/>Tailscale VPN 已连接]
+  end
+  subgraph ts[tailnet · WireGuard 加密]
+    R[直连打洞<br/>失败则回落 DERP 中继]
+  end
+  subgraph net2[桌面所在网络 · 家 / 公司]
+    D[💻 桌面守护进程<br/>网关 bind 0.0.0.0:42720<br/>tailnet 地址 100.x.x.x]
+  end
+  P -->|HTTP · GET 拉 / PUT 推| R
+  R --> D
+```
+
+对比 [server 节点](./self-host-server-node) 那条路：这里**没有 VPS、没有 Caddy、
+没有证书签发**，链路上少了一整台机器。代价是桌面必须醒着。
+
+## 前置条件
+
+- 一个 Tailscale 账号，桌面与手机都能登同一个。
+- 桌面端 UniClipboard **0.12 或更新**（「监听 IP」下拉从 0.12 起才列 CGNAT 段）。
+- 桌面在同步期间**保持唤醒** —— 休眠即不可达。
+- 手机端装 [UniClipboard 移动端 App](https://github.com/UniClipboard/UniClip)。
+
+## 配置步骤
+
+<Steps>
+
+<Step>
+
+### 两端装 Tailscale，登录同一账号
+
+桌面与手机都要装 Tailscale，并且**登录同一个账号**。以官网
+[tailscale.com/download](https://tailscale.com/download) 为准，常见平台如下：
+
+<Tabs items={['Linux', 'macOS', 'Windows', 'iOS', 'Android']}>
+
+<Tab value="Linux">
+
+官方一键脚本（自动识别发行版，装好 `tailscaled` 服务并设为开机自启）：
+
+```bash
+curl -fsSL https://tailscale.com/install.sh | sh
+```
+
+然后登录并接入（会打印一个授权链接，用浏览器打开完成登录）：
+
+```bash
+sudo tailscale up
+```
+
+`tailscale status` 应能列出本机和 tailnet 上的其它设备。
+
+</Tab>
+
+<Tab value="macOS">
+
+三选一：
+
+- **App Store** —— 搜 **Tailscale** 安装（含菜单栏 GUI，最省事）。
+- **独立版** —— 从 [tailscale.com/download/macos](https://tailscale.com/download/macos) 下 `.pkg`。
+- **Homebrew（CLI / 无头）**：
+
+  ```bash
+  brew install tailscale
+  sudo tailscale up
+  ```
+
+GUI 版装好后在菜单栏点 **Connect** 并登录即可。
+
+</Tab>
+
+<Tab value="Windows">
+
+从 [tailscale.com/download/windows](https://tailscale.com/download/windows) 下安装包，
+或用 winget：
+
+```powershell
+winget install tailscale.tailscale
+```
+
+装好后在系统托盘点 Tailscale 图标 → **Log in / Connect**，登录账号。
+
+</Tab>
+
+<Tab value="iOS">
+
+在 App Store 搜 **Tailscale** 安装（[App Store 链接](https://apps.apple.com/app/tailscale/id1470499037)），
+登录账号后打开 VPN 开关。系统会要求授权添加 VPN 配置，确认即可。
+
+</Tab>
+
+<Tab value="Android">
+
+在 Google Play 搜 **Tailscale** 安装
+（[Google Play 链接](https://play.google.com/store/apps/details?id=com.tailscale.ipn)），
+登录账号后打开 VPN 开关。国内设备没有 Google Play 时，可从官网下 APK。
+
+</Tab>
+
+</Tabs>
+
+桌面端保持「Connected」；手机端把 VPN 开关打开。两端都接入后，在任一端的
+Tailscale 客户端「Machines」列表里应该能看到对方，每台机器带一个 `100.x.x.x`
+的 tailnet IPv4。**先确认这一步成立再往下走** —— 后面所有问题九成出在这里。
+
+</Step>
+
+<Step>
+
+### 在桌面把广告地址指向 tailnet
+
+<Tabs items={['GUI', 'CLI']}>
+
+<Tab value="GUI">
+
+进 **设备 → 手机同步 → 配置**，在**监听 IP** 下拉里选那个 `100.x.x.x`
+（Tailscale 段）的条目。**当前监听地址**行会立刻切到 `http://100.x.x.x:42720`，
+之后签发的所有设备凭据 URL 都带这个地址。
+
+不需要重启 daemon —— 监听器是热切换的。
+
+</Tab>
+
+<Tab value="CLI">
+
+先列出可选网卡，找到 `100.` 开头的那个：
+
+```bash
+uniclip mobile network interfaces
+```
+
+然后把广告地址指过去（`--ip` 会渲染成 `http://<IP>:42720`）：
+
+```bash
+uniclip mobile network set --ip 100.101.102.103 --accept-network-risk
+```
+
+<Callout type="info">
+  `--accept-network-risk` 只是跳过那句交互式 y/N 确认，**不改变任何技术行为**；非交互
+  场景（脚本 / CI）下必须带。它打印的那段警告文案是 LAN 语境的硬编码文本，走 tailnet
+  时也会照样打印 —— 以本页上面那条 warn callout 为准。
+</Callout>
+
+</Tab>
+
+</Tabs>
+
+<Callout type="info">
+  这与 **设置 → 网络 → 允许覆盖网络地址** 开关**无关**。那个开关管的是桌面 ↔ 桌面的
+  P2P 路径候选（见[下文](#进阶让桌面之间的-p2p-也走-tailnet)），手机同步这里是你手动挑一个地址交给手机，
+  所以 Tailscale 段在这个下拉里**始终可见**。这两套机制是刻意分开的。
+</Callout>
+
+</Step>
+
+<Step>
+
+### 添加设备，让手机扫码
+
+照常走 [手机同步 → 添加设备](../core-features/mobile-sync#一键启用)：
+
+```bash
+uniclip mobile add --label "我的 iPhone"
+```
+
+弹窗 / 终端里的二维码现在编码的就是 tailnet 地址。**一次性密码只显示一次**，当场记下。
+
+已经配过、但当时选的是 LAN 网卡也不用重新添加设备 —— 在凭据弹窗 / 设备卡片
+dialog 的 **baseUrl 下拉**里切到 Tailscale 网卡，二维码会原地刷新。
+
+</Step>
+
+<Step>
+
+### 手机扫码，并保持 Tailscale 在线
+
+用 UniClipboard App 扫码，字段自动填好。之后**只要手机的 Tailscale VPN 处于
+「Connected」**，无论走蜂窝还是任意外部 Wi-Fi，都能跟桌面双向同步。
+
+</Step>
+
+</Steps>
+
+## 你不用手动填两条地址
+
+二维码里编码的**不是一个地址，而是一份候选列表**：桌面在签发凭据时会把所有合格
+网卡（LAN 的 `192.168.x` / `10.x` 与 tailnet 的 `100.x`）**一起**塞进 connect URI，
+客户端逐个探测、挑能拨通的那条。
+
+所以扫一次码，你就同时拿到了两条路：**在家自动走 LAN 直连**（快，不绕
+WireGuard），**在外自动回落 tailnet**。换网络后 App 会重新选路，界面上会标注
+「将使用」哪个地址，不需要手动切换。
+
+下拉里 CGNAT 段被**排在最后**（顺序为 `10/8 → 172.16/12 → 192.168/16 → 100.64/10`），
+所以真实 LAN 网卡优先；只有在**没有任何 RFC1918 网卡**可选时，才会自动选中 tailnet 地址。
+
+## 进阶：让桌面之间的 P2P 也走 tailnet
+
+上面讲的都是**手机 ↔ 桌面**。桌面之间走的是 iroh P2P，它对 Tailscale 地址的默认
+处理**恰好相反**：
+
+| | Tailscale `100.x` 默认行为 | 为什么 |
+| --- | --- | --- |
+| 手机同步（广告地址） | **默认带上** | 地址是你手动挑的，不存在探路成本 |
+| 桌面 P2P（直连候选） | **默认过滤掉** | 自动 path racing 会把探路预算烧在死路上 |
+
+这是刻意设计的不对称，也是本页最容易被搞混的一点。**两台桌面都接同一个 tailnet**
+且希望 iroh 利用这条路时，才需要打开：**设置 → 网络 → 允许覆盖网络地址**。
+
+打开后，Tailscale CGNAT（`100.64.0.0/10`）与 IPv6 ULA（`fd7a:115c:a1e0::/48`）
+才会作为直连候选发布、并写进配对邀请。
+
+<Callout type="warn">
+  **改完必须重启 daemon。** 地址过滤器是在 iroh endpoint **bind 时固定**的，这个开关不会热生效。
+</Callout>
+
+<Callout type="info">
+  Clash TUN 的 fake-ip（`198.18.0.0/15`）与 IPv4 link-local（`169.254.0.0/16`）**始终被过滤、
+  没有开关** —— 这类网卡本来就不能拿来真实拨号。
+</Callout>
+
+典型症状：sponsor 端跑着 Tailscale，joiner 拿到的邀请里全是不可达的 LAN 地址、
+一直拨不通 —— 见[配对失败](../help/troubleshooting#配对失败)。
+
+## 注意事项与限制
+
+- **两端都要保持 Tailscale 在线。** 手机端一旦断开（手动 Disconnect、被系统杀后台、
+  长时间无流量被挂起），就回到「LAN 外不可达」，请求会超时。
+- **不支持 MagicDNS 主机名。** connect URI 里固定写 `100.x.x.x` 数字 IP；即使你给
+  桌面配了 `desktop.tail-XXXX.ts.net` 这样的别名，我们**不会**把它写进去。
+- **DERP 回落会明显变慢。** tailnet 打洞失败时流量走 Tailscale 的 DERP 中继，带宽
+  远低于直连，传大图 / 大文件会很吃力。在 Tailscale 客户端里确认两台机器是
+  **直连**还是 **DERP**。
+- **手机后台限制依旧。** iOS 锁屏 / 切后台、Android 10+ 都会限制剪贴板读写 ——
+  这与 Tailscale 无关，是系统行为。需要稳定后台同步就把 App 留在前台。
+- **网关仍在 LAN 上监听**（见开头的 warn callout）。
+
+## 排错
+
+| 现象 | 看哪里 |
+| --- | --- |
+| App 报连接超时 | 先在两端 Tailscale 客户端的「Machines」列表确认**双方都在线**。九成问题在这一步。 |
+| 手机能 ping 通 `100.x` 但 App 超时 | 桌面端网关没开或端口不对。跑 `uniclip mobile status` 看当前监听 URL。 |
+| 同步很慢、大文件传不动 | 两端多半退到了 DERP 中继。在 Tailscale 客户端看连接类型是直连还是 DERP。 |
+| 提示鉴权失败 / 401 | 用户名或密码不对。桌面端轮换密码后在手机重填。 |
+| 换回家里 Wi-Fi 后连不上 | 看 App 里「将使用」的是哪条地址；确认 LAN 那条也在候选列表里。 |
+| 桌面 ↔ 桌面配对拨不通 | sponsor 端打开**允许覆盖网络地址**并**重启 daemon**，Tailscale 地址才会进邀请。 |
+
+## 该选哪个：Tailscale 还是 server 节点
+
+| | Tailscale | [server 节点](./self-host-server-node) |
+| --- | --- | --- |
+| 需要 VPS / 域名 | ❌ 不用 | ✅ 需要 |
+| 桌面休眠时仍能同步 | ❌ 不能 | ✅ 能 |
+| 手机端要另装 App | ✅ 要装 Tailscale | ❌ 不用 |
+| 传输机密性 | 🔒 WireGuard 隧道（网络层） | 🔒 真证书 HTTPS |
+| 大文件速度 | ⚡ 直连快；DERP 回落慢 | 🌐 取决于 VPS 带宽 |
+| 运维成本 | 🟢 几乎没有 | 🟡 需要维护容器、证书、备份 |
+
+两端都在你自己手里、又不想养一台 VPS —— 选 Tailscale。要「桌面全关机时手机
+依然能收发」或者需要一个稳定的公网 HTTPS 端点 —— 选 server 节点。
+
+两条路**不冲突**：你完全可以同时配好，让手机的候选地址列表里既有 tailnet
+也有公网网关。

--- a/docs-site/content/docs/zh/help/faq.mdx
+++ b/docs-site/content/docs/zh/help/faq.mdx
@@ -166,7 +166,7 @@ APK 在 [releases 页](https://github.com/UniClipboard/UniClip/releases/latest)
 - **不走 P2P。** 移动端同步走的是普通 HTTP —— **不走 iroh P2P、
   不做 NAT 打洞、也不会回落到加密中继**。同一 LAN 下开箱即用；需要
   跨网络时，自建 [无头 server 节点](../guides/self-host-server-node)
-  （公网 HTTPS 端点）或走 Tailscale / VPN overlay。
+  （公网 HTTPS 端点）或走 [Tailscale / VPN overlay](../guides/tailscale)。
 - **移动端不是真正的对端。** 移动设备不会加入空间的信任网络，也不会在移动设备
   之间互相同步；它们只与配对的那一台桌面互通剪贴。
 

--- a/docs-site/content/docs/zh/mobile/connect.mdx
+++ b/docs-site/content/docs/zh/mobile/connect.mdx
@@ -25,7 +25,7 @@ UniClipboard 移动 App 是一个纯局域网 / 自建服务器的同步客户�
 - 桌面侧如何开启手机同步、这份凭据里各字段是什么意思，见
   [移动端同步](../core-features/mobile-sync) 与 [配对与同步](../guides/pairing)。
 - 手机与电脑需要在**同一个 Wi-Fi** 下，或都接入同一个 Tailscale / VPN。跨网络访问
-  见 [自建 server 节点](../guides/self-host-server-node)。
+  见 [用 Tailscale 打通手机与桌面](../guides/tailscale) 或 [自建 server 节点](../guides/self-host-server-node)。
 
 弹窗里的**明文密码通常只显示一次**。如果没扫成或没填成，可以在桌面重新添加设备 /
 轮换密码再拿一份新的。


### PR DESCRIPTION
## Summary

- **New dedicated guide** `guides/tailscale.mdx` (en + zh) with the full cross-network mobile-sync walkthrough over a tailnet — setup steps, caveats, and troubleshooting that previously lived inline in the mobile-sync page.
- **Trim `core-features/mobile-sync.mdx`** down to a short overview plus a pointer to the new page, so the feature doc no longer mixes overview with step-by-step setup.
- **Register the page in the guides nav** (`guides/meta.json`, both locales) between `settings` and `self-host-relay`.
- **Update cross-references** in `pairing.mdx`, `sync.mdx`, `faq.mdx`, and `mobile/connect.mdx` to link the new guide.

en and zh are updated in lockstep.

## Test plan

- [ ] `cd docs-site && <build/dev command>` — site builds, the new **Guides → Tailscale** entry renders in both locales, and every updated cross-reference resolves (no broken `../guides/tailscale` links).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added English and Chinese guides for using Tailscale to sync between desktop and mobile devices across networks.
  * Documented setup steps, address selection, QR pairing, limitations, troubleshooting, and comparison with the self-hosted server option.
  * Updated related mobile sync, pairing, connection, and FAQ pages with links to the new guide.
  * Clarified that Tailscale provides reachability and tunnel confidentiality, while the existing HTTP and authentication behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->