### PR TITLE
fix(release): decouple membership matrix

### DIFF
--- a/.github/workflows/membership-e2e.yml
+++ b/.github/workflows/membership-e2e.yml
@@ -12,25 +12,13 @@ on:
         type: choice
         options:
           - nightly
-          - release
+          - pr
         default: nightly
       ref:
         description: '要测试的分支、标签或提交'
         required: false
         type: string
         default: ''
-  workflow_call:
-    inputs:
-      tier:
-        description: '测试层级'
-        required: true
-        type: string
-      ref:
-        description: '要测试的分支、标签或提交'
-        required: false
-        type: string
-        default: ''
-
 permissions:
   contents: read
   packages: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,16 +153,8 @@ jobs:
           echo "Previous reference: $PREV_TAG"
           rm -f "${TEMP_OUTPUT}"
 
-  membership-e2e:
-    needs: validate
-    uses: ./.github/workflows/membership-e2e.yml
-    with:
-      tier: release
-      ref: ${{ github.event_name == 'push' && github.ref || inputs.branch }}
-    secrets: inherit
-
   build:
-    needs: [validate, membership-e2e]
+    needs: validate
     uses: ./.github/workflows/build.yml
     with:
       platform: ${{ inputs.platform || 'all' }}
@@ -171,7 +163,7 @@ jobs:
     secrets: inherit
 
   build-cli:
-    needs: [validate, membership-e2e]
+    needs: validate
     uses: ./.github/workflows/build-cli.yml
     with:
       platform: ${{ inputs.platform || 'all' }}

--- a/scripts/__tests__/membership-e2e-hardening.test.ts
+++ b/scripts/__tests__/membership-e2e-hardening.test.ts
@@ -19,6 +19,29 @@ describe('membership E2E hardening', () => {
     )
   })
 
+  it('keeps the membership matrix out of the release dependency chain', () => {
+    const release = read('.github/workflows/release.yml')
+    const workflow = read('.github/workflows/membership-e2e.yml')
+    const script = read('scripts/e2e/run-membership-matrix.sh')
+
+    expect(release).not.toMatch(/^\s+membership-e2e:/m)
+    expect(release).not.toContain('needs: [validate, membership-e2e]')
+    expect(workflow).not.toContain('  workflow_call:')
+    expect(workflow).not.toContain('          - release')
+    expect(script).not.toContain('pr|nightly|release')
+    expect(script).not.toContain('if [[ "$TIER" == "release" ]]')
+  })
+
+  it('uses platform-specific binary names for tar archive fixtures', () => {
+    const releaseAssets = read('tests/e2e/tests/release_assets.rs')
+    const tarFixture = releaseAssets.match(
+      /fn tar_release_extracts_only_the_cli_pair\(\) \{[\s\S]*?\n\}/
+    )?.[0]
+
+    expect(tarFixture).toContain('let cli = binary_name("uniclip");')
+    expect(tarFixture).toContain('let daemon = binary_name("uniclipd");')
+  })
+
   it('preserves aggregate failures and explains a missing legacy release', () => {
     const script = read('scripts/e2e/run-membership-matrix.sh')
 

--- a/scripts/e2e/run-membership-matrix.sh
+++ b/scripts/e2e/run-membership-matrix.sh
@@ -3,9 +3,9 @@ set -uo pipefail
 
 TIER="${1:-nightly}"
 case "$TIER" in
-  pr|nightly|release) ;;
+  pr|nightly) ;;
   *)
-    echo "usage: $0 [pr|nightly|release]" >&2
+    echo "usage: $0 [pr|nightly]" >&2
     exit 2
     ;;
 esac
@@ -44,9 +44,6 @@ run_case() {
     --manifest-path tests/e2e/Cargo.toml
   )
 
-  if [[ "$TIER" == "release" ]]; then
-    effective_classification="required"
-  fi
   if [[ -n "$feature" ]]; then
     cargo_args+=(--features "$feature")
   fi

--- a/tests/e2e/Cargo.lock
+++ b/tests/e2e/Cargo.lock
@@ -1685,7 +1685,7 @@ checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "uc-app-paths"
-version = "0.20.0-alpha.6"
+version = "1.0.0-alpha.1"
 dependencies = [
  "dirs",
 ]

--- a/tests/e2e/tests/release_assets.rs
+++ b/tests/e2e/tests/release_assets.rs
@@ -105,9 +105,11 @@ fn release_payload_verification_rejects_tampered_inputs() {
 
 #[test]
 fn tar_release_extracts_only_the_cli_pair() {
+    let cli = binary_name("uniclip");
+    let daemon = binary_name("uniclipd");
     let archive = tar_gz(&[
-        ("uniclip", b"cli"),
-        ("uniclipd", b"daemon"),
+        (&cli, b"cli"),
+        (&daemon, b"daemon"),
         ("ignored.txt", b"ignored"),
     ]);
     let output = tempfile::tempdir().expect("output tempdir");


### PR DESCRIPTION
## Summary

- remove membership E2E from the release build dependency chain
- keep the matrix as scheduled and manually dispatched checks only
- fix Windows tar fixture binary names and refresh the E2E lockfile

## Root cause

The release workflow treated diagnostic recovery scenarios as required release gates, so unrelated convergence failures skipped all package builds and release creation.

## Validation

- bunx vitest run scripts/__tests__/membership-e2e-hardening.test.ts
- cargo test --locked --manifest-path tests/e2e/Cargo.toml --test release_assets
- actionlint .github/workflows/release.yml .github/workflows/membership-e2e.yml
- bash syntax and release-tier rejection checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release asset validation across platforms, including support for Windows executable naming.
  * Simplified membership checks by limiting supported test tiers to pull requests and nightly runs.

* **Release Improvements**
  * Release builds no longer wait for membership end-to-end checks, enabling faster release workflow execution.

* **Tests**
  * Added coverage to verify release workflow dependencies and platform-specific archive contents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->