### PR TITLE
chore: pin core dependencies to release tag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -331,7 +331,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -342,7 +342,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2205,7 +2205,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2598,7 +2598,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3085,8 +3085,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
 ]
 
 [[package]]
@@ -3738,7 +3738,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -3756,7 +3756,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.59.0",
 ]
 
 [[package]]
@@ -5019,7 +5019,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.19",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5377,7 +5377,7 @@ dependencies = [
  "pin-project-lite",
  "rustc-hash",
  "rustls",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "thiserror 2.0.19",
  "tokio",
  "tokio-stream",
@@ -5422,7 +5422,7 @@ checksum = "b3c1520eacd33fd6b009e2e70116b05508ade51db5e0d315ff8bf6b702148c2b"
 dependencies = [
  "cfg_aliases",
  "libc",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -5456,7 +5456,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5592,7 +5592,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 2.0.2",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -6816,7 +6816,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "thiserror 2.0.19",
  "tokio",
  "tracing",
@@ -6855,9 +6855,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7164,7 +7164,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "rustix 1.1.4",
- "windows 0.62.2",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -7488,7 +7488,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7547,7 +7547,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7746,7 +7746,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8294,7 +8294,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9214,7 +9214,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9737,7 +9737,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.19",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9786,7 +9786,7 @@ dependencies = [
 [[package]]
 name = "uc-application"
 version = "0.20.0-rc.5"
-source = "git+https://github.com/UniClipboard/core.git?rev=59e4339a2e1d7c247e3d33c7ec106bbb16c17c5c#59e4339a2e1d7c247e3d33c7ec106bbb16c17c5c"
+source = "git+https://github.com/UniClipboard/core.git?tag=core-v0.20.0-rc.5#59e4339a2e1d7c247e3d33c7ec106bbb16c17c5c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9883,7 +9883,7 @@ dependencies = [
 [[package]]
 name = "uc-content-hash"
 version = "0.20.0-rc.5"
-source = "git+https://github.com/UniClipboard/core.git?rev=59e4339a2e1d7c247e3d33c7ec106bbb16c17c5c#59e4339a2e1d7c247e3d33c7ec106bbb16c17c5c"
+source = "git+https://github.com/UniClipboard/core.git?tag=core-v0.20.0-rc.5#59e4339a2e1d7c247e3d33c7ec106bbb16c17c5c"
 dependencies = [
  "blake3",
  "hex",
@@ -9892,7 +9892,7 @@ dependencies = [
 [[package]]
 name = "uc-core"
 version = "0.20.0-rc.5"
-source = "git+https://github.com/UniClipboard/core.git?rev=59e4339a2e1d7c247e3d33c7ec106bbb16c17c5c#59e4339a2e1d7c247e3d33c7ec106bbb16c17c5c"
+source = "git+https://github.com/UniClipboard/core.git?tag=core-v0.20.0-rc.5#59e4339a2e1d7c247e3d33c7ec106bbb16c17c5c"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -10042,7 +10042,7 @@ dependencies = [
 [[package]]
 name = "uc-engine"
 version = "0.20.0-rc.5"
-source = "git+https://github.com/UniClipboard/core.git?rev=59e4339a2e1d7c247e3d33c7ec106bbb16c17c5c#59e4339a2e1d7c247e3d33c7ec106bbb16c17c5c"
+source = "git+https://github.com/UniClipboard/core.git?tag=core-v0.20.0-rc.5#59e4339a2e1d7c247e3d33c7ec106bbb16c17c5c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10064,7 +10064,7 @@ dependencies = [
 [[package]]
 name = "uc-infra"
 version = "0.20.0-rc.5"
-source = "git+https://github.com/UniClipboard/core.git?rev=59e4339a2e1d7c247e3d33c7ec106bbb16c17c5c#59e4339a2e1d7c247e3d33c7ec106bbb16c17c5c"
+source = "git+https://github.com/UniClipboard/core.git?tag=core-v0.20.0-rc.5#59e4339a2e1d7c247e3d33c7ec106bbb16c17c5c"
 dependencies = [
  "anyhow",
  "argon2",
@@ -10121,7 +10121,7 @@ dependencies = [
 [[package]]
 name = "uc-mobile-proto"
 version = "0.20.0-rc.5"
-source = "git+https://github.com/UniClipboard/core.git?rev=59e4339a2e1d7c247e3d33c7ec106bbb16c17c5c#59e4339a2e1d7c247e3d33c7ec106bbb16c17c5c"
+source = "git+https://github.com/UniClipboard/core.git?tag=core-v0.20.0-rc.5#59e4339a2e1d7c247e3d33c7ec106bbb16c17c5c"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -10156,7 +10156,7 @@ dependencies = [
 [[package]]
 name = "uc-observability-contract"
 version = "0.20.0-rc.5"
-source = "git+https://github.com/UniClipboard/core.git?rev=59e4339a2e1d7c247e3d33c7ec106bbb16c17c5c#59e4339a2e1d7c247e3d33c7ec106bbb16c17c5c"
+source = "git+https://github.com/UniClipboard/core.git?tag=core-v0.20.0-rc.5#59e4339a2e1d7c247e3d33c7ec106bbb16c17c5c"
 dependencies = [
  "anyhow",
  "chrono",
@@ -10311,7 +10311,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11025,7 +11025,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11640,8 +11640,8 @@ dependencies = [
  "log",
  "serde",
  "thiserror 2.0.19",
- "windows 0.62.2",
- "windows-core 0.62.2",
+ "windows 0.59.0",
+ "windows-core 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,12 +47,12 @@ print_stdout = "warn"
 print_stderr = "warn"
 dbg_macro = "warn"
 
-# Shared dependencies for the immutable core revision and Tauri plugins.
+# Shared dependencies for the immutable core release and Tauri plugins.
 [workspace.dependencies]
-# All desktop consumers use one immutable core revision. Features remain
+# All desktop consumers use one immutable core release tag. Features remain
 # opt-in at each host boundary so LAN compatibility cannot become a default.
-uc-engine = { git = "https://github.com/UniClipboard/core.git", rev = "59e4339a2e1d7c247e3d33c7ec106bbb16c17c5c" }
-uc-observability-contract = { git = "https://github.com/UniClipboard/core.git", rev = "59e4339a2e1d7c247e3d33c7ec106bbb16c17c5c" }
+uc-engine = { git = "https://github.com/UniClipboard/core.git", tag = "core-v0.20.0-rc.5" }
+uc-observability-contract = { git = "https://github.com/UniClipboard/core.git", tag = "core-v0.20.0-rc.5" }
 
 # tauri 2.11 是 specta rc.25 兼容的最低版本 —— 2.10.x 及之前在
 # `tauri/src/ipc/channel.rs` 用了 `#[specta(remote=..., rename="...")]`

--- a/crates/AGENTS.md
+++ b/crates/AGENTS.md
@@ -4,7 +4,7 @@
 
 ## OVERVIEW
 
-Desktop Rust workspace (root `Cargo.toml`): system adapters and daemon libraries live in `crates/`, runnable `uniclip` and `uniclipd` binaries live in `apps/`, and Tauri packaging lives in `src-tauri/`. The portable engine is owned by the independent `UniClipboard/core` repository and is consumed here through one immutable Git revision. The GUI and CLI are loopback HTTP+WS clients of the standalone daemon.
+桌面 Rust 工作区以根目录 `Cargo.toml` 为入口：系统适配器和守护进程库位于 `crates/`，`uniclip` 与 `uniclipd` 位于 `apps/`，Tauri 打包位于 `src-tauri/`。可移植引擎由独立的 `UniClipboard/core` 仓库拥有，本仓通过一个固定发布标签使用它。GUI 和 CLI 都通过本机 HTTP 与 WebSocket 访问独立守护进程。
 
 ## STRUCTURE
 
@@ -41,7 +41,7 @@ Desktop Rust workspace (root `Cargo.toml`): system adapters and daemon libraries
 | ------------------------- | ---------------------------------------------------- | ----------------------------------------------------------------------- |
 | Tauri run loop & setup    | `src-tauri/crates/uc-tauri/src/run.rs`               | `run()` (line ~200); window/lifecycle, `.manage(...)`, `.setup(...)`    |
 | IPC command registration  | `src-tauri/crates/uc-tauri/src/specta_builder.rs`    | tauri-specta single source of truth (runtime invoke + codegen)          |
-| Core revision             | `Cargo.toml`                                         | One immutable `UniClipboard/core` revision for all consumers            |
+| Core 发布版本             | `Cargo.toml`                                         | 所有使用方共享一个固定的 `UniClipboard/core` 发布标签                   |
 | Desktop host preparation  | `crates/uc-bootstrap/src/wiring/`                    | Desktop paths, secure storage and clipboard selection                   |
 | Runtime/usecase accessors | `src-tauri/crates/uc-tauri/src/bootstrap/runtime.rs` | `AppRuntime`, `usecases()` factory                                      |
 | Tauri commands            | `src-tauri/crates/uc-tauri/src/commands/`            | Commands call app-layer usecases (or daemon HTTP since ADR-008)         |
@@ -61,7 +61,7 @@ Desktop Rust workspace (root `Cargo.toml`): system adapters and daemon libraries
 
 - Rust commands run from the repo root (the cargo workspace root); stop if `Cargo.toml` absent.
 - Portable engine, protocol, persistence, migration, and binding changes belong in `UniClipboard/core`; never recreate those packages here.
-- Upgrade the engine only by changing the single pinned revision in root `Cargo.toml` and updating `Cargo.lock`.
+- 升级引擎时，只修改根目录 `Cargo.toml` 中唯一的固定发布标签，并同步更新 `Cargo.lock`。
 - Desktop-only capability flow: platform adapter -> `uc-bootstrap/src/wiring/` -> `HostCapabilities` -> `Engine::start`.
 - Tauri command pattern: command -> `runtime.usecases().x()`; avoid direct `deps` access from command layer.
 - Event payloads emitted via `app.emit()` must use `#[serde(rename_all = "camelCase")]`.
@@ -75,7 +75,7 @@ Desktop Rust workspace (root `Cargo.toml`): system adapters and daemon libraries
 ## ANTI-PATTERNS (THIS PROJECT)
 
 - Copying core source, migrations, bindings, or LAN protocol packages back into desktop.
-- Adding a local path, branch, or floating tag for any package owned by `UniClipboard/core`.
+- 对 `UniClipboard/core` 拥有的包使用本地路径、分支或非发布标签。
 - Depending on core implementation packages from desktop production code instead of `uc-engine`.
 - Adding business logic inside `uc-tauri` command handlers or platform adapters.
 - Reintroducing code under any `src-legacy/` path.

--- a/docs/agent/architecture-rules.md
+++ b/docs/agent/architecture-rules.md
@@ -4,7 +4,7 @@ Use this document when changes touch module boundaries, cross-crate types, commi
 
 ## Hexagonal Architecture Boundaries
 
-仓库所有权已经固定：`uc-core`、`uc-application`、`uc-infra`、`uc-engine`、数据库迁移、绑定和 LAN 协议包都属于 `UniClipboard/core`。desktop 不得重新创建这些内容。核心变更必须先在核心仓实现并验证，再由 desktop 更新唯一的固定提交。
+仓库所有权已经固定：`uc-core`、`uc-application`、`uc-infra`、`uc-engine`、数据库迁移、绑定和 LAN 协议包都属于 `UniClipboard/core`。desktop 不得重新创建这些内容。核心变更必须先在核心仓实现并验证，再由 desktop 更新唯一的固定发布标签。
 
 - **Layering is fixed:**
   - `desktop host → uc-engine → core internals`

--- a/scripts/architecture/check-core-repository.mjs
+++ b/scripts/architecture/check-core-repository.mjs
@@ -9,8 +9,9 @@ import { fileURLToPath } from 'node:url'
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url))
 const REPOSITORY_ROOT = resolve(SCRIPT_DIR, '../..')
 const CORE_REPOSITORY = 'https://github.com/UniClipboard/core.git'
+const CORE_TAG = 'core-v0.20.0-rc.5'
 const CORE_REVISION = '59e4339a2e1d7c247e3d33c7ec106bbb16c17c5c'
-const DECLARED_CORE_SOURCE = `git+${CORE_REPOSITORY}?rev=${CORE_REVISION}`
+const DECLARED_CORE_SOURCE = `git+${CORE_REPOSITORY}?tag=${CORE_TAG}`
 const RESOLVED_CORE_SOURCE = `${DECLARED_CORE_SOURCE}#${CORE_REVISION}`
 
 const MIGRATED_PACKAGES = new Set([
@@ -113,7 +114,7 @@ function checkRepositoryBoundary(metadata, { checkPaths = true } = {}) {
         addProblem(
           problems,
           'core provenance',
-          `${packageMetadata.name} does not pin ${item.name} to ${CORE_REVISION}`
+          `${packageMetadata.name} does not pin ${item.name} to ${CORE_TAG}`
         )
       }
     }
@@ -136,7 +137,7 @@ function checkRepositoryBoundary(metadata, { checkPaths = true } = {}) {
     addProblem(
       problems,
       'core provenance',
-      `expected one resolved core source at ${CORE_REVISION}; found ${[...coreSources].join(', ')}`
+      `expected one resolved core source at ${CORE_TAG} (${CORE_REVISION}); found ${[...coreSources].join(', ')}`
     )
   }
 
@@ -146,7 +147,7 @@ function checkRepositoryBoundary(metadata, { checkPaths = true } = {}) {
       addProblem(
         problems,
         'core provenance',
-        `${packageMetadata.name} resolved outside the pinned core revision`
+        `${packageMetadata.name} resolved outside the pinned core release`
       )
     }
   }
@@ -182,7 +183,7 @@ function checkPublicSurface(metadata) {
       addProblem(
         problems,
         'consumer firewall',
-        `${packageName} must consume ${dependencyName} from the pinned core revision`
+        `${packageName} must consume ${dependencyName} from the pinned core release`
       )
     }
   }
@@ -288,13 +289,13 @@ function runNegativeFixtures(metadata, sources) {
     sources
   )
   expectRejected(
-    'moving core revision',
+    'different core tag',
     changed => {
       const contract = dependency(
         workspacePackageByName(changed, 'uc-observability'),
         'uc-observability-contract'
       )
-      contract.source = `git+${CORE_REPOSITORY}?rev=main`
+      contract.source = `git+${CORE_REPOSITORY}?tag=core-v0.20.0-rc.6`
     },
     metadata,
     sources


### PR DESCRIPTION
## Summary

- select the Core release through `core-v0.20.0-rc.5` instead of a raw revision
- keep repository checks pinned to both the release tag and its resolved commit
- update dependency guidance to match the release-tag policy

## Validation

- `cargo check --workspace --locked`
- `npm run check:core-repository`
- `git diff --check HEAD^..HEAD`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated core components to use a stable, immutable release tag for more consistent builds.
  * Enhanced repository validation to verify that core components reference the expected tagged release.
* **Documentation**
  * Clarified architecture and contribution guidance around core release references.
  * Localized selected repository guidance into Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->