### PR TITLE
fix(ci): allow Engine adoption image access

### DIFF
--- a/.github/workflows/adopt-engine-release.yml
+++ b/.github/workflows/adopt-engine-release.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: read
+  packages: read
 
 concurrency:
   group: adopt-engine-${{ github.event.client_payload.version }}

--- a/scripts/__tests__/adopt-engine-release.test.ts
+++ b/scripts/__tests__/adopt-engine-release.test.ts
@@ -119,6 +119,7 @@ describe('desktop Engine release adoption', () => {
     expect(existsSync(workflowPath)).toBe(true)
     const workflow = existsSync(workflowPath) ? readFileSync(workflowPath, 'utf8') : ''
     expect(workflow).toContain('types: [engine_release_published]')
+    expect(workflow).toMatch(/permissions:\s*\n\s+contents: read\s*\n\s+packages: read/)
     expect(workflow).toContain('automation/adopt-engine-${{ github.event.client_payload.version }}')
     expect(workflow).toMatch(/create-pull-request:[\s\S]*needs:\s*validate/)
     expect(workflow).toContain('cargo check --workspace --locked')


### PR DESCRIPTION
## Summary

- Grant the Engine adoption workflow access to the private Linux build image so release notifications can reach validation instead of failing during job startup (7e593e34f).
- Lock the required package permission into the workflow regression test (7e593e34f).
- Leave user docs unchanged because this only repairs internal automation; no user-facing behavior, telemetry, or tracing surface changes.

## Test plan

- [x] `bun run test -- --run scripts/__tests__/adopt-engine-release.test.ts`
- [x] `bun run test -- --run scripts/__tests__`
- [x] `bun run test -- --run` (137 files, 954 tests)
- [x] `bunx prettier --check .github/workflows/adopt-engine-release.yml scripts/__tests__/adopt-engine-release.test.ts`
- [x] `git diff --check`
- [x] Confirmed an existing workflow with the same permission successfully pulls the same private build image
- [ ] Re-run the Engine adoption workflow after merge and confirm it passes container initialization

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release automation permissions to support package-related operations.
  * Added validation to ensure required access settings remain correctly configured.

* **Reliability**
  * Reduced the risk of release workflow failures caused by insufficient permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->