### PR TITLE
fix(ui): smooth route transitions and stabilize switch motion

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,13 @@
-import { LazyMotion, MotionConfig, domMax } from 'framer-motion'
+import { AnimatePresence, LazyMotion, MotionConfig, domMax, m } from 'framer-motion'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { BrowserRouter as Router, Route, Navigate, Outlet, useNavigate } from 'react-router-dom'
+import {
+  BrowserRouter as Router,
+  Route,
+  Navigate,
+  useLocation,
+  useNavigate,
+  useOutlet,
+} from 'react-router-dom'
 import { daemonClient } from '@/api/daemon/client'
 import { signalLifecycleReady } from '@/api/daemon/lifecycle'
 import { unlockEncryptionSession } from '@/api/security'
@@ -42,11 +49,30 @@ import './App.css'
  *  falls through to the actionable error screen instead of hanging (#995). */
 const LOADING_WATCHDOG_MS = 12_000
 
-// 认证布局包装器 - 保持 Sidebar 持久化
+const PAGE_TRANSITION = { duration: 0.16, ease: [0.22, 1, 0.36, 1] } as const
+
+// Keep the sidebar mounted while route bodies crossfade in the shared surface.
 const AuthenticatedLayout = () => {
+  const routerLocation = useLocation()
+  const outlet = useOutlet()
+  const { reduceVisualEffects } = usePlatform()
+
   return (
     <MainLayout>
-      <Outlet />
+      <div className="relative h-full overflow-hidden">
+        <AnimatePresence initial={false} mode="sync">
+          <m.div
+            key={routerLocation.pathname}
+            initial={reduceVisualEffects ? false : { opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={reduceVisualEffects ? undefined : { opacity: 0 }}
+            transition={reduceVisualEffects ? { duration: 0 } : PAGE_TRANSITION}
+            className="absolute inset-0"
+          >
+            {outlet}
+          </m.div>
+        </AnimatePresence>
+      </div>
     </MainLayout>
   )
 }

--- a/src/components/ui/__tests__/switch.test.tsx
+++ b/src/components/ui/__tests__/switch.test.tsx
@@ -1,0 +1,61 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import React from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import { Switch } from '@/components/ui/switch'
+
+vi.mock('framer-motion', async () => {
+  const ReactModule = await import('react')
+
+  return {
+    MotionConfig: ({ children }: { children: React.ReactNode }) => children,
+    useReducedMotion: () => false,
+    m: {
+      button: ({
+        children,
+        initial: _initial,
+        ...props
+      }: React.ButtonHTMLAttributes<HTMLButtonElement> & { initial?: unknown }) =>
+        ReactModule.createElement('button', props, children),
+      div: ({
+        animate,
+        initial,
+        layout,
+        ...props
+      }: React.HTMLAttributes<HTMLDivElement> & {
+        animate?: { x?: number; y?: number; scale?: number }
+        initial?: unknown
+        layout?: unknown
+      }) =>
+        ReactModule.createElement('div', {
+          ...props,
+          'data-motion-x': animate?.x,
+          'data-motion-y': animate?.y,
+          'data-motion-scale': animate?.scale,
+          'data-motion-initial': String(initial),
+          'data-motion-layout': layout == null ? undefined : String(layout),
+        }),
+    },
+  }
+})
+
+describe('Switch', () => {
+  it('limits thumb motion to the horizontal toggle axis', () => {
+    const onCheckedChange = vi.fn()
+    const { rerender } = render(
+      <Switch checked={false} onCheckedChange={onCheckedChange} aria-label="Sync" />
+    )
+    const control = screen.getByRole('switch', { name: 'Sync' })
+    const thumb = control.firstElementChild
+
+    expect(thumb).toHaveAttribute('data-motion-x', '0')
+    expect(thumb).not.toHaveAttribute('data-motion-y')
+    expect(thumb).not.toHaveAttribute('data-motion-layout')
+    expect(thumb).toHaveAttribute('data-motion-initial', 'false')
+
+    fireEvent.click(control)
+    expect(onCheckedChange).toHaveBeenCalledWith(true)
+
+    rerender(<Switch checked onCheckedChange={onCheckedChange} aria-label="Sync" />)
+    expect(thumb).toHaveAttribute('data-motion-x', '12')
+  })
+})

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -10,8 +10,8 @@ import { cn } from '@/lib/utils'
 const THUMB_SPRING = { type: 'spring', stiffness: 800, damping: 80, mass: 4 } as const
 
 const SIZES = {
-  default: { track: 'h-[18.4px] w-[32px] px-[2px]', thumb: 'size-4' },
-  sm: { track: 'h-[14px] w-[24px] px-[1px]', thumb: 'size-3' },
+  default: { track: 'h-[18.4px] w-[32px] px-[2px]', thumb: 'size-4', travel: 12 },
+  sm: { track: 'h-[14px] w-[24px] px-[1px]', thumb: 'size-3', travel: 10 },
 } as const
 
 // Drag/animation handlers collide with framer-motion's same-named props, so drop
@@ -75,17 +75,17 @@ function Switch({
         onPointerCancel={() => setIsPressed(false)}
         initial={false}
         className={cn(
-          'peer inline-flex shrink-0 cursor-pointer items-center rounded-full outline-none transition-colors duration-200',
+          'peer inline-flex shrink-0 cursor-pointer items-center justify-start rounded-full outline-none transition-colors duration-200',
           'focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
           'disabled:cursor-not-allowed disabled:opacity-50',
           dims.track,
-          checked ? 'justify-end bg-primary' : 'justify-start bg-input dark:bg-input/80',
+          checked ? 'bg-primary' : 'bg-input dark:bg-input/80',
           className
         )}
       >
         <m.div
-          layout
-          animate={{ scale: squish ? 0.9 : 1 }}
+          initial={false}
+          animate={{ x: checked ? dims.travel : 0, scale: squish ? 0.9 : 1 }}
           className={cn(
             'pointer-events-none block rounded-full bg-background shadow-sm dark:bg-foreground',
             dims.thumb


### PR DESCRIPTION
## Summary

- Crossfade authenticated route bodies while keeping the sidebar mounted.
- Limit switch thumb animation to horizontal state changes and disable mount-time motion.
- Add regression coverage for horizontal-only switch thumb motion.

## Root cause

The switch thumb used layout projection, so ancestor reflow during reload was animated as vertical thumb movement. Route bodies were also replaced in a single frame, which made navigation to Devices feel like a refresh.

## Verification

- Verified History to Devices navigation and switch behavior in the native Tauri development window.
- `npx vitest run src/components/ui/__tests__/switch.test.tsx src/pages/__tests__/DevicesPage.test.tsx src/layouts/__tests__/MainLayout.test.tsx --pool=threads --maxWorkers=1`
- `npx tsc --noEmit`
- `npx eslint src/App.tsx src/components/ui/switch.tsx src/components/ui/__tests__/switch.test.tsx`
- `npx prettier --check src/App.tsx src/components/ui/switch.tsx src/components/ui/__tests__/switch.test.tsx`
- `bun run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added smooth crossfade transitions when navigating between routes.
  * Respects reduced visual effects preferences by disabling route animations when enabled.
  * Improved switch toggle animations with consistent horizontal thumb movement.

* **Tests**
  * Added coverage verifying switch movement, initial state, and change handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->