### PR TITLE
fix(history): load full text for truncated previews

### DIFF
--- a/src/lib/__tests__/clipboard-transform.test.ts
+++ b/src/lib/__tests__/clipboard-transform.test.ts
@@ -222,6 +222,33 @@ describe('searchResultToDisplayItem', () => {
     expect(item.contentTags).toBeUndefined()
   })
 
+  it('marks a truncated, available text preview as detail-loadable', () => {
+    const item = searchResultToDisplayItem(
+      makeSearchResult({
+        textPreview: 'x'.repeat(200),
+        charCount: 400,
+      })
+    )
+
+    expect(item.content).toMatchObject({
+      display_text: 'x'.repeat(200),
+      has_detail: true,
+      char_count: 400,
+    })
+  })
+
+  it('does not request detail for an unrecoverable truncated preview', () => {
+    const item = searchResultToDisplayItem(
+      makeSearchResult({
+        textPreview: 'x'.repeat(200),
+        charCount: 400,
+        payloadState: 'Lost',
+      })
+    )
+
+    expect(item.content).toMatchObject({ has_detail: false })
+  })
+
   it('maps file search results to file content carrying names and local paths', () => {
     const item = searchResultToDisplayItem(
       makeSearchResult({

--- a/src/lib/clipboard-transform.ts
+++ b/src/lib/clipboard-transform.ts
@@ -201,7 +201,13 @@ export function searchResultToDisplayItem(r: SearchResultDto): DisplayClipboardI
           ? withLinkMetadata(
               {
                 display_text: r.textPreview,
-                has_detail: false,
+                // Search results carry only the first 200 characters. Load the
+                // authoritative payload when the indexed full count proves the
+                // preview is incomplete, unless the payload is unrecoverable.
+                has_detail:
+                  r.payloadState !== 'Lost' &&
+                  r.charCount !== null &&
+                  r.charCount > Array.from(r.textPreview).length,
                 size: 0,
                 char_count: r.charCount ?? undefined,
               },


### PR DESCRIPTION
## Summary

- Mark truncated, recoverable search previews as detail-loadable so the History detail pane fetches and renders the full text instead of its 200-character index summary. (beef55431)
- Keep unrecoverable (`Lost`) payloads on their existing summary-only path and add regression coverage for both states. (beef55431)
- Docs left as-is: no documented user-facing configuration, command, or API contract changed.
- Telemetry and tracing are not applicable: the change is frontend-only and contains no Rust or `uc-application` changes.

## Test plan

- [x] `npx vitest run src/lib/__tests__/clipboard-transform.test.ts src/components/clipboard/__tests__/useClipboardPreviewState.test.tsx`
- [x] `bunx tsc --noEmit`
- [x] `bunx eslint src/lib/clipboard-transform.ts src/lib/__tests__/clipboard-transform.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved truncated text previews so additional details can be loaded when available.
  * Prevented detail-loading requests for previews whose underlying content is unrecoverable.

* **Tests**
  * Added coverage for truncated previews with available and unavailable source content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->