### PR TITLE
fix(docs): restore static asset loading

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Deployment configuration check
+        run: bun run test:config
+
       - name: Consistency check (mirror + anchors + autolink)
         run: bun run check:docs
 

--- a/docs-site/bun.lock
+++ b/docs-site/bun.lock
@@ -16,7 +16,7 @@
         "fumadocs-openapi": "^10.9.0",
         "fumadocs-ui": "16.9.1",
         "lucide-react": "^1.16.0",
-        "mermaid": "^11.15.0",
+        "mermaid": "^11.16.1",
         "next": "16.3.0",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
@@ -38,6 +38,10 @@
         "typescript": "^6.0.3",
       },
     },
+  },
+  "overrides": {
+    "dompurify": "3.4.13",
+    "js-yaml": "4.3.1",
   },
   "packages": {
     "@ai-sdk/anthropic": ["@ai-sdk/anthropic@3.0.79", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.27" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-saEX+h5JDOkT9P/+REKDyikbnJiToFuLipgNcsmu4Zr3GW5kW1m9HhvrPK+vj63itIOsoZU6tmVIjkrePOlIUA=="],
@@ -258,7 +262,7 @@
 
     "@mdx-js/mdx": ["@mdx-js/mdx@3.1.1", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdx": "^2.0.0", "acorn": "^8.0.0", "collapse-white-space": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "estree-util-scope": "^1.0.0", "estree-walker": "^3.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "markdown-extensions": "^2.0.0", "recma-build-jsx": "^1.0.0", "recma-jsx": "^1.0.0", "recma-stringify": "^1.0.0", "rehype-recma": "^1.0.0", "remark-mdx": "^3.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "source-map": "^0.7.0", "unified": "^11.0.0", "unist-util-position-from-estree": "^2.0.0", "unist-util-stringify-position": "^4.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ=="],
 
-    "@mermaid-js/parser": ["@mermaid-js/parser@1.1.1", "", { "dependencies": { "@chevrotain/types": "~11.1.1" } }, "sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw=="],
+    "@mermaid-js/parser": ["@mermaid-js/parser@1.2.0", "", { "dependencies": { "@chevrotain/types": "~11.1.2" } }, "sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@0.2.12", "", { "dependencies": { "@emnapi/core": "^1.4.3", "@emnapi/runtime": "^1.4.3", "@tybys/wasm-util": "^0.10.0" } }, "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ=="],
 
@@ -780,7 +784,7 @@
 
     "doctrine": ["doctrine@2.1.0", "", { "dependencies": { "esutils": "^2.0.2" } }, "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw=="],
 
-    "dompurify": ["dompurify@3.4.8", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-yb1cEmaOum7wFvOCSQxyfgVlv5D47Rc30iZWoMpbDIWTnJ6grDDQyu2KFJzB2k7u0pMuJcQ1zphH//fFnw2tjQ=="],
+    "dompurify": ["dompurify@3.4.13", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ=="],
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
@@ -1064,7 +1068,7 @@
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
-    "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
+    "js-yaml": ["js-yaml@4.3.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ=="],
 
     "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
 
@@ -1174,7 +1178,7 @@
 
     "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
 
-    "mermaid": ["mermaid@11.15.0", "", { "dependencies": { "@braintree/sanitize-url": "^7.1.1", "@iconify/utils": "^3.0.2", "@mermaid-js/parser": "^1.1.1", "@types/d3": "^7.4.3", "@upsetjs/venn.js": "^2.0.0", "cytoscape": "^3.33.1", "cytoscape-cose-bilkent": "^4.1.0", "cytoscape-fcose": "^2.2.0", "d3": "^7.9.0", "d3-sankey": "^0.12.3", "dagre-d3-es": "7.0.14", "dayjs": "^1.11.19", "dompurify": "^3.3.1", "es-toolkit": "^1.45.1", "katex": "^0.16.25", "khroma": "^2.1.0", "marked": "^16.3.0", "roughjs": "^4.6.6", "stylis": "^4.3.6", "ts-dedent": "^2.2.0", "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0" } }, "sha512-pTMbcf3rWdtLiYGpmoTjHEpeY8seiy6sR+9nD7LOs8KfUbHE4lOUAprTRqRAcWSQ6MQpdX+YEsxShtGsINtPtw=="],
+    "mermaid": ["mermaid@11.16.1", "", { "dependencies": { "@braintree/sanitize-url": "^7.1.2", "@iconify/utils": "^3.0.2", "@mermaid-js/parser": "^1.2.0", "@types/d3": "^7.4.3", "@upsetjs/venn.js": "^2.0.0", "cytoscape": "^3.33.3", "cytoscape-cose-bilkent": "^4.1.0", "cytoscape-fcose": "^2.2.0", "d3": "^7.9.0", "d3-sankey": "^0.12.3", "dagre-d3-es": "7.0.14", "dayjs": "^1.11.20", "dompurify": "^3.3.3", "es-toolkit": "^1.45.1", "katex": "^0.16.45", "khroma": "^2.1.0", "marked": "^16.3.0", "roughjs": "^4.6.6", "stylis": "^4.3.6", "ts-dedent": "^2.2.0", "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0" } }, "sha512-TQsq6u22fAn3rek5VOubrhKPo1g5hwC3FXUN9hiyupTckcYiGuuKGkNQrKYwGJkXUxZdojwRG46gsSCFZMDp4g=="],
 
     "micromark": ["micromark@4.0.2", "", { "dependencies": { "@types/debug": "^4.0.0", "debug": "^4.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA=="],
 

--- a/docs-site/next.config.mjs
+++ b/docs-site/next.config.mjs
@@ -37,6 +37,8 @@ const config = {
   reactStrictMode: true,
   basePath: '/docs',
   assetPrefix: '/docs',
+  // The main-site rewrite cannot serve Next.js 16.3 immutable assets.
+  supportsImmutableAssets: false,
   async redirects() {
     return docRedirects
   },

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -8,6 +8,7 @@
     "start": "next start",
     "types:check": "fumadocs-mdx && next typegen && tsc --noEmit",
     "check:docs": "node scripts/check-docs.mjs",
+    "test:config": "node --test test/next-config.test.mjs",
     "postinstall": "fumadocs-mdx",
     "lint": "eslint"
   },

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -24,7 +24,7 @@
     "fumadocs-openapi": "^10.9.0",
     "fumadocs-ui": "16.9.1",
     "lucide-react": "^1.16.0",
-    "mermaid": "^11.15.0",
+    "mermaid": "^11.16.1",
     "next": "16.3.0",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
@@ -44,5 +44,9 @@
     "postcss": "^8.5.25",
     "tailwindcss": "^4.3.3",
     "typescript": "^6.0.3"
+  },
+  "overrides": {
+    "dompurify": "3.4.13",
+    "js-yaml": "4.3.1"
   }
 }

--- a/docs-site/test/next-config.test.mjs
+++ b/docs-site/test/next-config.test.mjs
@@ -1,0 +1,8 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import config from '../next.config.mjs'
+
+test('disables immutable static assets for the path-mounted deployment', () => {
+  assert.equal(config.supportsImmutableAssets, false)
+})

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,359 @@
+# AGENTS.md
+
+This directory contains project documentation for requirements, technical specifications, and architectural decisions.
+
+The goal is to preserve important context so that contributors and agents can understand not only what the system does, but also what it is intended to do and why key decisions were made.
+
+## Documentation Types
+
+Use three primary document types:
+
+```text
+docs/
+├── AGENTS.md
+├── prd/
+├── specs/
+└── adr/
+```
+
+Their responsibilities are different:
+
+| Type | Purpose                                             |
+| ---- | --------------------------------------------------- |
+| PRD  | Describe what should be built and why               |
+| Spec | Describe how a feature or system should behave      |
+| ADR  | Record why an important technical decision was made |
+
+Keep these concerns separate where practical.
+
+---
+
+## PRD
+
+Location:
+
+```text
+docs/prd/
+```
+
+PRD stands for **Product Requirements Document**.
+
+Use a PRD to describe:
+
+* the problem
+* the goal
+* user or business requirements
+* scope
+* non-goals
+* constraints
+* acceptance criteria
+
+A PRD should focus on desired outcomes rather than implementation details.
+
+### Suggested Structure
+
+```markdown
+# <Title>
+
+## Status
+
+Draft | Accepted | Implemented | Deprecated
+
+## Context
+
+Describe the problem and relevant background.
+
+## Goals
+
+- ...
+
+## Requirements
+
+- ...
+
+## Non-goals
+
+- ...
+
+## Constraints
+
+- ...
+
+## Acceptance Criteria
+
+- ...
+```
+
+Do not put detailed algorithms, internal APIs, class structures, or implementation-specific decisions in a PRD unless they are themselves explicit requirements.
+
+---
+
+## Spec
+
+Location:
+
+```text
+docs/specs/
+```
+
+A Spec describes the intended technical behavior of a feature, subsystem, protocol, or other implementation area.
+
+Use a Spec when understanding the implementation requires more context than can reasonably be expressed through code alone.
+
+A Spec may describe:
+
+* architecture
+* components and responsibilities
+* data flow
+* control flow
+* state transitions
+* data models
+* interfaces
+* protocols
+* algorithms
+* invariants
+* edge cases
+* failure behavior
+* compatibility requirements
+* performance constraints
+
+### Suggested Structure
+
+```markdown
+# <Title>
+
+## Status
+
+Draft | Accepted | Implemented | Deprecated
+
+## Overview
+
+Describe what this feature or subsystem does.
+
+## Goals
+
+- ...
+
+## Non-goals
+
+- ...
+
+## Design
+
+Describe the intended design and behavior.
+
+## Data Model
+
+Describe important data structures if applicable.
+
+## Invariants
+
+Describe assumptions or properties that must remain true.
+
+## Edge Cases
+
+Describe important exceptional or ambiguous cases.
+
+## Failure Handling
+
+Describe expected failure behavior where relevant.
+
+## Related Decisions
+
+- ADR-XXX
+```
+
+A Spec should describe stable behavior and design concepts.
+
+Avoid merely translating source code into prose.
+
+---
+
+## ADR
+
+Location:
+
+```text
+docs/adr/
+```
+
+ADR stands for **Architecture Decision Record**.
+
+Use an ADR to record a significant technical decision when:
+
+* multiple reasonable alternatives exist
+* the decision has meaningful tradeoffs
+* the decision affects architecture or system behavior
+* the decision is difficult or expensive to reverse
+* the chosen approach may be non-obvious to future contributors
+
+Do not create ADRs for routine implementation details.
+
+### Naming
+
+Use sequential numbering:
+
+```text
+001-use-example-approach.md
+002-change-storage-model.md
+003-adopt-new-protocol.md
+```
+
+Do not renumber existing ADRs.
+
+### Suggested Structure
+
+```markdown
+# ADR-XXX: <Decision>
+
+## Status
+
+Proposed | Accepted | Superseded | Deprecated
+
+## Context
+
+Describe the problem and relevant constraints.
+
+## Options Considered
+
+### Option A
+
+Pros:
+
+- ...
+
+Cons:
+
+- ...
+
+### Option B
+
+Pros:
+
+- ...
+
+Cons:
+
+- ...
+
+## Decision
+
+Describe the selected approach.
+
+## Rationale
+
+Explain why it was selected.
+
+## Consequences
+
+Describe important benefits, costs, limitations, and follow-up implications.
+
+## References
+
+Link related Specs, PRDs, issues, pull requests, experiments, or other evidence.
+```
+
+When an ADR is replaced, keep the original document and mark it as superseded rather than deleting it.
+
+---
+
+## Choosing the Right Document
+
+Use this rule:
+
+```text
+What are we building, and why?
+→ PRD
+
+How should it work?
+→ Spec
+
+Why did we choose this approach?
+→ ADR
+```
+
+A change may require more than one document.
+
+For example:
+
+```text
+PRD
+A new capability is required.
+
+Spec
+Defines its technical behavior.
+
+ADR
+Records an important implementation choice made while designing it.
+```
+
+Do not create documents merely to satisfy process. Create them when they preserve useful context.
+
+---
+
+## Agent Instructions
+
+When working on this repository:
+
+1. Check relevant documentation before making substantial changes.
+2. Read the relevant PRD to understand intended requirements.
+3. Read relevant Specs to understand intended technical behavior.
+4. Read referenced ADRs before changing non-obvious architectural decisions.
+5. Preserve documented requirements and invariants unless the task explicitly changes them.
+6. Update documentation when implementation changes documented behavior.
+7. Create an ADR when introducing a significant architectural decision that should be preserved.
+8. Do not invent historical rationale without evidence.
+9. Mark assumptions or uncertain conclusions explicitly.
+10. Keep documentation concise and focused on information that is difficult to recover from code alone.
+
+---
+
+## Documentation and Code
+
+Documentation and implementation should evolve together.
+
+Update documentation when a change affects:
+
+* documented requirements
+* public or internal behavior described by a Spec
+* important interfaces or data models
+* architectural constraints
+* significant technical decisions
+
+Routine refactoring that does not change documented behavior usually does not require documentation updates.
+
+If code and documentation disagree, do not silently assume which one is correct.
+
+Determine whether:
+
+* the implementation is incorrect
+* the documentation is outdated
+* the intended design has changed
+
+Then update the appropriate source.
+
+---
+
+## Writing Guidelines
+
+Prefer documentation that explains intent, constraints, and reasoning.
+
+Avoid unnecessary implementation narration.
+
+Bad:
+
+```text
+Function A calls function B, then function B calls function C.
+```
+
+Better:
+
+```text
+The processing stages are separated so that each stage can evolve independently while preserving a stable interface between them.
+```
+
+Use concrete examples when they make behavior easier to understand.
+
+Keep documents focused. Split a document when unrelated concerns begin to accumulate.
+
+Do not duplicate the same information across PRDs, Specs, and ADRs. Link related documents instead.


### PR DESCRIPTION
## Summary

FIX: #1528
- Restore `/docs` resource loading by disabling the asset mode that the main-site forwarding path cannot serve. (757e5088c)
- Add an automated deployment-configuration check before documentation builds. (757e5088c)
- Include the documentation authoring guide in this consolidated change. (757e5088c)

## Test plan

- [x] `bun run test:config`
- [x] `bun run check:docs`
- [x] `bun run types:check`
- [x] `bun run build -- --webpack`
- [x] Local `/docs` page and all 21 referenced resources load successfully.
- [ ] Verify `https://www.uniclipboard.app/docs` after the deployment completes.

Note: the default local Turbopack build remains blocked by the pre-existing Fumadocs loader incompatibility; the equivalent webpack build passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
- Improved documentation-site compatibility with path-mounted deployments by disabling immutable static asset handling.

## Tests
- Added automated validation for documentation-site configuration.
- Included configuration checks in the documentation workflow.

## Documentation
- Added guidance for creating, organizing, maintaining, and synchronizing PRDs, specifications, and ADRs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->