### PR TITLE
fix(macos): restore Monterey compatibility

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,7 @@
         "@reduxjs/toolkit": "^2.12.0",
         "@sentry/react": "^10.53.1",
         "@tauri-apps/api": "^2.11.0",
-        "@tauri-apps/plugin-log": "2.8.0",
+        "@tauri-apps/plugin-log": "2.9.0",
         "@tauri-apps/plugin-notification": "^2.3.3",
         "@tauri-apps/plugin-opener": "^2.5.4",
         "@types/culori": "^4.0.1",
@@ -37,7 +37,6 @@
         "react-resizable-panels": "^4.11.1",
         "react-router-dom": "^7.15.1",
         "react-virtuoso": "^4.18.7",
-        "remark-gfm": "^4.0.1",
         "semver": "^7.7.4",
         "sonner": "^2.0.7",
         "tw-animate-css": "^1.4.0",
@@ -605,7 +604,7 @@
 
     "@tauri-apps/cli-win32-x64-msvc": ["@tauri-apps/cli-win32-x64-msvc@2.11.1", "", { "os": "win32", "cpu": "x64" }, "sha512-b3ORhIAKgp9ZYY+zBt7b7r0kLU2kjvyGF0+MS2SBym3emsweGPybEqocJcmtMuxyBhkOKHP4CiuEJEDuAlTx6A=="],
 
-    "@tauri-apps/plugin-log": ["@tauri-apps/plugin-log@2.8.0", "", { "dependencies": { "@tauri-apps/api": "^2.8.0" } }, "sha512-a+7rOq3MJwpTOLLKbL8d0qGZ85hgHw5pNOWusA9o3cf7cEgtYHiGY/+O8fj8MvywQIGqFv0da2bYQDlrqLE7rw=="],
+    "@tauri-apps/plugin-log": ["@tauri-apps/plugin-log@2.9.0", "", { "dependencies": { "@tauri-apps/api": "^2.11.0" } }, "sha512-Ql8okrnsguk0eDq1GvRfttFV5KaeW/7vcao6bdbkXCRJ1+2sWE15ZJvJVEKVANrOKy1mRngqC3IFIAP+wP5qSw=="],
 
     "@tauri-apps/plugin-notification": ["@tauri-apps/plugin-notification@2.3.3", "", { "dependencies": { "@tauri-apps/api": "^2.8.0" } }, "sha512-Zw+ZH18RJb41G4NrfHgIuofJiymusqN+q8fGUIIV7vyCH+5sSn5coqRv/MWB9qETsUs97vmU045q7OyseCV3Qg=="],
 
@@ -1687,25 +1686,9 @@
 
     "make-dir": ["make-dir@4.0.0", "", { "dependencies": { "semver": "^7.5.3" } }, "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw=="],
 
-    "markdown-table": ["markdown-table@3.0.4", "", {}, "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw=="],
-
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
-    "mdast-util-find-and-replace": ["mdast-util-find-and-replace@3.0.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "escape-string-regexp": "^5.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg=="],
-
     "mdast-util-from-markdown": ["mdast-util-from-markdown@2.0.3", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "mdast-util-to-string": "^4.0.0", "micromark": "^4.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-decode-string": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q=="],
-
-    "mdast-util-gfm": ["mdast-util-gfm@3.1.0", "", { "dependencies": { "mdast-util-from-markdown": "^2.0.0", "mdast-util-gfm-autolink-literal": "^2.0.0", "mdast-util-gfm-footnote": "^2.0.0", "mdast-util-gfm-strikethrough": "^2.0.0", "mdast-util-gfm-table": "^2.0.0", "mdast-util-gfm-task-list-item": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ=="],
-
-    "mdast-util-gfm-autolink-literal": ["mdast-util-gfm-autolink-literal@2.0.1", "", { "dependencies": { "@types/mdast": "^4.0.0", "ccount": "^2.0.0", "devlop": "^1.0.0", "mdast-util-find-and-replace": "^3.0.0", "micromark-util-character": "^2.0.0" } }, "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ=="],
-
-    "mdast-util-gfm-footnote": ["mdast-util-gfm-footnote@2.1.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "devlop": "^1.1.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0" } }, "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ=="],
-
-    "mdast-util-gfm-strikethrough": ["mdast-util-gfm-strikethrough@2.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg=="],
-
-    "mdast-util-gfm-table": ["mdast-util-gfm-table@2.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "markdown-table": "^3.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg=="],
-
-    "mdast-util-gfm-task-list-item": ["mdast-util-gfm-task-list-item@2.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ=="],
 
     "mdast-util-mdx-expression": ["mdast-util-mdx-expression@2.0.1", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ=="],
 
@@ -1734,20 +1717,6 @@
     "micromark": ["micromark@4.0.2", "", { "dependencies": { "@types/debug": "^4.0.0", "debug": "^4.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA=="],
 
     "micromark-core-commonmark": ["micromark-core-commonmark@2.0.3", "", { "dependencies": { "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-factory-destination": "^2.0.0", "micromark-factory-label": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-factory-title": "^2.0.0", "micromark-factory-whitespace": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-html-tag-name": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg=="],
-
-    "micromark-extension-gfm": ["micromark-extension-gfm@3.0.0", "", { "dependencies": { "micromark-extension-gfm-autolink-literal": "^2.0.0", "micromark-extension-gfm-footnote": "^2.0.0", "micromark-extension-gfm-strikethrough": "^2.0.0", "micromark-extension-gfm-table": "^2.0.0", "micromark-extension-gfm-tagfilter": "^2.0.0", "micromark-extension-gfm-task-list-item": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w=="],
-
-    "micromark-extension-gfm-autolink-literal": ["micromark-extension-gfm-autolink-literal@2.1.0", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw=="],
-
-    "micromark-extension-gfm-footnote": ["micromark-extension-gfm-footnote@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw=="],
-
-    "micromark-extension-gfm-strikethrough": ["micromark-extension-gfm-strikethrough@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw=="],
-
-    "micromark-extension-gfm-table": ["micromark-extension-gfm-table@2.1.1", "", { "dependencies": { "devlop": "^1.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg=="],
-
-    "micromark-extension-gfm-tagfilter": ["micromark-extension-gfm-tagfilter@2.0.0", "", { "dependencies": { "micromark-util-types": "^2.0.0" } }, "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg=="],
-
-    "micromark-extension-gfm-task-list-item": ["micromark-extension-gfm-task-list-item@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw=="],
 
     "micromark-factory-destination": ["micromark-factory-destination@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA=="],
 
@@ -2073,13 +2042,9 @@
 
     "regexp.prototype.flags": ["regexp.prototype.flags@1.5.4", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-errors": "^1.3.0", "get-proto": "^1.0.1", "gopd": "^1.2.0", "set-function-name": "^2.0.2" } }, "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA=="],
 
-    "remark-gfm": ["remark-gfm@4.0.1", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-gfm": "^3.0.0", "micromark-extension-gfm": "^3.0.0", "remark-parse": "^11.0.0", "remark-stringify": "^11.0.0", "unified": "^11.0.0" } }, "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg=="],
-
     "remark-parse": ["remark-parse@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-from-markdown": "^2.0.0", "micromark-util-types": "^2.0.0", "unified": "^11.0.0" } }, "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA=="],
 
     "remark-rehype": ["remark-rehype@11.1.2", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "mdast-util-to-hast": "^13.0.0", "unified": "^11.0.0", "vfile": "^6.0.0" } }, "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw=="],
-
-    "remark-stringify": ["remark-stringify@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-to-markdown": "^2.0.0", "unified": "^11.0.0" } }, "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw=="],
 
     "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
 
@@ -2734,8 +2699,6 @@
     "loose-envify/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "make-dir/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
-
-    "mdast-util-find-and-replace/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
 
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 

--- a/docs-site/content/docs/en/getting-started/install.mdx
+++ b/docs-site/content/docs/en/getting-started/install.mdx
@@ -13,6 +13,8 @@ below points at the same release artefacts on
 Tagged pre-releases carry an `-alpha.N` suffix and are flagged
 "Pre-release" on that page; non-suffixed tags are the stable line.
 
+<Callout type="info">The macOS desktop app requires macOS 12.5 or later.</Callout>
+
 ## Quick install (Linux / macOS)
 
 In a hurry? One command picks the right artefact for your OS and CPU:

--- a/docs-site/content/docs/zh/getting-started/install.mdx
+++ b/docs-site/content/docs/zh/getting-started/install.mdx
@@ -12,6 +12,8 @@ UniClipboard 为 Windows、macOS、Linux 提供桌面应用与 `uniclip` 命令�
 构建产物。带 `-alpha.N` 后缀的 tag 是预发布版本，会在 Releases 页面被
 标记为「Pre-release」；不带后缀的 tag 即正式发布。
 
+<Callout type="info">macOS 桌面应用需要 macOS 12.5 或更高版本。</Callout>
+
 ## 一键安装（Linux / macOS）
 
 赶时间？一行命令自动识别系统与架构、挑对安装包：

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "cross-env UNICLIPBOARD_ENV=development vite",
     "dev:sweep": "node -e \"try{require('child_process').execSync('cargo sweep --time 3 --target target',{stdio:'ignore'})}catch{}\"",
-    "build": "tsc && vite build",
+    "build": "tsc && vite build && node scripts/check-macos-compat.mjs",
     "preview": "vite preview",
     "version:bump": "node scripts/bump-version.js",
     "add:beui": "node scripts/add-beui.mjs",
@@ -65,7 +65,7 @@
     "@reduxjs/toolkit": "^2.12.0",
     "@sentry/react": "^10.53.1",
     "@tauri-apps/api": "^2.11.0",
-    "@tauri-apps/plugin-log": "2.8.0",
+    "@tauri-apps/plugin-log": "2.9.0",
     "@tauri-apps/plugin-notification": "^2.3.3",
     "@tauri-apps/plugin-opener": "^2.5.4",
     "@types/culori": "^4.0.1",
@@ -89,7 +89,6 @@
     "react-resizable-panels": "^4.11.1",
     "react-router-dom": "^7.15.1",
     "react-virtuoso": "^4.18.7",
-    "remark-gfm": "^4.0.1",
     "semver": "^7.7.4",
     "sonner": "^2.0.7",
     "tw-animate-css": "^1.4.0"

--- a/scripts/__tests__/macos-compat.test.ts
+++ b/scripts/__tests__/macos-compat.test.ts
@@ -1,0 +1,96 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { findUnsupportedJavaScript } from '../check-macos-compat.mjs'
+
+const projectRoot = path.resolve(__dirname, '../..')
+
+function readProjectFile(filePath: string): string {
+  try {
+    return fs.readFileSync(filePath, 'utf8')
+  } catch (error) {
+    throw new Error(`Unable to read required project file: ${filePath}`, { cause: error })
+  }
+}
+
+function parseProjectJson(filePath: string): unknown {
+  try {
+    return JSON.parse(readProjectFile(filePath))
+  } catch (error) {
+    throw new Error(`Unable to parse required project JSON: ${filePath}`, { cause: error })
+  }
+}
+
+function requireJsonObject(value: unknown, description: string): Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error(`Expected ${description} to be a JSON object`)
+  }
+  return value as Record<string, unknown>
+}
+
+describe('macOS 12.5 compatibility guard', () => {
+  const tempDirs: string[] = []
+
+  afterEach(() => {
+    while (tempDirs.length > 0) {
+      const dir = tempDirs.pop()
+      if (dir) fs.rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('reports positive and negative regular expression lookbehind in built JavaScript', () => {
+    const distDir = fs.mkdtempSync(path.join(os.tmpdir(), 'macos-compat-'))
+    tempDirs.push(distDir)
+    fs.mkdirSync(path.join(distDir, 'assets'))
+    fs.writeFileSync(path.join(distDir, 'assets', 'supported.js'), 'const value = /hello/u\n')
+    fs.writeFileSync(
+      path.join(distDir, 'assets', 'positive.js'),
+      'const value = /(?<=hello)world/u\n'
+    )
+    fs.writeFileSync(
+      path.join(distDir, 'assets', 'negative.js'),
+      'const value = /(?<!hello)world/u\n'
+    )
+
+    expect(findUnsupportedJavaScript(distDir)).toEqual([
+      {
+        file: path.join(distDir, 'assets', 'negative.js'),
+        syntax: 'negative regular expression lookbehind',
+      },
+      {
+        file: path.join(distDir, 'assets', 'positive.js'),
+        syntax: 'positive regular expression lookbehind',
+      },
+    ])
+  })
+
+  it('keeps the build and bundle configuration aligned with macOS 12.5', () => {
+    const packageJson = requireJsonObject(
+      parseProjectJson(path.join(projectRoot, 'package.json')),
+      'package.json'
+    )
+    const packageScripts = requireJsonObject(packageJson.scripts, 'package.json scripts')
+    const packageDependencies = requireJsonObject(
+      packageJson.dependencies,
+      'package.json dependencies'
+    )
+    const tauriConfig = requireJsonObject(
+      parseProjectJson(path.join(projectRoot, 'src-tauri', 'tauri.conf.json')),
+      'tauri.conf.json'
+    )
+    const tauriBundle = requireJsonObject(tauriConfig.bundle, 'tauri.conf.json bundle')
+    const macOSBundle = requireJsonObject(tauriBundle.macOS, 'tauri.conf.json macOS bundle')
+    const viteConfig = readProjectFile(path.join(projectRoot, 'vite.config.ts'))
+    const releaseNotes = readProjectFile(
+      path.join(projectRoot, 'src', 'components', 'update', 'ReleaseNotes.tsx')
+    )
+
+    expect(packageScripts.build).toContain('node scripts/check-macos-compat.mjs')
+    expect(packageDependencies).not.toHaveProperty('remark-gfm')
+    expect(macOSBundle.minimumSystemVersion).toBe('12.5')
+    expect(viteConfig).toMatch(/target:\s*'safari15\.6'/)
+    expect(viteConfig).toMatch(/cssTarget:\s*'safari15\.6'/)
+    expect(releaseNotes).not.toContain('remark-gfm')
+  })
+})

--- a/scripts/__tests__/macos-compat.test.ts
+++ b/scripts/__tests__/macos-compat.test.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
+import { resolveConfig } from 'vite'
 import { afterEach, describe, expect, it } from 'vitest'
 import { findUnsupportedJavaScript } from '../check-macos-compat.mjs'
 
@@ -39,7 +40,7 @@ describe('macOS 12.5 compatibility guard', () => {
     }
   })
 
-  it('reports positive and negative regular expression lookbehind in built JavaScript', () => {
+  it('reports lookbehind only in regular expression literals', () => {
     const distDir = fs.mkdtempSync(path.join(os.tmpdir(), 'macos-compat-'))
     tempDirs.push(distDir)
     fs.mkdirSync(path.join(distDir, 'assets'))
@@ -51,6 +52,15 @@ describe('macOS 12.5 compatibility guard', () => {
     fs.writeFileSync(
       path.join(distDir, 'assets', 'negative.js'),
       'const value = /(?<!hello)world/u\n'
+    )
+    fs.writeFileSync(
+      path.join(distDir, 'assets', 'non-regular-expression.js'),
+      [
+        "const text = '(?<=hello)world'",
+        'const template = `(?<!hello)world`',
+        '// (?<=hello)world',
+        '/* (?<!hello)world */',
+      ].join('\n')
     )
 
     expect(findUnsupportedJavaScript(distDir)).toEqual([
@@ -65,7 +75,7 @@ describe('macOS 12.5 compatibility guard', () => {
     ])
   })
 
-  it('keeps the build and bundle configuration aligned with macOS 12.5', () => {
+  it('keeps the build and bundle configuration aligned with macOS 12.5', async () => {
     const packageJson = requireJsonObject(
       parseProjectJson(path.join(projectRoot, 'package.json')),
       'package.json'
@@ -81,7 +91,11 @@ describe('macOS 12.5 compatibility guard', () => {
     )
     const tauriBundle = requireJsonObject(tauriConfig.bundle, 'tauri.conf.json bundle')
     const macOSBundle = requireJsonObject(tauriBundle.macOS, 'tauri.conf.json macOS bundle')
-    const viteConfig = readProjectFile(path.join(projectRoot, 'vite.config.ts'))
+    const viteConfig = await resolveConfig(
+      { configFile: path.join(projectRoot, 'vite.config.ts') },
+      'build',
+      'production'
+    )
     const releaseNotes = readProjectFile(
       path.join(projectRoot, 'src', 'components', 'update', 'ReleaseNotes.tsx')
     )
@@ -89,8 +103,8 @@ describe('macOS 12.5 compatibility guard', () => {
     expect(packageScripts.build).toContain('node scripts/check-macos-compat.mjs')
     expect(packageDependencies).not.toHaveProperty('remark-gfm')
     expect(macOSBundle.minimumSystemVersion).toBe('12.5')
-    expect(viteConfig).toMatch(/target:\s*'safari15\.6'/)
-    expect(viteConfig).toMatch(/cssTarget:\s*'safari15\.6'/)
+    expect(viteConfig.build.target).toBe('safari15.6')
+    expect(viteConfig.build.cssTarget).toBe('safari15.6')
     expect(releaseNotes).not.toContain('remark-gfm')
   })
 })

--- a/scripts/check-macos-compat.mjs
+++ b/scripts/check-macos-compat.mjs
@@ -1,0 +1,52 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+
+const unsupportedSyntax = [
+  { marker: '(?<!', syntax: 'negative regular expression lookbehind' },
+  { marker: '(?<=', syntax: 'positive regular expression lookbehind' },
+]
+
+function listJavaScriptFiles(directory) {
+  return fs
+    .readdirSync(directory, { recursive: true, withFileTypes: true })
+    .filter(entry => entry.isFile() && /\.m?js$/.test(entry.name))
+    .map(entry => path.join(entry.parentPath, entry.name))
+    .sort()
+}
+
+export function findUnsupportedJavaScript(directory) {
+  const findings = []
+
+  for (const file of listJavaScriptFiles(directory)) {
+    const content = fs.readFileSync(file, 'utf8')
+    for (const { marker, syntax } of unsupportedSyntax) {
+      if (content.includes(marker)) findings.push({ file, syntax })
+    }
+  }
+
+  return findings
+}
+
+export function checkMacOSCompatibility(directory) {
+  const findings = findUnsupportedJavaScript(directory)
+  if (findings.length === 0) return
+
+  const details = findings
+    .map(({ file, syntax }) => `- ${path.relative(process.cwd(), file)}: ${syntax}`)
+    .join('\n')
+  throw new Error(`Built JavaScript is incompatible with macOS 12.5:\n${details}`)
+}
+
+const isMain = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+if (isMain) {
+  const directory = path.resolve(process.argv[2] ?? 'dist')
+  try {
+    checkMacOSCompatibility(directory)
+    console.log(`macOS 12.5 compatibility check passed: ${path.relative(process.cwd(), directory)}`)
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : error)
+    process.exitCode = 1
+  }
+}

--- a/scripts/check-macos-compat.mjs
+++ b/scripts/check-macos-compat.mjs
@@ -2,6 +2,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 import process from 'node:process'
 import { fileURLToPath } from 'node:url'
+import { parseAst } from 'vite'
 
 const unsupportedSyntax = [
   { marker: '(?<!', syntax: 'negative regular expression lookbehind' },
@@ -16,13 +17,27 @@ function listJavaScriptFiles(directory) {
     .sort()
 }
 
+function findRegularExpressionPatterns(node, patterns = []) {
+  if (typeof node !== 'object' || node === null) return patterns
+
+  if (node.type === 'Literal' && node.regex?.pattern) patterns.push(node.regex.pattern)
+
+  for (const value of Object.values(node)) findRegularExpressionPatterns(value, patterns)
+
+  return patterns
+}
+
 export function findUnsupportedJavaScript(directory) {
   const findings = []
 
   for (const file of listJavaScriptFiles(directory)) {
     const content = fs.readFileSync(file, 'utf8')
+    const regularExpressionPatterns = findRegularExpressionPatterns(parseAst(content))
+
     for (const { marker, syntax } of unsupportedSyntax) {
-      if (content.includes(marker)) findings.push({ file, syntax })
+      if (regularExpressionPatterns.some(pattern => pattern.includes(marker))) {
+        findings.push({ file, syntax })
+      }
     }
   }
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -52,6 +52,9 @@
       "icons/icon.icns",
       "icons/icon.ico"
     ],
+    "macOS": {
+      "minimumSystemVersion": "12.5"
+    },
     "linux": {
       "deb": {
         "depends": ["libayatana-appindicator3-1"],

--- a/src/components/update/ReleaseNotes.tsx
+++ b/src/components/update/ReleaseNotes.tsx
@@ -2,7 +2,6 @@ import { openUrl } from '@tauri-apps/plugin-opener'
 import type { ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
 import Markdown from 'react-markdown'
-import remarkGfm from 'remark-gfm'
 import { createLogger } from '@/lib/logger'
 
 interface ReleaseNotesProps {
@@ -54,9 +53,7 @@ export function ReleaseNotes({ content, fallback }: ReleaseNotesProps) {
                     prose-headings:text-sm prose-headings:font-semibold prose-headings:mt-3 prose-headings:mb-1
                     prose-ul:my-1 prose-li:my-0 prose-p:my-1"
     >
-      <Markdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
-        {displayContent}
-      </Markdown>
+      <Markdown components={markdownComponents}>{displayContent}</Markdown>
     </div>
   )
 }

--- a/src/components/update/__tests__/ReleaseNotes.test.tsx
+++ b/src/components/update/__tests__/ReleaseNotes.test.tsx
@@ -1,0 +1,31 @@
+import { openUrl } from '@tauri-apps/plugin-opener'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ReleaseNotes } from '@/components/update/ReleaseNotes'
+
+vi.mock('@tauri-apps/plugin-opener', () => ({
+  openUrl: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ i18n: { language: 'en' } }),
+}))
+
+describe('ReleaseNotes', () => {
+  it('renders headings, lists, and explicit links without optional Markdown extensions', async () => {
+    const user = userEvent.setup()
+    render(
+      <ReleaseNotes
+        content={'## Changes\n\n- Fixed startup\n\n[Read more](https://example.com/release)'}
+        fallback="No notes"
+      />
+    )
+
+    expect(screen.getByRole('heading', { name: 'Changes' })).toBeInTheDocument()
+    expect(screen.getByRole('listitem')).toHaveTextContent('Fixed startup')
+
+    await user.click(screen.getByRole('link', { name: 'Read more' }))
+
+    expect(openUrl).toHaveBeenCalledWith('https://example.com/release')
+  })
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -29,6 +29,8 @@ export default defineConfig({
 
   // Multi-page build: main app + clipboard panel
   build: {
+    target: 'safari15.6',
+    cssTarget: 'safari15.6',
     // 'hidden' generates sourcemaps for upload but strips the
     // //# sourceMappingURL= comment from emitted JS, so the public bundle
     // does not advertise the map location.


### PR DESCRIPTION
## Summary

- Restore macOS 12.5 desktop compatibility by targeting Safari 15.6, declaring the bundle minimum system version, and rejecting unsupported regular-expression lookbehind in release bundles. (1f1731f8f)
- Remove the incompatible `remark-gfm` release-notes extension and upgrade the Tauri log plugin. (1f1731f8f)
- Document the macOS 12.5 minimum requirement in the English and Chinese installation guides. (6e483dc6a)

## Test plan

- [x] `./node_modules/.bin/vitest run scripts/__tests__/macos-compat.test.ts src/components/update/__tests__/ReleaseNotes.test.tsx --reporter=verbose`
- [x] `bun run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an installation callout in English and Chinese indicating the macOS desktop app requires macOS 12.5 or later.

* **Compatibility**
  * Added a stricter macOS 12.5 compatibility check for built JavaScript assets.
  * Updated macOS bundle minimum version and build target settings to align with macOS 12.5.

* **Bug Fixes**
  * Improved release-notes Markdown rendering while keeping headings, lists, and links working.

* **Tests**
  * Added automated coverage for the macOS compatibility checks and release-notes link behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->