### PR TITLE
ci(engine): automate release adoption

### DIFF
--- a/.github/workflows/adopt-engine-release.yml
+++ b/.github/workflows/adopt-engine-release.yml
@@ -1,0 +1,151 @@
+name: Adopt Engine release
+
+on:
+  repository_dispatch:
+    types: [engine_release_published]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: adopt-engine-${{ github.event.client_payload.version }}
+  cancel-in-progress: false
+
+jobs:
+  validate:
+    name: Verify and check Engine update
+    if: ${{ github.event.client_payload.repository == 'UniClipboard/Engine' }}
+    runs-on: ubuntu-latest
+    outputs:
+      base_sha: ${{ steps.base.outputs.sha }}
+      changed: ${{ steps.change.outputs.changed }}
+    container:
+      image: ghcr.io/uniclipboard/build-bookworm:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - id: base
+        name: Record the validated base
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Verify release and update the Engine pin
+        env:
+          ENGINE_VERSION: ${{ github.event.client_payload.version }}
+          ENGINE_COMMIT: ${{ github.event.client_payload.source_commit }}
+        run: node scripts/adopt-engine-release.mjs --version "$ENGINE_VERSION" --source-commit "$ENGINE_COMMIT"
+
+      - name: Refresh the Rust lockfile
+        env:
+          ENGINE_COMMIT: ${{ github.event.client_payload.source_commit }}
+        run: cargo update -p uc-engine --precise "$ENGINE_COMMIT"
+
+      - name: Check the desktop workspace
+        env:
+          TAURI_CONFIG: '{"bundle":{"externalBin":[]}}'
+        run: cargo check --workspace --locked
+
+      - name: Verify Engine repository boundaries
+        run: bun run check:engine-repository
+
+      - id: change
+        name: Detect the proposed update
+        run: |
+          if git diff --quiet -- Cargo.toml Cargo.lock; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            git diff --binary -- Cargo.toml Cargo.lock > engine-adoption.patch
+          fi
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ steps.change.outputs.changed == 'true' }}
+        with:
+          name: engine-adoption-patch
+          path: engine-adoption.patch
+          if-no-files-found: error
+          retention-days: 1
+
+  create-pull-request:
+    name: Create or update adoption pull request
+    needs: validate
+    if: ${{ needs.validate.outputs.changed == 'true' }}
+    runs-on: ubuntu-latest
+    env:
+      BRANCH: automation/adopt-engine-${{ github.event.client_payload.version }}
+      ENGINE_VERSION: ${{ github.event.client_payload.version }}
+      ENGINE_COMMIT: ${{ github.event.client_payload.source_commit }}
+    steps:
+      - id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.ENGINE_RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.ENGINE_RELEASE_APP_PRIVATE_KEY }}
+          owner: UniClipboard
+          repositories: UniClipboard
+          permission-contents: write
+          permission-pull-requests: write
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.validate.outputs.base_sha }}
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: engine-adoption-patch
+
+      - name: Apply the validated update
+        run: git apply --index engine-adoption.patch
+
+      - name: Push the deterministic branch
+        run: |
+          git config user.name "uniclipboard-engine-release[bot]"
+          git config user.email "uniclipboard-engine-release[bot]@users.noreply.github.com"
+          git checkout -B "$BRANCH"
+          git commit -m "chore(engine): adopt $ENGINE_VERSION"
+          if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            git fetch origin "refs/heads/$BRANCH:refs/remotes/origin/$BRANCH"
+            lease=$(git rev-parse "refs/remotes/origin/$BRANCH")
+            git push --force-with-lease="refs/heads/$BRANCH:$lease" origin "HEAD:refs/heads/$BRANCH"
+          else
+            git push origin "HEAD:refs/heads/$BRANCH"
+          fi
+
+      - name: Create or update the pull request
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          title="chore(engine): adopt $ENGINE_VERSION"
+          body=$(cat <<EOF
+          Adopt Engine $ENGINE_VERSION from source commit $ENGINE_COMMIT.
+
+          Verified before this pull request was created:
+          - public Engine release manifest and source archive
+          - Rust lockfile refresh
+          - desktop workspace check
+          - Engine repository boundary check
+          EOF
+          )
+          record=$(gh pr list --head "$BRANCH" --state all --json number,state --jq '.[0] | "\(.number // "") \(.state // "")"')
+          read -r number state <<<"$record"
+          if [[ "$state" == "OPEN" ]]; then
+            gh pr edit "$number" --title "$title" --body "$body"
+          elif [[ "$state" == "CLOSED" ]]; then
+            gh pr reopen "$number"
+            gh pr edit "$number" --title "$title" --body "$body"
+          else
+            gh pr create --base main --head "$BRANCH" --title "$title" --body "$body"
+          fi

--- a/scripts/__tests__/adopt-engine-release.test.ts
+++ b/scripts/__tests__/adopt-engine-release.test.ts
@@ -1,0 +1,184 @@
+import { execFileSync, spawnSync } from 'node:child_process'
+import { createHash } from 'node:crypto'
+import {
+  chmodSync,
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+
+const repositoryRoot = resolve(__dirname, '../..')
+const adopter = resolve(repositoryRoot, 'scripts/adopt-engine-release.mjs')
+const preflight = resolve(repositoryRoot, 'scripts/architecture/check-engine-repository.mjs')
+const workflowPath = resolve(repositoryRoot, '.github/workflows/adopt-engine-release.yml')
+const interopScript = resolve(repositoryRoot, 'scripts/test_pair_e2e.sh')
+const roots: string[] = []
+
+function write(path: string, content: string) {
+  mkdirSync(dirname(path), { recursive: true })
+  writeFileSync(path, content)
+}
+
+function fixture() {
+  const root = mkdtempSync(join(tmpdir(), 'desktop-engine-adoption-'))
+  roots.push(root)
+  const oldCommit = 'a'.repeat(40)
+  const newCommit = 'b'.repeat(40)
+  const version = 'v1.2.3-rc.4'
+  const sourceArchive = Buffer.from('verified source archive')
+  const manifest = {
+    schemaVersion: 1,
+    release: { version, commit: newCommit },
+    artifacts: [
+      {
+        name: 'UniClipboardEngine-source.tar.gz',
+        sha256: createHash('sha256').update(sourceArchive).digest('hex'),
+        size: sourceArchive.length,
+      },
+    ],
+  }
+  const manifestPath = join(root, 'release-manifest.json')
+  const archivePath = join(root, 'UniClipboardEngine-source.tar.gz')
+  write(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`)
+  write(archivePath, sourceArchive.toString())
+  write(
+    join(root, 'Cargo.toml'),
+    `[workspace.dependencies]\nuc-engine = { git = "https://github.com/UniClipboard/Engine.git", rev = "${oldCommit}" }\nuc-observability-contract = { git = "https://github.com/UniClipboard/Engine.git", rev = "${oldCommit}" }\n`
+  )
+  return { root, version, newCommit, manifestPath, archivePath }
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true })
+})
+
+describe('desktop Engine release adoption', () => {
+  it('updates every desktop Engine dependency after verifying the release source', () => {
+    const { root, version, newCommit, manifestPath, archivePath } = fixture()
+
+    execFileSync(
+      process.execPath,
+      [
+        adopter,
+        '--root',
+        root,
+        '--version',
+        version,
+        '--source-commit',
+        newCommit,
+        '--manifest',
+        manifestPath,
+        '--source-archive',
+        archivePath,
+      ],
+      { encoding: 'utf8' }
+    )
+
+    const cargo = readFileSync(join(root, 'Cargo.toml'), 'utf8')
+    expect(cargo.match(new RegExp(newCommit, 'g'))).toHaveLength(2)
+    expect(cargo).not.toContain('a'.repeat(40))
+  })
+
+  it('rejects a notification that disagrees with the public release manifest', () => {
+    const { root, version, manifestPath, archivePath } = fixture()
+    const result = spawnSync(
+      process.execPath,
+      [
+        adopter,
+        '--root',
+        root,
+        '--version',
+        version,
+        '--source-commit',
+        'c'.repeat(40),
+        '--manifest',
+        manifestPath,
+        '--source-archive',
+        archivePath,
+      ],
+      { encoding: 'utf8' }
+    )
+
+    expect(result.status).toBe(1)
+    expect(result.stderr).toContain('release source commit does not match the notification')
+  })
+
+  it('derives the preflight revision instead of keeping a second hard-coded pin', () => {
+    const source = readFileSync(preflight, 'utf8')
+    expect(source).not.toMatch(/const ENGINE_REVISION = ['"][0-9a-f]{40}['"]/)
+    expect(source).toContain('resolveEnginePin')
+  })
+
+  it('checks the update before creating one deterministic pull request', () => {
+    expect(existsSync(workflowPath)).toBe(true)
+    const workflow = existsSync(workflowPath) ? readFileSync(workflowPath, 'utf8') : ''
+    expect(workflow).toContain('types: [engine_release_published]')
+    expect(workflow).toContain('automation/adopt-engine-${{ github.event.client_payload.version }}')
+    expect(workflow).toMatch(/create-pull-request:[\s\S]*needs:\s*validate/)
+    expect(workflow).toContain('cargo check --workspace --locked')
+    expect(workflow).toContain('bun run check:engine-repository')
+    expect(workflow).toContain('changed: ${{ steps.change.outputs.changed }}')
+    expect(workflow).toContain("if: ${{ needs.validate.outputs.changed == 'true' }}")
+    expect(workflow).toContain('--state all')
+    expect(workflow).toContain('gh pr reopen')
+    expect(workflow).toContain('actions/create-github-app-token@v3')
+    expect(workflow).toContain('permission-pull-requests: write')
+    expect(workflow).toContain('repositories: UniClipboard')
+    expect(workflow).toContain('GH_TOKEN: ${{ steps.app-token.outputs.token }}')
+    expect(workflow).not.toContain('GH_TOKEN: ${{ github.token }}')
+  })
+
+  it('lets the interop gate run old and new clients and verify both transfer directions', () => {
+    const script = readFileSync(interopScript, 'utf8')
+    expect(script).toContain('ALICE_CLI')
+    expect(script).toContain('BOB_CLI')
+    expect(script).toContain('verify_transfer "$ALICE_CLI" "$BOB_CLI"')
+    expect(script).toContain('verify_transfer "$BOB_CLI" "$ALICE_CLI"')
+  })
+
+  it('stops the pending invitation immediately when the joiner fails', () => {
+    const root = mkdtempSync(join(tmpdir(), 'desktop-engine-interop-failure-'))
+    roots.push(root)
+    const fakeCli = join(root, 'fake-uniclip')
+    write(
+      fakeCli,
+      `#!/usr/bin/env bash
+if [[ " $* " == *" invite "* ]]; then
+  echo "INVITATION_CODE=1234-5678"
+  sleep 4
+  exit 0
+fi
+if [[ " $* " == *" join "* ]]; then
+  exit 23
+fi
+exit 0
+`
+    )
+    chmodSync(fakeCli, 0o755)
+
+    const startedAt = Date.now()
+    const result = spawnSync('bash', [interopScript], {
+      cwd: repositoryRoot,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        HOME: root,
+        TMPDIR: root,
+        ALICE_CLI: fakeCli,
+        BOB_CLI: fakeCli,
+        PROFILE_PREFIX: 'join-failure-test',
+        WAIT_SECS: '1',
+      },
+    })
+
+    expect(result.status).toBe(1)
+    expect(Date.now() - startedAt).toBeLessThan(2500)
+    expect(result.stderr).toContain('FAIL: bob exit status 23')
+  })
+})

--- a/scripts/adopt-engine-release.mjs
+++ b/scripts/adopt-engine-release.mjs
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+
+import { Buffer } from 'node:buffer'
+import { createHash } from 'node:crypto'
+import { readFileSync, writeFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import process from 'node:process'
+
+const ENGINE_REPOSITORY = 'UniClipboard/Engine'
+const ENGINE_GIT_URL = `https://github.com/${ENGINE_REPOSITORY}.git`
+
+function fail(message) {
+  process.stderr.write(`Engine adoption failed: ${message}\n`)
+  process.exit(1)
+}
+
+function readArg(name) {
+  const index = process.argv.indexOf(name)
+  if (index === -1) return undefined
+  const value = process.argv[index + 1]
+  if (!value) fail(`${name} requires a value`)
+  return value
+}
+
+async function readBytes(path, url) {
+  if (path) return readFileSync(resolve(path))
+  const response = await fetch(url, { redirect: 'follow' })
+  if (!response.ok) fail(`cannot download ${url}: HTTP ${response.status}`)
+  return Buffer.from(await response.arrayBuffer())
+}
+
+function sha256(bytes) {
+  return createHash('sha256').update(bytes).digest('hex')
+}
+
+const root = resolve(readArg('--root') ?? resolve(import.meta.dirname, '..'))
+const version = readArg('--version')
+const sourceCommit = readArg('--source-commit')
+if (!/^v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(version ?? '')) {
+  fail('version must be a v-prefixed semantic version')
+}
+if (!/^[0-9a-f]{40}$/.test(sourceCommit ?? '')) {
+  fail('source commit must be a full lowercase Git commit')
+}
+
+const releaseBase = `https://github.com/${ENGINE_REPOSITORY}/releases/download/${version}`
+const manifestBytes = await readBytes(readArg('--manifest'), `${releaseBase}/release-manifest.json`)
+let manifest
+try {
+  manifest = JSON.parse(manifestBytes.toString('utf8'))
+} catch (error) {
+  fail(`release manifest is invalid JSON: ${String(error)}`)
+}
+if (manifest.schemaVersion !== 1) fail('unsupported release manifest schema')
+if (manifest.release?.version !== version) fail('release version does not match the notification')
+if (manifest.release?.commit !== sourceCommit) {
+  fail('release source commit does not match the notification')
+}
+
+const sourceArtifact = manifest.artifacts?.find(
+  candidate => candidate.name === 'UniClipboardEngine-source.tar.gz'
+)
+if (!sourceArtifact || !/^[0-9a-f]{64}$/.test(sourceArtifact.sha256 ?? '')) {
+  fail('release manifest does not declare a valid source archive')
+}
+const sourceBytes = await readBytes(
+  readArg('--source-archive'),
+  `${releaseBase}/UniClipboardEngine-source.tar.gz`
+)
+if (sourceBytes.length !== sourceArtifact.size)
+  fail('source archive size does not match the release')
+if (sha256(sourceBytes) !== sourceArtifact.sha256) {
+  fail('source archive checksum does not match the release')
+}
+
+const cargoPath = resolve(root, 'Cargo.toml')
+let cargo = readFileSync(cargoPath, 'utf8')
+let replacements = 0
+for (const dependency of ['uc-engine', 'uc-observability-contract']) {
+  const pattern = new RegExp(
+    `^(${dependency.replace('-', '\\-')}\\s*=\\s*\\{[^\\n]*git\\s*=\\s*"${ENGINE_GIT_URL.replaceAll('.', '\\.')}"[^\\n]*rev\\s*=\\s*")[0-9a-f]{40}("[^\\n]*\\})$`,
+    'm'
+  )
+  if (!pattern.test(cargo)) fail(`Cargo.toml does not contain the pinned ${dependency} dependency`)
+  cargo = cargo.replace(pattern, `$1${sourceCommit}$2`)
+  replacements += 1
+}
+if (replacements !== 2) fail('did not update every Engine dependency')
+writeFileSync(cargoPath, cargo)
+
+process.stdout.write(`Adopted Engine ${version} at ${sourceCommit}\n`)

--- a/scripts/architecture/check-engine-repository.mjs
+++ b/scripts/architecture/check-engine-repository.mjs
@@ -9,9 +9,6 @@ import { fileURLToPath } from 'node:url'
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url))
 const REPOSITORY_ROOT = resolve(SCRIPT_DIR, '../..')
 const ENGINE_REPOSITORY = 'https://github.com/UniClipboard/Engine.git'
-const ENGINE_REVISION = 'e5101db6f470e6b2e539d314d1e3581538dcec62'
-const DECLARED_ENGINE_SOURCE = `git+${ENGINE_REPOSITORY}?rev=${ENGINE_REVISION}`
-const RESOLVED_ENGINE_SOURCE = `${DECLARED_ENGINE_SOURCE}#${ENGINE_REVISION}`
 
 const MIGRATED_PACKAGES = new Set([
   'uc-engine',
@@ -88,8 +85,24 @@ function addProblem(problems, check, message) {
   problems.push(`${check}: ${message}`)
 }
 
+function resolveEnginePin(metadata) {
+  const engine = dependency(workspacePackageByName(metadata, 'uc-daemon'), 'uc-engine')
+  const match = engine?.source?.match(
+    new RegExp(`^git\\+${ENGINE_REPOSITORY.replaceAll('.', '\\.')}\\?rev=([0-9a-f]{40})$`)
+  )
+  if (!match) throw new Error('uc-daemon must declare one full Engine Git revision')
+  const revision = match[1]
+  const declaredSource = `git+${ENGINE_REPOSITORY}?rev=${revision}`
+  return {
+    revision,
+    declaredSource,
+    resolvedSource: `${declaredSource}#${revision}`,
+  }
+}
+
 function checkRepositoryBoundary(metadata, { checkPaths = true } = {}) {
   const problems = []
+  const enginePin = resolveEnginePin(metadata)
 
   for (const packageMetadata of workspacePackages(metadata)) {
     if (MIGRATED_PACKAGES.has(packageMetadata.name)) {
@@ -109,11 +122,11 @@ function checkRepositoryBoundary(metadata, { checkPaths = true } = {}) {
           `${packageMetadata.name} uses a local path for ${item.name}`
         )
       }
-      if (item.source !== DECLARED_ENGINE_SOURCE) {
+      if (item.source !== enginePin.declaredSource) {
         addProblem(
           problems,
           'engine provenance',
-          `${packageMetadata.name} does not pin ${item.name} to ${ENGINE_REVISION}`
+          `${packageMetadata.name} does not pin ${item.name} to ${enginePin.revision}`
         )
       }
     }
@@ -132,17 +145,17 @@ function checkRepositoryBoundary(metadata, { checkPaths = true } = {}) {
       .map(candidate => candidate.source)
       .filter(source => source?.startsWith(`git+${ENGINE_REPOSITORY}`))
   )
-  if (engineSources.size !== 1 || !engineSources.has(RESOLVED_ENGINE_SOURCE)) {
+  if (engineSources.size !== 1 || !engineSources.has(enginePin.resolvedSource)) {
     addProblem(
       problems,
       'engine provenance',
-      `expected one resolved Engine source at revision ${ENGINE_REVISION}; found ${[...engineSources].join(', ')}`
+      `expected one resolved Engine source at revision ${enginePin.revision}; found ${[...engineSources].join(', ')}`
     )
   }
 
   for (const packageMetadata of metadata.packages) {
     if (!MIGRATED_PACKAGES.has(packageMetadata.name)) continue
-    if (packageMetadata.source !== RESOLVED_ENGINE_SOURCE) {
+    if (packageMetadata.source !== enginePin.resolvedSource) {
       addProblem(
         problems,
         'engine provenance',
@@ -256,11 +269,15 @@ function repositorySources() {
 }
 
 function collectProblems(metadata, sources, options) {
-  return [
-    ...checkRepositoryBoundary(metadata, options),
-    ...checkPublicSurface(metadata),
-    ...checkLanIsolation(metadata, sources),
-  ]
+  try {
+    return [
+      ...checkRepositoryBoundary(metadata, options),
+      ...checkPublicSurface(metadata),
+      ...checkLanIsolation(metadata, sources),
+    ]
+  } catch (error) {
+    return [`engine provenance: ${error instanceof Error ? error.message : String(error)}`]
+  }
 }
 
 function clone(value) {

--- a/scripts/test_pair_e2e.sh
+++ b/scripts/test_pair_e2e.sh
@@ -2,12 +2,13 @@
 #
 # Single-machine end-to-end pairing smoke test (Slice 1).
 #
-# Spawns two uniclipboard-cli processes under separate --profile names:
+# Spawns two uniclip processes under separate --profile names. The two paths
+# may point at different Engine versions for release interoperability checks:
 #   * alice: initialize space (A1) + issue invitation (B1) + wait for joiner
 #   * bob:   redeem invitation (B2)
 #
-# Assertion:
-#   bob exits 0 AND alice exits 0 (Success outcome fired).
+# Assertions:
+#   pairing succeeds, then an exact text payload is received in each direction.
 #
 # Requirements:
 #   - macOS (profile data dirs live under ~/Library/Application Support)
@@ -19,36 +20,55 @@
 
 set -euo pipefail
 
-CLI="${CLI:-./target/debug/uniclipboard-cli}"
+ALICE_CLI="${ALICE_CLI:-${CLI:-./target/debug/uniclip}}"
+BOB_CLI="${BOB_CLI:-${CLI:-./target/debug/uniclip}}"
 PASSPHRASE="${PASSPHRASE:-hunter22hunter22}"
 WAIT_SECS="${WAIT_SECS:-30}"
 COMMON_FLAGS="--dev"
+PROFILE_PREFIX="${PROFILE_PREFIX:-engine-interop}"
+
+if [[ ! "$PROFILE_PREFIX" =~ ^[A-Za-z0-9-]+$ ]]; then
+    echo "ERROR: PROFILE_PREFIX must contain only letters, digits, and hyphens." >&2
+    exit 2
+fi
+ALICE_PROFILE="${PROFILE_PREFIX}-alice"
+BOB_PROFILE="${PROFILE_PREFIX}-bob"
 
 if [[ "$(uname -s)" != "Darwin" ]]; then
     echo "ERROR: this script is macOS-only (paths under ~/Library/Application Support)." >&2
     exit 2
 fi
 
-if [[ ! -x "$CLI" ]]; then
-    echo "ERROR: CLI binary not found at $CLI" >&2
-    echo "Build first: cargo build -p uc-cli --bin uniclipboard-cli" >&2
-    exit 2
-fi
+for cli in "$ALICE_CLI" "$BOB_CLI"; do
+    if [[ ! -x "$cli" ]]; then
+        echo "ERROR: CLI binary not found at $cli" >&2
+        echo "Build first: cargo build -p uc-cli --bin uniclip" >&2
+        exit 2
+    fi
+done
 
 APP_ROOT="$HOME/Library/Application Support"
 # NB: uc-platform's `DirsAppDirsAdapter` joins APP_DIR_NAME with the
 # profile via a hyphen (`app.uniclipboard.desktop-<profile>`), so the
 # script's cleanup must match that exact scheme — NOT the underscore
 # form used by `apply_profile_suffix` elsewhere.
-ALICE_DIR="$APP_ROOT/app.uniclipboard.desktop-alice"
-BOB_DIR="$APP_ROOT/app.uniclipboard.desktop-bob"
+ALICE_DIR="$APP_ROOT/app.uniclipboard.desktop-$ALICE_PROFILE"
+BOB_DIR="$APP_ROOT/app.uniclipboard.desktop-$BOB_PROFILE"
 
 cleanup() {
     if [[ -n "${ALICE_PID:-}" ]] && kill -0 "$ALICE_PID" 2>/dev/null; then
         kill -INT "$ALICE_PID" 2>/dev/null || true
         wait "$ALICE_PID" 2>/dev/null || true
     fi
+    if [[ -n "${WATCH_PID:-}" ]] && kill -0 "$WATCH_PID" 2>/dev/null; then
+        kill -INT "$WATCH_PID" 2>/dev/null || true
+        wait "$WATCH_PID" 2>/dev/null || true
+    fi
+    "$ALICE_CLI" $COMMON_FLAGS --profile "$ALICE_PROFILE" stop >/dev/null 2>&1 || true
+    "$BOB_CLI" $COMMON_FLAGS --profile "$BOB_PROFILE" stop >/dev/null 2>&1 || true
     [[ -n "${ALICE_OUT:-}" ]] && rm -f "$ALICE_OUT"
+    [[ -n "${WATCH_OUT:-}" ]] && rm -f "$WATCH_OUT"
+    [[ -n "${WATCH_ERR:-}" ]] && rm -f "$WATCH_ERR"
 }
 trap cleanup EXIT
 
@@ -58,13 +78,13 @@ echo "==> Wiping previous profile state"
 /bin/rm -rf "$ALICE_DIR" "$BOB_DIR"
 
 echo "==> alice: init"
-"$CLI" $COMMON_FLAGS --profile alice init \
+"$ALICE_CLI" $COMMON_FLAGS --profile "$ALICE_PROFILE" init \
     --passphrase "$PASSPHRASE" \
     --device-name "alice (e2e)"
 
 echo "==> alice: invite (background)"
 ALICE_OUT="$(mktemp -t uc_alice_invite.XXXXXX)"
-"$CLI" $COMMON_FLAGS --profile alice invite > "$ALICE_OUT" 2>&1 &
+"$ALICE_CLI" $COMMON_FLAGS --profile "$ALICE_PROFILE" invite > "$ALICE_OUT" 2>&1 &
 ALICE_PID=$!
 
 echo "==> Waiting up to ${WAIT_SECS}s for INVITATION_CODE line from alice"
@@ -93,12 +113,16 @@ echo "    got code: $CODE"
 
 echo "==> bob: join --code $CODE"
 set +e
-"$CLI" $COMMON_FLAGS --profile bob join \
+"$BOB_CLI" $COMMON_FLAGS --profile "$BOB_PROFILE" join \
     --code "$CODE" \
     --passphrase "$PASSPHRASE"
 BOB_EXIT=$?
 set -e
 echo "    bob exited with $BOB_EXIT"
+
+if [[ $BOB_EXIT -ne 0 ]] && kill -0 "$ALICE_PID" 2>/dev/null; then
+    kill -TERM "$ALICE_PID" 2>/dev/null || true
+fi
 
 echo "==> Waiting for alice invite to settle"
 set +e
@@ -122,4 +146,59 @@ if [[ $ALICE_EXIT -ne 0 ]]; then
     exit 1
 fi
 
-echo "PASS: single-machine pairing end-to-end verified"
+verify_transfer() {
+    local sender_cli="$1"
+    local receiver_cli="$2"
+    local sender_profile="$3"
+    local receiver_profile="$4"
+    local payload="$5"
+
+    WATCH_OUT="$(mktemp -t uc_interop_watch.XXXXXX)"
+    WATCH_ERR="$(mktemp -t uc_interop_watch_err.XXXXXX)"
+    "$receiver_cli" $COMMON_FLAGS --profile "$receiver_profile" --json watch \
+        > "$WATCH_OUT" 2> "$WATCH_ERR" &
+    WATCH_PID=$!
+
+    local ready=""
+    for ((i = 0; i < WAIT_SECS * 2; i++)); do
+        if grep -Fq 'WATCH_READY' "$WATCH_ERR" 2>/dev/null; then
+            ready="true"
+            break
+        fi
+        if ! kill -0 "$WATCH_PID" 2>/dev/null; then
+            echo "ERROR: receiver watch exited before becoming ready" >&2
+            sed 's/^/  watch | /' "$WATCH_ERR" >&2
+            return 1
+        fi
+        sleep 0.5
+    done
+    if [[ -z "$ready" ]]; then
+        echo "ERROR: receiver watch did not become ready" >&2
+        return 1
+    fi
+
+    "$sender_cli" $COMMON_FLAGS --profile "$sender_profile" --json send "$payload"
+    local received=""
+    for ((i = 0; i < WAIT_SECS * 2; i++)); do
+        if grep -Fq "$payload" "$WATCH_OUT" 2>/dev/null; then
+            received="true"
+            break
+        fi
+        sleep 0.5
+    done
+    kill -INT "$WATCH_PID" 2>/dev/null || true
+    wait "$WATCH_PID" 2>/dev/null || true
+    WATCH_PID=""
+    if [[ -z "$received" ]]; then
+        echo "ERROR: exact interop payload was not received: $payload" >&2
+        sed 's/^/  watch | /' "$WATCH_OUT" >&2
+        return 1
+    fi
+}
+
+verify_transfer "$ALICE_CLI" "$BOB_CLI" "$ALICE_PROFILE" "$BOB_PROFILE" \
+    "old-to-new-$PROFILE_PREFIX"
+verify_transfer "$BOB_CLI" "$ALICE_CLI" "$BOB_PROFILE" "$ALICE_PROFILE" \
+    "new-to-old-$PROFILE_PREFIX"
+
+echo "PASS: cross-version pairing and bidirectional transfer verified"


### PR DESCRIPTION
## Summary

- Verify Engine release notifications against the public manifest and source archive before updating both pinned dependencies (cdf263bb0).
- Create or refresh a deterministic adoption PR only after the lockfile, workspace, and repository boundaries pass validation (cdf263bb0).
- Extend the cross-version pairing check to run old and new clients in both roles and verify exact text transfer in both directions (cdf263bb0).

## Test plan

- [x] `npx vitest run scripts/__tests__/adopt-engine-release.test.ts`
- [x] `bun run check:engine-repository`
- [x] `npx eslint scripts/__tests__/adopt-engine-release.test.ts scripts/adopt-engine-release.mjs scripts/architecture/check-engine-repository.mjs`
- [x] `bash -n scripts/test_pair_e2e.sh`
- [x] Prettier and workflow syntax checks
- [x] Verified adoption against the published Engine `v0.20.0-rc.18` manifest and source archive
- [ ] Confirm the organization GitHub App variable and secret are exposed to this repository; the current account cannot inspect organization-level Actions settings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated adoption of validated Engine releases, including dependency updates and pull request creation when changes are detected.
  * Added safeguards to verify release metadata, source integrity, repository provenance, and dependency consistency.

* **Tests**
  * Expanded coverage for release adoption, configuration validation, and interoperability.
  * Added cross-version pairing checks with bidirectional transfer verification and improved failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->