### PR TITLE
fix(diagnostics): export logs from resolved directory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10489,7 +10489,7 @@ dependencies = [
 [[package]]
 name = "uc-application"
 version = "0.20.0-rc.15"
-source = "git+https://github.com/UniClipboard/Engine.git?rev=cf0c74bf41047e40128807000b31994ebb9729eb#cf0c74bf41047e40128807000b31994ebb9729eb"
+source = "git+https://github.com/UniClipboard/Engine.git?rev=4226d16834c8517d3cb422775b056a5d197a6f63#4226d16834c8517d3cb422775b056a5d197a6f63"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10587,7 +10587,7 @@ dependencies = [
 [[package]]
 name = "uc-content-hash"
 version = "0.20.0-rc.15"
-source = "git+https://github.com/UniClipboard/Engine.git?rev=cf0c74bf41047e40128807000b31994ebb9729eb#cf0c74bf41047e40128807000b31994ebb9729eb"
+source = "git+https://github.com/UniClipboard/Engine.git?rev=4226d16834c8517d3cb422775b056a5d197a6f63#4226d16834c8517d3cb422775b056a5d197a6f63"
 dependencies = [
  "blake3",
  "hex",
@@ -10596,7 +10596,7 @@ dependencies = [
 [[package]]
 name = "uc-core"
 version = "0.20.0-rc.15"
-source = "git+https://github.com/UniClipboard/Engine.git?rev=cf0c74bf41047e40128807000b31994ebb9729eb#cf0c74bf41047e40128807000b31994ebb9729eb"
+source = "git+https://github.com/UniClipboard/Engine.git?rev=4226d16834c8517d3cb422775b056a5d197a6f63#4226d16834c8517d3cb422775b056a5d197a6f63"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -10746,7 +10746,7 @@ dependencies = [
 [[package]]
 name = "uc-engine"
 version = "0.20.0-rc.15"
-source = "git+https://github.com/UniClipboard/Engine.git?rev=cf0c74bf41047e40128807000b31994ebb9729eb#cf0c74bf41047e40128807000b31994ebb9729eb"
+source = "git+https://github.com/UniClipboard/Engine.git?rev=4226d16834c8517d3cb422775b056a5d197a6f63#4226d16834c8517d3cb422775b056a5d197a6f63"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10768,7 +10768,7 @@ dependencies = [
 [[package]]
 name = "uc-infra"
 version = "0.20.0-rc.15"
-source = "git+https://github.com/UniClipboard/Engine.git?rev=cf0c74bf41047e40128807000b31994ebb9729eb#cf0c74bf41047e40128807000b31994ebb9729eb"
+source = "git+https://github.com/UniClipboard/Engine.git?rev=4226d16834c8517d3cb422775b056a5d197a6f63#4226d16834c8517d3cb422775b056a5d197a6f63"
 dependencies = [
  "anyhow",
  "argon2",
@@ -10830,7 +10830,7 @@ dependencies = [
 [[package]]
 name = "uc-mobile-proto"
 version = "0.20.0-rc.15"
-source = "git+https://github.com/UniClipboard/Engine.git?rev=cf0c74bf41047e40128807000b31994ebb9729eb#cf0c74bf41047e40128807000b31994ebb9729eb"
+source = "git+https://github.com/UniClipboard/Engine.git?rev=4226d16834c8517d3cb422775b056a5d197a6f63#4226d16834c8517d3cb422775b056a5d197a6f63"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -10865,7 +10865,7 @@ dependencies = [
 [[package]]
 name = "uc-observability-contract"
 version = "0.20.0-rc.15"
-source = "git+https://github.com/UniClipboard/Engine.git?rev=cf0c74bf41047e40128807000b31994ebb9729eb#cf0c74bf41047e40128807000b31994ebb9729eb"
+source = "git+https://github.com/UniClipboard/Engine.git?rev=4226d16834c8517d3cb422775b056a5d197a6f63#4226d16834c8517d3cb422775b056a5d197a6f63"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,8 +51,8 @@ dbg_macro = "warn"
 [workspace.dependencies]
 # All desktop consumers use one immutable Engine revision. Features remain
 # opt-in at each host boundary so LAN compatibility cannot become a default.
-uc-engine = { git = "https://github.com/UniClipboard/Engine.git", rev = "cf0c74bf41047e40128807000b31994ebb9729eb" }
-uc-observability-contract = { git = "https://github.com/UniClipboard/Engine.git", rev = "cf0c74bf41047e40128807000b31994ebb9729eb" }
+uc-engine = { git = "https://github.com/UniClipboard/Engine.git", rev = "4226d16834c8517d3cb422775b056a5d197a6f63" }
+uc-observability-contract = { git = "https://github.com/UniClipboard/Engine.git", rev = "4226d16834c8517d3cb422775b056a5d197a6f63" }
 
 # tauri 2.11 是 specta rc.25 兼容的最低版本 —— 2.10.x 及之前在
 # `tauri/src/ipc/channel.rs` 用了 `#[specta(remote=..., rename="...")]`

--- a/crates/uc-bootstrap/src/wiring/desktop_host.rs
+++ b/crates/uc-bootstrap/src/wiring/desktop_host.rs
@@ -77,6 +77,15 @@ impl DesktopHostProcessPaths {
     }
 }
 
+fn host_directories(paths: &DesktopHostPaths, temporary_dir: PathBuf) -> HostDirectories {
+    HostDirectories::new(
+        paths.app_data_root_dir.clone(),
+        paths.cache_dir.clone(),
+        temporary_dir,
+        paths.logs_dir.clone(),
+    )
+}
+
 pub fn prepare_desktop_engine_host() -> WiringResult<DesktopEngineHost> {
     let paths = resolve_desktop_host_paths()?;
     let secure_storage = build_secure_storage_prelude(&paths)?.secure_storage;
@@ -93,11 +102,7 @@ pub fn prepare_desktop_engine_host() -> WiringResult<DesktopEngineHost> {
     let engine_config = EngineConfig::new(env!("CARGO_PKG_VERSION"))
         .with_portable_storage(uc_app_paths::is_portable());
     let capabilities = HostCapabilities::new(
-        HostDirectories::new(
-            paths.app_data_root_dir.clone(),
-            paths.cache_dir.clone(),
-            temporary_dir,
-        ),
+        host_directories(&paths, temporary_dir),
         Box::new(DesktopSecureStorage { secure_storage }),
         Box::new(DesktopClipboard {
             system_clipboard,
@@ -533,6 +538,22 @@ mod tests {
         fn write_snapshot(&self, _snapshot: SystemClipboardSnapshot) -> anyhow::Result<()> {
             Ok(())
         }
+    }
+
+    #[test]
+    fn engine_directories_use_the_resolved_log_directory() {
+        let paths = DesktopHostPaths {
+            db_path: "/host/private/uniclipboard.db".into(),
+            vault_dir: "/host/private/vault".into(),
+            settings_path: "/host/private/settings.json".into(),
+            logs_dir: "/host/platform-logs".into(),
+            cache_dir: "/host/cache".into(),
+            app_data_root_dir: "/host/private".into(),
+        };
+
+        let directories = host_directories(&paths, "/host/temporary".into());
+
+        assert_eq!(directories.logs(), Path::new("/host/platform-logs"));
     }
 
     #[test]

--- a/scripts/architecture/check-engine-repository.mjs
+++ b/scripts/architecture/check-engine-repository.mjs
@@ -9,7 +9,7 @@ import { fileURLToPath } from 'node:url'
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url))
 const REPOSITORY_ROOT = resolve(SCRIPT_DIR, '../..')
 const ENGINE_REPOSITORY = 'https://github.com/UniClipboard/Engine.git'
-const ENGINE_REVISION = 'cf0c74bf41047e40128807000b31994ebb9729eb'
+const ENGINE_REVISION = '4226d16834c8517d3cb422775b056a5d197a6f63'
 const DECLARED_ENGINE_SOURCE = `git+${ENGINE_REPOSITORY}?rev=${ENGINE_REVISION}`
 const RESOLVED_ENGINE_SOURCE = `${DECLARED_ENGINE_SOURCE}#${ENGINE_REVISION}`
 


### PR DESCRIPTION
## Summary

- Pass the platform-resolved log directory through the desktop host boundary so diagnostic exports collect the files actually written by GUI, daemon, and CLI processes (`7c9359a30`).
- Pin Engine to `4226d168`, which makes the host log directory explicit, and keep the repository provenance check in sync.
- Leave docs and telemetry unchanged because the documented export behavior and user flow did not change.

## Test plan

- [x] `cargo test -p uc-engine --locked` in Engine: 167 passed, 1 LAN multicast test skipped by its existing environment requirement.
- [x] `cargo check --workspace --all-targets --locked` in Engine and desktop.
- [x] `cargo test -p uc-application diagnostics --locked`.
- [x] `cargo test -p uc-bootstrap --locked`.
- [x] Engine and desktop repository architecture preflight checks.
- [x] Real isolated daemon + CLI export: archive contained `logs/uniclipboard-daemon.json.2026-08-01` and passed ZIP integrity validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected desktop engine directory configuration so logs are stored in the resolved platform-specific location.

* **Maintenance**
  * Updated the shared engine revision and repository validation checks to keep components aligned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->