### PR TITLE
fix(observability): stop uploading session data while telemetry is off

### DIFF
--- a/crates/uc-bootstrap/src/layer/platform.rs
+++ b/crates/uc-bootstrap/src/layer/platform.rs
@@ -175,7 +175,7 @@ pub fn create_platform_layer(
                     };
                     if entry.path().is_file() {
                         let path = entry.path();
-                        if path.file_name().map_or(false, |n| n == ".v2_migrated") {
+                        if path.file_name().is_some_and(|n| n == ".v2_migrated") {
                             continue;
                         }
                         if is_v2_blob(&path) {

--- a/crates/uc-bootstrap/src/observability/mod.rs
+++ b/crates/uc-bootstrap/src/observability/mod.rs
@@ -12,6 +12,11 @@ pub mod tracing;
 /// `event_mapper`.
 mod correlation;
 
+/// The two `uc_observability::telemetry_gate` attachment points that are not
+/// payload hooks: the transaction sampler and the outbound envelope transport.
+/// Both are consumed only by `tracing`'s `sentry::init` call.
+mod sentry_gate;
+
 /// Default host-event transport (`LoggingHostEventEmitter`) for non-GUI / CLI
 /// processes, pre-registered on the shared host-event bus at wire time. Lives
 /// here — below the entrypoint layer — so the common wiring root stays

--- a/crates/uc-bootstrap/src/observability/sentry_gate.rs
+++ b/crates/uc-bootstrap/src/observability/sentry_gate.rs
@@ -1,0 +1,178 @@
+//! The non-payload halves of the Sentry telemetry gate.
+//!
+//! Sentry's `before_send` / `before_breadcrumb` / `before_send_log` hooks each
+//! gate one payload kind and live inline at the `sentry::init` call site in
+//! [`super::tracing`]. This module holds the two attachment points that are not
+//! payload hooks:
+//!
+//! - [`transaction_sample_rate`] — refuses to record new transactions while the
+//!   gate is off, so no span data is even collected.
+//! - [`TelemetryGatedTransportFactory`] — the final envelope boundary. Required
+//!   in addition to the sampler because it is the only thing that covers
+//!   envelopes no `before_*` hook sees: transactions sampled before the user
+//!   toggled telemetry off, `release-health` session updates (see sentry-core
+//!   `session.rs`, which calls `send_envelope` directly), and any envelope type
+//!   a future SDK upgrade introduces.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use sentry::{ClientOptions, Envelope, TransactionContext, Transport, TransportFactory};
+
+/// Baseline transaction sample rate — the **single source of truth**.
+///
+/// Emergency reduction to 2% for quota control: by the end of 2026-05 the
+/// monthly quota was 80% consumed, and triage attributed 81% of it to the iroh
+/// `poll_send` and presence paths. Combined with the Sentry target filter in
+/// [`super::tracing`] (`SENTRY_MUTED_TARGET_PREFIXES`), 2% still retains useful
+/// observability.
+///
+/// Do **not** restate this value as `ClientOptions::traces_sample_rate`. Once
+/// `traces_sampler` is set, sentry-core ignores `traces_sample_rate` entirely
+/// (`performance.rs`: `(Some(traces_sampler), _) => traces_sampler(ctx)`), so a
+/// second copy would be dead config that silently disagrees with this one.
+const BASE_TRACE_SAMPLE_RATE: f32 = 0.02;
+
+/// Transaction names hard-muted to 0% regardless of the gate.
+///
+/// Backstop against quota burn: returning 0.0 by name means adding an
+/// `#[instrument]` on one of these paths later cannot silently start billing
+/// again.
+///
+/// The list comes from the 2026-05 monthly quota diagnosis — each name is a
+/// root transaction from iroh / noq_proto. `SENTRY_MUTED_TARGET_PREFIXES` in
+/// [`super::tracing`] already mutes these crates by tracing target, but that
+/// filter keys off the target while sentry-tracing can, on some paths, name the
+/// transaction with the shorter span name alone; this is the second line of
+/// defense for exactly that case.
+///
+/// Recovery: drop an entry once the corresponding path stops being hot, or once
+/// per-transaction quota controls land on the Sentry side.
+const MUTED_TRANSACTION_NAMES: &[&str] = &["poll_send", "connect", "QADv4", "tx", "state"];
+
+pub(super) struct TelemetryGatedTransportFactory;
+
+impl TransportFactory for TelemetryGatedTransportFactory {
+    fn create_transport(&self, options: &ClientOptions) -> Arc<dyn Transport> {
+        let inner = sentry::transports::DefaultTransportFactory.create_transport(options);
+        Arc::new(TelemetryGatedTransport::new(inner))
+    }
+}
+
+struct TelemetryGatedTransport {
+    inner: Arc<dyn Transport>,
+}
+
+impl TelemetryGatedTransport {
+    fn new(inner: Arc<dyn Transport>) -> Self {
+        Self { inner }
+    }
+}
+
+impl Transport for TelemetryGatedTransport {
+    fn send_envelope(&self, envelope: Envelope) {
+        if uc_observability::is_telemetry_enabled() {
+            self.inner.send_envelope(envelope);
+        }
+    }
+
+    fn flush(&self, timeout: Duration) -> bool {
+        self.inner.flush(timeout)
+    }
+
+    fn shutdown(&self, timeout: Duration) -> bool {
+        self.inner.shutdown(timeout)
+    }
+}
+
+/// `ClientOptions::traces_sampler`: resolves the sample rate for one new
+/// transaction.
+///
+/// Returns 0% while the telemetry gate is off or when the transaction is in
+/// [`MUTED_TRANSACTION_NAMES`]; otherwise [`BASE_TRACE_SAMPLE_RATE`].
+pub(super) fn transaction_sample_rate(ctx: &TransactionContext) -> f32 {
+    if !uc_observability::is_telemetry_enabled() || MUTED_TRANSACTION_NAMES.contains(&ctx.name()) {
+        0.0
+    } else {
+        BASE_TRACE_SAMPLE_RATE
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex};
+
+    use sentry::protocol::Envelope;
+    use sentry::Transport;
+
+    use super::*;
+
+    static TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    #[derive(Default)]
+    struct CountingTransport {
+        sent: AtomicUsize,
+    }
+
+    impl Transport for CountingTransport {
+        fn send_envelope(&self, _envelope: Envelope) {
+            self.sent.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    #[test]
+    fn transaction_started_before_disable_is_blocked_at_transport() {
+        let _guard = TEST_LOCK.lock().unwrap_or_else(|error| error.into_inner());
+        let inner = Arc::new(CountingTransport::default());
+        let inner_for_factory = inner.clone();
+        let client = Arc::new(sentry::Client::from((
+            "https://public@example.com/1",
+            ClientOptions {
+                transport: Some(Arc::new(move |_options: &ClientOptions| {
+                    Arc::new(TelemetryGatedTransport::new(inner_for_factory.clone()))
+                        as Arc<dyn Transport>
+                })),
+                default_integrations: false,
+                traces_sampler: Some(Arc::new(|_| 1.0)),
+                enable_logs: false,
+                ..Default::default()
+            },
+        )));
+        let hub = Arc::new(sentry::Hub::new(Some(client), Arc::new(Default::default())));
+
+        uc_observability::set_telemetry_enabled(true);
+        sentry::Hub::run(hub, || {
+            let transaction = sentry::start_transaction(TransactionContext::new(
+                "started-before-disable",
+                "test",
+            ));
+            assert!(transaction.is_sampled());
+
+            uc_observability::set_telemetry_enabled(false);
+            transaction.finish();
+            assert_eq!(inner.sent.load(Ordering::SeqCst), 0);
+
+            uc_observability::set_telemetry_enabled(true);
+            sentry::start_transaction(TransactionContext::new("started-after-enable", "test"))
+                .finish();
+            assert_eq!(inner.sent.load(Ordering::SeqCst), 1);
+        });
+    }
+
+    #[test]
+    fn sampler_blocks_disabled_and_muted_transactions() {
+        let _guard = TEST_LOCK.lock().unwrap_or_else(|error| error.into_inner());
+        let ordinary = TransactionContext::new("settings.load", "test");
+
+        uc_observability::set_telemetry_enabled(false);
+        assert_eq!(transaction_sample_rate(&ordinary), 0.0);
+
+        uc_observability::set_telemetry_enabled(true);
+        assert_eq!(transaction_sample_rate(&ordinary), BASE_TRACE_SAMPLE_RATE);
+        for name in MUTED_TRANSACTION_NAMES {
+            let transaction = TransactionContext::new(name, "test");
+            assert_eq!(transaction_sample_rate(&transaction), 0.0);
+        }
+    }
+}

--- a/crates/uc-bootstrap/src/observability/tracing.rs
+++ b/crates/uc-bootstrap/src/observability/tracing.rs
@@ -37,6 +37,7 @@ use tracing_subscriber::filter::{filter_fn, FilterExt};
 use tracing_subscriber::prelude::*;
 
 use super::correlation::{self, CorrelationLayer};
+use super::sentry_gate::{transaction_sample_rate, TelemetryGatedTransportFactory};
 use uc_application::facade::AppPaths;
 use uc_infra::settings::repository::load_settings_snapshot;
 use uc_observability::redact::{is_sensitive_key, REDACTED_PLACEHOLDER};
@@ -185,7 +186,7 @@ pub fn init_tracing_subscriber() -> anyhow::Result<()> {
     }
 
     // Step 1b: Resolve device_id for process-wide logging correlation
-    let device_id = std::fs::read_to_string(&paths.device_id_path()).ok();
+    let device_id = std::fs::read_to_string(paths.device_id_path()).ok();
 
     if let Some(device_id) = device_id.as_ref() {
         let _ = uc_observability::set_global_device_id(device_id.clone());
@@ -246,9 +247,10 @@ pub fn init_tracing_subscriber() -> anyhow::Result<()> {
     //
     // ## 与 telemetry_enabled 的关系
     //
-    // Sentry 在有 DSN 时无条件初始化,但每条出站事件 / breadcrumb / log 都会
-    // 被对应的 `before_*` 钩子拦截,在用户关闭 telemetry 时一律返回 None。
-    // 净效果是用户开关即时生效,不需要重启进程。
+    // Sentry initializes whenever a DSN exists. Payload-specific hooks drop
+    // events, breadcrumbs, and logs while telemetry is disabled; the sampler
+    // rejects new transactions, and the final transport gate catches every
+    // envelope, including transactions started before the toggle changed.
     //
     // ## 防双重 panic 上报
     //
@@ -275,31 +277,19 @@ pub fn init_tracing_subscriber() -> anyhow::Result<()> {
                 environment: option_env!("APP_ENV")
                     .filter(|s| !s.is_empty())
                     .map(Into::into),
-                // ERROR / Exception 全采样;performance trace 紧急下调至 2%
-                // 控制 quota —— 2026-05 月底配额已用 80%,经诊断 iroh
-                // poll_send 与 presence 链路占 81%,在加上下方 iroh
-                // target 过滤后,2% 仍能保留可观测性。
+                // Sample every ERROR / Exception.
                 sample_rate: 1.0,
-                traces_sample_rate: 0.02,
-                // 兜底过滤:对一组已知"高频且无业务价值"的 transaction
-                // 名直接返回 0.0,确保即使有人后续加 instrument 也不会再
-                // 烧配额。对其他 transaction 退回 traces_sample_rate
-                // 的 0.02。`traces_sampler` 一旦设置就完全取代
-                // `traces_sample_rate`,所以必须显式在这里复述基线值
-                // (sentry-rust 行为详见 performance::sample_rate)。
-                //
-                // 命中表来自 2026-05 月度配额诊断 —— 这几个名字对应
-                // iroh / noq_proto 的 root transaction(虽然上方 layer
-                // filter 已经按 target 屏蔽,但 sentry-tracing 也可能
-                // 在某些路径下用更短的 transaction name,这里加一道。
-                traces_sampler: Some(Arc::new(|ctx| {
-                    matches!(
-                        ctx.name(),
-                        "poll_send" | "connect" | "QADv4" | "tx" | "state"
-                    )
-                    .then_some(0.0)
-                    .unwrap_or(0.02)
-                })),
+                // Transaction sampling: rate, quota backstop, and telemetry gate
+                // all live in `sentry_gate::transaction_sample_rate`. Note there
+                // is deliberately no `traces_sample_rate` here — sentry-core
+                // ignores it once `traces_sampler` is set, so setting it would
+                // only create a second, dead copy of the baseline rate.
+                traces_sampler: Some(Arc::new(transaction_sample_rate)),
+                // Final process-wide envelope gate. Unlike the payload-specific
+                // before_* hooks below, this also covers transactions sampled
+                // before the toggle flipped, release-health sessions, and future
+                // Sentry envelope types added by SDK upgrades.
+                transport: Some(Arc::new(TelemetryGatedTransportFactory)),
                 // Enable Sentry Logs (replaces the legacy OTLP→Seq pipeline).
                 // Tracing ERROR + WARN events are routed to Logs by the
                 // `event_filter` below; INFO stays as a breadcrumb only.

--- a/crates/uc-observability/src/telemetry_gate.rs
+++ b/crates/uc-observability/src/telemetry_gate.rs
@@ -6,9 +6,9 @@
 //! - Frontend has its own gate (`setFrontendSentryEnabled` in
 //!   `src/observability/sentry.ts`) since the gate must live in the JS runtime.
 //! - This module is the equivalent for the Rust side: `uc-bootstrap` consults
-//!   it from Sentry's `before_send`, `before_breadcrumb`, and `before_send_log`
-//!   hooks. When the gate is off, Issues / breadcrumbs / Logs are all dropped
-//!   at capture time.
+//!   it from Sentry's transaction sampler, final transport, `before_send`,
+//!   `before_breadcrumb`, and `before_send_log` hooks. When the gate is off,
+//!   payloads are dropped before capture or at the final envelope boundary.
 //!
 //! ## Default
 //!

--- a/docs/architecture/logging-architecture.md
+++ b/docs/architecture/logging-architecture.md
@@ -793,10 +793,31 @@ The previous OTLP→Seq pipeline was retired in commit `faa8eb8d` (backend) and 
 
 ### Privacy and Telemetry Gate
 
-Both backend and frontend honor the in-app **Settings → General → Telemetry** toggle (`general.telemetry_enabled`):
+Both backend and frontend honor the in-app **Settings → General → Telemetry** toggle (`general.telemetry_enabled`). Each side gates at three depths, because no single hook covers every payload:
 
-- **Backend** — `uc_observability::telemetry_gate` is consulted by Sentry's `before_send`, `before_breadcrumb`, and `before_send_log` hooks. When the gate is off, all three return `None` and nothing leaves the process.
-- **Frontend** — `setFrontendSentryEnabled` flips the same flag for the browser SDK. The `beforeSend` / `beforeBreadcrumb` / `beforeSendLog` hooks in `src/observability/sentry.ts` short-circuit to `null` while disabled. The default is **off** at startup; SettingContext flips it on once the daemon returns the persisted user preference, so any events captured before that point are dropped silently.
+| Depth               | Backend (`uc-bootstrap/src/observability/`)                         | Frontend (`src/observability/sentry.ts`)                        |
+| ------------------- | ------------------------------------------------------------------- | --------------------------------------------------------------- |
+| Transaction sampler | `traces_sampler` -> `sentry_gate::transaction_sample_rate` -> `0.0` | `tracesSampler` -> `0`                                           |
+| Payload hooks       | `before_send` / `before_breadcrumb` / `before_send_log` -> `None`    | `beforeSend` / `beforeBreadcrumb` / `beforeSendLog` -> `null`    |
+| Envelope transport  | `sentry_gate::TelemetryGatedTransportFactory` drops the envelope     | `makeTelemetryGatedTransport` resolves without sending           |
+
+The sampler stops new transactions from being recorded at all. The payload hooks
+drop their respective payload at capture time — breadcrumbs in particular must be
+dropped there rather than at the transport, so that re-enabling telemetry
+mid-session cannot leak the preceding quiet period's context into the next event.
+
+The transport is the final boundary and is **not** redundant with the hooks: it is
+the only gate covering envelopes that no `before_*` hook ever sees — transactions
+sampled before the user flipped the toggle, `release-health` session updates
+(sentry-core's `session.rs` calls `send_envelope` directly, bypassing
+`before_send`), and any envelope type a future SDK upgrade introduces.
+
+The frontend gate defaults to **off** at startup and mirrors the last confirmed
+preference into `localStorage` (`uc.telemetry_enabled`), so a user who disabled
+telemetry stays covered during the early window before SettingContext receives the
+persisted value from the daemon. The backend equivalent is `tracing.rs` reading
+`settings.json` synchronously and calling `set_telemetry_enabled` before
+`sentry::init`.
 
 A shared field-name redaction blocklist (backend: `uc_observability::redact`, frontend: `src/observability/redaction.ts`) is applied to attributes regardless of the gate state, so secrets like `password`, `token`, `auth`, `api_key`, etc. never leave the process even if telemetry is enabled.
 

--- a/docs/architecture/logging-architecture.md
+++ b/docs/architecture/logging-architecture.md
@@ -793,31 +793,19 @@ The previous OTLP→Seq pipeline was retired in commit `faa8eb8d` (backend) and 
 
 ### Privacy and Telemetry Gate
 
-Both backend and frontend honor the in-app **Settings → General → Telemetry** toggle (`general.telemetry_enabled`). Each side gates at three depths, because no single hook covers every payload:
+后端与前端都遵守应用内的 **设置 → 通用 → 遥测** 开关（`general.telemetry_enabled`）。没有任何单一钩子能覆盖全部载荷，因此两端都在三个深度上设卡：
 
-| Depth               | Backend (`uc-bootstrap/src/observability/`)                         | Frontend (`src/observability/sentry.ts`)                        |
-| ------------------- | ------------------------------------------------------------------- | --------------------------------------------------------------- |
-| Transaction sampler | `traces_sampler` -> `sentry_gate::transaction_sample_rate` -> `0.0` | `tracesSampler` -> `0`                                           |
-| Payload hooks       | `before_send` / `before_breadcrumb` / `before_send_log` -> `None`    | `beforeSend` / `beforeBreadcrumb` / `beforeSendLog` -> `null`    |
-| Envelope transport  | `sentry_gate::TelemetryGatedTransportFactory` drops the envelope     | `makeTelemetryGatedTransport` resolves without sending           |
+| 深度                | 后端（`uc-bootstrap/src/observability/`）                            | 前端（`src/observability/sentry.ts`）                         |
+| ------------------- | ------------------------------------------------------------------- | ------------------------------------------------------------- |
+| Transaction 采样器  | `traces_sampler` -> `sentry_gate::transaction_sample_rate` -> `0.0` | `tracesSampler` -> `0`                                        |
+| 载荷钩子            | `before_send` / `before_breadcrumb` / `before_send_log` -> `None`    | `beforeSend` / `beforeBreadcrumb` / `beforeSendLog` -> `null` |
+| Envelope transport  | `sentry_gate::TelemetryGatedTransportFactory` 丢弃 envelope          | `makeTelemetryGatedTransport` 直接 resolve，不发送            |
 
-The sampler stops new transactions from being recorded at all. The payload hooks
-drop their respective payload at capture time — breadcrumbs in particular must be
-dropped there rather than at the transport, so that re-enabling telemetry
-mid-session cannot leak the preceding quiet period's context into the next event.
+采样器让新 Transaction 根本不被记录。载荷钩子在 capture 时丢弃各自的载荷——其中 breadcrumb 尤其必须在这一层丢弃而不是留到 transport：只有在 capture 时就丢掉，会话中途重新打开遥测才不会把此前静默期的上下文泄漏进下一条事件。
 
-The transport is the final boundary and is **not** redundant with the hooks: it is
-the only gate covering envelopes that no `before_*` hook ever sees — transactions
-sampled before the user flipped the toggle, `release-health` session updates
-(sentry-core's `session.rs` calls `send_envelope` directly, bypassing
-`before_send`), and any envelope type a future SDK upgrade introduces.
+transport 是最后一道边界，且与前面的钩子 **并不冗余**：它是唯一能覆盖那些任何 `before_*` 钩子都看不到的 envelope 的关卡——包括切换开关前已经采样的 Transaction、`release-health` 的 session 更新（sentry-core 的 `session.rs` 直接调用 `send_envelope`，绕过 `before_send`），以及未来 SDK 升级引入的新 envelope 类型。
 
-The frontend gate defaults to **off** at startup and mirrors the last confirmed
-preference into `localStorage` (`uc.telemetry_enabled`), so a user who disabled
-telemetry stays covered during the early window before SettingContext receives the
-persisted value from the daemon. The backend equivalent is `tracing.rs` reading
-`settings.json` synchronously and calling `set_telemetry_enabled` before
-`sentry::init`.
+前端的 gate 启动时默认 **关闭**，并把上次确认过的偏好镜像进 `localStorage`（`uc.telemetry_enabled`），这样在 SettingContext 从 daemon 拿到持久化值之前的启动早期窗口，关掉过遥测的用户依然受保护。后端的等价做法是 `tracing.rs` 同步读 `settings.json`，在 `sentry::init` 之前调用 `set_telemetry_enabled`。
 
 A shared field-name redaction blocklist (backend: `uc_observability::redact`, frontend: `src/observability/redaction.ts`) is applied to attributes regardless of the gate state, so secrets like `password`, `token`, `auth`, `api_key`, etc. never leave the process even if telemetry is enabled.
 

--- a/src/contexts/SettingContext.tsx
+++ b/src/contexts/SettingContext.tsx
@@ -400,10 +400,9 @@ export const SettingProvider: React.FC<SettingProviderProps> = ({ children }) =>
     })
   }, [setting?.general?.language])
 
-  // 将用户侧遥测开关同步到前端观测出口；初次加载设置和后续变更都会立即生效。
-  // 前端通过 Sentry 的 beforeSend / beforeBreadcrumb / beforeSendLog 钩子
-  // 在 sentryRuntimeEnabled=false 时直接丢弃事件；后端 Sentry 由
-  // uc-observability 的 telemetry_gate 同步，不需要重启。
+  // Synchronize the user preference to every frontend Sentry payload path.
+  // Sampling and before-send hooks read the runtime gate on every capture, so
+  // both the initial settings load and later changes take effect immediately.
   useEffect(() => {
     const enabled = setting?.general?.telemetryEnabled
     if (typeof enabled !== 'boolean') return

--- a/src/observability/__tests__/sentry.test.ts
+++ b/src/observability/__tests__/sentry.test.ts
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   DEVICE_ROLE_WEBVIEW,
+  TRACES_SAMPLE_RATE,
   applyDeviceMetaToSentry,
   initSentry,
   setFrontendSentryEnabled,
@@ -16,6 +17,7 @@ vi.mock('@sentry/react', async importOriginal => {
     init: vi.fn(),
     browserTracingIntegration: vi.fn(),
     getReplay: vi.fn(),
+    makeFetchTransport: vi.fn(),
     replayIntegration: vi.fn(),
     setTag: vi.fn(),
     setUser: vi.fn(),
@@ -126,6 +128,50 @@ describe('initSentry', () => {
     expect(await Promise.resolve(beforeSend(event, {}))).toBeNull()
     expect(beforeBreadcrumb(breadcrumb, {})).toBeNull()
     expect(beforeSendLog(log)).toBeNull()
+  })
+
+  it('stops sampling new transactions while disabled', () => {
+    initSentry()
+    const tracesSampler = vi.mocked(Sentry.init).mock.calls[0][0].tracesSampler!
+    const inheritOrSampleWith = vi.fn((rate: number) => rate)
+    const samplingContext: Parameters<typeof tracesSampler>[0] = {
+      name: 'settings.load',
+      inheritOrSampleWith,
+    }
+
+    setFrontendSentryEnabled(false)
+    expect(tracesSampler(samplingContext)).toBe(0)
+    expect(inheritOrSampleWith).not.toHaveBeenCalled()
+
+    setFrontendSentryEnabled(true)
+    expect(tracesSampler(samplingContext)).toBe(TRACES_SAMPLE_RATE)
+    // 开启时必须走 inheritOrSampleWith,否则会丢掉上游 trace 的采样决定。
+    expect(inheritOrSampleWith).toHaveBeenCalledWith(TRACES_SAMPLE_RATE)
+  })
+
+  it('blocks every envelope at the final transport while disabled', async () => {
+    const send = vi.fn(() => Promise.resolve({ statusCode: 200 }))
+    const flush = vi.fn(() => Promise.resolve(true))
+    vi.mocked(Sentry.makeFetchTransport).mockReturnValue({ send, flush })
+    initSentry()
+    const initCall = vi.mocked(Sentry.init).mock.calls[0][0]
+    const transportFactory = initCall.transport!
+    const transport = transportFactory({
+      url: 'https://sentry.example/api/1/envelope/',
+      recordDroppedEvent: vi.fn(),
+    })
+    const envelope = [{}, []] as Parameters<typeof transport.send>[0]
+
+    setFrontendSentryEnabled(false)
+    await transport.send(envelope)
+    expect(send).not.toHaveBeenCalled()
+
+    setFrontendSentryEnabled(true)
+    await transport.send(envelope)
+    expect(send).toHaveBeenCalledWith(envelope)
+
+    await transport.flush(25)
+    expect(flush).toHaveBeenCalledWith(25)
   })
 
   it('configures Replay as diagnostics-gated error buffering', () => {

--- a/src/observability/sentry.ts
+++ b/src/observability/sentry.ts
@@ -77,6 +77,40 @@ function syncFrontendReplayEnabled(enabled: boolean): void {
   void replay.stop()
 }
 
+/**
+ * 基线 trace 采样率，前端的单一真相源。
+ *
+ * 与后端 `sentry_gate::BASE_TRACE_SAMPLE_RATE` 对称;两个 DSN 指向不同
+ * Sentry 项目,配额独立,所以数值不需要一致。
+ */
+export const TRACES_SAMPLE_RATE = import.meta.env.DEV ? 1.0 : 0.1
+
+/**
+ * 最终 envelope 出口 gate,对应后端的 `TelemetryGatedTransport`。
+ *
+ * 关闭遥测时在这里丢弃,而不是只靠 `beforeSend` 系列钩子:那些钩子每个只
+ * 管一种载荷,而 session(release-health)、client report 这类 envelope
+ * 不经过任何 `beforeSend`,只有 transport 能拦住。这一层也自动覆盖了
+ * "切换前已采样、切换后才结束"的 Transaction。
+ *
+ * 包在 `makeFetchTransport` 外面而不是里面:后者内部已经带缓冲与限流队列,
+ * 从外面拦截才能保证被丢弃的 envelope 根本不进队列。
+ */
+function makeTelemetryGatedTransport(
+  options: Parameters<typeof Sentry.makeFetchTransport>[0]
+): ReturnType<typeof Sentry.makeFetchTransport> {
+  const transport = Sentry.makeFetchTransport(options)
+  return {
+    send: envelope => {
+      if (!sentryRuntimeEnabled) {
+        return Promise.resolve({})
+      }
+      return transport.send(envelope)
+    },
+    flush: timeout => transport.flush(timeout),
+  }
+}
+
 const getTauriPlatform = (): string => {
   if (typeof window === 'undefined' || !('__TAURI__' in window)) {
     return 'unknown'
@@ -120,7 +154,18 @@ export function initSentry(): void {
 
   Sentry.init({
     dsn: import.meta.env.VITE_SENTRY_DSN,
-    tracesSampleRate: import.meta.env.DEV ? 1.0 : 0.1,
+    transport: makeTelemetryGatedTransport,
+    // 关闭遥测时返回 0,连 span 都不记录。已采样的 Transaction 若在切换后
+    // 才结束,由上面的 transport gate 兜住,这里不需要再加
+    // `beforeSendTransaction`。`inheritOrSampleWith` 复刻了原
+    // `tracesSampleRate` 的分布式追踪继承语义(先 parentSampleRate,
+    // 再 parentSampled,最后 fallback)。
+    tracesSampler: samplingContext => {
+      if (!sentryRuntimeEnabled) {
+        return 0
+      }
+      return samplingContext.inheritOrSampleWith(TRACES_SAMPLE_RATE)
+    },
     replaysSessionSampleRate: 0,
     replaysOnErrorSampleRate: 1.0,
     environment: import.meta.env.VITE_APP_ENV ?? import.meta.env.MODE,


### PR DESCRIPTION
## Summary

- **Fixes a real privacy leak** (`2cd3d8a`). The telemetry toggle was only enforced by the `before_send` / `before_breadcrumb` / `before_send_log` hooks, and each of those gates exactly one payload kind. `release-health` session updates never pass through any of them — sentry-core's `session.rs` hands them straight to `send_envelope`. **A user who turned telemetry off was still uploading session data** (process start/stop and crash state) on every run.
- **Adds the two non-payload gate points on both runtimes** (`2cd3d8a`). The *transaction sampler* refuses to record new transactions while the gate is off, so no span data is collected at all; the *envelope transport* is the final boundary, covering transactions that were sampled before the toggle flipped, release-health sessions, and any envelope type a future SDK upgrade introduces. Backend gets `crates/uc-bootstrap/src/observability/sentry_gate.rs`; the frontend equivalents live in `src/observability/sentry.ts`.
- **Removes a dead-config trap** (`2cd3d8a`). `ClientOptions::traces_sample_rate` is dropped: sentry-core ignores it entirely once `traces_sampler` is set (`performance.rs`: `(Some(traces_sampler), _) => traces_sampler(ctx)`), so keeping it meant two copies of the baseline `0.02` where only one was live. `BASE_TRACE_SAMPLE_RATE` is now the single source of truth on the backend, `TRACES_SAMPLE_RATE` on the frontend.
- **Lint cleanup, split out** (`bce8d25`) so the fix above stays one intent.

### Behavior notes for reviewers

- The frontend swaps `tracesSampleRate` for `tracesSampler` + `inheritOrSampleWith`. This is semantics-preserving: `hasSpansEnabled` accepts either field (so tracing does not silently turn off), and `inheritOrSampleWith` reproduces the old distributed-trace inheritance order (`parentSampleRate` → `parentSampled` → fallback).
- `beforeSendTransaction` was considered and deliberately **not** added — the transport gate already covers the only case it would catch, and the backend has no equivalent. Both runtimes now gate at the same two depths plus the payload hooks.
- Breadcrumbs stay gated at `before_breadcrumb` rather than at the transport on purpose: dropping them at capture time is what stops a re-enable mid-session from leaking the preceding quiet period's context into the next event.

## Test plan

- [x] `cargo test -p uc-bootstrap --lib observability::` — 11 passed. Includes a new test proving a transaction sampled *before* the toggle flips is still blocked at the transport, and that the sampler returns 0 while disabled / for each muted name.
- [x] `bun run test src/observability` — 29 passed. Covers the sampler gate and the transport blocking every envelope while disabled.
- [x] `bunx tsc --noEmit` — 0 errors. `cargo clippy -p uc-bootstrap --all-targets` — no new warnings from this diff.
- [ ] **Manual, needs a real DSN:** with `SENTRY_DSN` set, toggle Settings → General → Telemetry off, restart-free, and confirm no session envelope reaches the Sentry project (previously one arrived per process run). This is the actual regression being fixed and is not reachable from unit tests.
- [ ] Confirm `traces_sample_rate` removal did not change the observed transaction volume in the backend Sentry project — the effective rate should still be 2%.

## Docs

`docs/architecture/logging-architecture.md` updated with the three-depth gate table and why the transport layer is not redundant with the hooks.

Scanned `docs-site/` — no user-facing contract changed by this PR. `privacy.mdx` already claims *"Turning either toggle off drops the next matching event"*, which this PR makes true for the first time; the docs were right and the code has now caught up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Privacy and Telemetry**
  - Strengthened the telemetry gate so disabling telemetry blocks Sentry data from being sampled and delivered (including envelopes that previously could bypass earlier hooks).
  - Centralized transaction sampling under the live telemetry preference, muting configured transaction names and using a clear dev/prod baseline rate.
  - Telemetry preference changes now take effect immediately across supported capture paths.

- **Documentation**
  - Rewrote the “Privacy and Telemetry Gate” overview to describe the layered gating behavior end to end.

- **Bug Fixes**
  - Improved migration cleanup filename matching for the V2 sentinel check.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->