### PR TITLE
fix(sync): keep inbound notifications lightweight

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10285,6 +10285,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.19",
  "tokio",
+ "tokio-tungstenite",
  "tokio-util",
  "tower",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -331,7 +331,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -342,7 +342,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2205,7 +2205,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2598,7 +2598,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3085,8 +3085,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
 ]
 
 [[package]]
@@ -3738,7 +3738,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -3756,7 +3756,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.59.0",
 ]
 
 [[package]]
@@ -5019,7 +5019,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.19",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5377,7 +5377,7 @@ dependencies = [
  "pin-project-lite",
  "rustc-hash",
  "rustls",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "thiserror 2.0.19",
  "tokio",
  "tokio-stream",
@@ -5422,7 +5422,7 @@ checksum = "b3c1520eacd33fd6b009e2e70116b05508ade51db5e0d315ff8bf6b702148c2b"
 dependencies = [
  "cfg_aliases",
  "libc",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -5456,7 +5456,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5592,7 +5592,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 2.0.2",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -6816,7 +6816,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "thiserror 2.0.19",
  "tokio",
  "tracing",
@@ -6855,9 +6855,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7164,7 +7164,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "rustix 1.1.4",
- "windows 0.62.2",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -7488,7 +7488,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7547,7 +7547,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7746,7 +7746,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8294,7 +8294,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9214,7 +9214,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9737,7 +9737,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.19",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9785,8 +9785,8 @@ dependencies = [
 
 [[package]]
 name = "uc-application"
-version = "0.20.0-rc.6"
-source = "git+https://github.com/UniClipboard/core.git?tag=core-v0.20.0-rc.6#bd710f635169da0421373be0982f651b159e1e95"
+version = "0.20.0-rc.7"
+source = "git+https://github.com/UniClipboard/core.git?tag=core-v0.20.0-rc.7#069cdcc2e0cd2bd3f01e42a74ba56c820491bfe0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9882,8 +9882,8 @@ dependencies = [
 
 [[package]]
 name = "uc-content-hash"
-version = "0.20.0-rc.6"
-source = "git+https://github.com/UniClipboard/core.git?tag=core-v0.20.0-rc.6#bd710f635169da0421373be0982f651b159e1e95"
+version = "0.20.0-rc.7"
+source = "git+https://github.com/UniClipboard/core.git?tag=core-v0.20.0-rc.7#069cdcc2e0cd2bd3f01e42a74ba56c820491bfe0"
 dependencies = [
  "blake3",
  "hex",
@@ -9891,8 +9891,8 @@ dependencies = [
 
 [[package]]
 name = "uc-core"
-version = "0.20.0-rc.6"
-source = "git+https://github.com/UniClipboard/core.git?tag=core-v0.20.0-rc.6#bd710f635169da0421373be0982f651b159e1e95"
+version = "0.20.0-rc.7"
+source = "git+https://github.com/UniClipboard/core.git?tag=core-v0.20.0-rc.7#069cdcc2e0cd2bd3f01e42a74ba56c820491bfe0"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -10042,8 +10042,8 @@ dependencies = [
 
 [[package]]
 name = "uc-engine"
-version = "0.20.0-rc.6"
-source = "git+https://github.com/UniClipboard/core.git?tag=core-v0.20.0-rc.6#bd710f635169da0421373be0982f651b159e1e95"
+version = "0.20.0-rc.7"
+source = "git+https://github.com/UniClipboard/core.git?tag=core-v0.20.0-rc.7#069cdcc2e0cd2bd3f01e42a74ba56c820491bfe0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10064,8 +10064,8 @@ dependencies = [
 
 [[package]]
 name = "uc-infra"
-version = "0.20.0-rc.6"
-source = "git+https://github.com/UniClipboard/core.git?tag=core-v0.20.0-rc.6#bd710f635169da0421373be0982f651b159e1e95"
+version = "0.20.0-rc.7"
+source = "git+https://github.com/UniClipboard/core.git?tag=core-v0.20.0-rc.7#069cdcc2e0cd2bd3f01e42a74ba56c820491bfe0"
 dependencies = [
  "anyhow",
  "argon2",
@@ -10121,8 +10121,8 @@ dependencies = [
 
 [[package]]
 name = "uc-mobile-proto"
-version = "0.20.0-rc.6"
-source = "git+https://github.com/UniClipboard/core.git?tag=core-v0.20.0-rc.6#bd710f635169da0421373be0982f651b159e1e95"
+version = "0.20.0-rc.7"
+source = "git+https://github.com/UniClipboard/core.git?tag=core-v0.20.0-rc.7#069cdcc2e0cd2bd3f01e42a74ba56c820491bfe0"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -10156,8 +10156,8 @@ dependencies = [
 
 [[package]]
 name = "uc-observability-contract"
-version = "0.20.0-rc.6"
-source = "git+https://github.com/UniClipboard/core.git?tag=core-v0.20.0-rc.6#bd710f635169da0421373be0982f651b159e1e95"
+version = "0.20.0-rc.7"
+source = "git+https://github.com/UniClipboard/core.git?tag=core-v0.20.0-rc.7#069cdcc2e0cd2bd3f01e42a74ba56c820491bfe0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -10313,7 +10313,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11027,7 +11027,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11642,8 +11642,8 @@ dependencies = [
  "log",
  "serde",
  "thiserror 2.0.19",
- "windows 0.62.2",
- "windows-core 0.62.2",
+ "windows 0.59.0",
+ "windows-core 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,8 +51,8 @@ dbg_macro = "warn"
 [workspace.dependencies]
 # All desktop consumers use one immutable core release tag. Features remain
 # opt-in at each host boundary so LAN compatibility cannot become a default.
-uc-engine = { git = "https://github.com/UniClipboard/core.git", tag = "core-v0.20.0-rc.6" }
-uc-observability-contract = { git = "https://github.com/UniClipboard/core.git", tag = "core-v0.20.0-rc.6" }
+uc-engine = { git = "https://github.com/UniClipboard/core.git", tag = "core-v0.20.0-rc.7" }
+uc-observability-contract = { git = "https://github.com/UniClipboard/core.git", tag = "core-v0.20.0-rc.7" }
 
 # tauri 2.11 是 specta rc.25 兼容的最低版本 —— 2.10.x 及之前在
 # `tauri/src/ipc/channel.rs` 用了 `#[specta(remote=..., rename="...")]`

--- a/apps/daemon/src/daemon/engine_events.rs
+++ b/apps/daemon/src/daemon/engine_events.rs
@@ -177,8 +177,8 @@ fn peer_to_dto(peer: PeerConnectionSummary) -> PeerSnapshotDto {
 mod tests {
     use uc_daemon_contract::constants::{ws_event, ws_topic};
     use uc_engine::{
-        EngineEvent, InboundNoticeActionSummary, InboundNoticeEvent, PairingCompletion,
-        TransferDirectionSummary, TransferProgress,
+        EngineEvent, InboundNoticeEvent, PairingCompletion, TransferDirectionSummary,
+        TransferProgress,
     };
 
     use super::{daemon_ws_event, pairing_completion_ws_event};
@@ -221,22 +221,24 @@ mod tests {
 
     #[test]
     fn inbound_notice_keeps_the_existing_watch_wire_shape() {
-        let event = daemon_ws_event(EngineEvent::InboundNotice(InboundNoticeEvent {
-            from_device: "peer-1".into(),
-            snapshot_hash: "hash-1".into(),
-            plaintext: vec![1, 2, 3],
-            text_preview: None,
-            representations: Vec::new(),
-            action: InboundNoticeActionSummary::DuplicateIgnored,
-            at_ms: 42,
+        let notice = serde_json::from_value::<InboundNoticeEvent>(serde_json::json!({
+            "from_device": "peer-1",
+            "snapshot_hash": "hash-1",
+            "plaintext": [1, 2, 3],
+            "text_preview": null,
+            "representations": [],
+            "action": "duplicate_ignored",
+            "at_ms": 42
         }))
-        .expect("inbound notice websocket event");
+        .expect("deserialize inbound notice fixture");
+        let event = daemon_ws_event(EngineEvent::InboundNotice(notice))
+            .expect("inbound notice websocket event");
 
         assert_eq!(event.topic, ws_topic::CLIPBOARD);
         assert_eq!(event.event_type, ws_event::CLIPBOARD_INBOUND_NOTICE);
         assert_eq!(event.payload["fromDevice"], "peer-1");
         assert_eq!(event.payload["snapshotHash"], "hash-1");
-        assert_eq!(event.payload["plaintextBase64"], "AQID");
+        assert!(event.payload.get("plaintextBase64").is_none());
         assert_eq!(event.payload["action"], "duplicate_ignored");
         assert_eq!(event.payload["atMs"], 42);
     }

--- a/crates/uc-daemon-contract/src/api/dto/clipboard_command.rs
+++ b/crates/uc-daemon-contract/src/api/dto/clipboard_command.rs
@@ -142,15 +142,13 @@ pub struct CaptureCurrentClipboardResponse {
 
 /// Payload for the `clipboard.inbound_notice` WebSocket event.
 ///
-/// Carries the full V3 envelope for older clients plus structured display
-/// summaries so current clients do not need to understand the core envelope.
+/// Carries structured display summaries without duplicating the full clipboard
+/// payload that has already travelled through the sync pipeline.
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct InboundNoticeEvent {
     pub from_device: String,
     pub snapshot_hash: String,
-    /// Base64-encoded V3 envelope bytes.
-    pub plaintext_base64: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub text_preview: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -256,7 +254,6 @@ mod tests {
         let evt = InboundNoticeEvent {
             from_device: "d1".into(),
             snapshot_hash: "h".into(),
-            plaintext_base64: "base64data".into(),
             text_preview: Some("hello".into()),
             representations: vec![InboundRepresentationSummaryDto {
                 mime_type: Some("text/plain".into()),
@@ -268,7 +265,7 @@ mod tests {
         let json = serde_json::to_value(&evt).unwrap();
         assert!(json.get("fromDevice").is_some());
         assert!(json.get("snapshotHash").is_some());
-        assert!(json.get("plaintextBase64").is_some());
+        assert!(json.get("plaintextBase64").is_none());
         assert!(json.get("textPreview").is_some());
         assert!(json.get("representations").is_some());
     }

--- a/crates/uc-daemon-contract/src/constants.rs
+++ b/crates/uc-daemon-contract/src/constants.rs
@@ -58,10 +58,9 @@ pub mod ws_event {
     pub const SEARCH_STATUS_SNAPSHOT: &str = "search.status_snapshot";
     /// Search rebuild progress event (Phase 92).
     pub const SEARCH_REBUILD_PROGRESS: &str = "search.rebuild_progress";
-    /// Inbound clipboard notice with full V3 envelope payload (ADR-008 P2.5).
-    /// Emitted alongside `CLIPBOARD_NEW_CONTENT`; carries base64-encoded
-    /// plaintext so CLI `watch` can decode and render without an extra HTTP
-    /// round-trip.
+    /// Lightweight inbound clipboard notice for CLI `watch` (ADR-008 P2.5).
+    /// Emitted alongside `CLIPBOARD_NEW_CONTENT`; carries only display summaries
+    /// and delivery metadata, never the full clipboard payload.
     pub const CLIPBOARD_INBOUND_NOTICE: &str = "clipboard.inbound_notice";
 }
 

--- a/crates/uc-daemon-contract/src/lib.rs
+++ b/crates/uc-daemon-contract/src/lib.rs
@@ -1,6 +1,7 @@
 //! Shared daemon transport contracts.
 
-pub const DAEMON_API_REVISION: &str = "setup-pairing-http-routes-v2-event-wired-residency-restart";
+pub const DAEMON_API_REVISION: &str =
+    "setup-pairing-http-routes-v2-event-wired-residency-restart-inbound-notice-summary-v1";
 
 pub mod api;
 pub mod constants;

--- a/crates/uc-webserver/Cargo.toml
+++ b/crates/uc-webserver/Cargo.toml
@@ -42,6 +42,7 @@ tower = { version = "0.5", features = ["util"] }
 argon2 = "0.5.3"
 libc = "0.2"
 reqwest = { version = "0.12", default-features = false }
+tokio-tungstenite = "0.24"
 
 [lints]
 workspace = true

--- a/crates/uc-webserver/src/api/event_emitter.rs
+++ b/crates/uc-webserver/src/api/event_emitter.rs
@@ -1,5 +1,3 @@
-use base64::engine::general_purpose::STANDARD;
-use base64::Engine as _;
 use uc_daemon_contract::api::dto::clipboard_command::{
     InboundNoticeEvent as InboundNoticeDto, InboundRepresentationSummaryDto,
 };
@@ -23,7 +21,6 @@ pub fn engine_event_to_ws(event: EngineEvent) -> Option<DaemonWsEvent> {
             serde_json::to_value(InboundNoticeDto {
                 from_device: event.from_device,
                 snapshot_hash: event.snapshot_hash,
-                plaintext_base64: STANDARD.encode(event.plaintext),
                 text_preview: event.text_preview,
                 representations: event
                     .representations
@@ -141,9 +138,38 @@ pub fn engine_event_to_ws(event: EngineEvent) -> Option<DaemonWsEvent> {
 #[cfg(test)]
 mod engine_event_tests {
     use super::*;
+    use serde::Serialize;
     use uc_engine::{
         EngineError, EngineErrorCategory, InboundNoticeEvent, LifecycleAction, TransferProgress,
     };
+
+    #[derive(Serialize)]
+    struct InboundNoticeFixture {
+        from_device: &'static str,
+        snapshot_hash: &'static str,
+        plaintext: Vec<u8>,
+        text_preview: Option<&'static str>,
+        representations: Vec<serde_json::Value>,
+        action: &'static str,
+        at_ms: i64,
+    }
+
+    fn inbound_notice_with_payload(
+        payload_size: usize,
+        action: &'static str,
+    ) -> InboundNoticeEvent {
+        let encoded = serde_json::to_vec(&InboundNoticeFixture {
+            from_device: "peer-1",
+            snapshot_hash: "hash-1",
+            plaintext: vec![0; payload_size],
+            text_preview: None,
+            representations: Vec::new(),
+            action,
+            at_ms: 42,
+        })
+        .expect("serialize inbound notice fixture");
+        serde_json::from_slice(&encoded).expect("deserialize inbound notice fixture")
+    }
 
     #[test]
     fn lifecycle_failures_stay_on_the_host_event_stream() {
@@ -157,24 +183,46 @@ mod engine_event_tests {
 
     #[test]
     fn inbound_notice_keeps_the_existing_watch_wire_shape() {
-        let event = engine_event_to_ws(EngineEvent::InboundNotice(InboundNoticeEvent {
-            from_device: "peer-1".into(),
-            snapshot_hash: "hash-1".into(),
-            plaintext: vec![1, 2, 3],
-            text_preview: None,
-            representations: Vec::new(),
-            action: InboundNoticeActionSummary::DuplicateIgnored,
-            at_ms: 42,
-        }))
+        let event = engine_event_to_ws(EngineEvent::InboundNotice(inbound_notice_with_payload(
+            3,
+            "duplicate_ignored",
+        )))
         .expect("inbound notice websocket event");
 
         assert_eq!(event.topic, ws_topic::CLIPBOARD);
         assert_eq!(event.event_type, ws_event::CLIPBOARD_INBOUND_NOTICE);
         assert_eq!(event.payload["fromDevice"], "peer-1");
         assert_eq!(event.payload["snapshotHash"], "hash-1");
-        assert_eq!(event.payload["plaintextBase64"], "AQID");
+        assert!(event.payload.get("plaintextBase64").is_none());
         assert_eq!(event.payload["action"], "duplicate_ignored");
         assert_eq!(event.payload["atMs"], 42);
+    }
+
+    #[test]
+    fn inbound_notice_omits_full_clipboard_payload() {
+        let event = engine_event_to_ws(EngineEvent::InboundNotice(inbound_notice_with_payload(
+            20 * 1024 * 1024,
+            "new_entry",
+        )))
+        .expect("inbound notice websocket event");
+
+        assert!(event.payload.get("plaintextBase64").is_none());
+    }
+
+    #[test]
+    fn inbound_notice_wire_size_does_not_scale_with_clipboard_payload() {
+        let event = engine_event_to_ws(EngineEvent::InboundNotice(inbound_notice_with_payload(
+            20 * 1024 * 1024,
+            "new_entry",
+        )))
+        .expect("inbound notice websocket event");
+
+        let encoded = serde_json::to_vec(&event).expect("serialize inbound notice websocket event");
+        assert!(
+            encoded.len() < 64 * 1024,
+            "inbound notice unexpectedly contains {} bytes",
+            encoded.len()
+        );
     }
 
     #[test]

--- a/crates/uc-webserver/tests/inbound_notice_websocket.rs
+++ b/crates/uc-webserver/tests/inbound_notice_websocket.rs
@@ -1,0 +1,94 @@
+use futures_util::{SinkExt, StreamExt};
+use serde::Serialize;
+use tokio_tungstenite::{accept_async, connect_async, tungstenite::Message};
+use uc_daemon_contract::api::types::DaemonWsEvent;
+use uc_daemon_contract::constants::{ws_event, ws_topic};
+use uc_engine::{EngineEvent, InboundNoticeEvent};
+use uc_webserver::api::event_emitter::engine_event_to_ws;
+
+#[derive(Serialize)]
+struct InboundNoticeFixture {
+    from_device: &'static str,
+    snapshot_hash: &'static str,
+    plaintext: Vec<u8>,
+    text_preview: Option<&'static str>,
+    representations: Vec<serde_json::Value>,
+    action: &'static str,
+    at_ms: i64,
+}
+
+fn large_inbound_notice() -> InboundNoticeEvent {
+    let encoded = serde_json::to_vec(&InboundNoticeFixture {
+        from_device: "peer-1",
+        snapshot_hash: "hash-1",
+        plaintext: vec![0; 20 * 1024 * 1024],
+        text_preview: Some("large clipboard item"),
+        representations: Vec::new(),
+        action: "new_entry",
+        at_ms: 42,
+    })
+    .expect("serialize inbound notice fixture");
+    serde_json::from_slice(&encoded).expect("deserialize inbound notice fixture")
+}
+
+#[tokio::test]
+async fn large_inbound_payload_keeps_default_client_connection_usable() {
+    let inbound_notice = engine_event_to_ws(EngineEvent::InboundNotice(large_inbound_notice()))
+        .expect("inbound notice websocket event");
+    let follow_up = DaemonWsEvent {
+        topic: ws_topic::CLIPBOARD.to_string(),
+        event_type: ws_event::CLIPBOARD_NEW_CONTENT.to_string(),
+        session_id: None,
+        ts: 43,
+        payload: serde_json::json!({ "entryId": "entry-2" }),
+    };
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind websocket test listener");
+    let address = listener.local_addr().expect("websocket test address");
+    let server = tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.expect("accept websocket client");
+        let mut socket = accept_async(stream)
+            .await
+            .expect("accept websocket handshake");
+        for event in [inbound_notice, follow_up] {
+            let payload = serde_json::to_string(&event).expect("serialize websocket event");
+            socket
+                .send(Message::Text(payload))
+                .await
+                .expect("send websocket event");
+        }
+        socket.close(None).await.expect("close websocket server");
+    });
+
+    let (mut client, _) = connect_async(format!("ws://{address}"))
+        .await
+        .expect("connect websocket client with default limits");
+
+    let first = receive_event(&mut client).await;
+    assert_eq!(first.event_type, ws_event::CLIPBOARD_INBOUND_NOTICE);
+    assert!(first.payload.get("plaintextBase64").is_none());
+
+    let second = receive_event(&mut client).await;
+    assert_eq!(second.event_type, ws_event::CLIPBOARD_NEW_CONTENT);
+    assert_eq!(second.payload["entryId"], "entry-2");
+
+    server.await.expect("websocket test server task");
+}
+
+async fn receive_event(
+    client: &mut tokio_tungstenite::WebSocketStream<
+        tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+    >,
+) -> DaemonWsEvent {
+    let message = client
+        .next()
+        .await
+        .expect("websocket event")
+        .expect("read websocket event");
+    let Message::Text(payload) = message else {
+        panic!("expected text websocket event");
+    };
+    serde_json::from_str(&payload).expect("deserialize websocket event")
+}

--- a/scripts/architecture/check-core-repository.mjs
+++ b/scripts/architecture/check-core-repository.mjs
@@ -9,8 +9,8 @@ import { fileURLToPath } from 'node:url'
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url))
 const REPOSITORY_ROOT = resolve(SCRIPT_DIR, '../..')
 const CORE_REPOSITORY = 'https://github.com/UniClipboard/core.git'
-const CORE_TAG = 'core-v0.20.0-rc.6'
-const CORE_REVISION = 'bd710f635169da0421373be0982f651b159e1e95'
+const CORE_TAG = 'core-v0.20.0-rc.7'
+const CORE_REVISION = '069cdcc2e0cd2bd3f01e42a74ba56c820491bfe0'
 const DECLARED_CORE_SOURCE = `git+${CORE_REPOSITORY}?tag=${CORE_TAG}`
 const RESOLVED_CORE_SOURCE = `${DECLARED_CORE_SOURCE}#${CORE_REVISION}`
 


### PR DESCRIPTION
## Summary

- Stop forwarding complete clipboard content through daemon notifications while retaining summaries and delivery details.
- Reject incompatible daemon/client combinations so old and new processes cannot silently mix.
- Add a real connection regression test with a 20 MB clipboard payload and verify later notifications still arrive on the same connection.
- Pin all desktop Core consumers to the verified `core-v0.20.0-rc.7` release.

Core implementation: https://github.com/UniClipboard/core/pull/7
Core release: https://github.com/UniClipboard/core/releases/tag/core-v0.20.0-rc.7

## Test plan

- [x] Relevant package tests: CLI 88, daemon 43, contract 87, webserver 136, daemon client 9
- [x] 20 MB connection regression test
- [x] `cargo check --workspace --all-targets --locked`
- [x] `cargo fmt --all -- --check`
- [x] `cargo metadata --locked --format-version 1`
- [x] `npm run check:core-repository`
- [x] OpenAPI regeneration produces no diff
- [x] `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Clipboard inbound-notice WebSocket events now send lightweight display and delivery details only, omitting plaintext content (`plaintextBase64`).
  - Inbound notices no longer bloat with large clipboard payloads, helping keep WebSocket message size stable.
  - Inbound notices still arrive correctly alongside new-content events.
- **Documentation**
  - Updated inbound-notice event documentation to reflect the streamlined payload.
- **Tests**
  - Added/updated coverage to verify `plaintextBase64` is absent for both normal and large payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->