### PR TITLE
feat(release): add mobile download links to release notes matrix

### DIFF
--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -121,7 +121,7 @@ bun run version:bump --type patch --channel alpha --dry-run
 
 3. **创建发布 (create-release)**
    - 创建 Git 标签
-   - 生成发布说明（包含直接下载链接）
+   - 生成发布说明（含桌面端直接下载链接，以及移动端仓库 [UniClipboard/UniClip](https://github.com/UniClipboard/UniClip) 的 iOS 公测与安卓最新版下载链接）
    - 上传所有构建产物
    - 创建 GitHub Release 草稿
 

--- a/scripts/__tests__/generate-release-notes.test.ts
+++ b/scripts/__tests__/generate-release-notes.test.ts
@@ -67,6 +67,33 @@ describe('buildInstallerTable Windows rows', () => {
   })
 })
 
+describe('buildInstallerTable mobile rows', () => {
+  it('always advertises the latest iOS beta and Android APK links', () => {
+    seed(['UniClipboard_0.13.0_aarch64.dmg'])
+
+    const table = buildInstallerTable({ artifactsDir, baseUrl: BASE_URL })
+
+    expect(table).toContain(
+      '| iOS | Public Beta (TestFlight) | [Join the public beta](https://testflight.apple.com/join/nyNQ8dQe) |'
+    )
+    expect(table).toContain(
+      '| Android | APK (arm64-v8a / armeabi-v7a / x86_64 / universal) | [Latest release](https://github.com/UniClipboard/UniClip/releases/latest) |'
+    )
+    // Mobile links point at the companion repo / TestFlight, never this release's baseUrl.
+    expect(table).not.toContain(`${BASE_URL}/https`)
+  })
+
+  it('still surfaces mobile downloads when no desktop artifacts are present', () => {
+    const table = buildInstallerTable({ artifactsDir, baseUrl: BASE_URL })
+
+    expect(table).toContain('No desktop installer artifacts found for this release.')
+    expect(table).toContain('[Join the public beta](https://testflight.apple.com/join/nyNQ8dQe)')
+    expect(table).toContain(
+      '[Latest release](https://github.com/UniClipboard/UniClip/releases/latest)'
+    )
+  })
+})
+
 describe('readChangelogSection pinned announcement', () => {
   it('prepends announcement.md from the changelog directory', () => {
     const changelogPath = path.join(artifactsDir, '0.14.1.md')

--- a/scripts/changelog-draft.js
+++ b/scripts/changelog-draft.js
@@ -62,7 +62,7 @@ function assertFinalizedContent(filePath, version) {
     'Release notes are not available yet.',
     'Release notes pending.',
     'Pending release notes.',
-    'No installer artifacts found for this release.',
+    'No desktop installer artifacts found for this release.',
     'No CLI artifacts found for this release.',
     '<!--',
   ]

--- a/scripts/generate-release-notes.js
+++ b/scripts/generate-release-notes.js
@@ -100,6 +100,31 @@ function findFirstFile(artifactsDir, predicate) {
   return files.find(predicate) || ''
 }
 
+// Mobile apps live in the companion repo (UniClipboard/UniClip) and ship on
+// their own cadence, independent of this desktop release. These links always
+// resolve to the latest mobile build, so every desktop release advertises the
+// current iOS public beta and Android APK without being pinned to this tag.
+const MOBILE_REPO = 'UniClipboard/UniClip'
+const MOBILE_IOS_TESTFLIGHT_URL = 'https://testflight.apple.com/join/nyNQ8dQe'
+const MOBILE_ANDROID_LATEST_URL = `https://github.com/${MOBILE_REPO}/releases/latest`
+
+// Fixed, always-latest external rows for the App download matrix. Unlike the
+// desktop rows these are not scanned from artifactsDir, so the download cell is
+// a full URL rather than `baseUrl/fileName`.
+export function buildMobileInstallerRows() {
+  const makeRow = (platform, target, label, url) =>
+    `| ${platform} | ${target} | [${label}](${url}) |`
+  return [
+    makeRow('iOS', 'Public Beta (TestFlight)', 'Join the public beta', MOBILE_IOS_TESTFLIGHT_URL),
+    makeRow(
+      'Android',
+      'APK (arm64-v8a / armeabi-v7a / x86_64 / universal)',
+      'Latest release',
+      MOBILE_ANDROID_LATEST_URL
+    ),
+  ]
+}
+
 export function buildInstallerTable({ artifactsDir, baseUrl }) {
   // Tauri v2 Linux 产物命名约定:
   //   .deb       — `<lower-product>_<version>_<amd64|arm64>.deb`        (Debian arch)
@@ -157,11 +182,18 @@ export function buildInstallerTable({ artifactsDir, baseUrl }) {
   if (windowsPortableX64) rows.push(makeRow('Windows', 'x86_64 (Portable)', windowsPortableX64))
   if (windowsPortableArm) rows.push(makeRow('Windows', 'ARM64 (Portable)', windowsPortableArm))
 
+  const header = '| Platform | Architecture | Download |\n| --- | --- | --- |\n'
+  const mobileRows = buildMobileInstallerRows()
+
   if (rows.length === 0) {
-    return 'No installer artifacts found for this release.'
+    // No desktop installer artifacts detected (anomalous — a normal release
+    // always ships them). Flag it, but still surface the mobile downloads,
+    // which do not depend on this release's assets.
+    const mobileTable = header + mobileRows.join('\n')
+    return `No desktop installer artifacts found for this release.\n\n${mobileTable}`
   }
 
-  return '| Platform | Architecture | Download |\n| --- | --- | --- |\n' + rows.join('\n')
+  return header + [...rows, ...mobileRows].join('\n')
 }
 
 function buildCliInstallerTable({ artifactsDir, baseUrl }) {


### PR DESCRIPTION
## Summary

- The generated GitHub release notes' **App download matrix** only listed desktop installers. Append two always-latest rows for the companion mobile apps ([UniClipboard/UniClip](https://github.com/UniClipboard/UniClip)) so every desktop release advertises the current mobile downloads (8a03de6d5):
  - **iOS** → `Public Beta (TestFlight)` → https://testflight.apple.com/join/nyNQ8dQe
  - **Android** → `APK (arm64-v8a / armeabi-v7a / x86_64 / universal)` → https://github.com/UniClipboard/UniClip/releases/latest
- These are fixed external URLs that resolve to the newest mobile build (TestFlight beta is stable; `releases/latest` auto-redirects), so the links stay correct after the desktop release is cut and never pin to this tag. Mobile links are extracted into single-source-of-truth constants and matched the mobile repo's own README.
- Kept the empty-desktop-artifacts fallback meaningful — it now flags the anomaly *and* still surfaces the mobile links — and mirrored the renamed fallback string in the changelog placeholder sentinel list (`scripts/changelog-draft.js`).

## Test plan

- [x] Added unit tests in `scripts/__tests__/generate-release-notes.test.ts` (mobile rows always present; mobile links still shown when no desktop artifacts).
- [x] Verified matrix output end-to-end via a standalone Node harness against real desktop artifact names + the two mobile rows (`node --check` clean, prettier printWidth=100 respected).
- [x] Confirmed the mobile links resolve: `gh api repos/UniClipboard/UniClip/releases/latest` → `v1.3.0.162` with `UniClip-*.apk` assets; TestFlight link taken from the mobile repo README.
- [ ] Reviewer: run `pnpm vitest run scripts/__tests__/generate-release-notes.test.ts` in an env with deps installed (this worktree has no `node_modules`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Release notes now include direct download links for desktop installers.
  - Added mobile download links for the iOS public beta via TestFlight and the latest Android APK.
  - Mobile links remain available even when desktop installer artifacts are unavailable.

- **Documentation**
  - Updated release workflow guidance to clearly describe desktop and mobile download links.

- **Bug Fixes**
  - Improved release-note validation to correctly detect missing desktop installer information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->