### PR TITLE
fix(quick-panel): preserve keyboard flow after filtering

### DIFF
--- a/src/quick-panel/ClipboardHistoryPanel.tsx
+++ b/src/quick-panel/ClipboardHistoryPanel.tsx
@@ -520,6 +520,31 @@ const ClipboardHistoryPanelSession: React.FC<ClipboardHistoryPanelProps> = ({
     setSearchQuery(value)
   }, [])
 
+  const prepareForFilterChange = useCallback(() => {
+    dispatchPreview({ type: 'suppress', value: false })
+    dispatchPreview({ type: 'set-focus-source', source: 'selection' })
+    setHoveredIndex(null)
+    setIsKeyboardNav(true)
+    setSelectedIndex(0)
+    searchInputRef.current?.focus()
+  }, [])
+
+  const handleActiveFilterChange = useCallback(
+    (filter: Filter) => {
+      setActiveFilter(filter)
+      prepareForFilterChange()
+    },
+    [prepareForFilterChange]
+  )
+
+  const handleTagFilterChange = useCallback(
+    (tag: string | null) => {
+      setTagFilter(tag)
+      prepareForFilterChange()
+    },
+    [prepareForFilterChange]
+  )
+
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement>) => {
       if (isLocked) {
@@ -527,6 +552,49 @@ const ClipboardHistoryPanelSession: React.FC<ClipboardHistoryPanelProps> = ({
           e.preventDefault()
           void handleUnlock()
         }
+        return
+      }
+
+      // Tab changes the type filter even while another filter request is in
+      // flight. It must stay ahead of the pending-results guard below so focus
+      // remains in the launcher instead of moving onto the filter buttons.
+      if (e.key === 'Tab') {
+        e.preventDefault()
+        dispatchPreview({ type: 'suppress', value: false })
+        dispatchPreview({ type: 'set-focus-source', source: 'selection' })
+        setIsKeyboardNav(true)
+        setHoveredIndex(null)
+        setSelectedIndex(0)
+        setActiveFilter(prev => {
+          const count = QUICK_FILTER_ORDER.length
+          // A filter outside the cycle (e.g. Favorited) maps to All as the base.
+          const base = Math.max(0, QUICK_FILTER_ORDER.indexOf(prev))
+          const next = e.shiftKey ? (base - 1 + count) % count : (base + 1) % count
+          return QUICK_FILTER_ORDER[next]
+        })
+        return
+      }
+
+      // A narrowed query retains its previous rows while the daemon responds.
+      // Keep those stale rows completely inert so a fast Enter/copy/delete
+      // cannot act on content from the previous filter.
+      if (loading || isSearching) {
+        const input = e.currentTarget
+        const hasTextSelection = input.selectionStart !== input.selectionEnd
+        const usesCopyOnResult =
+          (e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'c' && !hasTextSelection
+        const usesPasteOnResult =
+          (e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'v' && input.value === ''
+        const isResultShortcut =
+          e.key === 'Enter' ||
+          e.key === 'ArrowDown' ||
+          e.key === 'ArrowUp' ||
+          (e.altKey && e.key === 'Backspace') ||
+          (e.ctrlKey && (e.key === 'n' || e.key === 'p')) ||
+          ((e.metaKey || e.ctrlKey) && e.key >= '0' && e.key <= '9') ||
+          usesCopyOnResult ||
+          usesPasteOnResult
+        if (isResultShortcut) e.preventDefault()
         return
       }
 
@@ -587,24 +655,6 @@ const ClipboardHistoryPanelSession: React.FC<ClipboardHistoryPanelProps> = ({
         return
       }
 
-      // Tab / Shift+Tab cycle the content-type filter without moving focus off
-      // the search input. The shared search box forwards unhandled Tab here, and
-      // the shortcut writes into the same content-filter register as `type:`.
-      if (e.key === 'Tab') {
-        e.preventDefault()
-        dispatchPreview({ type: 'suppress', value: false })
-        dispatchPreview({ type: 'set-focus-source', source: 'selection' })
-        setHoveredIndex(null)
-        setActiveFilter(prev => {
-          const count = QUICK_FILTER_ORDER.length
-          // A filter outside the cycle (e.g. Favorited) maps to All as the base.
-          const base = Math.max(0, QUICK_FILTER_ORDER.indexOf(prev))
-          const next = e.shiftKey ? (base - 1 + count) % count : (base + 1) % count
-          return QUICK_FILTER_ORDER[next]
-        })
-        return
-      }
-
       switch (e.key) {
         case 'ArrowDown':
         case 'ArrowUp':
@@ -632,7 +682,9 @@ const ClipboardHistoryPanelSession: React.FC<ClipboardHistoryPanelProps> = ({
       handleSelect,
       handleUnlock,
       hoveredIndex,
+      isSearching,
       isLocked,
+      loading,
       selectedIndex,
       visibleUnlocking,
     ]
@@ -685,9 +737,9 @@ const ClipboardHistoryPanelSession: React.FC<ClipboardHistoryPanelProps> = ({
           unlocking={visibleUnlocking}
           unlockError={visibleUnlockError}
           activeFilter={activeFilter}
-          setActiveFilter={setActiveFilter}
+          setActiveFilter={handleActiveFilterChange}
           tagFilter={tagFilter}
-          setTagFilter={setTagFilter}
+          setTagFilter={handleTagFilterChange}
           sourceFilter={sourceFilter}
           setSourceFilter={setSourceFilter}
           extensionFilter={extensionFilter}

--- a/src/quick-panel/__tests__/ClipboardHistoryPanel.single-window.test.tsx
+++ b/src/quick-panel/__tests__/ClipboardHistoryPanel.single-window.test.tsx
@@ -1,5 +1,6 @@
 import { configureStore } from '@reduxjs/toolkit'
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import type { ReactElement } from 'react'
 import { Provider } from 'react-redux'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -104,6 +105,14 @@ vi.mock('../hooks/useHistorySearch', () => ({
   })),
 }))
 
+const defaultHistorySearchImplementation = vi.mocked(useHistorySearch).getMockImplementation()
+
+beforeEach(() => {
+  if (defaultHistorySearchImplementation) {
+    vi.mocked(useHistorySearch).mockImplementation(defaultHistorySearchImplementation)
+  }
+})
+
 vi.mock('@/api/daemon', () => ({
   restoreClipboardEntry: vi.fn(),
   deleteClipboardEntry: vi.fn(),
@@ -203,6 +212,12 @@ describe('ClipboardHistoryPanel single-window preview', () => {
     expect(
       screen.queryByText(i18n.t('quickPanel.history.status.navigatePaste'))
     ).not.toBeInTheDocument()
+  })
+
+  it('does not render a divider below the search area', () => {
+    renderPanel()
+
+    expect(screen.getByRole('combobox').closest('.border-b')).toBeNull()
   })
 
   it('keeps history and preview panes flexible when the inline preview opens', async () => {
@@ -557,6 +572,93 @@ describe('ClipboardHistoryPanel hover/focus keyboard shortcuts', () => {
     await waitFor(() => {
       expect(invokeMock).toHaveBeenCalledWith('paste_to_previous_app', expect.any(Object))
     })
+  })
+
+  it('returns keyboard control to the results and resets selection after clicking a tag', async () => {
+    const user = userEvent.setup()
+    renderPanel()
+    const input = searchBox()
+    fireEvent.keyDown(input, { key: 'ArrowDown' })
+
+    await user.click(
+      within(screen.getByTestId('quick-panel-tag-filter-list')).getByRole('button', {
+        name: i18n.t('history.type.code'),
+      })
+    )
+
+    expect(input).toHaveFocus()
+    await user.keyboard('{Enter}')
+    await waitFor(() => {
+      expect(restoreClipboardEntry).toHaveBeenCalledWith('entry-1', undefined)
+    })
+  })
+
+  it('returns keyboard control to the results and resets selection after clicking a type', async () => {
+    const user = userEvent.setup()
+    renderPanel()
+    const input = searchBox()
+    fireEvent.keyDown(input, { key: 'ArrowDown' })
+
+    await user.click(screen.getByRole('button', { name: i18n.t('history.type.file') }))
+
+    expect(input).toHaveFocus()
+    await user.keyboard('{Enter}')
+    await waitFor(() => {
+      expect(restoreClipboardEntry).toHaveBeenCalledWith('entry-1', undefined)
+    })
+  })
+
+  it('does not expose or paste stale results while a filter is loading', () => {
+    vi.mocked(useHistorySearch).mockReturnValue({
+      filteredItems: [
+        {
+          id: 'stale-entry',
+          type: 'text',
+          preview: 'Stale preview title',
+          activeTime: Date.now(),
+          isUnavailable: false,
+        },
+      ],
+      previewItems: [],
+      isSearching: true,
+      searchTotal: null,
+      loading: false,
+      isLocked: false,
+      removeItem: vi.fn(),
+    })
+    renderPanel()
+
+    expect(screen.queryByText('Stale preview title')).not.toBeInTheDocument()
+    fireEvent.keyDown(searchBox(), { key: 'Enter' })
+
+    expect(restoreClipboardEntry).not.toHaveBeenCalled()
+  })
+
+  it('keeps native query copy available while a filter is loading', () => {
+    vi.mocked(useHistorySearch).mockReturnValue({
+      filteredItems: [],
+      previewItems: [],
+      isSearching: true,
+      searchTotal: null,
+      loading: false,
+      isLocked: false,
+      removeItem: vi.fn(),
+    })
+    renderPanel()
+    const input = searchBox()
+    fireEvent.change(input, { target: { value: 'abc' } })
+    input.setSelectionRange(0, 3)
+    const copyEvent = new KeyboardEvent('keydown', {
+      key: 'c',
+      metaKey: true,
+      bubbles: true,
+      cancelable: true,
+    })
+
+    fireEvent(input, copyEvent)
+
+    expect(copyEvent.defaultPrevented).toBe(false)
+    expect(restoreClipboardEntry).not.toHaveBeenCalled()
   })
 
   it('does not hijack Ctrl/Cmd+V once the search query is non-empty', async () => {

--- a/src/quick-panel/components/HistoryPane.tsx
+++ b/src/quick-panel/components/HistoryPane.tsx
@@ -182,7 +182,7 @@ const HistoryPane: React.FC<HistoryPaneProps> = React.memo(
         ) : (
           <>
             {/* --- SPOTLIGHT STYLE TOP BAR --- */}
-            <div className="border-b border-border/50 px-3 py-2">
+            <div className="px-3 py-2">
               <CompositeSearchBar
                 contentFilter={activeFilter}
                 tagFilter={tagFilter}
@@ -232,7 +232,7 @@ const HistoryPane: React.FC<HistoryPaneProps> = React.memo(
                   <Loader2 className="size-4 animate-spin mr-2" />
                   {t('status.loading')}
                 </div>
-              ) : isSearching && filteredItems.length === 0 ? (
+              ) : isSearching ? (
                 <div className="flex h-full items-center justify-center text-[13px] text-muted-foreground">
                   <Loader2 className="size-4 animate-spin mr-2" />
                   {t('status.searching')}


### PR DESCRIPTION
## Summary

- Keep keyboard control in the Quick Panel search flow after clicking type or tag filters, and reset the active result to the first matching item (`33dd35bff`).
- Hide stale results and block result actions while a filter refresh is pending without interfering with native query copy and paste (`33dd35bff`).
- Remove the divider below the Quick Panel search area (`33dd35bff`).

No docs changes: the existing Quick Panel guide already describes the keyboard-first behavior. No telemetry or tracing changes are applicable to this frontend-only interaction fix.

## Test plan

- [x] `bunx vitest run src/quick-panel/__tests__/ClipboardHistoryPanel.single-window.test.tsx src/quick-panel/components/__tests__/QuickPanelTagFilterBar.test.tsx src/quick-panel/components/__tests__/QuickPanelTypeFilterBar.test.tsx --pool forks` (31 tests)
- [x] `bunx vitest run --pool forks` (144 files, 974 tests)
- [x] `bun run build`
- [x] `npx react-doctor@latest --verbose --scope changed`
- [ ] Verify the click-filter-then-Enter flow in the native desktop Quick Panel

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filter navigation and reset behavior for preview, selection, keyboard mode, and search focus.
  * Prevented stale or conflicting actions while searches and filter requests are loading.
  * Ensured search progress displays consistently during active searches.
  * Preserved native text-copy behavior while content is loading.
* **Style**
  * Removed the unnecessary divider beneath the history search bar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->