### PR TITLE
fix(engine): adopt stale removed device repair

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -331,7 +331,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -342,7 +342,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2278,7 +2278,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2672,7 +2672,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3159,8 +3159,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
 ]
 
 [[package]]
@@ -3291,7 +3291,7 @@ dependencies = [
  "gobject-sys 0.21.5",
  "libc",
  "system-deps 7.0.8",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3989,7 +3989,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -4007,7 +4007,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.59.0",
 ]
 
 [[package]]
@@ -5502,7 +5502,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.19",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5860,7 +5860,7 @@ dependencies = [
  "pin-project-lite",
  "rustc-hash",
  "rustls",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "thiserror 2.0.19",
  "tokio",
  "tokio-stream",
@@ -5905,7 +5905,7 @@ checksum = "b3c1520eacd33fd6b009e2e70116b05508ade51db5e0d315ff8bf6b702148c2b"
 dependencies = [
  "cfg_aliases",
  "libc",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -5939,7 +5939,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6075,7 +6075,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 2.0.2",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -7418,7 +7418,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "thiserror 2.0.19",
  "tokio",
  "tracing",
@@ -7457,9 +7457,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7776,7 +7776,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "rustix 1.1.4",
- "windows 0.62.2",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -8100,7 +8100,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8159,7 +8159,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8358,7 +8358,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8906,7 +8906,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9895,7 +9895,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10440,7 +10440,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.19",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10489,7 +10489,7 @@ dependencies = [
 [[package]]
 name = "uc-application"
 version = "1.1.0-rc.2"
-source = "git+https://github.com/UniClipboard/Engine.git?rev=49976d5ea21c5d448d9ef5df2c581b77abeb52cf#49976d5ea21c5d448d9ef5df2c581b77abeb52cf"
+source = "git+https://github.com/UniClipboard/Engine.git?rev=aa88c6bcffdc7033f52730d70d46fd3a41868071#aa88c6bcffdc7033f52730d70d46fd3a41868071"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10584,7 +10584,7 @@ dependencies = [
 [[package]]
 name = "uc-content-hash"
 version = "1.1.0-rc.2"
-source = "git+https://github.com/UniClipboard/Engine.git?rev=49976d5ea21c5d448d9ef5df2c581b77abeb52cf#49976d5ea21c5d448d9ef5df2c581b77abeb52cf"
+source = "git+https://github.com/UniClipboard/Engine.git?rev=aa88c6bcffdc7033f52730d70d46fd3a41868071#aa88c6bcffdc7033f52730d70d46fd3a41868071"
 dependencies = [
  "blake3",
  "hex",
@@ -10593,7 +10593,7 @@ dependencies = [
 [[package]]
 name = "uc-core"
 version = "1.1.0-rc.2"
-source = "git+https://github.com/UniClipboard/Engine.git?rev=49976d5ea21c5d448d9ef5df2c581b77abeb52cf#49976d5ea21c5d448d9ef5df2c581b77abeb52cf"
+source = "git+https://github.com/UniClipboard/Engine.git?rev=aa88c6bcffdc7033f52730d70d46fd3a41868071#aa88c6bcffdc7033f52730d70d46fd3a41868071"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -10744,7 +10744,7 @@ dependencies = [
 [[package]]
 name = "uc-engine"
 version = "1.1.0-rc.2"
-source = "git+https://github.com/UniClipboard/Engine.git?rev=49976d5ea21c5d448d9ef5df2c581b77abeb52cf#49976d5ea21c5d448d9ef5df2c581b77abeb52cf"
+source = "git+https://github.com/UniClipboard/Engine.git?rev=aa88c6bcffdc7033f52730d70d46fd3a41868071#aa88c6bcffdc7033f52730d70d46fd3a41868071"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10768,7 +10768,7 @@ dependencies = [
 [[package]]
 name = "uc-infra"
 version = "1.1.0-rc.2"
-source = "git+https://github.com/UniClipboard/Engine.git?rev=49976d5ea21c5d448d9ef5df2c581b77abeb52cf#49976d5ea21c5d448d9ef5df2c581b77abeb52cf"
+source = "git+https://github.com/UniClipboard/Engine.git?rev=aa88c6bcffdc7033f52730d70d46fd3a41868071#aa88c6bcffdc7033f52730d70d46fd3a41868071"
 dependencies = [
  "anyhow",
  "argon2",
@@ -10830,7 +10830,7 @@ dependencies = [
 [[package]]
 name = "uc-mobile-lan"
 version = "1.1.0-rc.2"
-source = "git+https://github.com/UniClipboard/Engine.git?rev=49976d5ea21c5d448d9ef5df2c581b77abeb52cf#49976d5ea21c5d448d9ef5df2c581b77abeb52cf"
+source = "git+https://github.com/UniClipboard/Engine.git?rev=aa88c6bcffdc7033f52730d70d46fd3a41868071#aa88c6bcffdc7033f52730d70d46fd3a41868071"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10854,7 +10854,7 @@ dependencies = [
 [[package]]
 name = "uc-mobile-proto"
 version = "1.1.0-rc.2"
-source = "git+https://github.com/UniClipboard/Engine.git?rev=49976d5ea21c5d448d9ef5df2c581b77abeb52cf#49976d5ea21c5d448d9ef5df2c581b77abeb52cf"
+source = "git+https://github.com/UniClipboard/Engine.git?rev=aa88c6bcffdc7033f52730d70d46fd3a41868071#aa88c6bcffdc7033f52730d70d46fd3a41868071"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -10889,7 +10889,7 @@ dependencies = [
 [[package]]
 name = "uc-observability-contract"
 version = "1.1.0-rc.2"
-source = "git+https://github.com/UniClipboard/Engine.git?rev=49976d5ea21c5d448d9ef5df2c581b77abeb52cf#49976d5ea21c5d448d9ef5df2c581b77abeb52cf"
+source = "git+https://github.com/UniClipboard/Engine.git?rev=aa88c6bcffdc7033f52730d70d46fd3a41868071#aa88c6bcffdc7033f52730d70d46fd3a41868071"
 dependencies = [
  "anyhow",
  "chrono",
@@ -11048,7 +11048,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11764,7 +11764,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -12379,8 +12379,8 @@ dependencies = [
  "log",
  "serde",
  "thiserror 2.0.19",
- "windows 0.62.2",
- "windows-core 0.62.2",
+ "windows 0.59.0",
+ "windows-core 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,8 +51,8 @@ dbg_macro = "warn"
 [workspace.dependencies]
 # All desktop consumers use one immutable Engine revision. Features remain
 # opt-in at each host boundary so LAN compatibility cannot become a default.
-uc-engine = { git = "https://github.com/UniClipboard/Engine.git", rev = "49976d5ea21c5d448d9ef5df2c581b77abeb52cf" }
-uc-observability-contract = { git = "https://github.com/UniClipboard/Engine.git", rev = "49976d5ea21c5d448d9ef5df2c581b77abeb52cf" }
+uc-engine = { git = "https://github.com/UniClipboard/Engine.git", rev = "aa88c6bcffdc7033f52730d70d46fd3a41868071" }
+uc-observability-contract = { git = "https://github.com/UniClipboard/Engine.git", rev = "aa88c6bcffdc7033f52730d70d46fd3a41868071" }
 
 # tauri 2.11 是 specta rc.25 兼容的最低版本 —— 2.10.x 及之前在
 # `tauri/src/ipc/channel.rs` 用了 `#[specta(remote=..., rename="...")]`


### PR DESCRIPTION
## Summary

- Pin all Desktop Engine consumers to `aa88c6bc`, which includes the repair for stale removed devices after legacy upgrades (9024bc2c3).
- Regenerate the lockfile so all Engine packages resolve from the same immutable revision.
- Leave user documentation, telemetry, and tracing unchanged because this PR only adopts an Engine fix and adds no Desktop-owned behavior.

## Test plan

- [x] `cargo check --workspace --all-targets --locked`
- [x] `cargo fmt --all -- --check`
- [x] `cargo metadata --locked --format-version 1 --no-deps`
- [x] `bun scripts/architecture/check-engine-repository.mjs`
- [x] Engine regression: migrated workspace does not restore a removed peer
- [x] Engine regression: encrypted stale removed-device state is repaired across restart
- [ ] Verify an upgrade using real legacy data across two physical devices