### PR TITLE
fix(devices): advance invitation flows after pairing

### DIFF
--- a/src/components/device/AddDeviceDialog.tsx
+++ b/src/components/device/AddDeviceDialog.tsx
@@ -11,18 +11,15 @@ import {
 } from 'lucide-react'
 import { useEffect, useEffectEvent, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { getPairedPeers } from '@/api/daemon/members'
+import { getDeviceTrust } from '@/api/daemon/device-trust'
 import {
   cancelInvitation,
   getSetupState,
   issuePairingInvitation,
   type CurrentInvitation,
 } from '@/api/daemon/setupV2'
-import {
-  onSetupInvitationRevoked,
-  onSetupPairingCompleted,
-  type SetupInvitationRevokedEvent,
-} from '@/api/setupEvents'
+import type { SetupInvitationRevokedEvent } from '@/api/setupEvents'
+import { activeDeviceIds, findNewActiveDeviceId } from '@/components/device/pairing-success-utils'
 import { formatInvitationCode } from '@/components/invitation-code-utils'
 import { Button } from '@/components/ui/button'
 import {
@@ -34,6 +31,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import { Progress } from '@/components/ui/progress'
+import { daemonWs } from '@/lib/daemon-ws'
 import { createLogger } from '@/lib/logger'
 import { cn } from '@/lib/utils'
 
@@ -68,7 +66,7 @@ function AddDeviceDialogInner({ open, onOpenChange }: AddDeviceDialogProps) {
   const [copied, setCopied] = useState(false)
   const [step, setStep] = useState<Step>('invitation')
   const [failureReason, setFailureReason] = useState<string | null>(null)
-  const initialMemberCountRef = useRef<number | null>(null)
+  const initialDeviceIdsRef = useRef<ReadonlySet<string> | null>(null)
 
   // 倒计时 tick — 仅在邀请态 + 有邀请时启动
   useEffect(() => {
@@ -95,7 +93,7 @@ function AddDeviceDialogInner({ open, onOpenChange }: AddDeviceDialogProps) {
       setLoading(true)
       setError(null)
       try {
-        initialMemberCountRef.current = (await getPairedPeers()).length
+        initialDeviceIdsRef.current = activeDeviceIds(await getDeviceTrust())
         const state = await getSetupState()
         if (cancelled) return
         if (state.currentInvitation) {
@@ -120,8 +118,20 @@ function AddDeviceDialogInner({ open, onOpenChange }: AddDeviceDialogProps) {
     }
   }, [open])
 
-  const handlePairingCompleted = useEffectEvent((success: boolean) => {
-    if (step === 'invitation' && success) setStep('success')
+  const confirmPairingCompleted = useEffectEvent(async () => {
+    if (step !== 'invitation' || initialDeviceIdsRef.current === null) return
+    try {
+      const [state, trust] = await Promise.all([getSetupState(), getDeviceTrust()])
+      const peerDeviceId = findNewActiveDeviceId(
+        initialDeviceIdsRef.current,
+        activeDeviceIds(trust)
+      )
+      if (state.currentInvitation === null && peerDeviceId !== null) {
+        setStep('success')
+      }
+    } catch (err) {
+      log.warn({ err }, 'failed to verify completed invitation')
+    }
   })
 
   const handleInvitationRevoked = useEffectEvent((evt: SetupInvitationRevokedEvent) => {
@@ -132,34 +142,18 @@ function AddDeviceDialogInner({ open, onOpenChange }: AddDeviceDialogProps) {
 
   useEffect(() => {
     if (!open) return
-    let mounted = true
-    const unsubs: Array<() => void> = []
-
-    void onSetupInvitationRevoked(evt => {
-      if (!mounted) return
-      handleInvitationRevoked(evt)
-    }).then(
-      fn => {
-        if (mounted) unsubs.push(fn)
-        else fn()
-      },
-      err => log.warn({ err }, 'subscribe invitationRevoked failed')
-    )
-
-    void onSetupPairingCompleted(evt => {
-      if (!mounted) return
-      handlePairingCompleted(evt.success)
-    }).then(
-      fn => {
-        if (mounted) unsubs.push(fn)
-        else fn()
-      },
-      err => log.warn({ err }, 'subscribe pairingCompleted failed')
-    )
+    const unsubscribeEvents = daemonWs.subscribe(['device-trust', 'setup'], event => {
+      if (event.eventType === 'device-trust.changed') {
+        void confirmPairingCompleted()
+      } else if (event.eventType === 'setup.invitationRevoked') {
+        handleInvitationRevoked(event.payload as SetupInvitationRevokedEvent)
+      }
+    })
+    const unsubscribeReconnect = daemonWs.onReconnect(() => void confirmPairingCompleted())
 
     return () => {
-      mounted = false
-      unsubs.forEach(fn => fn())
+      unsubscribeEvents()
+      unsubscribeReconnect()
     }
   }, [open])
 
@@ -210,7 +204,7 @@ function AddDeviceDialogInner({ open, onOpenChange }: AddDeviceDialogProps) {
     setStep('invitation')
     setFailureReason(null)
     try {
-      initialMemberCountRef.current = (await getPairedPeers()).length
+      initialDeviceIdsRef.current = activeDeviceIds(await getDeviceTrust())
       try {
         await cancelInvitation()
       } catch (err) {

--- a/src/components/device/__tests__/AddDeviceDialog.test.tsx
+++ b/src/components/device/__tests__/AddDeviceDialog.test.tsx
@@ -15,8 +15,9 @@ import i18n from '@/i18n'
 
 const getSetupState = vi.fn()
 const issuePairingInvitation = vi.fn()
-const getPairedPeers = vi.fn()
-let pairingCompletedHandler: ((event: { success: boolean }) => void) | undefined
+const getDeviceTrust = vi.fn()
+let deviceTrustHandler: (() => void) | undefined
+let reconnectHandler: (() => void) | undefined
 
 vi.mock('@/api/daemon/setupV2', () => ({
   getSetupState: () => getSetupState(),
@@ -24,16 +25,21 @@ vi.mock('@/api/daemon/setupV2', () => ({
   cancelInvitation: vi.fn(() => Promise.resolve()),
 }))
 
-vi.mock('@/api/daemon/members', () => ({
-  getPairedPeers: () => getPairedPeers(),
+vi.mock('@/api/daemon/device-trust', () => ({
+  getDeviceTrust: () => getDeviceTrust(),
 }))
 
-vi.mock('@/api/setupEvents', () => ({
-  onSetupInvitationRevoked: vi.fn(() => Promise.resolve(() => undefined)),
-  onSetupPairingCompleted: vi.fn(callback => {
-    pairingCompletedHandler = callback
-    return Promise.resolve(() => undefined)
-  }),
+vi.mock('@/lib/daemon-ws', () => ({
+  daemonWs: {
+    subscribe: vi.fn((_topics, callback) => {
+      deviceTrustHandler = () => callback({ eventType: 'device-trust.changed' })
+      return () => undefined
+    }),
+    onReconnect: vi.fn(callback => {
+      reconnectHandler = callback
+      return () => undefined
+    }),
+  },
 }))
 
 vi.mock('@/store/hooks', () => ({
@@ -60,13 +66,17 @@ describe('AddDeviceDialog invitation issuing', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
-    pairingCompletedHandler = undefined
+    deviceTrustHandler = undefined
+    reconnectHandler = undefined
     getSetupState.mockResolvedValue({
       hasCompleted: true,
       currentInvitation: null,
       deviceName: 'test',
     })
-    getPairedPeers.mockResolvedValue([])
+    getDeviceTrust.mockResolvedValue({
+      localDeviceId: 'local',
+      devices: [{ deviceId: 'local', membership: 'active' }],
+    })
     issuePairingInvitation.mockResolvedValue({
       code: '123456789',
       expiresAtMs: Date.now() + 300_000,
@@ -100,8 +110,8 @@ describe('AddDeviceDialog invitation issuing', () => {
     expect(issuePairingInvitation).toHaveBeenCalledTimes(1)
   })
 
-  it('does not issue an invitation without a member-count baseline', async () => {
-    getPairedPeers.mockRejectedValue(new Error('member list unavailable'))
+  it('does not issue an invitation without a device-trust baseline', async () => {
+    getDeviceTrust.mockRejectedValue(new Error('device trust unavailable'))
 
     render(
       <I18nextProvider i18n={i18n}>
@@ -115,8 +125,25 @@ describe('AddDeviceDialog invitation issuing', () => {
     expect(issuePairingInvitation).not.toHaveBeenCalled()
   })
 
-  it('replaces the invitation with success when pairing completes', async () => {
-    getPairedPeers.mockResolvedValueOnce([]).mockResolvedValueOnce([{}])
+  it('replaces the invitation with success after a new member is confirmed', async () => {
+    getDeviceTrust
+      .mockResolvedValueOnce({
+        localDeviceId: 'local',
+        devices: [
+          { deviceId: 'local', membership: 'active' },
+          { deviceId: 'old', membership: 'active' },
+        ],
+      })
+      .mockResolvedValueOnce({
+        localDeviceId: 'local',
+        devices: [
+          { deviceId: 'local', membership: 'active' },
+          { deviceId: 'new', membership: 'active' },
+        ],
+      })
+    getSetupState
+      .mockResolvedValueOnce({ hasCompleted: true, currentInvitation: null, deviceName: 'test' })
+      .mockResolvedValueOnce({ hasCompleted: true, currentInvitation: null, deviceName: 'test' })
     render(
       <I18nextProvider i18n={i18n}>
         <AddDeviceDialog open onOpenChange={() => undefined} />
@@ -125,11 +152,11 @@ describe('AddDeviceDialog invitation issuing', () => {
 
     await waitFor(() => {
       expect(screen.getByLabelText('123456789')).toBeInTheDocument()
-      expect(pairingCompletedHandler).toBeTypeOf('function')
+      expect(deviceTrustHandler).toBeTypeOf('function')
     })
 
     act(() => {
-      pairingCompletedHandler?.({ success: true })
+      deviceTrustHandler?.()
     })
 
     await waitFor(() => {
@@ -140,7 +167,18 @@ describe('AddDeviceDialog invitation issuing', () => {
 
   it('keeps the success state visible briefly, then closes automatically', async () => {
     const onOpenChange = vi.fn()
-    getPairedPeers.mockResolvedValueOnce([]).mockResolvedValueOnce([{}])
+    getDeviceTrust
+      .mockResolvedValueOnce({
+        localDeviceId: 'local',
+        devices: [{ deviceId: 'local', membership: 'active' }],
+      })
+      .mockResolvedValueOnce({
+        localDeviceId: 'local',
+        devices: [
+          { deviceId: 'local', membership: 'active' },
+          { deviceId: 'peer', membership: 'active' },
+        ],
+      })
 
     render(
       <I18nextProvider i18n={i18n}>
@@ -150,12 +188,12 @@ describe('AddDeviceDialog invitation issuing', () => {
 
     await waitFor(() => {
       expect(screen.getByLabelText('123456789')).toBeInTheDocument()
-      expect(pairingCompletedHandler).toBeTypeOf('function')
+      expect(deviceTrustHandler).toBeTypeOf('function')
     })
 
     vi.useFakeTimers()
     act(() => {
-      pairingCompletedHandler?.({ success: true })
+      deviceTrustHandler?.()
     })
 
     await act(async () => {
@@ -174,5 +212,67 @@ describe('AddDeviceDialog invitation issuing', () => {
     })
     expect(onOpenChange).toHaveBeenCalledOnce()
     expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+
+  it('does not show success while the invitation is still active', async () => {
+    getDeviceTrust
+      .mockResolvedValueOnce({
+        localDeviceId: 'local',
+        devices: [{ deviceId: 'local', membership: 'active' }],
+      })
+      .mockResolvedValueOnce({
+        localDeviceId: 'local',
+        devices: [
+          { deviceId: 'local', membership: 'active' },
+          { deviceId: 'peer', membership: 'active' },
+        ],
+      })
+    getSetupState
+      .mockResolvedValueOnce({ hasCompleted: true, currentInvitation: null, deviceName: 'test' })
+      .mockResolvedValueOnce({
+        hasCompleted: true,
+        currentInvitation: { code: '123456789', expiresAtMs: Date.now() + 300_000 },
+        deviceName: 'test',
+      })
+
+    render(
+      <I18nextProvider i18n={i18n}>
+        <AddDeviceDialog open onOpenChange={() => undefined} />
+      </I18nextProvider>
+    )
+
+    await waitFor(() => expect(deviceTrustHandler).toBeTypeOf('function'))
+    act(() => deviceTrustHandler?.())
+
+    await waitFor(() => expect(getDeviceTrust).toHaveBeenCalledTimes(2))
+    expect(screen.getByLabelText('123456789')).toBeInTheDocument()
+  })
+
+  it('rechecks the completed invitation after reconnecting', async () => {
+    getDeviceTrust
+      .mockResolvedValueOnce({
+        localDeviceId: 'local',
+        devices: [{ deviceId: 'local', membership: 'active' }],
+      })
+      .mockResolvedValueOnce({
+        localDeviceId: 'local',
+        devices: [
+          { deviceId: 'local', membership: 'active' },
+          { deviceId: 'peer', membership: 'active' },
+        ],
+      })
+
+    render(
+      <I18nextProvider i18n={i18n}>
+        <AddDeviceDialog open onOpenChange={() => undefined} />
+      </I18nextProvider>
+    )
+
+    await waitFor(() => expect(reconnectHandler).toBeTypeOf('function'))
+    act(() => reconnectHandler?.())
+
+    await waitFor(() => {
+      expect(screen.getAllByText(i18n.t('devices.addDevice.success.title'))).not.toHaveLength(0)
+    })
   })
 })

--- a/src/components/device/__tests__/pairing-success-utils.test.ts
+++ b/src/components/device/__tests__/pairing-success-utils.test.ts
@@ -1,12 +1,24 @@
 import { describe, expect, it } from 'vitest'
-import { hasNewPairedMember } from '@/components/device/pairing-success-utils'
+import { activeDeviceIds, findNewActiveDeviceId } from '@/components/device/pairing-success-utils'
 
-describe('hasNewPairedMember', () => {
-  it('recognizes a newly admitted device after workspace convergence changes', () => {
-    expect(hasNewPairedMember(2, 3)).toBe(true)
+describe('pairing success helpers', () => {
+  it('finds a newly active device by id', () => {
+    expect(findNewActiveDeviceId(new Set(['local', 'old']), new Set(['local', 'new']))).toBe('new')
   })
 
-  it('does not treat ordinary convergence without a new member as pairing success', () => {
-    expect(hasNewPairedMember(2, 2)).toBe(false)
+  it('does not treat an unchanged active device set as pairing success', () => {
+    expect(findNewActiveDeviceId(new Set(['local', 'old']), new Set(['local', 'old']))).toBeNull()
+  })
+
+  it('ignores removed devices when building the active device baseline', () => {
+    expect(
+      activeDeviceIds({
+        devices: [
+          { deviceId: 'local', membership: 'active' },
+          { deviceId: 'peer', membership: 'active' },
+          { deviceId: 'removed', membership: 'removed' },
+        ],
+      })
+    ).toEqual(new Set(['local', 'peer']))
   })
 })

--- a/src/components/device/pairing-success-utils.ts
+++ b/src/components/device/pairing-success-utils.ts
@@ -1,3 +1,21 @@
-export function hasNewPairedMember(previousCount: number, currentCount: number): boolean {
-  return currentCount > previousCount
+import type { DeviceTrustRelationship } from '@/api/daemon/device-trust'
+
+export function activeDeviceIds(snapshot: {
+  devices: ReadonlyArray<Pick<DeviceTrustRelationship, 'deviceId' | 'membership'>>
+}): ReadonlySet<string> {
+  const deviceIds = new Set<string>()
+  for (const device of snapshot.devices) {
+    if (device.membership === 'active') deviceIds.add(device.deviceId)
+  }
+  return deviceIds
+}
+
+export function findNewActiveDeviceId(
+  previousDeviceIds: ReadonlySet<string>,
+  currentDeviceIds: ReadonlySet<string>
+): string | null {
+  for (const deviceId of currentDeviceIds) {
+    if (!previousDeviceIds.has(deviceId)) return deviceId
+  }
+  return null
 }

--- a/src/hooks/__tests__/useSetupFlow.test.tsx
+++ b/src/hooks/__tests__/useSetupFlow.test.tsx
@@ -1,0 +1,153 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useSetupFlow } from '@/hooks/useSetupFlow'
+import type { SetupFlow } from '@/store/setupRealtimeStore'
+
+const getDeviceTrust = vi.hoisted(() => vi.fn())
+const getSetupState = vi.hoisted(() => vi.fn())
+const issuePairingInvitation = vi.hoisted(() => vi.fn())
+const applyIssuedInvitation = vi.hoisted(() => vi.fn())
+const applyServerSetupState = vi.hoisted(() => vi.fn())
+const subscribe = vi.hoisted(() => vi.fn())
+const onReconnect = vi.hoisted(() => vi.fn())
+
+let deviceTrustHandler: ((event: { eventType: string }) => void) | undefined
+let reconnectHandler: (() => void) | undefined
+let flow: SetupFlow = {
+  kind: 'completed' as const,
+  deviceName: 'MacBook',
+  completion: { kind: 'space_ready' as const },
+}
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+vi.mock('sonner', () => ({ toast: { error: vi.fn() } }))
+
+vi.mock('@/api/daemon/device-trust', () => ({
+  getDeviceTrust: () => getDeviceTrust(),
+}))
+
+vi.mock('@/api/daemon/setupV2', () => ({
+  cancelInvitation: vi.fn(),
+  getSetupState: () => getSetupState(),
+  initializeSpace: vi.fn(),
+  issuePairingInvitation: () => issuePairingInvitation(),
+  redeemInvitation: vi.fn(),
+  resetSetup: vi.fn(),
+  SetupV2Error: class SetupV2Error extends Error {},
+}))
+
+vi.mock('@/lib/daemon-ws', () => ({
+  daemonWs: {
+    subscribe: (...args: unknown[]) => subscribe(...args),
+    onReconnect: (...args: unknown[]) => onReconnect(...args),
+  },
+}))
+
+vi.mock('@/lib/wdio-test-bridge', () => ({ recordWdioE2eEvent: vi.fn() }))
+
+vi.mock('@/store/setupRealtimeStore', () => ({
+  acknowledgeSetupCompletion: vi.fn(),
+  applyIssuedInvitation: (...args: unknown[]) => applyIssuedInvitation(...args),
+  applyServerSetupState: (...args: unknown[]) => applyServerSetupState(...args),
+  refreshSetupState: vi.fn(),
+  useSetupRealtimeStore: () => ({ flow, hydrated: true }),
+}))
+
+describe('useSetupFlow sponsor pairing completion', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    deviceTrustHandler = undefined
+    reconnectHandler = undefined
+    flow = {
+      kind: 'completed',
+      deviceName: 'MacBook',
+      completion: { kind: 'space_ready' },
+    }
+    subscribe.mockImplementation((_topics, callback) => {
+      deviceTrustHandler = callback
+      return () => undefined
+    })
+    onReconnect.mockImplementation(callback => {
+      reconnectHandler = callback
+      return () => undefined
+    })
+    getDeviceTrust.mockResolvedValue({
+      localDeviceId: 'local',
+      devices: [{ deviceId: 'local', membership: 'active' }],
+    })
+    getSetupState.mockResolvedValue({
+      hasCompleted: true,
+      currentInvitation: null,
+      deviceName: 'MacBook',
+    })
+    issuePairingInvitation.mockResolvedValue({ code: '123456789', expiresAtMs: 123_456 })
+  })
+
+  it('moves the sponsor to pairing complete after the issued invitation admits a device', async () => {
+    const { result, rerender } = renderHook(() => useSetupFlow())
+
+    await act(async () => {
+      await result.current.issueInvitation()
+    })
+
+    flow = {
+      kind: 'invitation_pending',
+      code: '123456789',
+      expiresAtMs: 123_456,
+      deviceName: 'MacBook',
+      completion: { kind: 'space_ready' },
+    }
+    rerender()
+    getDeviceTrust.mockResolvedValue({
+      localDeviceId: 'local',
+      devices: [
+        { deviceId: 'local', membership: 'active' },
+        { deviceId: 'peer', membership: 'active' },
+      ],
+    })
+
+    await waitFor(() => expect(deviceTrustHandler).toBeTypeOf('function'))
+    act(() => deviceTrustHandler?.({ eventType: 'device-trust.changed' }))
+
+    await waitFor(() => {
+      expect(applyServerSetupState).toHaveBeenCalledWith(
+        expect.objectContaining({ currentInvitation: null }),
+        {
+          kind: 'pairing_succeeded',
+          role: 'sponsor',
+          sponsorDeviceId: 'local',
+          peerDeviceId: 'peer',
+        }
+      )
+    })
+  })
+
+  it('rechecks sponsor completion after a WebSocket reconnect', async () => {
+    const { result, rerender } = renderHook(() => useSetupFlow())
+    await act(async () => result.current.issueInvitation())
+
+    flow = {
+      kind: 'invitation_pending',
+      code: '123456789',
+      expiresAtMs: 123_456,
+      deviceName: 'MacBook',
+      completion: { kind: 'space_ready' },
+    }
+    rerender()
+    getDeviceTrust.mockResolvedValue({
+      localDeviceId: 'local',
+      devices: [
+        { deviceId: 'local', membership: 'active' },
+        { deviceId: 'peer', membership: 'active' },
+      ],
+    })
+
+    await waitFor(() => expect(reconnectHandler).toBeTypeOf('function'))
+    act(() => reconnectHandler?.())
+
+    await waitFor(() => expect(applyServerSetupState).toHaveBeenCalledTimes(1))
+  })
+})

--- a/src/hooks/useSetupFlow.ts
+++ b/src/hooks/useSetupFlow.ts
@@ -1,6 +1,7 @@
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useEffectEvent, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
+import { getDeviceTrust } from '@/api/daemon/device-trust'
 import {
   cancelInvitation,
   getSetupState,
@@ -14,6 +15,8 @@ import {
   type InitializeSpaceErrorKind,
   type RedeemResponse,
 } from '@/api/daemon/setupV2'
+import { activeDeviceIds, findNewActiveDeviceId } from '@/components/device/pairing-success-utils'
+import { daemonWs } from '@/lib/daemon-ws'
 import { createLogger } from '@/lib/logger'
 import { recordWdioE2eEvent } from '@/lib/wdio-test-bridge'
 import {
@@ -93,6 +96,7 @@ export function useSetupFlow(): UseSetupFlowReturn {
   const { t } = useTranslation(undefined, { keyPrefix: 'setup.page' })
   const [pageScreen, setPageScreen] = useState<SetupScreen | null>(null)
   const [loading, setLoading] = useState(false)
+  const invitationDeviceIdsRef = useRef<ReadonlySet<string> | null>(null)
 
   const screen: SetupScreen = (() => {
     if (flow.kind === 'loading') return { kind: 'loading' }
@@ -121,6 +125,38 @@ export function useSetupFlow(): UseSetupFlowReturn {
   const startCreateSpace = useCallback(() => setPageScreen({ kind: 'initialize_space' }), [])
   const startJoinSpace = useCallback(() => setPageScreen({ kind: 'redeem_invitation' }), [])
   const startImportConfig = useCallback(() => setPageScreen({ kind: 'import_config' }), [])
+
+  const confirmSponsorPairing = useEffectEvent(async () => {
+    if (flow.kind !== 'invitation_pending' || invitationDeviceIdsRef.current === null) return
+    try {
+      const [state, trust] = await Promise.all([getSetupState(), getDeviceTrust()])
+      const peerDeviceId = findNewActiveDeviceId(
+        invitationDeviceIdsRef.current,
+        activeDeviceIds(trust)
+      )
+      if (state.currentInvitation !== null || peerDeviceId === null) return
+      applyServerSetupState(state, {
+        kind: 'pairing_succeeded',
+        role: 'sponsor',
+        sponsorDeviceId: trust.localDeviceId,
+        peerDeviceId,
+      })
+    } catch (err) {
+      log.warn({ err }, 'failed to verify completed sponsor invitation')
+    }
+  })
+
+  useEffect(() => {
+    if (flow.kind !== 'invitation_pending') return
+    const unsubscribeDeviceTrust = daemonWs.subscribe(['device-trust'], event => {
+      if (event.eventType === 'device-trust.changed') void confirmSponsorPairing()
+    })
+    const unsubscribeReconnect = daemonWs.onReconnect(() => void confirmSponsorPairing())
+    return () => {
+      unsubscribeDeviceTrust()
+      unsubscribeReconnect()
+    }
+  }, [flow.kind])
 
   const handleInitialize = useCallback(
     async (input: { passphrase: string; passphraseConfirm: string; deviceName: string }) => {
@@ -159,6 +195,7 @@ export function useSetupFlow(): UseSetupFlowReturn {
     setLoading(true)
     recordWdioE2eEvent('setup.issue.started')
     try {
+      invitationDeviceIdsRef.current = activeDeviceIds(await getDeviceTrust())
       const out = await issuePairingInvitation()
       recordWdioE2eEvent('setup.issue.returned')
       // The response is already authoritative. The matching WebSocket event


### PR DESCRIPTION
## Summary

- Replace the removed pairing-completed notification with authoritative invitation and device-trust state verification in both sponsor UI flows (`07a22908e`).
- Detect newly admitted devices by device ID and recheck after WebSocket reconnection so missed events do not leave the UI stuck (`07a22908e`).
- Add regression coverage for onboarding, the Devices invite dialog, unchanged device counts, active invitation guards, and reconnect recovery (`07a22908e`).

## Test plan

- [x] Manual pairing verification confirmed the invitation flow advances after a device joins.
- [x] `bun run test --run` (144 files, 968 tests)
- [x] `bun run build`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `npx react-doctor@latest --verbose --scope changed`

## Documentation and observability

- User documentation remains accurate; no docs-site changes are required.
- No Rust, use-case analytics, or tracing surface is changed by this frontend fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device pairing completion detection by tracking trusted devices directly.
  * Pairing status is now rechecked after connection recovery, reducing missed completions.
  * Invitation revocation and regeneration flows continue to work correctly.
  * Setup flows now handle device-trust lookup or verification errors without interruption.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->