### PR TITLE
fix(clipboard-sync): re-activate held content on inbound dedup hit

### DIFF
--- a/apps/daemon/src/daemon/app_facade_assembly.rs
+++ b/apps/daemon/src/daemon/app_facade_assembly.rs
@@ -11,7 +11,6 @@
 
 use std::sync::Arc;
 
-use uc_application::clipboard_write::ClipboardWriteCoordinator;
 use uc_application::deps::AppDeps;
 use uc_application::facade::{
     AppPaths, BlobTransferFacade, ClipboardOutboundFacade, ClipboardSyncFacade,
@@ -50,11 +49,6 @@ pub struct DaemonLifecycleFacadesInput<'a> {
     /// 喂给 `MobileSyncFacade`(本字段) 与 daemon `run()`(`DaemonApp`),
     /// 两条链路共用单点状态机。
     pub lan_lifecycle: Arc<dyn MobileLanLifecyclePort>,
-    /// 进程级剪贴板写边界。移动端 PUT 去重命中时, 用这次上传的 snapshot
-    /// 把内容写回系统剪贴板 (issue #1017 PR7 D1 call-site 4)。与
-    /// `sync_engine_assembly.active_clipboard` 一起喂给 mobile_sync facade,
-    /// 装出 active-clipboard 收敛 adapter。
-    pub clipboard_write_coordinator: Arc<ClipboardWriteCoordinator>,
 }
 
 /// 构造 5 个 daemon-lifecycle 子 facade。返回的 [`DaemonLifecycleFacades`]
@@ -73,7 +67,6 @@ pub fn build_daemon_lifecycle_facades(
         mobile_sync_apply_inbound,
         clipboard_outbound,
         lan_lifecycle,
-        clipboard_write_coordinator,
     } = input;
 
     let mobile_sync = build_mobile_sync_facade(
@@ -89,11 +82,10 @@ pub fn build_daemon_lifecycle_facades(
         // 这条装配路径必装,CLI fallback 与其他无 outbound dispatcher 的入口
         // 走 `None`。
         Some(Arc::clone(&clipboard_outbound)),
-        // active-clipboard 收敛 (issue #1017 PR7):写边界 + 进程级
-        // active-clipboard facade(由 SyncEngineAssembly 装好)。两者一起让
-        // mobile_sync facade 在入站激活后盖本设备激活戳、前进跨设备 register、
-        // 按 per-device send 闸门广播 0xC3 state(duplicate 命中先写回 OS)。
-        Some(Arc::clone(&clipboard_write_coordinator)),
+        // active-clipboard 收敛 (issue #1017 PR7):进程级 active-clipboard
+        // facade(由 SyncEngineAssembly 装好)让 mobile_sync facade 在入站激活
+        // 后盖本设备激活戳、前进跨设备 register、按 per-device send 闸门广播
+        // 0xC3 state。系统剪贴板由入站管线负责写, 不经过这里。
         Some(Arc::clone(&sync_engine_assembly.active_clipboard)),
     );
 

--- a/apps/daemon/src/daemon/host.rs
+++ b/apps/daemon/src/daemon/host.rs
@@ -348,7 +348,6 @@ pub async fn start_in_process(
             clipboard_outbound: runtime_workers.clipboard_outbound.clone(),
             lan_lifecycle: Arc::clone(&mobile_lan_lifecycle)
                 as Arc<dyn uc_core::ports::MobileLanLifecyclePort>,
-            clipboard_write_coordinator: clipboard_write_coordinator.clone(),
         });
 
     app_facade.install_daemon_lifecycle(lifecycle_facades);

--- a/apps/daemon/src/daemon/runtime_assembly.rs
+++ b/apps/daemon/src/daemon/runtime_assembly.rs
@@ -12,7 +12,7 @@ use uc_application::deps::AppDeps;
 use uc_application::facade::{
     BlobTransferFacade, ClipboardCaptureFacade, ClipboardLiveIndexDeps, ClipboardLiveIndexFacade,
     ClipboardLiveIndexPort, ClipboardLiveIndexer, ClipboardOutboundDeps, ClipboardOutboundFacade,
-    ClipboardSyncFacade, HostEventBus, InboundClipboardFacade,
+    ClipboardSnapshotDeps, ClipboardSyncFacade, HostEventBus, InboundClipboardFacade,
 };
 use uc_application::{
     ApplyInboundClipboardUseCase, FileCacheBlobMaterializer, InboundCapture as ApplyInboundCapture,
@@ -160,7 +160,28 @@ pub fn build_daemon_runtime_workers(
         )
         .with_search_live_index(Arc::clone(&search_live_indexer))
         .with_check_entry_availability(input.deps.clipboard.entry_ports.availability.clone())
-        .with_entry_identity_coordinator(input.deps.clipboard.entry_identity_coordinator.clone()),
+        .with_entry_identity_coordinator(input.deps.clipboard.entry_identity_coordinator.clone())
+        // This is the instance that owns the user's pasteboard (P2P + mobile
+        // LAN), so a delivery whose content is already held must re-activate it
+        // rather than be dropped — otherwise a peer re-copying an older clip
+        // leaves the pasteboard on the previous one until the periodic
+        // active-state broadcast repairs it.
+        .with_resurface(
+            ClipboardSnapshotDeps {
+                entry_repo: input.deps.clipboard.entry_ports.get.clone(),
+                selection_repo: input.deps.clipboard.selection_repo.clone(),
+                representation_repo: input.deps.clipboard.representation_ports.get.clone(),
+                rep_processing_repo: input
+                    .deps
+                    .clipboard
+                    .representation_ports
+                    .update_processing_result
+                    .clone(),
+                payload_resolver: input.deps.clipboard.payload_resolver.clone(),
+                blob_store: input.deps.storage.blob_store.clone(),
+            },
+            input.deps.clipboard.entry_ports.touch.clone(),
+        ),
     );
     let inbound_clipboard_facade = Arc::new(InboundClipboardFacade::new(apply_inbound_uc.clone()));
     let clipboard_outbound_facade = Arc::new(ClipboardOutboundFacade::new(ClipboardOutboundDeps {

--- a/apps/daemon/src/daemon/workers/inbound_clipboard_sync.rs
+++ b/apps/daemon/src/daemon/workers/inbound_clipboard_sync.rs
@@ -98,6 +98,21 @@ impl InboundClipboardSyncWorker {
                 info!(entry_id = %entry_id, "inbound clipboard applied; broadcasting WS event");
                 Self::emit_ws_event(&self.event_tx, entry_id, from_device);
             }
+            // The peer re-copied a clip we already hold: no new entry, but it
+            // moved to the top of history and is now the active clipboard, so
+            // the frontend needs the same refresh a fresh entry triggers.
+            Ok(InboundClipboardApplyOutcome::Resurfaced {
+                existing_entry_id,
+                os_write_succeeded,
+                ..
+            }) => {
+                info!(
+                    entry_id = %existing_entry_id,
+                    os_write_succeeded,
+                    "inbound clipboard re-activated already-held entry; broadcasting WS event"
+                );
+                Self::emit_ws_event(&self.event_tx, existing_entry_id, from_device);
+            }
             Ok(InboundClipboardApplyOutcome::DuplicateSkipped {
                 snapshot_hash,
                 existing_entry_id,
@@ -105,7 +120,7 @@ impl InboundClipboardSyncWorker {
                 debug!(
                     snapshot_hash = %snapshot_hash,
                     existing_entry_id = %existing_entry_id,
-                    "inbound dropped: duplicate of existing local entry"
+                    "inbound dropped: redundant delivery of existing local entry"
                 );
             }
             Ok(InboundClipboardApplyOutcome::DecodeFailed { reason }) => {

--- a/apps/daemon/src/daemon/workers/inbound_clipboard_sync.rs
+++ b/apps/daemon/src/daemon/workers/inbound_clipboard_sync.rs
@@ -103,15 +103,29 @@ impl InboundClipboardSyncWorker {
             // the frontend needs the same refresh a fresh entry triggers.
             Ok(InboundClipboardApplyOutcome::Resurfaced {
                 existing_entry_id,
-                os_write_succeeded,
+                os_write_succeeded: true,
                 ..
             }) => {
                 info!(
                     entry_id = %existing_entry_id,
-                    os_write_succeeded,
                     "inbound clipboard re-activated already-held entry; broadcasting WS event"
                 );
                 Self::emit_ws_event(&self.event_tx, existing_entry_id, from_device);
+            }
+            // The OS write failed, so the use case left the register unadvanced
+            // and the entry unmoved in history. `clipboard.new_content` would
+            // tell the frontend this entry is the active clip while the backend
+            // still points at the previous one, so stay silent — the use case
+            // already logged the write failure with its cause.
+            Ok(InboundClipboardApplyOutcome::Resurfaced {
+                existing_entry_id,
+                os_write_succeeded: false,
+                ..
+            }) => {
+                debug!(
+                    entry_id = %existing_entry_id,
+                    "inbound re-activation left the pasteboard untouched; no WS event"
+                );
             }
             Ok(InboundClipboardApplyOutcome::DuplicateSkipped {
                 snapshot_hash,

--- a/crates/uc-application/src/facade/active_clipboard/mod.rs
+++ b/crates/uc-application/src/facade/active_clipboard/mod.rs
@@ -38,8 +38,8 @@ use uc_core::ports::{
 use uc_core::{blob::ports::BlobReaderPort, MemberRepositoryPort};
 
 use crate::clipboard_write::{
-    ClipboardWriteCoordinator, LocalActiveRegisterAdvancer, MobileConsumabilityProbe,
-    RestoreBroadcastRequest,
+    ClipboardWriteCoordinator, ClipboardWriteIntent, LocalActiveRegisterAdvancer,
+    MobileConsumabilityProbe, RestoreBroadcastRequest,
 };
 use crate::facade::blob_transfer::{BlobTransferFacade, SharedHostEventEmitter};
 use crate::facade::clipboard_inbound::{
@@ -84,7 +84,7 @@ impl ClipboardSnapshotDeps {
     /// Fold the bundled ports into the shared `SnapshotReconstructor`. The free
     /// function `reconstruct_snapshot_from_entry` stays the single source of
     /// truth; this just owns the ports.
-    fn into_reconstructor(self) -> SnapshotReconstructor {
+    pub(crate) fn into_reconstructor(self) -> SnapshotReconstructor {
         SnapshotReconstructor::new(
             self.entry_repo,
             self.selection_repo,
@@ -478,6 +478,11 @@ impl InboundPulledContentStore for PulledContentStore {
                 snapshot_hash: snapshot_hash.to_string(),
                 plaintext: plaintext.into(),
                 flow_id: None,
+                // Store-only path: this apply's write port is a no-op (the
+                // convergence tail below owns the authoritative OS write), so
+                // the intent never reaches the clipboard. `RemotePush` states
+                // the truth of where the content came from.
+                resurface_intent: ClipboardWriteIntent::RemotePush,
             })
             .await
             .map_err(|err| InboundPulledContentStoreError::Store(err.to_string()))?;
@@ -487,7 +492,10 @@ impl InboundPulledContentStore for PulledContentStore {
             // A duplicate means the content landed locally between the pull and
             // the store (e.g. the bulk path raced us); the existing entry is
             // exactly what we wanted, so converge on it.
-            InboundClipboardApplyOutcome::DuplicateSkipped {
+            InboundClipboardApplyOutcome::Resurfaced {
+                existing_entry_id, ..
+            }
+            | InboundClipboardApplyOutcome::DuplicateSkipped {
                 existing_entry_id, ..
             } => Ok(EntryId::from(existing_entry_id)),
             InboundClipboardApplyOutcome::DecodeFailed { reason } => {

--- a/crates/uc-application/src/facade/clipboard_inbound/mod.rs
+++ b/crates/uc-application/src/facade/clipboard_inbound/mod.rs
@@ -6,6 +6,7 @@ use thiserror::Error;
 use uc_core::ids::DeviceId;
 use uc_observability::FlowId;
 
+use crate::clipboard_write::ClipboardWriteIntent;
 use crate::{ApplyInboundClipboardUseCase, ApplyInboundInput, ApplyOutcome};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -20,6 +21,13 @@ pub struct InboundClipboardNoticeInput {
 pub enum InboundClipboardApplyOutcome {
     Applied {
         entry_id: String,
+    },
+    /// Content already held locally; the existing entry was re-activated
+    /// instead of duplicated. Mirrors [`ApplyOutcome::Resurfaced`].
+    Resurfaced {
+        snapshot_hash: String,
+        existing_entry_id: String,
+        os_write_succeeded: bool,
     },
     DuplicateSkipped {
         snapshot_hash: String,
@@ -50,6 +58,9 @@ pub struct InboundClipboardApplyInput {
     pub snapshot_hash: String,
     pub plaintext: Bytes,
     pub flow_id: Option<FlowId>,
+    /// See [`ApplyInboundInput::resurface_intent`] — only consulted when the
+    /// delivery resolves to an already-held entry.
+    pub resurface_intent: ClipboardWriteIntent,
 }
 
 #[async_trait]
@@ -64,6 +75,7 @@ impl InboundClipboardApplyPort for ApplyInboundClipboardUseCase {
                 snapshot_hash: input.snapshot_hash,
                 plaintext: input.plaintext,
                 flow_id: input.flow_id,
+                resurface_intent: input.resurface_intent,
             })
             .await
             .map_err(|err| InboundClipboardApplyError::Internal(err.to_string()))?;
@@ -90,6 +102,10 @@ impl InboundClipboardFacade {
                 snapshot_hash: input.snapshot_hash,
                 plaintext: input.plaintext,
                 flow_id: input.flow_id,
+                // P2P bulk sync: the sender already broadcast this clip to the
+                // whole space, so anything we write must stay invisible to our
+                // own watcher rather than be re-dispatched.
+                resurface_intent: ClipboardWriteIntent::RemotePush,
             })
             .await
     }
@@ -99,6 +115,15 @@ fn apply_outcome_to_view(outcome: ApplyOutcome) -> InboundClipboardApplyOutcome 
     match outcome {
         ApplyOutcome::Applied { entry_id } => InboundClipboardApplyOutcome::Applied {
             entry_id: entry_id.to_string(),
+        },
+        ApplyOutcome::Resurfaced {
+            snapshot_hash,
+            existing_entry_id,
+            os_write_succeeded,
+        } => InboundClipboardApplyOutcome::Resurfaced {
+            snapshot_hash,
+            existing_entry_id: existing_entry_id.to_string(),
+            os_write_succeeded,
         },
         ApplyOutcome::DuplicateSkipped {
             snapshot_hash,

--- a/crates/uc-application/src/facade/mobile_sync/activation_announce_adapter.rs
+++ b/crates/uc-application/src/facade/mobile_sync/activation_announce_adapter.rs
@@ -7,16 +7,12 @@
 //! `ApplyIncomingMobileClipUseCase` 通过 [`MobileActivationAnnouncePort`]
 //! 这层薄抽象与"如何收敛一次本设备激活"解耦 ——
 //!
-//! - **测试时**: fake 实现直接 record 调用, 不必拉真实 coordinator /
-//!   register / dispatch;
-//! - **生产时**: 本 adapter 承担两件事:
-//!   1. duplicate 命中时, 用这次上传的 snapshot 把内容写回系统剪贴板
-//!      (`ClipboardWriteCoordinator`, `LocalRestore` intent —— 同本机
-//!      restore 一样的写回环防御);new 内容由入站管线写过, 跳过这步;
-//!   2. 不论新旧, 都委托 [`ActiveClipboardFacade::announce_local_activation`]
-//!      盖本设备激活戳 (`activated_by = self`, `activated_at_ms = now`)、
-//!      前进跨设备 register、按 per-device send 闸门 (`send_enabled` ∧
-//!      `send_content_types`) 广播 0xC3 state。
+//! - **测试时**: fake 实现直接 record 调用, 不必拉真实 register / dispatch;
+//! - **生产时**: 本 adapter 委托
+//!   [`ActiveClipboardFacade::announce_local_activation`] 盖本设备激活戳
+//!   (`activated_by = self`, `activated_at_ms = now`)、前进跨设备 register、
+//!   按 per-device send 闸门 (`send_enabled` ∧ `send_content_types`) 广播
+//!   0xC3 state。
 //!
 //! # 闸门
 //!
@@ -25,30 +21,25 @@
 //!
 //! # OS-write coupling (issue #1017 §1 invariant)
 //!
-//! `announce_local_activation` internally degrades best-effort on
-//! register / dispatch failure. The OS re-write on the `announce_duplicate`
-//! path, however, is part of the core invariant
-//! (register-advance <=> OS-write-success <=> re-broadcast): if it fails
-//! (e.g. the write coordinator's circuit breaker is open), the converge is
-//! skipped so this device cannot pin peers to a phantom activation it does not
-//! actually hold. The failure is `warn!`-logged but never propagated to the
-//! use case — the mobile upload's success depends only on the inbound
-//! pipeline, and convergence is after-the-fact propagation. `announce_new`
-//! does not re-write (the inbound pipeline already wrote the OS clipboard), so
-//! it converges unconditionally.
+//! 不变式 (register-advance <=> OS-write-success <=> re-broadcast) 依然成立,
+//! 但本 adapter 不再是它的执行点: 系统剪贴板由入站管线统一写(新内容走落库
+//! 后的后台写, 已有内容走 dedup 命中的重激活写), 调用方
+//! `ApplyIncomingMobileClipUseCase::maybe_announce_activation` 只在那次写
+//! 确认落地后才调到这里。因此本 adapter 无条件收敛, 不持写边界 ——
+//! 写失败的情况在调用方就被挡掉了。
+//!
+//! `announce_local_activation` 内部对 register / dispatch 失败仍是
+//! best-effort 降级。
 //!
 //! [`MobileActivationAnnouncePort`]: crate::usecases::mobile_sync::apply_incoming::MobileActivationAnnouncePort
 //! [`ActiveClipboardFacade`]: crate::facade::active_clipboard::ActiveClipboardFacade
 
 use std::sync::Arc;
 
-use tracing::warn;
-
 use uc_core::clipboard::ClipboardContentCategorySet;
 use uc_core::ids::EntryId;
 use uc_core::SystemClipboardSnapshot;
 
-use crate::clipboard_write::{ClipboardWriteCoordinator, ClipboardWriteIntent};
 use crate::facade::active_clipboard::ActiveClipboardFacade;
 use crate::usecases::mobile_sync::apply_incoming::MobileActivationAnnouncePort;
 
@@ -56,10 +47,9 @@ use crate::usecases::mobile_sync::apply_incoming::MobileActivationAnnouncePort;
 /// a local activation, advance the cross-device register, and fan the 0xC3
 /// state out under the per-device send gate.
 ///
-/// Existing only so the adapter's OS-write gating (`announce_duplicate`) can be
-/// unit-tested without standing up the full active-clipboard facade (~25
-/// ports). Production binds this to the real facade; tests bind a spy that
-/// records whether convergence ran.
+/// Existing so the adapter can be unit-tested without standing up the full
+/// active-clipboard facade (~25 ports). Production binds this to the real
+/// facade; tests bind a spy that records whether convergence ran.
 #[async_trait::async_trait]
 pub(crate) trait LocalActivationConverge: Send + Sync {
     async fn announce_local_activation(
@@ -86,142 +76,63 @@ impl LocalActivationConverge for ActiveClipboardFacade {
 }
 
 pub(crate) struct MobileActivationAnnounceAdapter {
-    coordinator: Arc<ClipboardWriteCoordinator>,
     active_clipboard: Arc<dyn LocalActivationConverge>,
 }
 
 impl MobileActivationAnnounceAdapter {
-    pub(crate) fn new(
-        coordinator: Arc<ClipboardWriteCoordinator>,
-        active_clipboard: Arc<dyn LocalActivationConverge>,
-    ) -> Self {
-        Self {
-            coordinator,
-            active_clipboard,
-        }
-    }
-
-    /// Derive the cross-device activation key + content category set from the
-    /// snapshot, then advance the register and fan the 0xC3 state out under the
-    /// per-device send gate. Shared tail of both `announce_*` paths.
-    async fn converge(&self, entry_id: EntryId, snapshot: &SystemClipboardSnapshot) {
-        let snapshot_hash = snapshot.snapshot_hash().to_string();
-        let categories = ClipboardContentCategorySet::from_snapshot(snapshot);
-        self.active_clipboard
-            .announce_local_activation(snapshot_hash, entry_id, categories)
-            .await;
+    pub(crate) fn new(active_clipboard: Arc<dyn LocalActivationConverge>) -> Self {
+        Self { active_clipboard }
     }
 }
 
 #[async_trait::async_trait]
 impl MobileActivationAnnouncePort for MobileActivationAnnounceAdapter {
     async fn announce_new(&self, entry_id: EntryId, snapshot: SystemClipboardSnapshot) {
-        // Inbound apply already wrote the OS clipboard; only converge peers.
-        self.converge(entry_id, &snapshot).await;
-    }
-
-    async fn announce_duplicate(&self, entry_id: EntryId, snapshot: SystemClipboardSnapshot) {
-        // Content already held locally, but the OS clipboard may have been
-        // overwritten by later copies. Re-write this upload's snapshot so the
-        // user's next paste yields it, then converge peers like a new push.
-        //
-        // Invariant (issue #1017 §1): register-advance <=> OS-write-success <=>
-        // re-broadcast. If the re-write fails (e.g. the coordinator's circuit
-        // breaker is open), skip the converge — otherwise this device would
-        // stamp a high LWW ts and broadcast a 0xC3 state for content its OS
-        // clipboard does not actually hold, pinning peers to a phantom
-        // activation. The mobile upload itself already succeeded; convergence
-        // is best-effort after-the-fact propagation, so dropping it here is
-        // safe.
-        if let Err(err) = self
-            .coordinator
-            .write(snapshot.clone(), ClipboardWriteIntent::LocalRestore)
-            .await
-        {
-            warn!(
-                entry_id = %entry_id,
-                error = %err,
-                "mobile_sync duplicate announce: OS clipboard re-write failed; \
-                 skipping register advance + 0xC3 fan-out"
-            );
-            return;
-        }
-        self.converge(entry_id, &snapshot).await;
+        // The inbound pipeline owns the OS write for both new and re-activated
+        // content, and the use case only calls this once that write is known to
+        // have landed — so converging here upholds the issue #1017 §1 invariant
+        // (register-advance <=> OS-write-success <=> re-broadcast) without
+        // needing to touch the clipboard itself.
+        let snapshot_hash = snapshot.snapshot_hash().to_string();
+        let categories = ClipboardContentCategorySet::from_snapshot(&snapshot);
+        self.active_clipboard
+            .announce_local_activation(snapshot_hash, entry_id, categories)
+            .await;
     }
 }
 
 #[cfg(test)]
 mod tests {
-    //! `announce_duplicate` must honour the issue #1017 §1 invariant: a failed
-    //! OS re-write must NOT advance the register / broadcast 0xC3. The seam
-    //! trait lets us assert that with a trivially-failing write coordinator.
+    //! The adapter is now a thin converge seam: the OS write lives in the
+    //! inbound pipeline, and the issue #1017 §1 gate (skip convergence when
+    //! that write failed) is enforced by the caller in
+    //! `ApplyIncomingMobileClipUseCase::maybe_announce_activation`.
     use super::*;
 
     use std::sync::atomic::{AtomicUsize, Ordering};
-    use std::time::Duration;
 
     use async_trait::async_trait;
 
-    use uc_core::clipboard::ClipboardChangeOrigin;
     use uc_core::ids::{FormatId, RepresentationId};
-    use uc_core::ports::clipboard::{
-        SelfWriteAttribution, SelfWriteLedgerPort, SelfWriteMatch, SystemClipboardPort,
-    };
     use uc_core::{MimeType, ObservedClipboardRepresentation};
 
     /// Records how many times convergence (register advance + 0xC3 fan-out) ran.
     #[derive(Default)]
     struct SpyConverge {
         calls: AtomicUsize,
+        last_hash: std::sync::Mutex<Option<String>>,
     }
 
     #[async_trait]
     impl LocalActivationConverge for SpyConverge {
         async fn announce_local_activation(
             &self,
-            _snapshot_hash: String,
+            snapshot_hash: String,
             _entry_id: EntryId,
             _categories: ClipboardContentCategorySet,
         ) {
             self.calls.fetch_add(1, Ordering::SeqCst);
-        }
-    }
-
-    /// System clipboard whose write outcome is fixed at construction.
-    struct FixedWriter {
-        write_ok: bool,
-    }
-
-    impl SystemClipboardPort for FixedWriter {
-        fn read_snapshot(&self) -> anyhow::Result<SystemClipboardSnapshot> {
-            unreachable!("the announce adapter never reads the OS clipboard")
-        }
-
-        fn write_snapshot(&self, _snapshot: SystemClipboardSnapshot) -> anyhow::Result<()> {
-            if self.write_ok {
-                Ok(())
-            } else {
-                Err(anyhow::anyhow!("simulated OS clipboard write failure"))
-            }
-        }
-    }
-
-    /// Origin guard port with no behaviour — the coordinator drives it but its
-    /// calls are irrelevant to this test.
-    struct NoopOrigin;
-
-    #[async_trait]
-    impl SelfWriteLedgerPort for NoopOrigin {
-        async fn record_self_write(
-            &self,
-            _matching: SelfWriteMatch,
-            _attribution: SelfWriteAttribution,
-            _ttl: Duration,
-        ) {
-        }
-
-        async fn attribute_observed_change(&self, _snapshot_hash: &str) -> ClipboardChangeOrigin {
-            ClipboardChangeOrigin::LocalCapture
+            *self.last_hash.lock().unwrap() = Some(snapshot_hash);
         }
     }
 
@@ -239,59 +150,20 @@ mod tests {
         }
     }
 
-    fn adapter_with(write_ok: bool, spy: Arc<SpyConverge>) -> MobileActivationAnnounceAdapter {
-        let coordinator = Arc::new(ClipboardWriteCoordinator::new(
-            Arc::new(FixedWriter { write_ok }),
-            Arc::new(NoopOrigin),
-        ));
-        MobileActivationAnnounceAdapter::new(coordinator, spy)
-    }
-
     #[tokio::test]
-    async fn duplicate_skips_converge_when_os_write_fails() {
+    async fn announce_converges_once_under_the_snapshot_identity() {
         let spy = Arc::new(SpyConverge::default());
-        let adapter = adapter_with(false, spy.clone());
+        let adapter = MobileActivationAnnounceAdapter::new(spy.clone());
+        let snapshot = text_snapshot();
+        let expected_hash = snapshot.snapshot_hash().to_string();
 
-        adapter
-            .announce_duplicate(EntryId::new(), text_snapshot())
-            .await;
+        adapter.announce_new(EntryId::new(), snapshot).await;
 
+        assert_eq!(spy.calls.load(Ordering::SeqCst), 1);
         assert_eq!(
-            spy.calls.load(Ordering::SeqCst),
-            0,
-            "failed OS re-write must not advance the register or broadcast 0xC3"
-        );
-    }
-
-    #[tokio::test]
-    async fn duplicate_converges_once_when_os_write_succeeds() {
-        let spy = Arc::new(SpyConverge::default());
-        let adapter = adapter_with(true, spy.clone());
-
-        adapter
-            .announce_duplicate(EntryId::new(), text_snapshot())
-            .await;
-
-        assert_eq!(
-            spy.calls.load(Ordering::SeqCst),
-            1,
-            "successful OS re-write must converge exactly once"
-        );
-    }
-
-    #[tokio::test]
-    async fn new_converges_unconditionally_without_os_write() {
-        // announce_new does not re-write the OS clipboard (the inbound pipeline
-        // already did), so a failing writer must not affect it.
-        let spy = Arc::new(SpyConverge::default());
-        let adapter = adapter_with(false, spy.clone());
-
-        adapter.announce_new(EntryId::new(), text_snapshot()).await;
-
-        assert_eq!(
-            spy.calls.load(Ordering::SeqCst),
-            1,
-            "announce_new converges once, independent of any OS write"
+            spy.last_hash.lock().unwrap().as_deref(),
+            Some(expected_hash.as_str()),
+            "convergence must key off the snapshot's own identity"
         );
     }
 }

--- a/crates/uc-application/src/facade/mobile_sync/facade.rs
+++ b/crates/uc-application/src/facade/mobile_sync/facade.rs
@@ -52,7 +52,6 @@ use uc_core::ports::{
 };
 use uc_observability::analytics::AnalyticsPort;
 
-use crate::clipboard_write::ClipboardWriteCoordinator;
 use crate::deps::MobileDevicePorts;
 use crate::facade::active_clipboard::ActiveClipboardFacade;
 use crate::facade::clipboard_outbound::ClipboardOutboundFacade;
@@ -247,16 +246,15 @@ pub struct MobileSyncFacadeDeps {
     /// `GatedAnalyticsSink`，运行时按用户 `usage_analytics_enabled` 切换
     /// noop / 真实 sink）。测试装配传 `NoopAnalyticsSink`。
     pub analytics: Arc<dyn AnalyticsPort>,
-    /// 可选剪贴板写边界 + active-clipboard facade。两者同时提供时, 移动端
-    /// 入站激活本机剪贴板后 (`Applied` 新内容 / `DuplicateSkipped` 重复命中)
-    /// 统一收敛对端 (issue #1017 D1 call-sites 3 & 4):盖本设备激活戳、前进
-    /// 跨设备 register、按 per-device send 闸门广播 0xC3 state; duplicate
-    /// 命中还先用 `write_coordinator` 把这次上传的 snapshot 写回系统剪贴板。
+    /// 可选 active-clipboard facade。提供时, 移动端入站激活本机剪贴板后
+    /// (`Applied` 新内容 / `Resurfaced` 重复命中且已写入系统剪贴板) 统一收敛
+    /// 对端 (issue #1017 D1 call-sites 3 & 4):盖本设备激活戳、前进跨设备
+    /// register、按 per-device send 闸门广播 0xC3 state。
     ///
-    /// daemon 装配两者都传 `Some(...)`;CLI fallback / 单测传 `None`,
-    /// 移动端上传仅落地本机, 不收敛(行为与本特性引入前一致)。两者
-    /// 必须**同时** `Some` 才装 announce adapter —— 缺一个就降级成 `None`。
-    pub write_coordinator: Option<Arc<ClipboardWriteCoordinator>>,
+    /// 系统剪贴板由入站管线负责写, 不在本 facade 的职责内。
+    ///
+    /// daemon 装配传 `Some(...)`;CLI fallback / 单测传 `None`,
+    /// 移动端上传仅落地本机, 不收敛(行为与本特性引入前一致)。
     pub active_clipboard: Option<Arc<ActiveClipboardFacade>>,
     /// Backs [`MobileSyncFacade::check_content_available`] — the mobile-only
     /// content-availability probe. Resolves a client-computed `snapshot_hash`
@@ -333,7 +331,6 @@ impl MobileSyncFacade {
             clipboard_outbound,
             lan_lifecycle,
             analytics,
-            write_coordinator,
             active_clipboard,
             find_entry_by_snapshot_hash,
             check_entry_availability,
@@ -390,19 +387,15 @@ impl MobileSyncFacade {
                         as Arc<dyn MobileInboundFanOutPort>
                 }),
                 analytics,
-                // Mobile-activation announce (issue #1017 PR7): wired only when
-                // both the write boundary and the active-clipboard facade are
-                // present, so the adapter can re-write the OS clipboard on a
-                // duplicate hit and converge peers via the send-gated 0xC3 path.
-                // Either missing → no announce (mobile upload lands locally only).
-                write_coordinator
-                    .zip(active_clipboard)
-                    .map(|(coordinator, active_clipboard)| {
-                        Arc::new(MobileActivationAnnounceAdapter::new(
-                            coordinator,
-                            active_clipboard,
-                        )) as Arc<dyn MobileActivationAnnouncePort>
-                    }),
+                // Mobile-activation announce (issue #1017 PR7): converges the
+                // activation onto peers via the send-gated 0xC3 path. The OS
+                // write itself belongs to the inbound pipeline, so only the
+                // active-clipboard facade is needed here; `None` → no announce
+                // (mobile upload lands locally only).
+                active_clipboard.map(|active_clipboard| {
+                    Arc::new(MobileActivationAnnounceAdapter::new(active_clipboard))
+                        as Arc<dyn MobileActivationAnnouncePort>
+                }),
             ),
             get_latest_doc: GetLatestMobileSyncDocUseCase::new(snapshot_port.clone()),
             get_file: GetMobileSyncFileUseCase::new(snapshot_port, file_staging.clone()),
@@ -750,6 +743,7 @@ mod tests {
     //! `snapshot_ports` 用 5 个 unimplemented stub。
 
     use super::*;
+    use crate::clipboard_write::ClipboardWriteIntent;
 
     use std::sync::Mutex;
 
@@ -1073,7 +1067,11 @@ mod tests {
     struct UnusedWrite;
     #[async_trait]
     impl InboundWrite for UnusedWrite {
-        async fn write(&self, _: SystemClipboardSnapshot) -> AnyResult<()> {
+        async fn write(
+            &self,
+            _: SystemClipboardSnapshot,
+            _: ClipboardWriteIntent,
+        ) -> AnyResult<()> {
             unimplemented!()
         }
     }
@@ -1163,7 +1161,6 @@ mod tests {
             clipboard_outbound: None,
             lan_lifecycle: None,
             analytics: Arc::new(uc_observability::analytics::NoopAnalyticsSink::default()),
-            write_coordinator: None,
             active_clipboard: None,
             find_entry_by_snapshot_hash: Arc::new(UnusedEntryRepo),
             check_entry_availability: Arc::new(UnusedEntryRepo),
@@ -1330,7 +1327,6 @@ mod tests {
             clipboard_outbound: None,
             lan_lifecycle: None,
             analytics: Arc::new(uc_observability::analytics::NoopAnalyticsSink::default()),
-            write_coordinator: None,
             active_clipboard: None,
             find_entry_by_snapshot_hash: Arc::new(UnusedEntryRepo),
             check_entry_availability: Arc::new(UnusedEntryRepo),
@@ -1419,7 +1415,6 @@ mod tests {
             clipboard_outbound: None,
             lan_lifecycle: None,
             analytics: Arc::new(uc_observability::analytics::NoopAnalyticsSink::default()),
-            write_coordinator: None,
             active_clipboard: None,
             find_entry_by_snapshot_hash: Arc::new(UnusedEntryRepo),
             check_entry_availability: Arc::new(UnusedEntryRepo),
@@ -1539,7 +1534,6 @@ mod tests {
             clipboard_outbound: None,
             lan_lifecycle: Some(lifecycle),
             analytics: Arc::new(uc_observability::analytics::NoopAnalyticsSink::default()),
-            write_coordinator: None,
             active_clipboard: None,
             find_entry_by_snapshot_hash: Arc::new(UnusedEntryRepo),
             check_entry_availability: Arc::new(UnusedEntryRepo),
@@ -1692,7 +1686,6 @@ mod tests {
             clipboard_outbound: None,
             lan_lifecycle: Some(lifecycle),
             analytics: Arc::new(uc_observability::analytics::NoopAnalyticsSink::default()),
-            write_coordinator: None,
             active_clipboard: None,
             find_entry_by_snapshot_hash: Arc::new(UnusedEntryRepo),
             check_entry_availability: Arc::new(UnusedEntryRepo),

--- a/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/mod.rs
+++ b/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/mod.rs
@@ -4,9 +4,16 @@
 //! ## Flow
 //!
 //! 1. **Dedup short-circuit**: if `snapshot_hash` already exists in the
-//!    local `clipboard_event` table, return `DuplicateSkipped`. Skips
-//!    persist + OS-clipboard write — Phase 3 acceptance #4 guarantees a
-//!    repeat copy from a peer doesn't double-write the user's clipboard.
+//!    local `clipboard_event` table as a *fully-held* entry, the payload is
+//!    already ours — skip the download and the duplicate row, but still
+//!    **re-activate** it (`Resurfaced`): rebuild the snapshot from the local
+//!    entry, write it to the OS clipboard, advance the register, and bump it
+//!    to the top of history. "This content exists in history" is not the same
+//!    claim as "the OS clipboard currently holds it": a peer re-copying an
+//!    older clip (A → B → A) must still land on the user's pasteboard.
+//!    Genuinely redundant deliveries — a re-push inside the sub-second
+//!    [`timing`] windows, or a partial superseding a partial — stay
+//!    `DuplicateSkipped` (no OS write).
 //! 2. **Envelope decode**: V3 → `SystemClipboardSnapshot`. Decode failure
 //!    is non-fatal (`DecodeFailed` outcome) — corrupted payloads from a
 //!    misbehaving peer don't crash the daemon's ingest loop.
@@ -59,6 +66,8 @@ use thiserror::Error;
 use uc_core::ids::{DeviceId, EntryId};
 use uc_observability::FlowId;
 
+use crate::clipboard_write::ClipboardWriteIntent;
+
 mod materializer;
 mod ports;
 mod timing;
@@ -72,7 +81,7 @@ pub use materializer::{
     FileCacheBlobMaterializer, InboundBlobFetcher, InboundBlobMaterializer, InboundFileSetManifest,
     InboundFileSetMember,
 };
-pub use ports::{InboundCapture, InboundWrite};
+pub use ports::{InboundCapture, InboundSnapshotRebuild, InboundWrite};
 pub use usecase::ApplyInboundClipboardUseCase;
 
 /// Caller-supplied input mapped from the facade's public `InboundNotice`.
@@ -86,17 +95,53 @@ pub struct ApplyInboundInput {
     pub snapshot_hash: String,
     pub plaintext: Bytes,
     pub flow_id: Option<FlowId>,
+    /// Write intent for the [`ApplyOutcome::Resurfaced`] branch only — the
+    /// fresh-content branch always writes as `RemotePush`.
+    ///
+    /// The two inbound channels re-activate held content under different
+    /// identities, and the intent is what encodes that difference to the
+    /// watcher (see [`ClipboardWriteIntent`]):
+    ///
+    /// * **P2P bulk sync** → `RemotePush`. The sending peer already broadcast
+    ///   this clip to the whole space, so the watcher must short-circuit on our
+    ///   own write rather than re-dispatch it (loop defence).
+    /// * **Mobile LAN sync** → `LocalRestore`. The phone reached exactly one
+    ///   desktop; this device is the one activating the content, so the watcher
+    ///   is expected to pick the write up and propagate it to the remaining
+    ///   desktops.
+    ///
+    /// [`ClipboardWriteIntent`]: crate::clipboard_write::ClipboardWriteIntent
+    pub resurface_intent: ClipboardWriteIntent,
 }
 
 /// Result of one `execute` call. Daemon's worker maps each variant to a
-/// distinct telemetry path (WS event for `Applied`, debug log for
-/// `DuplicateSkipped`, warn log for `DecodeFailed`).
+/// distinct telemetry path (WS event for `Applied` / `Resurfaced`, debug log
+/// for `DuplicateSkipped`, warn log for `DecodeFailed`).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ApplyOutcome {
     /// New content — persisted + OS clipboard written. WS event fires.
     Applied { entry_id: EntryId },
-    /// `snapshot_hash` was already present in the local DB. No persist,
+    /// `snapshot_hash` matched a fully-held local entry: no download and no
+    /// new row, but the entry was re-activated — OS clipboard written under
+    /// [`ApplyInboundInput::resurface_intent`], register advanced, entry
+    /// bumped to the top of history. WS event fires.
+    Resurfaced {
+        snapshot_hash: String,
+        existing_entry_id: EntryId,
+        /// Whether the OS clipboard write succeeded. `false` means the content
+        /// is still held locally and still surfaced in history, but the
+        /// pasteboard was left untouched — so the register was **not** advanced
+        /// either. Callers that converge peers off this activation must treat
+        /// `false` as "do not propagate": broadcasting it would pin peers to an
+        /// activation this device does not actually hold.
+        os_write_succeeded: bool,
+    },
+    /// Delivery carried nothing to act on — a re-push inside the sub-second
+    /// dedup windows, or a partial superseding an existing partial. No persist,
     /// no OS write, no WS event.
+    ///
+    /// This is **not** the "peer re-copied an older clip" case; that resolves
+    /// to [`Self::Resurfaced`].
     DuplicateSkipped {
         snapshot_hash: String,
         existing_entry_id: EntryId,

--- a/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/ports.rs
+++ b/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/ports.rs
@@ -11,6 +11,7 @@ use uc_core::{ClipboardChangeOrigin, DeviceId, SnapshotHash, SystemClipboardSnap
 
 use crate::clipboard_capture::{CaptureClipboardUseCase, CommitMode};
 use crate::clipboard_write::{ClipboardWriteCoordinator, ClipboardWriteIntent};
+use crate::usecases::clipboard_sync::snapshot_from_entry::SnapshotReconstructor;
 
 /// Internal abstraction over the persistence pipeline. Production uses
 /// the blanket impl on `CaptureClipboardUseCase`; tests use a `mockall`
@@ -140,19 +141,51 @@ impl InboundCapture for CaptureClipboardUseCase {
     }
 }
 
+/// Internal abstraction over "rebuild the snapshot this entry holds locally".
+/// Production uses the blanket impl on `SnapshotReconstructor` (6 ports); tests
+/// mock this one method.
+#[async_trait]
+pub trait InboundSnapshotRebuild: Send + Sync {
+    /// Rebuild `entry_id`'s snapshot from local storage, resolving every
+    /// representation's bytes. Used to re-activate held content without
+    /// re-downloading the sender's payload.
+    async fn rebuild(&self, entry_id: &EntryId) -> Result<SystemClipboardSnapshot>;
+}
+
+#[async_trait]
+impl InboundSnapshotRebuild for SnapshotReconstructor {
+    async fn rebuild(&self, entry_id: &EntryId) -> Result<SystemClipboardSnapshot> {
+        self.reconstruct(entry_id).await.map_err(Into::into)
+    }
+}
+
 /// Internal abstraction over the OS clipboard write boundary. Production
 /// uses the blanket impl on `ClipboardWriteCoordinator`; tests mock it.
 #[async_trait]
 pub trait InboundWrite: Send + Sync {
-    /// Write `snapshot` to the OS clipboard with the `RemotePush`
-    /// intent (registers the appropriate hash guards + next-origin
-    /// override per the coordinator's contract).
-    async fn write(&self, snapshot: SystemClipboardSnapshot) -> Result<()>;
+    /// Write `snapshot` to the OS clipboard under `intent` (registers the
+    /// appropriate hash guards + next-origin override per the coordinator's
+    /// contract).
+    ///
+    /// Fresh content always arrives as `RemotePush`; the resurface path passes
+    /// [`ApplyInboundInput::resurface_intent`], which differs per inbound
+    /// channel — see its docs for why.
+    ///
+    /// [`ApplyInboundInput::resurface_intent`]: super::ApplyInboundInput::resurface_intent
+    async fn write(
+        &self,
+        snapshot: SystemClipboardSnapshot,
+        intent: ClipboardWriteIntent,
+    ) -> Result<()>;
 }
 
 #[async_trait]
 impl InboundWrite for ClipboardWriteCoordinator {
-    async fn write(&self, snapshot: SystemClipboardSnapshot) -> Result<()> {
-        ClipboardWriteCoordinator::write(self, snapshot, ClipboardWriteIntent::RemotePush).await
+    async fn write(
+        &self,
+        snapshot: SystemClipboardSnapshot,
+        intent: ClipboardWriteIntent,
+    ) -> Result<()> {
+        ClipboardWriteCoordinator::write(self, snapshot, intent).await
     }
 }

--- a/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/tests.rs
+++ b/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/tests.rs
@@ -10,6 +10,7 @@ use tracing_subscriber::layer::{Context, Layer};
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::registry::LookupSpan;
 
+use crate::clipboard_write::ClipboardWriteIntent;
 use crate::facade::host_event::{
     ClipboardHostEvent, ClipboardOriginKind, EmitError, HostEvent, HostEventBus,
     HostEventEmitterPort,
@@ -18,7 +19,7 @@ use crate::facade::host_event::{
 use uc_core::clipboard::ClipboardRepositoryError;
 use uc_core::ids::{DeviceId, EntryId, FormatId, RepresentationId};
 use uc_core::ports::blob::{BlobDigest, BlobTicket, PlaintextHash};
-use uc_core::ports::clipboard::FindEntryIdBySnapshotHashPort;
+use uc_core::ports::clipboard::{FindEntryIdBySnapshotHashPort, TouchClipboardEntryPort};
 use uc_core::{MimeType, ObservedClipboardRepresentation, SystemClipboardSnapshot};
 use uc_observability::FlowId;
 
@@ -32,7 +33,7 @@ use super::materializer::{
     InboundBlobMaterializer, InboundFileSetManifest, InboundFileSetMember, MaterializeResult,
     RootRenamer,
 };
-use super::ports::{InboundCapture, InboundWrite};
+use super::ports::{InboundCapture, InboundSnapshotRebuild, InboundWrite};
 use super::usecase::verify_file_set_identity;
 use super::usecase::ApplyInboundClipboardUseCase;
 use super::{ApplyInboundError, ApplyInboundInput, ApplyOutcome};
@@ -126,7 +127,27 @@ mockall::mock! {
     pub Write {}
     #[async_trait]
     impl InboundWrite for Write {
-        async fn write(&self, snapshot: SystemClipboardSnapshot) -> Result<()>;
+        async fn write(&self, snapshot: SystemClipboardSnapshot, intent: ClipboardWriteIntent) -> Result<()>;
+    }
+}
+
+mockall::mock! {
+    pub SnapshotRebuild {}
+    #[async_trait]
+    impl InboundSnapshotRebuild for SnapshotRebuild {
+        async fn rebuild(&self, entry_id: &EntryId) -> Result<SystemClipboardSnapshot>;
+    }
+}
+
+mockall::mock! {
+    pub TouchEntry {}
+    #[async_trait]
+    impl TouchClipboardEntryPort for TouchEntry {
+        async fn touch_entry(
+            &self,
+            entry_id: &EntryId,
+            active_time_ms: i64,
+        ) -> std::result::Result<bool, ClipboardRepositoryError>;
     }
 }
 
@@ -188,6 +209,7 @@ fn fixture_input(text: &str) -> (ApplyInboundInput, String) {
             snapshot_hash: snapshot_hash.clone(),
             plaintext,
             flow_id: None,
+            resurface_intent: ClipboardWriteIntent::RemotePush,
         },
         snapshot_hash,
     )
@@ -215,6 +237,7 @@ fn fixture_input_from_snapshot(snapshot: SystemClipboardSnapshot) -> (ApplyInbou
             snapshot_hash: snapshot_hash.clone(),
             plaintext,
             flow_id: None,
+            resurface_intent: ClipboardWriteIntent::RemotePush,
         },
         snapshot_hash,
     )
@@ -299,7 +322,7 @@ async fn applied_on_new_content() {
         .returning(|_, _, _| Ok(Some(EntryId::from("entry-new"))));
 
     let mut write = MockWrite::new();
-    write.expect_write().times(1).returning(|_| Ok(()));
+    write.expect_write().times(1).returning(|_, _| Ok(()));
 
     let uc = build(repo, capture, write);
     let outcome = uc.execute(input).await.expect("happy path returns ok");
@@ -334,18 +357,17 @@ async fn from_device_is_forwarded_to_capture() {
         .returning(|_, _, _| Ok(Some(EntryId::from("entry-remote"))));
 
     let mut write = MockWrite::new();
-    write.expect_write().times(1).returning(|_| Ok(()));
+    write.expect_write().times(1).returning(|_, _| Ok(()));
 
     let uc = build(repo, capture, write);
     uc.execute(input).await.expect("forwarding path ok");
 }
 
-/// Verdict 2 — dedup hit: returns `DuplicateSkipped` and **does
-/// not** call capture or write. Critical correctness property —
-/// repeated dispatches from a peer must not double-write the user's
-/// OS clipboard (Phase 3 acceptance #4).
+/// Store-only paths (pull / CLI) leave resurface unwired: a dedup hit then
+/// degrades to the plain skip — no capture, no write. Their write port is a
+/// no-op anyway, and the pull path's convergence tail owns the real OS write.
 #[tokio::test]
-async fn duplicate_skipped_when_hash_already_local() {
+async fn dedup_hit_skips_when_resurface_is_unwired() {
     let (input, hash) = fixture_input("already-here");
 
     let mut repo = MockEntryRepo::new();
@@ -387,7 +409,7 @@ async fn rapid_duplicate_skipped_even_when_repo_has_not_caught_up() {
         .returning(|_, _, _| Ok(Some(EntryId::from("entry-first"))));
 
     let mut write = MockWrite::new();
-    write.expect_write().times(1).returning(|_| Ok(()));
+    write.expect_write().times(1).returning(|_, _| Ok(()));
 
     let uc = build(repo, capture, write);
     let first = uc
@@ -469,7 +491,7 @@ async fn visible_duplicate_skipped_across_channel_representation_expansion() {
         .returning(|_, _, _| Ok(Some(EntryId::from("entry-visible"))));
 
     let mut write = MockWrite::new();
-    write.expect_write().times(1).returning(|_| Ok(()));
+    write.expect_write().times(1).returning(|_, _| Ok(()));
 
     let uc = build(repo, capture, write);
     let first = uc
@@ -537,7 +559,7 @@ async fn visible_duplicate_window_expires() {
         .returning(|_, _, _| Ok(Some(EntryId::new())));
 
     let mut write = MockWrite::new();
-    write.expect_write().times(2).returning(|_| Ok(()));
+    write.expect_write().times(2).returning(|_, _| Ok(()));
 
     let uc = build(repo, capture, write);
     assert!(
@@ -568,6 +590,7 @@ async fn decode_failed_on_truncated_envelope() {
         snapshot_hash: "blake3v1:00".to_string(),
         plaintext: Bytes::from_static(b"not a valid V3 envelope"),
         flow_id: None,
+        resurface_intent: ClipboardWriteIntent::RemotePush,
     };
 
     let mut repo = MockEntryRepo::new();
@@ -600,6 +623,7 @@ async fn execute_records_incoming_flow_id_on_span() {
         snapshot_hash: "blake3v1:11".to_string(),
         plaintext: Bytes::from_static(b"not a valid V3 envelope"),
         flow_id: Some(incoming_flow_id.clone()),
+        resurface_intent: ClipboardWriteIntent::RemotePush,
     };
 
     let mut repo = MockEntryRepo::new();
@@ -697,7 +721,7 @@ async fn write_failure_does_not_surface_after_capture_commits() {
     let tx_for_mock = std::sync::Arc::clone(&tx);
 
     let mut write = MockWrite::new();
-    write.expect_write().times(1).returning(move |_| {
+    write.expect_write().times(1).returning(move |_, _| {
         if let Some(tx) = tx_for_mock.lock().unwrap_or_else(|p| p.into_inner()).take() {
             let _ = tx.send(());
         }
@@ -772,6 +796,7 @@ async fn materializes_blob_refs_before_capture_and_write() {
         snapshot_hash: snapshot_hash.clone(),
         plaintext,
         flow_id: None,
+        resurface_intent: ClipboardWriteIntent::RemotePush,
     };
 
     let mut repo = MockEntryRepo::new();
@@ -812,9 +837,9 @@ async fn materializes_blob_refs_before_capture_and_write() {
     let mut write = MockWrite::new();
     write
         .expect_write()
-        .withf(move |snapshot| assert_local_file(snapshot))
+        .withf(move |snapshot, _| assert_local_file(snapshot))
         .times(1)
-        .returning(|_| Ok(()));
+        .returning(|_, _| Ok(()));
 
     let uc = build_with_blob_materializer(repo, capture, write, materializer);
     let outcome = uc.execute(input).await.expect("blob materialize path ok");
@@ -861,6 +886,7 @@ async fn partial_materialize_persists_entry_but_skips_os_write() {
         snapshot_hash,
         plaintext,
         flow_id: None,
+        resurface_intent: ClipboardWriteIntent::RemotePush,
     };
 
     let mut repo = MockEntryRepo::new();
@@ -946,12 +972,14 @@ async fn partial_materialize_does_not_register_dedup_entry() {
         snapshot_hash: snapshot_hash.clone(),
         plaintext: plaintext.clone(),
         flow_id: None,
+        resurface_intent: ClipboardWriteIntent::RemotePush,
     };
     let input2 = ApplyInboundInput {
         from_device: DeviceId::new("peer-sender"),
         snapshot_hash,
         plaintext,
         flow_id: None,
+        resurface_intent: ClipboardWriteIntent::RemotePush,
     };
 
     let mut repo = MockEntryRepo::new();
@@ -999,7 +1027,7 @@ async fn partial_materialize_does_not_register_dedup_entry() {
 
     // OS write 只发生在第二次(complete)。
     let mut write = MockWrite::new();
-    write.expect_write().times(1).returning(|_| Ok(()));
+    write.expect_write().times(1).returning(|_, _| Ok(()));
 
     let uc = build_with_blob_materializer(repo, capture, write, materializer);
 
@@ -1444,10 +1472,10 @@ async fn apply_inbound_materializes_and_commits_mixed_directory_payload() {
     write
         .expect_write()
         .times(1)
-        .withf(snapshot_paths_exist)
+        .withf(|s, _| snapshot_paths_exist(s))
         .returning({
             let write_completed = Arc::clone(&write_completed);
-            move |_| {
+            move |_, _| {
                 write_completed.notify_one();
                 Ok(())
             }
@@ -1463,6 +1491,7 @@ async fn apply_inbound_materializes_and_commits_mixed_directory_payload() {
             snapshot_hash,
             plaintext,
             flow_id: None,
+            resurface_intent: ClipboardWriteIntent::RemotePush,
         })
         .await
         .expect("directory payload should apply");
@@ -2338,7 +2367,7 @@ async fn happy_path_emits_incoming_pending_then_new_content() {
         .returning(|preset, _, _| Ok(Some(preset)));
 
     let mut write = MockWrite::new();
-    write.expect_write().times(1).returning(|_| Ok(()));
+    write.expect_write().times(1).returning(|_, _| Ok(()));
 
     let (uc, recorder) = build_with_recording_emitter(repo, capture, write);
     let outcome = uc.execute(input).await.expect("happy path");
@@ -2431,6 +2460,7 @@ fn file_blob_input() -> ApplyInboundInput {
         snapshot_hash,
         plaintext,
         flow_id: None,
+        resurface_intent: ClipboardWriteIntent::RemotePush,
     }
 }
 
@@ -2474,7 +2504,7 @@ async fn partial_match_is_upgraded_in_place_by_complete_delivery() {
         .returning(|preset, _, _| Ok(Some(preset)));
 
     let mut write = MockWrite::new();
-    write.expect_write().times(1).returning(|_| Ok(()));
+    write.expect_write().times(1).returning(|_, _| Ok(()));
 
     let uc = build_with_blob_materializer(repo, capture, write, materializer)
         .with_check_entry_availability(Arc::new(FakeAvailability { available: false }));
@@ -2569,5 +2599,315 @@ async fn partial_delivery_does_not_replace_existing_partial() {
             snapshot_hash: file_blob_input().snapshot_hash,
             existing_entry_id: partial_id,
         }
+    );
+}
+
+// ── resurface: a peer re-copying an older clip ──────────────────────
+//
+// Regression cover for the A → B → A bug: peer copies `abc`, then `xyz`, then
+// `abc` again. The third delivery's content is already held here, so the old
+// code dropped it and left the pasteboard on `xyz` until the periodic
+// active-state broadcast repaired it up to a minute later.
+
+fn resurface_uc(
+    repo: MockEntryRepo,
+    capture: MockCapture,
+    write: MockWrite,
+    rebuild: MockSnapshotRebuild,
+    touch: MockTouchEntry,
+) -> ApplyInboundClipboardUseCase {
+    ApplyInboundClipboardUseCase::new(Arc::new(repo), Arc::new(capture), Arc::new(write))
+        .with_resurface_ports(Arc::new(rebuild), Arc::new(touch))
+}
+
+/// The held entry is rebuilt from local storage and written to the OS
+/// clipboard — never re-downloaded, never duplicated as a new row.
+#[tokio::test]
+async fn dedup_hit_rewrites_held_entry_to_os_clipboard() {
+    let (input, hash) = fixture_input("abc");
+    let existing = EntryId::from("entry-abc");
+
+    let mut repo = MockEntryRepo::new();
+    let existing_for_repo = existing.clone();
+    repo.expect_find_entry_id_by_snapshot_hash()
+        .with(eq(hash.clone()))
+        .times(1)
+        .returning(move |_| Ok(Some(existing_for_repo.clone())));
+
+    // No new row: capture must never be called on this path.
+    let capture = MockCapture::new();
+
+    let mut rebuild = MockSnapshotRebuild::new();
+    let existing_for_rebuild = existing.clone();
+    rebuild
+        .expect_rebuild()
+        .withf(move |id| id == &existing_for_rebuild)
+        .times(1)
+        .returning(|_| {
+            Ok(SystemClipboardSnapshot {
+                // The rebuilt snapshot carries the entry's *original* creation
+                // time — deliberately different from the inbound activation
+                // time asserted below.
+                ts_ms: 1_600_000_000_000,
+                representations: vec![ObservedClipboardRepresentation::new(
+                    RepresentationId::new(),
+                    FormatId::from("text"),
+                    Some(MimeType("text/plain".to_string())),
+                    b"abc".to_vec(),
+                )],
+                file_content_digests: Vec::new(),
+                file_set_v1_component: None,
+            })
+        });
+
+    let mut write = MockWrite::new();
+    write
+        .expect_write()
+        .withf(|snapshot, intent| {
+            *intent == ClipboardWriteIntent::RemotePush
+                && snapshot.representations[0].inline_bytes() == Some(b"abc".as_slice())
+        })
+        .times(1)
+        .returning(|_, _| Ok(()));
+
+    let mut touch = MockTouchEntry::new();
+    touch
+        .expect_touch_entry()
+        .times(1)
+        .returning(|_, _| Ok(true));
+
+    let uc = resurface_uc(repo, capture, write, rebuild, touch);
+    let outcome = uc.execute(input).await.expect("resurface path ok");
+
+    assert_eq!(
+        outcome,
+        ApplyOutcome::Resurfaced {
+            snapshot_hash: hash,
+            existing_entry_id: existing,
+            os_write_succeeded: true,
+        }
+    );
+}
+
+/// The history bump must be stamped with the *inbound* activation time, not the
+/// rebuilt snapshot's `created_at_ms`. Getting this wrong stamps the entry with
+/// when the content was first seen, which loses the LWW comparison against the
+/// clip it is meant to supersede.
+#[tokio::test]
+async fn resurface_stamps_the_inbound_activation_time_not_the_entrys_creation_time() {
+    let (input, _hash) = fixture_input("abc");
+    // `fixture_input` stamps the inbound snapshot with this observation time.
+    let inbound_ts = 1_700_000_000_000i64;
+
+    let mut repo = MockEntryRepo::new();
+    repo.expect_find_entry_id_by_snapshot_hash()
+        .times(1)
+        .returning(|_| Ok(Some(EntryId::from("entry-abc"))));
+
+    let mut rebuild = MockSnapshotRebuild::new();
+    rebuild.expect_rebuild().times(1).returning(|_| {
+        Ok(SystemClipboardSnapshot {
+            ts_ms: 1_600_000_000_000, // entry.created_at_ms — the wrong source
+            representations: vec![ObservedClipboardRepresentation::new(
+                RepresentationId::new(),
+                FormatId::from("text"),
+                Some(MimeType("text/plain".to_string())),
+                b"abc".to_vec(),
+            )],
+            file_content_digests: Vec::new(),
+            file_set_v1_component: None,
+        })
+    });
+
+    let mut write = MockWrite::new();
+    write.expect_write().times(1).returning(|_, _| Ok(()));
+
+    let mut touch = MockTouchEntry::new();
+    touch
+        .expect_touch_entry()
+        .withf(move |_, active_time_ms| *active_time_ms == inbound_ts)
+        .times(1)
+        .returning(|_, _| Ok(true));
+
+    let uc = resurface_uc(repo, MockCapture::new(), write, rebuild, touch);
+    uc.execute(input).await.expect("resurface path ok");
+}
+
+/// A rebuild failure (payload lost / blob gone) must not fabricate an
+/// activation: fall back to the plain skip rather than writing a broken
+/// snapshot to the pasteboard.
+#[tokio::test]
+async fn resurface_degrades_to_skip_when_rebuild_fails() {
+    let (input, hash) = fixture_input("abc");
+
+    let mut repo = MockEntryRepo::new();
+    repo.expect_find_entry_id_by_snapshot_hash()
+        .times(1)
+        .returning(|_| Ok(Some(EntryId::from("entry-abc"))));
+
+    let mut rebuild = MockSnapshotRebuild::new();
+    rebuild
+        .expect_rebuild()
+        .times(1)
+        .returning(|_| Err(anyhow::anyhow!("payload lost")));
+
+    // Nothing may reach the clipboard or history.
+    let write = MockWrite::new();
+    let mut touch = MockTouchEntry::new();
+    touch.expect_touch_entry().never();
+
+    let uc = resurface_uc(repo, MockCapture::new(), write, rebuild, touch);
+    let outcome = uc.execute(input).await.expect("degraded path ok");
+
+    assert_eq!(
+        outcome,
+        ApplyOutcome::DuplicateSkipped {
+            snapshot_hash: hash,
+            existing_entry_id: EntryId::from("entry-abc"),
+        }
+    );
+}
+
+/// A failed OS write reports `os_write_succeeded: false` and skips the history
+/// bump — callers use that flag to avoid broadcasting an activation this device
+/// does not actually hold.
+#[tokio::test]
+async fn resurface_reports_failed_os_write_and_skips_history_bump() {
+    let (input, _hash) = fixture_input("abc");
+
+    let mut repo = MockEntryRepo::new();
+    repo.expect_find_entry_id_by_snapshot_hash()
+        .times(1)
+        .returning(|_| Ok(Some(EntryId::from("entry-abc"))));
+
+    let mut rebuild = MockSnapshotRebuild::new();
+    rebuild.expect_rebuild().times(1).returning(|_| {
+        Ok(SystemClipboardSnapshot {
+            ts_ms: 1,
+            representations: vec![ObservedClipboardRepresentation::new(
+                RepresentationId::new(),
+                FormatId::from("text"),
+                Some(MimeType("text/plain".to_string())),
+                b"abc".to_vec(),
+            )],
+            file_content_digests: Vec::new(),
+            file_set_v1_component: None,
+        })
+    });
+
+    let mut write = MockWrite::new();
+    write
+        .expect_write()
+        .times(1)
+        .returning(|_, _| Err(anyhow::anyhow!("clipboard busy")));
+
+    let mut touch = MockTouchEntry::new();
+    touch.expect_touch_entry().never();
+
+    let uc = resurface_uc(repo, MockCapture::new(), write, rebuild, touch);
+    let outcome = uc.execute(input).await.expect("failed-write path still ok");
+
+    assert!(matches!(
+        outcome,
+        ApplyOutcome::Resurfaced {
+            os_write_succeeded: false,
+            ..
+        }
+    ));
+}
+
+/// A retried frame (or the same clip arriving over a second channel) must not
+/// re-write the pasteboard again: only the first re-activation acts.
+#[tokio::test]
+async fn rapid_re_delivery_of_held_entry_resurfaces_only_once() {
+    let (input, _hash) = fixture_input("abc");
+
+    let mut repo = MockEntryRepo::new();
+    repo.expect_find_entry_id_by_snapshot_hash()
+        .times(2)
+        .returning(|_| Ok(Some(EntryId::from("entry-abc"))));
+
+    // Rebuild + write happen exactly once across the two deliveries.
+    let mut rebuild = MockSnapshotRebuild::new();
+    rebuild.expect_rebuild().times(1).returning(|_| {
+        Ok(SystemClipboardSnapshot {
+            ts_ms: 1,
+            representations: vec![ObservedClipboardRepresentation::new(
+                RepresentationId::new(),
+                FormatId::from("text"),
+                Some(MimeType("text/plain".to_string())),
+                b"abc".to_vec(),
+            )],
+            file_content_digests: Vec::new(),
+            file_set_v1_component: None,
+        })
+    });
+    let mut write = MockWrite::new();
+    write.expect_write().times(1).returning(|_, _| Ok(()));
+    let mut touch = MockTouchEntry::new();
+    touch
+        .expect_touch_entry()
+        .times(1)
+        .returning(|_, _| Ok(true));
+
+    let uc = resurface_uc(repo, MockCapture::new(), write, rebuild, touch);
+
+    let first = uc.execute(input.clone()).await.expect("first ok");
+    assert!(matches!(first, ApplyOutcome::Resurfaced { .. }));
+
+    let second = uc.execute(input).await.expect("second ok");
+    assert!(
+        matches!(second, ApplyOutcome::DuplicateSkipped { .. }),
+        "a rapid re-delivery must not touch the pasteboard again, got {second:?}"
+    );
+}
+
+/// The rapid guard must not swallow a genuine repeat copy: once the window
+/// lapses, the same content re-activates again (peer copies abc → xyz → abc).
+#[tokio::test]
+async fn repeat_copy_after_window_resurfaces_again() {
+    let (input, _hash) = fixture_input("abc");
+
+    let mut repo = MockEntryRepo::new();
+    repo.expect_find_entry_id_by_snapshot_hash()
+        .times(2)
+        .returning(|_| Ok(Some(EntryId::from("entry-abc"))));
+
+    // Both deliveries act: this is the A → B → A case the fix exists for.
+    let mut rebuild = MockSnapshotRebuild::new();
+    rebuild.expect_rebuild().times(2).returning(|_| {
+        Ok(SystemClipboardSnapshot {
+            ts_ms: 1,
+            representations: vec![ObservedClipboardRepresentation::new(
+                RepresentationId::new(),
+                FormatId::from("text"),
+                Some(MimeType("text/plain".to_string())),
+                b"abc".to_vec(),
+            )],
+            file_content_digests: Vec::new(),
+            file_set_v1_component: None,
+        })
+    });
+    let mut write = MockWrite::new();
+    write.expect_write().times(2).returning(|_, _| Ok(()));
+    let mut touch = MockTouchEntry::new();
+    touch
+        .expect_touch_entry()
+        .times(2)
+        .returning(|_, _| Ok(true));
+
+    let uc = resurface_uc(repo, MockCapture::new(), write, rebuild, touch);
+
+    let first = uc.execute(input.clone()).await.expect("first ok");
+    assert!(matches!(first, ApplyOutcome::Resurfaced { .. }));
+
+    // Past RAPID_DUPLICATE_WINDOW (200ms), matching how the sibling
+    // visible-window test waits it out.
+    tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+
+    let second = uc.execute(input).await.expect("second ok");
+    assert!(
+        matches!(second, ApplyOutcome::Resurfaced { .. }),
+        "a deliberate repeat copy must re-activate, got {second:?}"
     );
 }

--- a/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/usecase.rs
+++ b/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/usecase.rs
@@ -10,12 +10,14 @@ use uc_core::clipboard::ActiveClipboardState;
 use uc_core::ids::EntryId;
 use uc_core::ports::clipboard::{
     AdvanceActiveClipboardPort, CheckEntryAvailabilityPort, FindEntryIdBySnapshotHashPort,
+    TouchClipboardEntryPort,
 };
 use uc_core::{SnapshotHash, SystemClipboardSnapshot};
 
-use crate::clipboard_write::MobileConsumabilityProbe;
+use crate::clipboard_write::{ClipboardWriteIntent, MobileConsumabilityProbe};
 use crate::entry_identity::EntryIdentityCoordinator;
 
+use crate::facade::active_clipboard::ClipboardSnapshotDeps;
 use crate::facade::blob_transfer::SharedHostEventEmitter;
 use crate::facade::clipboard_live_index::{
     ClipboardLiveIndexInput, ClipboardLiveIndexOutcome, ClipboardLiveIndexPort,
@@ -26,7 +28,7 @@ use crate::facade::host_event::{
 use crate::usecases::clipboard_sync::payload_codec::decode_v3_bytes_to_snapshot_blob_refs_and_file_set;
 
 use super::materializer::InboundBlobMaterializer;
-use super::ports::{InboundCapture, InboundWrite};
+use super::ports::{InboundCapture, InboundSnapshotRebuild, InboundWrite};
 use super::timing::{RAPID_DUPLICATE_WINDOW, VISIBLE_DUPLICATE_WINDOW};
 use super::{ApplyInboundError, ApplyInboundInput, ApplyOutcome};
 
@@ -75,6 +77,22 @@ pub struct ApplyInboundClipboardUseCase {
     /// clipboard is searchable just like local captures. `None` in tests /
     /// contexts without a search subsystem.
     search_live_index: Option<Arc<dyn ClipboardLiveIndexPort>>,
+    /// Optional resurface support for the fully-held dedup hit: rebuild the
+    /// held entry's snapshot and bump it to the top of history. Both ports are
+    /// wired together or not at all ([`Self::with_resurface`]). `None` degrades
+    /// a dedup hit to a plain skip — correct for the store-only paths (pull /
+    /// CLI), whose OS write is a no-op anyway.
+    resurface: Option<ResurfacePorts>,
+}
+
+/// Ports needed to re-activate an already-held entry on a dedup hit.
+struct ResurfacePorts {
+    /// Rebuilds the snapshot from local storage, so re-activating held content
+    /// never re-downloads the sender's payload.
+    rebuild: Arc<dyn InboundSnapshotRebuild>,
+    /// Bumps the entry to the top of history, mirroring what a local re-copy
+    /// of the same content does.
+    touch_entry: Arc<dyn TouchClipboardEntryPort>,
 }
 
 impl ApplyInboundClipboardUseCase {
@@ -94,6 +112,7 @@ impl ApplyInboundClipboardUseCase {
             active_register: None,
             mobile_consumability: None,
             search_live_index: None,
+            resurface: None,
             recent_snapshot_hashes: Cache::builder()
                 .max_capacity(RECENT_INBOUND_MAX_RECORDS)
                 .time_to_live(RAPID_DUPLICATE_WINDOW)
@@ -161,6 +180,35 @@ impl ApplyInboundClipboardUseCase {
     /// remote-origin clipboard shows up in search like local captures.
     pub fn with_search_live_index(mut self, index: Arc<dyn ClipboardLiveIndexPort>) -> Self {
         self.search_live_index = Some(index);
+        self
+    }
+
+    /// Wire resurface support, so a delivery whose content is already held
+    /// locally still re-activates it (OS write + register advance + history
+    /// bump) instead of being dropped.
+    ///
+    /// Required on any path that owns the user's pasteboard. Leaving it unwired
+    /// keeps the prior skip-on-match behavior, which is what the store-only
+    /// paths (pull / CLI) want — they pair it with a no-op write port.
+    pub fn with_resurface(
+        self,
+        snapshot_deps: ClipboardSnapshotDeps,
+        touch_entry: Arc<dyn TouchClipboardEntryPort>,
+    ) -> Self {
+        self.with_resurface_ports(Arc::new(snapshot_deps.into_reconstructor()), touch_entry)
+    }
+
+    /// [`Self::with_resurface`] against the narrow rebuild seam, so tests can
+    /// mock one method instead of standing up six repository ports.
+    pub fn with_resurface_ports(
+        mut self,
+        rebuild: Arc<dyn InboundSnapshotRebuild>,
+        touch_entry: Arc<dyn TouchClipboardEntryPort>,
+    ) -> Self {
+        self.resurface = Some(ResurfacePorts {
+            rebuild,
+            touch_entry,
+        });
         self
     }
 
@@ -267,6 +315,150 @@ impl ApplyInboundClipboardUseCase {
         }
     }
 
+    /// Re-activate an entry whose content this device already holds in full.
+    ///
+    /// Reached when a peer re-copies an older clip (A → B → A): the payload is
+    /// already ours, so there is nothing to download and no row to add — but the
+    /// activation is real and the OS clipboard must follow it. Skipping the
+    /// write here is what used to leave the pasteboard on the *previous* clip
+    /// until the periodic active-state broadcast repaired it up to a minute
+    /// later.
+    ///
+    /// `activated_at_ms` comes from the **inbound** snapshot (when the sender
+    /// activated this content), never from the rebuilt one — the rebuilt
+    /// snapshot carries `entry.created_at_ms`, i.e. when this content was
+    /// *first* seen. Feeding that to the register would look like a stale
+    /// activation and lose the LWW comparison against the clip it is meant to
+    /// supersede.
+    ///
+    /// Ordering mirrors the active-state convergence tail: OS write first, and
+    /// only on success advance the register. A register pointing at content the
+    /// pasteboard does not hold would let this device broadcast a phantom
+    /// activation to its peers. The history bump and the UI event are
+    /// best-effort tails that never fail the outcome.
+    async fn resurface_held_entry(
+        &self,
+        input: &ApplyInboundInput,
+        existing_id: &EntryId,
+        activated_at_ms: i64,
+    ) -> ApplyOutcome {
+        let Some(resurface) = self.resurface.as_ref() else {
+            debug!(
+                existing_entry_id = %existing_id,
+                "inbound dropped: duplicate of existing, fully-held local entry (resurface unwired)"
+            );
+            return ApplyOutcome::DuplicateSkipped {
+                snapshot_hash: input.snapshot_hash.clone(),
+                existing_entry_id: existing_id.clone(),
+            };
+        };
+
+        // A re-activation this recent is the same logical delivery arriving
+        // twice (a retried frame, or one clip reaching us over both the direct
+        // dispatch and the active-state channel) — not the user copying the
+        // same thing again. Re-writing the pasteboard for it is pure noise.
+        // The window is sub-second (see `timing`), far below any human re-copy,
+        // so a genuine repeat copy still resurfaces.
+        if self
+            .recent_snapshot_hashes
+            .get(&input.snapshot_hash)
+            .is_some()
+        {
+            debug!(
+                existing_entry_id = %existing_id,
+                "inbound dropped: re-activation of a just-activated entry (rapid duplicate)"
+            );
+            return ApplyOutcome::DuplicateSkipped {
+                snapshot_hash: input.snapshot_hash.clone(),
+                existing_entry_id: existing_id.clone(),
+            };
+        }
+
+        // Rebuild from local storage rather than the inbound envelope: the
+        // envelope's blob-backed reps are unresolved refs, and re-materializing
+        // them would re-download bytes we already have.
+        let snapshot = match resurface.rebuild.rebuild(existing_id).await {
+            Ok(snapshot) => snapshot,
+            Err(err) => {
+                warn!(
+                    error = %err,
+                    existing_entry_id = %existing_id,
+                    "inbound: held entry could not be rebuilt; skipping re-activation"
+                );
+                return ApplyOutcome::DuplicateSkipped {
+                    snapshot_hash: input.snapshot_hash.clone(),
+                    existing_entry_id: existing_id.clone(),
+                };
+            }
+        };
+
+        if let Err(err) = self.write.write(snapshot, input.resurface_intent).await {
+            warn!(
+                error = %err,
+                existing_entry_id = %existing_id,
+                "inbound: OS clipboard write failed while re-activating held entry; \
+                 not advancing the active register"
+            );
+            return ApplyOutcome::Resurfaced {
+                snapshot_hash: input.snapshot_hash.clone(),
+                existing_entry_id: existing_id.clone(),
+                os_write_succeeded: false,
+            };
+        }
+
+        // Arms the rapid-duplicate guard above against this delivery's own
+        // retries / second channel. Only recorded once the write landed, so a
+        // failed re-activation stays retryable.
+        self.remember_recent_inbound(input.snapshot_hash.clone(), None, existing_id.clone());
+
+        self.advance_active_register(
+            input.snapshot_hash.clone(),
+            existing_id.clone(),
+            input.from_device,
+            activated_at_ms,
+        )
+        .await;
+
+        // Bump to the top of history, mirroring the local-capture dedup path
+        // (`clipboard_capture::usecase`), so a re-copy on either side of the
+        // link surfaces the entry the same way.
+        match resurface
+            .touch_entry
+            .touch_entry(existing_id, activated_at_ms)
+            .await
+        {
+            Ok(true) => {}
+            Ok(false) => debug!(
+                existing_entry_id = %existing_id,
+                "inbound: resurface target vanished before history bump"
+            ),
+            Err(err) => warn!(
+                error = %err,
+                existing_entry_id = %existing_id,
+                "inbound: history bump failed (best-effort, ignored)"
+            ),
+        }
+
+        info!(
+            existing_entry_id = %existing_id,
+            "inbound: re-activated already-held entry (no download, no duplicate row)"
+        );
+
+        // Same event the fresh-content path emits: the entry moved in history
+        // and is now the active clipboard, so the list has to re-render.
+        self.emit_host_event(HostEvent::Clipboard(ClipboardHostEvent::NewContent {
+            entry_id: existing_id.as_ref().to_string(),
+            preview: "New clipboard content".to_string(),
+            origin: ClipboardOriginKind::Remote,
+        }));
+
+        ApplyOutcome::Resurfaced {
+            snapshot_hash: input.snapshot_hash.clone(),
+            existing_entry_id: existing_id.clone(),
+            os_write_succeeded: true,
+        }
+    }
+
     // 跨设备可观测性(PR2):
     //   - `peer.device_id` 是 PR2 起的标准字段名,把发送方 device 摆到一级
     //     span field;`from_device` 暂时保留兼容现有日志查询,Sentry tag
@@ -321,8 +513,10 @@ impl ApplyInboundClipboardUseCase {
         // identities proceed in parallel via the coordinator's lock striping.
         let _identity_guard = self.coordinator.lock(&input.snapshot_hash).await;
 
-        // 3. Pre-download dedup. A hash match that is *fully held* is skipped
-        // before we show a progress card or download anything. A match that is
+        // 3. Pre-download dedup. A hash match that is *fully held* needs no
+        // download and no new row — but it still re-activates the held entry
+        // (see `resurface_held_entry`), because the sender copying an older clip
+        // is a real activation the pasteboard must follow. A match that is
         // *partial* (e.g. a cancelled transfer's `uniclip-missing://`
         // placeholder) is NOT held — fall through to materialize and upgrade it
         // in place. The repo's default `Ok(None)` impl (in-memory test fakes)
@@ -335,14 +529,9 @@ impl ApplyInboundClipboardUseCase {
             .map_err(|e| ApplyInboundError::DedupQuery(e.to_string()))?;
         if let Some(existing_id) = existing.as_ref() {
             if self.is_entry_available(existing_id).await {
-                debug!(
-                    existing_entry_id = %existing_id,
-                    "inbound dropped: duplicate of existing, fully-held local entry"
-                );
-                return Ok(ApplyOutcome::DuplicateSkipped {
-                    snapshot_hash: input.snapshot_hash,
-                    existing_entry_id: existing_id.clone(),
-                });
+                return Ok(self
+                    .resurface_held_entry(&input, existing_id, snapshot.ts_ms)
+                    .await);
             }
             debug!(
                 existing_entry_id = %existing_id,
@@ -602,7 +791,13 @@ impl ApplyInboundClipboardUseCase {
                     // (refcount is 1 here) and only guards a future second holder.
                     let snapshot_for_write = Arc::try_unwrap(snapshot_for_write)
                         .unwrap_or_else(|shared| (*shared).clone());
-                    if let Err(e) = write_port.write(snapshot_for_write).await {
+                    // Fresh content is always a remote push regardless of which
+                    // channel delivered it: this write must not be re-captured
+                    // and re-dispatched by our own watcher.
+                    if let Err(e) = write_port
+                        .write(snapshot_for_write, ClipboardWriteIntent::RemotePush)
+                        .await
+                    {
                         error!(
                             event = "inbound_os_write_failed",
                             error_kind = "inbound_os_write_failed",

--- a/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/usecase.rs
+++ b/crates/uc-application/src/usecases/clipboard_sync/apply_inbound/usecase.rs
@@ -394,6 +394,8 @@ impl ApplyInboundClipboardUseCase {
 
         if let Err(err) = self.write.write(snapshot, input.resurface_intent).await {
             warn!(
+                event = "inbound_os_write_failed",
+                error_kind = "inbound_os_write_failed",
                 error = %err,
                 existing_entry_id = %existing_id,
                 "inbound: OS clipboard write failed while re-activating held entry; \

--- a/crates/uc-application/src/usecases/mobile_sync/apply_incoming.rs
+++ b/crates/uc-application/src/usecases/mobile_sync/apply_incoming.rs
@@ -540,23 +540,45 @@ impl ApplyIncomingMobileClipUseCase {
         }
     }
 
-    /// schema doc §7.6 / §12.2 P1：iPhone → 桌面剪贴板实际落地 inbound。
+    /// schema doc §7.6 / §12.2 P1: iPhone -> desktop clipboard actually
+    /// landing once, inbound.
     ///
-    /// **仅** `Applied` outcome emit；`Buffered` / `DuplicateSkipped` /
-    /// `DecodeFailed` / `Err` 全不上报：
+    /// Emitted for the two outcomes that really put content on the pasteboard:
     ///
-    /// - `DuplicateSkipped` 命中本机 dedup——内容此前已存在，重复埋点会
-    ///   让 dashboard 频率口径双计（沿用 `ClipboardEntryCaptured` RemotePush
-    ///   红线哲学）。
-    /// - `Buffered` 是文件两步 PUT 协议的中间态，不代表用户可感知的同步。
-    /// - `DecodeFailed` / `Err` 本机入站没成功，与产品视角的"sync 成功
-    ///   一次"语义不一致。
+    /// - `Applied` — new content: persisted, then written.
+    /// - `Resurfaced { os_write_succeeded: true }` — content was already held
+    ///   locally, but this delivery re-activated it (OS write + register
+    ///   advance + history bump). §7.6 counts a landing, not a new row, so a
+    ///   re-copy from the phone is a real sync. It does not double-count: the
+    ///   resurface write carries a non-capturing intent, so
+    ///   `ClipboardEntryCaptured` never fires for it (the RemotePush red line)
+    ///   and this stays the only event for the delivery.
+    ///
+    /// Everything else stays silent:
+    ///
+    /// - `Resurfaced { os_write_succeeded: false }` — the pasteboard was left
+    ///   untouched, so nothing landed.
+    /// - `DuplicateSkipped` — redundant delivery (sub-second re-push /
+    ///   partial-over-partial). No OS write, and the content already landed via
+    ///   the delivery that emitted its own event.
+    /// - `Buffered` is the intermediate state of the two-step file PUT
+    ///   protocol, not a user-perceivable sync.
+    /// - `DecodeFailed` / `Err` never landed locally, which contradicts the
+    ///   product-level "synced once" semantics.
     fn maybe_emit_inbound_synced(
         &self,
         outcome: &Result<ApplyIncomingMobileClipOutcome, ApplyIncomingMobileClipError>,
         payload_bytes: u64,
     ) {
-        if let Ok(ApplyIncomingMobileClipOutcome::Applied { .. }) = outcome {
+        let landed = matches!(
+            outcome,
+            Ok(ApplyIncomingMobileClipOutcome::Applied { .. })
+                | Ok(ApplyIncomingMobileClipOutcome::Resurfaced {
+                    os_write_succeeded: true,
+                    ..
+                })
+        );
+        if landed {
             self.analytics.capture(Event::MobileClipboardSynced {
                 direction: Direction::Inbound,
                 payload_size_bucket: PayloadSizeBucket::from_bytes(payload_bytes),
@@ -2013,6 +2035,59 @@ mod tests {
         )
     }
 
+    /// Dedup hit with resurface wired: the held entry is rebuilt and written
+    /// back to the pasteboard. `os_write_ok` selects which `Resurfaced` branch
+    /// the delivery takes.
+    fn build_uc_with_analytics_expect_resurface(
+        existing_entry_id: &str,
+        os_write_ok: bool,
+        analytics: Arc<dyn AnalyticsPort>,
+    ) -> ApplyIncomingMobileClipUseCase {
+        let mut repo = MockEntryRepo::new();
+        let id_clone = EntryId::from(existing_entry_id);
+        repo.expect_find_entry_id_by_snapshot_hash()
+            .times(1)
+            .returning(move |_| Ok(Some(id_clone.clone())));
+        // dedup hit → no new row, but rebuild + write back.
+        let capture = MockCapture::new();
+        let mut rebuild = MockSnapshotRebuild::new();
+        rebuild
+            .expect_rebuild()
+            .times(1)
+            .returning(|_| Ok(held_snapshot()));
+        let mut write = MockWrite::new();
+        write.expect_write().times(1).returning(move |_, _| {
+            if os_write_ok {
+                Ok(())
+            } else {
+                Err(anyhow::anyhow!("clipboard busy"))
+            }
+        });
+        let mut touch = MockTouchEntry::new();
+        if os_write_ok {
+            touch
+                .expect_touch_entry()
+                .times(1)
+                .returning(|_, _| Ok(true));
+        } else {
+            // A failed OS write must not bump history.
+            touch.expect_touch_entry().never();
+        }
+        let inbound =
+            ApplyInboundClipboardUseCase::new(Arc::new(repo), Arc::new(capture), Arc::new(write))
+                .with_resurface_ports(Arc::new(rebuild), Arc::new(touch));
+        ApplyIncomingMobileClipUseCase::new(
+            Arc::new(inbound),
+            Arc::new(IncomingMobileBuffer::new()),
+            staging_never_called(),
+            Arc::new(FixedClock),
+            None,
+            None,
+            analytics,
+            None,
+        )
+    }
+
     /// inbound + capture + write + staging 全无期望（短路在 use case 层）。
     fn build_uc_with_analytics_expect_no_inbound(
         analytics: Arc<dyn AnalyticsPort>,
@@ -2056,9 +2131,9 @@ mod tests {
 
     #[tokio::test]
     async fn duplicate_skipped_does_not_emit_synced() {
-        // dedup 命中 = 本机已存在该 snapshot_hash；重复埋点会让 dashboard
-        // 频率口径双计，沿用 ClipboardEntryCaptured 防 RemotePush 双计的
-        // 红线哲学。
+        // Resurface is unwired here, so the dedup hit degrades to a plain skip:
+        // the pasteboard is never written, so nothing landed. (With resurface
+        // wired, the same hit becomes `Resurfaced` and does emit — see below.)
         let analytics = capturing_analytics();
         let uc = build_uc_with_analytics_expect_dedup_hit(
             "entry-existing",
@@ -2071,6 +2146,63 @@ mod tests {
         assert!(matches!(
             outcome,
             ApplyIncomingMobileClipOutcome::DuplicateSkipped { .. }
+        ));
+        assert!(analytics.events().is_empty(), "{:?}", analytics.events());
+    }
+
+    #[tokio::test]
+    async fn resurfaced_emits_mobile_clipboard_synced_inbound() {
+        // The phone re-copies content this desktop already holds: no new row,
+        // but the pasteboard really was rewritten, so §7.6 counts a landing.
+        // This delivery emitted nothing before resurface existed.
+        let analytics = capturing_analytics();
+        let uc = build_uc_with_analytics_expect_resurface(
+            "entry-existing",
+            true,
+            analytics.clone() as Arc<dyn AnalyticsPort>,
+        );
+        let outcome = uc
+            .execute(input_sync_doc(SyncClipboardItemType::Text, "hello", None))
+            .await
+            .expect("dedup hit returns Ok");
+        assert!(matches!(
+            outcome,
+            ApplyIncomingMobileClipOutcome::Resurfaced {
+                os_write_succeeded: true,
+                ..
+            }
+        ));
+        // The bucket comes from the inbound payload (5 bytes "hello"), not the
+        // rebuilt snapshot.
+        assert_eq!(
+            analytics.events(),
+            vec![Event::MobileClipboardSynced {
+                direction: Direction::Inbound,
+                payload_size_bucket: PayloadSizeBucket::Lt1Kb,
+            }]
+        );
+    }
+
+    #[tokio::test]
+    async fn resurface_with_failed_os_write_does_not_emit_synced() {
+        // The pasteboard was left untouched, so nothing landed — emitting here
+        // would count a sync the user never actually received.
+        let analytics = capturing_analytics();
+        let uc = build_uc_with_analytics_expect_resurface(
+            "entry-existing",
+            false,
+            analytics.clone() as Arc<dyn AnalyticsPort>,
+        );
+        let outcome = uc
+            .execute(input_sync_doc(SyncClipboardItemType::Text, "hello", None))
+            .await
+            .expect("dedup hit returns Ok");
+        assert!(matches!(
+            outcome,
+            ApplyIncomingMobileClipOutcome::Resurfaced {
+                os_write_succeeded: false,
+                ..
+            }
         ));
         assert!(analytics.events().is_empty(), "{:?}", analytics.events());
     }

--- a/crates/uc-application/src/usecases/mobile_sync/apply_incoming.rs
+++ b/crates/uc-application/src/usecases/mobile_sync/apply_incoming.rs
@@ -43,6 +43,7 @@ use std::sync::{Arc, Mutex};
 use thiserror::Error;
 use tracing::{debug, info, instrument, warn};
 
+use crate::clipboard_write::ClipboardWriteIntent;
 use uc_core::file_transfer::FileTransferFailureReason;
 use uc_core::ids::{DeviceId, EntryId, FormatId, RepresentationId};
 use uc_core::mobile_sync::{MobileDeviceId, StagedFile};
@@ -106,15 +107,13 @@ pub(crate) trait MobileInboundFanOutPort: Send + Sync {
 ///
 /// 用户从手机推送一条内容, 语义是"现在让桌面也活跃这条内容"——这是**本
 /// 设备**的一次激活 (`activated_by = self`, `activated_at_ms = now`), 不论
-/// 这条 snapshot_hash 本机此前是否存在。因此两个入站结果都要收敛对端:
+/// 这条 snapshot_hash 本机此前是否存在。
 ///
-/// - `announce_new`: 内容是新的, 入站管线已写过系统剪贴板; 只需盖本设备
-///   激活戳、前进跨设备 register、按 per-device send 闸门广播 0xC3 state。
-/// - `announce_duplicate`: 内容本机已有 (`DuplicateSkipped`), 系统剪贴板
-///   可能早被后续复制覆盖, 需要先把这次上传的 snapshot 写回系统剪贴板,
-///   再盖激活戳 + 前进 register + 同一条 send-gated 广播。
+/// 系统剪贴板由入站管线负责写(新内容走落库后的后台写, 已有内容走 dedup
+/// 命中的重激活写), 所以本 port 只做一件事: 盖本设备激活戳、前进跨设备
+/// register、按 per-device send 闸门广播 0xC3 state。
 ///
-/// 两条路径的 register 前进与 0xC3 广播只受 **per-device send 闸门**
+/// register 前进与 0xC3 广播只受 **per-device send 闸门**
 /// (`send_enabled` ∧ `send_content_types`) 约束, **不**看 `sync_on_restore`
 /// (那个 flag 仅作用于历史 restore 广播)。
 ///
@@ -122,22 +121,22 @@ pub(crate) trait MobileInboundFanOutPort: Send + Sync {
 ///
 /// - use case 持 trait 而非具体 facade, 测试可注入 fake;
 /// - 生产 adapter 在 `facade/mobile_sync/activation_announce_adapter.rs`,
-///   委托 `ClipboardWriteCoordinator` (duplicate 写 OS) +
-///   `ActiveClipboardFacade::announce_local_activation` (advance + fan-out);
+///   委托 `ActiveClipboardFacade::announce_local_activation` (advance + fan-out);
 /// - 失败仅 `warn!`, 不回灌成 HTTP 错误 —— mobile 上传是否"成功"只取决
 ///   于本机入站管线的 outcome, 收敛是事后传播。
 ///
-/// ## 仅 `Applied` / `DuplicateSkipped` 分支调用
+/// ## 仅 `Applied` / `Resurfaced { os_write_succeeded: true }` 分支调用
 ///
 /// - `DecodeFailed` / `Err(...)`: 本机入站没成功, 没有激活可收敛;
-/// - `Buffered`: 两步 PUT 中间态, 还没有 entry。
+/// - `Buffered`: 两步 PUT 中间态, 还没有 entry;
+/// - `DuplicateSkipped`: 冗余投递, 没有新激活;
+/// - `Resurfaced { os_write_succeeded: false }`: 系统剪贴板没写成功, 收敛
+///   会把 peer 钉在本机并不持有的 activation 上 (issue #1017 §1)。
 #[async_trait::async_trait]
 pub(crate) trait MobileActivationAnnouncePort: Send + Sync {
-    /// New content already on the OS clipboard (inbound apply wrote it).
+    /// Converge an activation the inbound pipeline already put on the OS
+    /// clipboard: stamp it as local, advance the register, fan the state out.
     async fn announce_new(&self, entry_id: EntryId, snapshot: SystemClipboardSnapshot);
-    /// Duplicate of existing content: re-write `snapshot` to the OS clipboard,
-    /// then converge the activation like `announce_new`.
-    async fn announce_duplicate(&self, entry_id: EntryId, snapshot: SystemClipboardSnapshot);
 }
 
 // ─── Public types (pub(crate) per AGENTS.md §11.4) ──────────────────────
@@ -205,8 +204,18 @@ pub enum ApplyIncomingMobileClipOutcome {
         entry_id: EntryId,
         content_id: String,
     },
-    /// `snapshot_hash` already exists locally — no persist, no OS write.
-    /// Mirrors `ApplyOutcome::DuplicateSkipped`.
+    /// `snapshot_hash` already exists locally as a fully-held entry — no
+    /// persist, but the entry was re-activated (OS write + register advance +
+    /// history bump). Mirrors `ApplyOutcome::Resurfaced`.
+    Resurfaced {
+        snapshot_hash: String,
+        existing_entry_id: EntryId,
+        /// `false` means the pasteboard was left untouched, so this activation
+        /// must not be converged onto peers.
+        os_write_succeeded: bool,
+    },
+    /// Redundant delivery (sub-second re-push / partial-over-partial) — no
+    /// persist, no OS write. Mirrors `ApplyOutcome::DuplicateSkipped`.
     DuplicateSkipped {
         snapshot_hash: String,
         existing_entry_id: EntryId,
@@ -595,14 +604,19 @@ impl ApplyIncomingMobileClipUseCase {
     ///
     /// 移动端推送的语义是"现在让桌面也活跃这条内容"——本设备的一次激活:
     ///
-    /// - `Applied` (新内容): 入站管线已写过系统剪贴板, 只需盖本设备激活戳
-    ///   + 前进跨设备 register + 按 per-device send 闸门广播 0xC3 state;
-    /// - `DuplicateSkipped` (本机已有): 系统剪贴板可能早被后续复制覆盖,
-    ///   先把这次上传的 snapshot 写回系统剪贴板, 再走同一条 advance + 广播。
+    /// 两条 outcome 到这里时, 入站管线都已经写过系统剪贴板了 —— `Applied`
+    /// 走新内容落库后的后台写, `Resurfaced` 走 dedup 命中的重激活写 —— 所以
+    /// 这里只需盖本设备激活戳 + 前进跨设备 register + 按 per-device send 闸门
+    /// 广播 0xC3 state。
+    ///
+    /// 唯一例外是 `Resurfaced { os_write_succeeded: false }`: 系统剪贴板没写
+    /// 成功, 收敛会把 peer 钉在本机并不持有的 activation 上(issue #1017 §1),
+    /// 直接跳过。
     ///
     /// 收敛只受 per-device send 闸门(`send_enabled` ∧ `send_content_types`)
     /// 约束, **不**看 `sync_on_restore`。`DecodeFailed` / `Err(...)` 本机入站
-    /// 没成功、`Buffered` 还没有 entry, 都不收敛。
+    /// 没成功、`Buffered` 还没有 entry、`DuplicateSkipped` 是冗余投递,
+    /// 都不收敛。
     ///
     /// adapter 一定接了才会到这里时 snapshot 已被上游克隆; 若 announce 已接
     /// 但 snapshot 为 `None` 属编程错误, 沉默跳过(收敛只是事后传播, 不应
@@ -617,32 +631,36 @@ impl ApplyIncomingMobileClipUseCase {
         };
         let entry_id = match outcome {
             Ok(ApplyIncomingMobileClipOutcome::Applied { entry_id, .. }) => entry_id.clone(),
-            Ok(ApplyIncomingMobileClipOutcome::DuplicateSkipped {
-                existing_entry_id, ..
+            Ok(ApplyIncomingMobileClipOutcome::Resurfaced {
+                existing_entry_id,
+                os_write_succeeded: true,
+                ..
             }) => existing_entry_id.clone(),
+            // OS write failed — converging would broadcast an activation this
+            // device does not hold (issue #1017 §1).
+            Ok(ApplyIncomingMobileClipOutcome::Resurfaced {
+                existing_entry_id,
+                os_write_succeeded: false,
+                ..
+            }) => {
+                warn!(
+                    entry_id = %existing_entry_id,
+                    "mobile_sync apply_incoming: held entry re-activation did not reach the OS \
+                     clipboard; skipping active-clipboard convergence"
+                );
+                return;
+            }
             _ => return,
         };
         let Some(snapshot) = snapshot_for_announce else {
             warn!("mobile_sync announce: announce wired but snapshot_for_announce=None, skipping");
             return;
         };
-        match outcome {
-            Ok(ApplyIncomingMobileClipOutcome::Applied { .. }) => {
-                info!(
-                    entry_id = %entry_id,
-                    "mobile_sync apply_incoming: new content applied, announcing active-clipboard state"
-                );
-                announce.announce_new(entry_id, snapshot).await;
-            }
-            Ok(ApplyIncomingMobileClipOutcome::DuplicateSkipped { .. }) => {
-                info!(
-                    entry_id = %entry_id,
-                    "mobile_sync apply_incoming: duplicate detected, re-writing to OS and announcing active-clipboard state"
-                );
-                announce.announce_duplicate(entry_id, snapshot).await;
-            }
-            _ => {}
-        }
+        info!(
+            entry_id = %entry_id,
+            "mobile_sync apply_incoming: inbound activated local clipboard, announcing active-clipboard state"
+        );
+        announce.announce_new(entry_id, snapshot).await;
     }
 
     /// SyncDoc apply 完成后把 mobile_lan 路径预先打开的 transfer 关闭。
@@ -650,9 +668,9 @@ impl ApplyIncomingMobileClipUseCase {
     /// - `Applied { entry_id }`:把 transfer 行从占位 entry_id 改挂到真实
     ///   entry_id,然后发 `Completed` 事件。这是 mobile_lan 路径独有的
     ///   "buffered 期间没有 entry_id → SyncDoc apply 后 backfill" 模式。
-    /// - `DuplicateSkipped { existing_entry_id }`:重定向到已存在的 entry,
-    ///   仍然 complete —— transfer 字节已经收齐, dedup 命中只是没产生新
-    ///   entry, 不应让 transfer 永久卡在 transferring。
+    /// - `Resurfaced` / `DuplicateSkipped { existing_entry_id }`:重定向到
+    ///   已存在的 entry, 仍然 complete —— transfer 字节已经收齐, dedup 命中
+    ///   只是没产生新 entry, 不应让 transfer 永久卡在 transferring。
     /// - `DecodeFailed`:几乎不可能 (我们刚 encode 出来的 envelope),但若
     ///   发生应 fail —— 否则 transfer 也会卡在 transferring。
     /// - 应用层错误 (`Err(...)`):capture / write 链路真出问题, fail。
@@ -674,7 +692,10 @@ impl ApplyIncomingMobileClipUseCase {
                 self.link_then_complete(facade, &transfer_id, entry_id.as_ref(), &peer_id)
                     .await;
             }
-            Ok(ApplyIncomingMobileClipOutcome::DuplicateSkipped {
+            Ok(ApplyIncomingMobileClipOutcome::Resurfaced {
+                existing_entry_id, ..
+            })
+            | Ok(ApplyIncomingMobileClipOutcome::DuplicateSkipped {
                 existing_entry_id, ..
             }) => {
                 self.link_then_complete(facade, &transfer_id, existing_entry_id.as_ref(), &peer_id)
@@ -897,6 +918,12 @@ impl ApplyIncomingMobileClipUseCase {
                 snapshot_hash: snapshot_hash.clone(),
                 plaintext,
                 flow_id: None,
+                // The phone reached exactly one desktop, so re-activating held
+                // content is *this* device's activation: `LocalRestore` lets the
+                // watcher pick the write up and carry it to the other desktops.
+                // (The fresh-content branch needs no such help — it propagates
+                // through `maybe_fan_out_to_paired_peers`.)
+                resurface_intent: ClipboardWriteIntent::LocalRestore,
             })
             .await?;
 
@@ -908,6 +935,23 @@ impl ApplyIncomingMobileClipUseCase {
                     content_id: snapshot_hash,
                 }
             }
+            ApplyOutcome::Resurfaced {
+                snapshot_hash: hash,
+                existing_entry_id,
+                os_write_succeeded,
+            } => {
+                debug!(
+                    snapshot_hash = %hash,
+                    existing_entry_id = %existing_entry_id,
+                    os_write_succeeded,
+                    "mobile_sync apply_incoming: dedup hit, held entry re-activated"
+                );
+                ApplyIncomingMobileClipOutcome::Resurfaced {
+                    snapshot_hash: hash,
+                    existing_entry_id,
+                    os_write_succeeded,
+                }
+            }
             ApplyOutcome::DuplicateSkipped {
                 snapshot_hash: hash,
                 existing_entry_id,
@@ -915,7 +959,7 @@ impl ApplyIncomingMobileClipUseCase {
                 debug!(
                     snapshot_hash = %hash,
                     existing_entry_id = %existing_entry_id,
-                    "mobile_sync apply_incoming: dedup hit, skipping"
+                    "mobile_sync apply_incoming: redundant delivery, skipping"
                 );
                 ApplyIncomingMobileClipOutcome::DuplicateSkipped {
                     snapshot_hash: hash,
@@ -970,7 +1014,9 @@ mod tests {
 
     use uc_core::ports::clipboard::FindEntryIdBySnapshotHashPort;
 
-    use crate::usecases::clipboard_sync::apply_inbound::{InboundCapture, InboundWrite};
+    use crate::usecases::clipboard_sync::apply_inbound::{
+        InboundCapture, InboundSnapshotRebuild, InboundWrite,
+    };
 
     use uc_core::mobile_sync::{StagedFile, StagedFileUri};
     use uc_observability::analytics::NoopAnalyticsSink;
@@ -1037,7 +1083,42 @@ mod tests {
         Write {}
         #[async_trait]
         impl InboundWrite for Write {
-            async fn write(&self, snapshot: SystemClipboardSnapshot) -> AnyResult<()>;
+            async fn write(&self, snapshot: SystemClipboardSnapshot, intent: ClipboardWriteIntent) -> AnyResult<()>;
+        }
+    }
+
+    mockall::mock! {
+        SnapshotRebuild {}
+        #[async_trait]
+        impl InboundSnapshotRebuild for SnapshotRebuild {
+            async fn rebuild(&self, entry_id: &EntryId) -> AnyResult<SystemClipboardSnapshot>;
+        }
+    }
+
+    mockall::mock! {
+        TouchEntry {}
+        #[async_trait]
+        impl uc_core::ports::clipboard::TouchClipboardEntryPort for TouchEntry {
+            async fn touch_entry(
+                &self,
+                entry_id: &EntryId,
+                active_time_ms: i64,
+            ) -> Result<bool, uc_core::clipboard::ClipboardRepositoryError>;
+        }
+    }
+
+    /// A held-content snapshot the rebuild seam hands back on a dedup hit.
+    fn held_snapshot() -> SystemClipboardSnapshot {
+        SystemClipboardSnapshot {
+            ts_ms: 1,
+            representations: vec![ObservedClipboardRepresentation::new(
+                RepresentationId::new(),
+                FormatId::from("text"),
+                Some(MimeType("text/plain".to_string())),
+                b"already-here".to_vec(),
+            )],
+            file_content_digests: Vec::new(),
+            file_set_v1_component: None,
         }
     }
 
@@ -1065,7 +1146,7 @@ mod tests {
             .returning(move |_, _, _| Ok(Some(id_for_capture.clone())));
 
         let mut write = MockWrite::new();
-        write.expect_write().times(1).returning(|_| Ok(()));
+        write.expect_write().times(1).returning(|_, _| Ok(()));
 
         let inbound =
             ApplyInboundClipboardUseCase::new(Arc::new(repo), Arc::new(capture), Arc::new(write));
@@ -1122,7 +1203,7 @@ mod tests {
             .returning(move |_, _, _| Ok(Some(id_for_capture.clone())));
 
         let mut write = MockWrite::new();
-        write.expect_write().times(1).returning(|_| Ok(()));
+        write.expect_write().times(1).returning(|_, _| Ok(()));
 
         let inbound =
             ApplyInboundClipboardUseCase::new(Arc::new(repo), Arc::new(capture), Arc::new(write));
@@ -1158,7 +1239,7 @@ mod tests {
             .times(1)
             .returning(move |_, _, _| Ok(Some(id_for_capture.clone())));
         let mut write = MockWrite::new();
-        write.expect_write().times(1).returning(|_| Ok(()));
+        write.expect_write().times(1).returning(|_, _| Ok(()));
 
         let inbound =
             ApplyInboundClipboardUseCase::new(Arc::new(repo), Arc::new(capture), Arc::new(write));
@@ -1515,7 +1596,7 @@ mod tests {
             .returning(|_, _, _| Ok(Some(EntryId::from("entry-file-win"))));
 
         let mut write = MockWrite::new();
-        write.expect_write().times(1).returning(|_| Ok(()));
+        write.expect_write().times(1).returning(|_, _| Ok(()));
 
         let inbound =
             ApplyInboundClipboardUseCase::new(Arc::new(repo), Arc::new(capture), Arc::new(write));
@@ -1662,7 +1743,7 @@ mod tests {
             .times(1)
             .returning(|_, _, _| Ok(Some(EntryId::from("entry-fanout-1"))));
         let mut write = MockWrite::new();
-        write.expect_write().times(1).returning(|_| Ok(()));
+        write.expect_write().times(1).returning(|_, _| Ok(()));
         let inbound =
             ApplyInboundClipboardUseCase::new(Arc::new(repo), Arc::new(capture), Arc::new(write));
 
@@ -1846,7 +1927,7 @@ mod tests {
             .returning(|_, _, _| Ok(Some(EntryId::from("entry-clock"))));
 
         let mut write = MockWrite::new();
-        write.expect_write().times(1).returning(|_| Ok(()));
+        write.expect_write().times(1).returning(|_, _| Ok(()));
 
         let inbound =
             ApplyInboundClipboardUseCase::new(Arc::new(repo), Arc::new(capture), Arc::new(write));
@@ -1890,7 +1971,7 @@ mod tests {
             .times(1)
             .returning(move |_, _, _| Ok(Some(id_for_capture.clone())));
         let mut write = MockWrite::new();
-        write.expect_write().times(1).returning(|_| Ok(()));
+        write.expect_write().times(1).returning(|_, _| Ok(()));
         let inbound =
             ApplyInboundClipboardUseCase::new(Arc::new(repo), Arc::new(capture), Arc::new(write));
         ApplyIncomingMobileClipUseCase::new(
@@ -2043,15 +2124,11 @@ mod tests {
     #[derive(Default)]
     struct RecordingAnnounce {
         new_calls: std::sync::Mutex<Vec<(EntryId, SystemClipboardSnapshot)>>,
-        duplicate_calls: std::sync::Mutex<Vec<(EntryId, SystemClipboardSnapshot)>>,
     }
 
     impl RecordingAnnounce {
         fn new_calls(&self) -> Vec<(EntryId, SystemClipboardSnapshot)> {
             self.new_calls.lock().unwrap().clone()
-        }
-        fn duplicate_calls(&self) -> Vec<(EntryId, SystemClipboardSnapshot)> {
-            self.duplicate_calls.lock().unwrap().clone()
         }
     }
 
@@ -2060,15 +2137,9 @@ mod tests {
         async fn announce_new(&self, entry_id: EntryId, snapshot: SystemClipboardSnapshot) {
             self.new_calls.lock().unwrap().push((entry_id, snapshot));
         }
-        async fn announce_duplicate(&self, entry_id: EntryId, snapshot: SystemClipboardSnapshot) {
-            self.duplicate_calls
-                .lock()
-                .unwrap()
-                .push((entry_id, snapshot));
-        }
     }
 
-    /// `Applied` (新内容) → `announce_new` 一次, `announce_duplicate` 零次。
+    /// `Applied` (新内容) → `announce_new` 一次。
     /// snapshot 必须随之透传 (adapter 据此派生 snapshot_hash / categories)。
     #[tokio::test]
     async fn applied_invokes_announce_new_with_snapshot() {
@@ -2082,7 +2153,7 @@ mod tests {
             .times(1)
             .returning(|_, _, _| Ok(Some(EntryId::from("entry-new"))));
         let mut write = MockWrite::new();
-        write.expect_write().times(1).returning(|_| Ok(()));
+        write.expect_write().times(1).returning(|_, _| Ok(()));
         let inbound =
             ApplyInboundClipboardUseCase::new(Arc::new(repo), Arc::new(capture), Arc::new(write));
 
@@ -2116,28 +2187,41 @@ mod tests {
         assert_eq!(new_calls[0].0, EntryId::from("entry-new"));
         // snapshot 至少携带原 rep, 让 adapter 能派生 snapshot_hash / categories。
         assert_eq!(new_calls[0].1.representations.len(), 1);
-        assert_eq!(
-            recorder.duplicate_calls().len(),
-            0,
-            "Applied 分支不得触发 announce_duplicate"
-        );
     }
 
-    /// `DuplicateSkipped` (本机已有) → `announce_duplicate` 一次,
-    /// `announce_new` 零次。entry_id 用 `existing_entry_id`。
+    /// 已有内容命中 → 入站管线重激活 (`Resurfaced`) → `announce_new` 一次,
+    /// entry_id 用 `existing_entry_id`。写 OS 用 `LocalRestore` —— 手机推给
+    /// 单台桌面, 本机是激活者, watcher 要接手转播给其他桌面。
     #[tokio::test]
-    async fn duplicate_skipped_invokes_announce_duplicate() {
+    async fn resurfaced_invokes_announce_new_with_local_restore_intent() {
         let mut repo = MockEntryRepo::new();
         let existing = EntryId::from("entry-existing");
         let existing_clone = existing.clone();
         repo.expect_find_entry_id_by_snapshot_hash()
             .times(1)
             .returning(move |_| Ok(Some(existing_clone.clone())));
-        // dedup hit → capture / write 都不该被调。
+        // dedup hit → 不建新行, 但要重建 + 写回 OS。
         let capture = MockCapture::new();
-        let write = MockWrite::new();
+        let mut rebuild = MockSnapshotRebuild::new();
+        rebuild
+            .expect_rebuild()
+            .times(1)
+            .returning(|_| Ok(held_snapshot()));
+        let mut write = MockWrite::new();
+        write
+            .expect_write()
+            .times(1)
+            .withf(|_, intent| *intent == ClipboardWriteIntent::LocalRestore)
+            .returning(|_, _| Ok(()));
+        let mut touch = MockTouchEntry::new();
+        touch
+            .expect_touch_entry()
+            .times(1)
+            .returning(|_, _| Ok(true));
+
         let inbound =
-            ApplyInboundClipboardUseCase::new(Arc::new(repo), Arc::new(capture), Arc::new(write));
+            ApplyInboundClipboardUseCase::new(Arc::new(repo), Arc::new(capture), Arc::new(write))
+                .with_resurface_ports(Arc::new(rebuild), Arc::new(touch));
 
         let recorder = Arc::new(RecordingAnnounce::default());
         let uc = ApplyIncomingMobileClipUseCase::new(
@@ -2161,21 +2245,76 @@ mod tests {
             .expect("dedup hit ok");
         assert!(matches!(
             outcome,
-            ApplyIncomingMobileClipOutcome::DuplicateSkipped { .. }
+            ApplyIncomingMobileClipOutcome::Resurfaced {
+                os_write_succeeded: true,
+                ..
+            }
         ));
 
-        let dup_calls = recorder.duplicate_calls();
-        assert_eq!(
-            dup_calls.len(),
-            1,
-            "DuplicateSkipped 必须触发 announce_duplicate 一次"
+        let new_calls = recorder.new_calls();
+        assert_eq!(new_calls.len(), 1, "Resurfaced 必须触发 announce_new 一次");
+        assert_eq!(new_calls[0].0, existing);
+    }
+
+    /// issue #1017 §1: 重激活没写进系统剪贴板时不得收敛 —— 否则本机会把 peer
+    /// 钉在一个自己并不持有的 activation 上。
+    #[tokio::test]
+    async fn resurface_with_failed_os_write_does_not_announce() {
+        let mut repo = MockEntryRepo::new();
+        let existing = EntryId::from("entry-existing");
+        repo.expect_find_entry_id_by_snapshot_hash()
+            .times(1)
+            .returning(move |_| Ok(Some(existing.clone())));
+        let capture = MockCapture::new();
+        let mut rebuild = MockSnapshotRebuild::new();
+        rebuild
+            .expect_rebuild()
+            .times(1)
+            .returning(|_| Ok(held_snapshot()));
+        let mut write = MockWrite::new();
+        write
+            .expect_write()
+            .times(1)
+            .returning(|_, _| Err(anyhow::anyhow!("clipboard busy")));
+        // OS write 失败 → 不该再 bump 历史。
+        let mut touch = MockTouchEntry::new();
+        touch.expect_touch_entry().never();
+
+        let inbound =
+            ApplyInboundClipboardUseCase::new(Arc::new(repo), Arc::new(capture), Arc::new(write))
+                .with_resurface_ports(Arc::new(rebuild), Arc::new(touch));
+
+        let recorder = Arc::new(RecordingAnnounce::default());
+        let uc = ApplyIncomingMobileClipUseCase::new(
+            Arc::new(inbound),
+            Arc::new(IncomingMobileBuffer::new()),
+            staging_never_called(),
+            Arc::new(FixedClock),
+            None,
+            None,
+            noop_analytics(),
+            Some(Arc::clone(&recorder) as Arc<dyn MobileActivationAnnouncePort>),
         );
-        assert_eq!(dup_calls[0].0, existing);
-        assert_eq!(dup_calls[0].1.representations.len(), 1);
+
+        let outcome = uc
+            .execute(input_sync_doc(
+                SyncClipboardItemType::Text,
+                "already-here",
+                None,
+            ))
+            .await
+            .expect("dedup hit ok");
+        assert!(matches!(
+            outcome,
+            ApplyIncomingMobileClipOutcome::Resurfaced {
+                os_write_succeeded: false,
+                ..
+            }
+        ));
         assert_eq!(
             recorder.new_calls().len(),
             0,
-            "DuplicateSkipped 分支不得触发 announce_new"
+            "OS 写失败的重激活不得收敛对端"
         );
     }
 
@@ -2210,13 +2349,13 @@ mod tests {
             ApplyIncomingMobileClipOutcome::DecodeFailed { .. }
         ));
         assert_eq!(
-            recorder.new_calls().len() + recorder.duplicate_calls().len(),
+            recorder.new_calls().len(),
             0,
             "DecodeFailed 分支不得触发任何 announce"
         );
     }
 
-    /// `BufferFile` 中间态两个 announce 方法都不调 —— 还没有 entry / 激活。
+    /// `BufferFile` 中间态不调 announce —— 还没有 entry / 激活。
     #[tokio::test]
     async fn buffer_file_does_not_invoke_announce() {
         let repo = MockEntryRepo::new();
@@ -2248,7 +2387,7 @@ mod tests {
             .expect("buffer-file path returns Ok");
         assert_eq!(outcome, ApplyIncomingMobileClipOutcome::Buffered);
         assert_eq!(
-            recorder.new_calls().len() + recorder.duplicate_calls().len(),
+            recorder.new_calls().len(),
             0,
             "Buffered 分支不得触发任何 announce"
         );

--- a/crates/uc-bootstrap/src/entrypoint/non_gui.rs
+++ b/crates/uc-bootstrap/src/entrypoint/non_gui.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use uc_application::clipboard_capture::CaptureClipboardUseCase;
-use uc_application::clipboard_write::ClipboardWriteCoordinator;
+use uc_application::clipboard_write::ClipboardWriteIntent;
 use uc_application::deps::AppDeps;
 use uc_application::facade::settings::{RelayDiagnosticPort, RelayProbeError, RelayProbeReport};
 use uc_application::facade::space_setup::SpaceSetupFacade;
@@ -207,7 +207,11 @@ struct NoopInboundWrite;
 
 #[async_trait]
 impl ApplyInboundWrite for NoopInboundWrite {
-    async fn write(&self, _snapshot: SystemClipboardSnapshot) -> anyhow::Result<()> {
+    async fn write(
+        &self,
+        _snapshot: SystemClipboardSnapshot,
+        _intent: ClipboardWriteIntent,
+    ) -> anyhow::Result<()> {
         Ok(())
     }
 }
@@ -242,12 +246,10 @@ pub fn build_mobile_sync_facade(
     // CLI fallback / 不接 P2P 出站的入口传 `None`, mobile 上传仅落地本机,
     // 不传播。
     clipboard_outbound: Option<Arc<ClipboardOutboundFacade>>,
-    // Mobile-activation announce (issue #1017 PR7): the shared write boundary
-    // (re-write OS on a duplicate hit) + the active-clipboard facade (advance
-    // register + send-gated 0xC3 fan-out). daemon 装配两者都传 `Some(...)`;
+    // Mobile-activation announce (issue #1017 PR7): the active-clipboard facade
+    // (advance register + send-gated 0xC3 fan-out). daemon 装配传 `Some(...)`;
     // CLI fallback / 不接 active-clipboard 的入口传 `None`,移动端上传仅落地
-    // 本机, 不向对端收敛。两者必须同时 `Some` 才装 announce adapter。
-    write_coordinator: Option<Arc<ClipboardWriteCoordinator>>,
+    // 本机, 不向对端收敛。OS 剪贴板由入站管线负责写, 不经过这里。
     active_clipboard: Option<Arc<ActiveClipboardFacade>>,
 ) -> Arc<MobileSyncFacade> {
     Arc::new(MobileSyncFacade::new(MobileSyncFacadeDeps {
@@ -282,7 +284,6 @@ pub fn build_mobile_sync_facade(
         // sink。bootstrap 已把 GatedAnalyticsSink 包好，runtime 切换 noop / 真
         // 实 sink 是 sink 自身职责，不在此装配。
         analytics: deps.analytics.clone(),
-        write_coordinator,
         active_clipboard,
         find_entry_by_snapshot_hash: deps.clipboard.entry_ports.find_by_snapshot_hash.clone(),
         check_entry_availability: deps.clipboard.entry_ports.availability.clone(),
@@ -386,10 +387,8 @@ pub fn build_app_facade_from_deps(
                 // `Some(clipboard_outbound)` 装入完整 fan-out 能力(含文件 blob
                 // 发布)。
                 None,
-                // CLI fallback 不接 active-clipboard 收敛 (无 OS clipboard 写
-                // 边界 / 无 active-clipboard facade) —— write_coordinator +
-                // active_clipboard 都留 None, mobile 上传仅落地本机。
-                None,
+                // CLI fallback 不接 active-clipboard 收敛, mobile 上传仅落地
+                // 本机。
                 None,
             )
         });

--- a/crates/uc-bootstrap/src/subsystem/sync_engine.rs
+++ b/crates/uc-bootstrap/src/subsystem/sync_engine.rs
@@ -44,6 +44,7 @@ use tracing::debug;
 const TRANSLATOR_PROGRESS_MIN_INTERVAL: Duration = Duration::from_millis(200);
 
 use uc_application::clipboard_capture::CaptureClipboardUseCase;
+use uc_application::clipboard_write::ClipboardWriteIntent;
 use uc_application::facade::{
     build_active_clipboard_pull_serve_port, ActiveClipboardDeps, ActiveClipboardFacade,
     ActiveClipboardHandle, ActiveClipboardPeerOnlineResyncHandle,
@@ -319,7 +320,11 @@ struct NoopPullStoreWrite;
 
 #[async_trait::async_trait]
 impl ApplyInboundWrite for NoopPullStoreWrite {
-    async fn write(&self, _snapshot: uc_core::SystemClipboardSnapshot) -> anyhow::Result<()> {
+    async fn write(
+        &self,
+        _snapshot: uc_core::SystemClipboardSnapshot,
+        _intent: ClipboardWriteIntent,
+    ) -> anyhow::Result<()> {
         Ok(())
     }
 }

--- a/crates/uc-observability/src/analytics/events.rs
+++ b/crates/uc-observability/src/analytics/events.rs
@@ -148,13 +148,23 @@ pub enum Event {
     /// 当前完全 0 信号，仅靠日志推断。
     MobileDeviceRegistered,
 
-    /// iPhone 与桌面之间剪贴板内容实际落地一次（`apply_incoming::execute`
-    /// SyncDoc arm 的 `Applied` outcome）。
+    /// The clipboard actually landing once between iPhone and desktop
+    /// (`apply_incoming::execute`, SyncDoc arm).
     ///
-    /// **仅 `Applied` 分支 emit**：`Buffered` / `DuplicateSkipped` /
-    /// `DecodeFailed` / `Err` 都不触发——`DuplicateSkipped` 已在本机存在
-    /// （`ClipboardEntryCaptured` 的 RemotePush 红线同理），重复广播会
-    /// 污染 dashboard 频率口径；`Buffered` 是文件两步 PUT 协议的中间态。
+    /// Emitted for the two outcomes that really write the pasteboard:
+    /// `Applied` (new content) and `Resurfaced { os_write_succeeded: true }`
+    /// (already held locally, re-activated by this delivery — §7.6 counts a
+    /// landing, not a new row, so a re-copy from the phone is a real sync).
+    /// Resurface does not double-count: its write carries a non-capturing
+    /// intent, so `ClipboardEntryCaptured` never fires alongside it (the same
+    /// RemotePush red line).
+    ///
+    /// Not emitted: `Resurfaced { os_write_succeeded: false }` (pasteboard
+    /// left untouched, nothing landed); `DuplicateSkipped` (redundant delivery
+    /// — sub-second re-push / partial-over-partial — no OS write, and the
+    /// content already landed via the delivery that emitted its own event);
+    /// `DecodeFailed` / `Err` (never landed locally); `Buffered` (intermediate
+    /// state of the two-step file PUT protocol).
     ///
     /// v1 `direction` 恒为 [`Direction::Inbound`]——`GetLatestMobileSyncDoc`
     /// 出站埋点延后到 v2（iPhone 客户端的轮询频率会让 outbound 量级比

--- a/crates/uc-webserver/src/mobile_lan/routes/common.rs
+++ b/crates/uc-webserver/src/mobile_lan/routes/common.rs
@@ -29,6 +29,7 @@ pub(super) const FILE_UPLOAD_DISK_SANITY_LIMIT: usize = 10 * 1024 * 1024 * 1024;
 pub(super) fn outcome_kind(outcome: &ApplyIncomingMobileClipOutcome) -> &'static str {
     match outcome {
         ApplyIncomingMobileClipOutcome::Applied { .. } => "applied",
+        ApplyIncomingMobileClipOutcome::Resurfaced { .. } => "resurfaced",
         ApplyIncomingMobileClipOutcome::DuplicateSkipped { .. } => "duplicate_skipped",
         ApplyIncomingMobileClipOutcome::DecodeFailed { .. } => "decode_failed",
         ApplyIncomingMobileClipOutcome::Buffered => "buffered",

--- a/crates/uc-webserver/src/mobile_lan/routes/sync_doc.rs
+++ b/crates/uc-webserver/src/mobile_lan/routes/sync_doc.rs
@@ -143,7 +143,8 @@ pub(super) struct SyncClipboardPutAck {
 fn put_ack_content_id(outcome: &ApplyIncomingMobileClipOutcome) -> Option<String> {
     match outcome {
         ApplyIncomingMobileClipOutcome::Applied { content_id, .. } => Some(content_id.clone()),
-        ApplyIncomingMobileClipOutcome::DuplicateSkipped { snapshot_hash, .. } => {
+        ApplyIncomingMobileClipOutcome::Resurfaced { snapshot_hash, .. }
+        | ApplyIncomingMobileClipOutcome::DuplicateSkipped { snapshot_hash, .. } => {
             Some(snapshot_hash.clone())
         }
         ApplyIncomingMobileClipOutcome::DecodeFailed { .. }

--- a/crates/uc-webserver/src/mobile_lan/test_support.rs
+++ b/crates/uc-webserver/src/mobile_lan/test_support.rs
@@ -24,6 +24,7 @@ use async_trait::async_trait;
 use base64::engine::general_purpose::STANDARD as BASE64_STD;
 use base64::Engine;
 
+use uc_application::clipboard_write::ClipboardWriteIntent;
 use uc_application::deps::MobileDevicePorts;
 use uc_application::facade::{
     IncomingMobileBuffer, MobileSyncFacade, MobileSyncFacadeDeps, MobileSyncSnapshotPorts,
@@ -306,7 +307,6 @@ async fn build_facade_deps_with_seeded_device(
         lan_lifecycle: None,
         // schema doc §7.6 / §12.2 P1：测试装配走 noop sink，不污染 capture。
         analytics: Arc::new(uc_observability::analytics::NoopAnalyticsSink::default()),
-        write_coordinator: None,
         active_clipboard: None,
         find_entry_by_snapshot_hash: Arc::new(NoopEntryRepo),
         check_entry_availability: Arc::new(NoopEntryRepo),
@@ -435,7 +435,7 @@ impl ApplyInboundCapture for NoopInboundCapture {
 struct NoopInboundWrite;
 #[async_trait]
 impl ApplyInboundWrite for NoopInboundWrite {
-    async fn write(&self, _: SystemClipboardSnapshot) -> AnyResult<()> {
+    async fn write(&self, _: SystemClipboardSnapshot, _: ClipboardWriteIntent) -> AnyResult<()> {
         Err(anyhow!(
             "test_support: NoOp InboundWrite should not be reached"
         ))

--- a/docs/architecture/telemetry-events.md
+++ b/docs/architecture/telemetry-events.md
@@ -593,10 +593,12 @@ P1 落地（2026-05-15）。LAN HTTP 协议（iPhone Shortcut 客户端）三件
 | 事件名 | 触发位置 | 关键 properties |
 |---|---|---|
 | `mobile_device_registered` | `mobile_sync/register_device.rs::execute` 成功（`device_repo.save` 之后） | （仅 EventContext） |
-| `mobile_clipboard_synced` | `mobile_sync/apply_incoming.rs::execute` SyncDoc arm 的 `Applied` outcome | `direction`: `inbound` \| `outbound`（v1 恒为 `inbound`）, `payload_size_bucket` |
+| `mobile_clipboard_synced` | `mobile_sync/apply_incoming.rs::execute` SyncDoc arm 的 `Applied` / `Resurfaced { os_write_succeeded: true }` outcome | `direction`: `inbound` \| `outbound`（v1 恒为 `inbound`）, `payload_size_bucket` |
 | `mobile_auth_failed` | `mobile_sync/authenticate_basic.rs::execute` 失败分支 | `failure_kind`: `MobileAuthFailureKind`（见 §7.7） |
 
-**`mobile_clipboard_synced` 红线**：仅 `Applied` outcome emit；`Buffered`（两步 PUT 协议中间态）/ `DuplicateSkipped`（命中本机 dedup）/ `DecodeFailed` / 应用层错误一律不上报。沿用 `clipboard_entry_captured` 防 RemotePush 双计的红线哲学——重复埋点会让 dashboard 频率口径双计。
+**`mobile_clipboard_synced` 红线**：仅在内容真的写进 pasteboard 时 emit —— `Applied`（新内容）与 `Resurfaced { os_write_succeeded: true }`（内容已在本机，但这次投递重新激活了它：写 OS + 推进 register + 历史上浮）。本节统计的是「落地一次」而非「新增一行」，所以手机重新复制同一份已同步过的内容是一次真实同步。resurface 不构成双计：它的写入走非 capture intent（`RemotePush` 在 `telemetry_capture_origin` 映射为 `None`；`LocalRestore` 在 `execute_with_origin` 入口短路），`clipboard_entry_captured` 不会与之并发 emit。
+
+`Resurfaced { os_write_succeeded: false }`（pasteboard 未被写，没有落地）/ `DuplicateSkipped`（冗余投递：亚秒重推、partial-over-partial；无 OS 写，且内容已由此前那次 emit 过事件的投递落地）/ `Buffered`（两步 PUT 协议中间态）/ `DecodeFailed` / 应用层错误一律不上报。沿用 `clipboard_entry_captured` 防 RemotePush 双计的红线哲学——重复埋点会让 dashboard 频率口径双计。
 
 **v1 `direction = Inbound` 恒值**：`GetLatestMobileSyncDoc` 出站埋点延后到 v2。原因——iPhone 客户端的轮询频率会让 outbound 量级比 inbound 高一个数量级，需要单独评估采样口径。`direction` 字段保留枚举槽位是为了 v2 直接扩展（§8：新增 property 取值非破坏式演化，dashboard 零迁移）。
 
@@ -605,7 +607,8 @@ P1 落地（2026-05-15）。LAN HTTP 协议（iPhone Shortcut 客户端）三件
 落地备注（保留以便回溯）：
 
 - `mobile_device_registered`：emit 在 `device_repo.save` 成功之后、QR 渲染之前——后续 QR 渲染失败仍保留事件（schema 主目录说明"已登记但拿不到 install URL"是孤儿记录路径，但设备 IS registered，telemetry 反映事实）。
-- `mobile_clipboard_synced`：`payload_size_bucket` 用 `PayloadSizeBucket::from_bytes(snapshot.total_size_bytes())`。BufferFile arm 不 emit（中间态），SyncDoc DuplicateSkipped 不 emit（dedup 双计红线）。
+- `mobile_clipboard_synced`：`payload_size_bucket` 用 `PayloadSizeBucket::from_bytes(snapshot.total_size_bytes())`，在 dispatch 消费 snapshot 之前取好，`Applied` 与 `Resurfaced` 共用同一份入站字节数。BufferFile arm 不 emit（中间态），SyncDoc `DuplicateSkipped` 与 `Resurfaced { os_write_succeeded: false }` 不 emit。
+  - `Resurfaced` 分支自「dedup 命中改为重新激活」起纳入 emit 范围。此前手机重新复制同一份内容会走 `DuplicateSkipped` 且完全不上报，因此该事件的 inbound 量在改动落地后会上升——这是补回一直漏计的真实同步，不是口径破坏（事件名与 property 取值均未变，§8 意义上非破坏）。读 dashboard 时注意改动前后的基线不可直接比较。
 - `mobile_auth_failed`：6 个失败分支统一走 `emit_failure(kind)` 薄包装；happy path **不** emit——产品视角"成功"由 `mobile_clipboard_synced` inbound 间接覆盖。
 
 ### 7.7 MobileAuthFailureKind 枚举（mobile_auth_failed 专用）


### PR DESCRIPTION
## Summary

- **A peer re-copying an older clip left the receiver pasting stale content** (`77e8a9c`). Repro: peer copies `abc`, then `xyz`, then `abc` again — the receiver keeps pasting `xyz`. `apply_inbound` conflated two different claims: a hash match against a fully-held local entry means "no download needed, no duplicate row", **not** "the OS clipboard already holds this". The dedup branch returned `DuplicateSkipped` before the OS write, dropping the activation. The periodic active-state (0xC3) broadcast repaired it, which is why this surfaced as a delay of up to ~50s rather than a hard failure. The local-capture path already got this right (`resurface_existing_entry` bumps instead of dropping), so the two sides of the link disagreed on what a repeat copy means.

  A fully-held hit now **resurfaces** the entry: rebuild its snapshot from local storage (no re-download, so image/file clips benefit too), write it to the OS clipboard, advance the register, bump it to the top of history, emit `clipboard.new_content`. New `ApplyOutcome::Resurfaced` carries `os_write_succeeded` so callers can tell a real activation from a no-op. Genuinely redundant deliveries (sub-second re-push, partial-over-partial) still resolve to `DuplicateSkipped`. Mobile's `announce_duplicate` — which used to own that OS re-write — is removed, making the inbound pipeline the single place that writes the clipboard. The #1017 §1 invariant (register-advance ⟺ OS-write-success ⟺ re-broadcast) still holds, enforced at the caller via `os_write_succeeded`.

- **Classify resurface OS-write failures** (`1e179df`). The new failure branch warned with only `error` + `existing_entry_id`, while the identical failure on the fresh-content path carries `event`/`error_kind = "inbound_os_write_failed"`. Since this is the branch that mints `os_write_succeeded: false`, an operator filtering on that classification would have missed every resurface-path write failure. Level stays `warn!` (the caller handles it) rather than the sibling's `error!` (fires from a detached task with nobody left to react).

- **Count resurfaced mobile deliveries as inbound syncs** (`48935eb`). `maybe_emit_inbound_synced` matched `Applied` only, which predates this path — a phone re-copying already-held content emitted nothing. Such a delivery now lands on the pasteboard exactly like fresh content, which is what schema doc §7.6 counts (a landing, not a new row), so the funnel was dropping a real sync. `Resurfaced { os_write_succeeded: false }` stays silent (nothing landed), as does `DuplicateSkipped`. No double-count: the resurface write carries a non-capturing intent (`RemotePush` → `None` in `telemetry_capture_origin`; `LocalRestore` short-circuits at `execute_with_origin`'s entry), so `clipboard_entry_captured` never fires alongside it.

Closes #866.

> [!NOTE]
> `mobile_clipboard_synced` inbound volume will rise once this ships. That is recovering syncs the funnel never counted, not a metric break — event name and property values are unchanged (§8-non-breaking) — but pre/post baselines aren't directly comparable. The schema doc now says so.

### Notes for review

- `resurface_intent` is an **input** because the two inbound channels re-activate under different identities: P2P uses `RemotePush` (the sender already broadcast to the space, so our own write must not be re-dispatched), mobile LAN uses `LocalRestore` (the phone reached one desktop, so the watcher is expected to propagate to the rest).
- Only the daemon instance that owns the user's pasteboard gets `with_resurface`. Store-only paths (active-clipboard pull, CLI fallback) leave it unwired and keep the prior skip — their write port is a no-op and the pull path's convergence tail owns the authoritative write.
- Two subtleties worth a close look: (1) the activation timestamp must come from the **inbound** snapshot, not the rebuilt one — the rebuilt snapshot carries `entry.created_at_ms` (when content was *first* seen), which would lose the register's LWW comparison against the clip it supersedes; (2) the rapid-duplicate window was previously only consulted when the DB had no match, because a match short-circuited. It is now checked *before* resurfacing, so a retried frame (or one clip arriving over both channels) doesn't re-write the pasteboard twice.
- Pre-existing hazard this diff relocates rather than creates: `telemetry_capture_origin` maps `LocalRestore → Some(ManualRestore)`, safe only because of the `execute_with_origin` short-circuit. An *inbound* path now depends on that short-circuit; if it's ever lifted, mobile resurface starts emitting `clipboard_entry_captured{origin: manual_restore}` from an inbound frame.

## Test plan

- [x] `cargo test -p uc-application` — 796 pass.
- [x] Reverting the resurface fix in place fails 6 of the new tests, while `dedup_hit_skips_when_resurface_is_unwired` correctly still passes.
- [x] Reverting the telemetry emit to the `Applied`-only match fails `resurfaced_emits_mobile_clipboard_synced_inbound` — the new test isn't vacuous.
- [x] `cargo clippy -p uc-application -p uc-observability --all-targets` — warning count identical to `main` (293), nothing new introduced.
- [x] Scanned `docs-site/`: found nothing that depends on this PR's surface area. The docs never documented inbound dedup semantics, history re-ordering on a repeat copy, or a sync-latency figure. (The `core-features/sync.mdx` "Deduplication is automatic" line is content-addressed blob-chunk dedup — a different mechanism.)
- [x] **Manual cross-device repro** — the reason this was filed. On two paired desktops: copy `abc` on the peer, then `xyz`, then `abc` again; confirm the receiver's Cmd+V yields `abc` immediately (not after the ~50s broadcast), the card surfaces to the top of history, and `SELECT count(*) FROM clipboard_entry` is unchanged.
- [x] **Mobile LAN path** — re-copy already-synced content from the iPhone Shortcut client; confirm the desktop pasteboard updates, and that the write propagates to *other* paired desktops (the `LocalRestore` intent's whole point).
- [ ] **Echo check** — confirm the receiver's watcher doesn't bounce the resurface write back out as a new outbound (hash guard should swallow it).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Re-activates previously received clipboard content when it’s delivered again, restoring it to the system clipboard and recent history.
  * Improves mobile sync status and acknowledgments by distinguishing successful versus failed resurfacing.
  * Sync acknowledgments now identify reactivated clipboard content correctly.
* **Bug Fixes**
  * Prevents redundant re-deliveries from being treated as new clipboard content.
  * Ensures analytics reflect only clipboard content successfully written to the system clipboard.
* **Documentation**
  * Clarified mobile synchronization telemetry and event-counting behavior, including resurfacing cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->