### PR TITLE
feat(macos): modernize transfer activity HUD

### DIFF
--- a/src-tauri/crates/uc-tauri/Cargo.toml
+++ b/src-tauri/crates/uc-tauri/Cargo.toml
@@ -108,6 +108,9 @@ core-foundation = "0.10"
 objc2 = "0.6"
 objc2-app-kit = { version = "0.3", features = [
   "NSApplication",
+  "NSAccessibility",
+  "NSAccessibilityProtocols",
+  "NSGlassEffectView",
   "NSImage",
   "NSEvent",
   "NSScreen",
@@ -119,6 +122,9 @@ objc2-app-kit = { version = "0.3", features = [
   "NSWorkspace",
   "NSRunningApplication",
   "NSStackView",
+  "NSGestureRecognizer",
+  "NSClickGestureRecognizer",
+  "NSTrackingArea",
   "NSProgressIndicator",
   "NSTextField",
   "NSText",
@@ -127,6 +133,7 @@ objc2-app-kit = { version = "0.3", features = [
   "NSCell",
   "NSView",
   "NSVisualEffectView",
+  "objc2-core-foundation",
   "NSLayoutConstraint",
   "NSFont",
   "objc2-quartz-core",
@@ -146,6 +153,7 @@ core-graphics = "0.24"
 objc2-foundation = { version = "0.3", features = [
   "NSBundle",
   "NSGeometry",
+  "NSProcessInfo",
   "objc2-core-foundation",
   "NSBackgroundActivityScheduler",
   "NSString",

--- a/src-tauri/crates/uc-tauri/src/activity_hud/actions.rs
+++ b/src-tauri/crates/uc-tauri/src/activity_hud/actions.rs
@@ -38,6 +38,7 @@ pub trait ActivityHudActions: Send + Sync {
     /// 3. 后端落地的 `StatusChanged: cancelled` 会通过 host event bus
     ///    回流到状态机,把行最终切到 `Cancelled`
     fn cancel(&self, entry_id: &str, attempt_id: Option<&str>, transfer_id: &str);
+    fn dismiss(&self, entry_id: &str, attempt_id: Option<&str>, transfer_id: &str);
 }
 
 /// 默认实现:把"乐观状态更新"和"调 facade"两件事捏在一起。
@@ -96,5 +97,9 @@ impl ActivityHudActions for DefaultActivityHudActions {
                 );
             }
         });
+    }
+
+    fn dismiss(&self, entry_id: &str, attempt_id: Option<&str>, transfer_id: &str) {
+        self.emitter.dismiss(entry_id, attempt_id, transfer_id);
     }
 }

--- a/src-tauri/crates/uc-tauri/src/activity_hud/emitter.rs
+++ b/src-tauri/crates/uc-tauri/src/activity_hud/emitter.rs
@@ -93,6 +93,10 @@ impl ActivityHudEmitter {
         });
     }
 
+    pub fn dismiss(&self, entry_id: &str, attempt_id: Option<&str>, transfer_id: &str) {
+        self.apply(|state| state.dismiss_scoped(entry_id, attempt_id, transfer_id));
+    }
+
     /// 给后台 sweep 任务调用:扫掉过保留期的终态行,如有变化通知 listener。
     pub fn tick(&self) {
         let snapshot_opt = {
@@ -339,5 +343,30 @@ mod tests {
             },
         ));
         assert!(recorder.snapshots().is_empty());
+    }
+
+    #[test]
+    fn dismiss_failed_removes_the_row_and_notifies_listener() {
+        let (emitter, recorder, _clock) = make_emitter();
+        emitter.emit(progress_event(
+            "t1",
+            "peer-a",
+            FileTransferDirection::Receiving,
+            50,
+            Some(100),
+        ));
+        emitter.emit(RealtimeEvent::FileTransferStatusChanged(
+            FileTransferStatusChangedEvent {
+                transfer_id: "t1".into(),
+                entry_id: "t1".into(),
+                attempt_id: None,
+                status: "failed".into(),
+                reason: Some("disk_full".into()),
+            },
+        ));
+
+        emitter.dismiss("t1", None, "t1");
+
+        assert!(recorder.snapshots().last().unwrap().is_empty());
     }
 }

--- a/src-tauri/crates/uc-tauri/src/activity_hud/state.rs
+++ b/src-tauri/crates/uc-tauri/src/activity_hud/state.rs
@@ -61,8 +61,8 @@ const SPEED_WINDOW_MAX_SAMPLES: usize = 32;
 /// 终态保留时长:Completed 后保留多久才被 sweep 移除。配 UI 上"打勾
 /// 停一下再淡出"的视觉节奏。
 pub const COMPLETED_RETAIN_MS: u64 = 2_000;
-/// Failed / Cancelled 终态保留时长。用户需要更多时间读失败原因。
-pub const FAILED_RETAIN_MS: u64 = 4_000;
+/// Cancelled terminal rows remain briefly so the user can see the outcome.
+pub const CANCELLED_RETAIN_MS: u64 = 4_000;
 
 /// 单条传输行的对外快照。`speed_window` 是内部状态,不进 snapshot。
 #[derive(Debug, Clone, PartialEq)]
@@ -442,21 +442,44 @@ impl ActivityHudState {
         true
     }
 
-    /// 把过保留期的终态行扫掉。`completed_retain_ms` / `failed_retain_ms`
-    /// 用模块常量 [`COMPLETED_RETAIN_MS`] / [`FAILED_RETAIN_MS`]。返回
-    /// true 表示有行被移除。
+    /// Sweep timed terminal rows. Failed rows are retained until dismissed;
+    /// completed and cancelled rows use their module retention constants.
     pub fn sweep(&mut self) -> bool {
         let now_ms = self.clock.now_ms();
         let before = self.rows.len();
         self.rows.retain(|_, row| {
             let retain_ms = match row.state {
                 RowState::Receiving | RowState::CancelPending => return true,
+                RowState::Failed { .. } => return true,
                 RowState::Completed => COMPLETED_RETAIN_MS,
-                RowState::Failed { .. } | RowState::Cancelled { .. } => FAILED_RETAIN_MS,
+                RowState::Cancelled { .. } => CANCELLED_RETAIN_MS,
             };
             now_ms.saturating_sub(row.state_entered_at_ms) < retain_ms
         });
         self.rows.len() != before
+    }
+
+    pub fn dismiss_scoped(
+        &mut self,
+        entry_id: &str,
+        attempt_id: Option<&str>,
+        transfer_id: &str,
+    ) -> bool {
+        let key = row_key(entry_id, attempt_id, transfer_id);
+        let removed = self.rows.remove(&key).is_some();
+        if removed {
+            self.pending_filenames.remove(&key);
+            if let Some(attempt_id) = attempt_id {
+                if self
+                    .current_attempt_by_entry
+                    .get(entry_id)
+                    .is_some_and(|current| current == attempt_id)
+                {
+                    self.current_attempt_by_entry.remove(entry_id);
+                }
+            }
+        }
+        removed
     }
 
     /// 返回当前所有行的快照,按插入顺序稳定排序。UI 应拿这份去重绘。
@@ -698,7 +721,7 @@ mod tests {
     }
 
     #[test]
-    fn failed_retains_longer_than_completed() {
+    fn failed_persists_until_explicitly_dismissed() {
         let (mut state, clock) = make_state();
         state.apply_progress(
             "t1",
@@ -708,10 +731,10 @@ mod tests {
             Some(100),
         );
         state.apply_status_changed("t1", "failed", Some("disk_full".into()));
-        clock.advance(COMPLETED_RETAIN_MS + 100);
-        assert!(!state.sweep(), "Failed 比 Completed 保留更久");
-        clock.advance(FAILED_RETAIN_MS - COMPLETED_RETAIN_MS + 100);
-        assert!(state.sweep());
+        clock.advance(CANCELLED_RETAIN_MS * 10);
+        assert!(!state.sweep());
+        assert!(state.dismiss_scoped("t1", None, "t1"));
+        assert!(state.is_empty());
     }
 
     #[test]

--- a/src-tauri/crates/uc-tauri/src/activity_hud/ui/macos.rs
+++ b/src-tauri/crates/uc-tauri/src/activity_hud/ui/macos.rs
@@ -1,49 +1,22 @@
-// objc2 0.6 把大量 AppKit method 标成 safe;为了在跨版本升级时不需要逐
-// 个补回 `unsafe { ... }`,以及与 `quick_panel/macos.rs` 的 unsafe 习惯保
-// 持一致,这里 silence "unused_unsafe" warning。一旦发现某个 method 在
-// 新版本下变成 unsafe,unsafe 块本来就准备好,不需要再加。
+// Keep AppKit call sites consistent with the surrounding macOS adapters even
+// when objc2 marks a particular SDK method as safe.
 #![allow(unused_unsafe)]
 
-//! macOS AppKit panel,渲染
-//! [`ActivityHudState`](super::super::state::ActivityHudState) 的 snapshot。
+//! Native macOS receive-activity HUD.
 //!
-//! ## 设计要点
+//! Each receive task owns a titleless `NSPanel`. Multiple panels start as an
+//! overlapping stack; clicking the top panel toggles the expanded vertical
+//! list. Panels remain fixed in the system-managed upper-right position.
 //!
-//! ### 线程模型
+//! The cancel control is a separate child panel anchored to the parent panel's
+//! upper-left corner. It appears on hover, stays outside content layout, and
+//! delegates cancellation through [`ActivityHudActions`].
 //!
-//! [`MacosActivityHudListener::on_changed`] 可能从任意 publisher 线程
-//! (tokio worker 等) 进来,但所有 AppKit 调用必须在主线程。这里通过
-//! Tauri 的 `AppHandle::run_on_main_thread` 把闭包派发到主线程 —— 与
-//! `commands/quick_panel.rs` 等位置用的是同一套机制。
-//!
-//! ### 状态归属
-//!
-//! NSPanel / NSStackView / 行控件等 ObjC 对象不是 `Send + Sync`,无法
-//! 放进 `Arc<Mutex<...>>` 跨线程持有。这里用 `thread_local!` 把 panel
-//! 状态绑死在主线程上;listener 跨线程进来后,经 run_on_main_thread 派
-//! 发后才访问 thread_local。
-//!
-//! ### 取消按钮
-//!
-//! 每行右侧一个 NSButton("✕")。点击 path:
-//! 1. 调 [`ActivityHudActions::cancel`] —— actions 内部做乐观状态更新
-//!    + 异步发出真正的取消请求
-//! 2. UI 立即看到行变 "取消中…",几百 ms 内后端 status_changed 回流
-//!    把行落到最终 `Cancelled`
-//!
-//! 按钮的 target 是一个自定义 ObjC 子类 `UCHudCancelButton`,继承自
-//! NSObject,持有 transfer_id + actions 两个 ivars —— **不再直接持
-//! emitter 或 facade**,平台模块跟领域代码完全解耦。
-//!
-//! ### 视觉
-//!
-//! - panel.styleMask: Borderless + NonactivatingPanel + Utility + HUDWindow
-//! - contentView 是 NSVisualEffectView (material = HUDWindow,blending =
-//!   BehindWindow) —— 毛玻璃跟系统通知中心 / AirDrop 同一观感
-//! - 圆角 12pt (layer.cornerRadius + masksToBounds)
-//! - panel.setOpaque(false) + setHasShadow(true)
+//! Listener callbacks can arrive on publisher threads, so all AppKit work is
+//! dispatched through `AppHandle::run_on_main_thread`. Objective-C UI objects
+//! stay in main-thread-local state and never cross thread boundaries.
 
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -52,13 +25,20 @@ use objc2::rc::{Allocated, Retained};
 use objc2::runtime::{AnyObject, NSObject, Sel};
 use objc2::{msg_send, sel, AllocAnyThread, DefinedClass, MainThreadOnly};
 use objc2_app_kit::{
-    NSBackingStoreType, NSBezelStyle, NSButton, NSColor, NSControlSize, NSFont, NSLayoutAttribute,
+    NSAccessibility, NSApplication, NSBackingStoreType, NSButton, NSCellImagePosition,
+    NSClickGestureRecognizer, NSColor, NSControlSize, NSFont, NSGlassEffectView,
+    NSGlassEffectViewStyle, NSImage, NSImageNameStopProgressFreestandingTemplate, NSImageScaling,
+    NSImageSymbolConfiguration, NSImageSymbolScale, NSLayoutAttribute,
     NSLayoutConstraintOrientation, NSLineBreakMode, NSPanel, NSProgressIndicator,
     NSProgressIndicatorStyle, NSScreen, NSStackView, NSStackViewDistribution, NSTextField,
-    NSUserInterfaceLayoutOrientation, NSVisualEffectBlendingMode, NSVisualEffectMaterial,
-    NSVisualEffectState, NSVisualEffectView, NSWindowStyleMask,
+    NSTrackingArea, NSTrackingAreaOptions, NSUserInterfaceLayoutOrientation,
+    NSVisualEffectBlendingMode, NSVisualEffectMaterial, NSVisualEffectState, NSVisualEffectView,
+    NSWindowAnimationBehavior, NSWindowOrderingMode, NSWindowStyleMask, NSWorkspace,
 };
-use objc2_foundation::{MainThreadMarker, NSEdgeInsets, NSPoint, NSRect, NSSize, NSString};
+use objc2_foundation::{
+    MainThreadMarker, NSEdgeInsets, NSOperatingSystemVersion, NSPoint, NSProcessInfo, NSRect,
+    NSSize, NSString,
+};
 use tauri::AppHandle;
 use tracing::{debug, warn};
 
@@ -74,23 +54,80 @@ thread_local! {
 }
 
 struct HudInner {
-    panel: Retained<NSPanel>,
-    /// 行列表挂在这个 NSStackView 下(vertical)。
-    stack: Retained<NSStackView>,
-    /// transfer_id -> 对应行的视图聚合。
-    rows: HashMap<String, RowView>,
+    task_windows: HashMap<String, TaskWindow>,
+    overflow_window: Option<OverflowWindow>,
+    layout_signature: Vec<String>,
+    expanded: bool,
 }
 
-struct RowView {
-    /// 行根视图,水平方向:[text_column(filename + subtitle + progress) | cancel_btn]。
-    container: Retained<NSStackView>,
+struct TaskWindow {
+    panel: Retained<NSPanel>,
+    background: HudBackground,
+    close_overlay: Retained<NSPanel>,
     filename_label: Retained<NSTextField>,
     subtitle_label: Retained<NSTextField>,
     progress_bar: Retained<NSProgressIndicator>,
     cancel_button: Retained<NSButton>,
-    /// 持有 ObjC target,保证 NSButton.target weak 引用还活着(NSButton
-    /// 持有 target 是 weak,这里 strong 持一份避免被释放)。
-    _cancel_target: Retained<UCHudCancelButton>,
+    action_target: Retained<UCHudCancelButton>,
+    _hover_target: Retained<UCHudHoverTarget>,
+    _tracking_area: Retained<NSTrackingArea>,
+    _overlay_tracking_area: Retained<NSTrackingArea>,
+    toggle_recognizer: Retained<NSClickGestureRecognizer>,
+    _toggle_target: Retained<UCHudStackToggleTarget>,
+}
+
+struct OverflowWindow {
+    panel: Retained<NSPanel>,
+    background: HudBackground,
+    title: Retained<NSTextField>,
+}
+
+enum HudBackground {
+    LiquidGlass(Retained<NSGlassEffectView>),
+    Legacy(Retained<NSVisualEffectView>),
+}
+
+impl HudBackground {
+    fn root_view(&self) -> &objc2_app_kit::NSView {
+        match self {
+            Self::LiquidGlass(glass) => glass,
+            Self::Legacy(effect) => effect,
+        }
+    }
+
+    fn set_content(&self, content: &objc2_app_kit::NSView) {
+        match self {
+            Self::LiquidGlass(glass) => unsafe {
+                content.setTranslatesAutoresizingMaskIntoConstraints(false);
+                glass.setContentView(Some(content));
+            },
+            Self::Legacy(effect) => attach_legacy_content(effect, content),
+        }
+    }
+
+    fn add_tracking_area(&self, tracking_area: &NSTrackingArea) {
+        unsafe {
+            match self {
+                Self::LiquidGlass(glass) => glass.addTrackingArea(tracking_area),
+                Self::Legacy(effect) => effect.addTrackingArea(tracking_area),
+            }
+        }
+    }
+
+    fn add_gesture_recognizer(&self, recognizer: &NSClickGestureRecognizer) {
+        unsafe {
+            match self {
+                Self::LiquidGlass(glass) => glass.addGestureRecognizer(recognizer),
+                Self::Legacy(effect) => effect.addGestureRecognizer(recognizer),
+            }
+        }
+    }
+
+    fn apply_preferences(&self, preferences: AccessibilityPreferences) {
+        if let Self::Legacy(effect) = self {
+            apply_legacy_material_preferences(effect, preferences);
+        }
+    }
 }
 
 // ObjC 子类:NSButton 的 target/action 接收器。每行一个实例,持
@@ -104,6 +141,7 @@ struct UCHudCancelButtonIvars {
     entry_id: String,
     attempt_id: Option<String>,
     actions: Arc<dyn ActivityHudActions>,
+    dismiss_only: Cell<bool>,
 }
 
 define_class!(
@@ -121,15 +159,29 @@ define_class!(
         #[unsafe(method(cancelClicked:))]
         fn cancel_clicked(&self, _sender: *mut AnyObject) {
             let ivars = self.ivars();
+            let action = if ivars.dismiss_only.get() {
+                "dismiss"
+            } else {
+                "cancel"
+            };
             debug!(
                 transfer_id = %ivars.transfer_id,
-                "activity_hud: cancel button clicked"
+                user_action = action,
+                "activity_hud action invoked"
             );
-            ivars.actions.cancel(
-                &ivars.entry_id,
-                ivars.attempt_id.as_deref(),
-                &ivars.transfer_id,
-            );
+            if ivars.dismiss_only.get() {
+                ivars.actions.dismiss(
+                    &ivars.entry_id,
+                    ivars.attempt_id.as_deref(),
+                    &ivars.transfer_id,
+                );
+            } else {
+                ivars.actions.cancel(
+                    &ivars.entry_id,
+                    ivars.attempt_id.as_deref(),
+                    &ivars.transfer_id,
+                );
+            }
         }
     }
 );
@@ -149,7 +201,133 @@ impl UCHudCancelButton {
             entry_id,
             attempt_id,
             actions,
+            dismiss_only: Cell::new(false),
         });
+        unsafe { msg_send![super(this), init] }
+    }
+
+    fn set_close_action(&self, action: HudCloseAction) {
+        self.ivars()
+            .dismiss_only
+            .set(matches!(action, HudCloseAction::Dismiss));
+    }
+}
+
+struct UCHudHoverTargetIvars {
+    overlay: Retained<NSPanel>,
+    allowed: Cell<bool>,
+    force_visible: Cell<bool>,
+}
+
+define_class!(
+    #[unsafe(super(NSObject))]
+    #[name = "UCHudHoverTarget"]
+    #[ivars = UCHudHoverTargetIvars]
+    struct UCHudHoverTarget;
+
+    impl UCHudHoverTarget {
+        #[unsafe(method(mouseEntered:))]
+        fn mouse_entered(&self, _event: *mut AnyObject) {
+            if !self.ivars().allowed.get() {
+                return;
+            }
+            unsafe {
+                self.ivars()
+                    .overlay
+                    .setAlphaValue(hover_control_alpha(true));
+                self.ivars().overlay.setIgnoresMouseEvents(false);
+                self.ivars().overlay.orderFrontRegardless();
+            }
+        }
+
+        #[unsafe(method(mouseExited:))]
+        fn mouse_exited(&self, _event: *mut AnyObject) {
+            if self.ivars().force_visible.get() {
+                return;
+            }
+            unsafe {
+                self.ivars()
+                    .overlay
+                    .setAlphaValue(hover_control_alpha(false));
+                self.ivars().overlay.setIgnoresMouseEvents(true);
+            }
+        }
+    }
+);
+
+impl UCHudHoverTarget {
+    fn new(overlay: Retained<NSPanel>) -> Retained<Self> {
+        let allocated: Allocated<Self> = Self::alloc();
+        let this = allocated.set_ivars(UCHudHoverTargetIvars {
+            overlay,
+            allowed: Cell::new(true),
+            force_visible: Cell::new(false),
+        });
+        unsafe { msg_send![super(this), init] }
+    }
+
+    fn set_allowed(&self, allowed: bool) {
+        self.ivars().allowed.set(allowed);
+        if !allowed {
+            unsafe {
+                self.ivars()
+                    .overlay
+                    .setAlphaValue(hover_control_alpha(false));
+                self.ivars().overlay.setIgnoresMouseEvents(true);
+            }
+        }
+    }
+
+    fn set_force_visible(&self, force_visible: bool) {
+        if self.ivars().force_visible.replace(force_visible) == force_visible {
+            return;
+        }
+        if force_visible && self.ivars().allowed.get() {
+            unsafe {
+                self.ivars()
+                    .overlay
+                    .setAlphaValue(hover_control_alpha(true));
+                self.ivars().overlay.setIgnoresMouseEvents(false);
+                self.ivars().overlay.orderFrontRegardless();
+            }
+        } else if !force_visible {
+            unsafe {
+                self.ivars()
+                    .overlay
+                    .setAlphaValue(hover_control_alpha(false));
+                self.ivars().overlay.setIgnoresMouseEvents(true);
+            }
+        }
+    }
+}
+
+struct UCHudStackToggleTargetIvars;
+
+define_class!(
+    #[unsafe(super(NSObject))]
+    #[name = "UCHudStackToggleTarget"]
+    #[ivars = UCHudStackToggleTargetIvars]
+    struct UCHudStackToggleTarget;
+
+    impl UCHudStackToggleTarget {
+        #[unsafe(method(toggleStack:))]
+        fn toggle_stack(&self, _sender: *mut AnyObject) {
+            let Some(mtm) = MainThreadMarker::new() else {
+                return;
+            };
+            HUD.with(|cell| {
+                if let Some(inner) = cell.borrow_mut().as_mut() {
+                    inner.toggle_expanded(mtm);
+                }
+            });
+        }
+    }
+);
+
+impl UCHudStackToggleTarget {
+    fn new() -> Retained<Self> {
+        let allocated: Allocated<Self> = Self::alloc();
+        let this = allocated.set_ivars(UCHudStackToggleTargetIvars);
         unsafe { msg_send![super(this), init] }
     }
 }
@@ -195,98 +373,12 @@ impl ActivityHudListener for MacosActivityHudListener {
 }
 
 impl HudInner {
-    fn create(mtm: MainThreadMarker) -> Self {
-        // panel 初始大小:宽 380、高 80。真正的高度由 contentView 的
-        // autolayout 自动撑;这里只是给个起始 frame,后续 setFrame 调位置。
-        let initial_rect = NSRect::new(NSPoint::new(0.0, 0.0), NSSize::new(380.0, 80.0));
-
-        // Borderless + HUDWindow + Utility:无标题栏的 HUD 浮窗外观。
-        // NonactivatingPanel:点击 / 显示时不抢前台应用焦点 —— AirDrop 风格。
-        let style = NSWindowStyleMask::Borderless
-            | NSWindowStyleMask::NonactivatingPanel
-            | NSWindowStyleMask::UtilityWindow
-            | NSWindowStyleMask::HUDWindow;
-
-        let panel: Retained<NSPanel> = unsafe {
-            let alloc = NSPanel::alloc(mtm);
-            NSPanel::initWithContentRect_styleMask_backing_defer(
-                alloc,
-                initial_rect,
-                style,
-                NSBackingStoreType::Buffered,
-                false,
-            )
-        };
-
-        unsafe {
-            // 浮在普通窗口之上,主窗口失焦也保持可见。
-            panel.setLevel(objc2_app_kit::NSFloatingWindowLevel);
-            panel.setFloatingPanel(true);
-            panel.setBecomesKeyOnlyIfNeeded(true);
-            panel.setHidesOnDeactivate(false);
-            // 不挂"closed"释放 —— 进程级 HUD,生命周期与 thread_local 同步。
-            panel.setReleasedWhenClosed(false);
-            // 透明 panel + 系统阴影 + 毛玻璃 contentView:这是 macOS HUD
-            // 的标准三件套(AirDrop / 通知中心 / Spotlight 共享)。
-            panel.setOpaque(false);
-            panel.setBackgroundColor(Some(&NSColor::clearColor()));
-            panel.setHasShadow(true);
-        }
-
-        // contentView:NSVisualEffectView 毛玻璃。圆角通过 layer 设。
-        let effect: Retained<NSVisualEffectView> = unsafe { NSVisualEffectView::new(mtm) };
-        unsafe {
-            effect.setMaterial(NSVisualEffectMaterial::HUDWindow);
-            effect.setBlendingMode(NSVisualEffectBlendingMode::BehindWindow);
-            effect.setState(NSVisualEffectState::Active);
-            effect.setWantsLayer(true);
-            if let Some(layer) = effect.layer() {
-                let _: () = msg_send![&layer, setCornerRadius: 12.0_f64];
-                let _: () = msg_send![&layer, setMasksToBounds: true];
-            }
-            effect.setTranslatesAutoresizingMaskIntoConstraints(false);
-        }
-
-        // 行列表 stack:挂在 effect 下,通过约束铺满。
-        let stack: Retained<NSStackView> = unsafe { NSStackView::new(mtm) };
-        unsafe {
-            stack.setOrientation(NSUserInterfaceLayoutOrientation::Vertical);
-            stack.setAlignment(NSLayoutAttribute::Leading);
-            stack.setSpacing(10.0);
-            stack.setDistribution(NSStackViewDistribution::Fill);
-            stack.setEdgeInsets(NSEdgeInsets {
-                top: 14.0,
-                left: 16.0,
-                bottom: 14.0,
-                right: 16.0,
-            });
-            stack.setTranslatesAutoresizingMaskIntoConstraints(false);
-            effect.addSubview(&stack);
-            let constraints = [
-                stack
-                    .topAnchor()
-                    .constraintEqualToAnchor(&effect.topAnchor()),
-                stack
-                    .leadingAnchor()
-                    .constraintEqualToAnchor(&effect.leadingAnchor()),
-                stack
-                    .trailingAnchor()
-                    .constraintEqualToAnchor(&effect.trailingAnchor()),
-                stack
-                    .bottomAnchor()
-                    .constraintEqualToAnchor(&effect.bottomAnchor()),
-            ];
-            for c in &constraints {
-                c.setActive(true);
-            }
-            // effect 作为 panel.contentView;NSWindow.setContentView 接收 NSView。
-            panel.setContentView(Some(&effect));
-        }
-
+    fn create(_mtm: MainThreadMarker) -> Self {
         Self {
-            panel,
-            stack,
-            rows: HashMap::new(),
+            task_windows: HashMap::new(),
+            overflow_window: None,
+            layout_signature: Vec::new(),
+            expanded: false,
         }
     }
 
@@ -301,93 +393,165 @@ impl HudInner {
             "activity_hud: applying snapshot"
         );
 
-        // 1) 收集新 snapshot 里出现的 transfer_id —— 没在里头的现有行要移除。
-        let new_ids: std::collections::HashSet<&str> =
-            snapshot.iter().map(|r| r.transfer_id.as_str()).collect();
-        let to_remove: Vec<String> = self
-            .rows
-            .keys()
-            .filter(|k| !new_ids.contains(k.as_str()))
-            .cloned()
-            .collect();
-        for id in to_remove {
-            if let Some(row) = self.rows.remove(&id) {
-                unsafe {
-                    self.stack.removeArrangedSubview(&row.container);
-                    // removeArrangedSubview 不会把视图从 superview 拿掉,需要手动。
-                    row.container.removeFromSuperview();
-                }
-            }
-        }
+        let task_keys: Vec<String> = snapshot.iter().map(task_key).collect();
+        let task_key_refs: Vec<&str> = task_keys.iter().map(String::as_str).collect();
+        let (visible_keys, overflow_count) = presentation_plan(&task_key_refs);
+        let visible_key_set: std::collections::HashSet<&str> =
+            visible_keys.iter().copied().collect();
+        let rows_by_key: HashMap<String, &ActivityHudRow> =
+            snapshot.iter().map(|row| (task_key(row), row)).collect();
 
-        // 2) 新增 / 更新行。
-        for row in snapshot {
-            if let Some(existing) = self.rows.get(&row.transfer_id) {
-                existing.update_from(row);
+        self.task_windows.retain(|key, window| {
+            let keep = visible_key_set.contains(key.as_str());
+            if !keep {
+                window.hide();
+            }
+            keep
+        });
+
+        for key in &visible_keys {
+            let Some(row) = rows_by_key.get(*key).copied() else {
+                continue;
+            };
+            if let Some(window) = self.task_windows.get(*key) {
+                window.update_from(row);
             } else {
-                let view = RowView::create(mtm, row, actions);
-                unsafe {
-                    self.stack.addArrangedSubview(&view.container);
-                }
-                self.rows.insert(row.transfer_id.clone(), view);
+                self.task_windows
+                    .insert((*key).to_owned(), TaskWindow::create(mtm, row, actions));
             }
         }
 
-        // 3) 显示 / 隐藏 panel。
-        if snapshot.is_empty() {
-            unsafe {
-                self.panel.orderOut(None);
+        if overflow_count > 0 {
+            if let Some(window) = self.overflow_window.as_ref() {
+                window.update(overflow_count);
+            } else {
+                self.overflow_window = Some(OverflowWindow::create(mtm, overflow_count));
             }
+        } else if let Some(window) = self.overflow_window.take() {
+            window.hide();
+        }
+
+        let visible_window_count = visible_keys.len() + usize::from(overflow_count > 0);
+        if visible_window_count <= 1 {
+            self.expanded = false;
+        }
+
+        let mut next_layout_signature: Vec<String> =
+            visible_keys.iter().map(|key| (*key).to_owned()).collect();
+        if overflow_count > 0 {
+            next_layout_signature.push("__overflow__".to_owned());
+        }
+        let current_refs: Vec<&str> = self.layout_signature.iter().map(String::as_str).collect();
+        let next_refs: Vec<&str> = next_layout_signature.iter().map(String::as_str).collect();
+        if should_relayout(&current_refs, &next_refs) {
+            self.position_and_show(mtm, &visible_keys);
+            self.layout_signature = next_layout_signature;
+        }
+        self.update_stack_interactions(&visible_keys, visible_window_count);
+    }
+
+    fn position_and_show(&self, mtm: MainThreadMarker, visible_keys: &[&str]) {
+        let mut panels: Vec<Retained<NSPanel>> = visible_keys
+            .iter()
+            .filter_map(|key| {
+                self.task_windows
+                    .get(*key)
+                    .map(|window| window.panel.clone())
+            })
+            .collect();
+        if let Some(window) = self.overflow_window.as_ref() {
+            panels.push(window.panel.clone());
+        }
+
+        let visible_frame = NSScreen::mainScreen(mtm)
+            .map(|screen| screen.visibleFrame())
+            .unwrap_or(NSRect::new(
+                NSPoint::new(0.0, 0.0),
+                NSSize::new(1_024.0, 768.0),
+            ));
+        let heights: Vec<f64> = panels.iter().map(|panel| panel_height(panel)).collect();
+        let screen_top = visible_frame.origin.y + visible_frame.size.height;
+        let origins = if self.expanded {
+            stack_origins(screen_top, &heights)
         } else {
-            self.position_and_show(mtm);
+            collapsed_origins(screen_top, &heights)
+        };
+        let origin_x = visible_frame.origin.x + visible_frame.size.width - HUD_WIDTH - STACK_MARGIN;
+        let animate_layout =
+            should_animate_layout(current_accessibility_preferences().reduce_motion);
+
+        for ((panel, height), origin_y) in panels.iter().zip(heights).zip(origins) {
+            let frame = NSRect::new(
+                NSPoint::new(origin_x, origin_y),
+                NSSize::new(HUD_WIDTH, height),
+            );
+            unsafe {
+                if panel.isVisible() && animate_layout {
+                    panel.setFrame_display_animate(frame, true, true);
+                } else {
+                    panel.setFrame_display(frame, true);
+                }
+            }
+        }
+        for panel in panels.iter().rev() {
+            unsafe {
+                panel.orderFrontRegardless();
+            }
+        }
+        for key in visible_keys {
+            if let Some(window) = self.task_windows.get(*key) {
+                window.anchor_close_overlay();
+            }
         }
     }
 
-    /// 把 panel 摆到主屏右上角并 orderFront。每次 snapshot 重新摆 ——
-    /// snapshot 应用导致内容尺寸变化时,位置跟着变。
-    fn position_and_show(&self, mtm: MainThreadMarker) {
-        unsafe {
-            let content_size = self.panel.contentView().map(|v| v.fittingSize());
-            let target_size = content_size.unwrap_or(NSSize::new(380.0, 80.0));
-            let width = 380.0_f64;
-            let height = target_size.height.max(64.0);
-
-            // 右上角:屏幕 visibleFrame 右上角内缩 16pt。
-            let origin = match NSScreen::mainScreen(mtm) {
-                Some(screen) => {
-                    let vf = screen.visibleFrame();
-                    NSPoint::new(
-                        vf.origin.x + vf.size.width - width - 16.0,
-                        vf.origin.y + vf.size.height - height - 16.0,
-                    )
-                }
-                None => NSPoint::new(40.0, 40.0),
-            };
-            self.panel
-                .setFrame_display(NSRect::new(origin, NSSize::new(width, height)), true);
-            self.panel.orderFrontRegardless();
+    fn update_stack_interactions(&self, visible_keys: &[&str], visible_window_count: usize) {
+        for (index, key) in visible_keys.iter().enumerate() {
+            if let Some(window) = self.task_windows.get(*key) {
+                window.set_stack_interaction(index == 0, self.expanded, visible_window_count > 1);
+            }
         }
+    }
+
+    fn toggle_expanded(&mut self, mtm: MainThreadMarker) {
+        let visible_window_count = self.layout_signature.len();
+        let next = toggled_expanded(self.expanded, visible_window_count);
+        if next == self.expanded {
+            return;
+        }
+        self.expanded = next;
+        let keys: Vec<String> = self
+            .layout_signature
+            .iter()
+            .filter(|key| key.as_str() != "__overflow__")
+            .cloned()
+            .collect();
+        let key_refs: Vec<&str> = keys.iter().map(String::as_str).collect();
+        self.position_and_show(mtm, &key_refs);
+        self.update_stack_interactions(&key_refs, visible_window_count);
     }
 }
 
-impl RowView {
+impl TaskWindow {
     fn create(
         mtm: MainThreadMarker,
         row: &ActivityHudRow,
         actions: &Arc<dyn ActivityHudActions>,
     ) -> Self {
-        // 文件名标签(主标题)。labelWithString 等价于 NSTextField 的
-        // 标准 label 风格:无边框、无背景、不可编辑。
-        let title_text = format_title(row);
-        let filename_label = NSTextField::labelWithString(&NSString::from_str(&title_text), mtm);
+        let (panel, background) = create_panel(mtm, 68.0);
+        let filename_label =
+            NSTextField::labelWithString(&NSString::from_str(&format_title(row)), mtm);
         unsafe {
             filename_label.setFont(Some(&NSFont::systemFontOfSize(NSFont::systemFontSize())));
             filename_label.setMaximumNumberOfLines(1);
             filename_label.setLineBreakMode(NSLineBreakMode::ByTruncatingMiddle);
+            filename_label.setContentCompressionResistancePriority_forOrientation(
+                249.0,
+                NSLayoutConstraintOrientation::Horizontal,
+            );
             filename_label.setTranslatesAutoresizingMaskIntoConstraints(false);
         }
 
-        // 副标题:速度 / 进度 / 终态文案。
         let subtitle_text = format_subtitle(row);
         let subtitle_label = NSTextField::labelWithString(&NSString::from_str(&subtitle_text), mtm);
         unsafe {
@@ -396,10 +560,13 @@ impl RowView {
             subtitle_label.setTextColor(Some(&NSColor::secondaryLabelColor()));
             subtitle_label.setMaximumNumberOfLines(1);
             subtitle_label.setLineBreakMode(NSLineBreakMode::ByTruncatingTail);
+            subtitle_label.setContentCompressionResistancePriority_forOrientation(
+                249.0,
+                NSLayoutConstraintOrientation::Horizontal,
+            );
             subtitle_label.setTranslatesAutoresizingMaskIntoConstraints(false);
         }
 
-        // 进度条。
         let progress_bar: Retained<NSProgressIndicator> = unsafe { NSProgressIndicator::new(mtm) };
         unsafe {
             progress_bar.setStyle(NSProgressIndicatorStyle::Bar);
@@ -407,23 +574,32 @@ impl RowView {
             progress_bar.setMinValue(0.0);
             progress_bar.setMaxValue(1.0);
             progress_bar.setControlSize(NSControlSize::Small);
+            progress_bar.setAccessibilityLabel(Some(&NSString::from_str("文件接收进度")));
             progress_bar.setTranslatesAutoresizingMaskIntoConstraints(false);
-            // 进度条横向铺满文本列宽度。
             let width_constraint = progress_bar
                 .widthAnchor()
-                .constraintGreaterThanOrEqualToConstant(280.0);
+                .constraintEqualToConstant(content_width());
             width_constraint.setActive(true);
         }
         apply_progress_value(&progress_bar, row);
 
-        // 文本列(vertical sub-stack):filename + subtitle + progress。
         let text_column: Retained<NSStackView> = unsafe { NSStackView::new(mtm) };
         unsafe {
             text_column.setOrientation(NSUserInterfaceLayoutOrientation::Vertical);
             text_column.setAlignment(NSLayoutAttribute::Leading);
-            text_column.setSpacing(4.0);
+            text_column.setSpacing(3.0);
             text_column.setDistribution(NSStackViewDistribution::Fill);
+            text_column.setEdgeInsets(NSEdgeInsets {
+                top: 10.0,
+                left: 12.0,
+                bottom: 10.0,
+                right: 12.0,
+            });
             text_column.setTranslatesAutoresizingMaskIntoConstraints(false);
+            text_column
+                .widthAnchor()
+                .constraintEqualToConstant(HUD_WIDTH)
+                .setActive(true);
             text_column.addArrangedSubview(&filename_label);
             text_column.addArrangedSubview(&subtitle_label);
             text_column.addArrangedSubview(&progress_bar);
@@ -433,62 +609,62 @@ impl RowView {
             );
         }
 
-        // 取消按钮:文本 "✕",bezelStyle 圆形小按钮。终态行的按钮设
-        // disabled,update_from 里也会跟着切。
         let cancel_target = UCHudCancelButton::new(
             row.transfer_id.clone(),
             row.entry_id.clone(),
             row.attempt_id.clone(),
             Arc::clone(actions),
         );
-        let cancel_button: Retained<NSButton> = unsafe { NSButton::new(mtm) };
+        cancel_target.set_close_action(close_action_for_state(&row.state));
+        background.set_content(&text_column);
+        let (close_overlay, cancel_button) = create_close_overlay(mtm, &cancel_target, row);
+        let hover_target = UCHudHoverTarget::new(close_overlay.clone());
+        let hover_owner: &AnyObject =
+            unsafe { &*(&*hover_target as *const UCHudHoverTarget as *const AnyObject) };
+        let tracking_area = create_tracking_area(hover_owner);
+        let overlay_tracking_area = create_tracking_area(hover_owner);
         unsafe {
-            cancel_button.setTitle(&NSString::from_str("✕"));
-            cancel_button.setBezelStyle(NSBezelStyle::Circular);
-            cancel_button.setControlSize(NSControlSize::Small);
-            cancel_button.setTranslatesAutoresizingMaskIntoConstraints(false);
-            // 固定按钮宽高,bezel circular 在小尺寸下需要明确约束。
-            cancel_button
-                .widthAnchor()
-                .constraintEqualToConstant(22.0)
-                .setActive(true);
-            cancel_button
-                .heightAnchor()
-                .constraintEqualToConstant(22.0)
-                .setActive(true);
-            // 关联 target/action。target 是我们自定义 NSObject 子类的实例。
-            // 所有 ObjC 对象 layout 一致(单 isa 指针起头),通过 raw
-            // pointer 重解释把 `&UCHudCancelButton` 转成 `&AnyObject`。
-            let target_obj: &AnyObject =
-                &*(&*cancel_target as *const UCHudCancelButton as *const AnyObject);
-            cancel_button.setTarget(Some(target_obj));
-            cancel_button.setAction(Some(sel!(cancelClicked:)));
-            apply_cancel_button_enabled(&cancel_button, row);
-        }
-
-        // 行总容器(horizontal):[text_column | cancel_button]。
-        let container: Retained<NSStackView> = unsafe { NSStackView::new(mtm) };
+            if let Some(overlay_view) = close_overlay.contentView() {
+                overlay_view.addTrackingArea(&overlay_tracking_area);
+            }
+            panel.addChildWindow_ordered(&close_overlay, NSWindowOrderingMode::Above);
+        };
+        background.add_tracking_area(&tracking_area);
+        let toggle_target = UCHudStackToggleTarget::new();
+        let toggle_target_obj: &AnyObject =
+            unsafe { &*(&*toggle_target as *const UCHudStackToggleTarget as *const AnyObject) };
+        let toggle_recognizer = unsafe {
+            NSClickGestureRecognizer::initWithTarget_action(
+                NSClickGestureRecognizer::alloc(mtm),
+                Some(toggle_target_obj),
+                Some(sel!(toggleStack:)),
+            )
+        };
         unsafe {
-            container.setOrientation(NSUserInterfaceLayoutOrientation::Horizontal);
-            container.setAlignment(NSLayoutAttribute::CenterY);
-            container.setSpacing(10.0);
-            container.setDistribution(NSStackViewDistribution::Fill);
-            container.setTranslatesAutoresizingMaskIntoConstraints(false);
-            container.addArrangedSubview(&text_column);
-            container.addArrangedSubview(&cancel_button);
+            toggle_recognizer.setNumberOfClicksRequired(1);
+            toggle_recognizer.setButtonMask(1);
+            toggle_recognizer.setDelaysPrimaryMouseButtonEvents(false);
+            toggle_recognizer.setEnabled(false);
         }
+        background.add_gesture_recognizer(&toggle_recognizer);
 
         Self {
-            container,
+            panel,
+            background,
+            close_overlay,
             filename_label,
             subtitle_label,
             progress_bar,
             cancel_button,
-            _cancel_target: cancel_target,
+            action_target: cancel_target,
+            _hover_target: hover_target,
+            _tracking_area: tracking_area,
+            _overlay_tracking_area: overlay_tracking_area,
+            toggle_recognizer,
+            _toggle_target: toggle_target,
         }
     }
 
-    /// 用新 snapshot 行原地更新本视图的文本/进度/按钮状态,不重建控件。
     fn update_from(&self, row: &ActivityHudRow) {
         unsafe {
             self.filename_label
@@ -497,31 +673,334 @@ impl RowView {
                 .setStringValue(&NSString::from_str(&format_subtitle(row)));
         }
         apply_progress_value(&self.progress_bar, row);
-        apply_cancel_button_enabled(&self.cancel_button, row);
+        let close_action = close_action_for_state(&row.state);
+        self.action_target.set_close_action(close_action);
+        update_close_control(&self.cancel_button, row, close_action);
+        self.background
+            .apply_preferences(current_accessibility_preferences());
     }
+
+    fn hide(&self) {
+        unsafe {
+            self.close_overlay.setAlphaValue(hover_control_alpha(false));
+            self.close_overlay.setIgnoresMouseEvents(true);
+            self.panel.orderOut(None);
+        }
+    }
+
+    fn anchor_close_overlay(&self) {
+        let frame = self.panel.frame();
+        let (x, y) = close_overlay_origin(frame.origin.x, frame.origin.y, frame.size.height);
+        unsafe {
+            self.close_overlay.setFrameOrigin(NSPoint::new(x, y));
+        }
+    }
+
+    fn set_stack_interaction(&self, is_top: bool, expanded: bool, has_multiple: bool) {
+        let close_allowed = expanded || is_top;
+        self._hover_target.set_allowed(close_allowed);
+        let preferences = current_accessibility_preferences();
+        self._hover_target.set_force_visible(
+            close_allowed
+                && close_control_visible(
+                    false,
+                    preferences.voice_over,
+                    preferences.full_keyboard_access,
+                ),
+        );
+        unsafe {
+            self.panel.setMovable(false);
+            self.toggle_recognizer.setEnabled(is_top && has_multiple);
+        }
+    }
+}
+
+impl OverflowWindow {
+    fn create(mtm: MainThreadMarker, count: usize) -> Self {
+        let (panel, background) = create_panel(mtm, 50.0);
+        let title =
+            NSTextField::labelWithString(&NSString::from_str(&format_overflow_title(count)), mtm);
+        let label = NSTextField::labelWithString(&NSString::from_str("较早的传输仍在继续"), mtm);
+        unsafe {
+            title.setFont(Some(&NSFont::systemFontOfSize(NSFont::systemFontSize())));
+            label.setFont(Some(&NSFont::systemFontOfSize(
+                NSFont::smallSystemFontSize(),
+            )));
+            label.setTextColor(Some(&NSColor::secondaryLabelColor()));
+        }
+        let container: Retained<NSStackView> = unsafe { NSStackView::new(mtm) };
+        unsafe {
+            container.setOrientation(NSUserInterfaceLayoutOrientation::Vertical);
+            container.setAlignment(NSLayoutAttribute::Leading);
+            container.setSpacing(2.0);
+            container.setEdgeInsets(NSEdgeInsets {
+                top: 9.0,
+                left: 12.0,
+                bottom: 9.0,
+                right: 12.0,
+            });
+            container.addArrangedSubview(&title);
+            container.addArrangedSubview(&label);
+        }
+        background.set_content(&container);
+        Self {
+            panel,
+            background,
+            title,
+        }
+    }
+
+    fn update(&self, count: usize) {
+        unsafe {
+            self.title
+                .setStringValue(&NSString::from_str(&format_overflow_title(count)));
+        }
+        self.background
+            .apply_preferences(current_accessibility_preferences());
+    }
+
+    fn hide(&self) {
+        unsafe {
+            self.panel.orderOut(None);
+        }
+    }
+}
+
+fn create_panel(mtm: MainThreadMarker, initial_height: f64) -> (Retained<NSPanel>, HudBackground) {
+    let initial_rect = NSRect::new(
+        NSPoint::new(0.0, 0.0),
+        NSSize::new(HUD_WIDTH, initial_height),
+    );
+    let style = NSWindowStyleMask::Borderless
+        | NSWindowStyleMask::NonactivatingPanel
+        | NSWindowStyleMask::UtilityWindow
+        | NSWindowStyleMask::HUDWindow;
+    let panel = unsafe {
+        NSPanel::initWithContentRect_styleMask_backing_defer(
+            NSPanel::alloc(mtm),
+            initial_rect,
+            style,
+            NSBackingStoreType::Buffered,
+            false,
+        )
+    };
+    unsafe {
+        panel.setLevel(objc2_app_kit::NSFloatingWindowLevel);
+        panel.setFloatingPanel(true);
+        panel.setBecomesKeyOnlyIfNeeded(true);
+        panel.setHidesOnDeactivate(false);
+        panel.setReleasedWhenClosed(false);
+        panel.setOpaque(false);
+        panel.setBackgroundColor(Some(&NSColor::clearColor()));
+        panel.setHasShadow(false);
+        panel.setAnimationBehavior(NSWindowAnimationBehavior::UtilityWindow);
+        panel.setMovable(false);
+        panel.setMovableByWindowBackground(false);
+    }
+
+    let background = create_background(mtm, 10.0, current_accessibility_preferences());
+    unsafe {
+        panel.setContentView(Some(background.root_view()));
+    }
+    (panel, background)
+}
+
+fn create_background(
+    mtm: MainThreadMarker,
+    corner_radius: f64,
+    preferences: AccessibilityPreferences,
+) -> HudBackground {
+    match background_kind(
+        supports_liquid_glass(),
+        preferences.reduce_transparency,
+        preferences.increase_contrast,
+    ) {
+        HudBackgroundKind::LiquidGlass => {
+            let glass = unsafe { NSGlassEffectView::new(mtm) };
+            unsafe {
+                glass.setStyle(NSGlassEffectViewStyle::Regular);
+                glass.setCornerRadius(corner_radius);
+            }
+            HudBackground::LiquidGlass(glass)
+        }
+        HudBackgroundKind::LegacyTranslucent | HudBackgroundKind::LegacyOpaque => {
+            let effect = unsafe { NSVisualEffectView::new(mtm) };
+            unsafe {
+                effect.setState(NSVisualEffectState::Active);
+                effect.setWantsLayer(true);
+                if let Some(layer) = effect.layer() {
+                    let _: () = msg_send![&layer, setCornerRadius: corner_radius];
+                    let _: () = msg_send![&layer, setMasksToBounds: true];
+                }
+            }
+            let background = HudBackground::Legacy(effect);
+            background.apply_preferences(preferences);
+            background
+        }
+    }
+}
+
+fn create_close_overlay(
+    mtm: MainThreadMarker,
+    cancel_target: &UCHudCancelButton,
+    row: &ActivityHudRow,
+) -> (Retained<NSPanel>, Retained<NSButton>) {
+    let rect = NSRect::new(
+        NSPoint::new(0.0, 0.0),
+        NSSize::new(CLOSE_OVERLAY_SIZE, CLOSE_OVERLAY_SIZE),
+    );
+    let style = NSWindowStyleMask::Borderless
+        | NSWindowStyleMask::NonactivatingPanel
+        | NSWindowStyleMask::UtilityWindow;
+    let overlay = unsafe {
+        NSPanel::initWithContentRect_styleMask_backing_defer(
+            NSPanel::alloc(mtm),
+            rect,
+            style,
+            NSBackingStoreType::Buffered,
+            false,
+        )
+    };
+    let background = create_background(
+        mtm,
+        CLOSE_OVERLAY_SIZE / 2.0,
+        current_accessibility_preferences(),
+    );
+    let button: Retained<NSButton> = unsafe { NSButton::new(mtm) };
+    unsafe {
+        overlay.setLevel(objc2_app_kit::NSFloatingWindowLevel);
+        overlay.setFloatingPanel(true);
+        overlay.setBecomesKeyOnlyIfNeeded(true);
+        overlay.setHidesOnDeactivate(false);
+        overlay.setReleasedWhenClosed(false);
+        overlay.setOpaque(false);
+        overlay.setBackgroundColor(Some(&NSColor::clearColor()));
+        overlay.setHasShadow(false);
+        overlay.setAlphaValue(hover_control_alpha(false));
+        overlay.setIgnoresMouseEvents(true);
+        overlay.setContentView(Some(background.root_view()));
+
+        button.setTitle(&NSString::new());
+        button.setBordered(false);
+        button.setControlSize(NSControlSize::Small);
+        button.setImagePosition(NSCellImagePosition::ImageOnly);
+        button.setImageScaling(NSImageScaling::ScaleNone);
+        let symbol_name = NSString::from_str("xmark");
+        let symbol_description = NSString::from_str("关闭");
+        if let Some(image) = NSImage::imageWithSystemSymbolName_accessibilityDescription(
+            &symbol_name,
+            Some(&symbol_description),
+        )
+        .or_else(|| NSImage::imageNamed(NSImageNameStopProgressFreestandingTemplate))
+        {
+            let configuration =
+                NSImageSymbolConfiguration::configurationWithScale(NSImageSymbolScale::Small);
+            if let Some(configured) = image.imageWithSymbolConfiguration(&configuration) {
+                button.setImage(Some(&configured));
+            } else {
+                button.setImage(Some(&image));
+            }
+        }
+        let target_obj: &AnyObject =
+            &*(cancel_target as *const UCHudCancelButton as *const AnyObject);
+        button.setTarget(Some(target_obj));
+        button.setAction(Some(sel!(cancelClicked:)));
+        update_close_control(&button, row, close_action_for_state(&row.state));
+    }
+    background.set_content(&button);
+    (overlay, button)
+}
+
+fn create_tracking_area(owner: &AnyObject) -> Retained<NSTrackingArea> {
+    unsafe {
+        NSTrackingArea::initWithRect_options_owner_userInfo(
+            NSTrackingArea::alloc(),
+            NSRect::new(NSPoint::new(0.0, 0.0), NSSize::new(0.0, 0.0)),
+            NSTrackingAreaOptions::MouseEnteredAndExited
+                | NSTrackingAreaOptions::ActiveAlways
+                | NSTrackingAreaOptions::InVisibleRect,
+            Some(owner),
+            None,
+        )
+    }
+}
+
+fn attach_legacy_content(effect: &NSVisualEffectView, content: &objc2_app_kit::NSView) {
+    unsafe {
+        content.setTranslatesAutoresizingMaskIntoConstraints(false);
+        effect.addSubview(content);
+        for constraint in [
+            content
+                .topAnchor()
+                .constraintEqualToAnchor(&effect.topAnchor()),
+            content
+                .leadingAnchor()
+                .constraintEqualToAnchor(&effect.leadingAnchor()),
+            content
+                .trailingAnchor()
+                .constraintEqualToAnchor(&effect.trailingAnchor()),
+            content
+                .bottomAnchor()
+                .constraintEqualToAnchor(&effect.bottomAnchor()),
+        ] {
+            constraint.setActive(true);
+        }
+    }
+}
+
+fn panel_height(panel: &NSPanel) -> f64 {
+    unsafe {
+        panel
+            .contentView()
+            .map(|view| view.fittingSize().height.max(48.0))
+            .unwrap_or(66.0)
+    }
+}
+
+fn task_key(row: &ActivityHudRow) -> String {
+    format!(
+        "{}\u{1f}{}\u{1f}{}",
+        row.entry_id,
+        row.attempt_id.as_deref().unwrap_or_default(),
+        row.transfer_id
+    )
+}
+
+fn format_overflow_title(count: usize) -> String {
+    format!("还有 {count} 个传输")
 }
 
 fn apply_progress_value(bar: &NSProgressIndicator, row: &ActivityHudRow) {
-    let value = match row.total_bytes {
-        Some(total) if total > 0 => (row.bytes_transferred as f64 / total as f64).clamp(0.0, 1.0),
-        _ => 0.0,
-    };
-    let final_value = match row.state {
-        RowState::Completed => 1.0,
-        // 失败/取消时定格在当时进度,视觉上"中断"。
-        RowState::Failed { .. } | RowState::Cancelled { .. } => value,
-        _ => value,
-    };
     unsafe {
-        bar.setDoubleValue(final_value);
+        match progress_presentation(row.bytes_transferred, row.total_bytes, &row.state) {
+            ProgressPresentation::Indeterminate => {
+                bar.setIndeterminate(true);
+                bar.startAnimation(None);
+            }
+            ProgressPresentation::Determinate(value) => {
+                bar.stopAnimation(None);
+                bar.setIndeterminate(false);
+                bar.setDoubleValue(value);
+            }
+        }
     }
 }
 
-/// 终态行 / CancelPending 行的取消按钮 disabled —— 点击毫无意义。
-fn apply_cancel_button_enabled(button: &NSButton, row: &ActivityHudRow) {
-    let enabled = matches!(row.state, RowState::Receiving);
+fn update_close_control(button: &NSButton, row: &ActivityHudRow, action: HudCloseAction) {
+    let title = format_title(row);
+    let (label, help) = match action {
+        HudCloseAction::Cancel => (format!("取消传输 {title}"), "停止接收这个传输".to_owned()),
+        HudCloseAction::Dismiss => (
+            format!("关闭失败提示 {title}"),
+            "关闭这个失败的传输提示".to_owned(),
+        ),
+        HudCloseAction::Disabled => (format!("传输状态 {title}"), "当前无法关闭".to_owned()),
+    };
     unsafe {
-        button.setEnabled(enabled);
+        button.setEnabled(!matches!(action, HudCloseAction::Disabled));
+        button.setToolTip(Some(&NSString::from_str(&label)));
+        button.setAccessibilityLabel(Some(&NSString::from_str(&label)));
+        button.setAccessibilityHelp(Some(&NSString::from_str(&help)));
     }
 }
 
@@ -606,3 +1085,357 @@ fn format_eta(eta_ms: u64) -> String {
 // 在缩减时被误删。
 #[allow(dead_code)]
 fn _keep_sel_import(_: Sel) {}
+
+const MAX_VISIBLE_WINDOWS: usize = 4;
+const HUD_WIDTH: f64 = 336.0;
+const CLOSE_OVERLAY_SIZE: f64 = 16.0;
+const STACK_MARGIN: f64 = 16.0;
+const STACK_GAP: f64 = 8.0;
+const COLLAPSED_OFFSET: f64 = 6.0;
+
+fn content_width() -> f64 {
+    HUD_WIDTH - 24.0
+}
+
+fn presentation_plan<'a>(task_ids: &'a [&'a str]) -> (Vec<&'a str>, usize) {
+    let visible_task_count = if task_ids.len() > MAX_VISIBLE_WINDOWS {
+        MAX_VISIBLE_WINDOWS - 1
+    } else {
+        task_ids.len()
+    };
+    let visible = task_ids
+        .iter()
+        .rev()
+        .take(visible_task_count)
+        .copied()
+        .collect();
+    (visible, task_ids.len() - visible_task_count)
+}
+
+fn stack_origins(screen_top: f64, heights: &[f64]) -> Vec<f64> {
+    let mut next_top = screen_top - STACK_MARGIN;
+    heights
+        .iter()
+        .map(|height| {
+            let origin = next_top - height;
+            next_top = origin - STACK_GAP;
+            origin
+        })
+        .collect()
+}
+
+#[derive(Debug, PartialEq)]
+enum ProgressPresentation {
+    Indeterminate,
+    Determinate(f64),
+}
+
+fn progress_presentation(
+    bytes_transferred: u64,
+    total_bytes: Option<u64>,
+    state: &RowState,
+) -> ProgressPresentation {
+    if matches!(state, RowState::Completed) {
+        return ProgressPresentation::Determinate(1.0);
+    }
+    if let Some(total) = total_bytes.filter(|total| *total > 0) {
+        let fraction = (bytes_transferred as f64 / total as f64).clamp(0.0, 1.0);
+        return ProgressPresentation::Determinate(fraction);
+    }
+    if matches!(state, RowState::Receiving | RowState::CancelPending) {
+        ProgressPresentation::Indeterminate
+    } else {
+        ProgressPresentation::Determinate(0.0)
+    }
+}
+
+fn hover_control_alpha(hovered: bool) -> f64 {
+    if hovered {
+        1.0
+    } else {
+        0.0
+    }
+}
+
+fn should_relayout(current: &[&str], next: &[&str]) -> bool {
+    current != next
+}
+
+fn close_overlay_origin(window_x: f64, window_y: f64, window_height: f64) -> (f64, f64) {
+    (
+        window_x - 8.0,
+        window_y + window_height - CLOSE_OVERLAY_SIZE + 8.0,
+    )
+}
+
+fn collapsed_origins(_screen_top: f64, _heights: &[f64]) -> Vec<f64> {
+    let Some(first_height) = _heights.first() else {
+        return Vec::new();
+    };
+    let first_origin = _screen_top - STACK_MARGIN - first_height;
+    _heights
+        .iter()
+        .enumerate()
+        .map(|(index, _)| first_origin - index as f64 * COLLAPSED_OFFSET)
+        .collect()
+}
+
+fn toggled_expanded(expanded: bool, item_count: usize) -> bool {
+    item_count > 1 && !expanded
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum HudCloseAction {
+    Cancel,
+    Dismiss,
+    Disabled,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum HudBackgroundKind {
+    LiquidGlass,
+    LegacyTranslucent,
+    LegacyOpaque,
+}
+
+fn background_kind(
+    supports_liquid_glass: bool,
+    reduce_transparency: bool,
+    increase_contrast: bool,
+) -> HudBackgroundKind {
+    if supports_liquid_glass {
+        HudBackgroundKind::LiquidGlass
+    } else if uses_opaque_background(reduce_transparency, increase_contrast) {
+        HudBackgroundKind::LegacyOpaque
+    } else {
+        HudBackgroundKind::LegacyTranslucent
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct AccessibilityPreferences {
+    reduce_motion: bool,
+    reduce_transparency: bool,
+    increase_contrast: bool,
+    voice_over: bool,
+    full_keyboard_access: bool,
+}
+
+fn current_accessibility_preferences() -> AccessibilityPreferences {
+    let workspace = NSWorkspace::sharedWorkspace();
+    AccessibilityPreferences {
+        reduce_motion: workspace.accessibilityDisplayShouldReduceMotion(),
+        reduce_transparency: workspace.accessibilityDisplayShouldReduceTransparency(),
+        increase_contrast: workspace.accessibilityDisplayShouldIncreaseContrast(),
+        voice_over: workspace.isVoiceOverEnabled(),
+        full_keyboard_access: MainThreadMarker::new()
+            .is_some_and(|mtm| NSApplication::sharedApplication(mtm).isFullKeyboardAccessEnabled()),
+    }
+}
+
+fn supports_liquid_glass() -> bool {
+    NSProcessInfo::processInfo().isOperatingSystemAtLeastVersion(NSOperatingSystemVersion {
+        majorVersion: 26,
+        minorVersion: 0,
+        patchVersion: 0,
+    })
+}
+
+fn apply_legacy_material_preferences(
+    effect: &NSVisualEffectView,
+    preferences: AccessibilityPreferences,
+) {
+    unsafe {
+        if uses_opaque_background(
+            preferences.reduce_transparency,
+            preferences.increase_contrast,
+        ) {
+            effect.setMaterial(NSVisualEffectMaterial::WindowBackground);
+            effect.setBlendingMode(NSVisualEffectBlendingMode::WithinWindow);
+        } else {
+            effect.setMaterial(NSVisualEffectMaterial::Popover);
+            effect.setBlendingMode(NSVisualEffectBlendingMode::BehindWindow);
+        }
+    }
+}
+
+fn close_action_for_state(_state: &RowState) -> HudCloseAction {
+    match _state {
+        RowState::Receiving => HudCloseAction::Cancel,
+        RowState::Failed { .. } => HudCloseAction::Dismiss,
+        RowState::Completed | RowState::Cancelled { .. } | RowState::CancelPending => {
+            HudCloseAction::Disabled
+        }
+    }
+}
+
+fn close_control_visible(hovered: bool, voice_over: bool, full_keyboard_access: bool) -> bool {
+    hovered || voice_over || full_keyboard_access
+}
+
+fn should_animate_layout(reduce_motion: bool) -> bool {
+    !reduce_motion
+}
+
+fn uses_opaque_background(reduce_transparency: bool, increase_contrast: bool) -> bool {
+    reduce_transparency || increase_contrast
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        background_kind, close_action_for_state, close_control_visible, close_overlay_origin,
+        collapsed_origins, content_width, hover_control_alpha, presentation_plan,
+        progress_presentation, should_animate_layout, should_relayout, stack_origins,
+        toggled_expanded, uses_opaque_background, HudBackgroundKind, HudCloseAction,
+        ProgressPresentation, RowState, CLOSE_OVERLAY_SIZE, HUD_WIDTH,
+    };
+
+    #[test]
+    fn presentation_plan_orders_newest_task_first() {
+        let task_ids = ["oldest", "middle", "newest"];
+
+        let (visible, overflow) = presentation_plan(&task_ids);
+
+        assert_eq!(visible, vec!["newest", "middle", "oldest"]);
+        assert_eq!(overflow, 0);
+    }
+
+    #[test]
+    fn presentation_plan_uses_the_fourth_window_for_overflow() {
+        let task_ids = ["one", "two", "three", "four", "five"];
+
+        let (visible, overflow) = presentation_plan(&task_ids);
+
+        assert_eq!(visible, vec!["five", "four", "three"]);
+        assert_eq!(overflow, 2);
+    }
+
+    #[test]
+    fn presentation_plan_shows_all_four_tasks_without_overflow() {
+        let task_ids = ["one", "two", "three", "four"];
+
+        let (visible, overflow) = presentation_plan(&task_ids);
+
+        assert_eq!(visible, vec!["four", "three", "two", "one"]);
+        assert_eq!(overflow, 0);
+    }
+
+    #[test]
+    fn stack_origins_place_windows_top_down_and_close_removed_gaps() {
+        let origins = stack_origins(1_000.0, &[80.0, 64.0, 72.0]);
+        assert_eq!(origins, vec![904.0, 832.0, 752.0]);
+
+        let after_removal = stack_origins(1_000.0, &[80.0, 72.0]);
+        assert_eq!(after_removal, vec![904.0, 824.0]);
+    }
+
+    #[test]
+    fn unknown_total_is_indeterminate_only_while_transfer_is_active() {
+        assert_eq!(
+            progress_presentation(128, None, &RowState::Receiving),
+            ProgressPresentation::Indeterminate
+        );
+        assert_eq!(
+            progress_presentation(128, None, &RowState::Completed),
+            ProgressPresentation::Determinate(1.0)
+        );
+    }
+
+    #[test]
+    fn known_total_uses_a_clamped_fraction() {
+        assert_eq!(
+            progress_presentation(150, Some(100), &RowState::Receiving),
+            ProgressPresentation::Determinate(1.0)
+        );
+    }
+
+    #[test]
+    fn close_control_is_hidden_until_the_window_is_hovered() {
+        assert_eq!(hover_control_alpha(false), 0.0);
+        assert_eq!(hover_control_alpha(true), 1.0);
+    }
+
+    #[test]
+    fn progress_updates_do_not_relayout_an_unchanged_stack() {
+        let current = ["newest", "older"];
+        assert!(!should_relayout(&current, &current));
+        assert!(should_relayout(&current, &["new-task", "newest", "older"]));
+        assert!(should_relayout(&current, &["newest"]));
+    }
+
+    #[test]
+    fn close_component_is_anchored_to_the_window_upper_left() {
+        assert_eq!(close_overlay_origin(100.0, 200.0, 80.0), (92.0, 272.0));
+    }
+
+    #[test]
+    fn multiple_windows_default_to_an_overlapping_stack() {
+        assert_eq!(
+            collapsed_origins(1_000.0, &[80.0, 80.0, 80.0]),
+            vec![904.0, 898.0, 892.0]
+        );
+    }
+
+    #[test]
+    fn clicking_the_top_window_toggles_expansion_only_for_multiple_items() {
+        assert!(toggled_expanded(false, 2));
+        assert!(!toggled_expanded(true, 2));
+        assert!(!toggled_expanded(false, 1));
+    }
+
+    #[test]
+    fn accessibility_preferences_override_hover_and_animation() {
+        assert!(close_control_visible(false, true, false));
+        assert!(close_control_visible(false, false, true));
+        assert!(!close_control_visible(false, false, false));
+        assert!(!should_animate_layout(true));
+        assert!(should_animate_layout(false));
+        assert!(uses_opaque_background(true, false));
+        assert!(uses_opaque_background(false, true));
+        assert!(!uses_opaque_background(false, false));
+    }
+
+    #[test]
+    fn close_control_uses_compact_size_and_failed_rows_dismiss() {
+        assert_eq!(CLOSE_OVERLAY_SIZE, 16.0);
+        assert_eq!(
+            close_action_for_state(&RowState::Receiving),
+            HudCloseAction::Cancel
+        );
+        assert_eq!(
+            close_action_for_state(&RowState::Failed { reason: None }),
+            HudCloseAction::Dismiss
+        );
+        assert_eq!(
+            close_action_for_state(&RowState::Completed),
+            HudCloseAction::Disabled
+        );
+    }
+
+    #[test]
+    fn macos_26_uses_real_glass_and_older_systems_keep_accessible_fallbacks() {
+        assert_eq!(
+            background_kind(true, true, true),
+            HudBackgroundKind::LiquidGlass
+        );
+        assert_eq!(
+            background_kind(false, false, false),
+            HudBackgroundKind::LegacyTranslucent
+        );
+        assert_eq!(
+            background_kind(false, true, false),
+            HudBackgroundKind::LegacyOpaque
+        );
+        assert_eq!(
+            background_kind(false, false, true),
+            HudBackgroundKind::LegacyOpaque
+        );
+    }
+
+    #[test]
+    fn window_and_content_widths_are_fixed_for_long_filenames() {
+        assert_eq!(HUD_WIDTH, 336.0);
+        assert_eq!(content_width(), 312.0);
+    }
+}


### PR DESCRIPTION
## Summary

- Replace the single hand-built receive panel with fixed-width native transfer windows that collapse into a stack and expand from the top card (`9e4d90be6`).
- Use public macOS 26 Liquid Glass with a legacy appearance fallback, plus a compact hover close control and middle-truncated long filenames.
- Honor accessibility display settings, expose labeled cancel/dismiss actions, and retain failed transfers until the user dismisses them.

## Test plan

- [x] `cargo test -p uc-tauri --lib` (151 passed)
- [x] `cargo check -p uc-tauri`
- [x] Formatting and diff checks
- [x] Manual macOS preview: collapsed stack, click-to-expand, Liquid Glass, hover close control, and long filename truncation
- [ ] Intel macOS compile check (`x86_64-apple-darwin` is not installed in the local Rust toolchain)

## Review notes

- `CONTEXT.md` audit: no update required; this is desktop-shell presentation behavior.
- `docs-site`: no matching user-facing contract found, so docs are unchanged.
- Telemetry: no application-layer activation or reliability flow changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned the macOS activity HUD with individual task panels, overflow handling, expandable stacks, and hover-based close controls.
  * Added Liquid Glass styling on macOS 26 with accessibility-friendly fallbacks.
  * Added click-to-toggle panel behavior and clearer progress indicators for active transfers without known totals.

* **Bug Fixes**
  * Failed transfers now remain visible until explicitly dismissed.
  * Cancelled transfers remain visible for four seconds before being removed.
  * Close actions now correctly cancel active transfers or dismiss completed failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->