### PR TITLE
ci(security-audit): label RustSec issues

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -66,6 +66,20 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Label RustSec issues
+        if: github.event_name == 'schedule'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LABEL: security-audit
+        run: |
+          set -euo pipefail
+          gh issue list --state all --limit 10000 --json number,title,labels \
+            --jq '.[] | select(.title | startswith("RUSTSEC-")) | select((.labels | map(.name) | index("security-audit")) == null) | .number' |
+            while IFS= read -r issue_number; do
+              [ -z "$issue_number" ] && continue
+              gh issue edit "$issue_number" --add-label "$LABEL"
+            done
+
   bun-audit:
     name: bun audit (${{ matrix.project.directory }})
     runs-on: ubuntu-latest

--- a/scripts/__tests__/security-audit-workflow.test.ts
+++ b/scripts/__tests__/security-audit-workflow.test.ts
@@ -1,0 +1,21 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const projectRoot = path.resolve(import.meta.dirname, '../..')
+
+function readWorkflow(): string {
+  return fs.readFileSync(path.join(projectRoot, '.github/workflows/security-audit.yml'), 'utf8')
+}
+
+describe('security audit issue labeling', () => {
+  it('labels every RustSec issue after the audit action creates it', () => {
+    const workflow = readWorkflow()
+
+    expect(workflow).toContain('security-audit')
+    expect(workflow).toContain('Label RustSec issues')
+    expect(workflow).toContain('gh issue list')
+    expect(workflow).toContain('startswith("RUSTSEC-")')
+    expect(workflow).toContain('--add-label "$LABEL"')
+  })
+})


### PR DESCRIPTION
## Summary

- Add the `security-audit` label to RustSec dependency advisory issues.
- Label existing RustSec issues and automatically label newly created issues after scheduled audits.
- Add a workflow regression test for the labeling step.

## Test plan

- [x] `bun test scripts/__tests__/security-audit-workflow.test.ts --run`
- [x] `git diff --check`
- [x] Existing RustSec issues verified to all have the `security-audit` label.
- [x] Context audit completed; no `CONTEXT.md` update is needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved scheduled security issue processing by automatically labeling unlabelled RustSec issues with `security-audit`.

* **Tests**
  * Added automated coverage to verify that RustSec issue filtering and labeling work as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->