### PR TITLE
chore(agent): load project Claude resources in Pi

### DIFF
--- a/.pi/settings.json
+++ b/.pi/settings.json
@@ -1,0 +1,4 @@
+{
+  "skills": ["../.claude/skills"],
+  "prompts": ["../.claude/commands"]
+}


### PR DESCRIPTION
## Summary

- Add project-level Pi settings that discover the repository Claude skills and commands without duplicating those resources (b1acc85ff).
- Expose Claude commands as Pi prompt templates and Claude skills as `/skill:*` commands for trusted project sessions (b1acc85ff).

No `docs-site` changes are needed because this only affects the repository agent tooling and does not change user-visible application behavior.

## Test plan

- [x] Validate `.pi/settings.json` with `jq empty`.
- [x] Run `git diff --check main...HEAD`.
- [x] Query Pi RPC `get_commands` with project trust enabled and confirm all 23 project skills and both project commands are loaded.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added configuration entries for shared skills and prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->