### PR TITLE
fix(clipboard): handle unavailable text previews

### DIFF
--- a/src/components/clipboard/ClipboardPreview.tsx
+++ b/src/components/clipboard/ClipboardPreview.tsx
@@ -49,6 +49,15 @@ const PreviewContent: React.FC<PreviewContentProps> = ({
   const textItem = item.content as ClipboardTextItem | null
   const hasCodeTag = item.contentTags?.includes('code') ?? false
   const hasLinkTag = item.contentTags?.includes('link') ?? false
+  if ((item.type === 'text' || item.type === 'richtext') && !textItem) {
+    return (
+      <div className="p-8 text-center font-medium italic text-muted-foreground opacity-40">
+        {t(
+          item.isUnavailable ? 'clipboard.errors.unavailableBadge' : 'clipboard.item.unknownContent'
+        )}
+      </div>
+    )
+  }
   switch (item.type) {
     case 'text': {
       if (hasCodeTag && textItem) {
@@ -150,6 +159,7 @@ const ClipboardPreview: React.FC<ClipboardPreviewProps> = ({ item, actions }) =>
 
   const isLargeText =
     (item.type === 'text' || item.type === 'richtext') &&
+    item.content !== null &&
     isLargeTextPreview(item.content as ClipboardTextItem, preview, loading)
   // Code renders as an editor-like pane that fills the available height and owns
   // its own scrolling, so it skips the auto-height ScrollArea wrapper.

--- a/src/components/clipboard/__tests__/ClipboardPreview.test.tsx
+++ b/src/components/clipboard/__tests__/ClipboardPreview.test.tsx
@@ -237,4 +237,20 @@ describe('ClipboardPreview', () => {
     expect(link).not.toHaveClass('rounded-xl', 'border', 'bg-muted/10', 'p-4')
     expect(screen.queryByText('example.com')).not.toBeInTheDocument()
   })
+
+  it('renders an unavailable message when a text result has no content', () => {
+    render(
+      <ClipboardPreview
+        item={{
+          id: 'lost-text-entry',
+          type: 'text',
+          activeTime: 1710000000000,
+          content: null,
+          isUnavailable: true,
+        }}
+      />
+    )
+
+    expect(screen.getByText('Content unavailable')).toBeInTheDocument()
+  })
 })

--- a/src/components/clipboard/__tests__/useClipboardPreviewState.test.tsx
+++ b/src/components/clipboard/__tests__/useClipboardPreviewState.test.tsx
@@ -70,4 +70,20 @@ describe('useClipboardPreviewState', () => {
     expect(result.current.preview).toBeNull()
     expect(cacheGetMock).not.toHaveBeenCalled()
   })
+
+  it('stays idle when a selected text item has no content', () => {
+    const item: DisplayClipboardItem = {
+      id: 'lost-text-entry',
+      type: 'text',
+      activeTime: Date.now(),
+      content: null,
+      isUnavailable: true,
+    }
+
+    const { result } = renderHook(() => useClipboardPreviewState(item))
+
+    expect(result.current.loading).toBe(false)
+    expect(result.current.preview).toBeNull()
+    expect(cacheGetMock).not.toHaveBeenCalled()
+  })
 })

--- a/src/hooks/useClipboardPreviewState.ts
+++ b/src/hooks/useClipboardPreviewState.ts
@@ -44,12 +44,14 @@ export function useClipboardPreviewState(item: DisplayClipboardItem | null): Cli
 
     if (!item) return
 
+    const textItem =
+      item.type === 'text' || item.type === 'richtext'
+        ? (item.content as ClipboardTextItem | null)
+        : null
     const shouldLoadPreview =
       item.type === 'image' ||
       item.type === 'file' ||
-      item.contentTags?.includes('code') === true ||
-      ((item.type === 'text' || item.type === 'richtext') &&
-        (item.content as ClipboardTextItem).has_detail)
+      (textItem !== null && (item.contentTags?.includes('code') === true || textItem.has_detail))
 
     if (!shouldLoadPreview) return
 


### PR DESCRIPTION
## Summary

- Prevent unavailable text search results from crashing the clipboard preview and show the existing unavailable-content state (`55081f848`).
- Skip detail loading when a text result has no content, while preserving image and file preview behavior (`55081f848`).
- Add focused regression coverage for rendering and preview loading (`55081f848`).

Docs are unchanged because this fixes an existing unavailable-content state without changing the user-facing contract. The diff does not touch telemetry or tracing surfaces.

## Test plan

- [x] `npx vitest run --maxWorkers=1 src/components/clipboard/__tests__/ClipboardPreview.test.tsx src/components/clipboard/__tests__/ClipboardPreviewInfo.test.tsx src/components/clipboard/__tests__/useClipboardPreviewState.test.tsx src/lib/__tests__/clipboard-transform.test.ts src/lib/__tests__/clipboard-utils.test.ts` (40 tests)
- [x] `bun run build`
- [x] `npx react-doctor@latest --verbose --diff` (no issues found)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved clipboard previews for unavailable or missing text content.
  * Displays a clear “Content unavailable” message instead of attempting to render invalid content.
  * Prevents unnecessary preview loading when unavailable text entries have no content.
  * Preserves existing preview behavior for images, files, and code content.

* **Tests**
  * Added coverage for unavailable clipboard content and preview loading behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->