### PR TITLE
fix(analytics): connect desktop PostHog runtime

### DIFF
--- a/apps/daemon/src/daemon/host.rs
+++ b/apps/daemon/src/daemon/host.rs
@@ -8,12 +8,13 @@ use tokio::sync::broadcast;
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 use uc_bootstrap::{
-    init_tracing_subscriber, install_panic_logging_hook, prepare_desktop_engine_host,
-    DesktopHostFileHandles, DesktopHostProcessPaths,
+    init_tracing_subscriber, initialize_analytics_context, install_panic_logging_hook,
+    prepare_desktop_engine_host, DesktopHostFileHandles, DesktopHostProcessPaths,
 };
 use uc_daemon_local::crash_marker::{DaemonExitReport, DaemonRunMarker};
 use uc_daemon_local::process_metadata::{DaemonPidManager, DaemonProcessMode};
 use uc_engine::{ActiveClipboardChanged, Engine, HostFileHandle, Operation, OperationResult};
+use uc_observability::analytics::AnalyticsPort;
 use uc_webserver::api::auth::load_or_create_auth_token;
 use uc_webserver::api::server::{run_http_server, DaemonApiState, DaemonFileHandles};
 use uc_webserver::api::types::{DaemonResidency, DaemonWsEvent};
@@ -79,6 +80,7 @@ async fn run_async(run_mode: DaemonRunMode) -> anyhow::Result<()> {
 
     let prepared = prepare_desktop_engine_host()?;
     let process_paths = prepared.process_paths().clone();
+    let analytics = prepared.analytics();
     let file_handles: Arc<dyn DaemonFileHandles> =
         Arc::new(DesktopDaemonFileHandles::new(prepared.file_handles()));
     let (engine_config, host_capabilities) = prepared.into_engine_start();
@@ -96,6 +98,13 @@ async fn run_async(run_mode: DaemonRunMode) -> anyhow::Result<()> {
         .map_err(anyhow::Error::new)?;
     let engine = Arc::new(engine);
 
+    initialize_analytics_context(
+        &analytics,
+        &engine,
+        run_mode.suppresses_device_presence_analytics(),
+    )
+    .await;
+
     record_upgrade_status_at_startup(&engine).await;
     spawn_startup_recovery(run_mode, Arc::clone(&engine));
 
@@ -105,6 +114,7 @@ async fn run_async(run_mode: DaemonRunMode) -> anyhow::Result<()> {
         events,
         file_handles,
         process_paths,
+        analytics.sink(),
     )
     .await;
     let shutdown = engine
@@ -121,6 +131,7 @@ async fn run_daemon_surfaces(
     events: uc_engine::EventStream,
     file_handles: Arc<dyn DaemonFileHandles>,
     process_paths: DesktopHostProcessPaths,
+    analytics_sink: Arc<dyn AnalyticsPort>,
 ) -> anyhow::Result<()> {
     let auth_token = load_or_create_auth_token(process_paths.daemon_token())?;
     let pid_manager = DaemonPidManager::new(process_paths.daemon_pid());
@@ -137,7 +148,8 @@ async fn run_daemon_surfaces(
         auth_token,
         Arc::clone(&security),
     )
-    .with_residency(run_mode.into());
+    .with_residency(run_mode.into())
+    .with_analytics(analytics_sink);
     let (event_tx, _) = broadcast::channel::<DaemonWsEvent>(64);
     api_state.event_tx = event_tx.clone();
 

--- a/crates/uc-bootstrap/src/lib.rs
+++ b/crates/uc-bootstrap/src/lib.rs
@@ -16,6 +16,7 @@ pub mod wiring;
 pub use entrypoint::cli::{build_cli_engine_runtime, CliEngineRuntime};
 pub use layer::platform::SystemClipboardWiring;
 pub use observability::tracing::{init_tracing_subscriber, install_panic_logging_hook};
+pub use wiring::analytics::{initialize_analytics_context, DesktopHostAnalytics};
 pub use wiring::desktop_host::{
     prepare_desktop_engine_host, DesktopEngineHost, DesktopHostFileHandles, DesktopHostProcessPaths,
 };

--- a/crates/uc-bootstrap/src/wiring/analytics.rs
+++ b/crates/uc-bootstrap/src/wiring/analytics.rs
@@ -1,0 +1,294 @@
+//! Desktop host wiring for product analytics.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use uc_engine::{Engine, Operation, OperationResult};
+use uc_observability::analytics::{
+    build_event_context, global_event_context, hash_space_id_for_telemetry, load_or_create_ids,
+    load_space_person_id, set_global_event_context, AnalyticsIdentityPort, AnalyticsIds,
+    AnalyticsPersonId, AnalyticsPort, AppChannel, Event, EventContextInputs, GatedAnalyticsSink,
+    InstallSource, LocalAnalyticsIdentity, NoopAnalyticsSink, PosthogSink, StdoutSink,
+};
+
+#[derive(Clone)]
+pub struct DesktopHostAnalytics {
+    sink: Arc<dyn AnalyticsPort>,
+    identity: Arc<dyn AnalyticsIdentityPort>,
+    ids: AnalyticsIds,
+    person_id: AnalyticsPersonId,
+}
+
+impl DesktopHostAnalytics {
+    pub(crate) fn new(analytics_dir: PathBuf) -> anyhow::Result<Self> {
+        let ids = load_or_create_ids(&analytics_dir).inspect_err(|_| {
+            tracing::error!(
+                error_kind = "analytics_identity_load_failed",
+                error = "analytics identity storage unavailable",
+                retryable = false,
+                "analytics host preparation failed"
+            );
+        })?;
+        let person_id = match load_space_person_id(&analytics_dir) {
+            Ok(Some(id)) => AnalyticsPersonId::SpaceShared(id),
+            Ok(None) => AnalyticsPersonId::Solo(ids.anonymous_user_id),
+            Err(_) => {
+                tracing::warn!(
+                    error_kind = "analytics_space_identity_load_failed",
+                    retryable = false,
+                    fallback = "solo",
+                    "analytics space identity unavailable"
+                );
+                AnalyticsPersonId::Solo(ids.anonymous_user_id)
+            }
+        };
+
+        Ok(Self {
+            sink: build_analytics_sink(),
+            identity: Arc::new(LocalAnalyticsIdentity::new(analytics_dir.clone())),
+            ids,
+            person_id,
+        })
+    }
+
+    pub fn sink(&self) -> Arc<dyn AnalyticsPort> {
+        Arc::clone(&self.sink)
+    }
+
+    pub(crate) fn identity(&self) -> Arc<dyn AnalyticsIdentityPort> {
+        Arc::clone(&self.identity)
+    }
+}
+
+/// Install the process-level event context before the daemon emits analytics.
+#[tracing::instrument(
+    name = "analytics.initialize_context",
+    level = "info",
+    skip_all,
+    fields(suppress_device_presence_events = suppress_device_presence_events)
+)]
+pub async fn initialize_analytics_context(
+    analytics: &DesktopHostAnalytics,
+    engine: &Engine,
+    suppress_device_presence_events: bool,
+) {
+    if global_event_context().is_some() {
+        tracing::debug!(
+            result = "already_initialized",
+            "analytics context unchanged"
+        );
+        return;
+    }
+
+    let active_device_count = read_active_device_count(engine).await;
+    let space_id_hash = read_space_id_hash(engine).await;
+    let context = build_event_context(EventContextInputs {
+        anonymous_user_id: analytics.ids.anonymous_user_id,
+        analytics_device_id: analytics.ids.analytics_device_id,
+        app_version: env!("CARGO_PKG_VERSION").to_string(),
+        app_channel: parse_app_channel(env!("CARGO_PKG_VERSION")),
+        install_source: InstallSource::Unknown,
+        is_first_run: analytics.ids.is_first_run,
+        active_device_count,
+        space_id_hash: space_id_hash.clone(),
+        analytics_person_id: analytics.person_id.clone(),
+    });
+    set_global_event_context(Arc::new(context));
+    emit_process_open_events(
+        analytics.sink.as_ref(),
+        analytics.ids.is_first_run,
+        suppress_device_presence_events,
+    );
+
+    tracing::info!(
+        result = "initialized",
+        active_device_count,
+        has_space = space_id_hash.is_some(),
+        is_first_run = analytics.ids.is_first_run,
+        "analytics context initialized"
+    );
+}
+
+async fn read_active_device_count(engine: &Engine) -> u32 {
+    match engine.execute(Operation::ListDevices).await {
+        Ok(OperationResult::Devices(devices)) => u32::try_from(devices.len()).unwrap_or(u32::MAX),
+        Ok(_) => {
+            tracing::warn!(
+                error_kind = "unexpected_engine_result",
+                operation = "list_devices",
+                fallback = 0,
+                "analytics device count unavailable"
+            );
+            0
+        }
+        Err(error) => {
+            tracing::warn!(
+                error_code = error.code(),
+                error_kind = %error.category(),
+                retryable = error.is_retryable(),
+                operation = "list_devices",
+                fallback = 0,
+                "analytics device count unavailable"
+            );
+            0
+        }
+    }
+}
+
+async fn read_space_id_hash(engine: &Engine) -> Option<String> {
+    match engine.execute(Operation::QuerySetupState).await {
+        Ok(OperationResult::SetupState(state)) => {
+            state.space_id.as_deref().map(hash_space_id_for_telemetry)
+        }
+        Ok(_) => {
+            tracing::warn!(
+                error_kind = "unexpected_engine_result",
+                operation = "query_setup_state",
+                fallback = "no_space",
+                "analytics space context unavailable"
+            );
+            None
+        }
+        Err(error) => {
+            tracing::warn!(
+                error_code = error.code(),
+                error_kind = %error.category(),
+                retryable = error.is_retryable(),
+                operation = "query_setup_state",
+                fallback = "no_space",
+                "analytics space context unavailable"
+            );
+            None
+        }
+    }
+}
+
+fn build_analytics_sink() -> Arc<dyn AnalyticsPort> {
+    let inner: Arc<dyn AnalyticsPort> = if cfg!(debug_assertions) {
+        Arc::new(StdoutSink::new())
+    } else {
+        let runtime_key = std::env::var("POSTHOG_PROJECT_KEY")
+            .ok()
+            .filter(|key| !key.is_empty());
+        match resolve_posthog_key(runtime_key, option_env!("POSTHOG_PROJECT_KEY")) {
+            Some(key) => Arc::new(PosthogSink::new(key)),
+            None => {
+                tracing::info!(
+                    analytics_backend = "noop",
+                    reason = "posthog_project_key_missing",
+                    "product analytics disabled"
+                );
+                Arc::new(NoopAnalyticsSink)
+            }
+        }
+    };
+    Arc::new(GatedAnalyticsSink::new(inner))
+}
+
+fn resolve_posthog_key(runtime: Option<String>, compile: Option<&'static str>) -> Option<String> {
+    runtime
+        .filter(|key| !key.is_empty())
+        .or_else(|| compile.filter(|key| !key.is_empty()).map(String::from))
+}
+
+fn parse_app_channel(version: &str) -> AppChannel {
+    let Some(suffix) = version.split_once('-').map(|(_, suffix)| suffix) else {
+        return AppChannel::Stable;
+    };
+    match suffix.split(['.', '+']).next().unwrap_or("") {
+        "beta" => AppChannel::Beta,
+        _ => AppChannel::Alpha,
+    }
+}
+
+fn emit_process_open_events(
+    analytics: &dyn AnalyticsPort,
+    is_first_run: bool,
+    suppress_device_presence_events: bool,
+) {
+    if suppress_device_presence_events {
+        tracing::debug!(result = "suppressed", "analytics presence events skipped");
+        return;
+    }
+    if is_first_run {
+        analytics.capture(Event::AppFirstOpen);
+    }
+    analytics.capture(Event::AppOpened);
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use super::*;
+
+    #[derive(Default)]
+    struct RecordingSink {
+        events: Mutex<Vec<Event>>,
+    }
+
+    impl AnalyticsPort for RecordingSink {
+        fn capture(&self, event: Event) {
+            self.events
+                .lock()
+                .unwrap_or_else(|poison| poison.into_inner())
+                .push(event);
+        }
+    }
+
+    #[test]
+    fn runtime_posthog_key_takes_precedence() {
+        assert_eq!(
+            resolve_posthog_key(Some("runtime".into()), Some("compile")).as_deref(),
+            Some("runtime")
+        );
+    }
+
+    #[test]
+    fn empty_posthog_keys_are_ignored() {
+        assert_eq!(resolve_posthog_key(Some(String::new()), Some("")), None);
+        assert_eq!(
+            resolve_posthog_key(Some(String::new()), Some("compile")).as_deref(),
+            Some("compile")
+        );
+    }
+
+    #[test]
+    fn app_channel_uses_stable_only_for_clean_versions() {
+        assert_eq!(parse_app_channel("1.0.0"), AppChannel::Stable);
+        assert_eq!(parse_app_channel("1.0.0-alpha.2"), AppChannel::Alpha);
+        assert_eq!(parse_app_channel("1.0.0-beta.1"), AppChannel::Beta);
+        assert_eq!(parse_app_channel("1.0.0-rc.1"), AppChannel::Alpha);
+    }
+
+    #[test]
+    fn process_open_events_respect_first_run_and_suppression() {
+        let first_run = RecordingSink::default();
+        emit_process_open_events(&first_run, true, false);
+        assert_eq!(
+            *first_run
+                .events
+                .lock()
+                .unwrap_or_else(|poison| poison.into_inner()),
+            vec![Event::AppFirstOpen, Event::AppOpened]
+        );
+
+        let returning = RecordingSink::default();
+        emit_process_open_events(&returning, false, false);
+        assert_eq!(
+            *returning
+                .events
+                .lock()
+                .unwrap_or_else(|poison| poison.into_inner()),
+            vec![Event::AppOpened]
+        );
+
+        let suppressed = RecordingSink::default();
+        emit_process_open_events(&suppressed, true, true);
+        assert!(suppressed
+            .events
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
+            .is_empty());
+    }
+}

--- a/crates/uc-bootstrap/src/wiring/analytics.rs
+++ b/crates/uc-bootstrap/src/wiring/analytics.rs
@@ -8,7 +8,8 @@ use uc_observability::analytics::{
     build_event_context, global_event_context, hash_space_id_for_telemetry, load_or_create_ids,
     load_space_person_id, set_global_event_context, AnalyticsIdentityPort, AnalyticsIds,
     AnalyticsPersonId, AnalyticsPort, AppChannel, Event, EventContextInputs, GatedAnalyticsSink,
-    InstallSource, LocalAnalyticsIdentity, NoopAnalyticsSink, PosthogSink, StdoutSink,
+    InstallSource, LocalAnalyticsIdentity, NoopAnalyticsIdentity, NoopAnalyticsSink, PosthogSink,
+    StdoutSink,
 };
 
 #[derive(Clone)]
@@ -20,35 +21,56 @@ pub struct DesktopHostAnalytics {
 }
 
 impl DesktopHostAnalytics {
-    pub(crate) fn new(analytics_dir: PathBuf) -> anyhow::Result<Self> {
-        let ids = load_or_create_ids(&analytics_dir).inspect_err(|_| {
-            tracing::error!(
-                error_kind = "analytics_identity_load_failed",
-                error = "analytics identity storage unavailable",
-                retryable = false,
-                "analytics host preparation failed"
-            );
-        })?;
-        let person_id = match load_space_person_id(&analytics_dir) {
-            Ok(Some(id)) => AnalyticsPersonId::SpaceShared(id),
-            Ok(None) => AnalyticsPersonId::Solo(ids.anonymous_user_id),
-            Err(_) => {
+    pub(crate) fn new(analytics_dir: PathBuf) -> Self {
+        let persisted_ids = std::fs::create_dir_all(&analytics_dir)
+            .map_err(anyhow::Error::from)
+            .and_then(|()| load_or_create_ids(&analytics_dir));
+        let (ids, identity, person_id): (
+            AnalyticsIds,
+            Arc<dyn AnalyticsIdentityPort>,
+            AnalyticsPersonId,
+        ) = match persisted_ids {
+            Ok(ids) => {
+                let person_id = match load_space_person_id(&analytics_dir) {
+                    Ok(Some(id)) => AnalyticsPersonId::SpaceShared(id),
+                    Ok(None) => AnalyticsPersonId::Solo(ids.anonymous_user_id),
+                    Err(error) => {
+                        tracing::warn!(
+                            error = %error,
+                            error_kind = "analytics_space_identity_load_failed",
+                            retryable = false,
+                            fallback = "solo",
+                            "analytics space identity unavailable"
+                        );
+                        AnalyticsPersonId::Solo(ids.anonymous_user_id)
+                    }
+                };
+                (
+                    ids,
+                    Arc::new(LocalAnalyticsIdentity::new(analytics_dir.clone())),
+                    person_id,
+                )
+            }
+            Err(error) => {
                 tracing::warn!(
-                    error_kind = "analytics_space_identity_load_failed",
+                    error = %error,
+                    error_kind = "analytics_identity_load_failed",
                     retryable = false,
-                    fallback = "solo",
-                    "analytics space identity unavailable"
+                    fallback = "ephemeral",
+                    "analytics identity storage unavailable"
                 );
-                AnalyticsPersonId::Solo(ids.anonymous_user_id)
+                let ids = AnalyticsIds::ephemeral();
+                let person_id = AnalyticsPersonId::Solo(ids.anonymous_user_id);
+                (ids, Arc::new(NoopAnalyticsIdentity), person_id)
             }
         };
 
-        Ok(Self {
+        Self {
             sink: build_analytics_sink(),
-            identity: Arc::new(LocalAnalyticsIdentity::new(analytics_dir.clone())),
+            identity,
             ids,
             person_id,
-        })
+        }
     }
 
     pub fn sink(&self) -> Arc<dyn AnalyticsPort> {
@@ -234,6 +256,38 @@ mod tests {
                 .unwrap_or_else(|poison| poison.into_inner())
                 .push(event);
         }
+    }
+
+    #[test]
+    fn desktop_host_analytics_creates_its_identity_directory() {
+        let root = tempfile::tempdir().expect("create analytics test root");
+        let analytics_dir = root.path().join("nested").join("analytics");
+
+        let analytics = DesktopHostAnalytics::new(analytics_dir.clone());
+
+        assert!(analytics_dir.is_dir());
+        assert!(analytics_dir.join("installation_id").is_file());
+        assert!(analytics_dir.join("analytics_device_id").is_file());
+        assert!(analytics.ids.is_first_run);
+    }
+
+    #[test]
+    fn desktop_host_analytics_uses_ephemeral_identity_when_storage_is_unavailable() {
+        let root = tempfile::tempdir().expect("create analytics test root");
+        let blocked_path = root.path().join("not-a-directory");
+        std::fs::write(&blocked_path, b"blocked").expect("create blocking file");
+
+        let analytics = DesktopHostAnalytics::new(blocked_path);
+
+        assert!(!analytics.ids.is_first_run);
+        assert_ne!(
+            analytics.ids.anonymous_user_id,
+            analytics.ids.analytics_device_id
+        );
+        assert_eq!(
+            analytics.person_id,
+            AnalyticsPersonId::Solo(analytics.ids.anonymous_user_id)
+        );
     }
 
     #[test]

--- a/crates/uc-bootstrap/src/wiring/desktop_host.rs
+++ b/crates/uc-bootstrap/src/wiring/desktop_host.rs
@@ -24,6 +24,7 @@ use uc_platform::ports::{SecureStorageError, SecureStorageProvider};
 
 use crate::layer::paths::{resolve_desktop_host_paths, DesktopHostPaths};
 use crate::layer::platform::{create_desktop_system_clipboard, SystemClipboardWiring};
+use crate::wiring::analytics::DesktopHostAnalytics;
 use crate::wiring::error::{WiringError, WiringResult};
 use crate::wiring::secure_storage::build_secure_storage_prelude;
 
@@ -32,6 +33,7 @@ pub struct DesktopEngineHost {
     capabilities: HostCapabilities,
     process_paths: DesktopHostProcessPaths,
     file_handles: DesktopHostFileHandles,
+    analytics: DesktopHostAnalytics,
 }
 
 impl DesktopEngineHost {
@@ -41,6 +43,10 @@ impl DesktopEngineHost {
 
     pub fn file_handles(&self) -> DesktopHostFileHandles {
         self.file_handles.clone()
+    }
+
+    pub fn analytics(&self) -> DesktopHostAnalytics {
+        self.analytics.clone()
     }
 
     pub fn into_engine_start(self) -> (EngineConfig, HostCapabilities) {
@@ -108,6 +114,8 @@ pub fn prepare_desktop_engine_host() -> WiringResult<DesktopEngineHost> {
         }
         _ => engine_config,
     };
+    let analytics = DesktopHostAnalytics::new(paths.app_data_root_dir.join("analytics"))
+        .map_err(|_| WiringError::ConfigInit("failed to prepare product analytics".into()))?;
     let capabilities = HostCapabilities::new(
         host_directories(&paths, temporary_dir),
         Box::new(DesktopSecureStorage { secure_storage }),
@@ -119,13 +127,15 @@ pub fn prepare_desktop_engine_host() -> WiringResult<DesktopEngineHost> {
             changes_enabled: clipboard_wiring == SystemClipboardWiring::Real,
         }),
         Box::new(file_handles.clone()),
-    );
+    )
+    .with_analytics(analytics.sink(), analytics.identity());
 
     Ok(DesktopEngineHost {
         engine_config,
         capabilities,
         process_paths: DesktopHostProcessPaths::from_app_paths(&paths),
         file_handles,
+        analytics,
     })
 }
 

--- a/crates/uc-bootstrap/src/wiring/desktop_host.rs
+++ b/crates/uc-bootstrap/src/wiring/desktop_host.rs
@@ -114,8 +114,7 @@ pub fn prepare_desktop_engine_host() -> WiringResult<DesktopEngineHost> {
         }
         _ => engine_config,
     };
-    let analytics = DesktopHostAnalytics::new(paths.app_data_root_dir.join("analytics"))
-        .map_err(|_| WiringError::ConfigInit("failed to prepare product analytics".into()))?;
+    let analytics = DesktopHostAnalytics::new(paths.app_data_root_dir.join("analytics"));
     let capabilities = HostCapabilities::new(
         host_directories(&paths, temporary_dir),
         Box::new(DesktopSecureStorage { secure_storage }),

--- a/crates/uc-bootstrap/src/wiring/mod.rs
+++ b/crates/uc-bootstrap/src/wiring/mod.rs
@@ -1,5 +1,6 @@
 //! Desktop host capability preparation.
 
+pub(crate) mod analytics;
 pub(crate) mod desktop_host;
 pub mod error;
 pub(crate) mod secure_storage;

--- a/crates/uc-bootstrap/tests/desktop_engine_host_contract.rs
+++ b/crates/uc-bootstrap/tests/desktop_engine_host_contract.rs
@@ -15,6 +15,25 @@ fn desktop_engine_host_preparation_does_not_assemble_the_core() {
 }
 
 #[test]
+fn daemon_runtime_connects_host_analytics_end_to_end() {
+    let desktop_host = include_str!("../src/wiring/desktop_host.rs");
+    let daemon_host = include_str!("../../../apps/daemon/src/daemon/host.rs");
+
+    assert!(
+        desktop_host.contains(".with_analytics("),
+        "desktop host capabilities must inject the host-owned analytics sink and identity"
+    );
+    assert!(
+        daemon_host.contains("initialize_analytics_context("),
+        "daemon startup must install the analytics event context before events are emitted"
+    );
+    assert!(
+        daemon_host.contains(".with_analytics(analytics_sink)"),
+        "daemon HTTP analytics events must use the same authoritative sink"
+    );
+}
+
+#[test]
 fn desktop_host_file_handles_share_opaque_input_and_output_paths() {
     let temp = tempfile::tempdir().unwrap();
     let input_path = temp.path().join("private-input.txt");

--- a/crates/uc-observability/src/analytics/ids.rs
+++ b/crates/uc-observability/src/analytics/ids.rs
@@ -69,6 +69,17 @@ pub struct AnalyticsIds {
     pub is_first_run: bool,
 }
 
+impl AnalyticsIds {
+    /// Create process-local IDs without reading or writing persistent storage.
+    pub fn ephemeral() -> Self {
+        Self {
+            anonymous_user_id: Uuid::now_v7(),
+            analytics_device_id: Uuid::now_v7(),
+            is_first_run: false,
+        }
+    }
+}
+
 /// 读取或首次生成两个 ID。
 ///
 /// 行为表：


### PR DESCRIPTION
## Summary

- Assemble the desktop analytics sender during daemon startup so existing pairing, sync, update, and UI events reach PostHog in production (`d80bed560`).
- Share one gated sender between Engine analytics and the daemon capture endpoint, while preserving anonymous identity, privacy settings, and oneshot suppression (`d80bed560`).
- Add a startup wiring regression test so the runtime cannot silently fall back to the no-op sender again (`d80bed560`).
- Leave user docs and the event catalog unchanged because this restores the documented behavior and adds no new telemetry events.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo test -p uc-bootstrap -p uc-observability -p uc-webserver -p uc-daemon --locked` (367 passed, 6 ignored)
- [x] Release-mode daemon check with a placeholder PostHog project key
- [x] Review new tracing fields and levels for privacy and spec conformance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added desktop analytics integration during application startup and daemon/API activity.
  * Added persistent analytics identity with an ephemeral fallback when storage is unavailable.
  * Added device and space metadata collection.
  * Added configurable reporting through PostHog, console output, or disabled tracking.
  * Added process-open event reporting with privacy-aware suppression options.

* **Bug Fixes**
  * Added fallback handling when device or space information cannot be retrieved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->