### PR TITLE
feat(daemon): daemon.conn connection file + ephemeral loopback port (ADR-011)

### DIFF
--- a/apps/cli/src/local_daemon.rs
+++ b/apps/cli/src/local_daemon.rs
@@ -9,7 +9,6 @@ use uc_daemon_contract::probe::{
     classify_health_response, running_daemon_is_strictly_newer, ProbeOutcome,
 };
 use uc_daemon_process::process_metadata::DaemonSpawnOrigin;
-use uc_daemon_process::socket::try_resolve_daemon_http_addr;
 use uc_daemon_process::spawn::{spawn_detached_daemon, SpawnDaemonError};
 
 const HEALTH_PATH: &str = "/health";
@@ -194,8 +193,7 @@ pub async fn probe_running() -> Result<ProbeOutcome, LocalDaemonError> {
         .timeout(PROBE_TIMEOUT)
         .build()
         .map_err(|error| LocalDaemonError::ProbeClient(error.into()))?;
-    let base_url = resolve_base_url()?;
-    probe_daemon_health(&client, &base_url).await
+    probe_daemon_health(&client).await
 }
 
 /// Probe-then-reuse-or-spawn entry used by the `#[autostop]` business-command
@@ -211,15 +209,14 @@ pub async fn ensure_local_daemon_running() -> Result<LocalDaemonSession, LocalDa
         .timeout(PROBE_TIMEOUT)
         .build()
         .map_err(|error| LocalDaemonError::ProbeClient(error.into()))?;
-    let base_url = resolve_base_url()?;
 
     // Classify the daemon (if any) already bound to this profile (ADR-008 P5-L
     // L2). Compatible → reuse it; Incompatible → clear error (do NOT spawn a
     // competitor or kill it — restart/takeover is L8); Absent → spawn below.
-    match probe_daemon_health(&client, &base_url).await? {
+    match probe_daemon_health(&client).await? {
         ProbeOutcome::Compatible(_) => {
             return Ok(LocalDaemonSession {
-                base_url,
+                base_url: resolve_base_url()?,
                 spawned: false,
             });
         }
@@ -233,7 +230,7 @@ pub async fn ensure_local_daemon_running() -> Result<LocalDaemonSession, LocalDa
         ProbeOutcome::Absent => {}
     }
 
-    spawn_and_wait_healthy(&client, &base_url).await
+    spawn_and_wait_healthy(&client).await
 }
 
 /// The action [`ensure_or_promote_local_daemon`] takes for a probed daemon
@@ -283,16 +280,15 @@ pub async fn ensure_or_promote_local_daemon(
         .timeout(PROBE_TIMEOUT)
         .build()
         .map_err(|error| LocalDaemonError::ProbeClient(error.into()))?;
-    let base_url = resolve_base_url()?;
 
-    let outcome = probe_daemon_health(&client, &base_url).await?;
+    let outcome = probe_daemon_health(&client).await?;
     match classify_probe_action(&outcome) {
-        ProbeAction::Promote => promote_oneshot_daemon(&client, &base_url, target).await,
+        ProbeAction::Promote => promote_oneshot_daemon(&client, target).await,
         ProbeAction::Reuse => Ok(LocalDaemonSession {
-            base_url,
+            base_url: resolve_base_url()?,
             spawned: false,
         }),
-        ProbeAction::Spawn => spawn_and_wait_healthy(&client, &base_url).await,
+        ProbeAction::Spawn => spawn_and_wait_healthy(&client).await,
         ProbeAction::Incompatible => match outcome {
             ProbeOutcome::Incompatible {
                 details,
@@ -317,12 +313,11 @@ pub async fn spawn_oneshot_and_wait() -> Result<LocalDaemonSession, LocalDaemonE
         .timeout(PROBE_TIMEOUT)
         .build()
         .map_err(|error| LocalDaemonError::ProbeClient(error.into()))?;
-    let base_url = resolve_base_url()?;
     std::env::set_var(
         uc_daemon_process::spawn_contract::RUN_MODE_ENV,
         uc_daemon_process::spawn_contract::RUN_MODE_ONESHOT,
     );
-    spawn_and_wait_healthy(&client, &base_url).await
+    spawn_and_wait_healthy(&client).await
 }
 
 /// Promote a transient `Oneshot` daemon to a persistent `target` residency via a
@@ -342,7 +337,6 @@ pub async fn spawn_oneshot_and_wait() -> Result<LocalDaemonSession, LocalDaemonE
 /// is never reached (residency is always `Standalone`/`ServerHeadless`).
 async fn promote_oneshot_daemon(
     client: &Client,
-    base_url: &str,
     target: DaemonResidency,
 ) -> Result<LocalDaemonSession, LocalDaemonError> {
     // Spinner spans the whole promotion — including the restart round-trip — so
@@ -371,10 +365,12 @@ async fn promote_oneshot_daemon(
         "controlled restart accepted; promoting daemon"
     );
 
-    // (2) Wait for the old daemon to exit (endpoint goes absent).
-    let mut probe = || probe_daemon_health(client, base_url);
+    // (2) Wait for the old daemon to exit (endpoint goes absent). The probe
+    // re-resolves `daemon.conn` on every call (ADR-011), so the drain-wait
+    // survives the old daemon deleting its connection file on exit.
+    let mut probe = || probe_daemon_health(client);
     if let Err(error) =
-        wait_for_endpoint_absent(&mut probe, PROMOTE_DRAIN_TIMEOUT, POLL_INTERVAL, base_url).await
+        wait_for_endpoint_absent(&mut probe, PROMOTE_DRAIN_TIMEOUT, POLL_INTERVAL).await
     {
         crate::ui::spinner_finish_error(&spinner, "Daemon did not drain for promotion");
         return Err(error);
@@ -391,20 +387,14 @@ async fn promote_oneshot_daemon(
 
     // (4) Wait until the replacement is healthy AND reports the requested target
     // residency (not merely "any Compatible") before claiming success.
-    let mut probe = || probe_daemon_health(client, base_url);
-    match wait_for_daemon_health(
-        &mut probe,
-        STARTUP_TIMEOUT,
-        POLL_INTERVAL,
-        base_url,
-        Some(target),
-    )
-    .await
-    {
+    let mut probe = || probe_daemon_health(client);
+    match wait_for_daemon_health(&mut probe, STARTUP_TIMEOUT, POLL_INTERVAL, Some(target)).await {
         Ok(()) => {
             crate::ui::spinner_finish_success(&spinner, "Daemon promoted");
             Ok(LocalDaemonSession {
-                base_url: base_url.into(),
+                // The replacement binds a fresh ephemeral port — resolve its
+                // connection file rather than reusing the pre-restart URL.
+                base_url: resolve_base_url()?,
                 spawned: true,
             })
         }
@@ -419,10 +409,7 @@ async fn promote_oneshot_daemon(
 /// [`ensure_or_promote_local_daemon`]: spawn a detached daemon and wait for it to
 /// become healthy. Returns `spawned:true`. Show a spinner so the user sees
 /// progress — daemon cold start can take many seconds in debug builds.
-async fn spawn_and_wait_healthy(
-    client: &Client,
-    base_url: &str,
-) -> Result<LocalDaemonSession, LocalDaemonError> {
+async fn spawn_and_wait_healthy(client: &Client) -> Result<LocalDaemonSession, LocalDaemonError> {
     let spinner = crate::ui::spinner("Starting local daemon…");
 
     if let Err(error) =
@@ -435,12 +422,14 @@ async fn spawn_and_wait_healthy(
     // leader / process group — the CLI is no longer holding a wait-able
     // handle. The probe loop below is the only proof of life.
 
-    let mut probe = || probe_daemon_health(client, base_url);
-    match wait_for_daemon_health(&mut probe, STARTUP_TIMEOUT, POLL_INTERVAL, base_url, None).await {
+    let mut probe = || probe_daemon_health(client);
+    match wait_for_daemon_health(&mut probe, STARTUP_TIMEOUT, POLL_INTERVAL, None).await {
         Ok(()) => {
             crate::ui::spinner_finish_success(&spinner, "Local daemon ready");
             Ok(LocalDaemonSession {
-                base_url: base_url.into(),
+                // Resolve fresh — the spawned daemon may have bound a port
+                // different from any pre-existing connection file (ADR-011).
+                base_url: resolve_base_url()?,
                 spawned: true,
             })
         }
@@ -454,6 +443,9 @@ async fn spawn_and_wait_healthy(
 /// Poll `/health` until the daemon reports Compatible, or time out, or observe
 /// an Incompatible daemon.
 ///
+/// The probe closure re-resolves the daemon address on every call (ADR-011),
+/// so the loop tracks a daemon restart that changes the ephemeral port.
+///
 /// `expected_residency` is `None` for the plain spawn path (any `Compatible`
 /// daemon is "ready" — byte-identical to the pre-L8d-2 behaviour) and
 /// `Some(target)` for the controlled-restart promotion path, where a `Compatible`
@@ -464,7 +456,6 @@ async fn wait_for_daemon_health<Probe, ProbeFuture>(
     probe: &mut Probe,
     startup_timeout: Duration,
     poll_interval: Duration,
-    base_url: &str,
     expected_residency: Option<DaemonResidency>,
 ) -> Result<(), LocalDaemonError>
 where
@@ -500,7 +491,7 @@ where
             return Err(LocalDaemonError::StartupTimeout {
                 timeout_ms: startup_timeout.as_millis() as u64,
                 profile: std::env::var("UC_PROFILE").ok(),
-                base_url: base_url.to_string(),
+                base_url: resolve_base_url().unwrap_or_default(),
             });
         }
 
@@ -523,7 +514,6 @@ async fn wait_for_endpoint_absent<Probe, ProbeFuture>(
     probe: &mut Probe,
     timeout: Duration,
     poll_interval: Duration,
-    base_url: &str,
 ) -> Result<(), LocalDaemonError>
 where
     Probe: FnMut() -> ProbeFuture,
@@ -540,7 +530,7 @@ where
             return Err(LocalDaemonError::PromoteDrainTimeout {
                 timeout_ms: timeout.as_millis() as u64,
                 profile: std::env::var("UC_PROFILE").ok(),
-                base_url: base_url.to_string(),
+                base_url: resolve_base_url().unwrap_or_default(),
             });
         }
 
@@ -590,13 +580,26 @@ pub(crate) fn incompatible_outcome_error(outcome: ProbeOutcome) -> LocalDaemonEr
 
 /// Probe `/health` and classify the running daemon (ADR-008 P5-L L2).
 ///
+/// Resolves the daemon address fresh on every call (ADR-011): `daemon.conn`
+/// first, with the legacy profile-hash address as a P1 fallback for old
+/// daemons. No connection file in the single-track regime → `Absent`.
+///
 /// Connect/timeout errors map to [`ProbeOutcome::Absent`] (no daemon to talk
 /// to); a non-2xx response or an undecodable / version-mismatched body maps to
 /// [`ProbeOutcome::Incompatible`]; a healthy, version-matched daemon maps to
 /// [`ProbeOutcome::Compatible`]. The version/contract decision is delegated to
 /// the shared `uc-daemon-contract::probe::classify_health_response` so the CLI
 /// and GUI host classify byte-identically.
-async fn probe_daemon_health(
+async fn probe_daemon_health(client: &Client) -> Result<ProbeOutcome, LocalDaemonError> {
+    let Some(base_url) = resolve_probe_base_url()? else {
+        return Ok(ProbeOutcome::Absent);
+    };
+    probe_daemon_health_at(client, &base_url).await
+}
+
+/// Probe `/health` at an explicit base URL (HTTP part of
+/// [`probe_daemon_health`]).
+async fn probe_daemon_health_at(
     client: &Client,
     base_url: &str,
 ) -> Result<ProbeOutcome, LocalDaemonError> {
@@ -646,13 +649,30 @@ async fn probe_daemon_health(
     Ok(classify_health_response(health, EXPECTED_PACKAGE_VERSION))
 }
 
+/// Resolve the base URL a probe should target (ADR-011).
+///
+/// `daemon.conn` is the single source of truth. Returns `Ok(None)` when no
+/// connection file exists — callers classify that as `ProbeOutcome::Absent`.
+fn resolve_probe_base_url() -> Result<Option<String>, LocalDaemonError> {
+    let Some(conn) = uc_daemon_process::socket::read_daemon_conn_file().map_err(|error| {
+        LocalDaemonError::ResolveAddress(error.context("failed to read daemon connection file"))
+    })?
+    else {
+        return Ok(None);
+    };
+    Ok(Some(format!("http://{}:{}", conn.host, conn.port)))
+}
+
+/// Resolve the base URL of the running daemon for session handoff (ADR-011).
+///
+/// Same resolution as [`resolve_probe_base_url`], but an error when no daemon
+/// is discoverable — used when a session must carry a concrete URL.
 fn resolve_base_url() -> Result<String, LocalDaemonError> {
-    let addr = try_resolve_daemon_http_addr().map_err(|error| {
-        LocalDaemonError::ResolveAddress(
-            error.context("failed to resolve profile-aware daemon HTTP address"),
-        )
-    })?;
-    Ok(format!("http://{}:{}", addr.ip(), addr.port()))
+    resolve_probe_base_url()?.ok_or_else(|| {
+        LocalDaemonError::ResolveAddress(anyhow::anyhow!(
+            "daemon connection file not found (is the daemon running?)"
+        ))
+    })
 }
 
 /// Detached daemon spawn + binary resolution now live in the shared
@@ -758,7 +778,6 @@ mod tests {
             &mut probe,
             Duration::from_secs(5),
             Duration::from_millis(1),
-            "http://test",
             None,
         )
         .await
@@ -793,7 +812,6 @@ mod tests {
             &mut probe,
             Duration::from_secs(5),
             Duration::from_millis(1),
-            "http://test",
             None,
         )
         .await
@@ -824,7 +842,6 @@ mod tests {
             &mut probe,
             Duration::from_secs(5),
             Duration::from_millis(1),
-            "http://test",
             None,
         )
         .await
@@ -852,7 +869,6 @@ mod tests {
             &mut probe,
             Duration::from_millis(500),
             Duration::from_millis(50),
-            "http://example:1234",
             None,
         )
         .await
@@ -868,7 +884,13 @@ mod tests {
             } => {
                 assert_eq!(timeout_ms, 500);
                 assert_eq!(profile.as_deref(), Some("ci-profile"));
-                assert_eq!(base_url, "http://example:1234");
+                // ADR-011: the diagnostic URL is the live-resolved base URL —
+                // empty when no daemon is discoverable (no conn file), or the
+                // loopback URL of the daemon.conn when one is running.
+                assert!(
+                    base_url.is_empty() || base_url.starts_with("http://127.0.0.1:"),
+                    "unexpected base URL: {base_url}"
+                );
             }
             other => panic!("expected StartupTimeout, got {other:?}"),
         }
@@ -890,7 +912,6 @@ mod tests {
             &mut probe,
             Duration::from_secs(5),
             Duration::from_millis(1),
-            "http://test",
             None,
         )
         .await
@@ -926,7 +947,6 @@ mod tests {
             &mut probe,
             Duration::from_secs(5),
             Duration::from_millis(1),
-            "http://test",
             Some(DaemonResidency::ServerHeadless),
         )
         .await
@@ -959,7 +979,6 @@ mod tests {
             &mut probe,
             Duration::from_secs(5),
             Duration::from_millis(1),
-            "http://test",
             Some(DaemonResidency::Standalone),
         )
         .await
@@ -984,7 +1003,6 @@ mod tests {
             &mut probe,
             Duration::from_millis(100),
             Duration::from_millis(10),
-            "http://test",
             Some(DaemonResidency::Standalone),
         )
         .await
@@ -1013,14 +1031,9 @@ mod tests {
             }
         };
 
-        wait_for_endpoint_absent(
-            &mut probe,
-            Duration::from_secs(5),
-            Duration::from_millis(1),
-            "http://test",
-        )
-        .await
-        .expect("Absent must resolve the waiter");
+        wait_for_endpoint_absent(&mut probe, Duration::from_secs(5), Duration::from_millis(1))
+            .await
+            .expect("Absent must resolve the waiter");
         assert!(calls.load(Ordering::SeqCst) >= 3);
     }
 
@@ -1033,7 +1046,6 @@ mod tests {
             &mut probe,
             Duration::from_millis(100),
             Duration::from_millis(10),
-            "http://test",
         )
         .await
         .expect_err("an endpoint that never goes absent must time out");

--- a/apps/daemon/src/daemon/host.rs
+++ b/apps/daemon/src/daemon/host.rs
@@ -15,7 +15,7 @@ use uc_daemon_local::crash_marker::{DaemonExitReport, DaemonRunMarker};
 use uc_daemon_local::process_metadata::{DaemonPidManager, DaemonProcessMode};
 use uc_engine::{ActiveClipboardChanged, Engine, HostFileHandle, Operation, OperationResult};
 use uc_observability::analytics::AnalyticsPort;
-use uc_webserver::api::auth::load_or_create_auth_token;
+use uc_webserver::api::auth::load_or_create_auth_token_from_conn;
 use uc_webserver::api::server::{run_http_server, DaemonApiState, DaemonFileHandles};
 use uc_webserver::api::types::{DaemonResidency, DaemonWsEvent};
 use uc_webserver::security::{cleanup_rate_limiter_task, SecurityState};
@@ -133,7 +133,10 @@ async fn run_daemon_surfaces(
     process_paths: DesktopHostProcessPaths,
     analytics_sink: Arc<dyn AnalyticsPort>,
 ) -> anyhow::Result<()> {
-    let auth_token = load_or_create_auth_token(process_paths.daemon_token())?;
+    // ADR-011: the bearer token lives inside `daemon.conn` (load-or-create);
+    // the HTTP server publishes the full connection file once it has bound.
+    let conn_path = uc_daemon_local::socket::resolve_daemon_conn_path()?;
+    let auth_token = load_or_create_auth_token_from_conn(&conn_path)?;
     let pid_manager = DaemonPidManager::new(process_paths.daemon_pid());
     let _pid_file_guard = DaemonPidFileGuard::activate(pid_manager, run_mode.process_mode())?;
     let pid = std::process::id();
@@ -220,6 +223,12 @@ async fn run_daemon_surfaces(
     if !http_completed {
         let _ =
             tokio::time::timeout(uc_daemon_local::timing::SHUTDOWN_JOIN_TIMEOUT, http_handle).await;
+    }
+    // ADR-011: a graceful exit must not leave a stale connection file behind —
+    // clients probe it and would otherwise see a dead PID until their identity
+    // check kicks in. Crash leftovers are still handled by that PID check.
+    if let Err(error) = uc_daemon_local::socket::remove_daemon_conn_file() {
+        warn!(error = %error, "failed to remove daemon connection file on shutdown");
     }
     let _ = tokio::time::timeout(
         uc_daemon_local::timing::SHUTDOWN_JOIN_TIMEOUT,

--- a/crates/AGENTS.md
+++ b/crates/AGENTS.md
@@ -68,7 +68,7 @@
 - Use `tracing` structured logs; avoid `println!/eprintln!/log` macros in production.
 - 做产品/架构方向判断前先读根目录 `VISION.md`。
 
-- Daemon HTTP port is deterministic from `UC_PROFILE` via FNV-1a hash (see `uc-daemon-process/src/socket.rs`); no port file exists.
+- Daemon binds an ephemeral loopback port and publishes host/port/token/pid in `<app_data_root>/daemon.conn` (`0o600`, atomic write; ADR-011). Clients discover the daemon through this file only; the legacy `UC_PROFILE`-hash fixed port is retired.
 - Daemon auth flow: Bearer file-token → `POST /auth/connect` `{"pid":N,"clientType":"cli"}` → Session JWT; use `Session <jwt>` header afterward.
 - `POST /clipboard/dispatch` sends to peers only; dispatched content does NOT appear in sender's `/clipboard/entries` (entries come from OS clipboard captures).
 

--- a/crates/p2p-bench/src/bin/mobile_healthz_process_bench.rs
+++ b/crates/p2p-bench/src/bin/mobile_healthz_process_bench.rs
@@ -438,6 +438,22 @@ fn run_cli(binary: &Path, profile: &str, args: &[&str], stdin: Option<&str>) -> 
     Ok(output)
 }
 
+/// Wait for the isolated daemon's `daemon.conn` to appear and return its
+/// `/health` URL (ADR-011: the daemon publishes an ephemeral port there).
+async fn wait_for_daemon_health_url(timeout: Duration) -> Result<String> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if let Some(conn) = uc_daemon_process::socket::read_daemon_conn_file()? {
+            return Ok(format!("http://{}:{}/health", conn.host, conn.port));
+        }
+        ensure!(
+            Instant::now() < deadline,
+            "timed out waiting for daemon.conn to appear"
+        );
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
 async fn wait_for_status(
     daemon: &mut DaemonChild,
     client: &reqwest::Client,
@@ -743,8 +759,6 @@ async fn main() -> Result<()> {
 
     let daemon_binary = sibling_binary(cli.daemon_bin, "uniclipd")?;
     let cli_binary = sibling_binary(cli.cli_bin, "uniclip")?;
-    let main_addr = uc_daemon_process::socket::try_resolve_daemon_http_addr()
-        .context("resolve isolated daemon HTTP address")?;
 
     println!(
         "=== mobile LAN process-isolated health benchmark ===\n\
@@ -775,7 +789,9 @@ async fn main() -> Result<()> {
         .build()
         .context("build benchmark HTTP client")?;
     let mut daemon = DaemonChild::spawn(&daemon_binary, &profile, &log_file)?;
-    let daemon_health = format!("http://{main_addr}/health");
+    // ADR-011: the daemon binds an ephemeral port and publishes it in
+    // `daemon.conn`; wait for the connection file to appear and use its URL.
+    let daemon_health = wait_for_daemon_health_url(Duration::from_secs(30)).await?;
     wait_for_status(
         &mut daemon,
         &client,

--- a/crates/uc-bootstrap/src/wiring/desktop_host.rs
+++ b/crates/uc-bootstrap/src/wiring/desktop_host.rs
@@ -57,7 +57,6 @@ impl DesktopEngineHost {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DesktopHostProcessPaths {
     app_data_root: PathBuf,
-    daemon_token: PathBuf,
     daemon_pid: PathBuf,
 }
 
@@ -65,17 +64,12 @@ impl DesktopHostProcessPaths {
     fn from_app_paths(paths: &DesktopHostPaths) -> Self {
         Self {
             app_data_root: paths.app_data_root_dir.clone(),
-            daemon_token: paths.app_data_root_dir.join(".daemon-token"),
             daemon_pid: paths.app_data_root_dir.join(".daemon-pid"),
         }
     }
 
     pub fn app_data_root(&self) -> &Path {
         &self.app_data_root
-    }
-
-    pub fn daemon_token(&self) -> &Path {
-        &self.daemon_token
     }
 
     pub fn daemon_pid(&self) -> PathBuf {

--- a/crates/uc-daemon-client/Cargo.toml
+++ b/crates/uc-daemon-client/Cargo.toml
@@ -16,7 +16,8 @@ uc-daemon-contract = { path = "../uc-daemon-contract" }
 # uc-daemon-local. This severs the uc-application → uc-infra → iroh/diesel edge
 # from the daemon-client stack — the only symbols this crate used from
 # uc-daemon-local were socket::{resolve_daemon_http_addr, resolve_daemon_token_path},
-# both of which now live in uc-daemon-process.
+# both of which now live in uc-daemon-process (and the token file was
+# retired into the `daemon.conn` connection file, ADR-011).
 uc-daemon-process = { path = "../uc-daemon-process" }
 
 # HTTP + WebSocket

--- a/crates/uc-daemon-client/src/lib.rs
+++ b/crates/uc-daemon-client/src/lib.rs
@@ -16,7 +16,6 @@ pub mod ws_bridge;
 
 use anyhow::{Context, Result};
 use uc_daemon_contract::api::auth::DaemonConnectionInfo;
-use uc_daemon_process::socket::resolve_daemon_http_addr;
 
 pub use connection::DaemonConnectionState;
 pub use http::{
@@ -33,87 +32,98 @@ pub use ws_bridge::{BridgeState, DaemonWsBridge, DaemonWsBridgeConfig, DaemonWsB
 const ENV_BASE_URL: &str = "UNICLIPBOARD_DAEMON_BASE_URL";
 const ENV_TOKEN_PATH: &str = "UNICLIPBOARD_DAEMON_TOKEN_PATH";
 
-/// Resolve the daemon base URL for client connections.
-///
-/// Checks `UNICLIPBOARD_DAEMON_BASE_URL` env var first, then falls back to
-/// resolving the profile-aware loopback HTTP address from the daemon socket.
-fn resolve_base_url() -> Result<String> {
-    if let Ok(value) = std::env::var(ENV_BASE_URL) {
-        let trimmed = value.trim();
-        if !trimmed.is_empty() {
-            return Ok(trimmed.trim_end_matches('/').to_string());
-        }
-    }
-
-    // resolve_daemon_http_addr() returns SocketAddr directly (panics on error)
-    let addr = resolve_daemon_http_addr();
-    Ok(format!("http://{}:{}", addr.ip(), addr.port()))
-}
-
-/// Resolve the filesystem path to the daemon authentication token.
-///
-/// Checks the `UNICLIPBOARD_DAEMON_TOKEN_PATH` environment variable first (if set and non-empty);
-/// otherwise uses the platform/profile-aware daemon token location.
-///
-/// # Returns
-///
-/// The resolved `PathBuf` pointing to the daemon token on success.
-///
-/// # Examples
-///
-/// ```ignore
-/// let path = uc_daemon_client::resolve_token_path().unwrap();
-/// eprintln!("daemon token path: {}", path.display());
-/// ```
-fn resolve_token_path() -> Result<PathBuf> {
-    if let Ok(value) = std::env::var(ENV_TOKEN_PATH) {
-        let trimmed = value.trim();
-        if !trimmed.is_empty() {
-            return Ok(PathBuf::from(trimmed));
-        }
-    }
-
-    uc_daemon_process::socket::resolve_daemon_token_path()
-}
-
 /// Resolve the daemon connection info from environment for CLI clients.
 ///
 /// This is the CLI equivalent of what the GUI gets from the daemon lifecycle manager.
-/// Reads bearer token from daemon.token file and resolves the HTTP base URL.
+///
+/// Resolution order (ADR-011):
+/// 1. Explicit `UNICLIPBOARD_DAEMON_BASE_URL` / `UNICLIPBOARD_DAEMON_TOKEN_PATH`
+///    overrides (CI / tests / manual runs) — unchanged legacy contract.
+/// 2. The `daemon.conn` connection file — the single source of truth for the
+///    loopback address and bearer token of the running daemon. Missing file or
+///    an unsupported format means the daemon is not reachable / incompatible.
 pub fn resolve_connection_info_from_env() -> Result<DaemonConnectionInfo> {
-    let base_url = resolve_base_url()?;
-    let token_path = resolve_token_path()?;
+    let env_base_url = non_empty_env(ENV_BASE_URL);
+    let env_token_path = non_empty_env(ENV_TOKEN_PATH);
 
-    let token = std::fs::read_to_string(&token_path).with_context(|| {
-        if token_path.exists() {
-            format!(
-                "failed to read daemon auth token at {}",
-                token_path.display()
-            )
-        } else {
-            format!(
-                "daemon auth token not found at {} (is the daemon running?)",
-                token_path.display()
-            )
-        }
-    })?;
-    let token = token.trim().to_string();
-    if token.is_empty() {
-        anyhow::bail!("daemon auth token at {} is empty", token_path.display());
+    if env_base_url.is_some() || env_token_path.is_some() {
+        return resolve_connection_info_env_only(env_base_url, env_token_path);
     }
 
-    let cli_pid = std::process::id();
+    let conn = uc_daemon_process::socket::read_daemon_conn_file()?
+        .with_context(|| "daemon connection file not found (is the daemon running?)")?;
+    let base_url = format!("http://{}:{}", conn.host, conn.port);
+    let ws_url = format!(
+        "{}/ws",
+        base_url
+            .replacen("http://", "ws://", 1)
+            .replacen("https://", "wss://", 1)
+    );
+    Ok(DaemonConnectionInfo {
+        base_url,
+        ws_url,
+        token: conn.token,
+        pid: std::process::id(),
+    })
+}
+
+/// Resolve connection info from explicit env overrides only.
+///
+/// `UNICLIPBOARD_DAEMON_BASE_URL` pins the base URL; the bearer token comes
+/// from `UNICLIPBOARD_DAEMON_TOKEN_PATH` (a plain token file) when set, else
+/// from the `daemon.conn` connection file. Kept for the CI/test contract that
+/// points at mock daemons.
+fn resolve_connection_info_env_only(
+    env_base_url: Option<String>,
+    env_token_path: Option<String>,
+) -> Result<DaemonConnectionInfo> {
+    let base_url = env_base_url.ok_or_else(|| {
+        anyhow::anyhow!(
+            "{ENV_BASE_URL} must be set when using env-based daemon connection overrides"
+        )
+    })?;
+
+    let token = match env_token_path {
+        Some(path) => {
+            let path = PathBuf::from(path);
+            let token = std::fs::read_to_string(&path).with_context(|| {
+                if path.exists() {
+                    format!("failed to read daemon auth token at {}", path.display())
+                } else {
+                    format!(
+                        "daemon auth token not found at {} (is the daemon running?)",
+                        path.display()
+                    )
+                }
+            })?;
+            let token = token.trim().to_string();
+            if token.is_empty() {
+                anyhow::bail!("daemon auth token at {} is empty", path.display());
+            }
+            token
+        }
+        None => {
+            uc_daemon_process::socket::read_daemon_conn_file()?
+                .context("daemon connection file not found (is the daemon running?)")?
+                .token
+        }
+    };
+
     Ok(DaemonConnectionInfo {
         base_url: base_url.clone(),
-        ws_url: format!(
-            "{}/ws",
-            base_url
-                .replacen("http://", "ws://", 1)
-                .replacen("https://", "wss://", 1)
-        ),
+        ws_url: base_url
+            .replacen("http://", "ws://", 1)
+            .replacen("https://", "wss://", 1),
         token,
-        pid: cli_pid,
+        pid: std::process::id(),
     })
+}
+
+fn non_empty_env(name: &str) -> Option<String> {
+    match std::env::var(name) {
+        Ok(value) if !value.trim().is_empty() => Some(value.trim().to_string()),
+        _ => None,
+    }
 }
 
 /// Shared context for all daemon HTTP clients.
@@ -157,7 +167,8 @@ impl DaemonClientContext {
 
     /// Create a CLI context by resolving connection info from environment.
     ///
-    /// Reads the bearer token from `daemon.token` and resolves the HTTP base URL
+    /// Reads the bearer token from `daemon.conn` and resolves the HTTP base URL
+    /// (ADR-011); env overrides bypass the file for CI/mock scenarios.
     /// via the same profile-aware logic the daemon uses for its socket.
     ///
     /// Uses `"cli"` as the client type — each HTTP request exchanges a fresh

--- a/crates/uc-daemon-local/AGENTS.md
+++ b/crates/uc-daemon-local/AGENTS.md
@@ -39,7 +39,7 @@ detached spawn 原语从 `uc-cli` 下沉到此处由 CLI 与 GUI shell 共用。
 
 | 模块 | 职责 |
 |---|---|
-| `auth.rs` | daemon bearer token 文件持久化（`load_or_create_auth_token`） |
+| `auth.rs` | daemon bearer token 管理（`load_or_create_auth_token_from_conn`，token 随 `daemon.conn` 持久化，ADR-011） |
 | `contract.rs` | `ProbeOutcome` / `DaemonBootstrapError` / `terminate_local_daemon_pid` |
 | `health_wait.rs` | probe-only 的健康轮询（`wait_for_daemon_health`、`wait_for_endpoint_absent`） |
 
@@ -50,7 +50,7 @@ detached spawn 原语从 `uc-cli` 下沉到此处由 CLI 与 GUI shell 共用。
 | 模块（re-export 自 `uc-daemon-process`） | 职责 |
 |---|---|
 | `process_metadata` | PID 文件读写 + `DaemonProcessMode` |
-| `socket` | IPC/HTTP socket 路径解析（`try_resolve_daemon_http_addr`） |
+| `socket` | `daemon.conn` 连接文件路径解析与读写（ADR-011，替代固定端口 hash 解析与 `.daemon-token`） |
 | `spawn` | `uniclipd` detached spawn + 二进制解析（`spawn_detached_daemon`、`resolve_daemon_exe_path`） |
 | `spawn_contract` | CLI→daemon run-mode / unattended-unlock 环境契约 |
 | `handover` | 跨进程受控重启交接存储（`HandoverRecord{target_mode,generation}` 落锁目录，read/write/clear；ADR-008 P5-L L7） |

--- a/crates/uc-daemon-local/src/auth.rs
+++ b/crates/uc-daemon-local/src/auth.rs
@@ -1,10 +1,8 @@
 //! Daemon-local auth token persistence and helpers.
 
-use std::fs::{self, OpenOptions};
-use std::io::Write;
 use std::path::Path;
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use rand::RngCore;
 use subtle::ConstantTimeEq;
 use tracing::debug;
@@ -20,10 +18,10 @@ impl DaemonAuthToken {
     /// # Examples
     ///
     /// ```
-    /// use uc_daemon_local::auth::load_or_create_auth_token;
+    /// use uc_daemon_local::auth::load_or_create_auth_token_from_conn;
     ///
     /// let tmp = tempfile::tempdir().unwrap();
-    /// let token = load_or_create_auth_token(&tmp.path().join("daemon.token")).unwrap();
+    /// let token = load_or_create_auth_token_from_conn(&tmp.path().join("daemon.conn")).unwrap();
     /// assert_eq!(token.as_str().len(), 64);
     /// ```
     pub fn as_str(&self) -> &str {
@@ -45,52 +43,65 @@ impl DaemonAuthToken {
     }
 }
 
-/// Ensure a daemon authentication token exists at the provided path and return it.
+/// Ensure a daemon bearer token exists and return it (ADR-011).
 ///
-/// If a non-empty token file exists at `token_path`, the function repairs its permissions (on Unix)
-/// and returns the contained token. If the file is missing or contains no token, a new
-/// cryptographically-random token is generated, persisted to `token_path`, and returned. On Unix,
-/// persisted token files are created with permission mode `0o600`.
+/// The token now lives inside the `daemon.conn` connection file, which is the
+/// single source of truth for the daemon's connection info. If a non-empty
+/// token can be read from an existing connection file, it is returned
+/// (token persists across daemon restarts); otherwise a fresh
+/// cryptographically-random token is generated. The token is NOT persisted
+/// here — the HTTP server publishes it as part of the connection file once
+/// the loopback listener is bound.
 ///
 /// # Parameters
 ///
-/// - `token_path`: Filesystem path where the daemon token is read from or written to.
+/// - `conn_path`: Filesystem path of the `daemon.conn` connection file.
 ///
 /// # Returns
 ///
-/// `DaemonAuthToken` containing the token read from disk or the newly generated token.
+/// `DaemonAuthToken` containing the token read from disk or a newly generated token.
 ///
 /// # Examples
 ///
 /// ```
-/// use uc_daemon_local::auth::load_or_create_auth_token;
+/// use uc_daemon_local::auth::load_or_create_auth_token_from_conn;
 ///
 /// let tmp = tempfile::tempdir().unwrap();
-/// let path = tmp.path().join("daemon.token");
-/// let token = load_or_create_auth_token(&path).unwrap();
+/// let path = tmp.path().join("daemon.conn");
+/// let token = load_or_create_auth_token_from_conn(&path).unwrap();
 /// assert_eq!(token.as_str().len(), 64);
-/// // A second call reads the persisted token back.
-/// assert_eq!(load_or_create_auth_token(&path).unwrap(), token);
+/// // A second call on an existing connection file reads the persisted token.
+/// uc_daemon_process::socket::write_daemon_conn_file_at(
+///     &path,
+///     &uc_daemon_process::socket::DaemonConnFile::new("127.0.0.1", 43127, token.as_str(), 42),
+/// )
+/// .unwrap();
+/// assert_eq!(load_or_create_auth_token_from_conn(&path).unwrap(), token);
 /// ```
-pub fn load_or_create_auth_token(token_path: &Path) -> Result<DaemonAuthToken> {
-    debug!(token_path = %token_path.display(), token_path_exists = token_path.exists(), "load_or_create_auth_token: entering");
-    if token_path.exists() {
-        let existing = fs::read_to_string(token_path).with_context(|| {
-            format!(
-                "failed to read daemon auth token at {}",
-                token_path.display()
-            )
-        })?;
-        let token = existing.trim().to_string();
-        if !token.is_empty() {
-            repair_token_permissions(token_path)?;
-            return Ok(DaemonAuthToken(token));
+pub fn load_or_create_auth_token_from_conn(conn_path: &Path) -> Result<DaemonAuthToken> {
+    debug!(conn_path = %conn_path.display(), conn_path_exists = conn_path.exists(), "load_or_create_auth_token_from_conn: entering");
+    if conn_path.exists() {
+        // A corrupt / unsupported connection file is NOT fatal: the daemon
+        // will overwrite the file on this very start, so falling back to a
+        // fresh token self-heals (and every client re-reads the file anyway).
+        match uc_daemon_process::socket::read_daemon_conn_file_at(conn_path) {
+            Ok(Some(conn)) => {
+                let token = conn.token.trim().to_string();
+                if !token.is_empty() {
+                    return Ok(DaemonAuthToken(token));
+                }
+            }
+            Ok(None) => {}
+            Err(error) => {
+                tracing::warn!(
+                    error = %error,
+                    "existing daemon connection file is unreadable; generating a fresh token"
+                );
+            }
         }
     }
 
-    let token = generate_auth_token();
-    persist_auth_token(token_path, &token)?;
-    Ok(DaemonAuthToken(token))
+    Ok(DaemonAuthToken(generate_auth_token()))
 }
 
 /// Constructs connection metadata for the local daemon.
@@ -104,10 +115,12 @@ pub fn load_or_create_auth_token(token_path: &Path) -> Result<DaemonAuthToken> {
 /// # Examples
 ///
 /// ```
-/// use uc_daemon_local::auth::{build_connection_info, load_or_create_auth_token};
+/// use uc_daemon_local::auth::{
+///     build_connection_info, load_or_create_auth_token_from_conn,
+/// };
 ///
 /// let tmp = tempfile::tempdir().unwrap();
-/// let token = load_or_create_auth_token(&tmp.path().join("daemon.token")).unwrap();
+/// let token = load_or_create_auth_token_from_conn(&tmp.path().join("daemon.conn")).unwrap();
 /// let info = build_connection_info("127.0.0.1", 8080, &token, 12345);
 /// assert_eq!(info.base_url, "http://127.0.0.1:8080");
 /// assert_eq!(info.ws_url, "ws://127.0.0.1:8080/ws");
@@ -177,108 +190,6 @@ fn generate_auth_token() -> String {
     let mut bytes = [0_u8; 32];
     rand::rngs::OsRng.fill_bytes(&mut bytes);
     bytes.iter().map(|byte| format!("{byte:02x}")).collect()
-}
-
-/// Persists the daemon auth token to disk, creating parent directories if needed and restricting file permissions.
-///
-/// Writes `token` to `token_path`, truncating any existing file, flushes the file, and (on Unix) ensures the file mode is set to `0o600`. This function will create any missing parent directories before writing.
-///
-/// # Errors
-///
-/// Returns an error if creating directories, opening the file, writing, flushing, or repairing file permissions fails.
-///
-/// # Examples
-///
-/// Private helper — not importable from doctests; behavior is covered by the
-/// `persist_auth_token_*` unit tests below.
-///
-/// ```ignore
-/// let tmp = tempfile::tempdir().unwrap();
-/// let path = tmp.path().join("auth_token");
-/// persist_auth_token(&path, "0123abcd").unwrap();
-/// assert!(path.exists());
-/// ```
-fn persist_auth_token(token_path: &Path, token: &str) -> Result<()> {
-    if let Some(parent) = token_path.parent() {
-        fs::create_dir_all(parent).with_context(|| {
-            format!(
-                "failed to create daemon auth token directory {}",
-                parent.display()
-            )
-        })?;
-    }
-
-    #[cfg(unix)]
-    use std::os::unix::fs::OpenOptionsExt;
-
-    let mut options = OpenOptions::new();
-    options.create(true).truncate(true).write(true);
-
-    #[cfg(unix)]
-    options.mode(0o600);
-
-    let mut file = options.open(token_path).with_context(|| {
-        format!(
-            "failed to open daemon auth token file {}",
-            token_path.display()
-        )
-    })?;
-
-    file.write_all(token.as_bytes()).with_context(|| {
-        format!(
-            "failed to write daemon auth token file {}",
-            token_path.display()
-        )
-    })?;
-    file.flush().with_context(|| {
-        format!(
-            "failed to flush daemon auth token file {}",
-            token_path.display()
-        )
-    })?;
-
-    repair_token_permissions(token_path)?;
-    Ok(())
-}
-
-/// Ensure the token file has restrictive Unix permissions (mode `0o600`) when running on Unix; on non-Unix platforms this is a no-op.
-///
-/// Attempts to read the file metadata and, if the file's permission bits are not `0o600`, set them to `0o600`. Errors are returned with contextual messages if metadata cannot be read or permissions cannot be changed.
-///
-/// # Examples
-///
-/// Private helper — not importable from doctests; behavior is covered by the
-/// `repair_token_permissions_*` unit tests below.
-///
-/// ```ignore
-/// use std::path::Path;
-/// // After creating or writing the token file:
-/// repair_token_permissions(Path::new("/path/to/daemon_token")).unwrap();
-/// ```
-fn repair_token_permissions(token_path: &Path) -> Result<()> {
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-
-        let metadata = fs::metadata(token_path).with_context(|| {
-            format!(
-                "failed to read daemon auth token metadata {}",
-                token_path.display()
-            )
-        })?;
-        let current_mode = metadata.permissions().mode() & 0o777;
-        if current_mode != 0o600 {
-            let permissions = std::fs::Permissions::from_mode(0o600);
-            fs::set_permissions(token_path, permissions).with_context(|| {
-                format!(
-                    "failed to repair daemon auth token permissions {}",
-                    token_path.display()
-                )
-            })?;
-        }
-    }
-
-    Ok(())
 }
 
 #[cfg(test)]
@@ -383,145 +294,68 @@ mod tests {
         assert_eq!(info.pid, 12345);
     }
 
-    // ── persist_auth_token ───────────────────────────────────────────────
+    // ── load_or_create_auth_token_from_conn (ADR-011) ────────────────────
 
     #[test]
-    fn persist_auth_token_creates_missing_parent_dirs() {
+    fn load_or_create_from_conn_generates_fresh_token_when_missing() {
         let tmp = tempfile::tempdir().unwrap();
-        let path = tmp
-            .path()
-            .join("nested")
-            .join("deeper")
-            .join("daemon.token");
-        persist_auth_token(&path, "0123abcd").unwrap();
-        assert_eq!(fs::read_to_string(&path).unwrap(), "0123abcd");
-    }
+        let path = tmp.path().join("daemon.conn");
+        assert!(!path.exists());
 
-    #[cfg(unix)]
-    #[test]
-    fn persist_auth_token_writes_file_as_0600() {
-        let tmp = tempfile::tempdir().unwrap();
-        let path = tmp.path().join("daemon.token");
-        persist_auth_token(&path, "secret").unwrap();
-        assert_eq!(
-            mode_of(&path),
-            0o600,
-            "freshly persisted token must be 0600"
+        let token = load_or_create_auth_token_from_conn(&path).unwrap();
+        assert_eq!(token.as_str().len(), 64);
+        // The token is NOT persisted here — the HTTP server publishes it
+        // inside the connection file after binding.
+        assert!(
+            !path.exists(),
+            "token must not be persisted by load-or-create"
         );
     }
 
-    // ── repair_token_permissions ─────────────────────────────────────────
-
-    #[cfg(unix)]
     #[test]
-    fn repair_token_permissions_tightens_world_readable_file() {
-        use std::os::unix::fs::PermissionsExt;
+    fn load_or_create_from_conn_reads_existing_token() {
         let tmp = tempfile::tempdir().unwrap();
-        let path = tmp.path().join("loose.token");
-        fs::write(&path, "tok").unwrap();
-        fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
-        assert_eq!(mode_of(&path), 0o644);
+        let path = tmp.path().join("daemon.conn");
+        uc_daemon_process::socket::write_daemon_conn_file_at(
+            &path,
+            &uc_daemon_process::socket::DaemonConnFile::new(
+                "127.0.0.1",
+                43127,
+                "persisted-token",
+                7,
+            ),
+        )
+        .unwrap();
 
-        repair_token_permissions(&path).unwrap();
-        assert_eq!(mode_of(&path), 0o600, "0644 must be tightened to 0600");
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn repair_token_permissions_is_noop_when_already_0600() {
-        use std::os::unix::fs::PermissionsExt;
-        let tmp = tempfile::tempdir().unwrap();
-        let path = tmp.path().join("ok.token");
-        fs::write(&path, "tok").unwrap();
-        fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).unwrap();
-        repair_token_permissions(&path).unwrap();
-        assert_eq!(mode_of(&path), 0o600);
-    }
-
-    // ── load_or_create_auth_token ────────────────────────────────────────
-
-    #[test]
-    fn load_or_create_generates_and_persists_when_missing() {
-        let tmp = tempfile::tempdir().unwrap();
-        let path = tmp.path().join("daemon.token");
-        assert!(!path.exists());
-
-        let token = load_or_create_auth_token(&path).unwrap();
-        assert_eq!(token.as_str().len(), 64);
-        assert!(path.exists(), "token must be persisted on first creation");
-        assert_eq!(fs::read_to_string(&path).unwrap(), token.as_str());
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn load_or_create_persists_new_token_as_0600() {
-        let tmp = tempfile::tempdir().unwrap();
-        let path = tmp.path().join("daemon.token");
-        let _ = load_or_create_auth_token(&path).unwrap();
-        assert_eq!(mode_of(&path), 0o600);
+        let token = load_or_create_auth_token_from_conn(&path).unwrap();
+        assert_eq!(token.as_str(), "persisted-token");
     }
 
     #[test]
-    fn load_or_create_is_idempotent_returning_same_token() {
+    fn load_or_create_from_conn_is_idempotent_returning_same_token() {
         let tmp = tempfile::tempdir().unwrap();
-        let path = tmp.path().join("daemon.token");
-        let first = load_or_create_auth_token(&path).unwrap();
-        let second = load_or_create_auth_token(&path).unwrap();
+        let path = tmp.path().join("daemon.conn");
+        uc_daemon_process::socket::write_daemon_conn_file_at(
+            &path,
+            &uc_daemon_process::socket::DaemonConnFile::new("127.0.0.1", 43127, "tok", 7),
+        )
+        .unwrap();
+
+        let first = load_or_create_auth_token_from_conn(&path).unwrap();
+        let second = load_or_create_auth_token_from_conn(&path).unwrap();
         assert_eq!(first, second, "second call must read the persisted token");
     }
 
     #[test]
-    fn load_or_create_trims_surrounding_whitespace_in_existing_file() {
+    fn load_or_create_from_conn_regenerates_on_corrupt_file() {
+        // A corrupt / unknown-format connection file must not block daemon
+        // startup: the daemon overwrites the file on this very start, so a
+        // fresh token self-heals.
         let tmp = tempfile::tempdir().unwrap();
-        let path = tmp.path().join("daemon.token");
-        fs::write(&path, "  padded-token\n").unwrap();
-        let token = load_or_create_auth_token(&path).unwrap();
-        assert_eq!(token.as_str(), "padded-token");
-    }
+        let path = tmp.path().join("daemon.conn");
+        std::fs::write(&path, "not-json").unwrap();
 
-    #[test]
-    fn load_or_create_regenerates_when_existing_file_is_empty() {
-        let tmp = tempfile::tempdir().unwrap();
-        let path = tmp.path().join("daemon.token");
-        fs::write(&path, "").unwrap();
-        let token = load_or_create_auth_token(&path).unwrap();
-        assert_eq!(
-            token.as_str().len(),
-            64,
-            "an empty token file must be replaced with a fresh token"
-        );
-    }
-
-    #[test]
-    fn load_or_create_regenerates_when_existing_file_is_whitespace_only() {
-        let tmp = tempfile::tempdir().unwrap();
-        let path = tmp.path().join("daemon.token");
-        fs::write(&path, "   \n\t").unwrap();
-        let token = load_or_create_auth_token(&path).unwrap();
+        let token = load_or_create_auth_token_from_conn(&path).unwrap();
         assert_eq!(token.as_str().len(), 64);
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn load_or_create_repairs_permissions_on_existing_loose_file() {
-        use std::os::unix::fs::PermissionsExt;
-        let tmp = tempfile::tempdir().unwrap();
-        let path = tmp.path().join("daemon.token");
-        fs::write(&path, "existing-token").unwrap();
-        fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
-
-        let token = load_or_create_auth_token(&path).unwrap();
-        assert_eq!(token.as_str(), "existing-token");
-        assert_eq!(
-            mode_of(&path),
-            0o600,
-            "loading an existing token must tighten its perms"
-        );
-    }
-
-    #[cfg(unix)]
-    fn mode_of(path: &Path) -> u32 {
-        use std::os::unix::fs::PermissionsExt;
-        fs::metadata(path).unwrap().permissions().mode() & 0o777
     }
 }

--- a/crates/uc-daemon-local/src/instance_lock.rs
+++ b/crates/uc-daemon-local/src/instance_lock.rs
@@ -77,7 +77,7 @@ impl DaemonInstanceLock {
     /// Try to acquire the per-profile instance lock.
     ///
     /// `data_dir` is the profile's `app_data_root_dir` (same directory that
-    /// holds `.daemon-pid` and `.daemon-token`).
+    /// holds `.daemon-pid` and `daemon.conn`).
     ///
     /// Returns `Err(AlreadyRunning)` immediately (non-blocking) if another
     /// process already holds the lock.

--- a/crates/uc-daemon-process/AGENTS.md
+++ b/crates/uc-daemon-process/AGENTS.md
@@ -27,7 +27,7 @@ ADR-008 P5-0 从 `uc-daemon-local` 抽出，目的是切断一条污染依赖边
 | 模块 | 职责 |
 |---|---|
 | `process_metadata` | PID 文件读写 + `DaemonProcessMode` |
-| `socket` | loopback HTTP 地址 + daemon token 路径解析 |
+| `socket` | `daemon.conn` 连接文件（路径解析 / read / 原子写，ADR-011）；`DEFAULT_HTTP_HOST` |
 | `spawn` | `uniclipd` detached spawn（`setsid` / `DETACHED_PROCESS`）+ 二进制解析 |
 | `spawn_contract` | CLI→daemon run-mode / unattended-unlock 环境契约 |
 | `app_data_root`（私有） | 自洽的 app-data-root 路径解析，供 `process_metadata` / `socket` 用 |

--- a/crates/uc-daemon-process/src/socket.rs
+++ b/crates/uc-daemon-process/src/socket.rs
@@ -1,141 +1,360 @@
-//! Shared daemon HTTP address resolution.
+//! Shared daemon connection-file (`daemon.conn`) resolution (ADR-011).
+//!
+//! The daemon binds an ephemeral loopback port and publishes the actual
+//! address + bearer token + process identity in `<app_data_root>/daemon.conn`;
+//! every local client discovers the daemon through this file. The legacy
+//! `UC_PROFILE`-hash fixed-port resolution was retired with the single-track
+//! switch (ADR-011 P2).
 
-use std::path::PathBuf;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result};
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use serde::{Deserialize, Serialize};
 
 use uc_app_paths::app_data_root;
 
+/// Loopback host the daemon listens on and advertises in `daemon.conn`.
 pub const DEFAULT_HTTP_HOST: &str = "127.0.0.1";
-pub const DEFAULT_HTTP_PORT: u16 = 42715;
-const PROFILE_A_HTTP_PORT: u16 = 42716;
-const PROFILE_B_HTTP_PORT: u16 = 42717;
-// `package.json` runs `tauri:dev` with `UC_PROFILE=dev`.
-// Keep that common profile on a stable reserved port instead of hashing it
-// into the general high-port space, which can collide with unrelated local services.
-const PROFILE_DEV_HTTP_PORT: u16 = 42718;
-const PROFILE_HTTP_PORT_START: u16 = 42719;
 
-/// Returns the loopback HTTP socket address where the daemon should listen.
+// ── daemon.conn connection file (ADR-011) ───────────────────────────────────
+
+/// Format version of the `daemon.conn` connection-info file.
 ///
-/// This function resolves the daemon's HTTP port and pairs it with the loopback
-/// IPv4 address `127.0.0.1`.
+/// Readers must reject an unknown format rather than guess: a shape change is
+/// a client/daemon contract change gated by `DAEMON_API_REVISION` (ADR-011
+/// §4.5). Clients that cannot read the file treat the daemon as
+/// absent/incompatible and let the existing version handshake decide.
+pub const DAEMON_CONN_FORMAT: u32 = 1;
+
+/// Leaf filename of the daemon connection-info file
+/// (`<app_data_root>/daemon.conn`).
+const DAEMON_CONN_FILE_NAME: &str = "daemon.conn";
+
+/// Connection-info payload the daemon publishes for local clients (ADR-011).
 ///
-/// # Panics
-///
-/// Panics if port resolution fails.
-///
-/// # Examples
-///
-/// ```
-/// use uc_daemon_process::socket::resolve_daemon_http_addr;
-///
-/// let addr = resolve_daemon_http_addr();
-/// assert_eq!(addr.ip().to_string(), "127.0.0.1");
-/// ```
-pub fn resolve_daemon_http_addr() -> SocketAddr {
-    try_resolve_daemon_http_addr()
-        .expect("daemon http address resolution should stay within loopback port range")
+/// The single source of truth for the loopback HTTP address, the bearer token
+/// and the owning process identity. Written atomically (temp + rename, `0o600`)
+/// AFTER the loopback listener is bound, so a client that reads the file can
+/// connect immediately without racing the bind.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DaemonConnFile {
+    pub format: u32,
+    pub host: String,
+    pub port: u16,
+    pub token: String,
+    pub pid: u32,
+    pub started_at_ms: u64,
 }
 
-/// Resolves the loopback daemon HTTP socket address.
-///
-/// Returns the socket address bound to 127.0.0.1 with the resolved daemon HTTP port,
-/// propagating any error that occurs while resolving the port.
-///
-/// # Examples
-///
-/// ```
-/// use uc_daemon_process::socket::try_resolve_daemon_http_addr;
-///
-/// let addr = try_resolve_daemon_http_addr().unwrap();
-/// assert_eq!(addr.ip().to_string(), "127.0.0.1");
-/// ```
-pub fn try_resolve_daemon_http_addr() -> Result<SocketAddr> {
-    Ok(SocketAddr::new(
-        IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
-        resolve_daemon_http_port()?,
-    ))
-}
-
-/// Selects the daemon HTTP port according to the `UC_PROFILE` environment variable.
-///
-/// Behavior:
-/// - If `UC_PROFILE` is unset or cannot be read, the default port is returned.
-/// - If `UC_PROFILE` is set but contains only whitespace, the default port is returned.
-/// - If `UC_PROFILE` equals (case-insensitive) `"a"`, the profile A port is returned.
-/// - If `UC_PROFILE` equals (case-insensitive) `"b"`, the profile B port is returned.
-/// - For any other non-empty profile value, a deterministic port is chosen from the reserved hashed profile range based on a stable hash of the profile string.
-/// # Returns
-///
-/// The resolved port number: `DEFAULT_HTTP_PORT` for default/empty/unreadable `UC_PROFILE`, `PROFILE_A_HTTP_PORT` for `"a"`, `PROFILE_B_HTTP_PORT` for `"b"`, or a deterministic port within the reserved profile range for other profile values.
-fn resolve_daemon_http_port() -> Result<u16> {
-    match std::env::var("UC_PROFILE") {
-        Ok(profile) if profile.trim().is_empty() => Ok(DEFAULT_HTTP_PORT),
-        Ok(profile) if profile.eq_ignore_ascii_case("a") => Ok(PROFILE_A_HTTP_PORT),
-        Ok(profile) if profile.eq_ignore_ascii_case("b") => Ok(PROFILE_B_HTTP_PORT),
-        Ok(profile) if profile.eq_ignore_ascii_case("dev") => Ok(PROFILE_DEV_HTTP_PORT),
-        Ok(profile) => resolve_hashed_profile_http_port(&profile),
-        Err(_) => Ok(DEFAULT_HTTP_PORT),
+impl DaemonConnFile {
+    /// Build a connection record for the daemon process itself.
+    ///
+    /// `started_at_ms` is the wall-clock timestamp at publication time; it is
+    /// diagnostic only — staleness is detected via PID identity
+    /// (`verify_pid_identity`), never by age.
+    pub fn new(host: &str, port: u16, token: &str, pid: u32) -> Self {
+        let started_at_ms = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|elapsed| elapsed.as_millis() as u64)
+            .unwrap_or(0);
+        Self {
+            format: DAEMON_CONN_FORMAT,
+            host: host.to_string(),
+            port,
+            token: token.to_string(),
+            pid,
+            started_at_ms,
+        }
     }
 }
 
-/// Derives a stable, deterministic HTTP port for an arbitrary non-empty profile name.
+/// Resolve the daemon connection-info file path.
 ///
-/// The result is a port inside the reserved range starting at `PROFILE_HTTP_PORT_START` up to
-/// `u16::MAX`. The function computes a stable hash of `profile`, maps it into the slot count of
-/// the reserved range, and returns `PROFILE_HTTP_PORT_START + offset`. If the computed offset
-/// would overflow the reserved range the function returns an error.
-fn resolve_hashed_profile_http_port(profile: &str) -> Result<u16> {
-    let slot_count = u32::from(u16::MAX) - u32::from(PROFILE_HTTP_PORT_START) + 1;
-    let hash = stable_profile_hash(profile);
-    let offset = (hash % u64::from(slot_count)) as u16;
-
-    PROFILE_HTTP_PORT_START.checked_add(offset).ok_or_else(|| {
-        anyhow::anyhow!(
-            "profile-derived daemon HTTP port overflowed reserved range for UC_PROFILE={profile}"
-        )
-    })
-}
-
-/// Computes a stable 64-bit hash for a profile string using the FNV-1a algorithm.
-///
-/// The returned value is deterministic for a given input and intended for stable
-/// derivation of offsets (for example, mapping a profile name into a port slot).
-fn stable_profile_hash(profile: &str) -> u64 {
-    const FNV_OFFSET: u64 = 0xcbf29ce484222325;
-    const FNV_PRIME: u64 = 0x100000001b3;
-
-    profile.as_bytes().iter().fold(FNV_OFFSET, |hash, byte| {
-        (hash ^ u64::from(*byte)).wrapping_mul(FNV_PRIME)
-    })
-}
-
-/// Resolve the daemon auth token filesystem path from the platform-specific application directories.
-///
-/// Returns the path at which the daemon stores its authentication token as a `PathBuf`.
-///
-/// # Errors
-///
-/// Returns an error if the platform application directories cannot be determined.
+/// Returns the path at which the daemon publishes its connection info as a
+/// `PathBuf`. Reproduces `AppPaths` (`<app_data_root>/daemon.conn`) via the
+/// directory-layout authority without touching the app stack.
 ///
 /// # Examples
 ///
 /// ```
-/// use uc_daemon_process::socket::resolve_daemon_token_path;
+/// use uc_daemon_process::socket::resolve_daemon_conn_path;
 ///
-/// let path = resolve_daemon_token_path().unwrap();
-/// println!("daemon token path: {}", path.display());
+/// let path = resolve_daemon_conn_path().unwrap();
+/// assert_eq!(path.file_name().unwrap(), "daemon.conn");
 /// ```
-pub fn resolve_daemon_token_path() -> Result<PathBuf> {
-    // Reproduces `AppPaths::from_app_dirs(&dirs).daemon_token_path()` =
-    // `<app_data_root>/.daemon-token` via the directory-layout authority
-    // (`uc_app_paths::app_data_root`) without touching the app stack.
+pub fn resolve_daemon_conn_path() -> Result<PathBuf> {
     let root = app_data_root().context("the system data-local directory is unavailable")?;
-    Ok(root.join(DAEMON_TOKEN_FILE_NAME))
+    Ok(root.join(DAEMON_CONN_FILE_NAME))
 }
 
-/// Leaf filename of the daemon auth-token file, kept byte-identical to
-/// `AppPaths::daemon_token_path()` (`<app_data_root>/.daemon-token`).
-const DAEMON_TOKEN_FILE_NAME: &str = ".daemon-token";
+/// Read the daemon connection-info file, returning `Ok(None)` when it does not
+/// exist yet (daemon not running).
+///
+/// A malformed payload or an unsupported `format` is an error — callers decide
+/// whether to surface it or treat the daemon as absent (ADR-011 §4.5).
+///
+/// # Examples
+///
+/// ```
+/// use uc_daemon_process::socket::{DaemonConnFile, read_daemon_conn_file_at, write_daemon_conn_file_at};
+///
+/// let tmp = tempfile::tempdir().unwrap();
+/// let path = tmp.path().join("daemon.conn");
+/// assert!(read_daemon_conn_file_at(&path).unwrap().is_none());
+/// write_daemon_conn_file_at(&path, &DaemonConnFile::new("127.0.0.1", 43127, "tok", 42)).unwrap();
+/// let conn = read_daemon_conn_file_at(&path).unwrap().unwrap();
+/// assert_eq!(conn.port, 43127);
+/// ```
+pub fn read_daemon_conn_file() -> Result<Option<DaemonConnFile>> {
+    read_daemon_conn_file_at(&resolve_daemon_conn_path()?)
+}
+
+/// Read the daemon connection-info file at an explicit path.
+pub fn read_daemon_conn_file_at(path: &Path) -> Result<Option<DaemonConnFile>> {
+    if !path.exists() {
+        return Ok(None);
+    }
+    let content = std::fs::read_to_string(path).with_context(|| {
+        format!(
+            "failed to read daemon connection file at {}",
+            path.display()
+        )
+    })?;
+    let conn: DaemonConnFile = serde_json::from_str(&content).with_context(|| {
+        format!(
+            "failed to parse daemon connection file at {}",
+            path.display()
+        )
+    })?;
+    if conn.format != DAEMON_CONN_FORMAT {
+        anyhow::bail!(
+            "unsupported daemon connection file format {} at {} (expected {})",
+            conn.format,
+            path.display(),
+            DAEMON_CONN_FORMAT
+        );
+    }
+    Ok(Some(conn))
+}
+
+/// Atomically publish the daemon connection-info file (temp + rename, `0o600`).
+///
+/// The temp file is created in the same directory as the target so the rename
+/// is a same-filesystem atomic publish; readers either see the old file or the
+/// new file, never a partial write.
+///
+/// # Examples
+///
+/// ```
+/// use uc_daemon_process::socket::{DaemonConnFile, write_daemon_conn_file_at};
+///
+/// let tmp = tempfile::tempdir().unwrap();
+/// let path = tmp.path().join("daemon.conn");
+/// write_daemon_conn_file_at(&path, &DaemonConnFile::new("127.0.0.1", 43127, "tok", 42)).unwrap();
+/// assert!(path.exists());
+/// ```
+pub fn write_daemon_conn_file(conn: &DaemonConnFile) -> Result<()> {
+    write_daemon_conn_file_at(&resolve_daemon_conn_path()?, conn)
+}
+
+/// Remove the daemon connection-info file.
+///
+/// Called on graceful daemon shutdown so a clean exit leaves no stale file
+/// behind. Crash leftovers are still handled: clients verify the recorded PID
+/// identity and treat a dead PID as absent (ADR-011 §4.2).
+///
+/// # Examples
+///
+/// ```
+/// use uc_daemon_process::socket::{DaemonConnFile, remove_daemon_conn_file_at, write_daemon_conn_file_at};
+///
+/// let tmp = tempfile::tempdir().unwrap();
+/// let path = tmp.path().join("daemon.conn");
+/// write_daemon_conn_file_at(&path, &DaemonConnFile::new("127.0.0.1", 1, "t", 1)).unwrap();
+/// remove_daemon_conn_file_at(&path).unwrap();
+/// assert!(!path.exists());
+/// ```
+pub fn remove_daemon_conn_file() -> Result<()> {
+    remove_daemon_conn_file_at(&resolve_daemon_conn_path()?)
+}
+
+/// Remove the daemon connection-info file at an explicit path.
+pub fn remove_daemon_conn_file_at(path: &Path) -> Result<()> {
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error)
+            .with_context(|| format!("failed to remove daemon connection file {}", path.display())),
+    }
+}
+
+/// Atomically publish the daemon connection-info file at an explicit path.
+pub fn write_daemon_conn_file_at(path: &Path, conn: &DaemonConnFile) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).with_context(|| {
+            format!(
+                "failed to create daemon connection file directory {}",
+                parent.display()
+            )
+        })?;
+    }
+
+    let content =
+        serde_json::to_string_pretty(conn).context("failed to serialize daemon connection file")?;
+
+    // Publish through a uniquely-named temp file in the same directory, then
+    // rename over the target. `create` + `truncate` on the temp file is safe:
+    // the name embeds our PID, so two daemons racing here cannot share a temp.
+    let tmp_path = path.with_extension(format!("conn.tmp-{}", std::process::id()));
+
+    #[cfg(unix)]
+    use std::os::unix::fs::OpenOptionsExt;
+
+    let mut options = std::fs::OpenOptions::new();
+    options.create(true).truncate(true).write(true);
+
+    #[cfg(unix)]
+    options.mode(0o600);
+
+    let mut tmp = options.open(&tmp_path).with_context(|| {
+        format!(
+            "failed to open temporary daemon connection file {}",
+            tmp_path.display()
+        )
+    })?;
+    tmp.write_all(content.as_bytes()).with_context(|| {
+        format!(
+            "failed to write temporary daemon connection file {}",
+            tmp_path.display()
+        )
+    })?;
+    tmp.flush().with_context(|| {
+        format!(
+            "failed to flush temporary daemon connection file {}",
+            tmp_path.display()
+        )
+    })?;
+    drop(tmp);
+
+    // `rename` cannot replace an existing file on Windows; a short non-atomic
+    // window here is acceptable (readers of a missing file treat the daemon as
+    // absent and retry — the connection handshake is retry-tolerant).
+    #[cfg(windows)]
+    let _ = std::fs::remove_file(path);
+
+    std::fs::rename(&tmp_path, path).with_context(|| {
+        format!(
+            "failed to atomically publish daemon connection file {}",
+            path.display()
+        )
+    })?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod daemon_conn_file_tests {
+    use super::*;
+
+    #[test]
+    fn conn_file_write_read_roundtrip_preserves_all_fields() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("daemon.conn");
+        let conn = DaemonConnFile::new("127.0.0.1", 43127, "deadbeef", 4242);
+        write_daemon_conn_file_at(&path, &conn).unwrap();
+
+        let loaded = read_daemon_conn_file_at(&path).unwrap().unwrap();
+        assert_eq!(loaded, conn);
+        assert_eq!(loaded.format, DAEMON_CONN_FORMAT);
+        assert_eq!(loaded.host, "127.0.0.1");
+        assert_eq!(loaded.port, 43127);
+        assert_eq!(loaded.token, "deadbeef");
+        assert_eq!(loaded.pid, 4242);
+    }
+
+    #[test]
+    fn conn_file_serializes_with_camel_case_wire_names() {
+        // ADR-011: the on-disk JSON uses the camelCase field names the contract
+        // types use across the wire; a snake_case regression would silently
+        // break every reader.
+        let conn = DaemonConnFile::new("127.0.0.1", 43127, "tok", 7);
+        let json = serde_json::to_string(&conn).unwrap();
+        assert!(json.contains("\"startedAtMs\""), "got {json}");
+        assert!(!json.contains("started_at_ms"), "got {json}");
+        assert!(json.contains("\"format\":1"), "got {json}");
+    }
+
+    #[test]
+    fn conn_file_missing_reads_as_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("daemon.conn");
+        assert_eq!(read_daemon_conn_file_at(&path).unwrap(), None);
+    }
+
+    #[test]
+    fn conn_file_corrupt_payload_is_an_error_not_silent_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("daemon.conn");
+        std::fs::write(&path, "not-json").unwrap();
+        let err = read_daemon_conn_file_at(&path).unwrap_err();
+        assert!(err.to_string().contains("parse"), "got {err}");
+    }
+
+    #[test]
+    fn conn_file_unknown_format_is_rejected() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("daemon.conn");
+        std::fs::write(
+            &path,
+            r#"{"format":99,"host":"127.0.0.1","port":1,"token":"t","pid":1,"startedAtMs":1}"#,
+        )
+        .unwrap();
+        let err = read_daemon_conn_file_at(&path).unwrap_err();
+        assert!(err.to_string().contains("format"), "got {err}");
+    }
+
+    #[test]
+    fn conn_file_write_creates_missing_parent_dirs() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("nested").join("deeper").join("daemon.conn");
+        write_daemon_conn_file_at(&path, &DaemonConnFile::new("127.0.0.1", 1, "t", 1)).unwrap();
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn conn_file_overwrite_replaces_previous_payload() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("daemon.conn");
+        write_daemon_conn_file_at(&path, &DaemonConnFile::new("127.0.0.1", 1000, "old", 1))
+            .unwrap();
+        write_daemon_conn_file_at(&path, &DaemonConnFile::new("127.0.0.1", 2000, "new", 2))
+            .unwrap();
+        let loaded = read_daemon_conn_file_at(&path).unwrap().unwrap();
+        assert_eq!(loaded.port, 2000);
+        assert_eq!(loaded.token, "new");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn conn_file_is_written_as_0600() {
+        use std::os::unix::fs::PermissionsExt;
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("daemon.conn");
+        write_daemon_conn_file_at(&path, &DaemonConnFile::new("127.0.0.1", 1, "t", 1)).unwrap();
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "freshly published conn file must be 0600");
+    }
+
+    #[test]
+    fn conn_new_stamps_format_and_epoch_ms() {
+        let conn = DaemonConnFile::new("127.0.0.1", 1, "t", 1);
+        assert_eq!(conn.format, DAEMON_CONN_FORMAT);
+        assert!(
+            conn.started_at_ms > 1_600_000_000_000,
+            "startedAtMs must be a plausible epoch-ms timestamp, got {}",
+            conn.started_at_ms
+        );
+    }
+}

--- a/crates/uc-desktop/src/daemon_probe.rs
+++ b/crates/uc-desktop/src/daemon_probe.rs
@@ -24,9 +24,8 @@ use uc_daemon_process::contract::{
 };
 use uc_daemon_process::health_wait::{wait_for_daemon_health, wait_for_endpoint_absent};
 use uc_daemon_process::process_metadata::{
-    find_pid_by_port, read_pid_metadata, DaemonPidMetadata, DaemonProcessMode, DaemonSpawnOrigin,
+    read_pid_metadata, DaemonPidMetadata, DaemonProcessMode, DaemonSpawnOrigin,
 };
-use uc_daemon_process::socket::try_resolve_daemon_http_addr;
 use uc_daemon_process::spawn::spawn_detached_daemon;
 
 use crate::daemon::{DaemonLaunchOrigin, DaemonOwnership};
@@ -50,16 +49,61 @@ pub const INCOMPATIBLE_DAEMON_EXIT_TIMEOUT: Duration = Duration::from_millis(150
 /// `expected_package_version` 由调用方传入——典型情况是 shell crate 自己的
 /// `env!("CARGO_PKG_VERSION")`，因为 `uc-desktop` 的 cargo 版本号未必和 GUI
 /// shell 想校验的一致。
+///
+/// ADR-011: the probe address comes from `daemon.conn` (PID-verified so a
+/// leftover file from a crashed daemon is not treated as a live one), with the
+/// legacy hash-derived address as a P1 fallback for old daemons. Re-resolving
+/// on every call keeps the health-wait loops self-healing across daemon
+/// restarts that change the port.
 pub async fn probe_daemon_health(
     client: &reqwest::Client,
     expected_package_version: &str,
 ) -> Result<ProbeOutcome, DaemonBootstrapError> {
-    let addr = try_resolve_daemon_http_addr().map_err(|error| {
+    let Some(addr) = resolve_probe_addr().map_err(|error| {
         DaemonBootstrapError::Probe(
-            error.context("failed to resolve profile-aware daemon HTTP address"),
+            error.context("failed to resolve daemon HTTP address from connection file"),
         )
-    })?;
+    })?
+    else {
+        // No connection file and no legacy address → no daemon to talk to.
+        return Ok(ProbeOutcome::Absent);
+    };
     probe_daemon_health_at(client, addr, expected_package_version).await
+}
+
+/// Resolve the address the health probe should target (ADR-011).
+///
+/// Reads `daemon.conn` and accepts it only when its recorded PID passes the
+/// D22 identity check (liveness + daemon binary name). A stale PID means the
+/// daemon is gone; the leftover file must not masquerade as a live daemon.
+///
+/// Returns `Ok(None)` when there is nothing to probe (no connection file) —
+/// callers classify that as `ProbeOutcome::Absent`.
+fn resolve_probe_addr() -> anyhow::Result<Option<std::net::SocketAddr>> {
+    use uc_daemon_process::process_metadata::{verify_pid_identity, PidVerification};
+
+    let Some(conn) = uc_daemon_process::socket::read_daemon_conn_file()? else {
+        return Ok(None);
+    };
+    let synthetic = DaemonPidMetadata {
+        pid: conn.pid,
+        mode: DaemonProcessMode::Standalone,
+        started_at_ms: conn.started_at_ms,
+        spawned_by: DaemonSpawnOrigin::Unknown,
+        // Unused by `verify_pid_identity` (liveness + exe name only).
+        package_version: String::new(),
+    };
+    if !matches!(verify_pid_identity(&synthetic), PidVerification::Active) {
+        tracing::info!(
+            pid = conn.pid,
+            "daemon.conn PID is stale — treating the daemon as absent"
+        );
+        return Ok(None);
+    }
+    let host: std::net::IpAddr = conn.host.parse().map_err(|error| {
+        anyhow::anyhow!("daemon.conn host {:?} is not an IP: {error}", conn.host)
+    })?;
+    Ok(Some(std::net::SocketAddr::new(host, conn.port)))
 }
 
 pub async fn probe_daemon_health_at(
@@ -293,76 +337,72 @@ pub fn terminate_incompatible_daemon_from_pid_file() -> Result<(), DaemonBootstr
     terminate_incompatible_daemon_with(|| Ok(Some(metadata)), terminate_local_daemon_pid)
 }
 
-/// Terminate an incompatible daemon: PID file first, port-based PID lookup as fallback.
+/// Terminate an incompatible daemon: PID file first, `daemon.conn`-based PID
+/// lookup as fallback.
 ///
 /// The PID-file path preserves all safety checks (InProcess refusal, D22
-/// identity verification). The port-based fallback fires only when the PID
+/// identity verification). The conn-file fallback fires only when the PID
 /// file is missing or unreadable — a scenario observed in the wild when a
 /// daemon from an older/different installation runs without leaving a PID
-/// file, blocking the current GUI from starting.
+/// file, blocking the current GUI from starting. The daemon's own connection
+/// file records its PID (ADR-011), replacing the old port-based lookup.
 fn terminate_incompatible_daemon() -> Result<(), DaemonBootstrapError> {
     match read_pid_metadata() {
         Ok(Some(_)) => terminate_incompatible_daemon_from_pid_file(),
         Ok(None) => {
-            tracing::warn!("daemon PID file missing; trying port-based PID lookup");
-            terminate_incompatible_daemon_by_port()
+            tracing::warn!("daemon PID file missing; trying daemon.conn-based PID lookup");
+            terminate_incompatible_daemon_by_conn_file()
         }
         Err(error) => {
-            tracing::warn!(%error, "daemon PID file unreadable; trying port-based PID lookup");
-            terminate_incompatible_daemon_by_port()
+            tracing::warn!(%error, "daemon PID file unreadable; trying daemon.conn-based PID lookup");
+            terminate_incompatible_daemon_by_conn_file()
         }
     }
 }
 
-/// Port-based fallback: resolve the daemon's configured port, find the
-/// listening PID via OS tools (`netstat` / `lsof`), verify identity (D22),
-/// and terminate.
-fn terminate_incompatible_daemon_by_port() -> Result<(), DaemonBootstrapError> {
+/// `daemon.conn`-based fallback: read the daemon's recorded PID, verify
+/// identity (D22), and terminate (ADR-011).
+fn terminate_incompatible_daemon_by_conn_file() -> Result<(), DaemonBootstrapError> {
     use uc_daemon_process::process_metadata::{verify_pid_identity, PidVerification};
 
-    let addr = try_resolve_daemon_http_addr().map_err(|error| {
-        DaemonBootstrapError::IncompatibleDaemon {
-            details: format!("port fallback: failed to resolve daemon address: {error}"),
-        }
-    })?;
-    let port = addr.port();
+    let conn = uc_daemon_process::socket::read_daemon_conn_file()
+        .map_err(|error| DaemonBootstrapError::IncompatibleDaemon {
+            details: format!("daemon.conn fallback: failed to read connection file: {error}"),
+        })?
+        .ok_or_else(|| DaemonBootstrapError::IncompatibleDaemon {
+            details: "incompatible daemon has no PID file and no daemon.conn; cannot identify it"
+                .to_string(),
+        })?;
 
-    let pid = find_pid_by_port(port).ok_or_else(|| DaemonBootstrapError::IncompatibleDaemon {
-        details: format!(
-            "incompatible daemon has no PID file and no process found listening on port {port}"
-        ),
-    })?;
-
-    tracing::info!(
-        pid,
-        port,
-        "found incompatible daemon PID via port lookup (PID file missing)"
-    );
-
-    // D22: verify PID identity before signaling. Construct synthetic metadata
-    // assuming Standalone mode — an InProcess daemon would have a PID file
-    // from the hosting GUI, so reaching this fallback implies Standalone.
     let synthetic = DaemonPidMetadata {
-        pid,
+        pid: conn.pid,
         mode: DaemonProcessMode::Standalone,
-        started_at_ms: 0,
+        started_at_ms: conn.started_at_ms,
         spawned_by: DaemonSpawnOrigin::Unknown,
         // Unused by `verify_pid_identity` (liveness + exe name only); the real
-        // version is not knowable from a port lookup with no PID file.
+        // version is not knowable from a connection file lookup.
         package_version: String::new(),
     };
 
     if let PidVerification::Stale(reason) = verify_pid_identity(&synthetic) {
         tracing::info!(
-            pid,
+            pid = conn.pid,
             %reason,
-            "port-based daemon PID is stale — skipping terminate"
+            "daemon.conn-based daemon PID is stale — skipping terminate"
         );
         return Ok(());
     }
 
-    terminate_local_daemon_pid(pid).map_err(|e| DaemonBootstrapError::IncompatibleDaemon {
-        details: format!("failed to terminate daemon (pid {pid}, found via port {port}): {e}"),
+    tracing::info!(
+        pid = conn.pid,
+        "found incompatible daemon PID via daemon.conn (PID file missing)"
+    );
+
+    terminate_local_daemon_pid(conn.pid).map_err(|e| DaemonBootstrapError::IncompatibleDaemon {
+        details: format!(
+            "failed to terminate daemon (pid {}, found via daemon.conn): {e}",
+            conn.pid
+        ),
     })
 }
 

--- a/crates/uc-webserver/src/api/auth.rs
+++ b/crates/uc-webserver/src/api/auth.rs
@@ -1,4 +1,4 @@
 pub use uc_daemon_contract::api::auth::DaemonConnectionInfo;
 pub use uc_daemon_local::auth::{
-    build_connection_info, load_or_create_auth_token, parse_bearer_token, DaemonAuthToken,
+    build_connection_info, load_or_create_auth_token_from_conn, parse_bearer_token, DaemonAuthToken,
 };

--- a/crates/uc-webserver/src/api/server.rs
+++ b/crates/uc-webserver/src/api/server.rs
@@ -1,12 +1,12 @@
 //! HTTP server bootstrap for the daemon API.
 
-use std::io;
 use std::net::SocketAddr;
 use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
+use anyhow::Context;
 use axum::body::Body;
 use axum::http::header::{
     HeaderName, HeaderValue, ACCESS_CONTROL_ALLOW_HEADERS, ACCESS_CONTROL_ALLOW_METHODS,
@@ -41,10 +41,7 @@ use crate::api::types::{
 };
 use crate::api::ws;
 use crate::security::SecurityState;
-use crate::socket::{try_resolve_daemon_http_addr, DEFAULT_HTTP_HOST};
-
-const HTTP_BIND_RETRY_TIMEOUT: Duration = Duration::from_secs(5);
-const HTTP_BIND_RETRY_INTERVAL: Duration = Duration::from_millis(100);
+use crate::socket::{DaemonConnFile, DEFAULT_HTTP_HOST};
 
 fn network_recovery_status_response(
     status: NetworkRecoveryStatusSummary,
@@ -638,11 +635,28 @@ pub async fn run_http_server(
     state: DaemonApiState,
     cancel: CancellationToken,
 ) -> anyhow::Result<()> {
-    let addr = try_resolve_daemon_http_addr()?;
-    let connection_info = state.connection_info_for_addr(addr, std::process::id());
-    let listener =
-        bind_http_listener_with_retry(addr, HTTP_BIND_RETRY_TIMEOUT, HTTP_BIND_RETRY_INTERVAL)
-            .await?;
+    // ADR-011: bind an ephemeral loopback port — the kernel picks a free one,
+    // so no fixed port can ever collide with unrelated local services. The
+    // actual port is published in `daemon.conn` for local clients.
+    let bind_addr = SocketAddr::new(std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST), 0);
+    let listener = tokio::net::TcpListener::bind(bind_addr)
+        .await
+        .context("failed to bind daemon HTTP listener on 127.0.0.1")?;
+    // ADR-011: publish `daemon.conn` AFTER the bind so a client that reads the
+    // file can connect immediately. Hard failure — without the file no client
+    // can discover the daemon.
+    let bound_addr = listener
+        .local_addr()
+        .context("failed to read bound daemon listener address")?;
+    let connection_info = state.connection_info_for_addr(bound_addr, std::process::id());
+    let conn = DaemonConnFile::new(
+        DEFAULT_HTTP_HOST,
+        bound_addr.port(),
+        state.auth_token.as_str(),
+        std::process::id(),
+    );
+    uc_daemon_local::socket::write_daemon_conn_file(&conn)
+        .context("failed to publish daemon connection file")?;
     tracing::info!(
         base_url = %connection_info.base_url,
         ws_url = %connection_info.ws_url,
@@ -662,80 +676,6 @@ pub async fn run_http_server(
         .await?;
 
     Ok(())
-}
-
-async fn bind_http_listener_with_retry(
-    addr: SocketAddr,
-    retry_timeout: Duration,
-    retry_interval: Duration,
-) -> io::Result<tokio::net::TcpListener> {
-    let started_at = tokio::time::Instant::now();
-    let deadline = started_at + retry_timeout;
-    let mut retry_count = 0_u32;
-
-    loop {
-        match tokio::net::TcpListener::bind(addr).await {
-            Ok(listener) => {
-                if retry_count > 0 {
-                    tracing::info!(
-                        addr = %addr,
-                        retry_count,
-                        elapsed_ms = started_at.elapsed().as_millis(),
-                        "daemon HTTP API port became available"
-                    );
-                }
-                return Ok(listener);
-            }
-            Err(error)
-                if error.kind() == io::ErrorKind::AddrInUse
-                    && tokio::time::Instant::now() < deadline =>
-            {
-                retry_count += 1;
-                if retry_count == 1 {
-                    tracing::warn!(
-                        addr = %addr,
-                        retry_count,
-                        retry_timeout_ms = retry_timeout.as_millis(),
-                        error_kind = "http_bind_addr_in_use",
-                        retryable = true,
-                        error = %error,
-                        "daemon HTTP API port is temporarily unavailable; retrying"
-                    );
-                }
-                let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
-                tokio::time::sleep(retry_interval.min(remaining)).await;
-            }
-            Err(error) => return Err(error),
-        }
-    }
-}
-
-#[cfg(test)]
-mod http_listener_bind_tests {
-    use std::net::{Ipv4Addr, TcpListener};
-    use std::time::Duration;
-
-    use super::bind_http_listener_with_retry;
-
-    #[tokio::test(start_paused = true)]
-    async fn retries_until_a_transiently_occupied_port_is_released() {
-        let blocker = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).expect("bind blocker");
-        let addr = blocker.local_addr().expect("read blocker address");
-        let started_at = tokio::time::Instant::now();
-        let bind =
-            bind_http_listener_with_retry(addr, Duration::from_secs(1), Duration::from_millis(10));
-        let release = async move {
-            tokio::time::sleep(Duration::from_millis(60)).await;
-            drop(blocker);
-        };
-
-        let (listener, ()) = tokio::join!(bind, release);
-        let listener =
-            listener.expect("listener should bind after the transient owner releases the port");
-
-        assert_eq!(listener.local_addr().expect("read listener address"), addr);
-        assert!(started_at.elapsed() >= Duration::from_millis(60));
-    }
 }
 
 #[cfg(test)]

--- a/crates/uc-webserver/src/mobile_lan/mod.rs
+++ b/crates/uc-webserver/src/mobile_lan/mod.rs
@@ -3,7 +3,7 @@
 //! `GET/PUT /file/:dataName`), 接受 iPhone SyncClipboard shortcut 客户端
 //! 的 LAN 直连。
 //!
-//! 与现有 `crate::api::server`(`127.0.0.1:42715` 的 daemon API)是**两个**
+//! 与现有 `crate::api::server`(`127.0.0.1` 动态端口的 daemon API,ADR-011)是**两个**
 //! 独立 listener, 互不共享 router / 中间件。理由(SPEC §3.1):
 //!
 //! * daemon API 走 JWT + PID 白名单中间件;mobile LAN 走 Basic Auth(v3

--- a/crates/uc-webserver/src/security/connect.rs
+++ b/crates/uc-webserver/src/security/connect.rs
@@ -155,7 +155,7 @@ async fn connect_handler(
     // Step 3: Register PID in whitelist
     //
     // NOTE: The PID from the request body is trusted because:
-    // 1. The bearer token (from daemon.token file) has already been validated above
+    // 1. The bearer token (from daemon.conn, ADR-011) has already been validated above
     // 2. The frontend runs on the same machine as the daemon
     // 3. PID verification is defense-in-depth against local malware, not a hard security boundary
     // 4. The bearer token file has filesystem permissions (600)

--- a/docs/architecture/adr-011-daemon-connection-discovery-conn-file.md
+++ b/docs/architecture/adr-011-daemon-connection-discovery-conn-file.md
@@ -1,0 +1,92 @@
+# ADR-011: 本地连接发现改为动态端口 + `daemon.conn` 连接信息文件（否决新增 UDS / 独立 IPC 通道）
+
+- **状态**：Accepted（2026-08-11）
+- **日期**：2026-08-11
+- **相关文档**：[`adr-008-uniclipd-split-gui-as-client.md`](./adr-008-uniclipd-split-gui-as-client.md)（D4/D5/D13/D14/D22）、[`adr-008-review-2026-05-30.md`](./adr-008-review-2026-05-30.md)（C7 现状订正）、`docs/uat/direct-daemon-ws.md`、`docs/development/config.md`、`crates/uc-daemon-process/AGENTS.md`
+
+## 1. 决策
+
+1. **维持 ADR-008 D4**：不引入 UDS / Windows named pipe / 第二套 IPC 协议；GUI↔daemon 传输仍为 `127.0.0.1` HTTP + WebSocket 单通道。本 ADR 是对"新增一套 sock 通道"议题的正式评审结论落档。
+2. **loopback 监听改为动态端口**（`127.0.0.1:0`，由内核分配），废弃 `UC_PROFILE` hash 固定端口解析。
+3. **连接信息收敛为单一 `daemon.conn` 文件**（`<app_data_root>/daemon.conn`，`0o600`，temp+rename 原子写），内容含 host / port / token / pid / startedAtMs；`.daemon-token` 文件与 hash 端口解析退役。
+4. **所有本地客户端（CLI / Tauri 原生 / daemon probe / health-wait）改为"读 `daemon.conn` + PID 身份校验"**；前端 webview 数据通路不变（仍由原生侧注入连接信息）。
+
+## 2. 背景
+
+- 现状（代码已核实）：端口由 `crates/uc-daemon-process/src/socket.rs` 以 FNV-1a hash 派生（默认 `42715`，profile 落入 `42719+` 区间）；该文件注释自认"会与无关本地服务碰撞"。碰撞后 `crates/uc-webserver/src/api/server.rs` 的 `run_http_server` 重试 5 秒，超时即 daemon 启动失败。
+- 前端连接信息经 ~500ms 轮询 `get_daemon_connection_info` 获取（`src/lib/daemon-connection-info.ts`，60s 超时上限）；RAW bearer 经该命令进入 webview（ADR-008 C7 已订正的现状）。
+- 评审触发：评估"在 HTTP+WS 之外新增一套 socket 通道"（动机：Windows 防火墙 / 端口冲突 / 原生侧连接可靠性 / 安全加固）。
+
+## 3. 被否掉的方案
+
+### 3.1 UDS / named pipe / 新 IPC 协议（新增独立通道）
+
+- **违反 ADR-008 D4 锁定决策**：D4 明确"再加一条 IPC = API 面 fork 成两套，违反单一来源"，只保留"同 API 换传输"的出口，且"本期不做传输替换"。
+- **webview 物理约束**：前端是浏览器（fetch/WebSocket），**无法连接 UDS / named pipe**——任何 UDS 方案必然双通道（原生侧走 UDS、webview 留 TCP），API 面分裂成两套客户端契约。
+- **安全增量≈0**：D14 威胁模型已显式声明"本机同 UID 进程视为可信"，UDS 的 `0o600` 权限模型只挡跨用户进程，在该模型下无增量收益；若主张更强的跨用户隔离，须先改写威胁模型而非换传输。
+- **Windows 成本**：UDS 不存在，须 named pipe + DACL + hyper 兼容层，跨平台工作量翻倍。
+- **仓库历史教训**：`.planning/milestones/v0.4.0-phases/41-*` 曾实现 UDS + JSON-RPC 控制面，phase 45 整体替换为 HTTP+WS——已走过一次完整弯路。
+- **动机错配**：端口冲突只涉及 TCP 传输层，新通道并存解决不了它；防火墙弹窗大概率来自 iroh magicsock 的 UDP 端口（loopback 监听不触发 Windows Firewall），与 HTTP 通道无关，UDS 同样解决不了。
+
+### 3.2 固定端口 + 冲突时换端口 fallback
+
+- 复杂度≈动态端口（同样要写连接信息文件、同样要客户端改读文件），却多保留一段 hash 解析死代码，否决。
+
+## 4. 决策细节
+
+1. **绑定顺序（防 race）**：先同步 `TcpListener::bind("127.0.0.1:0")` → 写 `daemon.conn` → 开始 serve。客户端读到文件时端口必已可连。该"先 bind 后写连接信息"模式在 `crates/uc-webserver/src/mobile_lan/server.rs`（`endpoint_info`）已有先例。
+2. **`daemon.conn` 文件格式**（JSON，camelCase，`format` 字段版本化）：
+
+   ```json
+   {
+     "format": 1,
+     "host": "127.0.0.1",
+     "port": 43127,
+     "token": "<bearer>",
+     "pid": 12345,
+     "startedAtMs": 1720000000000
+   }
+   ```
+
+   - 写入 `0o600`（复用 `uc-daemon-local/src/auth.rs` 既有写文件 + temp+rename 模式）；daemon 每次启动重写，token 沿用既有 `load_or_create_auth_token` 语义（跨重启持久，不每次换新；每次换新的只是 JWT session secret）。
+   - token 迁移：切换时可直接把旧 `.daemon-token` 内容搬入 conn（load-or-create 来源换路径），或直接换新——捆绑分发（D13）下客户端一律读 conn，换新亦安全。
+   - graceful shutdown 删除；崩溃残留由客户端 PID 身份校验（D22 `verify_pid_identity`）识别为 stale，不依赖文件存在性。
+3. **退役内容**：`resolve_daemon_http_addr` / hash 端口解析 / `resolve_daemon_token_path` / `.daemon-token` 全部删除；`uc-daemon-process/src/socket.rs` 新增 `resolve_daemon_conn_path` + `read_daemon_conn`（serde_json 已在允许依赖面内，`uc-daemon-process` 薄 crate 约束不破坏）。
+4. **客户端改造点**（均已核实存在）：
+   - `crates/uc-daemon-client/src/lib.rs`：`resolve_connection_info_from_env` / base URL 解析改读 conn 文件。
+   - `crates/uc-desktop/src/daemon_probe.rs`：probe 改"读 conn 文件 + `verify_pid_identity`"（比"连 hash 端口可达"更可靠，且天然复用 D22 机制）。
+   - `apps/cli/src/local_daemon.rs`：health-wait 改"等 conn 文件出现 → 校验 → 连接"。
+   - `src-tauri/crates/uc-tauri/src/commands/startup.rs`（`get_daemon_connection_info`）：数据源改读 conn 文件，每次调用读到最新端口/token，不再依赖进程内 state 设置时序。
+   - 前端 `daemon-connection-info.ts` / `daemon-ws.ts`：**不动**；原生侧数据源新鲜后，轮询读到的信息自动跟随端口/token 轮换，60s 超时兜底保留。
+5. **版本与互操作**：
+   - conn 文件 `format` 字段未知 / 文件缺失 → 视为 Incompatible → 走既有 `terminate_incompatible_daemon` 替换路径（与 `DAEMON_API_REVISION` 联动，D13 捆绑分发下同版本收敛）。
+   - **双轨过渡（P1，revert-safe）**：daemon 写 conn 文件 + 仍绑 hash 端口；客户端优先读 conn、缺失时 fallback hash+token（兼容旧 daemon / 旧 client 混跑）。**P2 单轨**：daemon 只绑 `:0`，删 hash 解析、`.daemon-token`、AddrInUse 重试（bind `:0` 永不冲突）与 fallback。
+6. **多 profile**：conn 文件位于 app_data_root，天然 per-profile，无需额外隔离。
+7. **范围外**：bearer 不进 webview 的 D5 反转（原生侧 `/auth/connect` 换 session + 续期通道）仍属 ADR-008 P3 计划内工作，本文档不扩不缩其范围；conn 文件使该落地更顺（原生侧读文件即可拿到 bearer）。
+
+## 5. 后果
+
+**正面**
+
+- 端口冲突归零（内核分配），删 AddrInUse 重试路径。
+- 连接发现收敛为单一事实源（一份文件承载 port + token + pid），客户端不再各自推导。
+- probe / health-wait 语义升级为"文件 + PID 身份校验"，天然复用 D22，且对 stale 文件鲁棒。
+- 前端轮询问题消解（读到的信息永远新鲜），为 D5 收口铺路。
+
+**代价**
+
+- 日志中的端口值随进程变化（不再稳定可记忆）。
+- 依赖固定端口的文档与工具须迁移：`docs/uat/direct-daemon-ws.md`（42715 示例）、`crates/AGENTS.md` CONVENTIONS、`crates/uc-daemon-process/AGENTS.md`。
+- 既有固定端口断言类测试须改写为 conn 文件语义。
+
+**不做的事**
+
+- 不引入 UDS / 新 IPC（D4 保持）；不改 webview 数据通路；不并入 LAN mobile（其动态端口模式仅作先例引用；LAN mobile 已 demote 为 deprecated）。
+
+## 6. 实施路径
+
+| 阶段 | 内容 | 用户可见行为 | 提交类型 |
+|---|---|---|---|
+| **P1 · 双轨** | daemon 写 `daemon.conn`（保留 hash 监听）；客户端读 conn、缺失 fallback hash+token；单测固定 conn 路径与格式 | 无 | `arch:` |
+| **P2 · 单轨** | daemon 改绑 `127.0.0.1:0`；删 hash 解析 / `.daemon-token` / AddrInUse 重试 / fallback；probe 与 health-wait 改文件+pid 校验；同步清理上述文档 | 端口冲突消失 | `arch:` / `refactor:` |
+| **P3 ·（可选，与 D5 合并）** | 前端轮询收口为事件推送；原生侧 `/auth/connect` 换 session（ADR-008 P3 既有计划） | bearer 不进 webview | `feat:` |

--- a/docs/security-audit.md
+++ b/docs/security-audit.md
@@ -264,7 +264,7 @@ node scripts/verify-direct-daemon-ws.mjs --self-test
 
 # Live mode (requires running daemon)
 DAEMON_BASE_URL=http://127.0.0.1:<port> \
-DAEMON_TOKEN=$(cat ~/Library/Application\ Support/uniclipboard/daemon.token) \
+DAEMON_TOKEN=$(python3 -c 'import json,sys;print(json.load(open(sys.argv[1]))["token"])' ~/Library/Application\ Support/app.uniclipboard.desktop/daemon.conn) \
 node scripts/verify-direct-daemon-ws.mjs --live
 ```
 

--- a/docs/uat/direct-daemon-ws.md
+++ b/docs/uat/direct-daemon-ws.md
@@ -30,7 +30,7 @@ This runbook verifies the end-to-end WebSocket path from the browser (React fron
 
 ## Prerequisites
 
-1. **Daemon must be running** with a valid `daemon.token` file
+1. **Daemon must be running** with a valid `daemon.conn` connection file (ADR-011)
 2. **`scripts/verify-direct-daemon-ws.mjs`** must exist and be executable
 3. **Node.js ≥ 18** (for native `fetch` and `WebSocket`)
 4. **Known daemon base URL and bearer token**
@@ -41,22 +41,27 @@ The bearer token is stored in the daemon's data directory:
 
 ```bash
 # Find the token file
-find ~/Library/Application\ Support/uniclipboard -name "daemon.token" 2>/dev/null
+find ~/Library/Application\ Support/app.uniclipboard.desktop -name "daemon.conn" 2>/dev/null
 
-# Read the token (keep it private!)
-cat ~/Library/Application\ Support/uniclipboard/daemon.token
+# Read the token from daemon.conn (keep it private!)
+cat ~/Library/Application\ Support/app.uniclipboard.desktop/daemon.conn
 ```
+
+> **ADR-011 之后**：daemon 绑定 **ephemeral loopback 端口**，把 host/port/token/pid
+> 发布在 `<app_data_root>/daemon.conn`（`0o600`，原子写）。下文示例中的
+> `42715` / `daemon.token` 均为旧固定端口时代的写法，现只作格式示意；
+> 实际端口以 `daemon.conn` 为准。
 
 ### Finding the Daemon Port
 
-The daemon listens on an ephemeral port (chosen at startup). The Tauri app emits it via `daemon://connection-info`:
+The daemon binds an ephemeral port and publishes it in `daemon.conn`:
 
 ```bash
-# Look for the daemon port in recent logs
-grep -r "listening" ~/Library/Application\ Support/uniclipboard/logs/ 2>/dev/null | tail -5
+# Read the published connection info
+cat ~/Library/Application\ Support/app.uniclipboard.desktop/daemon.conn
 
-# Or look for the HTTP server binding
-grep -r "127.0.0.1:" ~/Library/Application\ Support/uniclipboard/logs/ 2>/dev/null | grep -v "442\|443" | tail -10
+# Or look for the HTTP server binding in logs
+grep -r "daemon HTTP API listening" ~/Library/Logs/app.uniclipboard.desktop/ 2>/dev/null | tail -5
 ```
 
 ---
@@ -80,7 +85,7 @@ VERIFICATION: Direct Daemon WS — Self-Test Mode
 [AUTH        ] Simulating bearer→session exchange...
 [AUTH        ] ✅ Session exchange shape valid (expiresInSecs=300)
 [WS_OPEN     ] Testing WebSocket URL with ?auth= query param...
-[WS_OPEN     ] ✅ WS URL construction valid (base=ws://127.0.0.1:42715/ws)
+[WS_OPEN     ] ✅ WS URL construction valid (base=ws://127.0.0.1:43127/ws)
 [SUBSCRIBE   ] Testing subscribe message envelope...
 [SUBSCRIBE   ] ✅ Subscribe envelope valid (topics=clipboard,peers)
 [SNAPSHOT    ] Testing event envelope parsing...
@@ -111,14 +116,14 @@ Requires a running daemon with valid credentials:
 
 ```bash
 DAEMON_BASE_URL=http://127.0.0.1:<port> \
-DAEMON_TOKEN=$(cat ~/Library/Application\ Support/uniclipboard/daemon.token) \
+DAEMON_TOKEN=$(python3 -c 'import json,sys;print(json.load(open(sys.argv[1]))["token"])' ~/Library/Application\ Support/app.uniclipboard.desktop/daemon.conn) \
 DAEMON_PID=$(pgrep -f "uniclipboard" | head -1) \
 node scripts/verify-direct-daemon-ws.mjs --live
 ```
 
 **Example with real values:**
 ```bash
-DAEMON_BASE_URL=http://127.0.0.1:42715 \
+DAEMON_BASE_URL=http://127.0.0.1:<port-from-daemon.conn> \
 DAEMON_TOKEN=3f4a9c2e1b7d... \
 node scripts/verify-direct-daemon-ws.mjs --live
 ```
@@ -129,11 +134,11 @@ node scripts/verify-direct-daemon-ws.mjs --live
 VERIFICATION: Direct Daemon WS — Live Mode
 ============================================================
 
-[CONFIG      ] DAEMON_BASE_URL=http://127.0.0.1:42715
+[CONFIG      ] DAEMON_BASE_URL=http://127.0.0.1:43127
 [CONFIG      ] DAEMON_PID=12345
-[CONFIG      ] ✅ Config valid (host=127.0.0.1:42715)
+[CONFIG      ] ✅ Config valid (host=127.0.0.1:43127)
 [AUTH        ] Exchanging bearer→session...
-[AUTH        ]    POST http://127.0.0.1:42715/auth/connect
+[AUTH        ]    POST http://127.0.0.1:43127/auth/connect
 [AUTH        ] ✅ Auth success (sessionToken=[redacted], expiresIn=300s, latency=12ms)
 [WS_OPEN     ] Opening WebSocket...
 [WS_OPEN     ] ✅ WebSocket open (latency=8ms)
@@ -186,11 +191,11 @@ Evidence:
 ```bash
 # Regenerate token by restarting the daemon (the app does this automatically)
 # Check token file permissions
-ls -la ~/Library/Application\ Support/uniclipboard/daemon.token
+ls -la ~/Library/Application\ Support/app.uniclipboard.desktop/daemon.conn
 # Should show: -rw------- (600)
 
 # Get fresh token
-cat ~/Library/Application\ Support/uniclipboard/daemon.token
+cat ~/Library/Application\ Support/app.uniclipboard.desktop/daemon.conn
 ```
 
 ### Invalid Session Token (WS 401)
@@ -265,7 +270,7 @@ The proof harness must NOT print raw bearer or session tokens:
 
 ```bash
 # Run live mode and capture output
-DAEMON_BASE_URL=http://127.0.0.1:42715 \
+DAEMON_BASE_URL=http://127.0.0.1:<port-from-daemon.conn> \
 DAEMON_TOKEN=test-secret-abc123 \
 node scripts/verify-direct-daemon-ws.mjs --live 2>&1 | grep -i token
 
@@ -279,10 +284,10 @@ node scripts/verify-direct-daemon-ws.mjs --live 2>&1 | grep -i token
 # Send 101 rapid auth requests — the 101st should get 429
 for i in $(seq 1 101); do
   STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
-    -H "Authorization: Bearer $(cat ~/Library/Application\ Support/uniclipboard/daemon.token)" \
+    -H "Authorization: Bearer $(python3 -c 'import json,sys;print(json.load(open(sys.argv[1]))["token"])' ~/Library/Application\ Support/app.uniclipboard.desktop/daemon.conn)" \
     -H "Content-Type: application/json" \
     -d '{"pid":1234,"clientType":"gui"}' \
-    http://127.0.0.1:42715/auth/connect)
+    http://127.0.0.1:<port-from-daemon.conn>/auth/connect)
   echo "Request $i: HTTP $STATUS"
 done
 

--- a/e2e/specs/setup-dual-peer.e2e.js
+++ b/e2e/specs/setup-dual-peer.e2e.js
@@ -135,26 +135,29 @@ function daemonConnection(profile) {
     'Application Support',
     `app.uniclipboard.desktop-${profile}`
   )
-  return {
-    baseUrl: `http://127.0.0.1:${daemonPortForProfile(profile)}`,
-    token: readFileSync(path.join(dataDir, '.daemon-token'), 'utf8').trim(),
-    sessionToken: null,
+  // ADR-011: the daemon binds an ephemeral port and publishes port + token in
+  // `daemon.conn`; retry until the file appears.
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    try {
+      const conn = JSON.parse(readFileSync(path.join(dataDir, 'daemon.conn'), 'utf8'))
+      if (conn.port && conn.token) {
+        return {
+          baseUrl: `http://${conn.host ?? '127.0.0.1'}:${conn.port}`,
+          token: conn.token.trim(),
+          sessionToken: null,
+        }
+      }
+    } catch {
+      // not published yet — keep polling
+    }
+    sleepSync(200)
   }
+  throw new Error(`daemon.conn not published for profile ${profile} at ${dataDir}`)
 }
 
-function daemonPortForProfile(profile) {
-  const normalized = profile.trim().toLowerCase()
-  if (normalized === 'a') return 42716
-  if (normalized === 'b') return 42717
-  if (normalized === 'dev') return 42718
-
-  let hash = 0xcbf29ce484222325n
-  for (const byte of Buffer.from(profile)) {
-    hash = BigInt.asUintN(64, (hash ^ BigInt(byte)) * 0x100000001b3n)
-  }
-  const firstProfilePort = 42719n
-  const profilePortCount = 65535n - firstProfilePort + 1n
-  return Number(firstProfilePort + (hash % profilePortCount))
+function sleepSync(ms) {
+  const buffer = new SharedArrayBuffer(4)
+  Atomics.wait(new Int32Array(buffer), 0, 0, ms)
 }
 
 async function daemonRequest(connection, requestPath, options = {}) {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "dev": "cross-env UNICLIPBOARD_ENV=development vite",
     "dev:sweep": "node -e \"try{require('child_process').execSync('cargo sweep --time 3 --target target',{stdio:'ignore'})}catch{}\"",
+    "dev:sweep-port": "node scripts/sweep-dev-port.mjs",
     "build": "tsc && vite build && node scripts/check-macos-compat.mjs",
     "build:e2e": "cross-env VITE_E2E=1 bun run build",
     "preview": "vite preview",

--- a/scripts/sweep-dev-port.mjs
+++ b/scripts/sweep-dev-port.mjs
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+// Kill any stale process listening on the Vite dev-server ports before
+// `tauri dev` starts, so repeated dev sessions never collide on port 1420
+// ("Port 1420 is already in use").
+//
+// Why this exists:
+// - Tauri CLI polls the fixed `build.devUrl` (http://localhost:1420) and does
+//   NOT auto-detect a different Vite port, so `strictPort: false` (auto-increment)
+//   is not an option here.
+// - A previous dev session that was killed abruptly (IDE restart, `kill -9`,
+//   laptop sleep while `tauri dev` was running) leaves the Vite process alive;
+//   the next `tauri dev` then hard-fails on the occupied port.
+//
+// Scope: only the dev-server ports (1420, plus 1421 for HMR in host mode).
+// The daemon's own ports are never touched. No-op when nothing is listening.
+//
+// Platform strategy:
+// - macOS / Linux: `lsof -ti tcp:<port>` lists owning PIDs.
+// - Windows: `netstat -ano -p tcp` + `taskkill /F /PID`.
+
+import { execFileSync } from 'node:child_process'
+import process from 'node:process'
+
+const DEV_PORTS = [1420, 1421]
+
+function pidsOnPort(port) {
+  try {
+    if (process.platform === 'win32') {
+      const netstat = execFileSync('netstat', ['-ano', '-p', 'tcp'], {
+        encoding: 'utf8',
+      })
+      const pids = new Set()
+      for (const line of netstat.split(/\r?\n/)) {
+        const match = line.match(/TCP\s+[^:]+:(\d+)\s+\S+\s+LISTENING\s+(\d+)/i)
+        if (match && Number(match[1]) === port) {
+          pids.add(Number(match[2]))
+        }
+      }
+      return [...pids]
+    }
+    const out = execFileSync('lsof', ['-ti', `tcp:${port}`], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    })
+    return out
+      .split(/\r?\n/)
+      .map(line => Number(line.trim()))
+      .filter(pid => Number.isFinite(pid) && pid > 0)
+  } catch {
+    return []
+  }
+}
+
+function killPid(pid) {
+  try {
+    if (process.platform === 'win32') {
+      execFileSync('taskkill', ['/F', '/PID', String(pid)], { stdio: 'ignore' })
+    } else {
+      process.kill(pid, 'SIGTERM')
+    }
+    return true
+  } catch {
+    return false
+  }
+}
+
+let killed = 0
+for (const port of DEV_PORTS) {
+  for (const pid of pidsOnPort(port)) {
+    if (killPid(pid)) {
+      console.log(`[dev-port-sweep] killed stale dev-server process ${pid} on port ${port}`)
+      killed += 1
+    }
+  }
+}
+
+if (killed === 0) {
+  console.log('[dev-port-sweep] no stale dev server on ports 1420/1421')
+}

--- a/scripts/verify-direct-daemon-ws.mjs
+++ b/scripts/verify-direct-daemon-ws.mjs
@@ -170,7 +170,9 @@ async function runSelfTest() {
   try {
     log(STAGE.WS_OPEN, 'Testing WebSocket URL with ?auth= query param...')
 
-    const baseWsUrl = 'ws://127.0.0.1:42715/ws'
+    // ADR-011: the daemon binds an ephemeral port; the exact port is
+    // irrelevant to this construction test (any loopback port works).
+    const baseWsUrl = 'ws://127.0.0.1:43127/ws'
     const sessionToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.test.signature'
 
     // This mirrors daemonWs.ts _openSocket() logic
@@ -349,8 +351,9 @@ async function runSelfTest() {
  * Live mode: connect to a real daemon and exercise the full WS path.
  *
  * Required env vars:
- *   DAEMON_BASE_URL  — e.g. http://127.0.0.1:42715
- *   DAEMON_TOKEN     — bearer token from daemon.token file
+ *   DAEMON_BASE_URL  — e.g. http://127.0.0.1:43127 (the ephemeral port is
+ *   published in <app_data_root>/daemon.conn, ADR-011)
+ *   DAEMON_TOKEN     — bearer token from daemon.conn (ADR-011)
  *   DAEMON_PID       — PID of the GUI client (for /auth/connect body)
  *
  * Optional:

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -4,7 +4,7 @@
   "version": "1.0.0-alpha.3",
   "identifier": "app.uniclipboard.desktop",
   "build": {
-    "beforeDevCommand": "bun run dev:sweep && bun run daemon:dev && bun run dev",
+    "beforeDevCommand": "bun run dev:sweep && bun run dev:sweep-port && bun run daemon:dev && bun run dev",
     "devUrl": "http://localhost:1420",
     "beforeBuildCommand": "bun run build",
     "frontendDist": "../dist"

--- a/tests/e2e/Cargo.lock
+++ b/tests/e2e/Cargo.lock
@@ -18,6 +18,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstyle"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -83,6 +92,12 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
@@ -94,6 +109,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
 ]
 
 [[package]]
@@ -142,6 +166,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-link",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -176,6 +220,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "deadpool"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -194,6 +272,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "derive_arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -201,7 +319,7 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -270,8 +388,26 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "either"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
+
+[[package]]
+name = "env_home"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
 
 [[package]]
 name = "equivalent"
@@ -407,7 +543,7 @@ checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -501,12 +637,18 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
  "tracing",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -534,6 +676,12 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
@@ -642,6 +790,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -730,6 +902,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -748,6 +926,17 @@ checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
 ]
 
 [[package]]
@@ -773,6 +962,59 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jiff"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
+dependencies = [
+ "defmt",
+ "jiff-core",
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "windows-link",
+]
+
+[[package]]
+name = "jiff-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
+dependencies = [
+ "defmt",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
+dependencies = [
+ "jiff-core",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142bd39932ad231f10513df9ab62661fead8719872150b7ad02a2df79f4e141e"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
 
 [[package]]
 name = "js-sys"
@@ -880,6 +1122,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -946,6 +1194,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "portable-atomic"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -953,6 +1216,12 @@ checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1000,7 +1269,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
 ]
 
 [[package]]
@@ -1123,7 +1416,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -1146,6 +1439,26 @@ dependencies = [
  "getrandom 0.2.17",
  "libredox",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1241,7 +1554,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1296,6 +1609,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1334,7 +1671,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1360,6 +1697,39 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee78f1fbe43ac4a0e47aadb3dbd357b69eb0d3793e948624cd03dd2750ab1c0a"
+dependencies = [
+ "base64",
+ "bs58",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.14.0",
+ "jiff",
+ "schemars 0.9.0",
+ "schemars 1.2.2",
+ "serde_core",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8705578779c2b6bd90d84d66eb2e206b708b1a4d7b9f17641b293545bf1c7e46"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1424,6 +1794,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1431,9 +1807,30 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1457,7 +1854,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1516,7 +1913,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1527,7 +1924,37 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "time"
+version = "0.3.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
+name = "time-macros"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -1580,7 +2007,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1628,7 +2055,7 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "bytes",
  "futures-util",
  "http",
@@ -1659,7 +2086,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1691,6 +2130,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "uc-daemon-contract"
+version = "1.0.0-alpha.3"
+dependencies = [
+ "chrono",
+ "semver",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "utoipa",
+]
+
+[[package]]
+name = "uc-daemon-process"
+version = "1.0.0-alpha.3"
+dependencies = [
+ "anyhow",
+ "libc",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "uc-app-paths",
+ "uc-daemon-contract",
+ "which",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "uc-e2e-tests"
 version = "0.0.0"
 dependencies = [
@@ -1707,6 +2176,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "uc-app-paths",
+ "uc-daemon-process",
  "uuid",
  "wiremock",
  "zip",
@@ -1749,6 +2219,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
+name = "utoipa"
+version = "4.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5afb1a60e207dca502682537fefcfd9921e71d0b83e9576060f09abc6efab23"
+dependencies = [
+ "indexmap 2.14.0",
+ "serde",
+ "serde_json",
+ "utoipa-gen",
+]
+
+[[package]]
+name = "utoipa-gen"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20c24e8ab68ff9ee746aad22d39b5535601e6416d1b0feeabf78be986a5c4392"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "url",
+ "uuid",
+]
+
+[[package]]
 name = "uuid"
 version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1756,6 +2252,7 @@ checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
+ "serde_core",
  "wasm-bindgen",
 ]
 
@@ -1849,7 +2346,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -1879,7 +2376,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap",
+ "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -1890,9 +2387,9 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.14.0",
  "semver",
 ]
 
@@ -1926,6 +2423,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "7.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d643ce3fd3e5b54854602a080f34fb10ab75e0b813ee32d00ca2b44fa74762"
+dependencies = [
+ "either",
+ "env_home",
+ "rustix",
+ "winsafe",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1948,16 +2457,78 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -2110,6 +2681,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
+
+[[package]]
 name = "wiremock"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2166,9 +2743,9 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap",
+ "indexmap 2.14.0",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -2184,7 +2761,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -2196,8 +2773,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
- "indexmap",
+ "bitflags 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -2216,7 +2793,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",
@@ -2261,7 +2838,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -2282,7 +2859,7 @@ checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2302,7 +2879,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -2342,7 +2919,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2356,7 +2933,7 @@ dependencies = [
  "crossbeam-utils",
  "displaydoc",
  "flate2",
- "indexmap",
+ "indexmap 2.14.0",
  "memchr",
  "thiserror 2.0.18",
  "zopfli",

--- a/tests/e2e/Cargo.toml
+++ b/tests/e2e/Cargo.toml
@@ -24,6 +24,7 @@ tempfile = "3"
 uuid = { version = "1", features = ["v4"] }
 dirs-next = "2"
 uc-app-paths = { path = "../../crates/uc-app-paths" }
+uc-daemon-process = { path = "../../crates/uc-daemon-process" }
 libc = "0.2"
 wiremock = "0.6"
 flate2 = "1"

--- a/tests/e2e/src/auth.rs
+++ b/tests/e2e/src/auth.rs
@@ -1,8 +1,9 @@
 //! Daemon HTTP auth helpers for tests that hit the API directly.
 //!
-//! The daemon writes a file token under the profile data dir; tests exchange
-//! it for a JWT session token via `POST /auth/connect` and send that as
-//! `Authorization: Session <token>` on subsequent API calls.
+//! The daemon publishes a file token inside `daemon.conn` under the profile
+//! data dir (ADR-011); tests exchange it for a JWT session token via
+//! `POST /auth/connect` and send that as `Authorization: Session <token>` on
+//! subsequent API calls.
 
 use std::time::Duration;
 
@@ -10,20 +11,24 @@ use serde_json::Value;
 
 use crate::TestDaemon;
 
-/// Read the daemon's file token from the profile data dir, polling briefly
-/// until the daemon has written it.
+/// Read the daemon's file token from `daemon.conn` in the profile data dir,
+/// polling briefly until the daemon has published it.
 pub fn read_daemon_file_token(daemon: &TestDaemon) -> String {
-    let token_path = daemon.profile.data_dir().join(".daemon-token");
+    let conn_path = daemon.profile.data_dir().join("daemon.conn");
     for _ in 0..30 {
-        if let Ok(token) = std::fs::read_to_string(&token_path) {
-            let trimmed = token.trim().to_string();
-            if !trimmed.is_empty() {
-                return trimmed;
+        if let Ok(content) = std::fs::read_to_string(&conn_path) {
+            if let Ok(conn) = serde_json::from_str::<Value>(&content) {
+                if let Some(token) = conn.get("token").and_then(|t| t.as_str()) {
+                    let trimmed = token.trim().to_string();
+                    if !trimmed.is_empty() {
+                        return trimmed;
+                    }
+                }
             }
         }
         std::thread::sleep(Duration::from_millis(200));
     }
-    panic!("daemon token not found at {:?}", token_path);
+    panic!("daemon token not found in daemon.conn at {:?}", conn_path);
 }
 
 /// Exchange the daemon file token for a JWT session token via

--- a/tests/e2e/src/daemon.rs
+++ b/tests/e2e/src/daemon.rs
@@ -5,9 +5,25 @@ use std::path::PathBuf;
 use std::process::{Child, Command};
 use std::time::Duration;
 
+use serde::Deserialize;
+use uc_daemon_process::socket::DAEMON_CONN_FORMAT;
+
 use crate::{NodeBinarySet, TestProfile};
 
-const PROFILE_HTTP_PORT_START: u16 = 42719;
+/// The `daemon.conn` payload the daemon publishes (ADR-011) — the single
+/// source of truth for the ephemeral port and bearer token.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct DaemonConn {
+    format: u32,
+    #[allow(dead_code)]
+    host: String,
+    port: u16,
+    token: String,
+    pid: u32,
+    #[allow(dead_code)]
+    started_at_ms: u64,
+}
 
 /// Manages a `uniclipd` daemon process for a single test.
 pub struct TestDaemon {
@@ -19,23 +35,6 @@ pub struct TestDaemon {
 }
 
 impl TestDaemon {
-    /// Derive the deterministic HTTP port for a profile name (mirrors
-    /// `uc-daemon-process/src/socket.rs` resolve logic).
-    fn port_for_profile(profile: &str) -> u16 {
-        let slot_count = u32::from(u16::MAX) - u32::from(PROFILE_HTTP_PORT_START) + 1;
-        let hash = Self::fnv1a(profile);
-        let offset = (hash % u64::from(slot_count)) as u16;
-        PROFILE_HTTP_PORT_START + offset
-    }
-
-    fn fnv1a(s: &str) -> u64 {
-        const OFFSET: u64 = 0xcbf29ce484222325;
-        const PRIME: u64 = 0x100000001b3;
-        s.as_bytes()
-            .iter()
-            .fold(OFFSET, |h, b| (h ^ u64::from(*b)).wrapping_mul(PRIME))
-    }
-
     /// Spawn a new daemon with the given profile. Does NOT wait for health.
     pub fn spawn(profile: TestProfile) -> std::io::Result<Self> {
         Self::spawn_with(profile, |_| {})
@@ -57,7 +56,6 @@ impl TestDaemon {
         rendezvous_base_url: Option<&str>,
         configure: impl FnOnce(&mut Command),
     ) -> std::io::Result<Self> {
-        let port = Self::port_for_profile(&profile.name);
         profile.cleanup();
         let binary = binaries.daemon.clone();
         let rendezvous_base_url = rendezvous_base_url.map(str::to_string);
@@ -68,7 +66,9 @@ impl TestDaemon {
         Ok(Self {
             child: Some(child),
             profile,
-            port,
+            // Populated by `wait_for_conn`; unknown until the daemon publishes
+            // `daemon.conn` (ADR-011 ephemeral port).
+            port: 0,
             binary,
             rendezvous_base_url,
         })
@@ -100,8 +100,8 @@ impl TestDaemon {
         Ok(command)
     }
 
-    /// Spawn and wait until the daemon reports healthy AND the `.daemon-token`
-    /// file is written (or timeout).
+    /// Spawn and wait until the daemon publishes `daemon.conn` and reports
+    /// healthy (or timeout).
     pub async fn start(profile: TestProfile) -> Result<Self, String> {
         Self::start_clean_with(profile, &NodeBinarySet::current(), None).await
     }
@@ -113,8 +113,8 @@ impl TestDaemon {
     ) -> Result<Self, String> {
         let mut daemon = Self::spawn_clean_with(profile, binaries, rendezvous_base_url, |_| {})
             .map_err(|e| format!("spawn failed: {e}"))?;
+        daemon.wait_for_conn(Duration::from_secs(30)).await?;
         daemon.wait_healthy(Duration::from_secs(30)).await?;
-        daemon.wait_for_token(Duration::from_secs(10)).await?;
         Ok(daemon)
     }
 
@@ -146,8 +146,43 @@ impl TestDaemon {
                 .spawn()
                 .map_err(|e| format!("restart spawn failed: {e}"))?,
         );
-        self.wait_healthy(Duration::from_secs(30)).await?;
-        self.wait_for_token(Duration::from_secs(10)).await
+        self.wait_for_conn(Duration::from_secs(30)).await?;
+        self.wait_healthy(Duration::from_secs(30)).await
+    }
+
+    /// Poll until the daemon has published `daemon.conn` (ADR-011) and record
+    /// its port.
+    ///
+    /// The connection file is accepted only when its recorded PID matches the
+    /// spawned child process — a leftover `daemon.conn` from a previously
+    /// killed daemon (same profile) must not be mistaken for the new daemon's
+    /// publish.
+    pub async fn wait_for_conn(&mut self, timeout: Duration) -> Result<(), String> {
+        let conn_path = self.profile.data_dir().join("daemon.conn");
+        let expected_pid = self.child.as_ref().map(|child| child.id());
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            if let Ok(content) = std::fs::read_to_string(&conn_path) {
+                if let Ok(conn) = serde_json::from_str::<DaemonConn>(&content) {
+                    let pid_matches = expected_pid.is_none_or(|pid| conn.pid == pid);
+                    if pid_matches
+                        && conn.format == DAEMON_CONN_FORMAT
+                        && !conn.token.is_empty()
+                    {
+                        self.port = conn.port;
+                        return Ok(());
+                    }
+                }
+            }
+            if tokio::time::Instant::now() >= deadline {
+                return Err(format!(
+                    "daemon.conn not published within {}s at {:?}",
+                    timeout.as_secs(),
+                    conn_path
+                ));
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
     }
 
     /// Poll the daemon's health endpoint until it responds 200, or timeout.
@@ -182,33 +217,12 @@ impl TestDaemon {
         }
     }
 
-    /// Poll until the `.daemon-token` file exists and is non-empty.
-    pub async fn wait_for_token(&self, timeout: Duration) -> Result<(), String> {
-        let token_path = self.profile.data_dir().join(".daemon-token");
-        let deadline = tokio::time::Instant::now() + timeout;
-        loop {
-            if let Ok(token) = std::fs::read_to_string(&token_path) {
-                if !token.trim().is_empty() {
-                    return Ok(());
-                }
-            }
-            if tokio::time::Instant::now() >= deadline {
-                return Err(format!(
-                    "daemon token not written within {}s at {:?}",
-                    timeout.as_secs(),
-                    token_path
-                ));
-            }
-            tokio::time::sleep(Duration::from_millis(100)).await;
-        }
-    }
-
     /// The base URL for daemon HTTP API.
     pub fn base_url(&self) -> String {
         format!("http://127.0.0.1:{}", self.port)
     }
 
-    /// The HTTP port this daemon is expected to bind.
+    /// The HTTP port this daemon is bound to (from `daemon.conn`).
     pub fn port(&self) -> u16 {
         self.port
     }

--- a/tests/e2e/tests/stop_and_restart.rs
+++ b/tests/e2e/tests/stop_and_restart.rs
@@ -15,6 +15,25 @@
 use std::time::Duration;
 
 use uc_e2e_tests::{TestCli, TestDaemon, TestProfile};
+use uc_daemon_process::socket::read_daemon_conn_file_at;
+
+fn base_url_from_connection_file(profile: &TestProfile) -> String {
+    let conn_path = profile.data_dir().join("daemon.conn");
+    let conn = read_daemon_conn_file_at(&conn_path)
+        .unwrap_or_else(|error| {
+            panic!(
+                "failed to read daemon connection file at {}: {error}",
+                conn_path.display()
+            )
+        })
+        .unwrap_or_else(|| {
+            panic!(
+                "daemon connection file was absent after start at {}",
+                conn_path.display()
+            )
+        });
+    format!("http://{}:{}", conn.host, conn.port)
+}
 
 /// Helper: start a daemon and run `init`, returning (daemon, cli).
 async fn setup_initialized_node(name: &str) -> (TestDaemon, TestCli) {
@@ -228,19 +247,31 @@ async fn stop_then_start_background() {
         "expected status='started', got '{start_status}'. full json: {start_json}"
     );
 
-    // Wait for the daemon to become healthy.
+    // A daemon chooses a new ephemeral port on every process start. Resolve
+    // its post-restart address from the current connection file instead of
+    // polling the first process's now-closed listener.
+    let restarted_health_url = format!("{}/health", base_url_from_connection_file(&daemon.profile));
+
+    // Wait for the restarted daemon to become healthy.
     let deadline = tokio::time::Instant::now() + Duration::from_secs(15);
     let mut healthy = false;
+    let mut last_health_result = None;
     while tokio::time::Instant::now() < deadline {
-        if let Ok(resp) = client.get(&health_url).send().await {
-            if resp.status().is_success() {
+        match client.get(&restarted_health_url).send().await {
+            Ok(response) if response.status().is_success() => {
                 healthy = true;
                 break;
             }
+            Ok(response) => last_health_result = Some(format!("HTTP {}", response.status())),
+            Err(error) => last_health_result = Some(error.to_string()),
         }
         tokio::time::sleep(Duration::from_millis(300)).await;
     }
-    assert!(healthy, "daemon did not become healthy after restart");
+    assert!(
+        healthy,
+        "daemon did not become healthy after restart at {restarted_health_url}; last result: {}",
+        last_health_result.unwrap_or_else(|| "no health request was made".to_string())
+    );
 
     let cleanup_out = cli.run_capture(&["--json", "stop"]);
     assert!(
@@ -253,7 +284,7 @@ async fn stop_then_start_background() {
 
     let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
     while tokio::time::Instant::now() < deadline {
-        if client.get(&health_url).send().await.is_err() {
+        if client.get(&restarted_health_url).send().await.is_err() {
             return;
         }
         tokio::time::sleep(Duration::from_millis(100)).await;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -63,7 +63,9 @@ export default defineConfig({
   //
   // 1. prevent vite from obscuring rust errors
   clearScreen: false,
-  // 2. tauri expects a fixed port, fail if that port is not available
+  // 2. tauri expects the fixed devUrl port; stale listeners from crashed dev
+  //    sessions are swept by `scripts/sweep-dev-port.mjs` (beforeDevCommand)
+  //    instead of auto-incrementing, which Tauri cannot follow.
   server: {
     port: 1420,
     strictPort: true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -86,7 +86,17 @@ export default defineConfig({
     environment: 'jsdom',
     globals: true,
     setupFiles: './src/test/setup.ts',
-    exclude: ['**/node_modules/**', '**/dist/**', '**/.worktrees/**', '**/worktrees/**'],
+    // docs-site/ 有独立的 CI job（docs-check.yml 的 test:config）与自己的
+    // 工具链（node:test + 独立 vitest 环境）；根 vitest 的默认 include 会把
+    // docs-site/test/next-config.test.mjs 卷进来，导致 "Cannot bundle Node.js
+    // built-in node:test"（根环境无法 bundle node:test）。
+    exclude: [
+      '**/node_modules/**',
+      '**/dist/**',
+      '**/.worktrees/**',
+      '**/worktrees/**',
+      '**/docs-site/**',
+    ],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'lcov'],


### PR DESCRIPTION
## Summary

- daemon 改绑 ephemeral loopback 端口（`127.0.0.1:0`），连接信息（host/port/token/pid/startedAtMs）原子发布到 `<app_data_root>/daemon.conn`（`0o600`，temp+rename）；`UC_PROFILE` hash 固定端口解析与 `.daemon-token` 文件退役（e671cd7）
- 所有本地客户端（CLI / Tauri 原生 / daemon probe / health-wait / e2e harness）改为读 `daemon.conn` + D22 PID 身份校验发现 daemon；探测循环每次重解析，端口漂移自愈（e671cd7）
- 修复实测发现的 WS URL 拼接 bug（漏 `/ws` 路径，e2e 404 根因）（e671cd7）
- dev 会话残留 vite 进程占用 1420 端口的问题：新增 `scripts/sweep-dev-port.mjs`，`tauri dev` 启动前清扫（c2d86a0）

Related to #1538. 相关用户报告 #1537（win11 daemon 启动超时）疑似本方案触发的端口占用症状，P2 落地后应回归验证。

## Test plan

- [x] `cargo check --workspace` 零警告；`cargo test --workspace` 45 套件全绿
- [x] e2e 全量（`e2e-rendezvous` + `dev-tools` 构建）：仅 `refresh_connects_third_device_after_cli_exits` 失败——stash 对照实验确认基线同样失败，是套件并行负载下的固有 flaky，非本 PR 回归
- [x] 手动冒烟：`uniclip init/status/stop` 全通；conn 文件启动写入、优雅退出删除
- [ ] 桌面 GUI 实机验证：冷启动 attach / 重启重连 / 轻量模式路径（daemon_probe 改造未在 Tauri 进程内实测）
- [ ] Windows 平台验证（`netstat`+`taskkill` 清扫路径与 named-pipe 无涉，但 e2e 未在 Windows 跑过）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Daemons now use dynamically assigned local ports and securely publish connection details through a connection file.
  * Added a development command to detect and stop stale development-port processes.
* **Bug Fixes**
  * Improved daemon discovery, health checks, and authentication by validating current connection details and process identity.
  * Refreshed connection information after daemon startup or promotion.
* **Documentation**
  * Updated setup, troubleshooting, security, and testing guidance.
* **Tests**
  * Updated end-to-end and integration coverage for dynamic ports and connection-file handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
