### PR TITLE
fix(history): bound wide-screen list width

### DIFF
--- a/src/pages/HistoryPage.tsx
+++ b/src/pages/HistoryPage.tsx
@@ -107,7 +107,7 @@ const HistoryPage: React.FC = () => {
         />
         <ResizablePanelGroup orientation="horizontal" className="min-h-0 flex-1">
           {/* List */}
-          <ResizablePanel id="history-list" defaultSize="42%" minSize="30%" maxSize="65%">
+          <ResizablePanel id="history-list" defaultSize="42%" minSize="20rem" maxSize="36rem">
             <div className="flex h-full min-w-0 flex-col">
               <HistoryGrid
                 items={c.items}

--- a/src/pages/__tests__/HistoryPage.test.tsx
+++ b/src/pages/__tests__/HistoryPage.test.tsx
@@ -111,8 +111,29 @@ vi.mock('@/components/ui/resizable', async () => {
   const ReactModule = await import('react')
   return {
     ResizableHandle: () => ReactModule.createElement('div', { 'data-testid': 'resize-handle' }),
-    ResizablePanel: ({ children }: { children: React.ReactNode }) =>
-      ReactModule.createElement('section', null, children),
+    ResizablePanel: ({
+      children,
+      id,
+      defaultSize,
+      minSize,
+      maxSize,
+    }: {
+      children: React.ReactNode
+      id?: string
+      defaultSize?: string
+      minSize?: string
+      maxSize?: string
+    }) =>
+      ReactModule.createElement(
+        'section',
+        {
+          'data-testid': id ? `${id}-panel` : undefined,
+          'data-default-size': defaultSize,
+          'data-min-size': minSize,
+          'data-max-size': maxSize,
+        },
+        children
+      ),
     ResizablePanelGroup: ({ children }: { children: React.ReactNode }) =>
       ReactModule.createElement('div', { 'data-testid': 'resizable-group' }, children),
   }
@@ -214,5 +235,14 @@ describe('HistoryPage', () => {
       JSON.stringify({ type: 'spring', stiffness: 400, damping: 30, delay: 0.08 })
     )
     expect(screen.getByTestId('clipboard-preview')).toBeInTheDocument()
+  })
+
+  it('keeps the history list within readable bounds while preview uses extra width', () => {
+    render(<HistoryPage />)
+
+    expect(screen.getByTestId('history-list-panel')).toHaveAttribute('data-default-size', '42%')
+    expect(screen.getByTestId('history-list-panel')).toHaveAttribute('data-min-size', '20rem')
+    expect(screen.getByTestId('history-list-panel')).toHaveAttribute('data-max-size', '36rem')
+    expect(screen.getByTestId('history-preview-panel')).toHaveAttribute('data-default-size', '58%')
   })
 })


### PR DESCRIPTION
## Summary

- Keep the existing 42/58 history split at ordinary window widths.
- Bound the history list to a readable range so extra width goes to the preview on wide screens.
- Add a regression check for the list and preview sizing rules.

Documentation left as-is: existing user documentation does not specify this layout behavior.

## Test plan

- [x] `npx vitest run src/pages/__tests__/HistoryPage.test.tsx`
- [x] `bun run test` (1012 tests)
- [x] `bun run build`
- [x] `npx react-doctor@latest --verbose --diff`
- [ ] Confirm the layout in the desktop window at ordinary and full-screen widths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the history panel’s responsive sizing for more consistent minimum and maximum widths.
  * Preserved the preview panel’s expected default width allocation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->