### PR TITLE
fix(release): refresh workspace lockfile

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -127,7 +127,7 @@ jobs:
           components: rustfmt
 
       - name: Refresh Cargo.lock for workspace members
-        run: cargo update -p uc-cli
+        run: cargo update --workspace
 
       - name: Generate changelog skeleton
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10481,7 +10481,7 @@ checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "uc-app-paths"
-version = "0.20.0-alpha.7"
+version = "1.0.0-alpha.1"
 dependencies = [
  "dirs 6.0.0",
 ]
@@ -10525,7 +10525,7 @@ dependencies = [
 
 [[package]]
 name = "uc-bootstrap"
-version = "0.20.0-alpha.7"
+version = "1.0.0-alpha.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10546,7 +10546,7 @@ dependencies = [
 
 [[package]]
 name = "uc-cli"
-version = "0.20.0-alpha.7"
+version = "1.0.0-alpha.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -10577,7 +10577,7 @@ dependencies = [
 
 [[package]]
 name = "uc-cli-macros"
-version = "0.20.0-alpha.7"
+version = "1.0.0-alpha.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10622,7 +10622,7 @@ dependencies = [
 
 [[package]]
 name = "uc-daemon"
-version = "0.20.0-alpha.7"
+version = "1.0.0-alpha.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10645,7 +10645,7 @@ dependencies = [
 
 [[package]]
 name = "uc-daemon-client"
-version = "0.20.0-alpha.7"
+version = "1.0.0-alpha.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10666,7 +10666,7 @@ dependencies = [
 
 [[package]]
 name = "uc-daemon-contract"
-version = "0.20.0-alpha.7"
+version = "1.0.0-alpha.1"
 dependencies = [
  "chrono",
  "semver",
@@ -10678,7 +10678,7 @@ dependencies = [
 
 [[package]]
 name = "uc-daemon-local"
-version = "0.20.0-alpha.7"
+version = "1.0.0-alpha.1"
 dependencies = [
  "anyhow",
  "fs2",
@@ -10696,7 +10696,7 @@ dependencies = [
 
 [[package]]
 name = "uc-daemon-process"
-version = "0.20.0-alpha.7"
+version = "1.0.0-alpha.1"
 dependencies = [
  "anyhow",
  "libc",
@@ -10715,7 +10715,7 @@ dependencies = [
 
 [[package]]
 name = "uc-desktop"
-version = "0.20.0-alpha.7"
+version = "1.0.0-alpha.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10844,7 +10844,7 @@ dependencies = [
 
 [[package]]
 name = "uc-observability"
-version = "0.20.0-alpha.7"
+version = "1.0.0-alpha.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -10879,7 +10879,7 @@ dependencies = [
 
 [[package]]
 name = "uc-platform"
-version = "0.20.0-alpha.7"
+version = "1.0.0-alpha.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10923,7 +10923,7 @@ dependencies = [
 
 [[package]]
 name = "uc-tauri"
-version = "0.20.0-alpha.7"
+version = "1.0.0-alpha.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10978,7 +10978,7 @@ dependencies = [
 
 [[package]]
 name = "uc-webserver"
-version = "0.20.0-alpha.7"
+version = "1.0.0-alpha.1"
 dependencies = [
  "anyhow",
  "argon2",


### PR DESCRIPTION
## Summary

- Correct the v1.0.0-alpha.1 lockfile so every workspace package matches the release version.
- Refresh all workspace lockfile entries during release preparation, preventing a partial update from breaking the server-image build.

## Test plan

- [x] Reproduced the original strict release build failure before the lockfile refresh.
- [x] Ran `cargo update --workspace` and verified `cargo check --locked --release -p uc-cli -p uc-daemon` passes.
- [x] Ran `git diff --check`.
- [ ] Re-run the server-image workflow after merge to publish the missing v1.0.0-alpha.1 image.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release workflow to refresh dependencies across the entire Cargo workspace during release preparation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->