### PR TITLE
fix(devices): keep the new mobile device selected after adding

### DIFF
--- a/src/pages/DevicesPage.tsx
+++ b/src/pages/DevicesPage.tsx
@@ -179,10 +179,17 @@ const DevicesPage: React.FC = () => {
     selection.kind === 'peer' ? peers.find(p => p.peerId === selection.id) : undefined
   const selectedMobile =
     selection.kind === 'mobile' ? mobileDevices.find(d => d.deviceId === selection.id) : undefined
-  const selectionVanished =
+  // An unresolvable selection falls back to the local panel for this render
+  // only — it must not be written back into `selection`. The id may simply not
+  // have loaded yet: the add flow selects the new device while its
+  // `reload()` is still in flight, and resetting the state here would strand
+  // the user on the local panel once the device does arrive. A device that
+  // really vanished (unpaired / revoked) never comes back, so it keeps
+  // falling back for every subsequent render anyway.
+  const effectiveSelection: Selection =
     (selection.kind === 'peer' && !selectedPeer) || (selection.kind === 'mobile' && !selectedMobile)
-  if (selectionVanished) setSelection({ kind: 'local' })
-  const effectiveSelection: Selection = selectionVanished ? { kind: 'local' } : selection
+      ? { kind: 'local' }
+      : selection
 
   // ── p2p dialogs ──────────────────────────────────────────────
   const [addP2PDialogOpen, setAddP2PDialogOpen] = useState(false)

--- a/src/pages/__tests__/DevicesPage.test.tsx
+++ b/src/pages/__tests__/DevicesPage.test.tsx
@@ -19,10 +19,78 @@ import { act, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { refreshPresence } from '@/api/daemon'
-import { getMobileSyncSettings, type MobileSyncSettingsView } from '@/api/tauri-command/mobile_sync'
+import {
+  getMobileSyncSettings,
+  listMobileDevices,
+  type MobileDeviceView,
+  type MobileSyncSettingsView,
+  type RegisterMobileDeviceResult,
+} from '@/api/tauri-command/mobile_sync'
 import { toast } from '@/components/ui/toast'
 import i18n from '@/i18n'
 import DevicesPage from '@/pages/DevicesPage'
+
+/** The one-time registration result the stubbed add dialog hands back. */
+const REGISTERED: RegisterMobileDeviceResult = {
+  deviceId: 'mobile-1',
+  label: 'iPhone 15 Pro',
+  username: 'uc-user',
+  password: 'one-time-secret',
+  clientType: 'ios_shortcut',
+  baseUrl: 'http://192.168.1.10:42720',
+  connectUri: 'uniclipboard://connect?host=192.168.1.10',
+  createdAtMs: 1_700_000_000_000,
+  installUrl: 'https://www.icloud.com/shortcuts/stub',
+  installQrCodePngBase64: '',
+  qrCodeAscii: '',
+  qrCodePngBase64: '',
+}
+
+const settingsFixture = (overrides: Partial<MobileSyncSettingsView> = {}): MobileSyncSettingsView =>
+  ({
+    enabled: false,
+    lanListenEnabled: false,
+    lanAdvertiseIp: null,
+    lanPort: null,
+    lanListenerError: null,
+    shortcutInstallMethods: [],
+    ...overrides,
+  }) as MobileSyncSettingsView
+
+// The add dialog is stubbed down to a single "succeed" button: these suites are
+// about what DevicesPage does with the result, not about the form. The real
+// dialog's submit path is covered by its own unit tests.
+vi.mock('@/components/device/AddMobileSyncDeviceDialog', () => ({
+  default: ({
+    open,
+    onSuccess,
+  }: {
+    open: boolean
+    onSuccess: (result: RegisterMobileDeviceResult) => void
+  }) =>
+    open ? (
+      <button type="button" data-testid="stub-register" onClick={() => onSuccess(REGISTERED)}>
+        register
+      </button>
+    ) : null,
+}))
+
+// The panel is stubbed for the same reason: its fresh-state QR + credential
+// rendering is its own suite's job. Here we only need to see which device the
+// page selected and whether the one-time credential reached the panel.
+vi.mock('@/components/device/MobileDevicePanel', () => ({
+  default: ({
+    device,
+    initialCredential,
+  }: {
+    device: MobileDeviceView
+    initialCredential: RegisterMobileDeviceResult | null
+  }) => (
+    <div data-testid="mobile-panel" data-device-id={device.deviceId}>
+      {initialCredential ? 'has-credential' : 'no-credential'}
+    </div>
+  ),
+}))
 
 const dispatchMock = vi.fn()
 
@@ -168,19 +236,6 @@ describe('DevicesPage', () => {
 })
 
 describe('DevicesPage add-device entry points', () => {
-  const settingsFixture = (
-    overrides: Partial<MobileSyncSettingsView> = {}
-  ): MobileSyncSettingsView =>
-    ({
-      enabled: false,
-      lanListenEnabled: false,
-      lanAdvertiseIp: null,
-      lanPort: null,
-      lanListenerError: null,
-      shortcutInstallMethods: [],
-      ...overrides,
-    }) as MobileSyncSettingsView
-
   afterEach(() => {
     vi.mocked(toast.error).mockClear()
     vi.mocked(getMobileSyncSettings).mockReset()
@@ -235,5 +290,50 @@ describe('DevicesPage add-device entry points', () => {
     await user.click(addMobile)
 
     expect(toast.error).toHaveBeenCalledWith(expect.stringContaining('address in use'))
+  })
+})
+
+describe('DevicesPage mobile add flow', () => {
+  afterEach(() => {
+    vi.mocked(getMobileSyncSettings).mockReset()
+    vi.mocked(listMobileDevices).mockReset()
+    vi.mocked(listMobileDevices).mockResolvedValue([])
+  })
+
+  it('selects the newly added device and hands it the one-time credential', async () => {
+    // Regression guard (#1347): the page selected the new device while
+    // `reload()` was still in flight, so for one render the id resolved to
+    // nothing. A render-phase `setSelection({ kind: 'local' })` treated that
+    // gap as "device vanished" and overwrote the selection, leaving the user
+    // pinned to the local panel once the device finally loaded.
+    vi.mocked(getMobileSyncSettings).mockResolvedValue(
+      settingsFixture({ enabled: true, lanListenEnabled: true })
+    )
+    // Empty on mount; the device only appears on the post-register reload —
+    // this ordering is the whole point of the test.
+    const registered: MobileDeviceView = {
+      deviceId: REGISTERED.deviceId,
+      label: REGISTERED.label,
+      username: REGISTERED.username,
+      clientType: REGISTERED.clientType,
+      createdAtMs: REGISTERED.createdAtMs,
+      lastSeenAtMs: null,
+    }
+    vi.mocked(listMobileDevices).mockResolvedValueOnce([]).mockResolvedValue([registered])
+
+    const user = userEvent.setup()
+    render(<DevicesPage />)
+
+    // Let the preloaded settings settle so handleAddClick takes the add path
+    // instead of the first-run enable confirm.
+    await waitFor(() => expect(getMobileSyncSettings).toHaveBeenCalled())
+    await act(async () => {})
+
+    await user.click(screen.getByRole('button', { name: i18n.t('devices.panel.addMenu.mobile') }))
+    await user.click(await screen.findByTestId('stub-register'))
+
+    const panel = await screen.findByTestId('mobile-panel')
+    expect(panel).toHaveAttribute('data-device-id', REGISTERED.deviceId)
+    expect(panel).toHaveTextContent('has-credential')
   })
 })


### PR DESCRIPTION
## Summary

- Adding a mobile device left the user pinned to the local device panel, so the pairing QR never appeared. `onSuccess` selects the new device while `mobileActions.reload()` is still in flight, so for one render the id resolves to nothing — and the render-phase `setSelection({ kind: 'local' })` introduced in #1347 read that gap as "device vanished", overwriting the selection along with its one-time credential. The reload landed too late; the selection was already local and nothing brought it back. (235d4df20)
- `selectionVanished` can't distinguish "not loaded yet" from "gone", so the write-back is dropped and the fallback goes back to being purely derived, as it was before #1347. Selection is user intent, the device list is remote data — deriving what to show from both is correct; writing a transient data gap back into the intent is the bug. A genuinely vanished device (unpaired / revoked) never returns, so it keeps falling back on every later render, preserving the original behavior.
- Regression test drives the real sequence (`listMobileDevices` empty on mount, new device only on the post-register reload) and asserts the panel selects the new device and receives the one-time credential. Verified it fails against the pre-fix code rather than passing by construction.

## Test plan

- [x] New test fails on the broken code (`findByTestId('mobile-panel')` times out, other 7 pass) and passes with the fix — the regression is actually pinned.
- [x] `bunx vitest run` — 811 passed (120 files).
- [x] `bunx tsc --noEmit` clean; eslint + prettier clean on touched files.
- [ ] Manual check on a real device: 设备 → 移动端同步 → 添加设备, confirm the new device's panel opens with the pairing QR + one-time credential inline instead of staying on the local panel.

## Notes

- No `docs-site` changes: the docs already describe the behavior this fix restores (add device → QR shown), so nothing in them is made wrong by this PR. Separately noted for a future PR: `core-features/mobile-sync.mdx` (zh + en) still says "凭据弹窗 / credentials modal" though the code retired that modal for the inline panel — pre-existing drift, left out of scope here.
- No telemetry / tracing surface: the diff touches only `src/` (no `uc-application`, no Rust).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device selection during mobile device registration and reloads.
  * Prevented the page from becoming stranded on the local panel while a newly added device is loading.
  * Ensured newly added mobile devices are selected correctly and display their one-time credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->