### PR TITLE
feat(update-server): serve Android releases

### DIFF
--- a/workers/update-server/src/__tests__/android-routes.test.ts
+++ b/workers/update-server/src/__tests__/android-routes.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi } from 'vitest'
+import worker from '../index'
+import type { AndroidManifest } from '../types'
+
+const context = {
+  waitUntil: vi.fn(),
+  passThroughOnException: vi.fn(),
+} as unknown as ExecutionContext
+
+function r2Object(body: string): R2ObjectBody {
+  return {
+    body: new Response(body).body,
+    size: new TextEncoder().encode(body).byteLength,
+    httpEtag: '"test-etag"',
+  } as unknown as R2ObjectBody
+}
+
+function envWith(get: ReturnType<typeof vi.fn>): { RELEASES_BUCKET: R2Bucket } {
+  return {
+    RELEASES_BUCKET: { get } as unknown as R2Bucket,
+  }
+}
+
+describe('Android update routes', () => {
+  it('serves a channel manifest from its Android R2 key', async () => {
+    const manifest: AndroidManifest = {
+      version: '0.19.0',
+      tagName: 'v0.19.0',
+      prerelease: false,
+      pub_date: '2026-06-01T00:00:00Z',
+      notes: { en: 'Release notes', zh: 'Release notes zh' },
+      assets: [{ name: 'uniclipboard-arm64-v8a.apk', sha256: 'abc123' }],
+    }
+    const get = vi.fn(async () => r2Object(JSON.stringify(manifest)))
+
+    const response = await worker.fetch(
+      new Request('https://updates.example/android/stable.json', {
+        headers: { Origin: 'https://www.uniclipboard.app' },
+      }),
+      envWith(get),
+      context
+    )
+
+    expect(get).toHaveBeenCalledWith('android/stable.json')
+    expect(response.status).toBe(200)
+    expect(response.headers.get('Content-Type')).toBe('application/json')
+    expect(response.headers.get('Cache-Control')).toBe('public, max-age=60')
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe('https://www.uniclipboard.app')
+    expect(await response.json()).toEqual(manifest)
+  })
+
+  it('rejects unsupported Android channels before reading R2', async () => {
+    const get = vi.fn()
+
+    const response = await worker.fetch(
+      new Request('https://updates.example/android/alpha.json'),
+      envWith(get),
+      context
+    )
+
+    expect(response.status).toBe(400)
+    expect(get).not.toHaveBeenCalled()
+    expect(await response.json()).toEqual({ error: 'Invalid android channel: alpha' })
+  })
+
+  it('serves APK artifacts with download headers', async () => {
+    const get = vi.fn(async () => r2Object('apk bytes'))
+
+    const response = await worker.fetch(
+      new Request('https://updates.example/android/artifacts/v0.19.0/uniclipboard-arm64-v8a.apk'),
+      envWith(get),
+      context
+    )
+
+    expect(get).toHaveBeenCalledWith('android/artifacts/v0.19.0/uniclipboard-arm64-v8a.apk')
+    expect(response.status).toBe(200)
+    expect(response.headers.get('Content-Type')).toBe('application/vnd.android.package-archive')
+    expect(response.headers.get('Cache-Control')).toBe('public, max-age=86400, immutable')
+    expect(response.headers.get('Content-Disposition')).toBe(
+      'attachment; filename="uniclipboard-arm64-v8a.apk"'
+    )
+    expect(await response.text()).toBe('apk bytes')
+  })
+
+  it('does not grant browser access to unknown origins', async () => {
+    const response = await worker.fetch(
+      new Request('https://updates.example/health', {
+        headers: { Origin: 'https://attacker.example' },
+      }),
+      envWith(vi.fn()),
+      context
+    )
+
+    expect(response.status).toBe(200)
+    expect(response.headers.has('Access-Control-Allow-Origin')).toBe(false)
+  })
+})

--- a/workers/update-server/src/index.ts
+++ b/workers/update-server/src/index.ts
@@ -21,10 +21,30 @@ interface Env {
 
 const VALID_CHANNELS = new Set(['stable', 'alpha', 'beta', 'rc'])
 
-const CORS_HEADERS: Record<string, string> = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Methods': 'GET, HEAD, OPTIONS',
-  'Access-Control-Allow-Headers': 'Content-Type',
+// The Android companion app has two channels: stable and beta (including prereleases).
+const VALID_ANDROID_CHANNELS = new Set(['stable', 'beta'])
+
+const ALLOWED_BROWSER_ORIGINS = new Set([
+  'https://uniclipboard.app',
+  'https://www.uniclipboard.app',
+])
+
+function withCors(response: Response, request: Request): Response {
+  const headers = new Headers(response.headers)
+  headers.set('Access-Control-Allow-Methods', 'GET, HEAD, OPTIONS')
+  headers.set('Access-Control-Allow-Headers', 'Content-Type')
+
+  const origin = request.headers.get('Origin')
+  if (origin && ALLOWED_BROWSER_ORIGINS.has(origin)) {
+    headers.set('Access-Control-Allow-Origin', origin)
+    headers.append('Vary', 'Origin')
+  }
+
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  })
 }
 
 function jsonResponse(
@@ -36,7 +56,6 @@ function jsonResponse(
     status,
     headers: {
       'Content-Type': 'application/json',
-      ...CORS_HEADERS,
       ...extraHeaders,
     },
   })
@@ -47,7 +66,6 @@ function r2HeadersToResponse(
   extraHeaders?: Record<string, string>
 ): Record<string, string> {
   const headers: Record<string, string> = {
-    ...CORS_HEADERS,
     ...extraHeaders,
   }
 
@@ -198,6 +216,45 @@ async function handleArtifact(version: string, filename: string, env: Env): Prom
   return new Response(object.body, { status: 200, headers })
 }
 
+async function handleAndroidManifest(channel: string, env: Env): Promise<Response> {
+  if (!VALID_ANDROID_CHANNELS.has(channel)) {
+    return jsonResponse({ error: `Invalid android channel: ${channel}` }, 400)
+  }
+  const key = `android/${channel}.json`
+  const object = await env.RELEASES_BUCKET.get(key)
+  if (!object) {
+    return jsonResponse({ error: `Android manifest not found for channel: ${channel}` }, 404)
+  }
+  const headers = r2HeadersToResponse(object, {
+    'Content-Type': 'application/json',
+    'Cache-Control': 'public, max-age=60',
+  })
+  return new Response(object.body, { status: 200, headers })
+}
+
+async function handleAndroidArtifact(
+  version: string,
+  filename: string,
+  env: Env
+): Promise<Response> {
+  const key = `android/artifacts/v${version}/${filename}`
+  const object = await env.RELEASES_BUCKET.get(key)
+
+  if (!object) {
+    return jsonResponse({ error: 'Android artifact not found' }, 404)
+  }
+
+  const contentType = inferContentType(filename)
+
+  const headers = r2HeadersToResponse(object, {
+    'Content-Type': contentType,
+    'Cache-Control': 'public, max-age=86400, immutable',
+    'Content-Disposition': `attachment; filename="${filename}"`,
+  })
+
+  return new Response(object.body, { status: 200, headers })
+}
+
 function inferContentType(filename: string): string {
   if (filename.endsWith('.tar.gz')) return 'application/gzip'
   if (filename.endsWith('.sig')) return 'application/octet-stream'
@@ -206,6 +263,7 @@ function inferContentType(filename: string): string {
   if (filename.endsWith('.AppImage')) return 'application/x-executable'
   if (filename.endsWith('.msi')) return 'application/x-msi'
   if (filename.endsWith('.exe')) return 'application/x-msdownload'
+  if (filename.endsWith('.apk')) return 'application/vnd.android.package-archive'
   if (filename.endsWith('.zip')) return 'application/zip'
   if (filename.endsWith('.json')) return 'application/json'
   return 'application/octet-stream'
@@ -221,14 +279,19 @@ const VERSION_PATH_REGEX = /^\/release-notes\/v([0-9A-Za-z.\-+]+)\.json$/
 
 async function route(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
   if (request.method === 'OPTIONS') {
-    return new Response(null, { status: 204, headers: CORS_HEADERS })
+    return new Response(null, { status: 204 })
   }
 
   if (request.method !== 'GET' && request.method !== 'HEAD') {
     return jsonResponse({ error: 'Method not allowed' }, 405)
   }
 
-  const url = new URL(request.url)
+  let url: URL
+  try {
+    url = new URL(request.url)
+  } catch {
+    return jsonResponse({ error: 'Invalid request URL' }, 400)
+  }
   const path = url.pathname
 
   // GET /health
@@ -265,23 +328,38 @@ async function route(request: Request, env: Env, ctx: ExecutionContext): Promise
     return handleArtifact(artifactMatch[1], artifactMatch[2], env)
   }
 
+  // Keep the Android companion-app manifest route before the shared artifact prefix.
+  const androidManifestMatch = path.match(/^\/android\/([a-z]+)\.json$/)
+  if (androidManifestMatch) {
+    return handleAndroidManifest(androidManifestMatch[1], env)
+  }
+
+  // GET /android/artifacts/v{version}/{filename} (APK download)
+  const androidArtifactMatch = path.match(/^\/android\/artifacts\/v([^/]+)\/(.+)$/)
+  if (androidArtifactMatch) {
+    return handleAndroidArtifact(androidArtifactMatch[1], androidArtifactMatch[2], env)
+  }
+
   return jsonResponse({ error: 'Not found' }, 404)
 }
 
 export default {
   async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
     try {
-      return await route(request, env, ctx)
+      return withCors(await route(request, env, ctx), request)
     } catch (err) {
       // 兜底捕获意外错误（例如 getJsonFromR2 抛出的 R2 JSON 损坏），
       // 确保响应仍然带 CORS headers 与结构化 500 body，而不是 runtime 的裸错误页。
       console.error('Unhandled error:', err)
-      return jsonResponse(
-        {
-          error: 'Internal server error',
-          detail: err instanceof Error ? err.message : String(err),
-        },
-        500
+      return withCors(
+        jsonResponse(
+          {
+            error: 'Internal server error',
+            detail: err instanceof Error ? err.message : String(err),
+          },
+          500
+        ),
+        request
       )
     }
   },

--- a/workers/update-server/src/types.ts
+++ b/workers/update-server/src/types.ts
@@ -25,3 +25,20 @@ export interface MergeResult {
   mergedCount: number
   omittedCount: number
 }
+
+/**
+ * Android companion-app update manifest.
+ *
+ * Distinct from the desktop `Manifest`: the mobile app is not a Tauri updater,
+ * so it carries per-ABI APK descriptors (name + sha256) instead of signed
+ * platform tuples, and embeds bilingual notes inline rather than merging them
+ * from a separate archive. Served verbatim from R2 at `android/{channel}.json`.
+ */
+export interface AndroidManifest {
+  version: string
+  tagName: string
+  prerelease: boolean
+  pub_date: string
+  notes: { en: string; zh: string }
+  assets: Array<{ name: string; sha256: string }>
+}


### PR DESCRIPTION
## Summary

- Serve stable and beta Android update manifests plus versioned APK artifacts from R2, with cache and download headers (`3997acaaa`).
- Restrict browser CORS access to UniClipboard's production origins and add regression coverage for manifest, channel validation, APK, and origin handling (`3997acaaa`).
- Leave `docs-site` unchanged because these backend endpoints do not alter the current user-facing GitHub installation flow.

## Test plan

- [x] `cd workers/update-server && bun run typecheck`
- [x] `bunx vitest run workers/update-server/src/__tests__/android-routes.test.ts workers/update-server/src/__tests__/merge.test.ts`
- [x] `bunx prettier --check workers/update-server/src/index.ts workers/update-server/src/types.ts workers/update-server/src/__tests__/android-routes.test.ts`
- [ ] After deployment, fetch `/android/stable.json` and a versioned APK backed by production R2.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Android update endpoints for channel manifests and APK downloads.
  * Android manifests include version details, bilingual release notes, and asset checksums.
  * APK downloads now provide appropriate content types, download filenames, and long-term caching.

* **Bug Fixes**
  * Improved browser access controls by allowing CORS only for approved origins.
  * Unsupported Android channels now return clear validation errors.
  * Unknown origins are prevented from receiving browser CORS access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->