### PR TITLE
test(daemon-client): cover re-pairing setup state

### DIFF
--- a/crates/uc-daemon-client/src/http/setup_v2.rs
+++ b/crates/uc-daemon-client/src/http/setup_v2.rs
@@ -151,7 +151,8 @@ mod tests {
                 "data": {
                     "hasCompleted": true,
                     "currentInvitation": null,
-                    "deviceName": "Test Mac"
+                    "deviceName": "Test Mac",
+                    "rePairingRequired": true
                 },
                 "ts": 2
             })))
@@ -176,6 +177,7 @@ mod tests {
 
         assert!(state.has_completed);
         assert_eq!(state.device_name.as_deref(), Some("Test Mac"));
+        assert!(state.re_pairing_required);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- update the setup-state client fixture to match the current daemon response contract
- verify that the re-pairing-required state is decoded correctly

## Test plan

- [x] `cargo test -p uc-daemon-client --lib`
- [x] `cargo test --workspace`
- [x] `cargo fmt --all -- --check`
- [ ] `pending_join_survives_ctrl_c_and_daemon_restart_then_can_be_cancelled` remains blocked by an Engine-side state-query regression already present on `main`: the joiner receives durable admission, but concurrent status queries return `none` while the Engine state is locked

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated setup-state handling to correctly recognize when device re-pairing is required.
  * Added coverage to verify the re-pairing status is accurately reflected in decoded responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->