### PR TITLE
feat(history): polish search and code previews

### DIFF
--- a/src/components/clipboard/ClipboardPreview.tsx
+++ b/src/components/clipboard/ClipboardPreview.tsx
@@ -11,6 +11,7 @@ import type {
   DisplayClipboardItem,
 } from '@/lib/clipboard-entry'
 import { linkItemFromTextContent } from '@/lib/clipboard-utils'
+import { cn } from '@/lib/utils'
 import { reportError } from '@/observability/errors'
 import ClipboardPreviewInfo from './ClipboardPreviewInfo'
 import CodePreview from './preview-renderers/CodePreview'
@@ -161,9 +162,10 @@ const ClipboardPreview: React.FC<ClipboardPreviewProps> = ({ item, actions }) =>
     (item.type === 'text' || item.type === 'richtext') &&
     item.content !== null &&
     isLargeTextPreview(item.content as ClipboardTextItem, preview, loading)
+  const isCode = item.contentTags?.includes('code') === true
   // Code renders as an editor-like pane that fills the available height and owns
   // its own scrolling, so it skips the auto-height ScrollArea wrapper.
-  const fillsParent = isLargeText || item.contentTags?.includes('code') === true
+  const fillsParent = isLargeText || isCode
 
   const content = (
     <PreviewContent
@@ -178,7 +180,10 @@ const ClipboardPreview: React.FC<ClipboardPreviewProps> = ({ item, actions }) =>
   )
 
   return (
-    <div className="flex h-full flex-1 min-h-0 flex-col bg-card" data-testid="clipboard-detail">
+    <div
+      className={cn('flex h-full flex-1 min-h-0 flex-col', isCode ? 'bg-muted/15' : 'bg-card')}
+      data-testid="clipboard-detail"
+    >
       <ClipboardPreviewInfo
         item={item}
         preview={preview}
@@ -197,7 +202,12 @@ const ClipboardPreview: React.FC<ClipboardPreviewProps> = ({ item, actions }) =>
       </div>
 
       {(effectiveStatus === 'transferring' || actions) && (
-        <div className="flex min-h-[64px] shrink-0 items-center justify-between bg-card px-6 py-4">
+        <div
+          className={cn(
+            'flex min-h-[64px] shrink-0 items-center justify-between px-6 py-4',
+            isCode ? 'bg-transparent' : 'bg-card'
+          )}
+        >
           <div className="mr-8 min-w-0 flex-1">
             {effectiveStatus === 'transferring' && transfer && transfer.status === 'active' && (
               <div className="max-w-[280px]">

--- a/src/components/clipboard/ClipboardPreviewInfo.tsx
+++ b/src/components/clipboard/ClipboardPreviewInfo.tsx
@@ -10,6 +10,7 @@ import type {
 import type { ClipboardPreviewData } from '@/lib/clipboard-preview-cache'
 import { formatFileSize } from '@/utils'
 import EntryDeliveryBadge from './EntryDeliveryBadge'
+import { countCodeLines, resolveCodePreviewText } from './preview-renderers/codePreviewUtils'
 
 interface ClipboardPreviewInfoProps {
   imageDimensions: { width: number; height: number } | null
@@ -29,7 +30,8 @@ function buildInfoRows(
   imageDimensions: { width: number; height: number } | null,
   t: (key: string, options?: Record<string, unknown>) => string
 ): InfoRow[] {
-  const rows: InfoRow[] = [{ id: 'type', value: t('header.filters.' + item.type) }]
+  const displayType = item.contentTags?.includes('code') ? 'code' : item.type
+  const rows: InfoRow[] = [{ id: 'type', value: t('header.filters.' + displayType) }]
 
   if ((item.type === 'text' || item.type === 'richtext') && item.content) {
     const textItem = item.content as ClipboardTextItem
@@ -42,6 +44,13 @@ function buildInfoRows(
       id: 'text-chars',
       value: t('clipboard.preview.charactersCount', { count: charCount }),
     })
+    if (displayType === 'code') {
+      const code = resolveCodePreviewText(textItem.display_text, preview)
+      rows.push({
+        id: 'code-lines',
+        value: t('clipboard.preview.linesCount', { count: countCodeLines(code) }),
+      })
+    }
     if (textItem.size > 0) rows.push({ id: 'text-size', value: formatFileSize(textItem.size) })
   }
 

--- a/src/components/clipboard/__tests__/ClipboardPreview.test.tsx
+++ b/src/components/clipboard/__tests__/ClipboardPreview.test.tsx
@@ -253,4 +253,40 @@ describe('ClipboardPreview', () => {
 
     expect(screen.getByText('Content unavailable')).toBeInTheDocument()
   })
+
+  it('renders code as a full-bleed scrollable canvas without a nested card', () => {
+    const code = 'const first = 1\nconst second = 2'
+    previewMock.value = {
+      entryId: 'code-entry',
+      contentType: 'text',
+      sizeBytes: code.length,
+      textContent: code,
+    }
+
+    render(
+      <ClipboardPreview
+        item={{
+          id: 'code-entry',
+          type: 'text',
+          activeTime: 1710000000000,
+          contentTags: ['code'],
+          content: {
+            display_text: code,
+            has_detail: false,
+            size: code.length,
+            char_count: code.length,
+          },
+        }}
+      />
+    )
+
+    const codePreview = screen.getByTestId('code-preview')
+    const detail = screen.getByTestId('clipboard-detail')
+    expect(codePreview).toHaveClass('h-full', 'overflow-auto')
+    expect(codePreview).not.toHaveClass('p-6')
+    expect(codePreview.querySelector('.rounded-xl')).not.toBeInTheDocument()
+    expect(detail).toHaveClass('bg-muted/15')
+    expect(codePreview).toHaveClass('bg-transparent', 'text-foreground/85')
+    expect(codePreview.className).not.toContain('bg-[#0d1117]')
+  })
 })

--- a/src/components/clipboard/__tests__/ClipboardPreviewInfo.test.tsx
+++ b/src/components/clipboard/__tests__/ClipboardPreviewInfo.test.tsx
@@ -16,6 +16,21 @@ function createFileItem(): DisplayClipboardItem {
   }
 }
 
+function createCodeItem(text = 'const answer = 42'): DisplayClipboardItem {
+  return {
+    id: 'entry-code',
+    type: 'text',
+    activeTime: Date.now(),
+    contentTags: ['code'],
+    content: {
+      display_text: text,
+      has_detail: false,
+      size: text.length,
+      char_count: text.length,
+    },
+  }
+}
+
 describe('ClipboardPreviewInfo', () => {
   it('renders file count and combined size for file entries', () => {
     render(
@@ -40,5 +55,40 @@ describe('ClipboardPreviewInfo', () => {
     )
 
     expect(container).toBeEmptyDOMElement()
+  })
+
+  it('identifies code-tagged text as code', () => {
+    render(
+      <ClipboardPreviewInfo
+        item={createCodeItem()}
+        preview={null}
+        imageDimensions={null}
+        delivery={null}
+      />
+    )
+
+    expect(screen.getByText(i18n.t('header.filters.code'))).toBeInTheDocument()
+    expect(screen.queryByText(i18n.t('header.filters.text'))).not.toBeInTheDocument()
+  })
+
+  it('shows the full code preview line count without a trailing phantom line', () => {
+    const text = 'const first = 1\nconst second = 2\n'
+    render(
+      <ClipboardPreviewInfo
+        item={createCodeItem('const first = 1')}
+        preview={{
+          entryId: 'entry-code',
+          contentType: 'text',
+          sizeBytes: text.length,
+          textContent: text,
+        }}
+        imageDimensions={null}
+        delivery={null}
+      />
+    )
+
+    expect(
+      screen.getByText(i18n.t('clipboard.preview.linesCount', { count: 2 }))
+    ).toBeInTheDocument()
   })
 })

--- a/src/components/clipboard/preview-renderers/CodePreview.tsx
+++ b/src/components/clipboard/preview-renderers/CodePreview.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import type { ClipboardCodeItem } from '@/lib/clipboard-entry'
 import type { ClipboardPreviewData } from '@/lib/clipboard-preview-cache'
+import { countCodeLines, resolveCodePreviewText } from './codePreviewUtils'
 
 interface CodePreviewProps {
   item: ClipboardCodeItem
@@ -8,31 +9,26 @@ interface CodePreviewProps {
 }
 
 const CodePreview: React.FC<CodePreviewProps> = ({ item, preview }) => {
-  const code = preview?.contentType === 'text' ? (preview.textContent ?? item.code) : item.code
-  // Drop a single trailing newline so the gutter doesn't render a phantom last line.
-  const lineCount = code.replace(/\n$/, '').split('\n').length
+  const code = resolveCodePreviewText(item.code, preview)
+  const lineCount = countCodeLines(code)
 
   return (
-    <div className="h-full p-6">
-      <div className="group relative h-full">
-        <div className="pointer-events-none absolute inset-0 rounded-xl bg-primary/5 opacity-0 blur-xl transition-opacity group-hover:opacity-100" />
-        {/* Single scroll container: vertical scroll grows the whole grid, horizontal
-            scroll slides the code while the sticky gutter stays pinned at left. */}
-        <div className="scrollbar-code relative h-full overflow-auto rounded-xl border border-white/5 bg-[#0d1117] font-mono text-[13px] leading-relaxed text-blue-100/90 shadow-2xl">
-          <div className="flex w-max min-w-full">
-            <div
-              aria-hidden
-              className="sticky left-0 z-10 shrink-0 select-none border-r border-white/5 bg-[#0d1117] py-5 pl-3 pr-2 text-right tabular-nums text-blue-100/25"
-            >
-              {Array.from({ length: lineCount }, (_, i) => (
-                <div key={i}>{i + 1}</div>
-              ))}
-            </div>
-            <pre className="selectable shrink-0 px-4 py-5">
-              <code>{code}</code>
-            </pre>
-          </div>
+    <div
+      data-testid="code-preview"
+      className="scrollbar-code h-full overflow-auto bg-transparent font-mono text-[13px] leading-relaxed text-foreground/85"
+    >
+      <div className="flex w-max min-w-full">
+        <div
+          aria-hidden
+          className="sticky left-0 z-10 shrink-0 select-none border-r border-border/25 bg-muted/20 py-5 pl-3 pr-2 text-right tabular-nums text-muted-foreground/35"
+        >
+          {Array.from({ length: lineCount }, (_, i) => (
+            <div key={i}>{i + 1}</div>
+          ))}
         </div>
+        <pre className="selectable shrink-0 px-4 py-5">
+          <code>{code}</code>
+        </pre>
       </div>
     </div>
   )

--- a/src/components/clipboard/preview-renderers/codePreviewUtils.ts
+++ b/src/components/clipboard/preview-renderers/codePreviewUtils.ts
@@ -1,0 +1,12 @@
+import type { ClipboardPreviewData } from '@/lib/clipboard-preview-cache'
+
+export function resolveCodePreviewText(
+  fallback: string,
+  preview: ClipboardPreviewData | null
+): string {
+  return preview?.contentType === 'text' ? (preview.textContent ?? fallback) : fallback
+}
+
+export function countCodeLines(code: string): number {
+  return code.replace(/\n$/, '').split('\n').length
+}

--- a/src/components/history/composite-search/__tests__/CompositeSearchBar.quick-window.test.tsx
+++ b/src/components/history/composite-search/__tests__/CompositeSearchBar.quick-window.test.tsx
@@ -7,12 +7,14 @@ import CompositeSearchBar from '../CompositeSearchBar'
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
-    t: (key: string, opts?: string | Record<string, unknown>) =>
-      typeof opts === 'string'
+    t: (key: string, opts?: string | Record<string, unknown>) => {
+      if (key === 'history.type.link') return '链接'
+      return typeof opts === 'string'
         ? opts
         : typeof opts?.defaultValue === 'string'
           ? opts.defaultValue
-          : key,
+          : key
+    },
   }),
 }))
 
@@ -123,10 +125,37 @@ describe('CompositeSearchBar quick window usage', () => {
     expect(input).toHaveAttribute('aria-expanded', 'true')
     expect(screen.getByRole('listbox', { name: 'history.composite.title' })).toBeInTheDocument()
 
-    await user.keyboard('{ArrowDown}{Enter}')
+    await user.keyboard('{Enter}')
 
     expect(onContentFilterChange).toHaveBeenCalledWith(Filter.Text)
     expect(input).toHaveAttribute('aria-expanded', 'false')
     expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+  })
+
+  it('highlights the first tag as soon as the tag token opens', async () => {
+    const user = userEvent.setup()
+    renderSearchBar({ tagOptions: [{ id: 'code', count: 3, isBuiltin: true }] })
+
+    await user.type(screen.getByRole('combobox', { name: 'history.composite.title' }), '#')
+
+    expect(screen.getByRole('option', { name: 'code' })).toHaveAttribute('aria-selected', 'true')
+  })
+
+  it('confirms a localized tag match with Tab', async () => {
+    const user = userEvent.setup()
+    const onTagFilterChange = vi.fn()
+    renderSearchBar({
+      onTagFilterChange,
+      tagOptions: [{ id: 'link', count: 3, isBuiltin: true }],
+    })
+
+    await user.type(screen.getByRole('combobox', { name: 'history.composite.title' }), '#链')
+
+    expect(screen.getByRole('option', { name: '链接' })).toHaveAttribute('aria-selected', 'true')
+    expect(screen.queryByRole('option', { name: 'link' })).not.toBeInTheDocument()
+
+    await user.keyboard('{Tab}')
+
+    expect(onTagFilterChange).toHaveBeenCalledWith('link')
   })
 })

--- a/src/components/history/composite-search/__tests__/CompositeSearchBar.test.tsx
+++ b/src/components/history/composite-search/__tests__/CompositeSearchBar.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { Filter } from '@/api/clipboardItems'
 import type { TimeRangePreset } from '@/api/daemon/search'
 import CompositeSearchBar from '../CompositeSearchBar'
@@ -47,6 +47,10 @@ function renderSearchBar(overrides: Partial<React.ComponentProps<typeof Composit
 }
 
 describe('CompositeSearchBar', () => {
+  beforeEach(() => {
+    Element.prototype.scrollIntoView = vi.fn()
+  })
+
   it('submits free text with Enter when no suggestion is highlighted', async () => {
     const user = userEvent.setup()
     const props = renderSearchBar()

--- a/src/components/history/composite-search/__tests__/composite-search-model.test.ts
+++ b/src/components/history/composite-search/__tests__/composite-search-model.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 import { Filter } from '@/api/clipboardItems'
 import {
   buildCandidates,
+  buildChips,
   parseBuffer,
   searchableTagsToOptions,
   type FilterSnapshot,
@@ -68,6 +69,36 @@ describe('composite search model', () => {
     expect(values).toEqual(['link', 'code', 'favorited', 'image', 'directory'])
   })
 
+  it('ranks unfiltered tags by the number of matching records', () => {
+    const values = buildCandidates('tag', '', {
+      t,
+      sourceOptions: [],
+      current,
+      tagOptions: [
+        { id: 'link', count: 2, isBuiltin: true },
+        { id: 'code', count: 8, isBuiltin: true },
+        { id: 'project', count: 5, isBuiltin: false },
+      ],
+    }).map(candidate => candidate.value)
+
+    expect(values).toEqual(['code', 'project', 'link'])
+  })
+
+  it('ranks exact and prefix tag matches ahead of more frequent partial matches', () => {
+    const values = buildCandidates('tag', 'code', {
+      t,
+      sourceOptions: [],
+      current,
+      tagOptions: [
+        { id: 'archive-code', count: 20, isBuiltin: false },
+        { id: 'codec', count: 5, isBuiltin: false },
+        { id: 'code', count: 1, isBuiltin: true },
+      ],
+    }).map(candidate => candidate.value)
+
+    expect(values).toEqual(['code', 'codec', 'archive-code'])
+  })
+
   it('offers the builtin directory tag as a folder', () => {
     const tagOptions = searchableTagsToOptions([])
     const [candidate] = buildCandidates('tag', 'directory', {
@@ -80,5 +111,17 @@ describe('composite search model', () => {
     expect(candidate.value).toBe('directory')
     expect(candidate.label).toBe('文件夹')
     expect(candidate.icon).toBe(Folder)
+  })
+
+  it('prefixes a selected tag chip with a hash while preserving its localized name', () => {
+    const [chip] = buildChips({
+      t: key => (key === 'history.type.link' ? '链接' : key),
+      sourceOptions: [],
+      tagOptions: [{ id: 'link', count: 2, isBuiltin: true }],
+      current: { ...current, tag: 'link' },
+    })
+
+    expect(chip.dimension).toBe('tag')
+    expect(chip.label).toBe('#链接')
   })
 })

--- a/src/components/history/composite-search/composite-search-model.ts
+++ b/src/components/history/composite-search/composite-search-model.ts
@@ -249,10 +249,17 @@ export function buildSyntaxSuggestions(partial: string, t: Translate): SyntaxSug
   )
 }
 
-function matches(partial: string, ...haystacks: string[]): boolean {
-  if (!partial) return true
+function matchRank(partial: string, ...haystacks: string[]): number | null {
+  if (!partial) return 0
   const needle = partial.toLowerCase()
-  return haystacks.some(h => h.toLowerCase().includes(needle))
+  if (haystacks.some(haystack => haystack.toLowerCase() === needle)) return 0
+  if (haystacks.some(haystack => haystack.toLowerCase().startsWith(needle))) return 1
+  if (haystacks.some(haystack => haystack.toLowerCase().includes(needle))) return 2
+  return null
+}
+
+function matches(partial: string, ...haystacks: string[]): boolean {
+  return matchRank(partial, ...haystacks) !== null
 }
 
 /** Candidate values for one dimension, narrowed by the typed `partial`. */
@@ -284,21 +291,21 @@ export function buildCandidates(
           : []
       })
     case 'tag':
-      return ctx.tagOptions.flatMap(tag => {
-        const label = ctx.t(`history.type.${tag.id}`, { defaultValue: tag.id })
-        return matches(partial, tag.id, label)
-          ? [
-              {
-                id: `cand-tag-${tag.id}`,
-                dimension,
-                value: tag.id,
-                label,
-                icon: TYPE_ICONS[tag.id] ?? Hash,
-                isActive: ctx.current.tag === tag.id,
-              },
-            ]
-          : []
-      })
+      return ctx.tagOptions
+        .flatMap((tag, index) => {
+          const label = ctx.t(`history.type.${tag.id}`, { defaultValue: tag.id })
+          const rank = matchRank(partial, tag.id, label)
+          return rank === null ? [] : [{ tag, label, rank, index }]
+        })
+        .sort((a, b) => a.rank - b.rank || b.tag.count - a.tag.count || a.index - b.index)
+        .map(({ tag, label }) => ({
+          id: `cand-tag-${tag.id}`,
+          dimension,
+          value: tag.id,
+          label,
+          icon: TYPE_ICONS[tag.id] ?? Hash,
+          isActive: ctx.current.tag === tag.id,
+        }))
     case 'source':
       return ctx.sourceOptions.flatMap(opt =>
         matches(partial, opt.name, opt.id)
@@ -393,7 +400,7 @@ export function buildChips(ctx: {
     const opt = ctx.tagOptions.find(o => o.id === tag)
     chips.push({
       dimension: 'tag',
-      label: ctx.t(`history.type.${tag}`, { defaultValue: tag }),
+      label: `#${ctx.t(`history.type.${tag}`, { defaultValue: tag })}`,
       icon: TYPE_ICONS[opt?.id ?? tag] ?? Hash,
     })
   }

--- a/src/components/history/composite-search/useCompositeSearchBar.ts
+++ b/src/components/history/composite-search/useCompositeSearchBar.ts
@@ -135,7 +135,7 @@ export function useCompositeSearchBar({
     // trailing colon (`type:`). Seeding `#:` would make `parseBuffer` treat `:`
     // as the partial tag text and surface no useful matches.
     setBuffer(dimension === 'tag' ? SYNTAX_KEYS.tag : `${SYNTAX_KEYS[dimension]}:`)
-    setHighlight(-1)
+    setHighlight(0)
     onQueryChange('')
     inputRef.current?.focus()
     setOpen(true)
@@ -153,7 +153,7 @@ export function useCompositeSearchBar({
     const next = e.target.value
     const p = parseBuffer(next)
     setBuffer(next)
-    setHighlight(-1)
+    setHighlight(p.kind === 'token' ? 0 : -1)
     setOpen(suggestionActivation === 'focus' || p.kind === 'token')
     if (p.kind === 'query') {
       onQueryChange(next)
@@ -209,6 +209,11 @@ export function useCompositeSearchBar({
       setHighlight(h =>
         h < 0 ? (delta > 0 ? 0 : options.length - 1) : (h + delta + options.length) % options.length
       )
+      return
+    }
+    if (e.key === 'Tab' && !e.shiftKey && expanded && inToken) {
+      e.preventDefault()
+      selectOption(clampedHighlight >= 0 ? clampedHighlight : 0)
       return
     }
     if (e.key === 'Enter') {

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -990,6 +990,7 @@
       "contentType": "Content Type",
       "characters": "Characters",
       "charactersCount": "{{count}} chars",
+      "linesCount": "{{count}} lines",
       "words": "Words",
       "size": "Size",
       "dimensions": "Dimensions",

--- a/src/i18n/locales/ja-JP.json
+++ b/src/i18n/locales/ja-JP.json
@@ -990,6 +990,7 @@
       "contentType": "コンテンツ タイプ",
       "characters": "文字数",
       "charactersCount": "{{count}} 文字",
+      "linesCount": "{{count}} 行",
       "words": "単語",
       "size": "サイズ",
       "dimensions": "寸法",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -991,6 +991,7 @@
       "contentType": "Tipo de conteúdo",
       "characters": "Caracteres",
       "charactersCount": "{{count}} caracteres",
+      "linesCount": "{{count}} linhas",
       "words": "Palavras",
       "size": "Tamanho",
       "dimensions": "Dimensões",

--- a/src/i18n/locales/ru-RU.json
+++ b/src/i18n/locales/ru-RU.json
@@ -992,6 +992,7 @@
       "contentType": "Тип содержимого",
       "characters": "Символов",
       "charactersCount": "Символов: {{count}}",
+      "linesCount": "Строк: {{count}}",
       "words": "Слов",
       "size": "Размер",
       "dimensions": "Разрешение",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -989,6 +989,7 @@
       "contentType": "内容类型",
       "characters": "字符数",
       "charactersCount": "{{count}} 字符",
+      "linesCount": "{{count}} 行",
       "words": "词数",
       "size": "大小",
       "dimensions": "分辨率",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -989,6 +989,7 @@
       "contentType": "內容類型",
       "characters": "字符數",
       "charactersCount": "{{count}} 字符",
+      "linesCount": "{{count}} 行",
       "words": "詞數",
       "size": "大小",
       "dimensions": "分辨率",

--- a/src/layouts/WindowShell.tsx
+++ b/src/layouts/WindowShell.tsx
@@ -36,11 +36,6 @@ export const WindowShell: React.FC<WindowShellProps> = ({ titleBar, children }) 
         className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_50%_0%,var(--primary)_0%,transparent_100%)] opacity-[0.04] dark:opacity-[0.05]"
         aria-hidden="true"
       />
-      <div
-        data-uc-decorative-effect="true"
-        className="pointer-events-none absolute -left-20 -top-20 size-64 rounded-full bg-primary/5 blur-[100px] dark:bg-primary/10"
-        aria-hidden="true"
-      />
 
       {/* Window Chrome Layer - Full width titlebar */}
       {titleBar}

--- a/src/layouts/__tests__/WindowShell.test.tsx
+++ b/src/layouts/__tests__/WindowShell.test.tsx
@@ -28,4 +28,10 @@ describe('WindowShell', () => {
 
     expect(container.firstElementChild).not.toHaveClass('rounded-xl')
   })
+
+  it('does not render the circular window background accent', () => {
+    const { container } = render(<WindowShell titleBar={null}>body</WindowShell>)
+
+    expect(container.querySelector('[data-uc-decorative-effect].rounded-full')).toBeNull()
+  })
 })


### PR DESCRIPTION
## Summary

- Improve tag suggestions so the most relevant and most-used results are selected first, with keyboard completion and localized tag labels (`b18473a76`).
- Simplify code previews and make their text and line count consistent (`35cd31e81`).
- Remove the circular background accent near the sidebar (`02b4677d4`).
- Docs left as-is: no documented user-facing contract changed.

## Test plan

- [x] Run the focused frontend tests (37 checks).
- [x] Build the desktop frontend successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Code clipboard previews now display full-bleed, scrollable content with line numbers and line-count metadata.
  * Code-tagged clipboard items are labeled as “code” for clearer identification.
  * Added localized line-count labels across supported languages.
  * Search suggestions now prioritize stronger matches and support quicker keyboard selection.

* **Style**
  * Simplified code preview and window backgrounds for a cleaner, less distracting appearance.

* **Bug Fixes**
  * Improved handling of trailing newlines so line counts remain accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->