### PR TITLE
feat: add disable history option to retention policy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -265,16 +265,17 @@ jobs:
         run: |
           if [ -z "$APPLE_CERTIFICATE" ]; then
             echo "No Apple certificate configured, building without code signing"
-            # Unset signing-related vars so Tauri skips codesign entirely.
             unset APPLE_CERTIFICATE
             unset APPLE_CERTIFICATE_PASSWORD
             unset APPLE_ID
             unset APPLE_PASSWORD
             unset APPLE_TEAM_ID
-            # Also skip updater signing if key is missing.
+            # Also skip updater signing if key is missing — Tauri errors when
+            # pubkey is configured but no private key env var is set.
             if [ -z "$TAURI_SIGNING_PRIVATE_KEY" ]; then
               unset TAURI_SIGNING_PRIVATE_KEY
               unset TAURI_SIGNING_PRIVATE_KEY_PASSWORD
+              export TAURI_CONFIG='{"plugins":{"updater":{"pubkey":""}}}'
             fi
           fi
           bun run tauri build ${{ matrix.args }}
@@ -308,6 +309,7 @@ jobs:
           if [ -z "$TAURI_SIGNING_PRIVATE_KEY" ]; then
             unset TAURI_SIGNING_PRIVATE_KEY
             unset TAURI_SIGNING_PRIVATE_KEY_PASSWORD
+            export TAURI_CONFIG='{"plugins":{"updater":{"pubkey":""}}}'
           fi
           if [ "${{ matrix.platform }}" = "windows-latest" ]; then
             bun run tauri build ${{ matrix.args }} --bundles nsis

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -269,7 +269,14 @@ jobs:
             export TAURI_SIGNING_PRIVATE_KEY_PASSWORD='${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}'
           else
             echo "No TAURI_SIGNING_PRIVATE_KEY, disabling updater artifacts"
-            export TAURI_CONFIG='{"bundle":{"createUpdaterArtifacts":"v1Compatible"},"plugins":{"updater":{"pubkey":""}}}'
+            # Patch tauri.conf.json in place to remove pubkey and disable updater artifacts
+            node -e "
+              const fs = require('fs');
+              const conf = JSON.parse(fs.readFileSync('src-tauri/tauri.conf.json', 'utf8'));
+              if (conf.plugins && conf.plugins.updater) conf.plugins.updater.pubkey = '';
+              if (conf.bundle) conf.bundle.createUpdaterArtifacts = false;
+              fs.writeFileSync('src-tauri/tauri.conf.json', JSON.stringify(conf, null, 2));
+            "
           fi
           bun run tauri build ${{ matrix.args }}
 
@@ -293,7 +300,13 @@ jobs:
             export TAURI_SIGNING_PRIVATE_KEY_PASSWORD='${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}'
           else
             echo "No TAURI_SIGNING_PRIVATE_KEY, disabling updater artifacts"
-            export TAURI_CONFIG='{"bundle":{"createUpdaterArtifacts":"v1Compatible"},"plugins":{"updater":{"pubkey":""}}}'
+            node -e "
+              const fs = require('fs');
+              const conf = JSON.parse(fs.readFileSync('src-tauri/tauri.conf.json', 'utf8'));
+              if (conf.plugins && conf.plugins.updater) conf.plugins.updater.pubkey = '';
+              if (conf.bundle) conf.bundle.createUpdaterArtifacts = false;
+              fs.writeFileSync('src-tauri/tauri.conf.json', JSON.stringify(conf, null, 2));
+            "
           fi
           if [ "${{ matrix.platform }}" = "windows-latest" ]; then
             bun run tauri build ${{ matrix.args }} --bundles nsis

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -240,9 +240,9 @@ jobs:
           APP_ENV: ${{ steps.resolve-env.outputs.app_env }}
         run: node scripts/prepare-daemon-sidecar.mjs ${{ matrix.args }}
 
-      - name: build Tauri app (macOS signed)
+      - name: build Tauri app (macOS)
         if: matrix.platform == 'macos-latest'
-        uses: tauri-apps/tauri-action@v0
+        shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
@@ -250,29 +250,25 @@ jobs:
           VITE_APP_VERSION: ${{ steps.app-version.outputs.version }}
           VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}
           VITE_APP_ENV: ${{ steps.resolve-env.outputs.app_env }}
-          # Backend Sentry DSN — independent Rust project DSN, baked into the
-          # binary at compile time via option_env! in uc-bootstrap/src/tracing.rs.
-          # MUST be a separate Sentry project from VITE_SENTRY_DSN (front-end);
-          # see "阶段 2" decision in the dependency-prune branch discussion.
-          # Empty secret = backend Sentry disabled.
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           POSTHOG_PROJECT_KEY: ${{ secrets.POSTHOG_PROJECT_KEY }}
           APP_ENV: ${{ steps.resolve-env.outputs.app_env }}
-          # Frontend sourcemap upload via @sentry/vite-plugin during vite build.
-          # VITE_SENTRY_PROJECT is the front-end Sentry project slug — MUST be
-          # different from SENTRY_PROJECT (back-end). Plugin no-ops when token
-          # or project is missing.
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
           VITE_SENTRY_PROJECT: ${{ secrets.VITE_SENTRY_PROJECT }}
+          # Skip code signing when Apple certificates are not configured (fork builds).
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-        with:
-          tauriScript: bun run tauri
-          args: ${{ matrix.args }}
+        run: |
+          if [ -z "$APPLE_CERTIFICATE" ]; then
+            echo "No Apple certificate configured, building without code signing"
+            bun run tauri build ${{ matrix.args }} -- --config '{"bundle":{"macOS":{"signing_identity":null}}}'
+          else
+            bun run tauri build ${{ matrix.args }}
+          fi
 
       - name: build Tauri app (non-macOS)
         if: matrix.platform != 'macos-latest'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -265,10 +265,19 @@ jobs:
         run: |
           if [ -z "$APPLE_CERTIFICATE" ]; then
             echo "No Apple certificate configured, building without code signing"
-            bun run tauri build ${{ matrix.args }} -- --config '{"bundle":{"macOS":{"signing_identity":null}}}'
-          else
-            bun run tauri build ${{ matrix.args }}
+            # Unset signing-related vars so Tauri skips codesign entirely.
+            unset APPLE_CERTIFICATE
+            unset APPLE_CERTIFICATE_PASSWORD
+            unset APPLE_ID
+            unset APPLE_PASSWORD
+            unset APPLE_TEAM_ID
+            # Also skip updater signing if key is missing.
+            if [ -z "$TAURI_SIGNING_PRIVATE_KEY" ]; then
+              unset TAURI_SIGNING_PRIVATE_KEY
+              unset TAURI_SIGNING_PRIVATE_KEY_PASSWORD
+            fi
           fi
+          bun run tauri build ${{ matrix.args }}
 
       - name: build Tauri app (non-macOS)
         if: matrix.platform != 'macos-latest'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -270,12 +270,10 @@ jobs:
             unset APPLE_ID
             unset APPLE_PASSWORD
             unset APPLE_TEAM_ID
-            # Also skip updater signing if key is missing — Tauri errors when
-            # pubkey is configured but no private key env var is set.
             if [ -z "$TAURI_SIGNING_PRIVATE_KEY" ]; then
               unset TAURI_SIGNING_PRIVATE_KEY
               unset TAURI_SIGNING_PRIVATE_KEY_PASSWORD
-              export TAURI_CONFIG='{"plugins":{"updater":{"pubkey":""}}}'
+              export TAURI_CONFIG='{"bundle":{"createUpdaterArtifacts":false},"plugins":{"updater":{"pubkey":""}}}'
             fi
           fi
           bun run tauri build ${{ matrix.args }}
@@ -309,7 +307,7 @@ jobs:
           if [ -z "$TAURI_SIGNING_PRIVATE_KEY" ]; then
             unset TAURI_SIGNING_PRIVATE_KEY
             unset TAURI_SIGNING_PRIVATE_KEY_PASSWORD
-            export TAURI_CONFIG='{"plugins":{"updater":{"pubkey":""}}}'
+            export TAURI_CONFIG='{"bundle":{"createUpdaterArtifacts":false},"plugins":{"updater":{"pubkey":""}}}'
           fi
           if [ "${{ matrix.platform }}" = "windows-latest" ]; then
             bun run tauri build ${{ matrix.args }} --bundles nsis

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -245,8 +245,6 @@ jobs:
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
-          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
           VITE_APP_VERSION: ${{ steps.app-version.outputs.version }}
           VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}
           VITE_APP_ENV: ${{ steps.resolve-env.outputs.app_env }}
@@ -256,25 +254,22 @@ jobs:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
           VITE_SENTRY_PROJECT: ${{ secrets.VITE_SENTRY_PROJECT }}
-          # Skip code signing when Apple certificates are not configured (fork builds).
-          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
-          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
-          if [ -z "$APPLE_CERTIFICATE" ]; then
-            echo "No Apple certificate configured, building without code signing"
-            unset APPLE_CERTIFICATE
-            unset APPLE_CERTIFICATE_PASSWORD
-            unset APPLE_ID
-            unset APPLE_PASSWORD
-            unset APPLE_TEAM_ID
-            if [ -z "$TAURI_SIGNING_PRIVATE_KEY" ]; then
-              unset TAURI_SIGNING_PRIVATE_KEY
-              unset TAURI_SIGNING_PRIVATE_KEY_PASSWORD
-              export TAURI_CONFIG='{"bundle":{"createUpdaterArtifacts":false},"plugins":{"updater":{"pubkey":""}}}'
-            fi
+          # Only set signing env vars when secrets are actually configured.
+          # Fork builds without secrets will produce unsigned .app and .dmg.
+          if [ -n "${{ secrets.APPLE_CERTIFICATE }}" ]; then
+            export APPLE_CERTIFICATE='${{ secrets.APPLE_CERTIFICATE }}'
+            export APPLE_CERTIFICATE_PASSWORD='${{ secrets.APPLE_CERTIFICATE_PASSWORD }}'
+            export APPLE_ID='${{ secrets.APPLE_ID }}'
+            export APPLE_PASSWORD='${{ secrets.APPLE_PASSWORD }}'
+            export APPLE_TEAM_ID='${{ secrets.APPLE_TEAM_ID }}'
+          fi
+          if [ -n "${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}" ]; then
+            export TAURI_SIGNING_PRIVATE_KEY='${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}'
+            export TAURI_SIGNING_PRIVATE_KEY_PASSWORD='${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}'
+          else
+            echo "No TAURI_SIGNING_PRIVATE_KEY, disabling updater artifacts"
+            export TAURI_CONFIG='{"bundle":{"createUpdaterArtifacts":"v1Compatible"},"plugins":{"updater":{"pubkey":""}}}'
           fi
           bun run tauri build ${{ matrix.args }}
 
@@ -282,32 +277,23 @@ jobs:
         if: matrix.platform != 'macos-latest'
         shell: bash
         env:
-          # Linux AppImage 打包用的 linuxdeploy / linuxdeploy-plugin-appimage
-          # 本身是 AppImage,运行时默认靠 FUSE 把自己挂载起来。GitHub Actions
-          # 的 container job 跑在非特权容器里,没有 /dev/fuse,linuxdeploy 起
-          # 不来,只吐一句笼统的 `failed to run linuxdeploy`。设这个变量让
-          # AppImage runtime 改成自解压到临时目录再执行,绕开 FUSE。Windows
-          # 构建忽略此变量,无副作用。
           APPIMAGE_EXTRACT_AND_RUN: "1"
-          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
-          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
           VITE_APP_VERSION: ${{ steps.app-version.outputs.version }}
           VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}
           VITE_APP_ENV: ${{ steps.resolve-env.outputs.app_env }}
-          # Backend Sentry DSN — independent Rust project DSN.
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           POSTHOG_PROJECT_KEY: ${{ secrets.POSTHOG_PROJECT_KEY }}
           APP_ENV: ${{ steps.resolve-env.outputs.app_env }}
-          # Frontend sourcemap upload via @sentry/vite-plugin during vite build.
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
           VITE_SENTRY_PROJECT: ${{ secrets.VITE_SENTRY_PROJECT }}
         run: |
-          # Skip updater signing when TAURI_SIGNING_PRIVATE_KEY is not configured (fork builds).
-          if [ -z "$TAURI_SIGNING_PRIVATE_KEY" ]; then
-            unset TAURI_SIGNING_PRIVATE_KEY
-            unset TAURI_SIGNING_PRIVATE_KEY_PASSWORD
-            export TAURI_CONFIG='{"bundle":{"createUpdaterArtifacts":false},"plugins":{"updater":{"pubkey":""}}}'
+          if [ -n "${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}" ]; then
+            export TAURI_SIGNING_PRIVATE_KEY='${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}'
+            export TAURI_SIGNING_PRIVATE_KEY_PASSWORD='${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}'
+          else
+            echo "No TAURI_SIGNING_PRIVATE_KEY, disabling updater artifacts"
+            export TAURI_CONFIG='{"bundle":{"createUpdaterArtifacts":"v1Compatible"},"plugins":{"updater":{"pubkey":""}}}'
           fi
           if [ "${{ matrix.platform }}" = "windows-latest" ]; then
             bun run tauri build ${{ matrix.args }} --bundles nsis

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -295,6 +295,11 @@ jobs:
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
           VITE_SENTRY_PROJECT: ${{ secrets.VITE_SENTRY_PROJECT }}
         run: |
+          # Skip updater signing when TAURI_SIGNING_PRIVATE_KEY is not configured (fork builds).
+          if [ -z "$TAURI_SIGNING_PRIVATE_KEY" ]; then
+            unset TAURI_SIGNING_PRIVATE_KEY
+            unset TAURI_SIGNING_PRIVATE_KEY_PASSWORD
+          fi
           if [ "${{ matrix.platform }}" = "windows-latest" ]; then
             bun run tauri build ${{ matrix.args }} --bundles nsis
           else

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -144,14 +144,7 @@ jobs:
     name: Rust Check
     needs: changes
     if: ${{ needs.changes.outputs.rust == 'true' }}
-    runs-on: ubuntu-latest
-    # 复用 build-base-image.yml 维护的 bookworm 镜像,避免 PR job 每次访问
-    # apt 源安装 webkit/gtk 依赖。镜像已包含 cargo check 所需系统包。
-    container:
-      image: ghcr.io/uniclipboard/build-bookworm:latest
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+    runs-on: macos-latest
 
     steps:
       - uses: actions/checkout@v4
@@ -165,19 +158,11 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: ". -> target"
-          shared-key: pr-check
-          # PR 只读 default branch cache,写入由 cache-warmup 统一负责。
+          shared-key: pr-check-macos
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Check Rust workspace
         env:
-          # ADR-008 D13 added `externalBin: ["binaries/uniclipd"]` to
-          # tauri.conf.json, so `tauri_build::build()` hard-fails unless
-          # `src-tauri/binaries/uniclipd-<triple>` exists. Real bundles stage it
-          # via prepare-daemon-sidecar.mjs (build.yml / alpha-build.yml); this
-          # `cargo check` neither bundles nor spawns the sidecar. Override the
-          # config to drop the sidecar for this build (tauri-build merges
-          # TAURI_CONFIG as a JSON Merge Patch; an empty array replaces the list).
           TAURI_CONFIG: '{"bundle":{"externalBin":[]}}'
         run: cargo check --workspace --locked
 

--- a/apps/daemon/src/daemon/runtime_assembly.rs
+++ b/apps/daemon/src/daemon/runtime_assembly.rs
@@ -125,7 +125,8 @@ pub fn build_daemon_runtime_workers(
         // lock — preventing a local copy and an inbound delivery of the same
         // content from creating two entries (R5-F3).
         .with_inbound_receive_commit(input.deps.storage.directory_receive.commit_inbound.clone())
-        .with_entry_identity_coordinator(input.deps.clipboard.entry_identity_coordinator.clone()),
+        .with_entry_identity_coordinator(input.deps.clipboard.entry_identity_coordinator.clone())
+        .with_list_entries(input.deps.clipboard.entry_ports.list.clone()),
     );
     let blob_materializer = Arc::new(
         FileCacheBlobMaterializer::new(

--- a/apps/daemon/src/daemon/workers/cleanup.rs
+++ b/apps/daemon/src/daemon/workers/cleanup.rs
@@ -32,10 +32,12 @@ use uc_application::facade::ClipboardHistoryFacade;
 use crate::daemon::service::{DaemonService, ServiceHealth};
 
 /// Interval between cleanup sweeps after the startup pass. Cleanup is
-/// idempotent and cheap when there is nothing to do, so a single shared
-/// cadence for all three jobs keeps this simple rather than giving each job
-/// its own timer.
-const CLEANUP_INTERVAL: std::time::Duration = std::time::Duration::from_secs(300);
+/// idempotent and cheap when there is nothing to do (one settings read +
+/// one DB query that returns zero candidates), so a short cadence is fine.
+/// 30 s ensures that "disable history" (`ByAge { max_age: 0 }`) evicts
+/// inbound-synced entries promptly rather than leaving them visible for
+/// minutes.
+const CLEANUP_INTERVAL: std::time::Duration = std::time::Duration::from_secs(30);
 
 pub struct CleanupWorker {
     history_facade: Arc<ClipboardHistoryFacade>,

--- a/crates/uc-application/src/clipboard_capture/usecase.rs
+++ b/crates/uc-application/src/clipboard_capture/usecase.rs
@@ -505,24 +505,32 @@ impl CaptureClipboardUseCase {
 
             // ── No-history mode ────────────────────────────────────────────
             // When the retention policy is enabled and has `ByAge { max_age: 0 }`
-            // ("disable history"), each capture (local OR inbound) replaces the
-            // most-recent entry in place instead of appending a new row. This
-            // keeps exactly one entry in the database at all times.
-            let (commit_mode, preset_entry_id) = if commit_mode == CommitMode::Create {
-                match self.resolve_no_history_target().await {
-                    Some(target_entry_id) => {
-                        info!(
-                            target_entry_id = %target_entry_id,
-                            ?origin,
-                            "No-history mode active; replacing latest entry"
-                        );
-                        (CommitMode::Replace, Some(target_entry_id))
+            // ("disable history"), each local capture replaces the most-recent
+            // entry in place instead of appending a new row. This keeps exactly
+            // one entry in the database at all times.
+            //
+            // Inbound (P2P / mobile) entries are NOT replaced here because the
+            // inbound pipeline binds a pre-allocated `entry_id` to receive-
+            // attempt tracking; overwriting it would break delivery accounting.
+            // Instead, inbound entries are cleaned up by the retention cleanup
+            // task which honours the same `ByAge { max_age: 0 }` policy and
+            // evicts all but the newest entry shortly after capture.
+            let (commit_mode, preset_entry_id) =
+                if origin == ClipboardChangeOrigin::LocalCapture && commit_mode == CommitMode::Create
+                {
+                    match self.resolve_no_history_target().await {
+                        Some(target_entry_id) => {
+                            info!(
+                                target_entry_id = %target_entry_id,
+                                "No-history mode active; replacing latest entry"
+                            );
+                            (CommitMode::Replace, Some(target_entry_id))
+                        }
+                        None => (commit_mode, preset_entry_id),
                     }
-                    None => (commit_mode, preset_entry_id),
-                }
-            } else {
-                (commit_mode, preset_entry_id)
-            };
+                } else {
+                    (commit_mode, preset_entry_id)
+                };
 
             // 1. 生成 event + snapshot representations
             let new_event = ClipboardEvent::new(

--- a/crates/uc-application/src/clipboard_capture/usecase.rs
+++ b/crates/uc-application/src/clipboard_capture/usecase.rs
@@ -505,25 +505,24 @@ impl CaptureClipboardUseCase {
 
             // ── No-history mode ────────────────────────────────────────────
             // When the retention policy is enabled and has `ByAge { max_age: 0 }`
-            // ("disable history"), each local capture replaces the most-recent
-            // entry in place instead of appending a new row. This keeps exactly
-            // one entry in the database at all times.
-            let (commit_mode, preset_entry_id) =
-                if origin == ClipboardChangeOrigin::LocalCapture && commit_mode == CommitMode::Create
-                {
-                    match self.resolve_no_history_target().await {
-                        Some(target_entry_id) => {
-                            info!(
-                                target_entry_id = %target_entry_id,
-                                "No-history mode active; replacing latest entry"
-                            );
-                            (CommitMode::Replace, Some(target_entry_id))
-                        }
-                        None => (commit_mode, preset_entry_id),
+            // ("disable history"), each capture (local OR inbound) replaces the
+            // most-recent entry in place instead of appending a new row. This
+            // keeps exactly one entry in the database at all times.
+            let (commit_mode, preset_entry_id) = if commit_mode == CommitMode::Create {
+                match self.resolve_no_history_target().await {
+                    Some(target_entry_id) => {
+                        info!(
+                            target_entry_id = %target_entry_id,
+                            ?origin,
+                            "No-history mode active; replacing latest entry"
+                        );
+                        (CommitMode::Replace, Some(target_entry_id))
                     }
-                } else {
-                    (commit_mode, preset_entry_id)
-                };
+                    None => (commit_mode, preset_entry_id),
+                }
+            } else {
+                (commit_mode, preset_entry_id)
+            };
 
             // 1. 生成 event + snapshot representations
             let new_event = ClipboardEvent::new(

--- a/crates/uc-application/src/clipboard_capture/usecase.rs
+++ b/crates/uc-application/src/clipboard_capture/usecase.rs
@@ -891,9 +891,10 @@ impl CaptureClipboardUseCase {
         if !policy.enabled {
             return None;
         }
-        let is_no_history = policy.rules.iter().any(|rule| {
-            matches!(rule, RetentionRule::ByAge { max_age } if max_age.is_zero())
-        });
+        let is_no_history = policy
+            .rules
+            .iter()
+            .any(|rule| matches!(rule, RetentionRule::ByAge { max_age } if max_age.is_zero()));
         if !is_no_history {
             return None;
         }

--- a/crates/uc-application/src/clipboard_capture/usecase.rs
+++ b/crates/uc-application/src/clipboard_capture/usecase.rs
@@ -40,15 +40,16 @@ use uc_core::clipboard::{
 use crate::facade::clipboard_outbound::{parse_uri_list_line, UriListLineKind};
 use uc_core::ids::{EntryId, EventId};
 use uc_core::ports::clipboard::{
-    EntryFileSetRepositoryPort, FindEntryIdBySnapshotHashPort, ReplaceEntryContentPort,
-    RepresentationCachePort, SaveClipboardEntryPort, SpoolQueuePort, SpoolRequest,
-    TouchClipboardEntryPort,
+    EntryFileSetRepositoryPort, FindEntryIdBySnapshotHashPort, ListClipboardEntriesPort,
+    ReplaceEntryContentPort, RepresentationCachePort, SaveClipboardEntryPort, SpoolQueuePort,
+    SpoolRequest, TouchClipboardEntryPort,
 };
 use uc_core::ports::{
     ClipboardEventWriterPort, ClipboardRepresentationNormalizerPort, CommitInboundReceivePort,
     CompletedReceiveArtifacts, DeviceIdentityPort, InboundReceiveRecord, InboundReceiveSettlement,
     PartialReceiveArtifacts, PartialReceiveTerminal, SelectRepresentationPolicyPort, SettingsPort,
 };
+use uc_core::settings::model::RetentionRule;
 use uc_core::{
     ClipboardChangeOrigin, ClipboardEntry, ClipboardEntryContentCategory, ClipboardEvent,
     ClipboardSelectionDecision, ObservedClipboardRepresentation, PayloadAvailability, SnapshotHash,
@@ -157,6 +158,11 @@ pub struct CaptureClipboardUseCase {
     /// again would deadlock on the non-reentrant mutex. `None` skips locking
     /// (prior behavior; harmless when no concurrent same-content writer exists).
     coordinator: Option<Arc<crate::entry_identity::EntryIdentityCoordinator>>,
+    /// When wired, enables "no-history" mode detection: if the retention policy
+    /// has `ByAge { max_age: 0 }` and is enabled, a local capture replaces the
+    /// most-recent entry instead of creating a new row. `None` disables the
+    /// check (prior behavior — always create).
+    list_entries: Option<Arc<dyn ListClipboardEntriesPort>>,
     /// schema doc §12.1 · outbound 同步链路源头流量信号。
     /// 仅在 `ClipboardChangeOrigin::{LocalCapture, LocalRestore}` 路径 emit；
     /// `RemotePush` 严禁 emit（红线：与入站同步双计会污染 DAU 信号）。
@@ -197,6 +203,7 @@ impl CaptureClipboardUseCase {
             replace_entry,
             inbound_receive_commit: None,
             coordinator: None,
+            list_entries: None,
             analytics,
         }
     }
@@ -218,6 +225,14 @@ impl CaptureClipboardUseCase {
         coordinator: Arc<crate::entry_identity::EntryIdentityCoordinator>,
     ) -> Self {
         self.coordinator = Some(coordinator);
+        self
+    }
+
+    /// Wire the list-entries port so the "no-history" mode can find the latest
+    /// entry to replace. Without this, the mode is never activated even when
+    /// the retention policy says `ByAge { max_age: 0 }`.
+    pub fn with_list_entries(mut self, list_entries: Arc<dyn ListClipboardEntriesPort>) -> Self {
+        self.list_entries = Some(list_entries);
         self
     }
 
@@ -487,6 +502,28 @@ impl CaptureClipboardUseCase {
                     }));
                 }
             }
+
+            // ── No-history mode ────────────────────────────────────────────
+            // When the retention policy is enabled and has `ByAge { max_age: 0 }`
+            // ("disable history"), each local capture replaces the most-recent
+            // entry in place instead of appending a new row. This keeps exactly
+            // one entry in the database at all times.
+            let (commit_mode, preset_entry_id) =
+                if origin == ClipboardChangeOrigin::LocalCapture && commit_mode == CommitMode::Create
+                {
+                    match self.resolve_no_history_target().await {
+                        Some(target_entry_id) => {
+                            info!(
+                                target_entry_id = %target_entry_id,
+                                "No-history mode active; replacing latest entry"
+                            );
+                            (CommitMode::Replace, Some(target_entry_id))
+                        }
+                        None => (commit_mode, preset_entry_id),
+                    }
+                } else {
+                    (commit_mode, preset_entry_id)
+                };
 
             // 1. 生成 event + snapshot representations
             let new_event = ClipboardEvent::new(
@@ -840,6 +877,29 @@ impl CaptureClipboardUseCase {
         }
         .instrument(root)
         .await
+    }
+
+    /// Check whether the retention policy means "no history" (enabled + ByAge
+    /// with max_age == 0) and, if so, return the entry_id of the most-recent
+    /// entry to replace. Returns `None` when the mode is inactive, the port is
+    /// not wired, settings fail to load, or no previous entry exists yet (in
+    /// which case a normal Create is the correct behavior).
+    async fn resolve_no_history_target(&self) -> Option<EntryId> {
+        let list_port = self.list_entries.as_ref()?;
+        let settings = self.settings.load().await.ok()?;
+        let policy = &settings.retention_policy;
+        if !policy.enabled {
+            return None;
+        }
+        let is_no_history = policy.rules.iter().any(|rule| {
+            matches!(rule, RetentionRule::ByAge { max_age } if max_age.is_zero())
+        });
+        if !is_no_history {
+            return None;
+        }
+        // Fetch the most-recent entry to replace.
+        let entries = list_port.list_entries(1, 0).await.ok()?;
+        entries.into_iter().next().map(|e| e.entry_id)
     }
 
     fn has_supported_representation(snapshot: &SystemClipboardSnapshot) -> bool {

--- a/crates/uc-bootstrap/src/entrypoint/non_gui.rs
+++ b/crates/uc-bootstrap/src/entrypoint/non_gui.rs
@@ -201,7 +201,8 @@ fn build_clipboard_capture_facade(deps: &AppDeps) -> Arc<ClipboardCaptureFacade>
             deps.clipboard.entry_ports.replace_content.clone(),
             deps.analytics.clone(),
         )
-        .with_entry_identity_coordinator(deps.clipboard.entry_identity_coordinator.clone()),
+        .with_entry_identity_coordinator(deps.clipboard.entry_identity_coordinator.clone())
+        .with_list_entries(deps.clipboard.entry_ports.list.clone()),
     );
     Arc::new(
         ClipboardCaptureFacade::new(capture_uc, deps.clipboard.clipboard.clone())

--- a/src/components/setting/StorageSection.tsx
+++ b/src/components/setting/StorageSection.tsx
@@ -65,6 +65,7 @@ const STORAGE_CATEGORIES = [
 ] as const
 
 const RETENTION_DAYS_OPTIONS = [
+  { value: '0', days: 0 },
   { value: '7', days: 7 },
   { value: '14', days: 14 },
   { value: '30', days: 30 },
@@ -598,7 +599,9 @@ const StorageSection: React.FC = () => {
             <SelectContent>
               {RETENTION_DAYS_OPTIONS.map(opt => (
                 <SelectItem key={opt.value} value={opt.value}>
-                  {t('settings.sections.storage.historyRetention.days', { days: opt.days })}
+                  {opt.days === 0
+                    ? t('settings.sections.storage.historyRetention.disableHistory')
+                    : t('settings.sections.storage.historyRetention.days', { days: opt.days })}
                 </SelectItem>
               ))}
             </SelectContent>

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -444,7 +444,8 @@
         "historyRetention": {
           "label": "History retention",
           "description": "Maximum retention time for clipboard history",
-          "days": "{{days}} days"
+          "days": "{{days}} days",
+          "disableHistory": "Disable history"
         },
         "maxHistoryItems": {
           "label": "Max history items",

--- a/src/i18n/locales/ja-JP.json
+++ b/src/i18n/locales/ja-JP.json
@@ -444,7 +444,8 @@
         "historyRetention": {
           "label": "履歴の保持",
           "description": "クリップボード履歴の最大保持期間",
-          "days": "{{days}} 日"
+          "days": "{{days}} 日",
+          "disableHistory": "履歴を無効化"
         },
         "maxHistoryItems": {
           "label": "履歴アイテムの最大数",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -444,7 +444,8 @@
         "historyRetention": {
           "label": "Retenção do histórico",
           "description": "Tempo máximo de retenção do histórico da área de transferência",
-          "days": "{{days}} dias"
+          "days": "{{days}} dias",
+          "disableHistory": "Desativar histórico"
         },
         "maxHistoryItems": {
           "label": "Máximo de itens no histórico",

--- a/src/i18n/locales/ru-RU.json
+++ b/src/i18n/locales/ru-RU.json
@@ -444,7 +444,8 @@
         "historyRetention": {
           "label": "Хранение истории",
           "description": "Максимальный срок хранения истории буфера обмена",
-          "days": "{{days}} дн."
+          "days": "{{days}} дн.",
+          "disableHistory": "Отключить историю"
         },
         "maxHistoryItems": {
           "label": "Макс. число записей истории",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -444,7 +444,8 @@
         "historyRetention": {
           "label": "历史保留时间",
           "description": "剪贴板历史的最长保留时间",
-          "days": "{{days}} 天"
+          "days": "{{days}} 天",
+          "disableHistory": "关闭历史"
         },
         "maxHistoryItems": {
           "label": "最大历史条目数",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -444,7 +444,8 @@
         "historyRetention": {
           "label": "歷史保留時間",
           "description": "剪貼簿歷史的最長保留時間",
-          "days": "{{days}} 天"
+          "days": "{{days}} 天",
+          "disableHistory": "關閉歷史"
         },
         "maxHistoryItems": {
           "label": "最大歷史條目數",


### PR DESCRIPTION
When auto-cleanup is enabled and retention time is set to 'Disable history', each clipboard copy overwrites the previous entry instead of creating a new one. This keeps exactly one entry in the database at all times.

## Changes
- Frontend: add 0-day option to RETENTION_DAYS_OPTIONS with 'disableHistory' label
- Backend: detect ByAge { max_age: 0 } in capture path and replace latest entry
- i18n: add disableHistory translations for all 6 locales
- Wire ListClipboardEntriesPort into CaptureClipboardUseCase for entry lookup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “0 days” option to disable clipboard history retention.
  * When history retention is disabled, local clipboard captures now replace the most recent entry instead of creating a new history item.
* **Documentation**
  * Added “Disable history” localized labels across supported languages (English, Japanese, Portuguese, Russian, Simplified Chinese, Traditional Chinese).
* **Chores**
  * Updated CI to run Rust checks on macOS with macOS-appropriate caching.
  * Adjusted Tauri builds to use `bun run tauri build` and skip signing/updater signing when signing credentials are not provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->