### PR TITLE
fix(release): preserve Cargo dependency versions

### DIFF
--- a/scripts/__tests__/bump-version.test.ts
+++ b/scripts/__tests__/bump-version.test.ts
@@ -3,7 +3,7 @@ import os from 'node:os'
 import path from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
 import { bumpVersion, parseSemver } from '../bump-version-lib.js'
-import { updateCargoLock } from '../bump-version.js'
+import { updateCargoLock, updateCargoToml } from '../bump-version.js'
 
 describe('workspace version inheritance', () => {
   it('uc-cli uses version.workspace = true', () => {
@@ -28,6 +28,36 @@ describe('parseSemver target version', () => {
     const parsed = parseSemver('0.1.0-alpha.2')
     expect(parsed.prerelease).toBe('alpha')
     expect(parsed.prereleaseVersion).toBe(2)
+  })
+})
+
+describe('updateCargoToml', () => {
+  const tempDirs: string[] = []
+
+  afterEach(() => {
+    while (tempDirs.length > 0) {
+      const dir = tempDirs.pop()
+      if (dir) {
+        fs.rmSync(dir, { recursive: true, force: true })
+      }
+    }
+  })
+
+  it('updates only the package version and preserves dependency versions', () => {
+    const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bump-version-'))
+    tempDirs.push(repoDir)
+    const manifestPath = path.join(repoDir, 'Cargo.toml')
+    fs.writeFileSync(
+      manifestPath,
+      '[package]\nname = "uniclipboard"\nversion = "0.20.0-alpha.5"\n\n[dependencies.tauri-plugin-wdio]\nversion = "1"\noptional = true\n\n[dependencies.tauri-plugin-wdio-webdriver]\nversion = "1"\noptional = true\n',
+      'utf8'
+    )
+
+    updateCargoToml('0.20.0-alpha.6', false, path.relative(process.cwd(), manifestPath))
+
+    expect(fs.readFileSync(manifestPath, 'utf8')).toBe(
+      '[package]\nname = "uniclipboard"\nversion = "0.20.0-alpha.6"\n\n[dependencies.tauri-plugin-wdio]\nversion = "1"\noptional = true\n\n[dependencies.tauri-plugin-wdio-webdriver]\nversion = "1"\noptional = true\n'
+    )
   })
 })
 

--- a/scripts/__tests__/bump-version.test.ts
+++ b/scripts/__tests__/bump-version.test.ts
@@ -59,6 +59,28 @@ describe('updateCargoToml', () => {
       '[package]\nname = "uniclipboard"\nversion = "0.20.0-alpha.6"\n\n[dependencies.tauri-plugin-wdio]\nversion = "1"\noptional = true\n\n[dependencies.tauri-plugin-wdio-webdriver]\nversion = "1"\noptional = true\n'
     )
   })
+
+  it('updates only the workspace package version', () => {
+    const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bump-version-'))
+    tempDirs.push(repoDir)
+    const manifestPath = path.join(repoDir, 'Cargo.toml')
+    fs.writeFileSync(
+      manifestPath,
+      '[workspace.package]\nversion = "0.20.0-alpha.5"\n\n[dependencies.release-helper]\nversion = "2"\n',
+      'utf8'
+    )
+
+    updateCargoToml(
+      '0.20.0-alpha.6',
+      false,
+      path.relative(process.cwd(), manifestPath),
+      'workspace.package'
+    )
+
+    expect(fs.readFileSync(manifestPath, 'utf8')).toBe(
+      '[workspace.package]\nversion = "0.20.0-alpha.6"\n\n[dependencies.release-helper]\nversion = "2"\n'
+    )
+  })
 })
 
 describe('updateCargoLock', () => {

--- a/scripts/bump-version.js
+++ b/scripts/bump-version.js
@@ -80,21 +80,41 @@ export function updateTauriConfig(newVersion, dryRun) {
 export function updateCargoToml(
   newVersion,
   dryRun,
-  relativePath = path.join('src-tauri', 'Cargo.toml')
+  relativePath = path.join('src-tauri', 'Cargo.toml'),
+  section = 'package'
 ) {
   const cargoPath = path.join(process.cwd(), relativePath)
   const content = fs.readFileSync(cargoPath, 'utf8')
+  const lines = content.split('\n')
+  let currentSection = null
+  let versionLineIndex = -1
+  let oldVersion = null
 
-  // Match ALL lines with version = "..." — covers [package] and [workspace.package]
-  const versionLineRegex = /^version\s*=\s*"[^"]+"/gm
-  const matches = content.match(versionLineRegex)
+  for (const [index, line] of lines.entries()) {
+    const sectionMatch = line.match(/^\s*\[([^\]]+)\]\s*(?:#.*)?$/)
+    if (sectionMatch) {
+      currentSection = sectionMatch[1]
+      continue
+    }
 
-  if (!matches || matches.length === 0) {
-    throw new Error('Could not find version in Cargo.toml')
+    if (currentSection !== section) {
+      continue
+    }
+
+    const versionMatch = line.match(/^(\s*version\s*=\s*)"([^"]+)"(.*)$/)
+    if (versionMatch) {
+      versionLineIndex = index
+      oldVersion = versionMatch[2]
+      lines[index] = `${versionMatch[1]}"${newVersion}"${versionMatch[3]}`
+      break
+    }
   }
 
-  const oldVersion = matches[0].match(/^version\s*=\s*"([^"]+)"/)[1]
-  const newContent = content.replace(versionLineRegex, `version = "${newVersion}"`)
+  if (versionLineIndex === -1 || oldVersion === null) {
+    throw new Error(`Could not find version in [${section}] of ${relativePath}`)
+  }
+
+  const newContent = lines.join('\n')
 
   if (!dryRun) {
     fs.writeFileSync(cargoPath, newContent, 'utf8')
@@ -208,7 +228,12 @@ export function run(options = parseArgs()) {
 
   // Root workspace manifest: [workspace.package] version, inherited by all
   // workspace member crates via `version.workspace = true`.
-  const rootCargoResult = updateCargoToml(newVersion, options.dryRun, 'Cargo.toml')
+  const rootCargoResult = updateCargoToml(
+    newVersion,
+    options.dryRun,
+    'Cargo.toml',
+    'workspace.package'
+  )
   console.log(`${options.dryRun ? '[DRY RUN]' : '✓'} ${rootCargoResult.path}`)
   console.log(`  ${rootCargoResult.old} → ${rootCargoResult.new}`)
 


### PR DESCRIPTION
## Summary

- Restrict Cargo manifest version bumps to the package-owned version section.
- Preserve dependency versions when preparing a release.
- Add regression coverage for section-form optional dependencies.

## Test plan

- [x] `bunx vitest run scripts/__tests__/bump-version.test.ts --environment node --pool forks`
- [x] `bunx prettier --check scripts/bump-version.js scripts/__tests__/bump-version.test.ts`
- [x] `bunx eslint scripts/bump-version.js scripts/__tests__/bump-version.test.ts`
- [x] Run `node scripts/bump-version.js --to 0.20.0-alpha.6`, verify WebDriver dependency versions remain `1`, then run `cargo update -p uc-cli`
- [x] `git diff --check`

Docs left as-is because this changes only release automation and no user-facing behavior. The diff does not touch telemetry or Rust tracing surfaces.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved version updates for Cargo manifests to change only the intended package version.
  * Preserved dependency versions and surrounding file formatting during updates.
  * Added validation when the specified manifest section does not contain a version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->