### PR TITLE
fix: simplify URL preview display

### DIFF
--- a/src/components/clipboard/__tests__/ClipboardPreview.test.tsx
+++ b/src/components/clipboard/__tests__/ClipboardPreview.test.tsx
@@ -184,4 +184,57 @@ describe('ClipboardPreview', () => {
     expect(screen.queryByRole('img', { name: 'report.pdf' })).not.toBeInTheDocument()
     expect(screen.getByText('report.pdf')).toBeInTheDocument()
   })
+
+  it('wraps long URLs instead of truncating them', () => {
+    const longUrl =
+      'https://example.com/a/very/long/path/that/should/remain/fully/visible?query=complete-url-preview'
+
+    render(
+      <ClipboardPreview
+        item={{
+          id: 'link-entry',
+          type: 'text',
+          activeTime: 1710000000000,
+          contentTags: ['link'],
+          content: {
+            display_text: longUrl,
+            has_detail: false,
+            size: longUrl.length,
+            link_urls: [longUrl],
+            link_domains: ['example.com'],
+          },
+        }}
+      />
+    )
+
+    const url = screen.getByText(longUrl)
+    expect(url).not.toHaveClass('truncate')
+    expect(url).toHaveClass('break-all', 'whitespace-normal')
+  })
+
+  it('renders URLs as plain links instead of cards', () => {
+    const url = 'https://example.com/docs'
+
+    render(
+      <ClipboardPreview
+        item={{
+          id: 'link-entry',
+          type: 'text',
+          activeTime: 1710000000000,
+          contentTags: ['link'],
+          content: {
+            display_text: url,
+            has_detail: false,
+            size: url.length,
+            link_urls: [url],
+            link_domains: ['example.com'],
+          },
+        }}
+      />
+    )
+
+    const link = screen.getByRole('button', { name: url })
+    expect(link).not.toHaveClass('rounded-xl', 'border', 'bg-muted/10', 'p-4')
+    expect(screen.queryByText('example.com')).not.toBeInTheDocument()
+  })
 })

--- a/src/components/clipboard/preview-renderers/LinkPreview.tsx
+++ b/src/components/clipboard/preview-renderers/LinkPreview.tsx
@@ -12,23 +12,18 @@ interface LinkPreviewProps {
 
 const LinkPreview: React.FC<LinkPreviewProps> = ({ item }) => {
   return (
-    <div className="space-y-4 p-8">
+    <div className="divide-y divide-border/30 px-8 py-4">
       {item.urls.map((url, index) => (
         <button
           key={`${url}-${index}`}
           type="button"
-          className="group flex w-full items-center gap-3 rounded-xl border border-border/20 bg-muted/10 p-4 text-left transition-all hover:border-primary/30 hover:bg-muted/20"
+          className="group flex w-full items-start gap-2 py-3 text-left outline-none focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-ring"
           onClick={() => openUrl(url).catch(err => log.error({ err }, 'Failed to open URL'))}
         >
-          <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary transition-transform group-hover:scale-110">
-            <ExternalLink size={18} />
-          </div>
-          <div className="min-w-0 flex-1">
-            <div className="truncate text-sm font-semibold text-foreground/90">{url}</div>
-            {item.domains[index] && (
-              <div className="mt-0.5 text-xs text-muted-foreground/70">{item.domains[index]}</div>
-            )}
-          </div>
+          <ExternalLink className="mt-1 size-3.5 shrink-0 text-muted-foreground/60 transition-colors group-hover:text-foreground/80" />
+          <span className="break-all whitespace-normal font-mono text-sm leading-relaxed text-foreground/80 underline decoration-border underline-offset-4 transition-colors group-hover:text-foreground group-hover:decoration-foreground/40">
+            {url}
+          </span>
         </button>
       ))}
     </div>


### PR DESCRIPTION
## Summary

- replace URL preview cards with a plain link list
- keep long URLs fully visible with wrapping
- remove redundant domain labels while preserving open-link behavior

## Testing

- `npx vitest run src/components/clipboard/__tests__/ClipboardPreview.test.tsx`
- `bun run build`
- targeted ESLint and Prettier checks
- visual verification in light and dark themes at narrow and wide widths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved link previews with clearer, underlined URLs and an external-link indicator.
  * Long URLs now wrap cleanly without truncation.
  * URLs remain directly clickable for easier access.

* **Bug Fixes**
  * Simplified link presentation to avoid displaying unnecessary domain labels or card-style formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->