### PR TITLE
Fix badge URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@
     </a >
     <a href="https://github.com/UniClipboard/UniClipboard/releases">
       <img
-        src="https://img.shields.io/github/v/release/UniClipboard/UniClipboard?include_prereleases&style=flat-square"
+        src="https://img.shields.io/github/v/release/UniClipboard/UniClipboard?style=flat-square"
       />
     </a >
     <a href="https://codecov.io/gh/UniClipboard/UniClipboard" >


### PR DESCRIPTION
Updated badge URL to exclude prereleases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README release badge to display the latest stable release and exclude prerelease versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->