### PR TITLE
feat: keep quick panel filters visible

### DIFF
--- a/src/quick-panel/ClipboardHistoryPanel.tsx
+++ b/src/quick-panel/ClipboardHistoryPanel.tsx
@@ -8,6 +8,17 @@ import React, {
   useState,
 } from 'react'
 import { useTranslation } from 'react-i18next'
+import ClipboardPreviewPane from './ClipboardPreviewPane'
+import HistoryPane from './components/HistoryPane'
+import { PREVIEW_OPEN_DELAY_MS, PREVIEW_SWITCH_DELAY_MS, QUICK_FILTER_ORDER } from './constants'
+import { useHistorySearch } from './hooks/useHistorySearch'
+import type {
+  PreviewAction,
+  PreviewSide,
+  PreviewState,
+  QuickPanelContextMenuActions,
+  TimeRangePreset,
+} from './types'
 import { Filter, favoriteClipboardItem, unfavoriteClipboardItem } from '@/api/clipboardItems'
 import { deleteClipboardEntry, restoreClipboardEntry } from '@/api/daemon'
 import { unlockEncryptionSession } from '@/api/security'
@@ -24,17 +35,6 @@ import { playUiSound } from '@/lib/ui-sound'
 import { cn } from '@/lib/utils'
 import { useAppDispatch } from '@/store/hooks'
 import { fetchSpaceMembers } from '@/store/slices/devicesSlice'
-import ClipboardPreviewPane from './ClipboardPreviewPane'
-import HistoryPane from './components/HistoryPane'
-import { PREVIEW_OPEN_DELAY_MS, PREVIEW_SWITCH_DELAY_MS, QUICK_FILTER_ORDER } from './constants'
-import { useHistorySearch } from './hooks/useHistorySearch'
-import type {
-  PreviewAction,
-  PreviewSide,
-  PreviewState,
-  QuickPanelContextMenuActions,
-  TimeRangePreset,
-} from './types'
 
 const log = createLogger('clipboard-history-panel')
 
@@ -679,7 +679,6 @@ const ClipboardHistoryPanelSession: React.FC<ClipboardHistoryPanelProps> = ({
           onContextMenuSelect={handleContextMenuSelect}
           onUnlock={handleUnlock}
           searchInputRef={searchInputRef}
-          searchQuery={searchQuery}
           selectedIndex={selectedIndex}
           setHoveredIndex={setHoveredIndex}
           setIsKeyboardNav={setIsKeyboardNav}

--- a/src/quick-panel/ClipboardHistoryPanel.tsx
+++ b/src/quick-panel/ClipboardHistoryPanel.tsx
@@ -8,17 +8,6 @@ import React, {
   useState,
 } from 'react'
 import { useTranslation } from 'react-i18next'
-import ClipboardPreviewPane from './ClipboardPreviewPane'
-import HistoryPane from './components/HistoryPane'
-import { PREVIEW_OPEN_DELAY_MS, PREVIEW_SWITCH_DELAY_MS, QUICK_FILTER_ORDER } from './constants'
-import { useHistorySearch } from './hooks/useHistorySearch'
-import type {
-  PreviewAction,
-  PreviewSide,
-  PreviewState,
-  QuickPanelContextMenuActions,
-  TimeRangePreset,
-} from './types'
 import { Filter, favoriteClipboardItem, unfavoriteClipboardItem } from '@/api/clipboardItems'
 import { deleteClipboardEntry, restoreClipboardEntry } from '@/api/daemon'
 import { unlockEncryptionSession } from '@/api/security'
@@ -35,6 +24,17 @@ import { playUiSound } from '@/lib/ui-sound'
 import { cn } from '@/lib/utils'
 import { useAppDispatch } from '@/store/hooks'
 import { fetchSpaceMembers } from '@/store/slices/devicesSlice'
+import ClipboardPreviewPane from './ClipboardPreviewPane'
+import HistoryPane from './components/HistoryPane'
+import { PREVIEW_OPEN_DELAY_MS, PREVIEW_SWITCH_DELAY_MS, QUICK_FILTER_ORDER } from './constants'
+import { useHistorySearch } from './hooks/useHistorySearch'
+import type {
+  PreviewAction,
+  PreviewSide,
+  PreviewState,
+  QuickPanelContextMenuActions,
+  TimeRangePreset,
+} from './types'
 
 const log = createLogger('clipboard-history-panel')
 

--- a/src/quick-panel/__tests__/ClipboardHistoryPanel.single-window.test.tsx
+++ b/src/quick-panel/__tests__/ClipboardHistoryPanel.single-window.test.tsx
@@ -3,13 +3,13 @@ import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import type { ReactElement } from 'react'
 import { Provider } from 'react-redux'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import ClipboardHistoryPanel from '../ClipboardHistoryPanel'
+import { useHistorySearch } from '../hooks/useHistorySearch'
 import { deleteClipboardEntry, restoreClipboardEntry } from '@/api/daemon'
 import { __resetResendActionStoreForTests } from '@/hooks/useResendAction'
 import i18n from '@/i18n'
 import { playUiSound } from '@/lib/ui-sound'
 import devicesReducer from '@/store/slices/devicesSlice'
-import ClipboardHistoryPanel from '../ClipboardHistoryPanel'
-import { useHistorySearch } from '../hooks/useHistorySearch'
 
 const invokeMock = vi.fn()
 
@@ -190,6 +190,17 @@ describe('ClipboardHistoryPanel single-window preview', () => {
       )
     })
     expect(invokeMock).not.toHaveBeenCalledWith('show_preview_panel', expect.anything())
+  })
+
+  it('keeps type filters visible and replaces the shortcut hint with the tag bar', () => {
+    renderPanel()
+
+    expect(screen.getByRole('button', { name: i18n.t('history.filter.all') })).toBeInTheDocument()
+    expect(screen.getByTestId('quick-panel-tag-filter-list')).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: i18n.t('history.composite.openFilters') })
+    ).not.toBeInTheDocument()
+    expect(screen.queryByText(i18n.t('quickPanel.history.status.navigatePaste'))).not.toBeInTheDocument()
   })
 
   it('keeps history and preview panes flexible when the inline preview opens', async () => {

--- a/src/quick-panel/__tests__/ClipboardHistoryPanel.single-window.test.tsx
+++ b/src/quick-panel/__tests__/ClipboardHistoryPanel.single-window.test.tsx
@@ -3,13 +3,13 @@ import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import type { ReactElement } from 'react'
 import { Provider } from 'react-redux'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import ClipboardHistoryPanel from '../ClipboardHistoryPanel'
-import { useHistorySearch } from '../hooks/useHistorySearch'
 import { deleteClipboardEntry, restoreClipboardEntry } from '@/api/daemon'
 import { __resetResendActionStoreForTests } from '@/hooks/useResendAction'
 import i18n from '@/i18n'
 import { playUiSound } from '@/lib/ui-sound'
 import devicesReducer from '@/store/slices/devicesSlice'
+import ClipboardHistoryPanel from '../ClipboardHistoryPanel'
+import { useHistorySearch } from '../hooks/useHistorySearch'
 
 const invokeMock = vi.fn()
 
@@ -200,7 +200,9 @@ describe('ClipboardHistoryPanel single-window preview', () => {
     expect(
       screen.queryByRole('button', { name: i18n.t('history.composite.openFilters') })
     ).not.toBeInTheDocument()
-    expect(screen.queryByText(i18n.t('quickPanel.history.status.navigatePaste'))).not.toBeInTheDocument()
+    expect(
+      screen.queryByText(i18n.t('quickPanel.history.status.navigatePaste'))
+    ).not.toBeInTheDocument()
   })
 
   it('keeps history and preview panes flexible when the inline preview opens', async () => {

--- a/src/quick-panel/components/HistoryPane.tsx
+++ b/src/quick-panel/components/HistoryPane.tsx
@@ -1,11 +1,6 @@
 import { Loader2, Lock, Search, Unlock } from 'lucide-react'
 import React, { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Filter } from '@/api/clipboardItems'
-import { CompositeSearchBar, type SourceOption } from '@/components/history/composite-search'
-import type { DisplayClipboardItem } from '@/lib/clipboard-entry'
-import type { SearchTagOption } from '@/lib/search-tags'
-import { cn } from '@/lib/utils'
 import { quickCardClassName } from '../constants'
 import {
   peekQuickPanelImageAspectRatio,
@@ -16,6 +11,13 @@ import type { DisplayItem, QuickPanelContextMenuActions, TimeRangePreset } from 
 import ImageGridItem from './ImageGridItem'
 import PanelItem from './PanelItem'
 import PanelItemContextMenu from './PanelItemContextMenu'
+import QuickPanelTagFilterBar from './QuickPanelTagFilterBar'
+import QuickPanelTypeFilterBar from './QuickPanelTypeFilterBar'
+import { Filter } from '@/api/clipboardItems'
+import { CompositeSearchBar, type SourceOption } from '@/components/history/composite-search'
+import type { DisplayClipboardItem } from '@/lib/clipboard-entry'
+import type { SearchTagOption } from '@/lib/search-tags'
+import { cn } from '@/lib/utils'
 
 interface HistoryPaneProps {
   filteredItems: DisplayItem[]
@@ -34,7 +36,6 @@ interface HistoryPaneProps {
   onContextMenuSelect: (index: number) => void
   onUnlock: () => void
   searchInputRef: React.RefObject<HTMLInputElement | null>
-  searchQuery: string
   selectedIndex: number
   setHoveredIndex: React.Dispatch<React.SetStateAction<number | null>>
   setIsKeyboardNav: React.Dispatch<React.SetStateAction<boolean>>
@@ -101,7 +102,6 @@ const HistoryPane: React.FC<HistoryPaneProps> = React.memo(
     onContextMenuSelect,
     onUnlock,
     searchInputRef,
-    searchQuery,
     selectedIndex,
     setHoveredIndex,
     setIsKeyboardNav,
@@ -203,10 +203,10 @@ const HistoryPane: React.FC<HistoryPaneProps> = React.memo(
                 onUnhandledKeyDown={onKeyDown}
                 clearShortcutEnabled={false}
                 suggestionActivation="intentional"
-                showFilterPanelButton
                 className="w-full"
               />
             </div>
+            <QuickPanelTypeFilterBar activeFilter={activeFilter} onChange={setActiveFilter} />
 
             {/* --- SCROLLABLE LIST --- */}
             {/* role="listbox" 给下面 PanelItem 的 role="option" 提供合法父级。
@@ -298,24 +298,11 @@ const HistoryPane: React.FC<HistoryPaneProps> = React.memo(
               )}
             </div>
 
-            {/* --- MULTI-FUNCTION STATUS BAR --- */}
-            <div className="flex items-center justify-between gap-3 border-t border-border/50 bg-muted/5 px-4 py-1.5 text-[11px] text-muted-foreground">
-              <div className="flex items-center" />
-
-              <div className="flex items-center gap-2">
-                {(searchQuery ||
-                  activeFilter !== Filter.All ||
-                  tagFilter !== null ||
-                  sourceFilter !== null ||
-                  extensionFilter !== null ||
-                  timeRange !== 'all_time') && (
-                  <span className="font-mono text-[10px] bg-muted/50 px-1.5 py-0.5 rounded leading-none">
-                    {isSearching ? '…' : (searchTotal ?? filteredItems.length)}
-                  </span>
-                )}
-                <span className="truncate opacity-60">{t('status.navigatePaste')}</span>
-              </div>
-            </div>
+            <QuickPanelTagFilterBar
+              tagFilter={tagFilter}
+              tagOptions={searchableTags}
+              onChange={setTagFilter}
+            />
           </>
         )}
       </div>

--- a/src/quick-panel/components/HistoryPane.tsx
+++ b/src/quick-panel/components/HistoryPane.tsx
@@ -1,6 +1,11 @@
 import { Loader2, Lock, Search, Unlock } from 'lucide-react'
 import React, { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
+import { Filter } from '@/api/clipboardItems'
+import { CompositeSearchBar, type SourceOption } from '@/components/history/composite-search'
+import type { DisplayClipboardItem } from '@/lib/clipboard-entry'
+import type { SearchTagOption } from '@/lib/search-tags'
+import { cn } from '@/lib/utils'
 import { quickCardClassName } from '../constants'
 import {
   peekQuickPanelImageAspectRatio,
@@ -13,11 +18,6 @@ import PanelItem from './PanelItem'
 import PanelItemContextMenu from './PanelItemContextMenu'
 import QuickPanelTagFilterBar from './QuickPanelTagFilterBar'
 import QuickPanelTypeFilterBar from './QuickPanelTypeFilterBar'
-import { Filter } from '@/api/clipboardItems'
-import { CompositeSearchBar, type SourceOption } from '@/components/history/composite-search'
-import type { DisplayClipboardItem } from '@/lib/clipboard-entry'
-import type { SearchTagOption } from '@/lib/search-tags'
-import { cn } from '@/lib/utils'
 
 interface HistoryPaneProps {
   filteredItems: DisplayItem[]

--- a/src/quick-panel/components/QuickPanelTagFilterBar.tsx
+++ b/src/quick-panel/components/QuickPanelTagFilterBar.tsx
@@ -1,0 +1,49 @@
+import { Hash } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import type { SearchTagOption } from '@/lib/search-tags'
+import { cn } from '@/lib/utils'
+
+interface QuickPanelTagFilterBarProps {
+  tagFilter: string | null
+  tagOptions: SearchTagOption[]
+  onChange: (tag: string | null) => void
+}
+
+function QuickPanelTagFilterBar({ tagFilter, tagOptions, onChange }: QuickPanelTagFilterBarProps) {
+  const { t } = useTranslation()
+
+  return (
+    <div className="flex min-w-0 items-center gap-2 border-t border-border/50 bg-muted/5 px-3 py-1.5 text-[11px] text-muted-foreground">
+      <span className="shrink-0">{t('history.composite.dimension.tag')}</span>
+      <div
+        className="scrollbar-thin flex min-w-0 flex-1 items-center gap-1 overflow-x-auto"
+        data-testid="quick-panel-tag-filter-list"
+      >
+        {tagOptions.map(tag => {
+          const active = tagFilter === tag.id
+          const label = t(`history.type.${tag.id}`, { defaultValue: tag.id })
+
+          return (
+            <button
+              key={tag.id}
+              type="button"
+              aria-pressed={active}
+              onClick={() => onChange(active ? null : tag.id)}
+              className={cn(
+                'inline-flex shrink-0 items-center gap-1 rounded-md px-2 py-1 text-[11px] transition-colors',
+                active
+                  ? 'bg-primary text-primary-foreground'
+                  : 'bg-muted/60 text-muted-foreground hover:bg-muted hover:text-foreground'
+              )}
+            >
+              <Hash className="size-3" />
+              {label}
+            </button>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+export default QuickPanelTagFilterBar

--- a/src/quick-panel/components/QuickPanelTypeFilterBar.tsx
+++ b/src/quick-panel/components/QuickPanelTypeFilterBar.tsx
@@ -1,0 +1,41 @@
+import { useTranslation } from 'react-i18next'
+import { QUICK_FILTER_ORDER } from '../constants'
+import { Filter } from '@/api/clipboardItems'
+import { cn } from '@/lib/utils'
+
+interface QuickPanelTypeFilterBarProps {
+  activeFilter: Filter
+  onChange: (filter: Filter) => void
+}
+
+function QuickPanelTypeFilterBar({ activeFilter, onChange }: QuickPanelTypeFilterBarProps) {
+  const { t } = useTranslation()
+
+  return (
+    <div className="flex flex-wrap items-center gap-1 px-3 pb-2" aria-label={t('history.composite.dimension.type')}>
+      {QUICK_FILTER_ORDER.map(filter => {
+        const active = activeFilter === filter
+        const label = filter === Filter.All ? t('history.filter.all') : t(`history.type.${filter}`)
+
+        return (
+          <button
+            key={filter}
+            type="button"
+            aria-pressed={active}
+            onClick={() => onChange(filter)}
+            className={cn(
+              'rounded-md px-2 py-1 text-[11px] transition-colors',
+              active
+                ? 'bg-primary text-primary-foreground'
+                : 'bg-muted/60 text-muted-foreground hover:bg-muted hover:text-foreground'
+            )}
+          >
+            {label}
+          </button>
+        )
+      })}
+    </div>
+  )
+}
+
+export default QuickPanelTypeFilterBar

--- a/src/quick-panel/components/QuickPanelTypeFilterBar.tsx
+++ b/src/quick-panel/components/QuickPanelTypeFilterBar.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from 'react-i18next'
-import { QUICK_FILTER_ORDER } from '../constants'
 import { Filter } from '@/api/clipboardItems'
 import { cn } from '@/lib/utils'
+import { QUICK_FILTER_ORDER } from '../constants'
 
 interface QuickPanelTypeFilterBarProps {
   activeFilter: Filter
@@ -12,7 +12,10 @@ function QuickPanelTypeFilterBar({ activeFilter, onChange }: QuickPanelTypeFilte
   const { t } = useTranslation()
 
   return (
-    <div className="flex flex-wrap items-center gap-1 px-3 pb-2" aria-label={t('history.composite.dimension.type')}>
+    <div
+      className="flex flex-wrap items-center gap-1 px-3 pb-2"
+      aria-label={t('history.composite.dimension.type')}
+    >
       {QUICK_FILTER_ORDER.map(filter => {
         const active = activeFilter === filter
         const label = filter === Filter.All ? t('history.filter.all') : t(`history.type.${filter}`)

--- a/src/quick-panel/components/__tests__/QuickPanelTagFilterBar.test.tsx
+++ b/src/quick-panel/components/__tests__/QuickPanelTagFilterBar.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import QuickPanelTagFilterBar from '../QuickPanelTagFilterBar'
+import type { SearchTagOption } from '@/lib/search-tags'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: Record<string, unknown>) =>
+      ({
+        'history.composite.dimension.tag': 'Tags',
+        'history.type.code': 'Code',
+      })[key] ?? (typeof options?.defaultValue === 'string' ? options.defaultValue : key),
+  }),
+}))
+
+const tagOptions: SearchTagOption[] = [
+  { id: 'code', count: 3, isBuiltin: true },
+  { id: 'project', count: 1, isBuiltin: false },
+]
+
+describe('QuickPanelTagFilterBar', () => {
+  it('shows every provided tag in a horizontally scrollable row', () => {
+    const { container } = render(
+      <QuickPanelTagFilterBar tagFilter={null} tagOptions={tagOptions} onChange={vi.fn()} />
+    )
+
+    expect(screen.getByRole('button', { name: 'Code' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'project' })).toBeInTheDocument()
+    expect(container.querySelector('[data-testid="quick-panel-tag-filter-list"]')).toHaveClass(
+      'overflow-x-auto'
+    )
+  })
+
+  it('applies an unselected tag and clears the selected tag on a second click', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    const { rerender } = render(
+      <QuickPanelTagFilterBar tagFilter={null} tagOptions={tagOptions} onChange={onChange} />
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Code' }))
+    expect(onChange).toHaveBeenCalledWith('code')
+
+    rerender(<QuickPanelTagFilterBar tagFilter="code" tagOptions={tagOptions} onChange={onChange} />)
+    await user.click(screen.getByRole('button', { name: 'Code' }))
+
+    expect(onChange).toHaveBeenLastCalledWith(null)
+  })
+})

--- a/src/quick-panel/components/__tests__/QuickPanelTagFilterBar.test.tsx
+++ b/src/quick-panel/components/__tests__/QuickPanelTagFilterBar.test.tsx
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
-import QuickPanelTagFilterBar from '../QuickPanelTagFilterBar'
 import type { SearchTagOption } from '@/lib/search-tags'
+import QuickPanelTagFilterBar from '../QuickPanelTagFilterBar'
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
@@ -42,7 +42,9 @@ describe('QuickPanelTagFilterBar', () => {
     await user.click(screen.getByRole('button', { name: 'Code' }))
     expect(onChange).toHaveBeenCalledWith('code')
 
-    rerender(<QuickPanelTagFilterBar tagFilter="code" tagOptions={tagOptions} onChange={onChange} />)
+    rerender(
+      <QuickPanelTagFilterBar tagFilter="code" tagOptions={tagOptions} onChange={onChange} />
+    )
     await user.click(screen.getByRole('button', { name: 'Code' }))
 
     expect(onChange).toHaveBeenLastCalledWith(null)

--- a/src/quick-panel/components/__tests__/QuickPanelTypeFilterBar.test.tsx
+++ b/src/quick-panel/components/__tests__/QuickPanelTypeFilterBar.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import QuickPanelTypeFilterBar from '../QuickPanelTypeFilterBar'
+import { Filter } from '@/api/clipboardItems'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) =>
+      ({
+        'history.filter.all': 'All',
+        'history.type.text': 'Text',
+        'history.type.richtext': 'Rich Text',
+        'history.type.image': 'Image',
+        'history.type.file': 'File',
+      })[key] ?? key,
+  }),
+}))
+
+describe('QuickPanelTypeFilterBar', () => {
+  it('keeps every content type visible and applies the selected type', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+
+    render(<QuickPanelTypeFilterBar activeFilter={Filter.All} onChange={onChange} />)
+
+    expect(screen.getByRole('button', { name: 'All', pressed: true })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Text' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Rich Text' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Image' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'File' })).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Image' }))
+
+    expect(onChange).toHaveBeenCalledWith(Filter.Image)
+  })
+
+  it('uses the All control to reset the type filter', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+
+    render(<QuickPanelTypeFilterBar activeFilter={Filter.File} onChange={onChange} />)
+
+    await user.click(screen.getByRole('button', { name: 'All' }))
+
+    expect(onChange).toHaveBeenCalledWith(Filter.All)
+  })
+})

--- a/src/quick-panel/components/__tests__/QuickPanelTypeFilterBar.test.tsx
+++ b/src/quick-panel/components/__tests__/QuickPanelTypeFilterBar.test.tsx
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
-import QuickPanelTypeFilterBar from '../QuickPanelTypeFilterBar'
 import { Filter } from '@/api/clipboardItems'
+import QuickPanelTypeFilterBar from '../QuickPanelTypeFilterBar'
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({


### PR DESCRIPTION
## Summary
- Keep quick-panel type filters visible below the search box.
- Move dynamic tag filters to a horizontally scrollable footer.
- Remove the visible keyboard-hint text while preserving keyboard navigation and paste behavior.

## Validation
- `npm test -- --run src/quick-panel/components/__tests__/QuickPanelTypeFilterBar.test.tsx src/quick-panel/components/__tests__/QuickPanelTagFilterBar.test.tsx src/quick-panel/__tests__/ClipboardHistoryPanel.single-window.test.tsx`
  - 3 files, 26 tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated filters for clipboard content types.
  * Added a horizontal tag filter bar with selectable built-in and custom tags.
  * Active filters can be selected or cleared directly from the clipboard history panel.
* **Bug Fixes**
  * Improved filter visibility and removed the outdated filter shortcut hint.
* **Tests**
  * Added coverage for content-type and tag filtering, including selection and reset behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->