### PR TITLE
fix(ci): carry validated Engine files between jobs

### DIFF
--- a/.github/workflows/adopt-engine-release.yml
+++ b/.github/workflows/adopt-engine-release.yml
@@ -33,7 +33,10 @@ jobs:
 
       - id: base
         name: Record the validated base
-        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+        run: |
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          cp Cargo.toml "$RUNNER_TEMP/Cargo.toml.base"
+          cp Cargo.lock "$RUNNER_TEMP/Cargo.lock.base"
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -63,18 +66,20 @@ jobs:
       - id: change
         name: Detect the proposed update
         run: |
-          git diff --binary HEAD -- Cargo.toml Cargo.lock > engine-adoption.patch
-          if [ -s engine-adoption.patch ]; then
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-          else
+          if cmp -s "$RUNNER_TEMP/Cargo.toml.base" Cargo.toml &&
+            cmp -s "$RUNNER_TEMP/Cargo.lock.base" Cargo.lock; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
       - uses: actions/upload-artifact@v4
         if: ${{ steps.change.outputs.changed == 'true' }}
         with:
-          name: engine-adoption-patch
-          path: engine-adoption.patch
+          name: engine-adoption-files
+          path: |
+            Cargo.toml
+            Cargo.lock
           if-no-files-found: error
           retention-days: 1
 
@@ -97,10 +102,14 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          name: engine-adoption-patch
+          name: engine-adoption-files
+          path: engine-adoption-files
 
       - name: Apply the validated update
-        run: git apply --index engine-adoption.patch
+        run: |
+          cp engine-adoption-files/Cargo.toml Cargo.toml
+          cp engine-adoption-files/Cargo.lock Cargo.lock
+          git add Cargo.toml Cargo.lock
 
       - name: Push the deterministic branch
         env:

--- a/scripts/__tests__/adopt-engine-release.test.ts
+++ b/scripts/__tests__/adopt-engine-release.test.ts
@@ -130,41 +130,20 @@ describe('desktop Engine release adoption', () => {
     expect(workflow).not.toContain('run: node scripts/adopt-engine-release.mjs')
     expect(workflow).toContain('changed: ${{ steps.change.outputs.changed }}')
     expect(workflow).toContain("if: ${{ needs.validate.outputs.changed == 'true' }}")
-    const patchCommand = workflow.match(/^\s*(git diff .* > engine-adoption\.patch)$/m)?.[1]
-    expect(patchCommand).toBeDefined()
-    expect(patchCommand).not.toContain('--no-exit-code')
-    expect(workflow).toContain('if [ -s engine-adoption.patch ]; then')
-    expect(workflow).not.toContain('git diff --quiet -- Cargo.toml Cargo.lock')
-
-    const diffRoot = mkdtempSync(join(tmpdir(), 'desktop-engine-patch-command-'))
-    roots.push(diffRoot)
-    write(join(diffRoot, 'Cargo.toml'), '[workspace]\n')
-    write(join(diffRoot, 'Cargo.lock'), 'version = 4\n')
-    execFileSync('git', ['init'], { cwd: diffRoot })
-    execFileSync('git', ['add', 'Cargo.toml', 'Cargo.lock'], { cwd: diffRoot })
-    execFileSync(
-      'git',
-      [
-        '-c',
-        'user.name=Engine adoption test',
-        '-c',
-        'user.email=engine-adoption-test@example.invalid',
-        'commit',
-        '-m',
-        'fixture',
-      ],
-      { cwd: diffRoot }
+    expect(workflow).toContain('cp Cargo.toml "$RUNNER_TEMP/Cargo.toml.base"')
+    expect(workflow).toContain('cp Cargo.lock "$RUNNER_TEMP/Cargo.lock.base"')
+    expect(workflow).toContain('cmp -s "$RUNNER_TEMP/Cargo.toml.base" Cargo.toml')
+    expect(workflow).toContain('cmp -s "$RUNNER_TEMP/Cargo.lock.base" Cargo.lock')
+    expect(workflow).not.toContain('git diff')
+    expect(workflow).toMatch(
+      /actions\/upload-artifact@v4[\s\S]*name: engine-adoption-files[\s\S]*path: \|\s+Cargo\.toml\s+Cargo\.lock/
     )
-    write(join(diffRoot, 'Cargo.toml'), '[workspace]\nresolver = "2"\n')
-
-    const patchResult = spawnSync('sh', ['-c', patchCommand ?? 'exit 2'], {
-      cwd: diffRoot,
-      encoding: 'utf8',
-    })
-    expect(patchResult.status).toBe(0)
-    expect(readFileSync(join(diffRoot, 'engine-adoption.patch'), 'utf8')).toContain(
-      'resolver = "2"'
+    expect(workflow).toMatch(
+      /actions\/download-artifact@v4[\s\S]*name: engine-adoption-files[\s\S]*path: engine-adoption-files/
     )
+    expect(workflow).toContain('cp engine-adoption-files/Cargo.toml Cargo.toml')
+    expect(workflow).toContain('cp engine-adoption-files/Cargo.lock Cargo.lock')
+    expect(workflow).toContain('git add Cargo.toml Cargo.lock')
     expect(workflow).toContain('--state all')
     expect(workflow).toContain('gh pr reopen')
     expect(workflow).toMatch(


### PR DESCRIPTION
## Summary

- Compare the validated Engine dependency files against baseline copies without requiring a Git worktree late in the validation job.
- Upload the already-validated Cargo files directly and stage them in the pull-request job.
- Update regression coverage for the file artifact handoff and removal of late `git diff` usage.

## Test plan

- [x] `bunx vitest run scripts/__tests__/adopt-engine-release.test.ts --environment node --pool forks`
- [x] `bunx vitest run --pool forks` (137 files, 954 tests)
- [x] `bunx prettier --check .github/workflows/adopt-engine-release.yml scripts/__tests__/adopt-engine-release.test.ts`
- [x] `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/adopt-engine-release.yml`
- [x] `git diff --check`

Docs unchanged: this only affects CI artifact handoff. No telemetry or tracing surface is involved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release workflow handling for validated Cargo configuration files.
  * Ensured changed configuration files are transferred and restored reliably between workflow stages.
  * Added direct file comparisons to help prevent unintended release changes.

* **Tests**
  * Updated workflow coverage to verify artifact transfer, file restoration, comparison, and staging behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->