### PR TITLE
ci: automate issue verification lifecycle

### DIFF
--- a/.github/workflows/issue-lifecycle.yml
+++ b/.github/workflows/issue-lifecycle.yml
@@ -1,0 +1,260 @@
+name: Issue lifecycle
+run-name: >-
+  ${{ github.event_name == 'release'
+    && format('issue-lifecycle-{0}', github.event.release.tag_name)
+    || github.event_name == 'repository_dispatch'
+    && format('issue-lifecycle-{0}', github.event.client_payload.tag_name)
+    || format('issue-lifecycle-{0}', github.event_name) }}
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, closed]
+  issue_comment:
+    types: [created]
+  release:
+    types: [published]
+  repository_dispatch:
+    types: [issue-lifecycle-release]
+
+permissions: {}
+
+jobs:
+  validate-issue-references:
+    name: Validate issue references
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Reject closing keywords
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.pull_request.body ?? '';
+            const closingReferences = body.match(
+              /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s*:?\s+(?:#\d+|[\w.-]+\/[\w.-]+#\d+|https?:\/\/github\.com\/[\w.-]+\/[\w.-]+\/issues\/\d+)\b/gi
+            ) ?? [];
+
+            if (closingReferences.length > 0) {
+              core.setFailed(
+                `PR descriptions must not use GitHub closing keywords: ${closingReferences.join(', ')}. Use "Related to #123" or "Refs #123" instead.`
+              );
+            }
+
+  mark-issues-ready-for-test:
+    name: Mark linked issues ready for test
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.action == 'closed' &&
+      github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: read
+    steps:
+      - name: Update linked issues
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.pull_request.body ?? '';
+            const issueNumbers = [
+              ...new Set(
+                [...body.matchAll(
+                  /^\s*(?:[-*]\s*)?(?:related(?:\s+to)?|refs?)\s*:?\s+#(\d+)\b/gim
+                )].map((match) => Number(match[1]))
+              ),
+            ];
+            const statusLabels = new Set([
+              'status:triage',
+              'status:in-progress',
+              'status:ready-for-test',
+              'status:verified',
+            ]);
+
+            for (const issueNumber of issueNumbers) {
+              const { data: issue } = await github.rest.issues.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+              });
+
+              if (issue.pull_request) {
+                core.warning(`Skipping #${issueNumber}: linked pull requests are not lifecycle issues.`);
+                continue;
+              }
+
+              for (const label of issue.labels) {
+                const name = typeof label === 'string' ? label : label.name;
+                if (name && statusLabels.has(name) && name !== 'status:ready-for-test') {
+                  await github.rest.issues.removeLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issueNumber,
+                    name,
+                  });
+                }
+              }
+
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                labels: ['status:ready-for-test'],
+              });
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                body: `PR #${context.payload.pull_request.number} has merged. This issue is ready for release verification.`,
+              });
+            }
+
+  request-release-verification:
+    name: Request release verification
+    if: >-
+      github.event_name == 'release' ||
+      (github.event_name == 'repository_dispatch' && github.event.action == 'issue-lifecycle-release')
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Notify issues awaiting verification
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const release = context.eventName === 'release'
+              ? context.payload.release
+              : context.payload.client_payload;
+            const marker = `<!-- issue-lifecycle:verification-release=${release.tag_name} -->`;
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'status:ready-for-test',
+              per_page: 100,
+            });
+            const notifiedIssues = [];
+
+            for (const issue of issues) {
+              if (issue.pull_request) {
+                continue;
+              }
+
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                per_page: 100,
+              });
+              if (comments.some((comment) => comment.body?.includes(marker))) {
+                continue;
+              }
+
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: [
+                  `Release [${release.tag_name}](${release.html_url}) is available for verification.`,
+                  '',
+                  `After verification passes, an authorized collaborator can comment \`/verify ${release.tag_name}\` to close this issue.`,
+                  marker,
+                ].join('\n'),
+              });
+              notifiedIssues.push(`#${issue.number} ${issue.title}`);
+            }
+
+            await core.summary
+              .addHeading(`Issues awaiting verification for ${release.tag_name}`)
+              .addList(notifiedIssues.length > 0 ? notifiedIssues : ['No issues are awaiting verification.'])
+              .write();
+
+  close-verified-issue:
+    name: Close verified issue
+    if: >-
+      github.event_name == 'issue_comment' &&
+      !github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/verify ')
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Verify authorization and close the issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const command = context.payload.comment.body.trim();
+            const commandMatch = command.match(/^\/verify\s+(v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)$/);
+            if (!commandMatch) {
+              core.setFailed('Use the exact command /verify vX.Y.Z.');
+              return;
+            }
+
+            const verificationRelease = commandMatch[1];
+            const { data: permission } = await github.rest.repos.getCollaboratorPermissionLevel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              username: context.payload.comment.user.login,
+            });
+            if (!['admin', 'maintain', 'write', 'triage'].includes(permission.permission)) {
+              core.setFailed('Only repository collaborators with triage or higher permission can verify an issue.');
+              return;
+            }
+
+            const issueNumber = context.payload.issue.number;
+            const marker = `<!-- issue-lifecycle:verification-release=${verificationRelease} -->`;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              per_page: 100,
+            });
+            if (!comments.some((comment) => comment.body?.includes(marker))) {
+              core.setFailed(`Issue #${issueNumber} was not requested for verification in ${verificationRelease}.`);
+              return;
+            }
+
+            const statusLabels = new Set([
+              'status:triage',
+              'status:in-progress',
+              'status:ready-for-test',
+              'status:verified',
+            ]);
+            const { data: issue } = await github.rest.issues.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+            });
+            for (const label of issue.labels) {
+              const name = typeof label === 'string' ? label : label.name;
+              if (name && statusLabels.has(name) && name !== 'status:verified') {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  name,
+                });
+              }
+            }
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              labels: ['status:verified'],
+            });
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              body: [
+                `Verified in ${verificationRelease} by @${context.payload.comment.user.login}.`,
+                `<!-- issue-lifecycle:verified-release=${verificationRelease} -->`,
+              ].join('\n'),
+            });
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              state: 'closed',
+            });

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -376,6 +376,19 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Dispatch verification reminder for Alpha release
+        if: needs.validate.outputs.channel == 'alpha'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.validate.outputs.version }}
+        run: |
+          gh api \
+            --method POST \
+            "repos/${{ github.repository }}/dispatches" \
+            -f "event_type=issue-lifecycle-release" \
+            -f "client_payload[tag_name]=v${VERSION}" \
+            -f "client_payload[html_url]=https://github.com/${{ github.repository }}/releases/tag/v${VERSION}"
+
       - name: Upload artifacts to R2
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/docs/issue-lifecycle.md
+++ b/docs/issue-lifecycle.md
@@ -1,0 +1,48 @@
+# Issue 验证流程
+
+Issue 不会因为 PR 合并而自动关闭。每个状态的变更和关联的 PR、发布版本、验证记录都保留在 Issue 时间线中。
+
+## 状态流转
+
+```text
+status:triage -> status:in-progress -> status:ready-for-test -> status:verified -> closed
+```
+
+- 创建和排查：`status:triage`
+- 开始开发：`status:in-progress`
+- PR 合并：自动变为 `status:ready-for-test`
+- GitHub Release 发布：自动在每个待验证 Issue 留下版本和验证指令，包含自动发布的 Alpha 版本
+- 验证通过：有权限的协作者评论验证指令，自动标记为 `status:verified` 并关闭
+
+## 关联 PR
+
+PR 描述中只能使用非关闭式关联，每条关联独占一行：
+
+```markdown
+## Related Issues
+
+Related to #123
+Refs #456
+```
+
+禁止使用 `Close`、`Closes`、`Fix`、`Fixes`、`Resolve`、`Resolves` 及其过去式来引用 Issue。这些写法会被 GitHub 当作合并后自动关闭的指令，工作流会阻止该 PR 通过检查。
+
+在分支保护中，将 `Issue lifecycle / Validate issue references` 设为必需检查，才能强制执行这条规则。
+
+## 验证并关闭
+
+发布后，待验证 Issue 会收到类似下面的评论：
+
+```text
+Release v1.2.3 is available for verification.
+
+After verification passes, an authorized collaborator can comment `/verify v1.2.3` to close this issue.
+```
+
+完成验证后，在同一 Issue 评论：
+
+```text
+/verify v1.2.3
+```
+
+只有拥有仓库分流、写入、维护或管理权限的协作者可以执行该指令。指令必须对应 Issue 已收到的发布版本，避免把尚未进入该版本的修复误标记为已验证。

--- a/scripts/__tests__/issue-lifecycle-workflow.test.ts
+++ b/scripts/__tests__/issue-lifecycle-workflow.test.ts
@@ -1,0 +1,58 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, test } from 'vitest'
+
+const workflowPath = path.resolve(
+  import.meta.dirname,
+  '../../.github/workflows/issue-lifecycle.yml'
+)
+const releaseWorkflowPath = path.resolve(import.meta.dirname, '../../.github/workflows/release.yml')
+
+function readWorkflow(): string {
+  return fs.readFileSync(workflowPath, 'utf8')
+}
+
+function readReleaseWorkflow(): string {
+  return fs.readFileSync(releaseWorkflowPath, 'utf8')
+}
+
+describe('Issue lifecycle workflow', () => {
+  test('keeps linked issues open until an authorized verification command', () => {
+    const workflow = readWorkflow()
+
+    expect(workflow).toContain('pull_request:')
+    expect(workflow).toContain('issue_comment:')
+    expect(workflow).toContain('release:')
+    expect(workflow).toContain('status:ready-for-test')
+    expect(workflow).toContain('status:verified')
+    expect(workflow).toContain("state: 'closed'")
+    expect(workflow).toContain('getCollaboratorPermissionLevel')
+    expect(workflow).toContain("['admin', 'maintain', 'write', 'triage']")
+  })
+
+  test('rejects pull request text that would let GitHub close an issue on merge', () => {
+    const workflow = readWorkflow()
+
+    expect(workflow).toContain('closingReferences')
+    expect(workflow).toContain('closing keywords')
+    expect(workflow).toContain('Related to #123')
+    expect(workflow).toContain('(?:related(?:\\s+to)?|refs?)\\s*:?\\s+#(\\d+)\\b')
+  })
+
+  test('records the release that must be verified before accepting the command', () => {
+    const workflow = readWorkflow()
+
+    expect(workflow).toContain('verification-release=')
+    expect(workflow).toContain('/verify vX.Y.Z')
+    expect(workflow).toContain('listComments')
+  })
+
+  test('notifies issues for releases published by the release workflow itself', () => {
+    const workflow = readWorkflow()
+    const releaseWorkflow = readReleaseWorkflow()
+
+    expect(workflow).toContain('repository_dispatch:')
+    expect(workflow).toContain('issue-lifecycle-release')
+    expect(releaseWorkflow).toContain('-f "event_type=issue-lifecycle-release"')
+  })
+})


### PR DESCRIPTION
## Summary

- Add a tracked Issue lifecycle that moves linked issues to release verification after their PR merges without automatically closing them. (971e0f0f3)
- Notify every issue awaiting verification when a GitHub Release is published, including automatically published Alpha releases. (971e0f0f3)
- Allow authorized collaborators to verify a specific released version from the Issue timeline, then mark it verified and close it. (971e0f0f3)
- Document the workflow and add regression coverage for the lifecycle rules. (971e0f0f3)

## Test plan

- [x] `bun run test` (141 files, 987 tests)
- [x] Workflow syntax validation
- [x] Formatting and whitespace checks
- [ ] Confirm the first merged PR moves its linked Issue to verification
- [ ] Confirm a published release posts its verification instruction on the linked Issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated issue lifecycle management from pull request merge through testing and release verification.
  * Added release verification support using authorized `/verify <version>` comments.
  * Added reminders for verifying alpha releases.
* **Documentation**
  * Added guidance on issue status transitions, pull request linking, and release verification.
* **Bug Fixes**
  * Prevented pull request descriptions from using prohibited issue-closing references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->