### PR TITLE
fix(ci): use portable Engine patch command

### DIFF
--- a/.github/workflows/adopt-engine-release.yml
+++ b/.github/workflows/adopt-engine-release.yml
@@ -63,7 +63,7 @@ jobs:
       - id: change
         name: Detect the proposed update
         run: |
-          git diff --no-exit-code --binary HEAD -- Cargo.toml Cargo.lock > engine-adoption.patch
+          git diff --binary HEAD -- Cargo.toml Cargo.lock > engine-adoption.patch
           if [ -s engine-adoption.patch ]; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
           else

--- a/scripts/__tests__/adopt-engine-release.test.ts
+++ b/scripts/__tests__/adopt-engine-release.test.ts
@@ -130,11 +130,41 @@ describe('desktop Engine release adoption', () => {
     expect(workflow).not.toContain('run: node scripts/adopt-engine-release.mjs')
     expect(workflow).toContain('changed: ${{ steps.change.outputs.changed }}')
     expect(workflow).toContain("if: ${{ needs.validate.outputs.changed == 'true' }}")
-    expect(workflow).toContain(
-      'git diff --no-exit-code --binary HEAD -- Cargo.toml Cargo.lock > engine-adoption.patch'
-    )
+    const patchCommand = workflow.match(/^\s*(git diff .* > engine-adoption\.patch)$/m)?.[1]
+    expect(patchCommand).toBeDefined()
+    expect(patchCommand).not.toContain('--no-exit-code')
     expect(workflow).toContain('if [ -s engine-adoption.patch ]; then')
     expect(workflow).not.toContain('git diff --quiet -- Cargo.toml Cargo.lock')
+
+    const diffRoot = mkdtempSync(join(tmpdir(), 'desktop-engine-patch-command-'))
+    roots.push(diffRoot)
+    write(join(diffRoot, 'Cargo.toml'), '[workspace]\n')
+    write(join(diffRoot, 'Cargo.lock'), 'version = 4\n')
+    execFileSync('git', ['init'], { cwd: diffRoot })
+    execFileSync('git', ['add', 'Cargo.toml', 'Cargo.lock'], { cwd: diffRoot })
+    execFileSync(
+      'git',
+      [
+        '-c',
+        'user.name=Engine adoption test',
+        '-c',
+        'user.email=engine-adoption-test@example.invalid',
+        'commit',
+        '-m',
+        'fixture',
+      ],
+      { cwd: diffRoot }
+    )
+    write(join(diffRoot, 'Cargo.toml'), '[workspace]\nresolver = "2"\n')
+
+    const patchResult = spawnSync('sh', ['-c', patchCommand ?? 'exit 2'], {
+      cwd: diffRoot,
+      encoding: 'utf8',
+    })
+    expect(patchResult.status).toBe(0)
+    expect(readFileSync(join(diffRoot, 'engine-adoption.patch'), 'utf8')).toContain(
+      'resolver = "2"'
+    )
     expect(workflow).toContain('--state all')
     expect(workflow).toContain('gh pr reopen')
     expect(workflow).toMatch(


### PR DESCRIPTION
## Summary

- Remove a Git option that is unsupported in the Engine adoption build image.
- Keep the generated patch as the single decision source for whether an update exists.
- Execute the workflow patch command against a temporary Git repository in the regression test.

## Test plan

- [x] `bunx vitest run scripts/__tests__/adopt-engine-release.test.ts --environment node --pool forks`
- [x] `bunx vitest run --pool forks` (137 files, 954 tests)
- [x] `bunx prettier --check .github/workflows/adopt-engine-release.yml scripts/__tests__/adopt-engine-release.test.ts`
- [x] `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/adopt-engine-release.yml`
- [x] `git diff --check`

Docs unchanged: this only affects CI command portability. No telemetry or tracing surface is involved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved engine adoption release patch generation so differences are captured reliably without causing workflow failures.
  * Ensured generated patches include relevant Cargo changes.

* **Tests**
  * Added validation that release patch generation succeeds and produces the expected changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->