### PR TITLE
fix(quick-panel): hide tag filter scrollbar

### DIFF
--- a/src/quick-panel/components/QuickPanelTagFilterBar.tsx
+++ b/src/quick-panel/components/QuickPanelTagFilterBar.tsx
@@ -16,7 +16,7 @@ function QuickPanelTagFilterBar({ tagFilter, tagOptions, onChange }: QuickPanelT
     <div className="flex min-w-0 items-center gap-2 border-t border-border/50 bg-muted/5 px-3 py-1.5 text-[11px] text-muted-foreground">
       <span className="shrink-0">{t('history.composite.dimension.tag')}</span>
       <div
-        className="scrollbar-thin flex min-w-0 flex-1 items-center gap-1 overflow-x-auto"
+        className="no-scrollbar flex min-w-0 flex-1 items-center gap-1 overflow-x-auto"
         data-testid="quick-panel-tag-filter-list"
       >
         {tagOptions.map(tag => {

--- a/src/quick-panel/components/__tests__/QuickPanelTagFilterBar.test.tsx
+++ b/src/quick-panel/components/__tests__/QuickPanelTagFilterBar.test.tsx
@@ -28,7 +28,8 @@ describe('QuickPanelTagFilterBar', () => {
     expect(screen.getByRole('button', { name: 'Code' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'project' })).toBeInTheDocument()
     expect(container.querySelector('[data-testid="quick-panel-tag-filter-list"]')).toHaveClass(
-      'overflow-x-auto'
+      'overflow-x-auto',
+      'no-scrollbar'
     )
   })
 


### PR DESCRIPTION
## Summary

- Hide the Quick Panel tag filter scrollbar while preserving horizontal scrolling (5a210907d).
- Add regression coverage for the hidden-scrollbar behavior (5a210907d).

## Test plan

- [x] `npx vitest run src/quick-panel/components/__tests__/QuickPanelTagFilterBar.test.tsx`
- [x] `bunx oxlint src/quick-panel/components/QuickPanelTagFilterBar.tsx src/quick-panel/components/__tests__/QuickPanelTagFilterBar.test.tsx`
- [x] `bun run build`