### PR TITLE
feat(clipboard-history): status-only row for directory sends

### DIFF
--- a/apps/cli/src/commands/get.rs
+++ b/apps/cli/src/commands/get.rs
@@ -594,6 +594,7 @@ mod tests {
             file_sizes: None,
             image_width: None,
             image_height: None,
+            is_directory: false,
             payload_state: None,
         }
     }

--- a/crates/uc-application/src/facade/clipboard_history/mod.rs
+++ b/crates/uc-application/src/facade/clipboard_history/mod.rs
@@ -7,7 +7,8 @@ use uc_core::clipboard::link_utils::extract_domain;
 use uc_core::ids::{EntryId, EventId, FormatId, RepresentationId};
 use uc_core::ports::blob::BlobTransferPort;
 use uc_core::ports::clipboard::{
-    ClipboardPayloadResolverPort, SaveClipboardEntryPort, ThumbnailRepositoryPort,
+    ClipboardPayloadResolverPort, EntryFileSetRepositoryPort, SaveClipboardEntryPort,
+    ThumbnailRepositoryPort,
 };
 use uc_core::ports::search::search_index::SearchIndexPort;
 use uc_core::ports::{
@@ -58,6 +59,11 @@ pub struct EntryProjectionView {
     pub file_sizes: Option<Vec<i64>>,
     pub image_width: Option<i32>,
     pub image_height: Option<i32>,
+    /// Whether this file entry was captured as a directory. Sourced from the
+    /// single `EntryFileSet::has_directory_structure()` authority; `false` for
+    /// non-file entries or when no manifest is available. The sender UI keys off
+    /// this to render status only (no byte percentage) for directory sends.
+    pub is_directory: bool,
     /// `paste_rep` 的 payload_state, 仅在 `Lost` 时输出。其他状态为 `None`。
     /// 前端按此判断"该 entry 点了能不能粘贴" —— 粘贴行为基于 paste_rep,
     /// 而 list 里的 preview 基于 preview_rep, 两者可能不同。
@@ -141,6 +147,9 @@ pub struct ClipboardHistoryFacadeDeps {
     pub blob_store: Arc<dyn BlobReaderPort>,
     pub thumbnail_repo: Arc<dyn ThumbnailRepositoryPort>,
     pub file_transfer_repo: Arc<dyn GetEntryTransferSummaryPort>,
+    /// Directory-structure authority for the list projection's `is_directory`
+    /// flag (`EntryFileSet::has_directory_structure()`).
+    pub entry_file_set_repo: Arc<dyn EntryFileSetRepositoryPort>,
     pub search_index: Option<Arc<dyn SearchIndexPort>>,
     pub file_cache_dir: Option<PathBuf>,
     /// 删除剪贴板条目时释放对应的 iroh-blobs tag。`None` 表示该装配场景
@@ -190,6 +199,7 @@ impl ClipboardHistoryFacade {
             blob_store,
             thumbnail_repo,
             file_transfer_repo,
+            entry_file_set_repo,
             search_index,
             file_cache_dir,
             blob_transfer,
@@ -235,6 +245,7 @@ impl ClipboardHistoryFacade {
             rep_get.clone(),
             thumbnail_repo,
             file_transfer_repo,
+            entry_file_set_repo,
         );
 
         let detail_uc = GetEntryDetailUseCase::new(
@@ -614,6 +625,7 @@ fn projection_to_view(entry: EntryProjectionDto) -> EntryProjectionView {
         file_sizes: entry.file_sizes,
         image_width: entry.image_width,
         image_height: entry.image_height,
+        is_directory: entry.is_directory,
         payload_state: entry.payload_state,
     }
 }

--- a/crates/uc-application/src/facade/clipboard_live_index/mod.rs
+++ b/crates/uc-application/src/facade/clipboard_live_index/mod.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use thiserror::Error;
 use tracing::debug;
+use uc_core::clipboard::ClipboardEntryContentCategory;
 use uc_core::ids::EntryId;
 use uc_core::ports::clipboard::{
     ClipboardEventRepositoryPort, EntryFileSetRepositoryPort, GetClipboardEntryPort,
@@ -116,7 +117,9 @@ impl ClipboardLiveIndexPort for ClipboardLiveIndexer {
             }
         };
 
-        let has_directory =
+        // Only file entries can carry a directory manifest; skip the extra repo
+        // read for text/image/etc., mirroring the list projection.
+        let has_directory = if entry.content_category == ClipboardEntryContentCategory::File {
             load_has_directory_structure(self.deps.entry_file_set_repo.as_ref(), &entry_id)
                 .await
                 .unwrap_or_else(|err| {
@@ -126,7 +129,10 @@ impl ClipboardLiveIndexPort for ClipboardLiveIndexer {
                         "search: failed to load file set, indexing without directory tag"
                     );
                     false
-                });
+                })
+        } else {
+            false
+        };
 
         let Some(pipeline_input) = SearchProjectionBuilder::build_from_capture(
             &entry,

--- a/crates/uc-application/src/facade/clipboard_live_index/mod.rs
+++ b/crates/uc-application/src/facade/clipboard_live_index/mod.rs
@@ -12,6 +12,7 @@ use uc_core::ports::{SearchIndexPort, SearchKeyDerivationPort, SelectRepresentat
 use uc_core::SystemClipboardSnapshot;
 
 use crate::facade::SearchProjectionBuilder;
+use crate::file_set_query::load_has_directory_structure;
 
 #[derive(Debug, Clone)]
 pub struct ClipboardLiveIndexInput {
@@ -115,18 +116,17 @@ impl ClipboardLiveIndexPort for ClipboardLiveIndexer {
             }
         };
 
-        let has_directory = match self.deps.entry_file_set_repo.load(&entry_id).await {
-            Ok(Some(file_set)) => file_set.has_directory_structure(),
-            Ok(None) => false,
-            Err(err) => {
-                debug!(
-                    error = %err,
-                    entry_id = %entry_id,
-                    "search: failed to load file set, indexing without directory tag"
-                );
-                false
-            }
-        };
+        let has_directory =
+            load_has_directory_structure(self.deps.entry_file_set_repo.as_ref(), &entry_id)
+                .await
+                .unwrap_or_else(|err| {
+                    debug!(
+                        error = %err,
+                        entry_id = %entry_id,
+                        "search: failed to load file set, indexing without directory tag"
+                    );
+                    false
+                });
 
         let Some(pipeline_input) = SearchProjectionBuilder::build_from_capture(
             &entry,

--- a/crates/uc-application/src/facade/search/coordinator.rs
+++ b/crates/uc-application/src/facade/search/coordinator.rs
@@ -22,6 +22,7 @@ use uc_infra::search::constants::CURRENT_INDEX_VERSION;
 use uc_infra::search::text_extractor::SearchPipelineInput;
 
 use crate::facade::search::{SearchProjectionBuilder, SearchStatusView};
+use crate::file_set_query::load_has_directory_structure;
 
 pub const REASON_INITIAL_BACKFILL: &str = "initial_backfill";
 pub const REASON_VERSION_MISMATCH: &str = "version_mismatch";
@@ -667,18 +668,16 @@ async fn project_persisted_entry(
         }
     };
 
-    let has_directory = match entry_file_set_repo.load(&entry.entry_id).await {
-        Ok(Some(file_set)) => file_set.has_directory_structure(),
-        Ok(None) => false,
-        Err(e) => {
+    let has_directory = load_has_directory_structure(entry_file_set_repo, &entry.entry_id)
+        .await
+        .unwrap_or_else(|e| {
             debug!(
                 error = %e,
                 entry_id = %entry.entry_id,
                 "search projection: failed to load file set, projecting without directory tag"
             );
             false
-        }
-    };
+        });
 
     SearchProjectionBuilder::build_from_persisted(
         entry,

--- a/crates/uc-application/src/facade/search/coordinator.rs
+++ b/crates/uc-application/src/facade/search/coordinator.rs
@@ -7,7 +7,7 @@ use tokio::sync::{broadcast, mpsc, Mutex, Semaphore};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, info_span, instrument, warn, Instrument};
 
-use uc_core::clipboard::ClipboardEntry;
+use uc_core::clipboard::{ClipboardEntry, ClipboardEntryContentCategory};
 use uc_core::ids::EntryId;
 use uc_core::ports::clipboard::{
     ClipboardEventRepositoryPort, EntryFileSetRepositoryPort, GetClipboardEntryPort,
@@ -668,16 +668,22 @@ async fn project_persisted_entry(
         }
     };
 
-    let has_directory = load_has_directory_structure(entry_file_set_repo, &entry.entry_id)
-        .await
-        .unwrap_or_else(|e| {
-            debug!(
-                error = %e,
-                entry_id = %entry.entry_id,
-                "search projection: failed to load file set, projecting without directory tag"
-            );
-            false
-        });
+    // Only file entries can carry a directory manifest; skip the extra repo read
+    // for text/image/etc., mirroring the list projection.
+    let has_directory = if entry.content_category == ClipboardEntryContentCategory::File {
+        load_has_directory_structure(entry_file_set_repo, &entry.entry_id)
+            .await
+            .unwrap_or_else(|e| {
+                debug!(
+                    error = %e,
+                    entry_id = %entry.entry_id,
+                    "search projection: failed to load file set, projecting without directory tag"
+                );
+                false
+            })
+    } else {
+        false
+    };
 
     SearchProjectionBuilder::build_from_persisted(
         entry,

--- a/crates/uc-application/src/file_set_query.rs
+++ b/crates/uc-application/src/file_set_query.rs
@@ -1,0 +1,22 @@
+//! Shared reads over the entry file-set port.
+
+use uc_core::clipboard::EntryFileSetError;
+use uc_core::ids::EntryId;
+use uc_core::ports::clipboard::EntryFileSetRepositoryPort;
+
+/// Whether an entry's file-set manifest describes a directory root.
+///
+/// Folds the manifest load and its `None` case shared by the search,
+/// live-index, and history-list projections: an **absent** manifest is not a
+/// directory (`Ok(false)`). The directory rule itself is the single authority
+/// `EntryFileSet::has_directory_structure`. A load **error** is propagated so
+/// each projection can log it at its own level and degrade to non-directory.
+pub(crate) async fn load_has_directory_structure(
+    repo: &dyn EntryFileSetRepositoryPort,
+    entry_id: &EntryId,
+) -> Result<bool, EntryFileSetError> {
+    Ok(repo
+        .load(entry_id)
+        .await?
+        .is_some_and(|file_set| file_set.has_directory_structure()))
+}

--- a/crates/uc-application/src/lib.rs
+++ b/crates/uc-application/src/lib.rs
@@ -9,6 +9,7 @@ pub mod deps;
 // `deps` composition panel (`uc_application::deps::EntryIdentityCoordinator`).
 pub(crate) mod entry_identity;
 pub mod facade;
+pub(crate) mod file_set_query;
 pub mod file_sync;
 pub mod sync_planner;
 #[cfg(test)]

--- a/crates/uc-application/src/usecases/clipboard_history/list_entry_projections.rs
+++ b/crates/uc-application/src/usecases/clipboard_history/list_entry_projections.rs
@@ -7,7 +7,9 @@ use uc_core::clipboard::link_utils::{detect_link_urls as detect_web_urls, parse_
 use uc_core::clipboard::{
     ClipboardEntryContentCategory, MimeType, PayloadAvailability, PersistedClipboardRepresentation,
 };
-use uc_core::ports::clipboard::{GetRepresentationPort, ListClipboardEntriesPort};
+use uc_core::ports::clipboard::{
+    EntryFileSetRepositoryPort, GetRepresentationPort, ListClipboardEntriesPort,
+};
 use uc_core::ports::{
     ClipboardSelectionRepositoryPort, GetEntryTransferSummaryPort, ThumbnailRepositoryPort,
 };
@@ -15,6 +17,7 @@ use uc_core::search::document::ContentType;
 use uc_core::search::tag::TaggableContent;
 
 use crate::content_tags::evaluate_builtin_content_tags;
+use crate::file_set_query::load_has_directory_structure;
 
 /// Application-layer DTO for clipboard entry projection.
 #[derive(Debug, Clone, PartialEq)]
@@ -39,6 +42,14 @@ pub(crate) struct EntryProjectionDto {
     pub(crate) file_sizes: Option<Vec<i64>>,
     pub(crate) image_width: Option<i32>,
     pub(crate) image_height: Option<i32>,
+    /// Whether this file entry was captured as a directory (its manifest carries
+    /// members expanded from a directory root). Sourced from the single
+    /// `EntryFileSet::has_directory_structure()` authority. The sender UI hides
+    /// the (per-member-aliased, thus meaningless) byte percentage for directory
+    /// sends and renders status only; single-file / flat-multi-file entries keep
+    /// their real percentage. `false` for non-file entries and when the manifest
+    /// is absent or unreadable.
+    pub(crate) is_directory: bool,
     /// `paste_rep` 的 payload_state, 仅在该 representation 已不可恢复时输出
     /// (`Lost`)。其他状态返回 `None` —— 由前端默认渲染。这是面向 UI 列表
     /// "灰显损坏 entry" 的最小信号；list 渲染基于 preview_rep, 但实际粘贴
@@ -61,6 +72,7 @@ pub(crate) struct ListClipboardEntryProjectionsUseCase {
     representation_repo: Arc<dyn GetRepresentationPort>,
     thumbnail_repo: Arc<dyn ThumbnailRepositoryPort>,
     file_transfer_repo: Arc<dyn GetEntryTransferSummaryPort>,
+    entry_file_set_repo: Arc<dyn EntryFileSetRepositoryPort>,
     max_limit: usize,
 }
 
@@ -242,6 +254,7 @@ impl ListClipboardEntryProjectionsUseCase {
         representation_repo: Arc<dyn GetRepresentationPort>,
         thumbnail_repo: Arc<dyn ThumbnailRepositoryPort>,
         file_transfer_repo: Arc<dyn GetEntryTransferSummaryPort>,
+        entry_file_set_repo: Arc<dyn EntryFileSetRepositoryPort>,
     ) -> Self {
         Self {
             entry_repo,
@@ -249,6 +262,7 @@ impl ListClipboardEntryProjectionsUseCase {
             representation_repo,
             thumbnail_repo,
             file_transfer_repo,
+            entry_file_set_repo,
             max_limit: 1000,
         }
     }
@@ -464,6 +478,25 @@ impl ListClipboardEntryProjectionsUseCase {
                 }
             };
 
+            // Only file entries can carry a directory manifest; skip the extra
+            // repo read for text/image/etc. Mirror the search projection's
+            // degradation: on a load error or absent manifest, project as
+            // non-directory rather than failing the whole list.
+            let is_directory = if entry.content_category == ClipboardEntryContentCategory::File {
+                load_has_directory_structure(self.entry_file_set_repo.as_ref(), &entry.entry_id)
+                    .await
+                    .unwrap_or_else(|e| {
+                        warn!(
+                            entry_id = %entry_id_str,
+                            error = %e,
+                            "Failed to load file set for directory flag; projecting as non-directory"
+                        );
+                        false
+                    })
+            } else {
+                false
+            };
+
             projections.push(EntryProjectionDto {
                 id: entry_id_str,
                 preview,
@@ -485,6 +518,7 @@ impl ListClipboardEntryProjectionsUseCase {
                 file_sizes,
                 image_width,
                 image_height,
+                is_directory,
                 payload_state,
             });
         }
@@ -519,7 +553,9 @@ mod tests {
     use async_trait::async_trait;
     use uc_core::clipboard::{
         ClipboardEntry, ClipboardRepositoryError, ClipboardSelection, ClipboardSelectionDecision,
-        MimeType, SelectionPolicyVersion, ThumbnailMetadata,
+        ContentHash, EntryFileSet, EntryFileSetError, EntryFileSetLine, EntryFileSetLineKind,
+        FileSetMemberKind, FileSetMemberLocation, HashAlgorithm, MimeType, SelectionPolicyVersion,
+        ThumbnailMetadata,
     };
     use uc_core::ids::{BlobId, EntryId, EventId, FormatId, RepresentationId};
     use uc_core::ports::file_transfer::{EntryTransferSummary, FileTransferProjectionError};
@@ -622,6 +658,32 @@ mod tests {
                 entry_id: &str,
             ) -> Result<Option<EntryTransferSummary>, FileTransferProjectionError>;
         }
+    }
+
+    mockall::mock! {
+        FileSetRepo {}
+
+        #[async_trait]
+        impl EntryFileSetRepositoryPort for FileSetRepo {
+            async fn save(
+                &self,
+                entry_id: &EntryId,
+                file_set: &EntryFileSet,
+            ) -> Result<(), EntryFileSetError>;
+
+            async fn load(
+                &self,
+                entry_id: &EntryId,
+            ) -> Result<Option<EntryFileSet>, EntryFileSetError>;
+        }
+    }
+
+    /// A `FileSetRepo` that never reports a directory manifest (returns `None`
+    /// for every `load`). Used by tests whose subject is not the directory flag.
+    fn file_set_repo_none() -> MockFileSetRepo {
+        let mut repo = MockFileSetRepo::new();
+        repo.expect_load().returning(|_| Ok(None));
+        repo
     }
 
     #[test]
@@ -791,6 +853,7 @@ mod tests {
             Arc::new(representation_repo),
             Arc::new(thumbnail_repo),
             Arc::new(transfer_repo),
+            Arc::new(file_set_repo_none()),
         );
 
         let projections = usecase.execute(10, 0).await.expect("projection succeeds");
@@ -798,6 +861,181 @@ mod tests {
         assert_eq!(projections.len(), 1);
         assert_eq!(projections[0].preview, uri);
         assert_eq!(projections[0].file_sizes, Some(vec![5]));
+        assert!(!projections[0].is_directory);
+    }
+
+    /// A single-line manifest whose member is expanded from a directory root,
+    /// so `has_directory_structure()` is true.
+    fn directory_file_set() -> EntryFileSet {
+        EntryFileSet {
+            lines: vec![EntryFileSetLine {
+                line_index: 1,
+                original_text: "file:///root/child.txt".to_string(),
+                member_location: Some(FileSetMemberLocation {
+                    root_index: 0,
+                    root_name: "root".to_string(),
+                    relative_path: "child.txt".to_string(),
+                    kind: FileSetMemberKind::File,
+                }),
+                kind: EntryFileSetLineKind::File {
+                    content_hash: ContentHash {
+                        alg: HashAlgorithm::Blake3V1,
+                        bytes: [7u8; 32],
+                    },
+                    blob_id: None,
+                    size_bytes: Some(10),
+                },
+            }],
+        }
+    }
+
+    /// Project a single entry whose `preview_rep == paste_rep`, backed by
+    /// `file_set_repo` for the directory-flag lookup. Keeps the directory tests
+    /// focused on `is_directory` without repeating the full mock wiring.
+    async fn project_single_entry(
+        category: ClipboardEntryContentCategory,
+        mime: &str,
+        body: &str,
+        file_set_repo: MockFileSetRepo,
+    ) -> Vec<EntryProjectionDto> {
+        let entry_id = EntryId::from("entry-1");
+        let event_id = EventId::from("event-1");
+        let rep_id = RepresentationId::from("rep-1");
+        let rep = PersistedClipboardRepresentation::new(
+            rep_id.clone(),
+            FormatId::from("f"),
+            Some(MimeType(mime.to_string())),
+            body.len() as i64,
+            Some(body.as_bytes().to_vec()),
+            None,
+        );
+        let entry = ClipboardEntry::new(entry_id.clone(), event_id.clone(), 100, rep.size_bytes)
+            .with_content_category(category);
+        let selection = ClipboardSelectionDecision::new(
+            entry_id.clone(),
+            ClipboardSelection {
+                primary_rep_id: rep_id.clone(),
+                secondary_rep_ids: vec![],
+                preview_rep_id: rep_id.clone(),
+                paste_rep_id: rep_id.clone(),
+                policy_version: SelectionPolicyVersion::V1,
+            },
+        );
+
+        let mut entry_repo = MockEntryRepo::new();
+        entry_repo
+            .expect_list_entries()
+            .times(1)
+            .return_once(move |_, _| Ok(vec![entry]));
+
+        let mut selection_repo = MockSelectionRepo::new();
+        selection_repo
+            .expect_get_selection()
+            .times(1)
+            .return_once(move |_| Ok(Some(selection)));
+
+        let mut representation_repo = MockRepresentationRepo::new();
+        representation_repo
+            .expect_get_representation()
+            .times(1)
+            .return_once(move |_, _| Ok(Some(rep)));
+
+        // Non-image reps never touch the thumbnail repo.
+        let thumbnail_repo = MockThumbnailRepo::new();
+
+        let mut transfer_repo = MockTransferRepo::new();
+        transfer_repo
+            .expect_get_entry_transfer_summary()
+            .times(1)
+            .return_once(|_| Ok(None));
+
+        let usecase = ListClipboardEntryProjectionsUseCase::new(
+            Arc::new(entry_repo),
+            Arc::new(selection_repo),
+            Arc::new(representation_repo),
+            Arc::new(thumbnail_repo),
+            Arc::new(transfer_repo),
+            Arc::new(file_set_repo),
+        );
+
+        usecase.execute(10, 0).await.expect("projection succeeds")
+    }
+
+    #[tokio::test]
+    async fn execute_marks_file_entry_with_directory_manifest() {
+        let mut file_set_repo = MockFileSetRepo::new();
+        file_set_repo
+            .expect_load()
+            .times(1)
+            .return_once(|_| Ok(Some(directory_file_set())));
+
+        let projections = project_single_entry(
+            ClipboardEntryContentCategory::File,
+            "text/uri-list",
+            "file:///root/child.txt",
+            file_set_repo,
+        )
+        .await;
+
+        assert_eq!(projections.len(), 1);
+        assert!(projections[0].is_directory);
+    }
+
+    #[tokio::test]
+    async fn execute_flat_file_entry_is_not_directory() {
+        // A file manifest without directory structure projects as non-directory,
+        // preserving the single-file / flat-multi-file percentage path.
+        let projections = project_single_entry(
+            ClipboardEntryContentCategory::File,
+            "text/uri-list",
+            "file:///home/u/report.pdf",
+            file_set_repo_none(),
+        )
+        .await;
+
+        assert_eq!(projections.len(), 1);
+        assert!(!projections[0].is_directory);
+    }
+
+    #[tokio::test]
+    async fn execute_non_file_entry_skips_file_set_lookup() {
+        // Text/image/etc. can never carry a directory manifest, so the hot list
+        // path must not pay for the extra repo read.
+        let mut file_set_repo = MockFileSetRepo::new();
+        file_set_repo.expect_load().never();
+
+        let projections = project_single_entry(
+            ClipboardEntryContentCategory::Text,
+            "text/plain",
+            "hello world",
+            file_set_repo,
+        )
+        .await;
+
+        assert_eq!(projections.len(), 1);
+        assert!(!projections[0].is_directory);
+    }
+
+    #[tokio::test]
+    async fn execute_directory_lookup_error_degrades_to_non_directory() {
+        // A manifest load failure must not fail the whole list; the entry falls
+        // back to non-directory (percentage path) rather than erroring out.
+        let mut file_set_repo = MockFileSetRepo::new();
+        file_set_repo
+            .expect_load()
+            .times(1)
+            .return_once(|_| Err(EntryFileSetError::Storage("boom".to_string())));
+
+        let projections = project_single_entry(
+            ClipboardEntryContentCategory::File,
+            "text/uri-list",
+            "file:///root/child.txt",
+            file_set_repo,
+        )
+        .await;
+
+        assert_eq!(projections.len(), 1);
+        assert!(!projections[0].is_directory);
     }
 
     #[test]

--- a/crates/uc-bootstrap/src/entrypoint/non_gui.rs
+++ b/crates/uc-bootstrap/src/entrypoint/non_gui.rs
@@ -456,6 +456,7 @@ pub fn build_app_facade_from_deps(
             blob_store: deps.storage.blob_store.clone(),
             thumbnail_repo: deps.storage.thumbnail_repo.clone(),
             file_transfer_repo: deps.storage.file_transfer.entry_summary.clone(),
+            entry_file_set_repo: deps.storage.entry_file_set_repo.clone(),
             search_index: Some(deps.search.search_index.clone()),
             file_cache_dir: Some(storage_paths.file_cache_dir.clone()),
             blob_transfer: options.blob_transfer_port.clone(),

--- a/crates/uc-daemon-contract/src/api/dto/clipboard.rs
+++ b/crates/uc-daemon-contract/src/api/dto/clipboard.rs
@@ -43,6 +43,12 @@ pub struct EntryProjectionResponseDto {
     /// Original image height in pixels (only for image entries).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub image_height: Option<i32>,
+    /// Whether this file entry was captured as a directory. `true` lets the
+    /// sender UI render status only (no byte percentage) for directory sends,
+    /// whose reverse progress aliases every member onto one id. Defaults to
+    /// `false` for non-file entries and older responses that omit the field.
+    #[serde(default)]
+    pub is_directory: bool,
     /// `paste_rep` 的 payload_state, 仅在 `Lost` 时输出。前端用此把"内容已
     /// 丢失"的 entry 灰显, 让用户在点击粘贴前就知道这条记录已不可用。
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/uc-webserver/src/api/projection/clipboard.rs
+++ b/crates/uc-webserver/src/api/projection/clipboard.rs
@@ -48,6 +48,7 @@ impl IntoApiDto<EntryProjectionResponseDto> for EntryProjectionView {
             file_sizes: self.file_sizes,
             image_width: self.image_width,
             image_height: self.image_height,
+            is_directory: self.is_directory,
             payload_state: self.payload_state,
         }
     }

--- a/schema/openapi.json
+++ b/schema/openapi.json
@@ -1067,6 +1067,10 @@
             "nullable": true,
             "type": "integer"
           },
+          "isDirectory": {
+            "description": "Whether this file entry was captured as a directory. `true` lets the\nsender UI render status only (no byte percentage) for directory sends,\nwhose reverse progress aliases every member onto one id. Defaults to\n`false` for non-file entries and older responses that omit the field.",
+            "type": "boolean"
+          },
           "isEncrypted": {
             "type": "boolean"
           },

--- a/src/api/daemon/clipboard.ts
+++ b/src/api/daemon/clipboard.ts
@@ -71,6 +71,9 @@ export interface ClipboardEntryDto {
   linkDomains: string[] | null
   /** Per-file sizes in bytes for file (uri-list) entries. */
   fileSizes: number[] | null
+  /** True when a file entry was captured as a directory. Absent on older daemon
+   * responses (defaults to non-directory). */
+  isDirectory?: boolean
   /** Original image width in pixels (only for image entries). */
   imageWidth?: number | null
   /** Original image height in pixels (only for image entries). */

--- a/src/api/generated/types.gen.ts
+++ b/src/api/generated/types.gen.ts
@@ -693,6 +693,13 @@ export type EntryProjectionResponseDto = {
      * Original image width in pixels (only for image entries).
      */
     imageWidth?: number | null;
+    /**
+     * Whether this file entry was captured as a directory. `true` lets the
+     * sender UI render status only (no byte percentage) for directory sends,
+     * whose reverse progress aliases every member onto one id. Defaults to
+     * `false` for non-file entries and older responses that omit the field.
+     */
+    isDirectory?: boolean;
     isEncrypted: boolean;
     isFavorited: boolean;
     linkDomains?: Array<string> | null;

--- a/src/components/history/HistoryCard.tsx
+++ b/src/components/history/HistoryCard.tsx
@@ -59,6 +59,11 @@ const HistoryCard: React.FC<HistoryCardProps> = ({
     transfer && transfer.totalBytes && transfer.totalBytes > 0
       ? Math.round((transfer.bytesTransferred / transfer.totalBytes) * 100)
       : 0
+  // Directory sends reverse-report every member onto one transfer id, so the
+  // byte percentage resets on each member switch — it is meaningless. Render
+  // status only for those rows. Receiving directories keep their real
+  // per-member aggregate percentage; single-file / flat sends are unaffected.
+  const hideByteProgress = (item.isDirectory ?? false) && transfer?.direction === 'Sending'
 
   // Reveal the action bar on keyboard focus too, not just mouse hover — its
   // buttons are otherwise untabbable, so keyboard users could never reach
@@ -107,6 +112,7 @@ const HistoryCard: React.FC<HistoryCardProps> = ({
         isTransferring={isTransferring}
         transfer={transfer}
         percent={percent}
+        hideByteProgress={hideByteProgress}
       />
       <HistoryCardHeader
         item={item}
@@ -115,6 +121,7 @@ const HistoryCard: React.FC<HistoryCardProps> = ({
         transfer={transfer}
         state={cardState}
         percent={percent}
+        hideByteProgress={hideByteProgress}
       />
       <div
         className={cn(

--- a/src/components/history/__tests__/HistoryCardDirectorySend.test.tsx
+++ b/src/components/history/__tests__/HistoryCardDirectorySend.test.tsx
@@ -1,0 +1,109 @@
+import { configureStore } from '@reduxjs/toolkit'
+import { render, screen } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { describe, expect, it, vi } from 'vitest'
+import HistoryCard from '@/components/history/HistoryCard'
+import type { DisplayClipboardItem } from '@/lib/clipboard-entry'
+import fileTransferReducer, { updateTransferProgress } from '@/store/slices/fileTransferSlice'
+
+// Regression for issue #1330: the sender's directory transfer row shows status
+// only (no byte percentage), because its reverse progress aliases every member
+// onto one id. Single-file sends and directory *receives* keep their real
+// percentage.
+
+vi.mock('@/hooks/useEntryDelivery', () => ({
+  useEntryDelivery: () => ({ delivery: null, loading: false, error: null }),
+}))
+
+vi.mock('@/hooks/useRelativeTime', () => ({
+  useRelativeTime: () => 'now',
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: string | Record<string, unknown>) =>
+      typeof opts === 'string' ? opts : key,
+  }),
+}))
+
+const noop = vi.fn()
+
+function fileItem(overrides: Partial<DisplayClipboardItem>): DisplayClipboardItem {
+  return {
+    id: 'entry-1',
+    type: 'file',
+    content: { file_names: ['photos'], file_sizes: [100] },
+    activeTime: 1,
+    ...overrides,
+  } as DisplayClipboardItem
+}
+
+function renderWithTransfer(
+  item: DisplayClipboardItem,
+  transfer: { direction: 'Sending' | 'Receiving'; bytes: number; total: number }
+) {
+  const store = configureStore({ reducer: { fileTransfer: fileTransferReducer } })
+  store.dispatch(
+    updateTransferProgress({
+      transferId: item.id,
+      entryId: item.id,
+      peerId: 'peer',
+      direction: transfer.direction,
+      bytesTransferred: transfer.bytes,
+      totalBytes: transfer.total,
+    })
+  )
+  render(
+    <Provider store={store}>
+      <HistoryCard
+        item={item}
+        isHovered={false}
+        copySuccess={false}
+        isDeleting={false}
+        onCopy={noop}
+        onDelete={noop}
+        onToggleFavorite={noop}
+        onClick={noop}
+        onHoverChange={noop}
+      />
+    </Provider>
+  )
+}
+
+describe('HistoryCard directory send progress (issue #1330)', () => {
+  it('renders status only (no percentage) for a directory send', () => {
+    renderWithTransfer(fileItem({ isDirectory: true }), {
+      direction: 'Sending',
+      bytes: 50,
+      total: 100,
+    })
+
+    expect(screen.getByText('clipboard.transfer.transferring')).toBeInTheDocument()
+    expect(screen.queryByText('50%')).not.toBeInTheDocument()
+    expect(screen.queryByText('50 B / 100 B')).not.toBeInTheDocument()
+  })
+
+  it('keeps the byte percentage for a single-file send', () => {
+    renderWithTransfer(fileItem({ isDirectory: false }), {
+      direction: 'Sending',
+      bytes: 50,
+      total: 100,
+    })
+
+    expect(screen.getByText('50%')).toBeInTheDocument()
+    expect(screen.queryByText('clipboard.transfer.transferring')).not.toBeInTheDocument()
+  })
+
+  it('keeps the aggregate percentage for a directory receive', () => {
+    // Receiving directories aggregate real per-member progress, so their
+    // percentage is meaningful and must not be suppressed.
+    renderWithTransfer(fileItem({ isDirectory: true }), {
+      direction: 'Receiving',
+      bytes: 50,
+      total: 100,
+    })
+
+    expect(screen.getByText('50%')).toBeInTheDocument()
+    expect(screen.queryByText('clipboard.transfer.transferring')).not.toBeInTheDocument()
+  })
+})

--- a/src/components/history/history-card/HistoryCardHeader.tsx
+++ b/src/components/history/history-card/HistoryCardHeader.tsx
@@ -34,6 +34,9 @@ interface HistoryCardHeaderProps {
     isPending: boolean
   }
   percent: number
+  /** Directory sends: show a "Transferring" status label instead of the
+   * (meaningless) byte percentage + speed. */
+  hideByteProgress: boolean
 }
 
 function HistoryCardHeader({
@@ -43,6 +46,7 @@ function HistoryCardHeader({
   transfer,
   state,
   percent,
+  hideByteProgress,
 }: HistoryCardHeaderProps) {
   const { t } = useTranslation()
   const { isFileType, isFavorited, isUnavailable, isTransferring, isPending } = state
@@ -92,7 +96,14 @@ function HistoryCardHeader({
           />
         )}
         {isFavorited && <Star className="size-2.5 fill-amber-400 text-amber-400" />}
-        {isFileType && isTransferring ? (
+        {isFileType && isTransferring && hideByteProgress ? (
+          <>
+            <DirectionIcon className="size-2.5 text-primary/70" />
+            <span className="text-[10px] font-medium text-primary/80">
+              {t('clipboard.transfer.transferring')}
+            </span>
+          </>
+        ) : isFileType && isTransferring ? (
           <>
             <DirectionIcon className="size-2.5 text-primary/70" />
             <span className="text-[10px] font-medium tabular-nums text-primary/80">{percent}%</span>

--- a/src/components/history/history-card/HistoryCardTransferProgress.tsx
+++ b/src/components/history/history-card/HistoryCardTransferProgress.tsx
@@ -7,6 +7,10 @@ interface HistoryCardTransferProgressProps {
   isTransferring: boolean
   transfer?: TransferProgressInfo
   percent: number
+  /** When true (directory sends), suppress the byte-progress bar and byte text —
+   * their percentage is meaningless — and show a constant full-width activity
+   * tint instead. Status is conveyed by the header label. */
+  hideByteProgress: boolean
 }
 
 function HistoryCardTransferProgress({
@@ -14,40 +18,47 @@ function HistoryCardTransferProgress({
   isTransferring,
   transfer,
   percent,
+  hideByteProgress,
 }: HistoryCardTransferProgressProps) {
   if (!isFileType) return null
+
+  const active = isTransferring && !!transfer
 
   return (
     <>
       <div
         className={cn(
           'pointer-events-none absolute inset-0 z-0 bg-primary/8 transition-all duration-500 ease-out',
-          isTransferring && transfer ? 'opacity-100' : 'opacity-0'
+          active ? 'opacity-100' : 'opacity-0'
         )}
-        style={{ width: isTransferring && transfer ? `${percent}%` : '100%' }}
+        // Directory sends have no meaningful percentage, so the tint stays
+        // full-width to signal activity without a fake fill level.
+        style={{ width: active && !hideByteProgress ? `${percent}%` : '100%' }}
       />
-      <div
-        className={cn(
-          'pointer-events-none absolute bottom-1.5 left-3.5 right-3.5 z-10 flex items-center gap-1.5 transition-opacity duration-500 ease-out',
-          isTransferring && transfer ? 'opacity-100' : 'opacity-0'
-        )}
-      >
-        {transfer && (
-          <>
-            <div className="h-px flex-1 overflow-hidden rounded-full bg-primary/15">
-              <div
-                className="h-full bg-primary/40 transition-[width] duration-300 ease-out"
-                style={{ width: `${percent}%` }}
-              />
-            </div>
-            <span className="shrink-0 text-[9px] tabular-nums text-primary/50">
-              {transfer.totalBytes
-                ? `${formatFileSize(transfer.bytesTransferred)} / ${formatFileSize(transfer.totalBytes)}`
-                : formatFileSize(transfer.bytesTransferred)}
-            </span>
-          </>
-        )}
-      </div>
+      {!hideByteProgress && (
+        <div
+          className={cn(
+            'pointer-events-none absolute bottom-1.5 left-3.5 right-3.5 z-10 flex items-center gap-1.5 transition-opacity duration-500 ease-out',
+            active ? 'opacity-100' : 'opacity-0'
+          )}
+        >
+          {transfer && (
+            <>
+              <div className="h-px flex-1 overflow-hidden rounded-full bg-primary/15">
+                <div
+                  className="h-full bg-primary/40 transition-[width] duration-300 ease-out"
+                  style={{ width: `${percent}%` }}
+                />
+              </div>
+              <span className="shrink-0 text-[9px] tabular-nums text-primary/50">
+                {transfer.totalBytes
+                  ? `${formatFileSize(transfer.bytesTransferred)} / ${formatFileSize(transfer.totalBytes)}`
+                  : formatFileSize(transfer.bytesTransferred)}
+              </span>
+            </>
+          )}
+        </div>
+      )}
     </>
   )
 }

--- a/src/components/history/history-card/HistoryCardTransferProgress.tsx
+++ b/src/components/history/history-card/HistoryCardTransferProgress.tsx
@@ -32,8 +32,11 @@ function HistoryCardTransferProgress({
           active ? 'opacity-100' : 'opacity-0'
         )}
         // Directory sends have no meaningful percentage, so the tint stays
-        // full-width to signal activity without a fake fill level.
-        style={{ width: active && !hideByteProgress ? `${percent}%` : '100%' }}
+        // full-width to signal activity without a fake fill level. Regular sends
+        // keep their real percentage even when inactive: opacity (via `active`)
+        // handles hide/show, so the bar fades out at its last width instead of
+        // animating out to 100% on completion or cancel.
+        style={{ width: hideByteProgress ? '100%' : `${percent}%` }}
       />
       {!hideByteProgress && (
         <div

--- a/src/hooks/useLiveSearch.ts
+++ b/src/hooks/useLiveSearch.ts
@@ -5,7 +5,7 @@ import type { HistoryLiveSnapshot } from '@/hooks/historySessionSnapshot'
 import { useClipboardEventStream } from '@/hooks/useClipboardEventStream'
 import { useEncryptionSessionState } from '@/hooks/useEncryptionSessionState'
 import type { ClipboardEntry, DisplayClipboardItem } from '@/lib/clipboard-entry'
-import { searchResultToDisplayItem } from '@/lib/clipboard-transform'
+import { clipboardEntryToDisplayItem, searchResultToDisplayItem } from '@/lib/clipboard-transform'
 import { daemonWs } from '@/lib/daemon-ws'
 import { createLogger } from '@/lib/logger'
 import {
@@ -244,15 +244,7 @@ export function useLiveSearch(options: UseLiveSearchOptions): UseLiveSearchResul
         setRefetchNonce(n => n + 1)
         return
       }
-      const display: DisplayClipboardItem = {
-        id: entry.id,
-        type: entry.type,
-        contentTags: entry.contentTags,
-        content: entry.content,
-        activeTime: entry.activeTime,
-        isFavorited: entry.isFavorited,
-        isUnavailable: entry.isUnavailable,
-      }
+      const display = clipboardEntryToDisplayItem(entry)
       if (!matchesFilter(display, current)) return
       setItems(prev => prependLiveItem(prev, display))
     },

--- a/src/lib/__tests__/clipboard-transform.test.ts
+++ b/src/lib/__tests__/clipboard-transform.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from 'vitest'
 import type { ClipboardEntryDto } from '@/api/daemon/clipboard'
 import type { SearchResultDto } from '@/api/daemon/search'
-import { projectClipboardEntry, searchResultToDisplayItem } from '../clipboard-transform'
+import {
+  clipboardEntryToDisplayItem,
+  projectClipboardEntry,
+  searchResultToDisplayItem,
+} from '../clipboard-transform'
 import { getItemPreview } from '../clipboard-utils'
 
 function makeDto(overrides: Partial<ClipboardEntryDto> = {}): ClipboardEntryDto {
@@ -40,7 +44,18 @@ describe('projectClipboardEntry', () => {
       activeTime: 3,
       isFavorited: true,
       isUnavailable: false,
+      isDirectory: false,
     })
+  })
+
+  it('projects the directory flag from a file DTO', () => {
+    const dir = projectClipboardEntry(
+      makeDto({ contentType: 'file', preview: 'file:///root/child', isDirectory: true })
+    )
+    expect(dir.isDirectory).toBe(true)
+
+    // Absent flag (older daemon) and non-directory files fall back to false.
+    expect(projectClipboardEntry(makeDto({ contentType: 'file' })).isDirectory).toBe(false)
   })
 
   it('preserves image dimensions from daemon DTOs', () => {
@@ -221,6 +236,50 @@ describe('searchResultToDisplayItem', () => {
     expect(item.content).toMatchObject({
       file_names: ['report.pdf'],
       file_paths: ['/tmp/report.pdf'],
+    })
+  })
+
+  it('projects the directory flag from the builtin directory tag', () => {
+    // The search projection derives the `directory` builtin tag; the display
+    // item must key its status-only directory-send row off it. Regression for
+    // the flag being dropped between SearchResultDto and the rendered item.
+    const dir = searchResultToDisplayItem(
+      makeSearchResult({ contentType: 'file', tags: ['directory'], fileNames: ['photos'] })
+    )
+    expect(dir.isDirectory).toBe(true)
+
+    // A flat file result (no directory tag) stays non-directory.
+    const flat = searchResultToDisplayItem(makeSearchResult({ contentType: 'file' }))
+    expect(flat.isDirectory).toBe(false)
+  })
+})
+
+describe('clipboardEntryToDisplayItem', () => {
+  it('carries the directory flag from the browse entry into the display item', () => {
+    // The realtime browse path (useLiveSearch.onLocalItem) runs this over a
+    // freshly-captured entry. Regression for issue #1330: the flag was dropped
+    // by an inline field copy, so directory sends still showed a byte %.
+    const entry = projectClipboardEntry(
+      makeDto({ contentType: 'file', preview: 'file:///root/child', isDirectory: true })
+    )
+    expect(clipboardEntryToDisplayItem(entry).isDirectory).toBe(true)
+
+    const flat = projectClipboardEntry(makeDto({ contentType: 'file' }))
+    expect(clipboardEntryToDisplayItem(flat).isDirectory).toBe(false)
+  })
+
+  it('preserves the render-relevant fields', () => {
+    const entry = projectClipboardEntry(
+      makeDto({ id: 'e9', preview: 'hi', isFavorited: true, payloadState: 'Lost' })
+    )
+    const item = clipboardEntryToDisplayItem(entry)
+    expect(item).toMatchObject({
+      id: 'e9',
+      type: entry.type,
+      content: entry.content,
+      activeTime: entry.activeTime,
+      isFavorited: true,
+      isUnavailable: true,
     })
   })
 })

--- a/src/lib/__tests__/clipboard-utils.test.ts
+++ b/src/lib/__tests__/clipboard-utils.test.ts
@@ -20,6 +20,7 @@ function createEntry(
     activeTime: 0,
     isFavorited: false,
     isUnavailable: false,
+    isDirectory: false,
   }
 }
 

--- a/src/lib/clipboard-entry.ts
+++ b/src/lib/clipboard-entry.ts
@@ -103,6 +103,13 @@ export interface ClipboardEntry {
    * tell before clicking (see `DaemonErrorCode.PAYLOAD_UNAVAILABLE`).
    */
   isUnavailable: boolean
+  /**
+   * True when a file entry was captured as a directory. The sender's transfer
+   * row renders status only (no byte percentage) for directory sends, whose
+   * reverse progress aliases every member onto one id and would otherwise show
+   * a percentage that resets on each member. `false` for non-file entries.
+   */
+  isDirectory: boolean
 }
 
 /**
@@ -123,6 +130,10 @@ export interface DisplayClipboardItem {
   activeTime: number
   isFavorited?: boolean
   isUnavailable?: boolean
+  /** True for directory file entries; drives status-only send rows. Populated on
+   * both browse rows (projection `isDirectory`) and search rows (the builtin
+   * `directory` tag); absent only on synthetic pending placeholders. */
+  isDirectory?: boolean
   /** Source device name, only for pending inbound placeholder rows. */
   device?: string
   /** Fallback preview text when `content` is unavailable (search/pending rows). */

--- a/src/lib/clipboard-transform.ts
+++ b/src/lib/clipboard-transform.ts
@@ -88,6 +88,30 @@ export function projectClipboardEntry(dto: ClipboardEntryDto): ClipboardEntry {
     activeTime: dto.activeTime,
     isFavorited: dto.isFavorited,
     isUnavailable: dto.payloadState === 'Lost',
+    isDirectory: dto.isDirectory ?? false,
+  }
+}
+
+/**
+ * Project a browse-side {@link ClipboardEntry} into the {@link DisplayClipboardItem}
+ * the live list renders — the browse analogue of {@link searchResultToDisplayItem}.
+ *
+ * `ClipboardEntry` is a structural superset of the item, but the display model
+ * intentionally carries only the render-relevant subset (no `createdAt`/
+ * `updatedAt`). Centralizing the field copy here keeps every new entry field a
+ * one-line decision — a hand-maintained inline literal silently dropped
+ * `isDirectory` before, killing the directory-send status row (issue #1330).
+ */
+export function clipboardEntryToDisplayItem(entry: ClipboardEntry): DisplayClipboardItem {
+  return {
+    id: entry.id,
+    type: entry.type,
+    contentTags: entry.contentTags,
+    content: entry.content,
+    activeTime: entry.activeTime,
+    isFavorited: entry.isFavorited,
+    isUnavailable: entry.isUnavailable,
+    isDirectory: entry.isDirectory,
   }
 }
 
@@ -198,6 +222,11 @@ export function searchResultToDisplayItem(r: SearchResultDto): DisplayClipboardI
     activeTime: r.activeTimeMs,
     isFavorited: r.tags.includes('favorited'),
     isUnavailable: r.payloadState === 'Lost',
+    // Reuse the builtin `directory` tag the search projection already derives
+    // (evaluate_builtin_content_tags), so search rows key off the same
+    // single-source directory signal the browse projection carries via
+    // `isDirectory`. Drives the status-only send row for directory sends.
+    isDirectory: r.tags.includes('directory'),
     textPreview: r.textPreview ?? undefined,
   }
 }

--- a/src/store/slices/__tests__/fileTransferSlice.test.ts
+++ b/src/store/slices/__tests__/fileTransferSlice.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect } from 'vitest'
 import fileTransferReducer, {
   markTransferCancelled,
+  markTransferCompleted,
   normalizeCancelReason,
   resolveEntryTransferStatus,
+  selectTransferByEntryId,
   setEntryTransferStatus,
   hydrateEntryTransferStatuses,
   removeEntryTransferStatus,
@@ -358,6 +360,57 @@ describe('fileTransferSlice - file transfer status', () => {
         markTransferCancelled({ transferId: 'missing', reason: 'unknown' })
       )
       expect(next.activeTransfers).toEqual({})
+    })
+  })
+
+  // Regression for issue #1330: a directory send reverse-reports every member
+  // onto one transfer id (= the directory entry_id, no attemptId), so byte
+  // progress bounces. Progress events must never fabricate a terminal state;
+  // the terminal only arrives once, from the `status_changed` event the daemon
+  // emits after the last member completes.
+  describe('directory send terminal state (issue #1330)', () => {
+    const dirEntry = 'dir-entry'
+
+    function progress(state: typeof initialState, bytes: number, total: number | null) {
+      return fileTransferReducer(
+        state,
+        updateTransferProgress({
+          transferId: dirEntry,
+          entryId: dirEntry,
+          peerId: 'peer',
+          direction: 'Sending',
+          bytesTransferred: bytes,
+          totalBytes: total,
+        })
+      )
+    }
+
+    it('keeps the send active across resetting member progress; completes only on the terminal signal', () => {
+      // Member 1 climbs, then member 2 restarts from a low byte count — the
+      // shared id makes progress look like it went backwards.
+      let state = progress(initialState, 90, 100)
+      state = progress(state, 10, 100)
+      state = progress(state, 40, 100)
+
+      let transfer = selectTransferByEntryId({ fileTransfer: state } as never, dirEntry)
+      expect(transfer?.status).toBe('active')
+      expect(resolveEntryTransferStatus(undefined, transfer)).toBe('transferring')
+
+      // The daemon's post-last-member status_changed is what finalizes it.
+      state = fileTransferReducer(state, markTransferCompleted({ transferId: dirEntry }))
+      transfer = selectTransferByEntryId({ fileTransfer: state } as never, dirEntry)
+      expect(transfer?.status).toBe('completed')
+      expect(resolveEntryTransferStatus(undefined, transfer)).toBe('completed')
+    })
+
+    it('a late progress event does not regress a completed send back to transferring', () => {
+      let state = progress(initialState, 40, 100)
+      state = fileTransferReducer(state, markTransferCompleted({ transferId: dirEntry }))
+      // A straggler reverse-progress frame arrives after completion.
+      state = progress(state, 55, 100)
+
+      const transfer = selectTransferByEntryId({ fileTransfer: state } as never, dirEntry)
+      expect(transfer?.status).toBe('completed')
     })
   })
 })


### PR DESCRIPTION
## Summary

- Directory sends now render a **"Transferring" status label** instead of a byte percentage on the sender's history row. A directory reverse-reports every member onto one transfer id, so the byte % resets on each member switch and is meaningless. Single-file / flat-multi-file sends and directory *receives* keep their real percentage. (2878bf139)
- Thread the directory flag all the way to the rendered row through **both** list paths that feed the history grid — the previous phase-5 wiring stopped at the DTO and never reached the card:
  - **realtime browse**: carry the projection endpoint's `isDirectory` via a new `clipboardEntryToDisplayItem` projection, replacing the hand-copied field literal in `useLiveSearch.onLocalItem` that silently dropped the flag.
  - **search / browse results**: reuse the builtin `directory` tag the search projection already derives — no new `SearchResultDto` field.
- Guard the terminal state: a progress event never fabricates completion for a directory send; the terminal only arrives from the `status_changed` event after the last member completes (regression test).
- Consolidate the three file-set directory-probe degradation blocks (search, live-index, and history-list projections) behind a shared `load_has_directory_structure`, each call site keeping its own log level.

Closes #1330.

## Test plan

- [x] `bun run test` — 849 pass, incl. new directory-send-row, terminal-state, and both mapping-regression tests
- [x] `tsc --noEmit` and `eslint` clean
- [x] `cargo test -p uc-application` — list/search/live-index directory tests pass; `cargo clippy -p uc-application` no new warnings
- [x] `cargo check` — `uc-webserver` / `uc-daemon` / `uc-bootstrap` / `uc-cli` compile
- [ ] Manual: copy a directory and send it → row shows "Transferring" (no %); send a single file → keeps %; receive a directory → keeps aggregate %

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Clipboard history, clipboard projections, and search results now expose whether an entry was captured as a directory (`isDirectory`) and preserve it across browsing/search UI.
  * The UI uses this flag to adjust how directory items are represented during transfers.
* **Bug Fixes**
  * Directory sends no longer show misleading byte percentages or detailed progress UI.
  * Missing or failed directory metadata lookups now safely default to non-directory behavior.
  * Transfer completion behavior is stable with repeated or late progress updates.
* **Tests**
  * Added/updated regression and coverage tests for directory-send rendering and stable transfer completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->