### PR TITLE
fix(docs): serve site from root

### DIFF
--- a/docs-site/next.config.mjs
+++ b/docs-site/next.config.mjs
@@ -8,9 +8,8 @@ const withMDX = createMDX()
 
 // Old documentation URLs kept alive after the 2026 category restructure:
 // guides/* split into core-features/* and help/*, and the CLI page was
-// promoted to a top-level /cli group. `source` is matched after `basePath`
-// (/docs) is stripped, so paths are written without the /docs prefix. Each
-// move needs an en variant (default locale, no prefix) and a zh variant.
+// promoted to a top-level /cli group. Each move needs an en variant (default
+// locale, no prefix) and a zh variant.
 // Pages that did not move (guides/pairing, guides/settings,
 // guides/self-host-relay, reference/mobile-api, reference/mobile-connect-uri,
 // reference/search-internals, getting-started/*) are intentionally absent.
@@ -35,10 +34,6 @@ const docRedirects = docPageMoves.flatMap(([from, to]) => [
 /** @type {import('next').NextConfig} */
 const config = {
   reactStrictMode: true,
-  basePath: '/docs',
-  assetPrefix: '/docs',
-  // The main-site rewrite cannot serve Next.js 16.3 immutable assets.
-  supportsImmutableAssets: false,
   async redirects() {
     return docRedirects
   },

--- a/docs-site/src/app/api/chat/route.ts
+++ b/docs-site/src/app/api/chat/route.ts
@@ -10,7 +10,6 @@ import {
 } from 'ai'
 import { z } from 'zod'
 import { docsSearchServer } from '@/lib/docs-search'
-import { docsBasePath } from '@/lib/shared'
 
 type DocsLocale = 'en' | 'zh'
 type AIProvider = 'openai' | 'anthropic'
@@ -58,11 +57,6 @@ function createChatModel() {
   return openai.chat(requireEnv('OPENAI_MODEL'))
 }
 
-function withDocsBasePath(url: string) {
-  if (url === '/') return docsBasePath
-  return `${docsBasePath}${url}`
-}
-
 function getClientLocale(messages: ChatUIMessage[]): DocsLocale {
   for (const message of messages.toReversed()) {
     for (const part of message.parts ?? []) {
@@ -70,7 +64,7 @@ function getClientLocale(messages: ChatUIMessage[]): DocsLocale {
 
       try {
         const pathname = new URL(part.data.location).pathname
-        if (pathname === `${docsBasePath}/zh` || pathname.startsWith(`${docsBasePath}/zh/`)) {
+        if (pathname === '/zh' || pathname.startsWith('/zh/')) {
           return 'zh'
         }
       } catch {
@@ -97,7 +91,7 @@ function createSearchTool(defaultLocale: DocsLocale) {
       })
       return results.map(result => ({
         ...result,
-        url: withDocsBasePath(result.url),
+        url: result.url,
       }))
     },
   })

--- a/docs-site/src/app/sitemap.ts
+++ b/docs-site/src/app/sitemap.ts
@@ -1,6 +1,6 @@
 import type { MetadataRoute } from 'next'
 import { i18n } from '@/lib/i18n'
-import { docsBasePath, getSiteUrl } from '@/lib/shared'
+import { getSiteUrl } from '@/lib/shared'
 import { source } from '@/lib/source'
 
 export default function sitemap(): MetadataRoute.Sitemap {
@@ -13,7 +13,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     for (const page of pages) {
       const key = page.slugs.join('/')
       const bucket = slugToLangUrls.get(key) ?? {}
-      bucket[language] = `${origin}${docsBasePath}${page.url}`
+      bucket[language] = `${origin}${page.url}`
       slugToLangUrls.set(key, bucket)
     }
   }
@@ -22,7 +22,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     const key = page.slugs.join('/')
     const langs = slugToLangUrls.get(key) ?? {}
     return {
-      url: langs[i18n.defaultLanguage] ?? `${origin}${docsBasePath}${page.url}`,
+      url: langs[i18n.defaultLanguage] ?? `${origin}${page.url}`,
       lastModified: new Date(),
       alternates: {
         languages: langs,

--- a/docs-site/src/components/ai/search.tsx
+++ b/docs-site/src/components/ai/search.tsx
@@ -21,7 +21,6 @@ import {
 import type { ChatUIMessage, SearchTool } from '@/app/api/chat/route'
 import { Markdown } from '@/components/markdown'
 import { cn } from '@/lib/cn'
-import { docsBasePath } from '@/lib/shared'
 
 type AILocale = 'en' | 'zh'
 
@@ -364,7 +363,7 @@ export function AISearch({ children, locale = 'en' }: { children: ReactNode; loc
   const chat = useChat<ChatUIMessage>({
     id: 'search',
     transport: new DefaultChatTransport({
-      api: `${docsBasePath}/api/chat`,
+      api: '/api/chat',
     }),
   })
 

--- a/docs-site/src/components/docs-providers.tsx
+++ b/docs-site/src/components/docs-providers.tsx
@@ -2,11 +2,8 @@
 
 import { RootProvider } from 'fumadocs-ui/provider/next'
 import type { ReactNode } from 'react'
-import { docsBasePath } from '@/lib/shared'
 
-// fetch() in the search client doesn't honor Next.js `basePath`, so we must
-// pin the API URL to the prefixed route registered by `app/api/search/route.ts`.
-const SEARCH_API = `${docsBasePath}/api/search`
+const SEARCH_API = '/api/search'
 
 type I18nProp = Parameters<typeof RootProvider>[0]['i18n']
 

--- a/docs-site/src/components/page-view-options.tsx
+++ b/docs-site/src/components/page-view-options.tsx
@@ -6,7 +6,6 @@ import { ChevronDown, ExternalLinkIcon, TextIcon } from 'lucide-react'
 import { usePathname } from 'next/navigation'
 import { useMemo, type ReactNode } from 'react'
 import { twMerge as cn } from 'tailwind-merge'
-import { docsBasePath } from '@/lib/shared'
 
 type Props = {
   markdownUrl?: string
@@ -15,19 +14,15 @@ type Props = {
   children?: ReactNode
 }
 
-// Mirrors fumadocs' ViewOptionsPopover but builds the AI prompt URL
-// from `docsBasePath + pathname` so the prompt sent to ChatGPT / Claude /
-// Cursor / Scira resolves under the `/docs` basePath. fumadocs uses
-// `usePathname()` directly, which strips basePath in Next.js.
+// Mirrors fumadocs' ViewOptionsPopover while keeping AI prompt links absolute.
 export function PageViewOptions({ markdownUrl, githubUrl, className, children }: Props) {
   const pathname = usePathname()
 
   const items = useMemo(() => {
-    const fullPath = `${docsBasePath}${pathname}`
     const target =
       typeof window === 'undefined'
-        ? fullPath
-        : new URL(fullPath, window.location.origin).toString()
+        ? pathname
+        : new URL(pathname, window.location.origin).toString()
     const q = `Read ${target}, I want to ask questions about it.`
 
     return [

--- a/docs-site/src/lib/shared.ts
+++ b/docs-site/src/lib/shared.ts
@@ -2,7 +2,6 @@ export const appName = 'UniClipboard'
 export const docsRoute = '/'
 export const docsImageRoute = '/og'
 export const docsContentRoute = '/llms.mdx'
-export const docsBasePath = '/docs'
 
 export const gitConfig = {
   user: 'UniClipboard',

--- a/docs-site/src/lib/source.ts
+++ b/docs-site/src/lib/source.ts
@@ -2,7 +2,7 @@ import { docs } from 'collections/server'
 import { loader } from 'fumadocs-core/source'
 import { lucideIconsPlugin } from 'fumadocs-core/source/lucide-icons'
 import { i18n } from './i18n'
-import { docsBasePath, docsContentRoute, docsImageRoute, docsRoute } from './shared'
+import { docsContentRoute, docsImageRoute, docsRoute } from './shared'
 
 // See https://fumadocs.dev/docs/headless/source-api for more info
 export const source = loader({
@@ -18,7 +18,7 @@ export function getPageImage(page: (typeof source)['$inferPage']) {
 
   return {
     segments,
-    url: `${docsBasePath}${docsImageRoute}/${locale}/${segments.join('/')}`,
+    url: `${docsImageRoute}/${locale}/${segments.join('/')}`,
   }
 }
 
@@ -28,7 +28,7 @@ export function getPageMarkdownUrl(page: (typeof source)['$inferPage']) {
 
   return {
     segments,
-    url: `${docsBasePath}${docsContentRoute}/${locale}/${segments.join('/')}`,
+    url: `${docsContentRoute}/${locale}/${segments.join('/')}`,
   }
 }
 

--- a/docs-site/test/next-config.test.mjs
+++ b/docs-site/test/next-config.test.mjs
@@ -3,6 +3,8 @@ import test from 'node:test'
 
 import config from '../next.config.mjs'
 
-test('disables immutable static assets for the path-mounted deployment', () => {
-  assert.equal(config.supportsImmutableAssets, false)
+test('serves the independent documentation site from the domain root', () => {
+  assert.equal(config.basePath, undefined)
+  assert.equal(config.assetPrefix, undefined)
+  assert.equal(config.supportsImmutableAssets, undefined)
 })


### PR DESCRIPTION
## Summary

- Serve the documentation site directly from its domain root instead of the legacy `/docs` path.
- Update internal search, generated links, AI references, and the sitemap to use root-based addresses.
- Remove the path-mounted asset workaround and cover the root deployment configuration with a regression test.

## Test plan

- [x] `bun run test:config`
- [x] `bun run types:check`
- [x] `bun run check:docs`
- [x] `bun run build -- --webpack`
- [x] Verified the local root page, Chinese page, documentation page, search, sitemap, Markdown download, image, and 21 referenced page resources.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Documentation pages and related links now use root-based URLs without the `/docs` prefix.
  - Search, AI chat, page actions, images, and content links now resolve consistently from the site root.
  - Sitemap entries and language-specific links have been updated for the new URL structure.

- **Bug Fixes**
  - Fixed URL handling for localized pages and browser-based links.
  - Updated documentation deployment behavior to serve content directly from the site’s root domain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->