### PR TITLE
fix(ci): use available Engine adoption tools

### DIFF
--- a/.github/workflows/adopt-engine-release.yml
+++ b/.github/workflows/adopt-engine-release.yml
@@ -93,6 +93,7 @@ jobs:
           ref: ${{ needs.validate.outputs.base_sha }}
           fetch-depth: 0
           token: ${{ secrets.REPO_BOT_TOKEN }}
+          persist-credentials: false
 
       - uses: actions/download-artifact@v4
         with:
@@ -102,17 +103,22 @@ jobs:
         run: git apply --index engine-adoption.patch
 
       - name: Push the deterministic branch
+        env:
+          GH_TOKEN: ${{ secrets.REPO_BOT_TOKEN }}
         run: |
+          git_auth() {
+            git -c credential.helper= -c credential.helper='!f() { echo "username=x-access-token"; echo "password=$GH_TOKEN"; }; f' "$@"
+          }
           git config user.name "uniclipboard-engine-release[bot]"
           git config user.email "uniclipboard-engine-release[bot]@users.noreply.github.com"
           git checkout -B "$BRANCH"
           git commit -m "chore(engine): adopt $ENGINE_VERSION"
-          if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
-            git fetch origin "refs/heads/$BRANCH:refs/remotes/origin/$BRANCH"
+          if git_auth ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            git_auth fetch origin "refs/heads/$BRANCH:refs/remotes/origin/$BRANCH"
             lease=$(git rev-parse "refs/remotes/origin/$BRANCH")
-            git push --force-with-lease="refs/heads/$BRANCH:$lease" origin "HEAD:refs/heads/$BRANCH"
+            git_auth push --force-with-lease="refs/heads/$BRANCH:$lease" origin "HEAD:refs/heads/$BRANCH"
           else
-            git push origin "HEAD:refs/heads/$BRANCH"
+            git_auth push origin "HEAD:refs/heads/$BRANCH"
           fi
 
       - name: Create or update the pull request

--- a/.github/workflows/adopt-engine-release.yml
+++ b/.github/workflows/adopt-engine-release.yml
@@ -45,7 +45,7 @@ jobs:
         env:
           ENGINE_VERSION: ${{ github.event.client_payload.version }}
           ENGINE_COMMIT: ${{ github.event.client_payload.source_commit }}
-        run: node scripts/adopt-engine-release.mjs --version "$ENGINE_VERSION" --source-commit "$ENGINE_COMMIT"
+        run: bun scripts/adopt-engine-release.mjs --version "$ENGINE_VERSION" --source-commit "$ENGINE_COMMIT"
 
       - name: Refresh the Rust lockfile
         env:
@@ -88,21 +88,11 @@ jobs:
       ENGINE_VERSION: ${{ github.event.client_payload.version }}
       ENGINE_COMMIT: ${{ github.event.client_payload.source_commit }}
     steps:
-      - id: app-token
-        uses: actions/create-github-app-token@v3
-        with:
-          client-id: ${{ vars.ENGINE_RELEASE_APP_CLIENT_ID }}
-          private-key: ${{ secrets.ENGINE_RELEASE_APP_PRIVATE_KEY }}
-          owner: UniClipboard
-          repositories: UniClipboard
-          permission-contents: write
-          permission-pull-requests: write
-
       - uses: actions/checkout@v4
         with:
           ref: ${{ needs.validate.outputs.base_sha }}
           fetch-depth: 0
-          token: ${{ steps.app-token.outputs.token }}
+          token: ${{ secrets.REPO_BOT_TOKEN }}
 
       - uses: actions/download-artifact@v4
         with:
@@ -127,7 +117,7 @@ jobs:
 
       - name: Create or update the pull request
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.REPO_BOT_TOKEN }}
         run: |
           title="chore(engine): adopt $ENGINE_VERSION"
           body=$(cat <<EOF

--- a/scripts/__tests__/adopt-engine-release.test.ts
+++ b/scripts/__tests__/adopt-engine-release.test.ts
@@ -132,8 +132,16 @@ describe('desktop Engine release adoption', () => {
     expect(workflow).toContain("if: ${{ needs.validate.outputs.changed == 'true' }}")
     expect(workflow).toContain('--state all')
     expect(workflow).toContain('gh pr reopen')
-    expect(workflow).toContain('token: ${{ secrets.REPO_BOT_TOKEN }}')
-    expect(workflow).toContain('GH_TOKEN: ${{ secrets.REPO_BOT_TOKEN }}')
+    expect(workflow).toMatch(
+      /- uses: actions\/checkout@v4\s+with:\s+ref: \$\{\{ needs\.validate\.outputs\.base_sha \}\}\s+fetch-depth: 0\s+token: \$\{\{ secrets\.REPO_BOT_TOKEN \}\}\s+persist-credentials: false/
+    )
+    expect(workflow).toMatch(
+      /- name: Push the deterministic branch\s+env:\s+GH_TOKEN: \$\{\{ secrets\.REPO_BOT_TOKEN \}\}/
+    )
+    expect(workflow).toMatch(
+      /- name: Create or update the pull request\s+env:\s+GH_TOKEN: \$\{\{ secrets\.REPO_BOT_TOKEN \}\}/
+    )
+    expect(workflow).toContain("git -c credential.helper= -c credential.helper='!f()")
     expect(workflow).not.toContain('actions/create-github-app-token')
     expect(workflow).not.toContain('ENGINE_RELEASE_APP_')
     expect(workflow).not.toContain('GH_TOKEN: ${{ github.token }}')

--- a/scripts/__tests__/adopt-engine-release.test.ts
+++ b/scripts/__tests__/adopt-engine-release.test.ts
@@ -124,14 +124,18 @@ describe('desktop Engine release adoption', () => {
     expect(workflow).toMatch(/create-pull-request:[\s\S]*needs:\s*validate/)
     expect(workflow).toContain('cargo check --workspace --locked')
     expect(workflow).toContain('bun run check:engine-repository')
+    expect(workflow).toContain(
+      'run: bun scripts/adopt-engine-release.mjs --version "$ENGINE_VERSION" --source-commit "$ENGINE_COMMIT"'
+    )
+    expect(workflow).not.toContain('run: node scripts/adopt-engine-release.mjs')
     expect(workflow).toContain('changed: ${{ steps.change.outputs.changed }}')
     expect(workflow).toContain("if: ${{ needs.validate.outputs.changed == 'true' }}")
     expect(workflow).toContain('--state all')
     expect(workflow).toContain('gh pr reopen')
-    expect(workflow).toContain('actions/create-github-app-token@v3')
-    expect(workflow).toContain('permission-pull-requests: write')
-    expect(workflow).toContain('repositories: UniClipboard')
-    expect(workflow).toContain('GH_TOKEN: ${{ steps.app-token.outputs.token }}')
+    expect(workflow).toContain('token: ${{ secrets.REPO_BOT_TOKEN }}')
+    expect(workflow).toContain('GH_TOKEN: ${{ secrets.REPO_BOT_TOKEN }}')
+    expect(workflow).not.toContain('actions/create-github-app-token')
+    expect(workflow).not.toContain('ENGINE_RELEASE_APP_')
     expect(workflow).not.toContain('GH_TOKEN: ${{ github.token }}')
   })
 

--- a/scripts/__tests__/adopt-engine-release.test.ts
+++ b/scripts/__tests__/adopt-engine-release.test.ts
@@ -135,13 +135,16 @@ describe('desktop Engine release adoption', () => {
     expect(workflow).toMatch(
       /- uses: actions\/checkout@v4\s+with:\s+ref: \$\{\{ needs\.validate\.outputs\.base_sha \}\}\s+fetch-depth: 0\s+token: \$\{\{ secrets\.REPO_BOT_TOKEN \}\}\s+persist-credentials: false/
     )
-    expect(workflow).toMatch(
-      /- name: Push the deterministic branch\s+env:\s+GH_TOKEN: \$\{\{ secrets\.REPO_BOT_TOKEN \}\}/
-    )
+    const pushStep =
+      workflow.match(
+        / {6}- name: Push the deterministic branch\n[\s\S]*?(?=\n {6}- name: |$)/
+      )?.[0] ?? ''
+    expect(pushStep).toContain('GH_TOKEN: ${{ secrets.REPO_BOT_TOKEN }}')
+    expect(pushStep).toContain("git -c credential.helper= -c credential.helper='!f()")
+    expect(pushStep).toContain('git_auth push')
     expect(workflow).toMatch(
       /- name: Create or update the pull request\s+env:\s+GH_TOKEN: \$\{\{ secrets\.REPO_BOT_TOKEN \}\}/
     )
-    expect(workflow).toContain("git -c credential.helper= -c credential.helper='!f()")
     expect(workflow).not.toContain('actions/create-github-app-token')
     expect(workflow).not.toContain('ENGINE_RELEASE_APP_')
     expect(workflow).not.toContain('GH_TOKEN: ${{ github.token }}')


### PR DESCRIPTION
## Summary

- Run the Engine adoption validator with Bun, which is installed inside the Linux build container, instead of calling an unavailable Node executable (b4d3344f6).
- Reuse the repository's established bot token for adoption branches and pull requests, removing the uninstalled GitHub App credential path (b4d3344f6).
- Extend the workflow regression test to lock both runtime and authentication requirements; user docs remain unchanged because this is internal automation only.

## Test plan

- [x] `bun run test -- --run scripts/__tests__/adopt-engine-release.test.ts`
- [x] `bun run test -- --run scripts/__tests__`
- [x] `bun run test -- --run` (137 files, 954 tests)
- [x] `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/adopt-engine-release.yml`
- [x] Run the Bun validator against the published `v0.20.0-rc.19` manifest and source archive
- [ ] Re-dispatch `v0.20.0-rc.19` after merge and confirm the adoption pull request is created

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the engine adoption release workflow to run with Bun.
  * Simplified pull-request creation by using the repository bot token directly.
  * Updated checkout and Git push authentication for more reliable release updates.
  * Removed the previous GitHub App token-generation configuration.
* **Tests**
  * Updated workflow validation to reflect the new release process and authentication requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->