### PR TITLE
fix(pairing): restore completion notifications

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -331,7 +331,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -342,7 +342,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2205,7 +2205,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2598,7 +2598,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3085,8 +3085,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
 ]
 
 [[package]]
@@ -3738,7 +3738,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "tokio",
  "tower-service",
  "tracing",
@@ -3756,7 +3756,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.59.0",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -5019,7 +5019,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.19",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5377,7 +5377,7 @@ dependencies = [
  "pin-project-lite",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "thiserror 2.0.19",
  "tokio",
  "tokio-stream",
@@ -5422,7 +5422,7 @@ checksum = "b3c1520eacd33fd6b009e2e70116b05508ade51db5e0d315ff8bf6b702148c2b"
 dependencies = [
  "cfg_aliases",
  "libc",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -5456,7 +5456,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5592,7 +5592,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 2.0.2",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -6816,7 +6816,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "thiserror 2.0.19",
  "tokio",
  "tracing",
@@ -6855,9 +6855,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7164,7 +7164,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "rustix 1.1.4",
- "windows 0.61.3",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -7488,7 +7488,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7547,7 +7547,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7746,7 +7746,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8294,7 +8294,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9214,7 +9214,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9737,7 +9737,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.19",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9785,8 +9785,8 @@ dependencies = [
 
 [[package]]
 name = "uc-application"
-version = "0.20.0-rc.5"
-source = "git+https://github.com/UniClipboard/core.git?tag=core-v0.20.0-rc.5#59e4339a2e1d7c247e3d33c7ec106bbb16c17c5c"
+version = "0.20.0-rc.6"
+source = "git+https://github.com/UniClipboard/core.git?tag=core-v0.20.0-rc.6#bd710f635169da0421373be0982f651b159e1e95"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9882,8 +9882,8 @@ dependencies = [
 
 [[package]]
 name = "uc-content-hash"
-version = "0.20.0-rc.5"
-source = "git+https://github.com/UniClipboard/core.git?tag=core-v0.20.0-rc.5#59e4339a2e1d7c247e3d33c7ec106bbb16c17c5c"
+version = "0.20.0-rc.6"
+source = "git+https://github.com/UniClipboard/core.git?tag=core-v0.20.0-rc.6#bd710f635169da0421373be0982f651b159e1e95"
 dependencies = [
  "blake3",
  "hex",
@@ -9891,8 +9891,8 @@ dependencies = [
 
 [[package]]
 name = "uc-core"
-version = "0.20.0-rc.5"
-source = "git+https://github.com/UniClipboard/core.git?tag=core-v0.20.0-rc.5#59e4339a2e1d7c247e3d33c7ec106bbb16c17c5c"
+version = "0.20.0-rc.6"
+source = "git+https://github.com/UniClipboard/core.git?tag=core-v0.20.0-rc.6#bd710f635169da0421373be0982f651b159e1e95"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -10042,8 +10042,8 @@ dependencies = [
 
 [[package]]
 name = "uc-engine"
-version = "0.20.0-rc.5"
-source = "git+https://github.com/UniClipboard/core.git?tag=core-v0.20.0-rc.5#59e4339a2e1d7c247e3d33c7ec106bbb16c17c5c"
+version = "0.20.0-rc.6"
+source = "git+https://github.com/UniClipboard/core.git?tag=core-v0.20.0-rc.6#bd710f635169da0421373be0982f651b159e1e95"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10064,8 +10064,8 @@ dependencies = [
 
 [[package]]
 name = "uc-infra"
-version = "0.20.0-rc.5"
-source = "git+https://github.com/UniClipboard/core.git?tag=core-v0.20.0-rc.5#59e4339a2e1d7c247e3d33c7ec106bbb16c17c5c"
+version = "0.20.0-rc.6"
+source = "git+https://github.com/UniClipboard/core.git?tag=core-v0.20.0-rc.6#bd710f635169da0421373be0982f651b159e1e95"
 dependencies = [
  "anyhow",
  "argon2",
@@ -10121,8 +10121,8 @@ dependencies = [
 
 [[package]]
 name = "uc-mobile-proto"
-version = "0.20.0-rc.5"
-source = "git+https://github.com/UniClipboard/core.git?tag=core-v0.20.0-rc.5#59e4339a2e1d7c247e3d33c7ec106bbb16c17c5c"
+version = "0.20.0-rc.6"
+source = "git+https://github.com/UniClipboard/core.git?tag=core-v0.20.0-rc.6#bd710f635169da0421373be0982f651b159e1e95"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -10156,8 +10156,8 @@ dependencies = [
 
 [[package]]
 name = "uc-observability-contract"
-version = "0.20.0-rc.5"
-source = "git+https://github.com/UniClipboard/core.git?tag=core-v0.20.0-rc.5#59e4339a2e1d7c247e3d33c7ec106bbb16c17c5c"
+version = "0.20.0-rc.6"
+source = "git+https://github.com/UniClipboard/core.git?tag=core-v0.20.0-rc.6#bd710f635169da0421373be0982f651b159e1e95"
 dependencies = [
  "anyhow",
  "chrono",
@@ -10312,7 +10312,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11026,7 +11026,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11641,8 +11641,8 @@ dependencies = [
  "log",
  "serde",
  "thiserror 2.0.19",
- "windows 0.59.0",
- "windows-core 0.59.0",
+ "windows 0.62.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,8 +51,8 @@ dbg_macro = "warn"
 [workspace.dependencies]
 # All desktop consumers use one immutable core release tag. Features remain
 # opt-in at each host boundary so LAN compatibility cannot become a default.
-uc-engine = { git = "https://github.com/UniClipboard/core.git", tag = "core-v0.20.0-rc.5" }
-uc-observability-contract = { git = "https://github.com/UniClipboard/core.git", tag = "core-v0.20.0-rc.5" }
+uc-engine = { git = "https://github.com/UniClipboard/core.git", tag = "core-v0.20.0-rc.6" }
+uc-observability-contract = { git = "https://github.com/UniClipboard/core.git", tag = "core-v0.20.0-rc.6" }
 
 # tauri 2.11 是 specta rc.25 兼容的最低版本 —— 2.10.x 及之前在
 # `tauri/src/ipc/channel.rs` 用了 `#[specta(remote=..., rename="...")]`

--- a/apps/daemon/src/daemon/engine_events.rs
+++ b/apps/daemon/src/daemon/engine_events.rs
@@ -2,11 +2,12 @@ use std::sync::Arc;
 
 use tokio::sync::broadcast;
 use tokio_util::sync::CancellationToken;
+use uc_daemon_contract::api::dto::setup_events::SetupPairingCompletedEvent;
 use uc_daemon_contract::api::types::{DaemonWsEvent, PeerSnapshotDto, PeersChangedFullPayload};
 use uc_daemon_contract::constants::{ws_event, ws_topic};
 use uc_engine::{
     ActiveClipboardChanged, Engine, EngineEvent, EventStream, Operation, OperationResult,
-    PeerConnectionChannelSummary, PeerConnectionSummary,
+    PairingCompletion, PeerConnectionChannelSummary, PeerConnectionSummary,
 };
 
 use super::mobile_lan_lifecycle::{mobile_lan_target, MobileLanLifecycleController};
@@ -35,6 +36,9 @@ pub(crate) async fn forward_engine_events(
                     EngineEvent::PeerPresenceChanged(_) | EngineEvent::RefreshRequired { .. } => {
                         publish_peer_snapshot(&engine, &event_tx).await;
                     }
+                    EngineEvent::PairingCompleted(completion) => {
+                        publish_pairing_completion(&engine, &event_tx, completion).await;
+                    }
                     EngineEvent::MobileLanSettingsChanged(settings) => {
                         mobile_lan
                             .reconcile(mobile_lan_target(
@@ -58,6 +62,61 @@ pub(crate) async fn forward_engine_events(
             }
         }
     }
+}
+
+async fn publish_pairing_completion(
+    engine: &Engine,
+    event_tx: &broadcast::Sender<DaemonWsEvent>,
+    completion: PairingCompletion,
+) {
+    let local_device = match engine.execute(Operation::QueryLocalDevice).await {
+        Ok(OperationResult::LocalDevice(local_device)) => local_device,
+        Ok(_) => {
+            tracing::warn!("engine returned an unexpected local-device result");
+            return;
+        }
+        Err(error) => {
+            tracing::warn!(
+                code = error.code(),
+                category = %error.category(),
+                "failed to resolve the sponsor device for pairing completion"
+            );
+            return;
+        }
+    };
+
+    let event = match pairing_completion_ws_event(local_device.device_id, completion) {
+        Ok(event) => event,
+        Err(error) => {
+            tracing::warn!(error = %error, "failed to serialize pairing completion");
+            return;
+        }
+    };
+    let _ = event_tx.send(event);
+}
+
+fn pairing_completion_ws_event(
+    sponsor_device_id: String,
+    completion: PairingCompletion,
+) -> Result<DaemonWsEvent, serde_json::Error> {
+    let (joiner_device_id, success, reason) = match completion {
+        PairingCompletion::Success { peer_device_id } => (Some(peer_device_id), true, None),
+        PairingCompletion::Failure { reason } => (None, false, Some(reason)),
+    };
+    let payload = serde_json::to_value(SetupPairingCompletedEvent {
+        sponsor_device_id,
+        joiner_device_id,
+        success,
+        reason,
+    })?;
+
+    Ok(DaemonWsEvent {
+        topic: ws_topic::SETUP.to_string(),
+        event_type: ws_event::SETUP_PAIRING_COMPLETED.to_string(),
+        session_id: None,
+        ts: chrono::Utc::now().timestamp_millis(),
+        payload,
+    })
 }
 
 async fn publish_peer_snapshot(engine: &Engine, event_tx: &broadcast::Sender<DaemonWsEvent>) {
@@ -118,11 +177,47 @@ fn peer_to_dto(peer: PeerConnectionSummary) -> PeerSnapshotDto {
 mod tests {
     use uc_daemon_contract::constants::{ws_event, ws_topic};
     use uc_engine::{
-        EngineEvent, InboundNoticeActionSummary, InboundNoticeEvent, TransferDirectionSummary,
-        TransferProgress,
+        EngineEvent, InboundNoticeActionSummary, InboundNoticeEvent, PairingCompletion,
+        TransferDirectionSummary, TransferProgress,
     };
 
-    use super::daemon_ws_event;
+    use super::{daemon_ws_event, pairing_completion_ws_event};
+
+    #[test]
+    fn pairing_success_becomes_setup_completion_event() {
+        let event = pairing_completion_ws_event(
+            "sponsor-1".into(),
+            PairingCompletion::Success {
+                peer_device_id: "joiner-2".into(),
+            },
+        )
+        .expect("pairing completion websocket event");
+
+        assert_eq!(event.topic, ws_topic::SETUP);
+        assert_eq!(event.event_type, ws_event::SETUP_PAIRING_COMPLETED);
+        assert_eq!(event.payload["sponsorDeviceId"], "sponsor-1");
+        assert_eq!(event.payload["joinerDeviceId"], "joiner-2");
+        assert_eq!(event.payload["success"], true);
+        assert!(event.payload["reason"].is_null());
+    }
+
+    #[test]
+    fn pairing_failure_becomes_setup_completion_event() {
+        let event = pairing_completion_ws_event(
+            "sponsor-1".into(),
+            PairingCompletion::Failure {
+                reason: "passphrase_mismatch".into(),
+            },
+        )
+        .expect("pairing completion websocket event");
+
+        assert_eq!(event.topic, ws_topic::SETUP);
+        assert_eq!(event.event_type, ws_event::SETUP_PAIRING_COMPLETED);
+        assert_eq!(event.payload["sponsorDeviceId"], "sponsor-1");
+        assert!(event.payload["joinerDeviceId"].is_null());
+        assert_eq!(event.payload["success"], false);
+        assert_eq!(event.payload["reason"], "passphrase_mismatch");
+    }
 
     #[test]
     fn inbound_notice_keeps_the_existing_watch_wire_shape() {

--- a/crates/AGENTS.md
+++ b/crates/AGENTS.md
@@ -1,6 +1,6 @@
 # PROJECT KNOWLEDGE BASE
 
-**Last refreshed:** 2026-07-26 (auto; 16 workspace crates)
+**Last refreshed:** 2026-07-27 (auto; 16 workspace crates)
 
 ## OVERVIEW
 

--- a/crates/uc-webserver/src/api/event_emitter.rs
+++ b/crates/uc-webserver/src/api/event_emitter.rs
@@ -120,6 +120,7 @@ pub fn engine_event_to_ws(event: EngineEvent) -> Option<DaemonWsEvent> {
         ),
         EngineEvent::StateChanged { .. }
         | EngineEvent::PeerPresenceChanged(_)
+        | EngineEvent::PairingCompleted(_)
         | EngineEvent::ActiveClipboardChanged(_)
         | EngineEvent::MobileLanSettingsChanged(_)
         | EngineEvent::RefreshRequired { .. }

--- a/scripts/architecture/check-core-repository.mjs
+++ b/scripts/architecture/check-core-repository.mjs
@@ -9,8 +9,8 @@ import { fileURLToPath } from 'node:url'
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url))
 const REPOSITORY_ROOT = resolve(SCRIPT_DIR, '../..')
 const CORE_REPOSITORY = 'https://github.com/UniClipboard/core.git'
-const CORE_TAG = 'core-v0.20.0-rc.5'
-const CORE_REVISION = '59e4339a2e1d7c247e3d33c7ec106bbb16c17c5c'
+const CORE_TAG = 'core-v0.20.0-rc.6'
+const CORE_REVISION = 'bd710f635169da0421373be0982f651b159e1e95'
 const DECLARED_CORE_SOURCE = `git+${CORE_REPOSITORY}?tag=${CORE_TAG}`
 const RESOLVED_CORE_SOURCE = `${DECLARED_CORE_SOURCE}#${CORE_REVISION}`
 
@@ -295,7 +295,7 @@ function runNegativeFixtures(metadata, sources) {
         workspacePackageByName(changed, 'uc-observability'),
         'uc-observability-contract'
       )
-      contract.source = `git+${CORE_REPOSITORY}?tag=core-v0.20.0-rc.6`
+      contract.source = `git+${CORE_REPOSITORY}?tag=core-v0.20.0-rc.5`
     },
     metadata,
     sources

--- a/src/components/device/__tests__/AddDeviceDialog.test.tsx
+++ b/src/components/device/__tests__/AddDeviceDialog.test.tsx
@@ -6,7 +6,7 @@
  * 这里用 StrictMode 渲染,确保双跑后仍然能拿到邀请码而不是卡在 loading。
  */
 
-import { render, screen, waitFor } from '@testing-library/react'
+import { act, render, screen, waitFor } from '@testing-library/react'
 import { StrictMode } from 'react'
 import { I18nextProvider } from 'react-i18next'
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -15,6 +15,14 @@ import i18n from '@/i18n'
 
 const getSetupState = vi.fn()
 const issuePairingInvitation = vi.fn()
+let pairingCompletedHandler:
+  | ((event: {
+      sponsorDeviceId: string
+      joinerDeviceId: string | null
+      success: boolean
+      reason: string | null
+    }) => void)
+  | undefined
 
 vi.mock('@/api/daemon/setupV2', () => ({
   getSetupState: () => getSetupState(),
@@ -23,7 +31,10 @@ vi.mock('@/api/daemon/setupV2', () => ({
 }))
 
 vi.mock('@/api/setupEvents', () => ({
-  onSetupPairingCompleted: vi.fn(() => Promise.resolve(() => undefined)),
+  onSetupPairingCompleted: vi.fn(callback => {
+    pairingCompletedHandler = callback
+    return Promise.resolve(() => undefined)
+  }),
   onSetupInvitationRevoked: vi.fn(() => Promise.resolve(() => undefined)),
 }))
 
@@ -51,6 +62,7 @@ describe('AddDeviceDialog invitation issuing', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    pairingCompletedHandler = undefined
     getSetupState.mockResolvedValue({
       hasCompleted: true,
       currentInvitation: null,
@@ -83,5 +95,32 @@ describe('AddDeviceDialog invitation issuing', () => {
       expect(screen.getByLabelText('123456789')).toBeInTheDocument()
     })
     expect(issuePairingInvitation).toHaveBeenCalledTimes(1)
+  })
+
+  it('replaces the invitation with success when pairing completes', async () => {
+    render(
+      <I18nextProvider i18n={i18n}>
+        <AddDeviceDialog open onOpenChange={() => undefined} />
+      </I18nextProvider>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('123456789')).toBeInTheDocument()
+      expect(pairingCompletedHandler).toBeTypeOf('function')
+    })
+
+    act(() => {
+      pairingCompletedHandler?.({
+        sponsorDeviceId: 'sponsor-1',
+        joinerDeviceId: 'joiner-2',
+        success: true,
+        reason: null,
+      })
+    })
+
+    await waitFor(() => {
+      expect(screen.queryByLabelText('123456789')).not.toBeInTheDocument()
+      expect(screen.getAllByText(i18n.t('devices.addDevice.success.title'))).not.toHaveLength(0)
+    })
   })
 })


### PR DESCRIPTION
## Summary

- Restore the pairing completion notification from the Core engine to the desktop setup flow (`61de34378`).
- Update desktop to the released `core-v0.20.0-rc.6` version that provides the completion result.
- Hide the invitation and show the success state as soon as pairing completes.
- Leave user documentation unchanged because the documented pairing behavior did not change. No telemetry was added; logging remains privacy-safe.

## Test plan

- [x] Run daemon pairing completion tests (`cargo test -p uc-daemon pairing_ --locked`).
- [x] Run the Add Device dialog tests (`npm test -- --run src/components/device/__tests__/AddDeviceDialog.test.tsx`).
- [x] Verify the pinned Core release (`npm run check:core-repository`).
- [x] Check the full workspace, frontend types, lint, formatting, React health, and related test suites.
- [x] Reproduce invitation and join locally with two isolated desktop instances and confirm the success state replaces the invitation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pairing-completion notifications for setup flows, including sponsor device details and success or failure status.
  * Pairing completion now updates the invitation experience by removing the invitation code and displaying successful setup feedback.

* **Bug Fixes**
  * Improved pairing event handling to ensure completed pairing results are surfaced consistently.

* **Tests**
  * Added coverage for successful and failed pairing notifications and the updated invitation flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->