### PR TITLE
fix(unlock): remove blurred corner decoration

### DIFF
--- a/src/pages/UnlockPage.tsx
+++ b/src/pages/UnlockPage.tsx
@@ -309,11 +309,6 @@ export default function UnlockPage({ onUnlockSucceeded, onResetSucceeded }: Unlo
         className="absolute inset-0 bg-gradient-to-b from-transparent via-transparent to-muted/20"
       />
 
-      <div
-        data-uc-decorative-effect="true"
-        className="absolute -bottom-24 -right-16 size-96 rounded-full bg-primary/5 blur-3xl"
-      />
-
       <div className="relative z-10 flex w-full max-w-sm flex-col items-center gap-y-8 text-center">
         <div className="relative flex size-24 items-center justify-center rounded-3xl bg-muted/30 shadow-inner ring-1 ring-border/50">
           <div className="absolute inset-0 rounded-3xl bg-gradient-to-br from-primary/10 to-transparent opacity-50" />

--- a/src/pages/__tests__/UnlockPage.test.tsx
+++ b/src/pages/__tests__/UnlockPage.test.tsx
@@ -41,6 +41,12 @@ describe('UnlockPage', () => {
     vi.mocked(verifyKeychainAccess).mockResolvedValue(true)
   })
 
+  it('does not render the lower-right blurred decorative effect', () => {
+    const { container } = render(<UnlockPage />)
+
+    expect(container.querySelector('[data-uc-decorative-effect].blur-3xl')).toBeNull()
+  })
+
   it('notifies parent immediately when silent unlock succeeds', async () => {
     const onUnlockSucceeded = vi.fn()
     vi.mocked(unlockEncryptionSession).mockResolvedValue(true)


### PR DESCRIPTION
## Summary

- Remove the lower-right blurred decoration from the unlock page, preventing the macOS visual artifact. (7bb6a6296)
- Add a regression test to keep that decoration from returning. (7bb6a6296)
- Docs left as-is: no user-visible behavior changed.
- No telemetry or tracing changes: this diff only updates the frontend presentation.

## Test plan

- [x] `bunx --bun vitest run src/pages/__tests__/UnlockPage.test.tsx`
- [x] `bun run build`
- [x] `bunx prettier --check src/pages/UnlockPage.tsx src/pages/__tests__/UnlockPage.test.tsx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed an unnecessary decorative blur from the lower-right area of the unlock page for a cleaner visual presentation.

* **Tests**
  * Added coverage to prevent the decorative effect from being reintroduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->