### PR TITLE
fix(ci): make Engine patch detection reliable

### DIFF
--- a/.github/workflows/adopt-engine-release.yml
+++ b/.github/workflows/adopt-engine-release.yml
@@ -63,11 +63,11 @@ jobs:
       - id: change
         name: Detect the proposed update
         run: |
-          if git diff --quiet -- Cargo.toml Cargo.lock; then
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-          else
+          git diff --no-exit-code --binary HEAD -- Cargo.toml Cargo.lock > engine-adoption.patch
+          if [ -s engine-adoption.patch ]; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
-            git diff --binary -- Cargo.toml Cargo.lock > engine-adoption.patch
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
           fi
 
       - uses: actions/upload-artifact@v4

--- a/scripts/__tests__/adopt-engine-release.test.ts
+++ b/scripts/__tests__/adopt-engine-release.test.ts
@@ -130,6 +130,11 @@ describe('desktop Engine release adoption', () => {
     expect(workflow).not.toContain('run: node scripts/adopt-engine-release.mjs')
     expect(workflow).toContain('changed: ${{ steps.change.outputs.changed }}')
     expect(workflow).toContain("if: ${{ needs.validate.outputs.changed == 'true' }}")
+    expect(workflow).toContain(
+      'git diff --no-exit-code --binary HEAD -- Cargo.toml Cargo.lock > engine-adoption.patch'
+    )
+    expect(workflow).toContain('if [ -s engine-adoption.patch ]; then')
+    expect(workflow).not.toContain('git diff --quiet -- Cargo.toml Cargo.lock')
     expect(workflow).toContain('--state all')
     expect(workflow).toContain('gh pr reopen')
     expect(workflow).toMatch(


### PR DESCRIPTION
## Summary

- Generate the Engine adoption patch with a success-only diff command so expected dependency changes do not abort validation.
- Use the generated patch as the single source of truth for deciding whether an adoption pull request is needed.
- Add regression coverage for the patch detection contract.

## Test plan

- [x] `bunx vitest run scripts/__tests__/adopt-engine-release.test.ts --environment node --pool forks`
- [x] `bunx vitest run --pool forks` (137 files, 954 tests)
- [x] `bunx prettier --check .github/workflows/adopt-engine-release.yml scripts/__tests__/adopt-engine-release.test.ts`
- [x] `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/adopt-engine-release.yml`
- [x] `git diff --check`

Docs unchanged: this only affects CI control flow. No telemetry or tracing surface is involved.