### PR TITLE
test(mobile-sync): commit the process-isolated /healthz benchmark PR #1356 quoted

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3623,6 +3623,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "hdrhistogram"
+version = "7.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "765c9198f173dd59ce26ff9f95ef0aafd0a0fe01fb9d72841bc5066a4c06511d"
+dependencies = [
+ "base64 0.21.7",
+ "byteorder",
+ "crossbeam-channel",
+ "flate2",
+ "nom 7.1.3",
+ "num-traits",
+]
+
+[[package]]
 name = "heapless"
 version = "0.7.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5645,6 +5659,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5974,6 +5997,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "objc2-io-surface"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6240,15 +6273,21 @@ dependencies = [
  "clap",
  "futures-lite",
  "futures-util",
+ "hdrhistogram",
  "iroh",
  "iroh-blobs",
  "noq-proto",
  "reqwest 0.12.28",
+ "serde_json",
+ "sysinfo",
+ "tempfile",
  "time",
  "tokio",
  "tokio-util",
  "tracing",
  "tracing-subscriber",
+ "uc-app-paths",
+ "uc-daemon-process",
 ]
 
 [[package]]
@@ -8878,6 +8917,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ab6a2f8bfe508deb3c6406578252e491d299cbbf3bc0529ecc3313aee4a52f"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows 0.62.2",
 ]
 
 [[package]]

--- a/crates/AGENTS.md
+++ b/crates/AGENTS.md
@@ -1,6 +1,6 @@
 # PROJECT KNOWLEDGE BASE
 
-**Last refreshed:** 2026-07-16 (auto; 22 workspace crates)
+**Last refreshed:** 2026-07-17 (auto; 22 workspace crates)
 
 ## OVERVIEW
 

--- a/crates/p2p-bench/Cargo.toml
+++ b/crates/p2p-bench/Cargo.toml
@@ -3,7 +3,7 @@ name = "p2p-bench"
 version = "0.0.0"
 edition = "2021"
 publish = false
-description = "Throwaway spike bins, isolated from the uniclipboard app stack. `p2p-bench` (needs --features iroh) measures raw iroh P2P blob throughput; `http_blob_bench` measures the full-buffer blob-over-loopback path for ADR-008 OQ-perf-gate."
+description = "Throwaway spike and process-isolated performance binaries for P2P, loopback blob transfer, and mobile LAN health probes."
 
 # Raw iroh P2P throughput bench. Heavy iroh deps are feature-gated so the
 # lightweight http_blob_bench can build without dragging iroh/iroh-blobs in.
@@ -19,9 +19,21 @@ required-features = ["iroh"]
 name = "http_blob_bench"
 path = "src/bin/http_blob_bench.rs"
 
+# Mobile LAN liveness evidence: starts a real daemon profile, drives each route
+# from this separate load-generator process, and samples only the daemon PID.
+[[bin]]
+name = "mobile_healthz_process_bench"
+path = "src/bin/mobile_healthz_process_bench.rs"
+
 [features]
 # Opt-in to the heavy iroh stack (only the p2p-bench bin needs it).
-iroh = ["dep:iroh", "dep:iroh-blobs", "dep:noq-proto", "dep:futures-lite", "dep:time"]
+iroh = [
+  "dep:iroh",
+  "dep:iroh-blobs",
+  "dep:noq-proto",
+  "dep:futures-lite",
+  "dep:time",
+]
 
 [dependencies]
 anyhow = "1"
@@ -38,8 +50,26 @@ futures-lite = { version = "2", optional = true }
 time = { version = "0.3", features = ["formatting", "macros"], optional = true }
 
 # http_blob_bench deps (all already in src-tauri/Cargo.lock — no new downloads/lock churn)
-axum = { version = "0.7", default-features = false, features = ["tokio", "http1"] }
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "rustls-tls-webpki-roots", "stream"] }
+axum = { version = "0.7", default-features = false, features = [
+  "tokio",
+  "http1",
+] }
+reqwest = { version = "0.12", default-features = false, features = [
+  "rustls-tls",
+  "rustls-tls-webpki-roots",
+  "stream",
+] }
 bytes = "1"
 futures-util = "0.3"
 tokio-util = { version = "0.7", features = ["io"] }
+
+# mobile_healthz_process_bench only: black-box daemon orchestration, JSON log
+# validation, and cross-platform PID CPU sampling. These stay out of shipped bins.
+hdrhistogram = "7"
+serde_json = "1"
+sysinfo = "0.38"
+uc-app-paths = { path = "../uc-app-paths" }
+uc-daemon-process = { path = "../uc-daemon-process" }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/p2p-bench/src/bin/mobile_healthz_process_bench.rs
+++ b/crates/p2p-bench/src/bin/mobile_healthz_process_bench.rs
@@ -1,0 +1,945 @@
+//! Process-isolated benchmark for the mobile LAN `/healthz` endpoint.
+//!
+//! This binary starts a real `uniclipd` profile, configures a real mobile
+//! device through `uniclip`, drives both endpoints from this separate process,
+//! samples only the daemon PID, and validates the daemon's exact JSON log file.
+//!
+//! Build the three release binaries first, then provide an absolute log path:
+//!
+//! ```bash
+//! cargo build --release -p uc-daemon --bin uniclipd
+//! cargo build --release -p uc-cli --bin uniclip
+//! cargo build --release -p p2p-bench --bin mobile_healthz_process_bench
+//! UC_LOG_FILE="$(pwd)/target/mobile-healthz-daemon.jsonl" \
+//!   target/release/mobile_healthz_process_bench
+//! ```
+
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::net::{Ipv4Addr, SocketAddr, TcpListener};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Output, Stdio};
+use std::sync::Arc;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use anyhow::{bail, ensure, Context, Result};
+use clap::Parser;
+use hdrhistogram::Histogram;
+use sysinfo::{Pid, ProcessesToUpdate, System, MINIMUM_CPU_UPDATE_INTERVAL};
+use tokio::sync::oneshot;
+use tokio::task::JoinSet;
+
+const MOBILE_USERNAME: &str = "healthz_bench";
+const MOBILE_PASSWORD: &str = "healthz-benchmark-mobile-password";
+const SPACE_PASSPHRASE: &str = "healthz-benchmark-space-passphrase";
+const LOG_SETTLE_RETRIES: usize = 20;
+const LOG_SETTLE_DELAY: Duration = Duration::from_millis(100);
+const MAX_RECORDED_LATENCY_MICROS: u64 = 60_000_000;
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "mobile_healthz_process_bench",
+    about = "Measure /healthz and /SyncClipboard.json against a separate uniclipd process"
+)]
+struct Cli {
+    /// Concurrent persistent HTTP workers per endpoint.
+    #[arg(long, default_value_t = 20)]
+    concurrency: usize,
+
+    /// Measured duration for each endpoint.
+    #[arg(long, default_value_t = 30)]
+    duration_secs: u64,
+
+    /// Daemon CPU sampling interval in milliseconds.
+    #[arg(long, default_value_t = 200)]
+    cpu_sample_ms: u64,
+
+    /// Quiet period after setup before measured requests begin.
+    #[arg(long, default_value_t = 5)]
+    startup_settle_secs: u64,
+
+    /// Mobile LAN port. An ephemeral free port is selected when omitted.
+    #[arg(long)]
+    mobile_port: Option<u16>,
+
+    /// Isolated daemon profile. A unique profile is generated when omitted.
+    #[arg(long)]
+    profile: Option<String>,
+
+    /// Path to a prebuilt release `uniclipd` binary.
+    #[arg(long)]
+    daemon_bin: Option<PathBuf>,
+
+    /// Path to a prebuilt release `uniclip` binary.
+    #[arg(long)]
+    cli_bin: Option<PathBuf>,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+struct LogCounts {
+    info: u64,
+    warn: u64,
+    mobile_lan_info: u64,
+    mobile_lan_warn: u64,
+}
+
+impl LogCounts {
+    fn delta(self, before: Self) -> Result<Self> {
+        Ok(Self {
+            info: checked_log_delta(self.info, before.info, "daemon INFO")?,
+            warn: checked_log_delta(self.warn, before.warn, "daemon WARN")?,
+            mobile_lan_info: checked_log_delta(
+                self.mobile_lan_info,
+                before.mobile_lan_info,
+                "mobile LAN INFO",
+            )?,
+            mobile_lan_warn: checked_log_delta(
+                self.mobile_lan_warn,
+                before.mobile_lan_warn,
+                "mobile LAN WARN",
+            )?,
+        })
+    }
+}
+
+fn checked_log_delta(after: u64, before: u64, label: &str) -> Result<u64> {
+    after
+        .checked_sub(before)
+        .with_context(|| format!("{label} log count moved backwards"))
+}
+
+struct ArmResult {
+    label: &'static str,
+    successes: u64,
+    errors: u64,
+    wall_seconds: f64,
+    p50_ms: f64,
+    p95_ms: f64,
+    p99_ms: f64,
+    peak_daemon_cpu_pct: f32,
+    cpu_samples: usize,
+    logs: LogCounts,
+}
+
+impl ArmResult {
+    fn validate(&self) -> Result<()> {
+        ensure!(
+            self.errors == 0,
+            "{} returned {} errors",
+            self.label,
+            self.errors
+        );
+        ensure!(
+            self.successes > 0,
+            "{} produced no successful samples",
+            self.label
+        );
+        ensure!(
+            self.peak_daemon_cpu_pct.is_finite(),
+            "{} produced a non-finite daemon CPU peak",
+            self.label
+        );
+        ensure!(
+            self.cpu_samples > 0,
+            "{} produced no daemon CPU samples",
+            self.label
+        );
+        Ok(())
+    }
+
+    fn report(&self) {
+        println!(
+            "\n-- {} --\n\
+             requests             : {} ({:.0} req/s)\n\
+             errors               : {}\n\
+             latency p50/p95/p99  : {:.3} / {:.3} / {:.3} ms\n\
+             daemon peak CPU      : {:.1}% ({} samples)\n\
+             all daemon log delta : INFO +{}, WARN +{}\n\
+             mobile LAN log delta : INFO +{}, WARN +{}",
+            self.label,
+            self.successes,
+            self.successes as f64 / self.wall_seconds,
+            self.errors,
+            self.p50_ms,
+            self.p95_ms,
+            self.p99_ms,
+            self.peak_daemon_cpu_pct,
+            self.cpu_samples,
+            self.logs.info,
+            self.logs.warn,
+            self.logs.mobile_lan_info,
+            self.logs.mobile_lan_warn,
+        );
+    }
+}
+
+struct CpuPeak {
+    pct: f32,
+    samples: usize,
+}
+
+struct DaemonChild {
+    child: Child,
+}
+
+impl DaemonChild {
+    fn spawn(binary: &Path, profile: &str, log_file: &Path) -> Result<Self> {
+        let child = Command::new(binary)
+            .env("UC_PROFILE", profile)
+            .env("UC_LOG_FILE", log_file)
+            .env("UC_LOG_PROFILE", "prod")
+            .env("UC_PORTABLE", "1")
+            .env("UNICLIPBOARD_ENV", "development")
+            .env_remove("RUST_LOG")
+            .env_remove("SENTRY_DSN")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .with_context(|| format!("spawn daemon {}", binary.display()))?;
+        Ok(Self { child })
+    }
+
+    fn pid(&self) -> u32 {
+        self.child.id()
+    }
+
+    fn ensure_running(&mut self) -> Result<()> {
+        if let Some(status) = self.child.try_wait().context("query daemon status")? {
+            bail!("daemon exited early with {status}");
+        }
+        Ok(())
+    }
+}
+
+impl Drop for DaemonChild {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+struct ProfileArtifacts {
+    paths: Vec<PathBuf>,
+}
+
+impl ProfileArtifacts {
+    fn resolve(profile: &str) -> Result<Self> {
+        let data = uc_app_paths::app_data_root()
+            .context("failed to resolve isolated profile data path")?;
+        let cache = uc_app_paths::app_cache_root()
+            .context("failed to resolve isolated profile cache path")?;
+        let expected = benchmark_binary_dir()?
+            .join("data")
+            .join(format!("{}-{profile}", uc_app_paths::APP_DIR_NAME));
+        ensure!(
+            data == expected && cache == expected,
+            "refusing to clean unexpected portable profile paths: data={}, cache={}, expected={}",
+            data.display(),
+            cache.display(),
+            expected.display()
+        );
+        ensure!(
+            !expected.exists(),
+            "benchmark profile unexpectedly already exists: {}",
+            expected.display()
+        );
+        Ok(Self {
+            paths: vec![expected],
+        })
+    }
+}
+
+impl Drop for ProfileArtifacts {
+    fn drop(&mut self) {
+        for path in &self.paths {
+            let _ = fs::remove_dir_all(path);
+        }
+    }
+}
+
+fn exact_log_file() -> Result<PathBuf> {
+    let path = std::env::var_os("UC_LOG_FILE")
+        .map(PathBuf::from)
+        .context("UC_LOG_FILE must name an absolute, readable daemon JSON log file")?;
+    ensure!(
+        path.is_absolute(),
+        "UC_LOG_FILE must be absolute: {}",
+        path.display()
+    );
+    let parent = path
+        .parent()
+        .context("UC_LOG_FILE must have a parent directory")?;
+    fs::create_dir_all(parent)
+        .with_context(|| format!("create UC_LOG_FILE parent {}", parent.display()))?;
+    OpenOptions::new()
+        .create(true)
+        .truncate(true)
+        .read(true)
+        .write(true)
+        .open(&path)
+        .with_context(|| {
+            format!(
+                "UC_LOG_FILE is not readable and writable: {}",
+                path.display()
+            )
+        })?;
+    fs::read_to_string(&path)
+        .with_context(|| format!("UC_LOG_FILE is not readable UTF-8: {}", path.display()))?;
+    Ok(path)
+}
+
+fn validate_profile(profile: &str) -> Result<()> {
+    ensure!(!profile.is_empty(), "--profile must not be empty");
+    ensure!(
+        profile.len() <= 64,
+        "--profile must be at most 64 ASCII characters"
+    );
+    ensure!(
+        profile
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_')),
+        "--profile may contain only ASCII letters, digits, `-`, and `_`"
+    );
+    Ok(())
+}
+
+fn generated_profile() -> Result<String> {
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .context("system clock is before Unix epoch")?
+        .as_millis();
+    Ok(format!("healthz-bench-{}-{timestamp}", std::process::id()))
+}
+
+fn benchmark_binary_dir() -> Result<PathBuf> {
+    let executable = std::env::current_exe()
+        .context("resolve benchmark executable")?
+        .canonicalize()
+        .context("canonicalize benchmark executable")?;
+    executable
+        .parent()
+        .map(Path::to_path_buf)
+        .context("benchmark executable has no parent")
+}
+
+fn sibling_binary(explicit: Option<PathBuf>, name: &str) -> Result<PathBuf> {
+    let benchmark_dir = benchmark_binary_dir()?;
+    let path = match explicit {
+        Some(path) => path,
+        None => {
+            let suffix = if cfg!(windows) { ".exe" } else { "" };
+            benchmark_dir.join(format!("{name}{suffix}"))
+        }
+    };
+    let path = path
+        .canonicalize()
+        .with_context(|| format!("required binary is missing: {}", path.display()))?;
+    ensure!(
+        path.is_file(),
+        "required binary is not a file: {}",
+        path.display()
+    );
+    ensure!(
+        path.parent() == Some(benchmark_dir.as_path()),
+        "{name} must be a sibling of the benchmark binary so portable cleanup is exact: {}",
+        path.display()
+    );
+    Ok(path)
+}
+
+fn reserve_mobile_port() -> Result<u16> {
+    let listener = TcpListener::bind(SocketAddr::from((Ipv4Addr::LOCALHOST, 0)))
+        .context("reserve an ephemeral mobile LAN port")?;
+    Ok(listener.local_addr().context("read reserved port")?.port())
+}
+
+fn setup_mobile_listener(binary: &Path, profile: &str, requested_port: Option<u16>) -> Result<u16> {
+    let attempts = if requested_port.is_some() { 1 } else { 5 };
+    let mut last_error = None;
+    for _ in 0..attempts {
+        let port = match requested_port {
+            Some(port) => port,
+            None => reserve_mobile_port()?,
+        };
+        let port_arg = port.to_string();
+        match run_cli(
+            binary,
+            profile,
+            &[
+                "--json",
+                "mobile",
+                "setup",
+                "--non-interactive",
+                "--label",
+                "HealthzBenchmark",
+                "--port",
+                &port_arg,
+                "--username",
+                MOBILE_USERNAME,
+                "--password-stdin",
+                "--accept-network-risk",
+            ],
+            Some(&format!("{MOBILE_PASSWORD}\n")),
+        ) {
+            Ok(output) => {
+                let setup: serde_json::Value =
+                    serde_json::from_slice(&output.stdout).context("parse mobile setup JSON")?;
+                ensure!(
+                    setup.get("username").and_then(serde_json::Value::as_str)
+                        == Some(MOBILE_USERNAME),
+                    "mobile setup returned an unexpected username"
+                );
+                return Ok(port);
+            }
+            Err(error) => last_error = Some(error),
+        }
+    }
+    Err(last_error.context("mobile setup failed without an error")?)
+        .context("mobile setup failed after exhausting port attempts")
+}
+
+fn run_cli(binary: &Path, profile: &str, args: &[&str], stdin: Option<&str>) -> Result<Output> {
+    let mut command = Command::new(binary);
+    command
+        .env("UC_PROFILE", profile)
+        .env("UC_PORTABLE", "1")
+        .env("UNICLIPBOARD_ENV", "development")
+        .env_remove("UC_LOG_FILE")
+        .env_remove("RUST_LOG")
+        .args(args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    if stdin.is_some() {
+        command.stdin(Stdio::piped());
+    } else {
+        command.stdin(Stdio::null());
+    }
+
+    let mut child = command
+        .spawn()
+        .with_context(|| format!("spawn CLI {}", binary.display()))?;
+    if let Some(input) = stdin {
+        child
+            .stdin
+            .as_mut()
+            .context("CLI stdin pipe is missing")?
+            .write_all(input.as_bytes())
+            .context("write CLI stdin")?;
+    }
+    let output = child.wait_with_output().context("wait for CLI command")?;
+    ensure!(
+        output.status.success(),
+        "uniclip {:?} failed with {}: {}",
+        args,
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    Ok(output)
+}
+
+async fn wait_for_status(
+    daemon: &mut DaemonChild,
+    client: &reqwest::Client,
+    url: &str,
+    expected: reqwest::StatusCode,
+    timeout: Duration,
+) -> Result<()> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        daemon.ensure_running()?;
+        if let Ok(response) = client.get(url).send().await {
+            if response.status() == expected {
+                return Ok(());
+            }
+        }
+        ensure!(
+            Instant::now() < deadline,
+            "timed out waiting for {url} -> {expected}"
+        );
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+fn read_log_counts(path: &Path) -> Result<LogCounts> {
+    let bytes = fs::read(path).with_context(|| format!("read daemon log {}", path.display()))?;
+    let text = std::str::from_utf8(&bytes)
+        .with_context(|| format!("daemon log is not UTF-8: {}", path.display()))?;
+    ensure!(
+        text.is_empty() || text.ends_with('\n'),
+        "daemon log has an incomplete trailing line"
+    );
+
+    let mut counts = LogCounts::default();
+    for (index, line) in text.lines().enumerate() {
+        if line.is_empty() {
+            continue;
+        }
+        let value: serde_json::Value = serde_json::from_str(line)
+            .with_context(|| format!("daemon log line {} is not JSON", index + 1))?;
+        let level = value
+            .get("level")
+            .and_then(serde_json::Value::as_str)
+            .with_context(|| format!("daemon log line {} has no string level", index + 1))?;
+        let is_mobile_lan = value
+            .get("target")
+            .and_then(serde_json::Value::as_str)
+            .is_some_and(|target| target.starts_with("uc_webserver::mobile_lan"));
+        match level {
+            "INFO" => {
+                counts.info += 1;
+                if is_mobile_lan {
+                    counts.mobile_lan_info += 1;
+                }
+            }
+            "WARN" => {
+                counts.warn += 1;
+                if is_mobile_lan {
+                    counts.mobile_lan_warn += 1;
+                }
+            }
+            _ => {}
+        }
+    }
+    Ok(counts)
+}
+
+async fn settled_log_counts(path: &Path) -> Result<LogCounts> {
+    let mut previous = None;
+    let mut stable_reads = 0_usize;
+    let mut last_error = None;
+    for _ in 0..LOG_SETTLE_RETRIES {
+        match read_log_counts(path) {
+            Ok(counts) => {
+                last_error = None;
+                let length = fs::metadata(path)
+                    .with_context(|| format!("read daemon log metadata {}", path.display()))?
+                    .len();
+                let snapshot = (length, counts);
+                if previous == Some(snapshot) {
+                    stable_reads += 1;
+                    if stable_reads >= 2 {
+                        return Ok(counts);
+                    }
+                } else {
+                    previous = Some(snapshot);
+                    stable_reads = 0;
+                }
+            }
+            Err(error) => {
+                last_error = Some(error);
+                previous = None;
+                stable_reads = 0;
+            }
+        }
+        tokio::time::sleep(LOG_SETTLE_DELAY).await;
+    }
+    if let Some(error) = last_error {
+        return Err(error.context("daemon log remained unreadable or unstable"));
+    }
+    bail!("daemon log did not become stable within the settle deadline")
+}
+
+async fn one_request(
+    client: &reqwest::Client,
+    url: &str,
+    auth: Option<(&str, &str)>,
+    expected: reqwest::StatusCode,
+) -> Result<u64> {
+    let mut request = client.get(url);
+    if let Some((username, password)) = auth {
+        request = request.basic_auth(username, Some(password));
+    }
+    let started = Instant::now();
+    let response = request.send().await.context("send request")?;
+    ensure!(
+        response.status() == expected,
+        "{url} returned {}, expected {expected}",
+        response.status()
+    );
+    response.bytes().await.context("drain response body")?;
+    Ok(started.elapsed().as_micros() as u64)
+}
+
+async fn sample_daemon_cpu(
+    raw_pid: u32,
+    interval: Duration,
+    mut stop: oneshot::Receiver<()>,
+) -> Result<CpuPeak> {
+    let pid = Pid::from_u32(raw_pid);
+    let mut system = System::new();
+    system.refresh_processes(ProcessesToUpdate::Some(&[pid]), true);
+
+    let mut peak = 0.0_f32;
+    let mut samples = 0_usize;
+    loop {
+        let stopping = tokio::select! {
+            _ = tokio::time::sleep(interval) => false,
+            _ = &mut stop => true,
+        };
+        system.refresh_processes(ProcessesToUpdate::Some(&[pid]), true);
+        let process = system
+            .process(pid)
+            .context("daemon PID disappeared during CPU sampling")?;
+        peak = peak.max(process.cpu_usage());
+        samples += 1;
+        if stopping {
+            break;
+        }
+    }
+    Ok(CpuPeak { pct: peak, samples })
+}
+
+fn latency_histogram() -> Result<Histogram<u64>> {
+    Histogram::new_with_bounds(1, MAX_RECORDED_LATENCY_MICROS, 3)
+        .context("create bounded latency histogram")
+}
+
+fn histogram_percentile(histogram: &Histogram<u64>, quantile: f64) -> f64 {
+    if histogram.is_empty() {
+        return f64::NAN;
+    }
+    histogram.value_at_quantile(quantile) as f64 / 1000.0
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn run_arm(
+    label: &'static str,
+    client: &reqwest::Client,
+    url: Arc<str>,
+    auth: Option<(&'static str, &'static str)>,
+    expected: reqwest::StatusCode,
+    concurrency: usize,
+    duration: Duration,
+    daemon_pid: u32,
+    cpu_interval: Duration,
+    log_file: &Path,
+) -> Result<ArmResult> {
+    let logs_before = settled_log_counts(log_file).await?;
+    let (stop_tx, stop_rx) = oneshot::channel();
+    let cpu_task = tokio::spawn(sample_daemon_cpu(daemon_pid, cpu_interval, stop_rx));
+    let started = Instant::now();
+    let deadline = started + duration;
+
+    let mut workers = JoinSet::new();
+    for _ in 0..concurrency {
+        let worker_client = client.clone();
+        let worker_url = Arc::clone(&url);
+        let mut latencies = latency_histogram()?;
+        workers.spawn(async move {
+            let mut errors = 0_u64;
+            while Instant::now() < deadline {
+                match one_request(&worker_client, &worker_url, auth, expected).await {
+                    Ok(latency) => latencies
+                        .record(latency.max(1))
+                        .context("record request latency")?,
+                    Err(_) => errors += 1,
+                }
+            }
+            Ok::<_, anyhow::Error>((latencies, errors))
+        });
+    }
+
+    let mut latencies = latency_histogram()?;
+    let mut errors = 0_u64;
+    while let Some(joined) = workers.join_next().await {
+        let (worker_latencies, worker_errors) = joined.context("load worker panicked")??;
+        latencies
+            .add(&worker_latencies)
+            .context("merge worker latency histogram")?;
+        errors += worker_errors;
+    }
+    let wall_seconds = started.elapsed().as_secs_f64();
+    let _ = stop_tx.send(());
+    let cpu = cpu_task.await.context("CPU sampler task panicked")??;
+
+    let logs = settled_log_counts(log_file).await?.delta(logs_before)?;
+
+    Ok(ArmResult {
+        label,
+        successes: latencies.len(),
+        errors,
+        wall_seconds,
+        p50_ms: histogram_percentile(&latencies, 0.50),
+        p95_ms: histogram_percentile(&latencies, 0.95),
+        p99_ms: histogram_percentile(&latencies, 0.99),
+        peak_daemon_cpu_pct: cpu.pct,
+        cpu_samples: cpu.samples,
+        logs,
+    })
+}
+
+fn machine_model() -> String {
+    #[cfg(target_os = "macos")]
+    let model = command_text("sysctl", &["-n", "hw.model"])
+        .unwrap_or_else(|| "unknown Mac model".to_string());
+    #[cfg(target_os = "linux")]
+    let model = fs::read_to_string("/sys/devices/virtual/dmi/id/product_name")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .unwrap_or_else(|| "unknown Linux model".to_string());
+    #[cfg(target_os = "windows")]
+    let model = command_text(
+        "powershell",
+        &[
+            "-NoProfile",
+            "-Command",
+            "(Get-CimInstance Win32_ComputerSystem).Model",
+        ],
+    )
+    .unwrap_or_else(|| "unknown Windows model".to_string());
+    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+    let model = format!("unknown {} model", std::env::consts::OS);
+
+    let system = System::new_all();
+    let cpu = system
+        .cpus()
+        .first()
+        .map(|cpu| cpu.brand().trim())
+        .filter(|brand| !brand.is_empty())
+        .unwrap_or(std::env::consts::ARCH);
+    format!("{model} / {cpu}")
+}
+
+#[cfg(any(target_os = "macos", target_os = "windows"))]
+fn command_text(program: &str, args: &[&str]) -> Option<String> {
+    let output = Command::new(program).args(args).output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let text = String::from_utf8(output.stdout).ok()?;
+    let trimmed = text.trim();
+    (!trimmed.is_empty()).then(|| trimmed.to_string())
+}
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() -> Result<()> {
+    let cli = Cli::parse();
+    ensure!(
+        cli.concurrency > 0,
+        "--concurrency must be greater than zero"
+    );
+    ensure!(
+        cli.duration_secs > 0,
+        "--duration-secs must be greater than zero"
+    );
+
+    let cpu_interval = Duration::from_millis(cli.cpu_sample_ms);
+    ensure!(
+        cpu_interval >= MINIMUM_CPU_UPDATE_INTERVAL,
+        "--cpu-sample-ms must be at least {} ms",
+        MINIMUM_CPU_UPDATE_INTERVAL.as_millis()
+    );
+
+    let log_file = exact_log_file()?;
+    let profile = match cli.profile {
+        Some(profile) => profile,
+        None => generated_profile()?,
+    };
+    validate_profile(&profile)?;
+    std::env::set_var("UC_PROFILE", &profile);
+    std::env::set_var("UC_PORTABLE", "1");
+    let _artifacts = ProfileArtifacts::resolve(&profile)?;
+
+    let daemon_binary = sibling_binary(cli.daemon_bin, "uniclipd")?;
+    let cli_binary = sibling_binary(cli.cli_bin, "uniclip")?;
+    let main_addr = uc_daemon_process::socket::try_resolve_daemon_http_addr()
+        .context("resolve isolated daemon HTTP address")?;
+
+    println!(
+        "=== mobile LAN process-isolated health benchmark ===\n\
+         machine            : {}\n\
+         host               : {} / {} / {} logical cores\n\
+         profile            : {}\n\
+         daemon binary      : {}\n\
+         UC_LOG_FILE        : {}\n\
+         config             : {} workers x {}s per endpoint\n\
+         startup settle     : {}s before measurement\n\
+         CPU sampling       : daemon PID only, every {} ms (100% = one core)",
+        machine_model(),
+        std::env::consts::OS,
+        std::env::consts::ARCH,
+        std::thread::available_parallelism().map_or(0, |count| count.get()),
+        profile,
+        daemon_binary.display(),
+        log_file.display(),
+        cli.concurrency,
+        cli.duration_secs,
+        cli.startup_settle_secs,
+        cli.cpu_sample_ms,
+    );
+
+    let client = reqwest::Client::builder()
+        .pool_max_idle_per_host(cli.concurrency)
+        .timeout(Duration::from_secs(10))
+        .build()
+        .context("build benchmark HTTP client")?;
+    let mut daemon = DaemonChild::spawn(&daemon_binary, &profile, &log_file)?;
+    let daemon_health = format!("http://{main_addr}/health");
+    wait_for_status(
+        &mut daemon,
+        &client,
+        &daemon_health,
+        reqwest::StatusCode::OK,
+        Duration::from_secs(30),
+    )
+    .await?;
+
+    run_cli(
+        &cli_binary,
+        &profile,
+        &[
+            "init",
+            "--passphrase",
+            SPACE_PASSPHRASE,
+            "--device-name",
+            "healthz-benchmark",
+        ],
+        None,
+    )?;
+    let mobile_port = setup_mobile_listener(&cli_binary, &profile, cli.mobile_port)?;
+
+    let base = format!("http://127.0.0.1:{mobile_port}");
+    let health_url: Arc<str> = format!("{base}/healthz").into();
+    let sync_url: Arc<str> = format!("{base}/SyncClipboard.json").into();
+    wait_for_status(
+        &mut daemon,
+        &client,
+        &health_url,
+        reqwest::StatusCode::NO_CONTENT,
+        Duration::from_secs(10),
+    )
+    .await?;
+
+    one_request(
+        &client,
+        &sync_url,
+        Some((MOBILE_USERNAME, MOBILE_PASSWORD)),
+        reqwest::StatusCode::OK,
+    )
+    .await
+    .context("warm up authenticated control endpoint")?;
+    tokio::time::sleep(Duration::from_secs(cli.startup_settle_secs)).await;
+    settled_log_counts(&log_file).await?;
+
+    let duration = Duration::from_secs(cli.duration_secs);
+    let health = run_arm(
+        "GET /healthz",
+        &client,
+        Arc::clone(&health_url),
+        None,
+        reqwest::StatusCode::NO_CONTENT,
+        cli.concurrency,
+        duration,
+        daemon.pid(),
+        cpu_interval,
+        &log_file,
+    )
+    .await?;
+    let sync = run_arm(
+        "GET /SyncClipboard.json",
+        &client,
+        Arc::clone(&sync_url),
+        Some((MOBILE_USERNAME, MOBILE_PASSWORD)),
+        reqwest::StatusCode::OK,
+        cli.concurrency,
+        duration,
+        daemon.pid(),
+        cpu_interval,
+        &log_file,
+    )
+    .await?;
+
+    health.validate()?;
+    sync.validate()?;
+    health.report();
+    sync.report();
+
+    ensure!(
+        health.logs.mobile_lan_info == 0 && health.logs.mobile_lan_warn == 0,
+        "/healthz changed the real mobile LAN INFO/WARN log: INFO +{}, WARN +{}",
+        health.logs.mobile_lan_info,
+        health.logs.mobile_lan_warn
+    );
+    ensure!(
+        sync.logs.mobile_lan_info > 0,
+        "/SyncClipboard.json produced no real mobile LAN INFO log evidence"
+    );
+    ensure!(
+        sync.logs.mobile_lan_warn == 0,
+        "/SyncClipboard.json produced {} real mobile LAN WARN logs",
+        sync.logs.mobile_lan_warn
+    );
+
+    println!(
+        "\n-- comparison --\n\
+         throughput ratio    : {:.1}x (/healthz over control)\n\
+         peak CPU ratio      : {:.2}x (control over /healthz)\n\
+         verification        : both arms had successful samples and zero errors; \
+         /healthz added zero mobile LAN INFO/WARN lines",
+        (health.successes as f64 / health.wall_seconds)
+            / (sync.successes as f64 / sync.wall_seconds),
+        f64::from(sync.peak_daemon_cpu_pct)
+            / f64::from(health.peak_daemon_cpu_pct).max(f64::MIN_POSITIVE),
+    );
+
+    daemon.ensure_running()?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn profile_is_one_safe_path_segment() {
+        for valid in ["healthz-bench-123", "bench_01", "A"] {
+            assert!(validate_profile(valid).is_ok(), "valid profile: {valid}");
+        }
+        for invalid in ["", ".", "..", "x/../logs", "x\\logs", "has space", "中文"] {
+            assert!(
+                validate_profile(invalid).is_err(),
+                "invalid profile: {invalid}"
+            );
+        }
+    }
+
+    #[test]
+    fn log_counter_reads_info_and_warn_json_lines() {
+        let temp = tempfile::tempdir().expect("temp directory");
+        let path = temp.path().join("daemon.jsonl");
+        fs::write(
+            &path,
+            concat!(
+                "{\"level\":\"INFO\",\"target\":\"uc_webserver::mobile_lan::routes::sync_doc\",\"message\":\"one\"}\n",
+                "{\"level\":\"DEBUG\",\"target\":\"uc_webserver::mobile_lan\",\"message\":\"ignored\"}\n",
+                "{\"level\":\"WARN\",\"target\":\"iroh\",\"message\":\"two\"}\n"
+            ),
+        )
+        .expect("write log fixture");
+
+        let counts = read_log_counts(&path).expect("parse valid daemon log");
+        assert_eq!(counts.info, 1);
+        assert_eq!(counts.warn, 1);
+        assert_eq!(counts.mobile_lan_info, 1);
+        assert_eq!(counts.mobile_lan_warn, 0);
+    }
+
+    #[test]
+    fn log_counter_rejects_malformed_or_incomplete_logs() {
+        let temp = tempfile::tempdir().expect("temp directory");
+        let malformed = temp.path().join("malformed.jsonl");
+        fs::write(&malformed, "not-json\n").expect("write malformed fixture");
+        assert!(read_log_counts(&malformed).is_err());
+
+        let incomplete = temp.path().join("incomplete.jsonl");
+        fs::write(&incomplete, "{\"level\":\"INFO\"}").expect("write incomplete fixture");
+        assert!(read_log_counts(&incomplete).is_err());
+    }
+
+    #[test]
+    fn log_counter_rejects_unreadable_path() {
+        let temp = tempfile::tempdir().expect("temp directory");
+        assert!(read_log_counts(&temp.path().join("missing.jsonl")).is_err());
+    }
+}

--- a/crates/uc-observability/src/init.rs
+++ b/crates/uc-observability/src/init.rs
@@ -15,7 +15,8 @@
 //! [`init_tracing_subscriber`] is a convenience wrapper that calls the layer
 //! builders and registers a global subscriber without any extra layers.
 
-use std::path::Path;
+use std::ffi::OsStr;
+use std::path::{Path, PathBuf};
 
 use tracing::Subscriber;
 use tracing_appender::non_blocking::WorkerGuard;
@@ -31,6 +32,11 @@ use crate::profile::LogProfile;
 /// automatically on initialization, so the log directory cannot grow without
 /// bound.
 const LOG_RETENTION_DAYS: usize = 7;
+
+/// Diagnostic-only daemon override for writing JSON logs to one exact,
+/// non-rolling file. Benchmarks use this to measure one daemon process without
+/// racing daily rotation or accidentally reading a GUI/CLI role file.
+const LOG_FILE_ENV: &str = "UC_LOG_FILE";
 
 /// Build the console (pretty) layer with per-layer filtering.
 ///
@@ -73,9 +79,14 @@ where
 ///   role from [`crate::scope::role_log_file_stem`] so co-resident processes don't share a file)
 /// * `profile` - The [`LogProfile`] controlling filter verbosity
 ///
+/// When `UC_LOG_FILE` is set, `UC_HOST_ROLE` must be `daemon` and the value must
+/// be an absolute path. The JSON layer writes that exact non-rolling file with a
+/// lossless queue instead. This override is intended for diagnostics and
+/// process-isolated benchmarks; normal application runs should leave it unset.
+///
 /// # Errors
 ///
-/// Returns `Err` if the logs directory cannot be created.
+/// Returns `Err` if the log destination cannot be created or opened.
 pub fn build_json_layer<S>(
     logs_dir: &Path,
     profile: &LogProfile,
@@ -83,9 +94,71 @@ pub fn build_json_layer<S>(
 where
     S: Subscriber + for<'a> LookupSpan<'a>,
 {
-    std::fs::create_dir_all(logs_dir)?;
-
     let json_filter = profile.json_filter();
+    let exact_file = exact_log_file_from_env()?;
+    let (non_blocking, guard) = build_json_writer(logs_dir, exact_file.as_deref())?;
+
+    let json_layer = fmt::layer()
+        .event_format(FlatJsonFormat::new())
+        .fmt_fields(JsonFields::new())
+        .with_writer(non_blocking)
+        .with_ansi(false)
+        .with_filter(json_filter);
+
+    Ok((json_layer, guard))
+}
+
+fn exact_log_file_from_env() -> anyhow::Result<Option<PathBuf>> {
+    let Some(path) = std::env::var_os(LOG_FILE_ENV).map(PathBuf::from) else {
+        return Ok(None);
+    };
+    validate_exact_log_role(std::env::var_os("UC_HOST_ROLE").as_deref())?;
+    Ok(Some(path))
+}
+
+fn validate_exact_log_role(role: Option<&OsStr>) -> anyhow::Result<()> {
+    anyhow::ensure!(
+        role == Some(OsStr::new("daemon")),
+        "{LOG_FILE_ENV} is daemon-only; UC_HOST_ROLE must be `daemon`"
+    );
+    Ok(())
+}
+
+fn build_json_writer(
+    logs_dir: &Path,
+    exact_file: Option<&Path>,
+) -> anyhow::Result<(
+    tracing_appender::non_blocking::NonBlocking,
+    tracing_appender::non_blocking::WorkerGuard,
+)> {
+    if let Some(path) = exact_file {
+        anyhow::ensure!(
+            path.is_absolute(),
+            "{LOG_FILE_ENV} must be an absolute path: {}",
+            path.display()
+        );
+        let parent = path.parent().ok_or_else(|| {
+            anyhow::anyhow!("{LOG_FILE_ENV} has no parent directory: {}", path.display())
+        })?;
+        std::fs::create_dir_all(parent)?;
+        let file = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)
+            .map_err(|err| {
+                anyhow::anyhow!(
+                    "failed to open {LOG_FILE_ENV} {} for append: {err}",
+                    path.display()
+                )
+            })?;
+        return Ok(
+            tracing_appender::non_blocking::NonBlockingBuilder::default()
+                .lossy(false)
+                .finish(file),
+        );
+    }
+
+    std::fs::create_dir_all(logs_dir)?;
 
     // ADR-008 D20 (P4-0): per-role file name so the GUI host and the detached
     // `uniclipd` never append to the same rolling log file. The `.json` is part
@@ -99,16 +172,7 @@ where
         .max_log_files(LOG_RETENTION_DAYS)
         .build(logs_dir)
         .map_err(|err| anyhow::anyhow!("failed to build rolling log appender: {err}"))?;
-    let (non_blocking, guard) = tracing_appender::non_blocking(daily_appender);
-
-    let json_layer = fmt::layer()
-        .event_format(FlatJsonFormat::new())
-        .fmt_fields(JsonFields::new())
-        .with_writer(non_blocking)
-        .with_ansi(false)
-        .with_filter(json_filter);
-
-    Ok((json_layer, guard))
+    Ok(tracing_appender::non_blocking(daily_appender))
 }
 
 /// Initialize the dual-output tracing subscriber (convenience wrapper).
@@ -154,4 +218,43 @@ pub fn init_tracing_subscriber(
     tracing::info!(profile = %profile, "Tracing initialized with dual output");
 
     Ok(guard)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+
+    use super::*;
+
+    #[test]
+    fn exact_log_file_writer_uses_requested_readable_file() {
+        let temp = tempfile::tempdir().expect("temp directory");
+        let log_file = temp.path().join("daemon-benchmark.jsonl");
+        let (mut writer, guard) =
+            build_json_writer(temp.path(), Some(&log_file)).expect("exact log writer");
+
+        writer
+            .write_all(b"{\"level\":\"INFO\",\"message\":\"probe\"}\n")
+            .expect("write test log");
+        drop(writer);
+        drop(guard);
+
+        let contents = std::fs::read_to_string(&log_file).expect("exact log file is readable");
+        assert!(contents.contains(r#""level":"INFO""#));
+    }
+
+    #[test]
+    fn exact_log_file_writer_rejects_relative_path() {
+        let temp = tempfile::tempdir().expect("temp directory");
+        let err = build_json_writer(temp.path(), Some(Path::new("relative.jsonl")))
+            .expect_err("relative exact log path must fail");
+        assert!(err.to_string().contains("must be an absolute path"));
+    }
+
+    #[test]
+    fn exact_log_file_override_is_daemon_only() {
+        assert!(validate_exact_log_role(Some(OsStr::new("daemon"))).is_ok());
+        assert!(validate_exact_log_role(Some(OsStr::new("gui-host"))).is_err());
+        assert!(validate_exact_log_role(None).is_err());
+    }
 }

--- a/crates/uc-webserver/src/api/clipboard.rs
+++ b/crates/uc-webserver/src/api/clipboard.rs
@@ -361,7 +361,7 @@ async fn dispatch_text(
     // ADR-008 P5-L L8b: refuse new clipboard dispatch while a controlled restart drains.
     crate::api::server::ensure_not_quiescing(&state.quiescing)?;
     let app = require_app_facade(&state)?;
-    let Json(req) = body.map_err(|e| ApiError::bad_request(&e.to_string()))?;
+    let Json(req) = body.map_err(|e| ApiError::bad_request(e.to_string()))?;
 
     if req.text.is_empty() {
         return Err(ApiError::bad_request("text must not be empty"));
@@ -602,13 +602,13 @@ async fn cancel_transfer(
     body: Result<Json<CancelTransferRequest>, axum::extract::rejection::JsonRejection>,
 ) -> Result<Json<ApiEnvelope<CancelTransferResponse>>, ApiError> {
     let app = require_app_facade(&state)?;
-    let Json(req) = body.map_err(|e| ApiError::bad_request(&e.to_string()))?;
+    let Json(req) = body.map_err(|e| ApiError::bad_request(e.to_string()))?;
 
     let reason = match req.reason.as_str() {
         "local_user" => uc_core::FileTransferCancellationReason::LocalUser,
         "timeout" => uc_core::FileTransferCancellationReason::Timeout,
         other => {
-            return Err(ApiError::bad_request(&format!(
+            return Err(ApiError::bad_request(format!(
                 "unknown cancellation reason: {other}"
             )));
         }

--- a/crates/uc-webserver/src/api/ws.rs
+++ b/crates/uc-webserver/src/api/ws.rs
@@ -324,7 +324,7 @@ async fn handle_connection(socket: WebSocket, state: DaemonApiState, claims: Ses
                                 continue;
                             }
                         };
-                        if sender.send(Message::Text(payload.into())).await.is_err() {
+                        if sender.send(Message::Text(payload)).await.is_err() {
                             break;
                         }
                     }

--- a/crates/uc-webserver/src/bin/gen-openapi.rs
+++ b/crates/uc-webserver/src/bin/gen-openapi.rs
@@ -160,14 +160,12 @@ fn main() -> io::Result<()> {
     // Materialize once for validation, reusing the SAME serde_json model that
     // produces the pretty output below (so the gate inspects exactly what we
     // are about to write).
-    let value: Value =
-        serde_json::to_value(&doc).map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+    let value: Value = serde_json::to_value(&doc).map_err(io::Error::other)?;
     let (path_count, operation_count) = validate(&value);
 
     // Pretty JSON = serde_json::to_string_pretty (2-space indent). Deterministic
     // because utoipa uses BTreeMaps and serde_json has no preserve_order.
-    let mut json = serde_json::to_string_pretty(&value)
-        .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+    let mut json = serde_json::to_string_pretty(&value).map_err(io::Error::other)?;
     json.push('\n'); // POSIX-clean trailing newline.
 
     let schema_count = value

--- a/crates/uc-webserver/src/mobile_lan/healthz_load.rs
+++ b/crates/uc-webserver/src/mobile_lan/healthz_load.rs
@@ -26,17 +26,14 @@
 //! actually pays per probe.
 //!
 //! CPU is reported as total process CPU time (`getrusage`) across the run and
-//! as mean utilisation over wall-clock, not as an instantaneous peak. Peak
-//! sampling needs a sampling thread and reports whatever the scheduler happened
-//! to be doing at each tick; total CPU time is deterministic, reproducible, and
-//! is the quantity that actually matters here — "how much CPU did answering
-//! these probes burn". The PRD's "no sustained business CPU" is read as
-//! utilisation over the run.
+//! as mean utilisation over wall-clock. The numbers are whole-process, so both
+//! arms include the listener and load generator. This makes the test useful as
+//! a fast structural regression gate, but not as the PRD's daemon-process peak
+//! CPU or real log-file evidence.
 //!
-//! The numbers are whole-process, so both arms include the load generator's own
-//! CPU. That inflates `/healthz`'s figure (where the client is a large share of
-//! the work) and is negligible for the control arm — which biases *against*
-//! the result being argued, so it is left uncorrected rather than papered over.
+//! For quotable end-to-end evidence, run the process-isolated
+//! `mobile_healthz_process_bench` binary in `p2p-bench`. It starts a real daemon,
+//! samples only that PID, and verifies INFO/WARN deltas in `UC_LOG_FILE`.
 
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
@@ -298,11 +295,22 @@ async fn healthz_load_vs_sync_clipboard_json() {
     cancel.cancel();
     let _ = handle.join_handle.await;
 
+    assert_eq!(health.errors, 0, "/healthz must not error under probe load");
+    assert_eq!(
+        sync.errors, 0,
+        "/SyncClipboard.json must not error under control load"
+    );
+    assert!(health.total > 0, "/healthz must produce successful samples");
+    assert!(
+        sync.total > 0,
+        "/SyncClipboard.json must produce successful control samples"
+    );
+
     health.report();
     sync.report();
 
-    let health_cpu_per_req = health.cpu_seconds / health.total.max(1) as f64;
-    let sync_cpu_per_req = sync.cpu_seconds / sync.total.max(1) as f64;
+    let health_cpu_per_req = health.cpu_seconds / health.total as f64;
+    let sync_cpu_per_req = sync.cpu_seconds / sync.total as f64;
 
     println!(
         "\n── comparison ──\n\
@@ -335,8 +343,6 @@ async fn healthz_load_vs_sync_clipboard_json() {
         health_cpu_per_req * PROBE_RPS * 100.0,
         sync_cpu_per_req * PROBE_RPS * 100.0,
     );
-
-    assert_eq!(health.errors, 0, "/healthz must not error under probe load");
 
     // The claim under test is a cost *class* difference, not a tuned margin:
     // constant-cost handler vs memory-hard KDF. An order of magnitude is a

--- a/docs-site/content/docs/en/cli/environment.mdx
+++ b/docs-site/content/docs/en/cli/environment.mdx
@@ -37,6 +37,7 @@ a single machine. Values are read once at startup, so set them before launching
 | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `RUST_LOG`       | Standard tracing filter; **overrides `UC_LOG_PROFILE`** when set. Accepts a level (`RUST_LOG=debug`) or per-module directives (`RUST_LOG=uniclip=debug,iroh=info`). |
 | `UC_LOG_PROFILE` | Select a logging preset — `dev`, `prod`, `debug_clipboard`, or `cli`. Defaults to `dev` on debug builds and `prod` on release builds.                               |
+| `UC_LOG_FILE`    | Diagnostics only: write JSON logs to this one exact file, with no daily rotation and no retention pruning. Daemon-only — the value must be an absolute path and `UC_HOST_ROLE` must be `daemon`, or startup fails outright, so two roles can never append to the same file. Leave unset for the normal per-role, per-day rolling logs. |
 
 For everyday setup see [Install](../getting-started/install) and
 [Self-host a relay](../guides/self-host-relay). The binary's `--help` and the

--- a/docs-site/content/docs/zh/cli/environment.mdx
+++ b/docs-site/content/docs/zh/cli/environment.mdx
@@ -35,6 +35,7 @@ description: 面向无头、服务器与多 profile 部署的运营开关。
 | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
 | `RUST_LOG`       | 标准 tracing 过滤器，设置后 **覆盖 `UC_LOG_PROFILE`**。可以是级别（`RUST_LOG=debug`）或按模块指定（`RUST_LOG=uniclip=debug,iroh=info`）。 |
 | `UC_LOG_PROFILE` | 选择日志预设 —— `dev`、`prod`、`debug_clipboard` 或 `cli`。debug 构建默认 `dev`，release 构建默认 `prod`。                                |
+| `UC_LOG_FILE`    | 诊断专用：把 JSON 日志写入这一个指定文件，不按日滚动、不做保留期清理。仅限 daemon —— 取值必须是绝对路径，且 `UC_HOST_ROLE` 必须为 `daemon`，否则进程直接启动失败，以免多个角色同时追加同一文件。留空则沿用按角色、按日滚动的正常日志。 |
 
 日常配置见[安装](../getting-started/install)与[自建中继](../guides/self-host-relay)。
 可接受的取值与默认值，以二进制的 `--help` 和源码为准。

--- a/docs/development/mobile-healthz-benchmark.md
+++ b/docs/development/mobile-healthz-benchmark.md
@@ -1,0 +1,94 @@
+# Mobile LAN `/healthz` 性能基准
+
+本文定义 `/healthz` 与 `/SyncClipboard.json` 性能证据的可重复运行方式。两个基准用途不同，不能互相替代。
+
+## 快速回归门禁
+
+`crates/uc-webserver/src/mobile_lan/healthz_load.rs` 在同一进程内启动真实 TCP listener 和 load generator，并让控制组使用生产参数的 Argon2id。它用于快速发现 `/healthz` 重新进入鉴权或业务依赖等结构性回归。
+
+```bash
+cargo test -p uc-webserver --release --lib -- \
+  --ignored --nocapture healthz_load_vs_sync_clipboard_json
+```
+
+该门禁会在计算和输出比率前强制要求：
+
+- 两个路径的错误数均为 0。
+- 两个路径均至少产生一个成功样本。
+
+它报告的是 listener 与 load generator 所在进程的平均 CPU，不是 daemon PID 的峰值 CPU，也不读取真实 daemon 日志。因此这组结果不能单独作为 PRD 性能证据。
+
+## 进程隔离基准
+
+`mobile_healthz_process_bench` 会执行以下完整流程：
+
+1. 启动独立 `uniclipd` profile，并从 `Child::id()` 获取被采样 PID。
+   benchmark 强制使用 portable 文件安全存储，结束后删除该 profile 的 data/cache，
+   不在系统 Keychain、Credential Manager 或 Secret Service 遗留 KEK。profile
+   只允许 ASCII 字母、数字、`-`、`_`，且 daemon/CLI 必须与 benchmark
+   二进制同目录；清理前还会校验目标路径与该 portable profile 精确相等。
+2. 通过 `uniclip init` 初始化加密 Space。
+3. 通过非交互 `uniclip --json mobile setup` 启用 mobile LAN listener，
+   注册使用生产 Argon2id 的 Basic Auth 设备。
+4. 等待默认 5 秒启动稳定期，避免把 iroh 首次 relay 建连等一次性后台事件
+   归因给请求路径。
+5. 从独立 load generator 进程以 20 并发分别持续请求两个路径 30 秒。
+6. 每 200 ms 采样一次 daemon PID CPU，记录观测峰值；`100%` 表示占满
+   一个逻辑核心。
+7. 读取 `UC_LOG_FILE` 指定的真实 daemon JSON 日志，比较每个路径运行
+   前后的全进程 INFO/WARN 行数，以及 `uc_webserver::mobile_lan` 请求路径
+   INFO/WARN 行数。
+8. 输出机器型号、操作系统、架构、逻辑核心数、请求数、错误数、
+   p50/p95/p99、daemon 峰值 CPU 和两套日志增量。请求总数精确计数；
+   延迟写入固定内存、3 位有效数字的 HDR Histogram，避免高吞吐 `/healthz`
+   因保存数百万个原始样本而让 30 秒基准失去有界内存行为。
+
+先分别构建三个 release 二进制，避免 Cargo 多包目标选择掩盖缺失产物：
+
+```bash
+cargo build --release -p uc-daemon --bin uniclipd
+cargo build --release -p uc-cli --bin uniclip
+cargo build --release -p p2p-bench --bin mobile_healthz_process_bench
+```
+
+运行时必须提供绝对日志路径：
+
+```bash
+UC_LOG_FILE="$(pwd)/target/mobile-healthz-daemon.jsonl" \
+  target/release/mobile_healthz_process_bench
+```
+
+`UC_LOG_FILE` 是 daemon 诊断专用的精确文件覆盖；同时设置该变量的进程
+若 `UC_HOST_ROLE` 不是 `daemon` 会直接失败，避免 GUI、CLI 与 daemon 并发
+写同一文件。daemon 未设置该变量时仍使用现有的按角色、按日滚动日志。
+精确文件使用无损队列，基准会先清空并验证它可读写；每个 arm 结束后必须
+连续读到稳定的文件长度和计数才生成快照。路径缺失、相对路径、权限错误、
+非法 UTF-8、非 JSON 行、不完整尾行或在截止时间内未稳定都会直接令运行
+失败，不能折算成零日志增量。
+
+## 验收条件
+
+一次可引用的完整运行必须同时满足：
+
+- 配置为 20 并发、每路径 30 秒。
+- 两个路径均有成功样本且错误数为 0。
+- CPU 采样始终能读取同一个 daemon PID，并至少产生一个样本。
+- `/healthz` 的真实 `uc_webserver::mobile_lan` 日志增量为 `INFO +0, WARN +0`。
+- `/SyncClipboard.json` 在真实 `uc_webserver::mobile_lan` 日志中至少产生一条 INFO，且不产生 WARN。
+- 全进程 INFO/WARN 增量必须原样输出；daemon 后台任务产生的日志不能被静默折算为端点日志，也不能导致日志文件不可读时误报为零。
+- 结果包含 p50、p95、p99；结果表不得省略 p95。
+
+机器负载、调度器和采样间隔都会影响峰值 CPU，因此不要把普通共享 CI 上的一次峰值设为硬阈值。性能阈值应在固定硬件的专用运行中判定；请求正确性与日志不变量则由每次基准硬性验证。
+
+## 烟雾验证
+
+开发中可缩短时长来验证进程、认证、日志和采样闭环，但该结果不可引用为 PRD 证据：
+
+```bash
+UC_LOG_FILE="$(pwd)/target/mobile-healthz-daemon-smoke.jsonl" \
+  target/debug/mobile_healthz_process_bench \
+  --daemon-bin target/debug/uniclipd \
+  --cli-bin target/debug/uniclip \
+  --concurrency 2 \
+  --duration-secs 1
+```


### PR DESCRIPTION
## Summary

- **Commit the benchmark that PR #1356 already quoted** (fb16a9043). #1356 merged with a results table of daemon-PID peak CPU and real-log INFO/WARN deltas, plus a `cargo build --release -p p2p-bench --bin mobile_healthz_process_bench` command in its body — but that binary was never committed. Anyone following those build instructions on `main` today gets nothing. This is the missing binary: it starts a real `uniclipd` profile, initialises an encrypted Space, enables the mobile LAN listener with a production Argon2id device, drives both routes from a *separate* load-generator process, and samples only the daemon PID.

- **Add `UC_LOG_FILE`, a daemon-only exact log file override** (ccfff109d). The benchmark needs one daemon's JSON logs, but the rolling appender picks a per-role, per-date file — a run can race daily rotation or read a co-resident GUI/CLI role file instead. The override names one non-rolling file and uses a **lossless** queue, so a dropped record can't be read back as evidence of quiet code. It's rejected unless `UC_HOST_ROLE=daemon` and the path is absolute, keeping concurrent roles off the same file. Unset, rolling behaviour is byte-for-byte unchanged.

- **Fix a load gate that could pass vacuously** (f452f5ed6). The in-process `healthz_load` benchmark divided by `total.max(1)`, so an arm producing **zero** successful samples divided by a fabricated 1 and still passed; errors on the control arm were never checked at all. Both arms now need zero errors and at least one sample before any ratio is computed. Its module docs also over-claimed — the CPU figures are whole-process means covering the listener *and* the load generator, not a daemon peak, and it reads no real log file — so they now point at the process-isolated bench and scope this one to what it is: a fast structural regression gate. (#1356's body already described this change; it wasn't in the diff either.)

- **Document both benchmarks and the acceptance conditions** (9a8b7c9b5, 1eef60be7). The two answer different questions and were being conflated. `docs/development/mobile-healthz-benchmark.md` records which is quotable as PRD evidence and what a citable run must satisfy; the docs-site Logging table gains `UC_LOG_FILE` — it already lists every other JSON-log env var, and the `UC_HOST_ROLE` coupling is otherwise an opaque startup failure.

- **Drive-by clippy cleanup** (9ddf03cda), no behaviour change: a needless borrow into `bad_request` (it takes `impl Into<String>`), an identity `Into` on an already-`Utf8Bytes` websocket payload, and `io::Error::other` over the deprecated `Error::new(ErrorKind::Other, _)`. Kept as its own commit — skip it in review.

### Notes for reviewers

- **The benchmark is evidence tooling, so it fails loudly rather than degrading.** Unreadable, malformed, non-UTF-8, incomplete-tail, or unstable log files fail the run instead of counting as a zero INFO/WARN delta — a silent zero is exactly the result the benchmark exists to prove, so it must never be reachable by accident.
- **Bounded memory is deliberate.** `/healthz` sustains six figures of req/s; retaining raw latency samples would cost a 30s run its bounded-memory behaviour, so latency goes into a fixed-memory 3-significant-digit HDR histogram while request counts stay exact.
- **No secrets leak into the system keystore.** The benchmark profile is forced onto portable file-backed secret storage and its data/cache are removed afterwards — no KEK left in Keychain, Credential Manager, or Secret Service. Profile names are restricted to `[A-Za-z0-9_-]`, and cleanup re-verifies the target path equals that portable profile exactly before deleting.
- **Nothing to instrument.** The diff doesn't touch `uc-application`, and no activation or reliability milestone was added — a benchmark harness is not a funnel anchor.
- **No tracing surface.** The new bench binary uses `println!` only and emits no spans or events; `uc-observability` is infra, which the layering spec keeps span-free. No use case was added, so no use-case span applies.
- **New deps reach no shipped binary.** `hdrhistogram`, `serde_json`, `sysinfo`, `uc-app-paths`, and `uc-daemon-process` are `p2p-bench`-only, and `p2p-bench` is `publish = false`.

## Test plan

- [x] `cargo test -p uc-observability --lib` — 148 passed, including the three new `UC_LOG_FILE` tests (exact file is written and readable, relative path rejected, daemon-only role enforced)
- [x] `cargo test -p uc-webserver` — 155 passed across all targets, 3 ignored (the benchmarks)
- [x] `cargo clippy -p p2p-bench --bin mobile_healthz_process_bench --all-targets` — clean
- [x] `cargo clippy -p uc-webserver --all-targets` — no errors; the three targeted lints are gone
- [x] `cargo fmt --all --check`
- [x] `bun run check:docs` in `docs-site/` — 31 en / 31 zh pages, anchors pass
- [ ] Run the full release benchmark on fixed hardware and confirm the figures still match #1356's table — the smoke config in the doc is explicitly not quotable.
- [ ] Confirm the benchmark's profile cleanup leaves no residue on Windows and Linux; it has only been exercised on macOS. (`healthz_load` is already skipped on non-Unix.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional `UC_LOG_FILE` setting for daemon diagnostics, allowing JSON logs to be written to a specified absolute file without rotation or cleanup.
  * Improved validation and reliability for clipboard, transfer cancellation, and WebSocket communication.

* **Documentation**
  * Documented `UC_LOG_FILE` in English and Chinese configuration guides.
  * Added repeatable benchmarking guidance for mobile health endpoints.

* **Tests**
  * Added coverage for exact-file logging, path validation, and daemon-only restrictions.
  * Strengthened health endpoint benchmark assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->