### PR TITLE
fix(release): link preview Android releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -350,6 +350,26 @@ jobs:
           echo "Preview of GitHub-generated notes:"
           head -80 generated-notes.md || true
 
+      - name: Resolve mobile app download
+        id: mobile-release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CHANNEL: ${{ needs.validate.outputs.channel }}
+        run: |
+          if [ "$CHANNEL" = "stable" ]; then
+            echo "android_release_url=https://github.com/UniClipboard/UniClip/releases/latest" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          MOBILE_URL="$(gh api -X GET 'repos/UniClipboard/UniClip/releases?per_page=100' \
+            --jq 'map(select(.prerelease == true and .draft == false)) | .[0].html_url // empty')"
+          if [ -z "$MOBILE_URL" ]; then
+            echo "No published mobile preview release is available for the $CHANNEL desktop release." >&2
+            exit 1
+          fi
+
+          echo "android_release_url=$MOBILE_URL" >> "$GITHUB_OUTPUT"
+
       - name: Generate release notes
         id: release-notes
         run: |
@@ -359,6 +379,7 @@ jobs:
             --previous-tag "${{ needs.validate.outputs.previous_tag }}" \
             --channel "${{ needs.validate.outputs.channel }}" \
             --is-prerelease "${{ needs.validate.outputs.is_prerelease }}" \
+            --mobile-android-release-url "${{ steps.mobile-release.outputs.android_release_url }}" \
             --artifacts-dir "release-assets" \
             --template ".github/release-notes/release.md.tmpl" \
             --generated-notes-file "generated-notes.md" \

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -55,27 +55,27 @@ bun run version:bump --type patch --channel alpha --dry-run
 ### Stable（稳定版）
 
 - **用途**: 正式发布版本，推荐给所有用户使用
-- **版本格式**: `X.Y.Z` (例如: `1.0.0`)
+- **版本格式**: `X.Y.Z` (例如：`1.0.0`)
 - **GitHub Release**: 标记为正式版本（非 prerelease）
 
 ### Alpha（内测版）
 
 - **用途**: 早期功能测试，可能包含未完成的功能或已知问题
-- **版本格式**: `X.Y.Z-alpha.N` (例如: `0.1.0-alpha.1`)
+- **版本格式**: `X.Y.Z-alpha.N` (例如：`0.1.0-alpha.1`)
 - **GitHub Release**: 标记为 prerelease，带有警告说明
 - **建议**: 仅供开发者和高级用户测试使用
 
 ### Beta（公测版）
 
 - **用途**: 功能基本完成，进行更广泛的测试
-- **版本格式**: `X.Y.Z-beta.N` (例如: `0.1.0-beta.1`)
+- **版本格式**: `X.Y.Z-beta.N` (例如：`0.1.0-beta.1`)
 - **GitHub Release**: 标记为 prerelease
 - **建议**: 可供愿意帮助测试的用户使用
 
 ### RC（候选版）
 
 - **用途**: 发布候选版，即将成为稳定版
-- **版本格式**: `X.Y.Z-rc.N` (例如: `1.0.0-rc.1`)
+- **版本格式**: `X.Y.Z-rc.N` (例如：`1.0.0-rc.1`)
 - **GitHub Release**: 标记为 prerelease
 - **建议**: 适合最终验证和回归测试
 
@@ -121,7 +121,7 @@ bun run version:bump --type patch --channel alpha --dry-run
 
 3. **创建发布 (create-release)**
    - 创建 Git 标签
-   - 生成发布说明（含桌面端直接下载链接，以及移动端仓库 [UniClipboard/UniClip](https://github.com/UniClipboard/UniClip) 的 iOS 公测与安卓最新版下载链接）
+   - 生成发布说明（含桌面端直接下载链接，以及移动端仓库 [UniClipboard/UniClip](https://github.com/UniClipboard/UniClip) 的 iOS 公测与安卓下载链接；桌面预发布会链接到移动端最新预览版，正式发布会链接到移动端最新正式版）
    - 上传所有构建产物
    - 创建 GitHub Release 草稿
 
@@ -186,7 +186,7 @@ git push
 # channel: alpha
 ```
 
-结果: `0.1.0` -> `0.1.0-alpha.1`
+结果：`0.1.0` -> `0.1.0-alpha.1`
 
 ### 场景 2: 继续发布 alpha 版本
 
@@ -196,7 +196,7 @@ git push
 bun run version:bump --type patch --channel alpha
 ```
 
-结果: `0.1.0-alpha.1` -> `0.1.0-alpha.2`
+结果：`0.1.0-alpha.1` -> `0.1.0-alpha.2`
 
 如果希望从稳定版直接到指定预发布号（例如 `0.1.0` -> `0.1.0-alpha.2`）：
 
@@ -210,7 +210,7 @@ bun run version:bump --to 0.1.0-alpha.2
 bun run version:bump --type patch --channel stable
 ```
 
-结果: `0.1.0-alpha.5` -> `0.1.0`
+结果：`0.1.0-alpha.5` -> `0.1.0`
 
 ### 场景 4: 发布新的 minor 版本
 
@@ -218,7 +218,7 @@ bun run version:bump --type patch --channel stable
 bun run version:bump --type minor --channel stable
 ```
 
-结果: `0.1.5` -> `0.2.0`
+结果：`0.1.5` -> `0.2.0`
 
 ## 安装包命名规则
 
@@ -238,8 +238,8 @@ bun run version:bump --type minor --channel stable
 
 确保版本号符合语义化版本规范：
 
-- 稳定版: `X.Y.Z` (例如 `1.0.0`)
-- 预发布: `X.Y.Z-channel.N` (例如 `1.0.0-alpha.1`)
+- 稳定版：`X.Y.Z` (例如 `1.0.0`)
+- 预发布：`X.Y.Z-channel.N` (例如 `1.0.0-alpha.1`)
 
 ### 标签已存在
 
@@ -254,9 +254,9 @@ bun run version:bump --type minor --channel stable
 
 ## 相关文件
 
-- 版本管理脚本: [`scripts/bump-version.js`](../scripts/bump-version.js)
-- Codex changelog 提示词: [`.github/prompts/release-changelog.codex.md`](../.github/prompts/release-changelog.codex.md)
-- Changelog 写作规则: [`docs/CHANGELOG_TEMPLATE.md`](./CHANGELOG_TEMPLATE.md)
-- 发布工作流: [`.github/workflows/release.yml`](../.github/workflows/release.yml)
-- 预发布准备工作流: [`.github/workflows/prepare-release.yml`](../.github/workflows/prepare-release.yml)
-- 构建工作流: [`.github/workflows/build.yml`](../.github/workflows/build.yml)
+- 版本管理脚本：[`scripts/bump-version.js`](../scripts/bump-version.js)
+- Codex changelog 提示词：[`.github/prompts/release-changelog.codex.md`](../.github/prompts/release-changelog.codex.md)
+- Changelog 写作规则：[`docs/CHANGELOG_TEMPLATE.md`](./CHANGELOG_TEMPLATE.md)
+- 发布工作流：[`.github/workflows/release.yml`](../.github/workflows/release.yml)
+- 预发布准备工作流：[`.github/workflows/prepare-release.yml`](../.github/workflows/prepare-release.yml)
+- 构建工作流：[`.github/workflows/build.yml`](../.github/workflows/build.yml)

--- a/scripts/__tests__/generate-release-notes.test.ts
+++ b/scripts/__tests__/generate-release-notes.test.ts
@@ -68,7 +68,7 @@ describe('buildInstallerTable Windows rows', () => {
 })
 
 describe('buildInstallerTable mobile rows', () => {
-  it('always advertises the latest iOS beta and Android APK links', () => {
+  it('links stable desktop releases to the latest stable Android release', () => {
     seed(['UniClipboard_0.13.0_aarch64.dmg'])
 
     const table = buildInstallerTable({ artifactsDir, baseUrl: BASE_URL })
@@ -81,6 +81,28 @@ describe('buildInstallerTable mobile rows', () => {
     )
     // Mobile links point at the companion repo / TestFlight, never this release's baseUrl.
     expect(table).not.toContain(`${BASE_URL}/https`)
+  })
+
+  it('links prerelease desktop releases to the resolved Android preview release', () => {
+    seed(['UniClipboard_0.13.0-alpha.4_aarch64.dmg'])
+
+    const table = buildInstallerTable({
+      artifactsDir,
+      baseUrl: BASE_URL,
+      channel: 'alpha',
+      androidReleaseUrl: 'https://github.com/UniClipboard/UniClip/releases/tag/v1.3.0.173-alpha.1',
+    })
+
+    expect(table).toContain(
+      '[Latest preview release](https://github.com/UniClipboard/UniClip/releases/tag/v1.3.0.173-alpha.1)'
+    )
+    expect(table).not.toContain('https://github.com/UniClipboard/UniClip/releases/latest')
+  })
+
+  it('rejects prerelease notes without a mobile preview release URL', () => {
+    expect(() => buildInstallerTable({ artifactsDir, baseUrl: BASE_URL, channel: 'beta' })).toThrow(
+      'A mobile Android preview release URL is required for prerelease notes.'
+    )
   })
 
   it('still surfaces mobile downloads when no desktop artifacts are present', () => {

--- a/scripts/generate-release-notes.js
+++ b/scripts/generate-release-notes.js
@@ -16,6 +16,7 @@ function parseArgs(argv = process.argv.slice(2)) {
     output: null,
     docsBaseUrl: null,
     generatedNotesFile: null,
+    mobileAndroidReleaseUrl: null,
   }
 
   for (let index = 0; index < argv.length; index += 1) {
@@ -51,6 +52,9 @@ function parseArgs(argv = process.argv.slice(2)) {
       index += 1
     } else if (arg === '--generated-notes-file' && next) {
       options.generatedNotesFile = next
+      index += 1
+    } else if (arg === '--mobile-android-release-url' && next) {
+      options.mobileAndroidReleaseUrl = next
       index += 1
     }
   }
@@ -101,17 +105,21 @@ function findFirstFile(artifactsDir, predicate) {
 }
 
 // Mobile apps live in the companion repo (UniClipboard/UniClip) and ship on
-// their own cadence, independent of this desktop release. These links always
-// resolve to the latest mobile build, so every desktop release advertises the
-// current iOS public beta and Android APK without being pinned to this tag.
+// their own cadence, independent of this desktop release. The release workflow
+// resolves the Android URL for prereleases so its channel matches desktop.
 const MOBILE_REPO = 'UniClipboard/UniClip'
 const MOBILE_IOS_TESTFLIGHT_URL = 'https://testflight.apple.com/join/nyNQ8dQe'
 const MOBILE_ANDROID_LATEST_URL = `https://github.com/${MOBILE_REPO}/releases/latest`
 
-// Fixed, always-latest external rows for the App download matrix. Unlike the
-// desktop rows these are not scanned from artifactsDir, so the download cell is
-// a full URL rather than `baseUrl/fileName`.
-export function buildMobileInstallerRows() {
+// Mobile rows are external to artifactsDir, so their download cells use full
+// URLs rather than `baseUrl/fileName`.
+export function buildMobileInstallerRows({ channel = 'stable', androidReleaseUrl } = {}) {
+  const isPrerelease = channel !== 'stable'
+  const androidUrl = androidReleaseUrl || MOBILE_ANDROID_LATEST_URL
+  if (isPrerelease && !androidReleaseUrl) {
+    throw new Error('A mobile Android preview release URL is required for prerelease notes.')
+  }
+
   const makeRow = (platform, target, label, url) =>
     `| ${platform} | ${target} | [${label}](${url}) |`
   return [
@@ -119,13 +127,18 @@ export function buildMobileInstallerRows() {
     makeRow(
       'Android',
       'APK (arm64-v8a / armeabi-v7a / x86_64 / universal)',
-      'Latest release',
-      MOBILE_ANDROID_LATEST_URL
+      isPrerelease ? 'Latest preview release' : 'Latest release',
+      androidUrl
     ),
   ]
 }
 
-export function buildInstallerTable({ artifactsDir, baseUrl }) {
+export function buildInstallerTable({
+  artifactsDir,
+  baseUrl,
+  channel = 'stable',
+  androidReleaseUrl,
+}) {
   // Tauri v2 Linux 产物命名约定:
   //   .deb       — `<lower-product>_<version>_<amd64|arm64>.deb`        (Debian arch)
   //   .rpm       — `<ProductName>-<version>-1.<x86_64|aarch64>.rpm`     (RPM arch)
@@ -183,7 +196,7 @@ export function buildInstallerTable({ artifactsDir, baseUrl }) {
   if (windowsPortableArm) rows.push(makeRow('Windows', 'ARM64 (Portable)', windowsPortableArm))
 
   const header = '| Platform | Architecture | Download |\n| --- | --- | --- |\n'
-  const mobileRows = buildMobileInstallerRows()
+  const mobileRows = buildMobileInstallerRows({ channel, androidReleaseUrl })
 
   if (rows.length === 0) {
     // No desktop installer artifacts detected (anomalous — a normal release
@@ -373,7 +386,12 @@ export function generateReleaseNotes(options) {
     emitWarning(`Chinese release changelog file not found for version ${version}`, chinesePath)
   }
 
-  const installerTable = buildInstallerTable({ artifactsDir, baseUrl })
+  const installerTable = buildInstallerTable({
+    artifactsDir,
+    baseUrl,
+    channel: options.channel,
+    androidReleaseUrl: options.mobileAndroidReleaseUrl,
+  })
   const cliInstallerTable = buildCliInstallerTable({ artifactsDir, baseUrl })
   const template = fs.readFileSync(templatePath, 'utf8')
   const rendered =


### PR DESCRIPTION
## Summary

- Resolve the published Android preview release for desktop prerelease notes, and stop release-note generation when no matching preview is available. (fa498c636)
- Keep stable desktop releases linked to the stable Android download and document the channel-specific behavior. (17f4492da)

## Test plan

- [x] `bun run test -- --run scripts/__tests__/generate-release-notes.test.ts`
- [x] `node --check scripts/generate-release-notes.js`
- [x] Scoped ESLint check for the release-note script and its tests
- [x] YAML parse for `.github/workflows/release.yml`
- [x] `git diff --check origin/main...HEAD`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release notes now include the correct Android download link for stable and preview releases.
  * Preview Android builds are clearly labeled and require a specific preview download URL.
  * Mobile installer information is aligned with the selected release channel.

* **Documentation**
  * Clarified mobile download links and release-note examples for stable, beta, and preview releases.
  * Improved release workflow guidance and formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->