### PR TITLE
feat(quick-panel): support Wayland launcher

### DIFF
--- a/docs-site/content/docs/en/core-features/quick-panel.mdx
+++ b/docs-site/content/docs/en/core-features/quick-panel.mdx
@@ -28,6 +28,14 @@ hold focus indefinitely.
   Panel](../guides/settings#quick-panel) — that unregisters the hotkey immediately.
 </Callout>
 
+On native Wayland sessions whose compositor cannot provide global hotkeys, bind this command in
+the compositor instead. It opens the panel when UniClipboard is not running yet, and toggles the
+existing panel otherwise:
+
+```bash
+uniclipboard --quick-panel
+```
+
 ## Keyboard controls
 
 The panel is meant to be driven entirely by keyboard. The full set:

--- a/docs-site/content/docs/zh/core-features/quick-panel.mdx
+++ b/docs-site/content/docs/zh/core-features/quick-panel.mdx
@@ -22,6 +22,12 @@ import { Tab, Tabs } from 'fumadocs-ui/components/tabs'
   快捷面板](../guides/settings#快捷面板) 里整体关掉它 —— 关闭即时反注册全局快捷键。
 </Callout>
 
+原生 Wayland 桌面环境如果无法提供全局快捷键，可以在窗口管理器中绑定下面的命令。程序尚未运行时会启动并打开面板；程序已运行时会切换面板的显示状态：
+
+```bash
+uniclipboard --quick-panel
+```
+
 ## 键盘操作
 
 面板设计为完全用键盘驱动。下面这套键位可在打开后立即用：

--- a/src-tauri/crates/uc-tauri/src/commands/quick_panel.rs
+++ b/src-tauri/crates/uc-tauri/src/commands/quick_panel.rs
@@ -2,7 +2,7 @@
 //! 快捷面板相关的 Tauri 命令
 
 use serde::{Deserialize, Serialize};
-use tauri::State;
+use tauri::{Manager, State};
 use tracing::{error, info, info_span, Instrument};
 use uc_daemon_client::{DaemonConnectionState, DaemonSettingsClient};
 use uc_daemon_contract::api::dto::settings::{
@@ -237,6 +237,38 @@ pub async fn finalize_quick_panel_show(
     .await
 }
 
+/// Mark the quick-panel frontend ready to receive a queued toggle request.
+#[tauri::command]
+#[specta::specta]
+pub async fn mark_quick_panel_ready(
+    app: tauri::AppHandle,
+    _trace: Option<TraceMetadata>,
+) -> Result<(), String> {
+    let span = info_span!(
+        "command.quick_panel.mark_ready",
+        trace_id = tracing::field::Empty,
+        trace_ts = tracing::field::Empty,
+    );
+    record_trace_fields(&span, &_trace);
+
+    async {
+        if app
+            .state::<quick_panel::QuickPanelToggleController>()
+            .mark_panel_ready()
+        {
+            let handle = app.clone();
+            app.run_on_main_thread(move || quick_panel::toggle(&handle))
+                .map_err(|error| {
+                    format!("Failed to dispatch quick panel toggle to main thread: {error}")
+                })?;
+            info!("Applied queued quick panel toggle after frontend readiness");
+        }
+        Ok(())
+    }
+    .instrument(span)
+    .await
+}
+
 /// Return the current platform capability for global modifier observation.
 #[tauri::command]
 #[specta::specta]
@@ -434,6 +466,8 @@ pub async fn set_quick_panel_enabled(
         match client.update_settings(patch).await {
             Ok(_) => {
                 shortcut_registry.replace(target_shortcuts);
+                app.state::<quick_panel::QuickPanelToggleController>()
+                    .set_enabled(enabled);
                 Ok(())
             }
             Err(err) => {
@@ -561,7 +595,7 @@ async fn apply_global_shortcuts_on_main_thread(
             let toggle_handle = handle.clone();
             let registry =
                 quick_panel::TauriGlobalShortcutRegistry::new(handle.clone(), move || {
-                    quick_panel::toggle(&toggle_handle)
+                    quick_panel::request_toggle(&toggle_handle)
                 });
             shortcuts::update_shortcuts(&registry, &old, &new)
                 .map_err(|e| CommandError::Conflict(e.to_string()))?;

--- a/src-tauri/crates/uc-tauri/src/commands/settings.rs
+++ b/src-tauri/crates/uc-tauri/src/commands/settings.rs
@@ -248,10 +248,10 @@ async fn update_global_shortcuts_on_main_thread(
 
     app.run_on_main_thread(move || {
         // 在 main thread 闭包内构造 registry：捕获 AppHandle 用作回调上下文，
-        // 回调闭包绑定 `quick_panel::toggle`（GUI shell 自身的具体动作）。
+        // 回调闭包绑定 `quick_panel::request_toggle`（GUI shell 自身的具体动作）。
         let toggle_handle = handle.clone();
         let registry = quick_panel::TauriGlobalShortcutRegistry::new(handle.clone(), move || {
-            quick_panel::toggle(&toggle_handle)
+            quick_panel::request_toggle(&toggle_handle)
         });
         let result = shortcuts::update_shortcuts(&registry, &old, &new);
         let _ = tx.send(result);

--- a/src-tauri/crates/uc-tauri/src/quick_panel/mod.rs
+++ b/src-tauri/crates/uc-tauri/src/quick_panel/mod.rs
@@ -68,12 +68,138 @@ const PANEL_GAP: f64 = 8.0;
 const MIN_UI_SCALE: f64 = 0.8;
 const MAX_UI_SCALE: f64 = 1.5;
 
-/// Space (logical pixels) reserved around the cards for shadows and rounded corners.
-/// This padding is included in the window size but remains transparent in the UI.
+/// Space (logical pixels) reserved around floating cards on macOS and Windows.
+#[cfg(not(target_os = "linux"))]
 const WINDOW_PADDING: f64 = 16.0;
 
 /// Tauri window label for the quick panel.
 pub(crate) const PANEL_LABEL: &str = "quick-panel";
+
+#[derive(Default)]
+pub(crate) struct QuickPanelToggleController {
+    state: Mutex<QuickPanelToggleState>,
+}
+
+#[derive(Default)]
+struct QuickPanelToggleState {
+    configured: bool,
+    enabled: bool,
+    panel_ready: bool,
+    pending_toggle: bool,
+}
+
+impl QuickPanelToggleController {
+    pub(crate) fn configure(&self, enabled: bool) -> bool {
+        let mut state = self.lock_state();
+        state.configured = true;
+        state.enabled = enabled;
+        if !enabled {
+            state.pending_toggle = false;
+            return false;
+        }
+        if state.panel_ready {
+            return std::mem::take(&mut state.pending_toggle);
+        }
+        false
+    }
+
+    pub(crate) fn set_enabled(&self, enabled: bool) {
+        let mut state = self.lock_state();
+        state.configured = true;
+        state.enabled = enabled;
+        if !enabled {
+            state.pending_toggle = false;
+        }
+    }
+
+    pub(crate) fn request_toggle(&self) -> bool {
+        let mut state = self.lock_state();
+        if state.configured && !state.enabled {
+            return false;
+        }
+        if !state.configured || !state.panel_ready {
+            state.pending_toggle = !state.pending_toggle;
+            return false;
+        }
+        true
+    }
+
+    pub(crate) fn mark_panel_ready(&self) -> bool {
+        let mut state = self.lock_state();
+        state.panel_ready = true;
+        if state.enabled {
+            return std::mem::take(&mut state.pending_toggle);
+        }
+        false
+    }
+
+    fn lock_state(&self) -> std::sync::MutexGuard<'_, QuickPanelToggleState> {
+        match self.state.lock() {
+            Ok(state) => state,
+            Err(poisoned) => {
+                error!("Quick panel toggle controller lock was poisoned; recovering state");
+                poisoned.into_inner()
+            }
+        }
+    }
+}
+
+/// Request a quick-panel toggle after the user-visible panel is ready.
+///
+/// Requests arriving during startup are preserved as toggle parity so repeated
+/// presses before readiness have the same result as repeated presses after it.
+pub(crate) fn request_toggle(app: &tauri::AppHandle) {
+    if app.state::<QuickPanelToggleController>().request_toggle() {
+        let handle = app.clone();
+        if let Err(error) = app.run_on_main_thread(move || toggle(&handle)) {
+            error!(error = %error, "Failed to dispatch quick panel toggle to main thread");
+        }
+    }
+}
+
+#[cfg(test)]
+mod toggle_controller_tests {
+    use super::QuickPanelToggleController;
+
+    #[test]
+    fn defers_a_toggle_until_settings_and_panel_are_ready() {
+        let controller = QuickPanelToggleController::default();
+
+        assert!(!controller.request_toggle());
+        assert!(!controller.mark_panel_ready());
+        assert!(controller.configure(true));
+    }
+
+    #[test]
+    fn ignores_toggles_when_the_panel_is_disabled() {
+        let controller = QuickPanelToggleController::default();
+
+        assert!(!controller.configure(false));
+        assert!(!controller.request_toggle());
+        controller.set_enabled(true);
+        assert!(!controller.mark_panel_ready());
+    }
+
+    #[test]
+    fn stops_accepting_toggles_when_disabled_after_startup() {
+        let controller = QuickPanelToggleController::default();
+
+        assert!(!controller.configure(true));
+        assert!(!controller.mark_panel_ready());
+        controller.set_enabled(false);
+        assert!(!controller.request_toggle());
+    }
+
+    #[test]
+    fn two_deferred_toggles_cancel_each_other() {
+        let controller = QuickPanelToggleController::default();
+
+        assert!(!controller.request_toggle());
+        assert!(!controller.request_toggle());
+        assert!(!controller.configure(true));
+        assert!(!controller.mark_panel_ready());
+    }
+}
 
 // ── Cross-platform helpers ─────────────────────────────────────────────
 
@@ -364,18 +490,42 @@ fn normalize_ui_scale(scale: f64) -> f64 {
 }
 
 fn panel_dimensions(scale: f64, preview_expanded: bool) -> (f64, f64) {
+    panel_dimensions_for_window_padding(scale, preview_expanded, window_padding())
+}
+
+fn panel_dimensions_for_window_padding(
+    scale: f64,
+    preview_expanded: bool,
+    window_padding: f64,
+) -> (f64, f64) {
     let normalized_scale = normalize_ui_scale(scale);
     let width = if preview_expanded {
         (BASE_PANEL_WIDTH + PANEL_GAP + BASE_PREVIEW_WIDTH) * normalized_scale
-            + (WINDOW_PADDING * 2.0)
+            + (window_padding * 2.0)
     } else {
-        (BASE_PANEL_WIDTH * normalized_scale) + (WINDOW_PADDING * 2.0)
+        (BASE_PANEL_WIDTH * normalized_scale) + (window_padding * 2.0)
     };
 
     (
         width,
-        (BASE_PANEL_HEIGHT * normalized_scale) + (WINDOW_PADDING * 2.0),
+        (BASE_PANEL_HEIGHT * normalized_scale) + (window_padding * 2.0),
     )
+}
+
+fn window_padding() -> f64 {
+    #[cfg(target_os = "linux")]
+    {
+        0.0
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        WINDOW_PADDING
+    }
+}
+
+fn uses_transparent_window() -> bool {
+    !cfg!(target_os = "linux")
 }
 
 fn remember_panel_origin(x: f64, y: f64) {
@@ -443,7 +593,7 @@ pub fn pre_create(app: &tauri::AppHandle) {
         .inner_size(initial_width, initial_height)
         .position(-9999.0, -9999.0)
         .decorations(false)
-        .transparent(true)
+        .transparent(uses_transparent_window())
         .shadow(false)
         .always_on_top(true)
         .visible(false)
@@ -792,6 +942,23 @@ pub fn type_file_paths(app: &tauri::AppHandle, file_paths: &[String]) -> Result<
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn linux_dimensions_do_not_reserve_transparent_outer_padding() {
+        assert_eq!(
+            panel_dimensions_for_window_padding(1.0, false, 0.0),
+            (360.0, 420.0)
+        );
+        assert_eq!(
+            panel_dimensions_for_window_padding(1.0, true, 0.0),
+            (728.0, 420.0)
+        );
+    }
+
+    #[test]
+    fn window_transparency_matches_the_current_platform() {
+        assert_eq!(uses_transparent_window(), !cfg!(target_os = "linux"));
+    }
 
     // Monitor spanning logical [0, 1000) on each axis for readability.
     const MON_ORIGIN: f64 = 0.0;

--- a/src-tauri/crates/uc-tauri/src/run.rs
+++ b/src-tauri/crates/uc-tauri/src/run.rs
@@ -65,6 +65,42 @@ const EXPECTED_PACKAGE_VERSION: &str = env!("CARGO_PKG_VERSION");
 /// (a cold start) versus attached to one already running (a reopen), which
 /// covers both auto-start and manual first launches uniformly (issue #1169).
 const AUTOSTART_LAUNCH_ARG: &str = "--autostart";
+const QUICK_PANEL_LAUNCH_ARG: &str = "--quick-panel";
+
+fn has_quick_panel_launch_argument(args: impl IntoIterator<Item = String>) -> bool {
+    args.into_iter().any(|arg| arg == QUICK_PANEL_LAUNCH_ARG)
+}
+
+fn should_show_quick_panel_on_start(requested: bool, enabled: bool) -> bool {
+    requested && enabled
+}
+
+#[cfg(test)]
+mod launch_argument_tests {
+    use super::{has_quick_panel_launch_argument, should_show_quick_panel_on_start};
+
+    #[test]
+    fn recognizes_the_quick_panel_launch_argument() {
+        assert!(has_quick_panel_launch_argument([
+            "uniclipboard".to_string(),
+            "--quick-panel".to_string(),
+        ]));
+    }
+
+    #[test]
+    fn ignores_other_launch_arguments() {
+        assert!(!has_quick_panel_launch_argument([
+            "uniclipboard".to_string(),
+            "--autostart".to_string(),
+        ]));
+    }
+
+    #[test]
+    fn startup_request_respects_a_disabled_quick_panel() {
+        assert!(!should_show_quick_panel_on_start(true, false));
+        assert!(should_show_quick_panel_on_start(true, true));
+    }
+}
 
 /// Await the first process-level "terminate this app" signal.
 ///
@@ -193,6 +229,7 @@ pub fn run(tauri_ctx: tauri::Context<tauri::Wry>) -> anyhow::Result<()> {
     // run-loop closure below and dropped at `RunEvent::Exit` so buffered log
     // lines reach disk before tao's destructor-skipping `process::exit`.
     let mut json_log_guard = init_gui_tracing();
+    let quick_panel_requested_on_start = has_quick_panel_launch_argument(std::env::args());
 
     // WebKitGTK's DMABUF renderer is unreliable on Wayland (notably wlroots
     // compositors like hyprland / sway): the WebView crashes or renders blank.
@@ -258,6 +295,7 @@ pub fn run(tauri_ctx: tauri::Context<tauri::Wry>) -> anyhow::Result<()> {
         .manage(TrayState::default())
         .manage(crate::lightweight::QuitIntent::default())
         .manage(crate::commands::startup::PendingNavigation::default())
+        .manage(quick_panel::QuickPanelToggleController::default())
         .manage(task_registry.clone())
         .on_window_event(|window, event| {
             if let tauri::WindowEvent::CloseRequested { .. } = event {
@@ -328,9 +366,14 @@ pub fn run(tauri_ctx: tauri::Context<tauri::Wry>) -> anyhow::Result<()> {
         // A second launch means the user wants the window — surface it
         // (recreating it if it was destroyed-to-tray) instead of silently
         // doing nothing.
-        builder.plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
-            info!("Second instance launch detected; showing main window");
-            crate::main_window::show_main_window(app);
+        builder.plugin(tauri_plugin_single_instance::init(|app, args, _cwd| {
+            if has_quick_panel_launch_argument(args) {
+                info!("Second instance requested quick panel toggle");
+                quick_panel::request_toggle(app);
+            } else {
+                info!("Second instance launch detected; showing main window");
+                crate::main_window::show_main_window(app);
+            }
         }))
     };
 
@@ -527,6 +570,15 @@ pub fn run(tauri_ctx: tauri::Context<tauri::Wry>) -> anyhow::Result<()> {
                 }
             };
 
+            let show_quick_panel_on_start =
+                should_show_quick_panel_on_start(quick_panel_requested_on_start, quick_panel_enabled);
+            if app
+                .state::<quick_panel::QuickPanelToggleController>()
+                .configure(quick_panel_enabled)
+            {
+                quick_panel::request_toggle(app.handle());
+            }
+
             // Reconcile the OS launch-at-login registration with the persisted
             // preference. When enabled this always rewrites the entry to the
             // current executable path, self-healing stale entries left by older
@@ -589,12 +641,12 @@ pub fn run(tauri_ctx: tauri::Context<tauri::Wry>) -> anyhow::Result<()> {
                     );
 
                     // 启动期 setup callback 已在 main thread 上下文，可直接构造 Tauri
-                    // 适配器并调注册器。回调闭包绑定 `quick_panel::toggle`，避免桌面
+                    // 适配器并调注册器。回调闭包绑定 `quick_panel::request_toggle`，避免桌面
                     // 协调层耦合任何 GUI shell 概念。
                     let toggle_handle = app.handle().clone();
                     let registry = quick_panel::TauriGlobalShortcutRegistry::new(
                         app.handle().clone(),
-                        move || quick_panel::toggle(&toggle_handle),
+                        move || quick_panel::request_toggle(&toggle_handle),
                     );
                     for shortcut_str in &shortcuts {
                         if let Err(e) = registry.register(shortcut_str) {
@@ -619,7 +671,7 @@ pub fn run(tauri_ctx: tauri::Context<tauri::Wry>) -> anyhow::Result<()> {
                     let dispatch_handle = modifier_toggle_handle.clone();
                     let toggle_handle = dispatch_handle.clone();
                     if let Err(error) = dispatch_handle.run_on_main_thread(move || {
-                        quick_panel::toggle(&toggle_handle);
+                        quick_panel::request_toggle(&toggle_handle);
                     }) {
                         error!(
                             error = %error,
@@ -676,7 +728,7 @@ pub fn run(tauri_ctx: tauri::Context<tauri::Wry>) -> anyhow::Result<()> {
             // `show_main_window` creates it from config on demand. That is
             // exactly what a Lightweight *reopen* needs (issue #1169): the
             // cold-launch task calls `show_main_window` to bring it up.
-            if !silent_start {
+            if !silent_start && !show_quick_panel_on_start {
                 crate::main_window::show_main_window(app.handle());
                 info!("Main window show requested (silent_start=false)");
             } else {
@@ -699,6 +751,10 @@ pub fn run(tauri_ctx: tauri::Context<tauri::Wry>) -> anyhow::Result<()> {
             // window on the critical startup path.
             if quick_panel_enabled {
                 quick_panel::pre_create(app.handle());
+            }
+            if show_quick_panel_on_start {
+                info!("Initial launch requested quick panel toggle");
+                quick_panel::request_toggle(app.handle());
             }
 
             #[cfg(not(any(target_os = "android", target_os = "ios")))]
@@ -746,6 +802,7 @@ pub fn run(tauri_ctx: tauri::Context<tauri::Wry>) -> anyhow::Result<()> {
                 let daemon_conn_for_startup_actions = daemon_connection_state.clone();
                 let app_handle_for_lightweight_start = app_handle_for_startup.clone();
                 let launch_origin_for_startup = daemon_launch_origin.clone();
+                let keep_gui_for_quick_panel = show_quick_panel_on_start;
                 tauri::async_runtime::spawn(async move {
                     let outcome = uc_desktop::startup_actions::run_cold_launch_actions(
                         daemon_conn_for_startup_actions,
@@ -762,11 +819,15 @@ pub fn run(tauri_ctx: tauri::Context<tauri::Wry>) -> anyhow::Result<()> {
                     // only running; a later click that finds the daemon already
                     // running reopens the window instead.
                     match outcome.map(|o| o.window_action) {
-                        Some(uc_desktop::startup_actions::StartupWindowAction::EnterBackgroundOnly) => {
+                        Some(uc_desktop::startup_actions::StartupWindowAction::EnterBackgroundOnly)
+                            if !keep_gui_for_quick_panel => {
                             info!(
                                 "[Startup] Lightweight cold start: daemon ready, entering Lightweight Mode (GUI exits, daemon stays running)"
                             );
                             crate::lightweight::enter_lightweight_mode(&app_handle_for_lightweight_start);
+                        }
+                        Some(uc_desktop::startup_actions::StartupWindowAction::EnterBackgroundOnly) => {
+                            info!("Quick panel launch keeps GUI active instead of entering Lightweight Mode");
                         }
                         Some(uc_desktop::startup_actions::StartupWindowAction::ShowWindow) => {
                             info!(

--- a/src-tauri/crates/uc-tauri/src/specta_builder.rs
+++ b/src-tauri/crates/uc-tauri/src/specta_builder.rs
@@ -77,6 +77,7 @@ pub fn build() -> Builder<tauri::Wry> {
         crate::commands::quick_panel::dismiss_quick_panel,
         crate::commands::quick_panel::set_quick_panel_layout,
         crate::commands::quick_panel::finalize_quick_panel_show,
+        crate::commands::quick_panel::mark_quick_panel_ready,
         crate::commands::quick_panel::get_quick_panel_double_tap_availability,
         crate::commands::quick_panel::set_quick_panel_enabled,
         crate::commands::quick_panel::set_quick_panel_double_tap_modifier,

--- a/src/lib/ipc-bindings.generated.ts
+++ b/src/lib/ipc-bindings.generated.ts
@@ -348,6 +348,11 @@ export const commands = {
 	trace_id: string,
 	timestamp: number,
 } | null) => typedError<null, string>(__TAURI_INVOKE("finalize_quick_panel_show", { trace })),
+	/**  Mark the quick-panel frontend ready to receive a queued toggle request. */
+	markQuickPanelReady: (trace: {
+	trace_id: string,
+	timestamp: number,
+} | null) => typedError<null, string>(__TAURI_INVOKE("mark_quick_panel_ready", { trace })),
 	/**  Return the current platform capability for global modifier observation. */
 	getQuickPanelDoubleTapAvailability: (trace: {
 	trace_id: string,

--- a/src/quick-panel/ClipboardHistoryPanel.tsx
+++ b/src/quick-panel/ClipboardHistoryPanel.tsx
@@ -34,12 +34,12 @@ import {
   QUICK_FILTER_ORDER,
 } from './constants'
 import { useHistorySearch } from './hooks/useHistorySearch'
+import { useQuickPanelNavigation, useQuickPanelSearchFilters } from './hooks/useQuickPanelState'
 import type {
   PreviewAction,
   PreviewSide,
   PreviewState,
   QuickPanelContextMenuActions,
-  TimeRangePreset,
 } from './types'
 
 const log = createLogger('clipboard-history-panel')
@@ -146,29 +146,29 @@ const ClipboardHistoryPanelSession: React.FC<ClipboardHistoryPanelProps> = ({
       })
   }, [dispatch])
 
-  const [searchQuery, setSearchQuery] = useState('')
+  const {
+    filters,
+    setQuery,
+    setActiveFilter,
+    setTagFilter,
+    setSourceFilter,
+    setExtensionFilter,
+    setTimeRange,
+    cycleActiveFilter,
+  } = useQuickPanelSearchFilters()
   // Debounce typing only; clearing must hit the data layer immediately so the
   // list does not keep showing matches for ~300ms after the box is empty. The
   // `.trim()` here only gates empty-vs-not (whitespace-only reads as cleared);
   // `useHistorySearch` owns the actual query normalization for the daemon call.
-  const debouncedSearchQuery = useDebounce(searchQuery, 300)
-  const activeSearchQuery = searchQuery.trim() === '' ? '' : debouncedSearchQuery
-  const [activeFilter, setActiveFilter] = useState<Filter>(Filter.All)
-  const [tagFilter, setTagFilter] = useState<string | null>(null)
-  const [sourceFilter, setSourceFilter] = useState<string | null>(null)
-  const [extensionFilter, setExtensionFilter] = useState<string | null>(null)
-  const [timeRange, setTimeRange] = useState<TimeRangePreset>('all_time')
+  const debouncedSearchQuery = useDebounce(filters.query, 300)
+  const activeSearchQuery = filters.query.trim() === '' ? '' : debouncedSearchQuery
   const searchableTags = useSearchTags()
   const sourceOptions = useHistorySourceOptions()
 
-  const [selectedIndex, setSelectedIndex] = useState(0)
-  const [hoveredIndex, setHoveredIndex] = useState<number | null>(null)
-  const [isKeyboardNav, setIsKeyboardNav] = useState(true)
   const [unlocking, setUnlocking] = useState(false)
   const [unlockError, setUnlockError] = useState<string | null>(null)
   const [uiScale, setUiScale] = useState(() => readStoredUiScale())
   const [previewState, dispatchPreview] = useReducer(previewReducer, initialPreviewState)
-  const [hasPointerMovedSinceShow, setHasPointerMovedSinceShow] = useState(false)
   // Optimistic favorite overrides keyed by entry id, mirroring the history
   // controller: the live list does not re-fetch on toggle, so a flip is
   // reflected here immediately (and reverted if the backend call fails) — this
@@ -177,7 +177,7 @@ const ClipboardHistoryPanelSession: React.FC<ClipboardHistoryPanelProps> = ({
 
   const searchInputRef = useRef<HTMLInputElement>(null)
   const historyPaneRef = useRef<HTMLDivElement>(null)
-  const itemRefs = useRef<Map<number, HTMLDivElement>>(new Map())
+  const [itemRefs] = useState(() => new Map<number, HTMLDivElement>())
   const previewTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const previewLayoutTokenRef = useRef(0)
   const [skipTransition, setSkipTransition] = useState(showRequestId !== 0)
@@ -193,16 +193,24 @@ const ClipboardHistoryPanelSession: React.FC<ClipboardHistoryPanelProps> = ({
   const { filteredItems, previewItems, isSearching, searchTotal, loading, isLocked, removeItem } =
     useHistorySearch({
       searchQuery: activeSearchQuery,
-      activeFilter,
-      tagFilter,
-      sourceFilter,
-      extensionFilter,
-      timeRange,
+      activeFilter: filters.activeFilter,
+      tagFilter: filters.tagFilter,
+      sourceFilter: filters.sourceFilter,
+      extensionFilter: filters.extensionFilter,
+      timeRange: filters.timeRange,
     })
   const visibleUnlocking = isLocked && unlocking
   const visibleUnlockError = isLocked ? unlockError : null
-  const [previousFilteredCount, setPreviousFilteredCount] = useState(filteredItems.length)
-  const [preserveSelectionOnNextListChange, setPreserveSelectionOnNextListChange] = useState(false)
+  const {
+    navigation,
+    select: selectIndex,
+    move: moveSelection,
+    setHoveredIndex,
+    activateKeyboard,
+    notePointerMoved,
+    preserveSelection,
+  } = useQuickPanelNavigation(filteredItems.length)
+  const { selectedIndex, hoveredIndex, isKeyboardNav, hasPointerMovedSinceShow } = navigation
 
   const clearPreviewTimer = useCallback(() => {
     if (previewTimerRef.current) {
@@ -261,7 +269,7 @@ const ClipboardHistoryPanelSession: React.FC<ClipboardHistoryPanelProps> = ({
 
     window.addEventListener('keydown', handleWindowKeyDown)
     return () => window.removeEventListener('keydown', handleWindowKeyDown)
-  }, [])
+  }, [setHoveredIndex])
 
   const handleUnlock = useCallback(async () => {
     setUnlocking(true)
@@ -281,21 +289,10 @@ const ClipboardHistoryPanelSession: React.FC<ClipboardHistoryPanelProps> = ({
     if (isLocked) closePreview(false)
   }, [closePreview, isLocked])
 
-  // Reset selectedIndex in the same render that receives a different visible
-  // result count, so a new filter never paints the stale selected row.
-  if (previousFilteredCount !== filteredItems.length) {
-    setPreviousFilteredCount(filteredItems.length)
-    if (preserveSelectionOnNextListChange) {
-      setPreserveSelectionOnNextListChange(false)
-    } else if (selectedIndex !== 0) {
-      setSelectedIndex(0)
-    }
-  }
-
   useEffect(() => {
-    const el = itemRefs.current.get(selectedIndex)
+    const el = itemRefs.get(selectedIndex)
     el?.scrollIntoView?.({ block: 'nearest' })
-  }, [selectedIndex])
+  }, [itemRefs, selectedIndex])
 
   const selectedItem = filteredItems[selectedIndex] ?? null
   const hoveredItem = hoveredIndex != null ? (filteredItems[hoveredIndex] ?? null) : null
@@ -398,7 +395,7 @@ const ClipboardHistoryPanelSession: React.FC<ClipboardHistoryPanelProps> = ({
       dispatchPreview({ type: 'set-focus-source', source: 'hover' })
       setHoveredIndex(index)
     },
-    [filteredItems, hasPointerMovedSinceShow, isKeyboardNav]
+    [filteredItems, hasPointerMovedSinceShow, isKeyboardNav, setHoveredIndex]
   )
 
   const handleDelete = useCallback(
@@ -407,20 +404,20 @@ const ClipboardHistoryPanelSession: React.FC<ClipboardHistoryPanelProps> = ({
       if (!item) return
       try {
         await deleteClipboardEntry(item.id)
-        setPreserveSelectionOnNextListChange(true)
+        preserveSelection()
         clearPreviewTimer()
         setHoveredIndex(null)
         dispatchPreview({ type: 'suppress', value: false })
         dispatchPreview({ type: 'set-focus-source', source: 'selection' })
         const remainingItems = filteredItems.filter((_, i) => i !== index)
         const nextIndex = remainingItems.length > 0 ? Math.min(index, remainingItems.length - 1) : 0
-        setSelectedIndex(nextIndex)
+        selectIndex(nextIndex)
         removeItem(item.id)
       } catch (err) {
         log.error({ err }, 'Failed to delete clipboard entry')
       }
     },
-    [clearPreviewTimer, filteredItems, removeItem]
+    [clearPreviewTimer, filteredItems, preserveSelection, removeItem, selectIndex, setHoveredIndex]
   )
 
   // ── Right-click context menu (reuses the history menu) ──────────────
@@ -495,12 +492,15 @@ const ClipboardHistoryPanelSession: React.FC<ClipboardHistoryPanelProps> = ({
   // always the one the menu acts on (otherwise the keyboard-selected row stays
   // highlighted while the menu targets a different, right-clicked row). Preview
   // follows the selection; Base UI opens the menu on the same event.
-  const handleContextMenuSelect = useCallback((index: number) => {
-    dispatchPreview({ type: 'suppress', value: false })
-    dispatchPreview({ type: 'set-focus-source', source: 'selection' })
-    setHoveredIndex(null)
-    setSelectedIndex(index)
-  }, [])
+  const handleContextMenuSelect = useCallback(
+    (index: number) => {
+      dispatchPreview({ type: 'suppress', value: false })
+      dispatchPreview({ type: 'set-focus-source', source: 'selection' })
+      setHoveredIndex(null)
+      selectIndex(index)
+    },
+    [selectIndex, setHoveredIndex]
+  )
 
   // Rich items backing the menu, index-aligned with `filteredItems` (both derive
   // from the same live list), with optimistic favorite flips applied on top.
@@ -521,28 +521,31 @@ const ClipboardHistoryPanelSession: React.FC<ClipboardHistoryPanelProps> = ({
     [handleContextCopy, handleContextDelete, handleContextToggleFavorite, handlePasteFilePaths]
   )
 
-  const handleSearchChange = useCallback((value: string) => {
-    dispatchPreview({ type: 'suppress', value: false })
-    dispatchPreview({ type: 'set-focus-source', source: 'selection' })
-    setHoveredIndex(null)
-    setSearchQuery(value)
-  }, [])
+  const handleSearchChange = useCallback(
+    (value: string) => {
+      dispatchPreview({ type: 'suppress', value: false })
+      dispatchPreview({ type: 'set-focus-source', source: 'selection' })
+      setHoveredIndex(null)
+      setQuery(value)
+    },
+    [setHoveredIndex, setQuery]
+  )
 
   const prepareForFilterChange = useCallback(() => {
     dispatchPreview({ type: 'suppress', value: false })
     dispatchPreview({ type: 'set-focus-source', source: 'selection' })
     setHoveredIndex(null)
-    setIsKeyboardNav(true)
-    setSelectedIndex(0)
+    activateKeyboard()
+    selectIndex(0)
     searchInputRef.current?.focus()
-  }, [])
+  }, [activateKeyboard, selectIndex, setHoveredIndex])
 
   const handleActiveFilterChange = useCallback(
     (filter: Filter) => {
       setActiveFilter(filter)
       prepareForFilterChange()
     },
-    [prepareForFilterChange]
+    [prepareForFilterChange, setActiveFilter]
   )
 
   const handleTagFilterChange = useCallback(
@@ -550,7 +553,7 @@ const ClipboardHistoryPanelSession: React.FC<ClipboardHistoryPanelProps> = ({
       setTagFilter(tag)
       prepareForFilterChange()
     },
-    [prepareForFilterChange]
+    [prepareForFilterChange, setTagFilter]
   )
 
   const handleKeyDown = useCallback(
@@ -570,16 +573,10 @@ const ClipboardHistoryPanelSession: React.FC<ClipboardHistoryPanelProps> = ({
         e.preventDefault()
         dispatchPreview({ type: 'suppress', value: false })
         dispatchPreview({ type: 'set-focus-source', source: 'selection' })
-        setIsKeyboardNav(true)
+        activateKeyboard()
         setHoveredIndex(null)
-        setSelectedIndex(0)
-        setActiveFilter(prev => {
-          const count = QUICK_FILTER_ORDER.length
-          // A filter outside the cycle (e.g. Favorited) maps to All as the base.
-          const base = Math.max(0, QUICK_FILTER_ORDER.indexOf(prev))
-          const next = e.shiftKey ? (base - 1 + count) % count : (base + 1) % count
-          return QUICK_FILTER_ORDER[next]
-        })
+        selectIndex(0)
+        cycleActiveFilter(QUICK_FILTER_ORDER, e.shiftKey)
         return
       }
 
@@ -655,11 +652,9 @@ const ClipboardHistoryPanelSession: React.FC<ClipboardHistoryPanelProps> = ({
         e.preventDefault()
         dispatchPreview({ type: 'suppress', value: false })
         dispatchPreview({ type: 'set-focus-source', source: 'selection' })
-        setIsKeyboardNav(true)
+        activateKeyboard()
         setHoveredIndex(null)
-        setSelectedIndex(prev =>
-          e.key === 'n' ? Math.min(prev + 1, filteredItems.length - 1) : Math.max(prev - 1, 0)
-        )
+        moveSelection(e.key === 'n' ? 1 : -1)
         return
       }
 
@@ -669,13 +664,9 @@ const ClipboardHistoryPanelSession: React.FC<ClipboardHistoryPanelProps> = ({
           e.preventDefault()
           dispatchPreview({ type: 'suppress', value: false })
           dispatchPreview({ type: 'set-focus-source', source: 'selection' })
-          setIsKeyboardNav(true)
+          activateKeyboard()
           setHoveredIndex(null)
-          setSelectedIndex(prev =>
-            e.key === 'ArrowDown'
-              ? Math.min(prev + 1, filteredItems.length - 1)
-              : Math.max(prev - 1, 0)
-          )
+          moveSelection(e.key === 'ArrowDown' ? 1 : -1)
           break
         case 'Enter':
           e.preventDefault()
@@ -693,12 +684,17 @@ const ClipboardHistoryPanelSession: React.FC<ClipboardHistoryPanelProps> = ({
       isSearching,
       isLocked,
       loading,
+      activateKeyboard,
+      cycleActiveFilter,
+      moveSelection,
       selectedIndex,
+      selectIndex,
+      setHoveredIndex,
       visibleUnlocking,
     ]
   )
 
-  const handleHistoryMouseMove = useCallback(() => setHasPointerMovedSinceShow(true), [])
+  const handleHistoryMouseMove = notePointerMoved
 
   return (
     <div
@@ -725,9 +721,7 @@ const ClipboardHistoryPanelSession: React.FC<ClipboardHistoryPanelProps> = ({
       >
         <HistoryPane
           filteredItems={filteredItems}
-          hasPointerMovedSinceShow={hasPointerMovedSinceShow}
-          isKeyboardNav={isKeyboardNav}
-          isLocked={isLocked}
+          interaction={{ hasPointerMovedSinceShow, isKeyboardNav, isLocked, selectedIndex }}
           isSearching={isSearching}
           searchTotal={searchTotal}
           itemRefs={itemRefs}
@@ -739,20 +733,18 @@ const ClipboardHistoryPanelSession: React.FC<ClipboardHistoryPanelProps> = ({
           onContextMenuSelect={handleContextMenuSelect}
           onUnlock={handleUnlock}
           searchInputRef={searchInputRef}
-          selectedIndex={selectedIndex}
           setHoveredIndex={setHoveredIndex}
-          setIsKeyboardNav={setIsKeyboardNav}
           unlocking={visibleUnlocking}
           unlockError={visibleUnlockError}
-          activeFilter={activeFilter}
+          activeFilter={filters.activeFilter}
           setActiveFilter={handleActiveFilterChange}
-          tagFilter={tagFilter}
+          tagFilter={filters.tagFilter}
           setTagFilter={handleTagFilterChange}
-          sourceFilter={sourceFilter}
+          sourceFilter={filters.sourceFilter}
           setSourceFilter={setSourceFilter}
-          extensionFilter={extensionFilter}
+          extensionFilter={filters.extensionFilter}
           setExtensionFilter={setExtensionFilter}
-          timeRange={timeRange}
+          timeRange={filters.timeRange}
           setTimeRange={setTimeRange}
           searchableTags={searchableTags}
           sourceOptions={sourceOptions}

--- a/src/quick-panel/ClipboardHistoryPanel.tsx
+++ b/src/quick-panel/ClipboardHistoryPanel.tsx
@@ -180,7 +180,7 @@ const ClipboardHistoryPanelSession: React.FC<ClipboardHistoryPanelProps> = ({
   const itemRefs = useRef<Map<number, HTMLDivElement>>(new Map())
   const previewTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const previewLayoutTokenRef = useRef(0)
-  const [skipTransition, setSkipTransition] = useState(false)
+  const [skipTransition, setSkipTransition] = useState(showRequestId !== 0)
   const previewExpanded = previewState.mode === 'expanded'
   const previewReservingSpace = previewState.mode === 'reserving'
   const previewEntryId = previewState.entryId
@@ -228,7 +228,6 @@ const ClipboardHistoryPanelSession: React.FC<ClipboardHistoryPanelProps> = ({
   })
   useEffect(() => {
     if (showRequestId === 0) return
-    setSkipTransition(true)
 
     const focusTimer = setTimeout(() => {
       setSkipTransition(false)

--- a/src/quick-panel/ClipboardHistoryPanel.tsx
+++ b/src/quick-panel/ClipboardHistoryPanel.tsx
@@ -14,6 +14,7 @@ import { unlockEncryptionSession } from '@/api/security'
 import { toast } from '@/components/ui/toast'
 import { useDebounce } from '@/hooks/useDebounce'
 import { useHistorySourceOptions } from '@/hooks/useHistorySourceOptions'
+import { usePlatform } from '@/hooks/usePlatform'
 import { useSearchTags } from '@/hooks/useSearchTags'
 import { useThemeSync } from '@/hooks/useThemeSync'
 import { pasteableFilePaths } from '@/lib/clipboard-utils'
@@ -26,7 +27,12 @@ import { useAppDispatch } from '@/store/hooks'
 import { fetchSpaceMembers } from '@/store/slices/devicesSlice'
 import ClipboardPreviewPane from './ClipboardPreviewPane'
 import HistoryPane from './components/HistoryPane'
-import { PREVIEW_OPEN_DELAY_MS, PREVIEW_SWITCH_DELAY_MS, QUICK_FILTER_ORDER } from './constants'
+import {
+  getQuickPanelLayoutClassNames,
+  PREVIEW_OPEN_DELAY_MS,
+  PREVIEW_SWITCH_DELAY_MS,
+  QUICK_FILTER_ORDER,
+} from './constants'
 import { useHistorySearch } from './hooks/useHistorySearch'
 import type {
   PreviewAction,
@@ -124,6 +130,8 @@ const ClipboardHistoryPanelSession: React.FC<ClipboardHistoryPanelProps> = ({
 }) => {
   const { t } = useTranslation()
   const dispatch = useAppDispatch()
+  const { isLinux, isTauri } = usePlatform()
+  const isLinuxQuickPanel = isLinux && isTauri
 
   // Refresh the paired-device list so the row context menu's "send to device"
   // submenu shows current names and connection state. The quick panel is a
@@ -178,8 +186,9 @@ const ClipboardHistoryPanelSession: React.FC<ClipboardHistoryPanelProps> = ({
   const previewEntryId = previewState.entryId
   const previewSuppressed = previewState.suppressed
   const historyLockedWidth = previewState.historyLockedWidth
-  const previewFocusSource = previewState.focusSource
   const previewSide = previewState.side
+  const layoutClassNames = getQuickPanelLayoutClassNames(isLinuxQuickPanel, previewSide === 'left')
+  const previewFocusSource = previewState.focusSource
 
   const { filteredItems, previewItems, isSearching, searchTotal, loading, isLocked, removeItem } =
     useHistorySearch({
@@ -695,7 +704,7 @@ const ClipboardHistoryPanelSession: React.FC<ClipboardHistoryPanelProps> = ({
   return (
     <div
       className={cn(
-        'flex h-screen w-screen overflow-hidden bg-transparent p-4',
+        layoutClassNames.container,
         // Open the preview to the left of the history pane near the right edge.
         // Reversing the row keeps the history pane (now the last child) pinned
         // at its anchor while the preview occupies the freed space on the left.
@@ -757,23 +766,28 @@ const ClipboardHistoryPanelSession: React.FC<ClipboardHistoryPanelProps> = ({
       <div
         className={cn(
           'min-w-0',
-          // Gap between preview and history. With `flex-row-reverse` (preview
-          // on the left) the gap must sit on the preview's right edge instead.
+          // Linux uses a one-pixel divider; floating-card platforms retain the
+          // existing outer gap. With `flex-row-reverse`, the divider moves to
+          // the preview's right edge.
           previewExpanded
             ? cn(
-                previewSide === 'left' ? 'mr-2' : 'ml-2',
-                'flex-1 basis-0 opacity-100 translate-x-0'
+                !isLinuxQuickPanel && (previewSide === 'left' ? 'mr-2' : 'ml-2'),
+                layoutClassNames.previewExpanded
               )
             : previewReservingSpace && historyLockedWidth != null
               ? cn(
-                  previewSide === 'left' ? 'mr-2' : 'ml-2',
-                  'shrink-0 opacity-0 translate-x-0 pointer-events-none'
+                  !isLinuxQuickPanel && (previewSide === 'left' ? 'mr-2' : 'ml-2'),
+                  layoutClassNames.previewReserved
                 )
               : 'ml-0 w-0 opacity-0 translate-x-2 pointer-events-none'
         )}
         style={
           previewReservingSpace && historyLockedWidth != null
-            ? { width: `max(0px, calc(100% - ${historyLockedWidth}px - 0.5rem))` }
+            ? {
+                width: `max(0px, calc(100% - ${historyLockedWidth}px - ${
+                  isLinuxQuickPanel ? '1px' : '0.5rem'
+                }))`,
+              }
             : undefined
         }
         aria-hidden={!previewExpanded}

--- a/src/quick-panel/ClipboardPreviewPane.tsx
+++ b/src/quick-panel/ClipboardPreviewPane.tsx
@@ -1,7 +1,9 @@
 import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import ClipboardPreview from '@/components/clipboard/ClipboardPreview'
+import { usePlatform } from '@/hooks/usePlatform'
 import type { DisplayClipboardItem } from '@/lib/clipboard-entry'
+import { getQuickPanelLayoutClassNames } from './constants'
 
 interface ClipboardPreviewPaneProps {
   item: DisplayClipboardItem | null
@@ -10,9 +12,10 @@ interface ClipboardPreviewPaneProps {
 function ClipboardPreviewPane({ item }: ClipboardPreviewPaneProps) {
   const { t } = useTranslation(undefined, { keyPrefix: 'previewPanel' })
   const isMac = useMemo(() => navigator.platform.toUpperCase().includes('MAC'), [])
+  const { isLinux, isTauri } = usePlatform()
 
   return (
-    <div className="flex h-full w-full min-w-0 flex-col overflow-hidden rounded-xl border border-border/50 bg-card text-card-foreground shadow-xl backdrop-blur-xl">
+    <div className={getQuickPanelLayoutClassNames(isLinux && isTauri).previewCard}>
       <div className="min-h-0 flex-1" data-testid="quick-panel-preview-area">
         <ClipboardPreview item={item} />
       </div>

--- a/src/quick-panel/QuickPanelApp.tsx
+++ b/src/quick-panel/QuickPanelApp.tsx
@@ -10,19 +10,15 @@ import { commands } from '@/lib/ipc'
 import { createLogger } from '@/lib/logger'
 import { readStoredUiScale } from '@/lib/ui-scale'
 import ClipboardHistoryPanel from './ClipboardHistoryPanel'
+import { getQuickPanelLayoutClassNames } from './constants'
 
 const log = createLogger('quick-panel-app')
 const SHOW_FALLBACK_DELAY_MS = 50
 
-const loadingClassName =
-  'flex h-screen w-screen items-center justify-center bg-transparent text-[13px] text-muted-foreground'
-
-const errorClassName =
-  'flex h-screen w-screen items-center justify-center bg-transparent px-6 text-center text-[13px] text-destructive'
-
 const QuickPanelApp: React.FC = () => {
   const { t } = useTranslation(undefined, { keyPrefix: 'quickPanel' })
-  const { reduceVisualEffects } = usePlatform()
+  const { isLinux, isTauri, reduceVisualEffects } = usePlatform()
+  const layoutClassNames = getQuickPanelLayoutClassNames(isLinux && isTauri)
   const [daemonReady, setDaemonReady] = useState(daemonClient.initialized)
   const [bootstrapError, setBootstrapError] = useState<string | null>(null)
   const [showRequestId, setShowRequestId] = useState(0)
@@ -72,7 +68,18 @@ const QuickPanelApp: React.FC = () => {
       }, SHOW_FALLBACK_DELAY_MS)
     })
 
+    let active = true
+    void unlistenPrepare
+      .then(() => {
+        if (!active) return
+        return commands.markQuickPanelReady()
+      })
+      .catch(err => {
+        log.warn({ err }, 'failed to mark quick panel ready')
+      })
+
     return () => {
+      active = false
       clearFinalizeTimer()
       unlistenPrepare.then(fn => fn())
     }
@@ -105,9 +112,17 @@ const QuickPanelApp: React.FC = () => {
   let content: React.ReactNode
   if (!daemonReady) {
     content = bootstrapError ? (
-      <div className={errorClassName}>{t('unavailable')}</div>
+      <div
+        className={`flex h-screen w-screen items-center justify-center ${layoutClassNames.statusSurface} px-6 text-center text-[13px] text-destructive`}
+      >
+        {t('unavailable')}
+      </div>
     ) : (
-      <div className={loadingClassName}>{t('loading')}</div>
+      <div
+        className={`flex h-screen w-screen items-center justify-center ${layoutClassNames.statusSurface} text-[13px] text-muted-foreground`}
+      >
+        {t('loading')}
+      </div>
     )
   } else {
     content = <ClipboardHistoryPanel showRequestId={showRequestId} onShowPrepared={finalizeShow} />

--- a/src/quick-panel/__tests__/ClipboardHistoryPanel.single-window.test.tsx
+++ b/src/quick-panel/__tests__/ClipboardHistoryPanel.single-window.test.tsx
@@ -2,6 +2,7 @@ import { configureStore } from '@reduxjs/toolkit'
 import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import type { ReactElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
 import { Provider } from 'react-redux'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { deleteClipboardEntry, restoreClipboardEntry } from '@/api/daemon'
@@ -179,6 +180,17 @@ describe('ClipboardHistoryPanel single-window preview', () => {
     vi.clearAllMocks()
     invokeMock.mockResolvedValue(undefined)
     Element.prototype.scrollIntoView = vi.fn()
+  })
+
+  it('starts a shown session without a preview transition', () => {
+    const store = configureStore({ reducer: { devices: devicesReducer } })
+    const markup = renderToStaticMarkup(
+      <Provider store={store}>
+        <ClipboardHistoryPanel showRequestId={1} />
+      </Provider>
+    )
+
+    expect(markup).not.toContain('transition-[opacity,transform]')
   })
 
   it('renders preview content inside the same panel and requests expanded mode', async () => {

--- a/src/quick-panel/__tests__/QuickPanelApp.test.tsx
+++ b/src/quick-panel/__tests__/QuickPanelApp.test.tsx
@@ -70,6 +70,19 @@ describe('QuickPanelApp', () => {
     })
   })
 
+  it('announces readiness after subscribing to show requests', async () => {
+    connectDaemonWsMock.mockReturnValue(deferred().promise)
+
+    render(<QuickPanelApp />)
+
+    await waitFor(() => {
+      expect(invokeMock).toHaveBeenCalledWith(
+        'mark_quick_panel_ready',
+        expect.objectContaining({ trace: expect.any(Object) })
+      )
+    })
+  })
+
   it('finalizes show events even while daemon bootstrap is still pending', async () => {
     const pendingBootstrap = deferred()
     connectDaemonWsMock.mockReturnValue(pendingBootstrap.promise)

--- a/src/quick-panel/__tests__/constants.test.ts
+++ b/src/quick-panel/__tests__/constants.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   clampImageCardAspectRatio,
+  getQuickPanelLayoutClassNames,
   IMAGE_CARD_MAX_ASPECT_RATIO,
   IMAGE_CARD_MIN_ASPECT_RATIO,
 } from '@/quick-panel/constants'
@@ -27,5 +28,27 @@ describe('clampImageCardAspectRatio', () => {
 
   it('clamps extreme landscape ratios to the maximum', () => {
     expect(clampImageCardAspectRatio(10)).toBe(IMAGE_CARD_MAX_ASPECT_RATIO)
+  })
+})
+
+describe('Linux quick panel layout', () => {
+  it('uses an opaque unified surface with a divider instead of transparent gaps', () => {
+    expect(getQuickPanelLayoutClassNames(true)).toEqual({
+      container: 'flex h-screen w-screen overflow-hidden bg-background p-0',
+      statusSurface: 'bg-background',
+      card: 'flex h-full w-full min-w-0 flex-col overflow-hidden border border-border/50 bg-background',
+      previewCard:
+        'flex h-full w-full min-w-0 flex-col overflow-hidden border border-border/50 bg-card text-card-foreground',
+      previewExpanded: 'flex-1 basis-0 border-l border-border/50 opacity-100 translate-x-0',
+      previewReserved:
+        'shrink-0 border-l border-border/50 opacity-0 translate-x-0 pointer-events-none',
+    })
+  })
+
+  it('keeps the floating-card layout on non-Linux platforms', () => {
+    expect(getQuickPanelLayoutClassNames(false).container).toContain('bg-transparent')
+    expect(getQuickPanelLayoutClassNames(false).statusSurface).toBe('bg-transparent')
+    expect(getQuickPanelLayoutClassNames(false).container).toContain('p-4')
+    expect(getQuickPanelLayoutClassNames(false).card).toContain('rounded-xl')
   })
 })

--- a/src/quick-panel/components/HistoryPane.tsx
+++ b/src/quick-panel/components/HistoryPane.tsx
@@ -3,10 +3,11 @@ import React, { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Filter } from '@/api/clipboardItems'
 import { CompositeSearchBar, type SourceOption } from '@/components/history/composite-search'
+import { usePlatform } from '@/hooks/usePlatform'
 import type { DisplayClipboardItem } from '@/lib/clipboard-entry'
 import type { SearchTagOption } from '@/lib/search-tags'
 import { cn } from '@/lib/utils'
-import { quickCardClassName } from '../constants'
+import { getQuickPanelLayoutClassNames } from '../constants'
 import {
   peekQuickPanelImageAspectRatio,
   useQuickPanelImageAspectRatioEpoch,
@@ -124,6 +125,7 @@ const HistoryPane: React.FC<HistoryPaneProps> = React.memo(
     contextActions,
   }) => {
     const { t } = useTranslation(undefined, { keyPrefix: 'quickPanel.history' })
+    const { isLinux, isTauri } = usePlatform()
     const aspectRatioEpoch = useQuickPanelImageAspectRatioEpoch()
 
     const showImageWall = activeFilter === Filter.Image
@@ -140,7 +142,7 @@ const HistoryPane: React.FC<HistoryPaneProps> = React.memo(
     }, [filteredItems, showImageWall, aspectRatioEpoch])
 
     return (
-      <div className={quickCardClassName}>
+      <div className={getQuickPanelLayoutClassNames(isLinux && isTauri).card}>
         {isLocked && !loading ? (
           <>
             <div className="flex flex-1 flex-col items-center justify-center gap-4 px-6">

--- a/src/quick-panel/components/HistoryPane.tsx
+++ b/src/quick-panel/components/HistoryPane.tsx
@@ -22,12 +22,15 @@ import QuickPanelTypeFilterBar from './QuickPanelTypeFilterBar'
 
 interface HistoryPaneProps {
   filteredItems: DisplayItem[]
-  hasPointerMovedSinceShow: boolean
-  isKeyboardNav: boolean
-  isLocked: boolean
+  interaction: {
+    hasPointerMovedSinceShow: boolean
+    isKeyboardNav: boolean
+    isLocked: boolean
+    selectedIndex: number
+  }
   isSearching: boolean
   searchTotal: number | null
-  itemRefs: React.MutableRefObject<Map<number, HTMLDivElement>>
+  itemRefs: Map<number, HTMLDivElement>
   loading: boolean
   onHover: (index: number) => void
   onHistoryMouseMove: () => void
@@ -37,9 +40,7 @@ interface HistoryPaneProps {
   onContextMenuSelect: (index: number) => void
   onUnlock: () => void
   searchInputRef: React.RefObject<HTMLInputElement | null>
-  selectedIndex: number
-  setHoveredIndex: React.Dispatch<React.SetStateAction<number | null>>
-  setIsKeyboardNav: React.Dispatch<React.SetStateAction<boolean>>
+  setHoveredIndex: (index: number | null) => void
   unlocking: boolean
   unlockError: string | null
   activeFilter: Filter
@@ -77,21 +78,19 @@ function getShortcutKey(index: number): string | undefined {
  * arrow-key navigation can `scrollIntoView` the selected row (see
  * `ClipboardHistoryPanel`'s `itemRefs`-keyed effect). */
 function makeItemRef(
-  itemRefs: React.MutableRefObject<Map<number, HTMLDivElement>>,
+  itemRefs: Map<number, HTMLDivElement>,
   index: number
 ): (el: HTMLDivElement | null) => void {
   return el => {
-    if (el) itemRefs.current.set(index, el)
-    else itemRefs.current.delete(index)
+    if (el) itemRefs.set(index, el)
+    else itemRefs.delete(index)
   }
 }
 
 const HistoryPane: React.FC<HistoryPaneProps> = React.memo(
   ({
     filteredItems,
-    hasPointerMovedSinceShow,
-    isKeyboardNav,
-    isLocked,
+    interaction,
     isSearching,
     searchTotal,
     itemRefs,
@@ -103,9 +102,7 @@ const HistoryPane: React.FC<HistoryPaneProps> = React.memo(
     onContextMenuSelect,
     onUnlock,
     searchInputRef,
-    selectedIndex,
     setHoveredIndex,
-    setIsKeyboardNav,
     unlocking,
     unlockError,
     activeFilter,
@@ -124,6 +121,7 @@ const HistoryPane: React.FC<HistoryPaneProps> = React.memo(
     contextItems,
     contextActions,
   }) => {
+    const { hasPointerMovedSinceShow, isKeyboardNav, isLocked, selectedIndex } = interaction
     const { t } = useTranslation(undefined, { keyPrefix: 'quickPanel.history' })
     const { isLinux, isTauri } = usePlatform()
     const aspectRatioEpoch = useQuickPanelImageAspectRatioEpoch()
@@ -224,8 +222,7 @@ const HistoryPane: React.FC<HistoryPaneProps> = React.memo(
                 showImageWall && 'overflow-y-scroll px-2 py-2 [scrollbar-gutter:stable]'
               )}
               onMouseMove={() => {
-                if (!hasPointerMovedSinceShow) onHistoryMouseMove()
-                if (isKeyboardNav) setIsKeyboardNav(false)
+                if (!hasPointerMovedSinceShow || isKeyboardNav) onHistoryMouseMove()
               }}
               onMouseLeave={() => setHoveredIndex(null)}
             >

--- a/src/quick-panel/constants.ts
+++ b/src/quick-panel/constants.ts
@@ -16,8 +16,31 @@ export const typeIcons: Record<ClipboardEntryType, React.ElementType> = {
   unknown: FileText,
 }
 
-export const quickCardClassName =
-  'flex h-full w-full min-w-0 flex-col overflow-hidden rounded-xl border border-border/50 bg-background/95 shadow-xl backdrop-blur-xl'
+export function getQuickPanelLayoutClassNames(isLinux: boolean, previewOnLeft = false) {
+  if (isLinux) {
+    const dividerClassName = previewOnLeft ? 'border-r' : 'border-l'
+
+    return {
+      container: 'flex h-screen w-screen overflow-hidden bg-background p-0',
+      statusSurface: 'bg-background',
+      card: 'flex h-full w-full min-w-0 flex-col overflow-hidden border border-border/50 bg-background',
+      previewCard:
+        'flex h-full w-full min-w-0 flex-col overflow-hidden border border-border/50 bg-card text-card-foreground',
+      previewExpanded: `flex-1 basis-0 ${dividerClassName} border-border/50 opacity-100 translate-x-0`,
+      previewReserved: `shrink-0 ${dividerClassName} border-border/50 opacity-0 translate-x-0 pointer-events-none`,
+    }
+  }
+
+  return {
+    container: 'flex h-screen w-screen overflow-hidden bg-transparent p-4',
+    statusSurface: 'bg-transparent',
+    card: 'flex h-full w-full min-w-0 flex-col overflow-hidden rounded-xl border border-border/50 bg-background/95 shadow-xl backdrop-blur-xl',
+    previewCard:
+      'flex h-full w-full min-w-0 flex-col overflow-hidden rounded-xl border border-border/50 bg-card text-card-foreground shadow-xl backdrop-blur-xl',
+    previewExpanded: 'flex-1 basis-0 opacity-100 translate-x-0',
+    previewReserved: 'shrink-0 opacity-0 translate-x-0 pointer-events-none',
+  }
+}
 
 /**
  * Aspect-ratio clamp for the image-wall masonry. Extreme portrait/landscape

--- a/src/quick-panel/hooks/useQuickPanelState.ts
+++ b/src/quick-panel/hooks/useQuickPanelState.ts
@@ -1,0 +1,163 @@
+import { useCallback, useReducer } from 'react'
+import { Filter } from '@/api/clipboardItems'
+import type { TimeRangePreset } from '../types'
+
+interface SearchFiltersState {
+  query: string
+  activeFilter: Filter
+  tagFilter: string | null
+  sourceFilter: string | null
+  extensionFilter: string | null
+  timeRange: TimeRangePreset
+}
+
+type SearchFiltersAction =
+  | { type: 'query'; value: string }
+  | { type: 'active-filter'; value: Filter }
+  | { type: 'tag-filter'; value: string | null }
+  | { type: 'source-filter'; value: string | null }
+  | { type: 'extension-filter'; value: string | null }
+  | { type: 'time-range'; value: TimeRangePreset }
+  | { type: 'cycle-active-filter'; filters: readonly Filter[]; reverse: boolean }
+
+const initialSearchFiltersState: SearchFiltersState = {
+  query: '',
+  activeFilter: Filter.All,
+  tagFilter: null,
+  sourceFilter: null,
+  extensionFilter: null,
+  timeRange: 'all_time',
+}
+
+function searchFiltersReducer(
+  state: SearchFiltersState,
+  action: SearchFiltersAction
+): SearchFiltersState {
+  switch (action.type) {
+    case 'query':
+      return { ...state, query: action.value }
+    case 'active-filter':
+      return { ...state, activeFilter: action.value }
+    case 'tag-filter':
+      return { ...state, tagFilter: action.value }
+    case 'source-filter':
+      return { ...state, sourceFilter: action.value }
+    case 'extension-filter':
+      return { ...state, extensionFilter: action.value }
+    case 'time-range':
+      return { ...state, timeRange: action.value }
+    case 'cycle-active-filter': {
+      const base = Math.max(0, action.filters.indexOf(state.activeFilter))
+      const count = action.filters.length
+      const index = action.reverse ? (base - 1 + count) % count : (base + 1) % count
+      return { ...state, activeFilter: action.filters[index] }
+    }
+  }
+}
+
+export function useQuickPanelSearchFilters() {
+  const [filters, dispatch] = useReducer(searchFiltersReducer, initialSearchFiltersState)
+
+  return {
+    filters,
+    setQuery: useCallback((value: string) => dispatch({ type: 'query', value }), []),
+    setActiveFilter: useCallback((value: Filter) => dispatch({ type: 'active-filter', value }), []),
+    setTagFilter: useCallback(
+      (value: string | null) => dispatch({ type: 'tag-filter', value }),
+      []
+    ),
+    setSourceFilter: useCallback(
+      (value: string | null) => dispatch({ type: 'source-filter', value }),
+      []
+    ),
+    setExtensionFilter: useCallback(
+      (value: string | null) => dispatch({ type: 'extension-filter', value }),
+      []
+    ),
+    setTimeRange: useCallback(
+      (value: TimeRangePreset) => dispatch({ type: 'time-range', value }),
+      []
+    ),
+    cycleActiveFilter: useCallback(
+      (cycle: readonly Filter[], reverse: boolean) =>
+        dispatch({ type: 'cycle-active-filter', filters: cycle, reverse }),
+      []
+    ),
+  }
+}
+
+interface NavigationState {
+  selectedIndex: number
+  hoveredIndex: number | null
+  isKeyboardNav: boolean
+  hasPointerMovedSinceShow: boolean
+  previousFilteredCount: number
+  preserveSelectionOnNextListChange: boolean
+}
+
+type NavigationAction =
+  | { type: 'select'; index: number }
+  | { type: 'move'; direction: 1 | -1; itemCount: number }
+  | { type: 'hover'; index: number | null }
+  | { type: 'use-keyboard' }
+  | { type: 'pointer-moved' }
+  | { type: 'preserve-selection' }
+  | { type: 'list-changed'; itemCount: number }
+
+function navigationReducer(state: NavigationState, action: NavigationAction): NavigationState {
+  switch (action.type) {
+    case 'select':
+      return { ...state, selectedIndex: action.index }
+    case 'move':
+      return {
+        ...state,
+        selectedIndex:
+          action.direction === 1
+            ? Math.min(state.selectedIndex + 1, action.itemCount - 1)
+            : Math.max(state.selectedIndex - 1, 0),
+      }
+    case 'hover':
+      return { ...state, hoveredIndex: action.index }
+    case 'use-keyboard':
+      return { ...state, isKeyboardNav: true }
+    case 'pointer-moved':
+      return { ...state, hasPointerMovedSinceShow: true, isKeyboardNav: false }
+    case 'preserve-selection':
+      return { ...state, preserveSelectionOnNextListChange: true }
+    case 'list-changed':
+      return {
+        ...state,
+        previousFilteredCount: action.itemCount,
+        selectedIndex: state.preserveSelectionOnNextListChange ? state.selectedIndex : 0,
+        preserveSelectionOnNextListChange: false,
+      }
+  }
+}
+
+export function useQuickPanelNavigation(itemCount: number) {
+  const [navigation, dispatch] = useReducer(navigationReducer, itemCount, count => ({
+    selectedIndex: 0,
+    hoveredIndex: null,
+    isKeyboardNav: true,
+    hasPointerMovedSinceShow: false,
+    previousFilteredCount: count,
+    preserveSelectionOnNextListChange: false,
+  }))
+
+  if (navigation.previousFilteredCount !== itemCount) {
+    dispatch({ type: 'list-changed', itemCount })
+  }
+
+  return {
+    navigation,
+    select: useCallback((index: number) => dispatch({ type: 'select', index }), []),
+    move: useCallback(
+      (direction: 1 | -1) => dispatch({ type: 'move', direction, itemCount }),
+      [itemCount]
+    ),
+    setHoveredIndex: useCallback((index: number | null) => dispatch({ type: 'hover', index }), []),
+    activateKeyboard: useCallback(() => dispatch({ type: 'use-keyboard' }), []),
+    notePointerMoved: useCallback(() => dispatch({ type: 'pointer-moved' }), []),
+    preserveSelection: useCallback(() => dispatch({ type: 'preserve-selection' }), []),
+  }
+}


### PR DESCRIPTION
## Summary

- Add `uniclipboard --quick-panel` so a window-manager binding can open or toggle Quick Panel on Wayland, including during application startup.
- Make the Linux Quick Panel an opaque edge-to-edge surface and replace the preview gap with a divider, avoiding compositor focus-color bleed while preserving the existing macOS and Windows presentation.
- Document the Wayland window-manager launcher in English and Chinese.

Refs #1446

## Test plan

- [x] `cargo test -p uc-tauri --lib`
- [x] `cargo test -p uc-tauri --test specta_export`
- [x] `bun run test --run src/quick-panel/__tests__/constants.test.ts src/quick-panel/__tests__/ClipboardHistoryPanel.single-window.test.tsx src/quick-panel/__tests__/QuickPanelApp.test.tsx`
- [x] `bun run build`
- [x] `docs-site: bun run check:docs && bun run types:check`
- [x] Fedora niri runtime build and `--quick-panel` invocation; niri confirmed the focused floating Quick Panel window.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--quick-panel` support for launching or toggling the quick panel from compositor shortcuts on Wayland.
  * Quick-panel requests now work reliably during startup, app restarts, and lightweight mode transitions.
* **Improvements**
  * Improved quick-panel search, filtering, selection, and keyboard navigation.
  * Improved Linux layout and window appearance with unified opaque surfaces and dividers.
  * Preserved floating-card styling on other platforms.
* **Documentation**
  * Added English and Chinese guidance for configuring quick-panel shortcuts in native Wayland sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->