### PR TITLE
fix(quick-panel): disable production developer tools

### DIFF
--- a/src-tauri/crates/uc-tauri/src/quick_panel/mod.rs
+++ b/src-tauri/crates/uc-tauri/src/quick_panel/mod.rs
@@ -596,6 +596,7 @@ pub fn pre_create(app: &tauri::AppHandle) {
         .transparent(uses_transparent_window())
         .shadow(false)
         .always_on_top(true)
+        .devtools(crate::runtime_environment::development_mode())
         .visible(false)
         .resizable(false)
         .skip_taskbar(true)

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -24,7 +24,7 @@
         "hiddenTitle": true,
         "transparent": true,
         "visible": false,
-        "devtools": true,
+        "devtools": false,
         "windowEffects": {
           "effects": ["hudWindow"],
           "state": "active",

--- a/src-tauri/tauri.dev.conf.json
+++ b/src-tauri/tauri.dev.conf.json
@@ -2,6 +2,29 @@
   "$schema": "https://schema.tauri.app/config",
   "productName": "UniClipboard Dev",
   "identifier": "app.uniclipboard.desktop.dev",
+  "app": {
+    "windows": [
+      {
+        "label": "main",
+        "create": false,
+        "title": "UniClipboard",
+        "width": 800,
+        "height": 600,
+        "minWidth": 990,
+        "minHeight": 660,
+        "titleBarStyle": "Overlay",
+        "hiddenTitle": true,
+        "transparent": true,
+        "visible": false,
+        "devtools": true,
+        "windowEffects": {
+          "effects": ["hudWindow"],
+          "state": "active",
+          "radius": 16
+        }
+      }
+    ]
+  },
   "plugins": {
     "updater": {
       "endpoints": []

--- a/src/lib/webview-context-menu.ts
+++ b/src/lib/webview-context-menu.ts
@@ -1,0 +1,15 @@
+/**
+ * Keep the native webview context menu out of the production UI.
+ *
+ * Tauri dev builds retain the native menu so the platform's developer-tools
+ * entry remains available for local debugging.
+ */
+export function initializeWebviewContextMenu(): void {
+  if (import.meta.env.DEV || typeof window === 'undefined') return
+
+  window.addEventListener('contextmenu', preventContextMenu)
+}
+
+function preventContextMenu(event: MouseEvent): void {
+  event.preventDefault()
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,7 @@ import { Provider } from 'react-redux'
 import './i18n'
 import { getDeviceMeta } from '@/api/runtime'
 import { connectDaemonWs, registerDaemonShutdownListener } from '@/lib/daemon-ws-bootstrap'
+import { initializeWebviewContextMenu } from '@/lib/webview-context-menu'
 import { initializeWindowFrame } from '@/lib/window-frame-runtime'
 import { initializeWindowUi } from '@/lib/window-ui'
 import '@/lib/wdio-test-bridge'
@@ -12,24 +13,7 @@ import { applyDeviceMetaToSentry, initSentry, Sentry } from '@/observability/sen
 import App from './App'
 import { store } from './store'
 
-// 屏蔽 WebKit/WebView2 默认右键菜单(Inspect / Reload / 拼写检查),否则用户右键
-// Any text would expose the webview identity. Use the shared context menu where native right-click is needed.
-if (typeof window !== 'undefined') {
-  window.addEventListener('contextmenu', e => e.preventDefault())
-
-  // DevTools 用 ⌘⌥I (macOS) / Ctrl+Shift+I (Win/Linux) 打开,补偿被禁用的右键菜单。
-  window.addEventListener('keydown', e => {
-    const isMac = navigator.platform.toLowerCase().includes('mac')
-    const modifier = isMac ? e.metaKey && e.altKey : e.ctrlKey && e.shiftKey
-    if (modifier && e.key.toLowerCase() === 'i') {
-      e.preventDefault()
-      void import('@tauri-apps/api/webviewWindow').then(({ getCurrentWebviewWindow }) => {
-        const w = getCurrentWebviewWindow() as unknown as { openDevtools?: () => void }
-        w.openDevtools?.()
-      })
-    }
-  })
-}
+initializeWebviewContextMenu()
 
 // Sentry init runs before React mounts so that the global ErrorBoundary,
 // the pino → Sentry.logger transmit hook, and breadcrumb capture are all

--- a/src/quick-panel/main.tsx
+++ b/src/quick-panel/main.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { Provider } from 'react-redux'
 import '@/i18n'
+import { initializeWebviewContextMenu } from '@/lib/webview-context-menu'
 import { initializeWindowUi } from '@/lib/window-ui'
 import '@/lib/wdio-test-bridge'
 import { store } from '@/store'
@@ -9,6 +10,7 @@ import '@/styles/globals.css'
 import QuickPanelApp from './QuickPanelApp'
 
 initializeWindowUi()
+initializeWebviewContextMenu()
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>


### PR DESCRIPTION
## Summary

- Disable browser developer tools in production builds for the main window and Quick Panel.
- Keep developer tools available in development builds without a production keyboard opener.
- Apply the same production context-menu policy to both application entry points.

Closes #1576.

## Test plan

- [x] `bun run build`
- [x] `bunx vitest run` (151 files, 1002 tests)
- [x] `cargo check -p uc-tauri --lib`
- [x] `bunx tauri build --debug --no-bundle`
- [x] Production bundle scan confirms no developer-tools opener or shortcut.
- [ ] Verify the Quick Panel on macOS, Windows, and Linux release builds.

Documentation: no `CONTEXT.md` or `docs-site` changes are needed; this only changes production debugging access.
Telemetry: no new user flow or business milestone.
Tracing: no tracing or logging behavior was added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated development window configuration with transparent styling, HUD effects, minimum dimensions, and developer tools.
  * Developer tools are now available according to the application’s runtime development mode.

* **Bug Fixes**
  * Disabled native browser context menus in production while preserving them during development.
  * Disabled developer tools in the production main window for improved security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->