### PR TITLE
fix(ci): remove stale server image vendor copy

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,8 +5,8 @@
 # keeps the context transfer small and avoids shipping huge artifact trees
 # (Rust `target/`, node_modules) into the daemon.
 #
-# IMPORTANT: do NOT exclude `crates/`, `apps/`, `src-tauri/` or `vendor/` —
-# the build needs the workspace and the vendored `iroh-blobs` submodule.
+# IMPORTANT: do NOT exclude `crates/`, `apps/` or `src-tauri/` — the build
+# needs their workspace manifests and sources.
 
 .git
 .github

--- a/.github/workflows/build-server-image.yml
+++ b/.github/workflows/build-server-image.yml
@@ -71,8 +71,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref || github.ref }}
-          # The musl build needs the vendored iroh-blobs submodule.
-          submodules: recursive
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -89,7 +87,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           # Context is the repo root so the Dockerfile reaches the root cargo
-          # workspace + the vendored submodule. .dockerignore trims it.
+          # workspace. .dockerignore trims it.
           context: .
           file: deploy/vps/Dockerfile
           platforms: ${{ matrix.platform }}

--- a/deploy/vps/Dockerfile
+++ b/deploy/vps/Dockerfile
@@ -10,8 +10,7 @@
 #                 user with HOME=/data anchoring all state on a mounted volume.
 #
 # Build context is the repository ROOT (see deploy/vps/docker-compose.yml),
-# so paths below are repo-relative. Initialize submodules before building:
-#   git submodule update --init --recursive
+# so paths below are repo-relative.
 
 # ── builder ──────────────────────────────────────────────────────────────────
 # uc-cli's dependency graph is ring + rustls (no openssl-sys / aws-lc-sys), so
@@ -30,16 +29,13 @@ RUN echo 'Acquire::Retries "5";' > /etc/apt/apt.conf.d/80-retries \
 
 WORKDIR /build
 
-# The Rust workspace lives at the repo root. The vendored iroh-blobs fork
-# (vendor/iroh-blobs) is consumed via [patch.crates-io] and must be present
-# in the context — that is why submodules must be initialized first.
-# src-tauri/ is still copied because the workspace member list includes the
-# Tauri packages; only manifests are parsed, the GUI is not compiled here.
+# The Rust workspace lives at the repo root. src-tauri/ is still copied because
+# the workspace member list includes the Tauri packages; only manifests are
+# parsed, the GUI is not compiled here.
 COPY Cargo.toml Cargo.lock rust-toolchain.toml clippy.toml ./
 COPY .cargo/ ./.cargo/
 COPY crates/ ./crates/
 COPY apps/ ./apps/
-COPY vendor/ ./vendor/
 COPY src-tauri/ ./src-tauri/
 
 # Pick the musl target matching the build host arch (native compile, no cross).

--- a/deploy/vps/README.md
+++ b/deploy/vps/README.md
@@ -65,11 +65,9 @@ docker compose pull
 Track `:latest` by default, or pin a release in `.env` with
 `UC_IMAGE=ghcr.io/uniclipboard/uniclipboard-server:vX.Y.Z`.
 
-**Option B — build from source.** Requires the repository checked out **with
-submodules** (the build needs the vendored `iroh-blobs` fork) and ~4 GB RAM:
+**Option B — build from source.** Requires ~4 GB RAM:
 
 ```bash
-git submodule update --init --recursive   # or: git clone --recursive <repo-url>
 docker compose build
 ```
 

--- a/docs-site/content/docs/en/guides/self-host-server-node.mdx
+++ b/docs-site/content/docs/en/guides/self-host-server-node.mdx
@@ -116,12 +116,9 @@ Pin a release in `.env` with
 `UC_IMAGE=ghcr.io/uniclipboard/uniclipboard-server:vX.Y.Z` (defaults to
 `:latest`).
 
-**Option B — build from source.** Needs the repo checked out **with
-submodules** (the build uses the vendored `iroh-blobs` fork) and ~4 GB
-of RAM:
+**Option B — build from source.** Needs ~4 GB of RAM:
 
 ```bash
-git submodule update --init --recursive
 docker compose build
 ```
 

--- a/docs-site/content/docs/zh/guides/self-host-server-node.mdx
+++ b/docs-site/content/docs/zh/guides/self-host-server-node.mdx
@@ -101,11 +101,9 @@ docker compose pull
 想锁版本就在 `.env` 里写
 `UC_IMAGE=ghcr.io/uniclipboard/uniclipboard-server:vX.Y.Z`（默认 `:latest`）。
 
-**方案 B —— 源码构建。** 需要带 submodule 检出仓库（构建用到 vendored 的
-`iroh-blobs` 分支）和约 4 GB 内存：
+**方案 B —— 源码构建。** 需要约 4 GB 内存：
 
 ```bash
-git submodule update --init --recursive
 docker compose build
 ```
 

--- a/scripts/__tests__/server-image-context.test.ts
+++ b/scripts/__tests__/server-image-context.test.ts
@@ -1,0 +1,25 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const projectRoot = path.resolve(__dirname, '../..')
+
+function localCopySources(dockerfile: string): string[] {
+  return dockerfile
+    .split('\n')
+    .map(line => line.trim())
+    .filter(line => line.startsWith('COPY ') && !line.includes('--from='))
+    .flatMap(line => line.slice('COPY '.length).trim().split(/\s+/).slice(0, -1))
+    .map(source => source.replace(/\/$/, ''))
+}
+
+describe('server image build context', () => {
+  it('only copies paths that exist in the repository', () => {
+    const dockerfile = fs.readFileSync(path.join(projectRoot, 'deploy/vps/Dockerfile'), 'utf8')
+    const missingSources = localCopySources(dockerfile).filter(
+      source => !fs.existsSync(path.join(projectRoot, source))
+    )
+
+    expect(missingSources).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary\n\n- Remove the stale vendored source copy and submodule checkout left behind by the Engine repository migration, restoring server image builds. (58ccdf597)\n- Add a regression test that rejects Dockerfile copy sources missing from the repository. (58ccdf597)\n- Remove the obsolete submodule setup step from the English, Chinese, and deployment build instructions. (41d67fe54)\n\n## Test plan\n\n- [x] Run all script tests (9 files, 44 tests)\n- [x] Validate the server image Dockerfile build context\n- [x] Parse the GitHub Actions workflow and check changed-file formatting\n- [ ] Complete a full native image build in GitHub Actions; the local arm64 build reached final linking but Docker Desktop's 8 GB memory limit terminated it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified self-hosting and source-build instructions by removing submodule setup steps.
  * Clarified the approximate 4 GB memory requirement for source builds.

* **Build & Deployment**
  * Streamlined server image builds by removing the need for vendored submodules.
  * Updated Docker build-context guidance.

* **Tests**
  * Added validation to ensure all server image build sources are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->