### PR TITLE
fix(windows): restore clipboard build

### DIFF
--- a/crates/uc-platform/src/clipboard/common.rs
+++ b/crates/uc-platform/src/clipboard/common.rs
@@ -979,10 +979,9 @@ impl CommonClipboardImpl {
         ctx: &mut clipboard_rs::ClipboardContext,
         snapshot: SystemClipboardSnapshot,
     ) -> Result<()> {
-        let rep_count = snapshot.representations.len();
-
         #[cfg(target_os = "windows")]
         {
+            let _ = ctx;
             // 把实际实现委托给平台子模块。
             // common.rs 通过 `crate::clipboard::platform::windows::write_snapshot_multi_windows`
             // 调用，不跨 crate 暴露，符合 §4.4 cfg 收敛原则。
@@ -997,7 +996,6 @@ impl CommonClipboardImpl {
             // 不使用传入的 clipboard-rs `ctx`，也不需要 "提前 drop + dummy_ctx" 的绕道
             //（与 Windows 不同：macOS NSPasteboard 不是独占句柄模型）。
             let _ = ctx; // 显式标注未使用，消除 unused-variable warning。
-            let _ = rep_count; // macOS 分支不需要 rep_count，显式忽略。
             crate::clipboard::platform::macos::write_snapshot_multi_macos(snapshot)
         }
 
@@ -1014,6 +1012,7 @@ impl CommonClipboardImpl {
             not(any(target_os = "windows", target_os = "macos"))
         ))]
         {
+            let rep_count = snapshot.representations.len();
             let chosen_idx = crate::clipboard::model::select_paste_representation_index(&snapshot)
                 .ok_or_else(|| anyhow!("no usable clipboard representation"))?;
 

--- a/crates/uc-platform/src/clipboard/model.rs
+++ b/crates/uc-platform/src/clipboard/model.rs
@@ -97,6 +97,10 @@ impl MimeType {
         }
     }
 
+    pub fn is_text_plain(&self) -> bool {
+        self.classify() == MimeClass::TextPlain
+    }
+
     pub fn is_uri_list(&self) -> bool {
         self.classify() == MimeClass::UriList
     }
@@ -411,4 +415,15 @@ pub fn select_paste_representation_index(snapshot: &SystemClipboardSnapshot) -> 
             }
         })
         .map(|(index, _)| index)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::MimeType;
+
+    #[test]
+    fn mime_type_text_plain_predicate_accepts_parameters_and_rejects_images() {
+        assert!(MimeType("text/plain;charset=utf-8".into()).is_text_plain());
+        assert!(!MimeType("image/png".into()).is_text_plain());
+    }
 }

--- a/crates/uc-platform/src/clipboard/platform/windows.rs
+++ b/crates/uc-platform/src/clipboard/platform/windows.rs
@@ -1225,7 +1225,7 @@ fn read_image_windows_as_png() -> Result<Vec<u8>> {
 /// (PNG, TIFF, JPEG, BMP, etc.), decodes them, and writes as CF_DIB
 /// (BITMAPINFOHEADER + pixel data, without 14-byte BMP file header).
 fn write_image_windows(bytes: &[u8]) -> Result<()> {
-    use clipboard_win::{formats, Clipboard as ClipboardWin, Setter};
+    use clipboard_win::{formats, Clipboard as ClipboardWin};
 
     // Decode image bytes (supports PNG, TIFF, JPEG, BMP, etc. via `image` crate)
     let img = image::load_from_memory(bytes)


### PR DESCRIPTION
## Summary

- Restore the plain-text MIME predicate omitted during the core extraction so the Windows clipboard implementation compiles again (`7a916bae4`).
- Scope platform-only values and imports to the targets that use them, removing the three Windows build warnings (`7a916bae4`).
- Add regression coverage for parameterized `text/plain` detection (`7a916bae4`).
- Leave docs unchanged because this is a build-only repair with no user-facing behavior change.

## Test plan

- [x] `cargo check -p uc-platform --release --target x86_64-pc-windows-gnu --locked`
- [x] `cargo test -p uc-platform --locked`
- [x] `cargo fmt -p uc-platform -- --check`
- [x] `cargo check -p uc-daemon --bin uniclipd --release --locked`
- [ ] GitHub Actions Windows job builds `uniclipd` with the native MSVC toolchain


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved clipboard handling for plain-text content that includes character-set parameters, such as `text/plain; charset=utf-8`.
  * Improved platform-specific clipboard processing across Windows, macOS, and Linux while preserving existing behavior.
* **Tests**
  * Added coverage for recognizing plain-text MIME types and rejecting non-text formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->