### PR TITLE
fix(window): leave Linux corner shape to compositor

### DIFF
--- a/src/hooks/__tests__/useWindowFrame.test.tsx
+++ b/src/hooks/__tests__/useWindowFrame.test.tsx
@@ -1,0 +1,61 @@
+import { act, cleanup, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useWindowFrame } from '@/hooks/useWindowFrame'
+import { WindowShell } from '@/layouts/WindowShell'
+import { applyWindowFrameDocumentState, resolveWindowFrameMode } from '@/lib/window-frame'
+
+const mocks = vi.hoisted(() => ({
+  platform: { isWindows: false, isMac: false, isLinux: true, isTauri: true },
+  setDecorations: vi.fn().mockResolvedValue(undefined),
+}))
+vi.mock('@/hooks/usePlatform', () => ({ usePlatform: () => mocks.platform }))
+vi.mock('@tauri-apps/api/window', () => ({
+  getCurrentWindow: () => ({ setDecorations: mocks.setDecorations }),
+}))
+
+function FrameControls() {
+  const { setUseSystemWindowFrame } = useWindowFrame()
+  return (
+    <>
+      <button type="button" onClick={() => setUseSystemWindowFrame(true)}>
+        System
+      </button>
+      <button type="button" onClick={() => setUseSystemWindowFrame(false)}>
+        Custom
+      </button>
+    </>
+  )
+}
+
+describe('window frame switching', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    mocks.setDecorations.mockClear()
+  })
+  afterEach(() => {
+    cleanup()
+    delete document.documentElement.dataset.ucCustomWindowFrame
+  })
+
+  it.each(['linux', 'windows'] as const)(
+    'keeps %s corner and background policy after switching',
+    async platform => {
+      mocks.platform.isLinux = platform === 'linux'
+      mocks.platform.isWindows = platform === 'windows'
+      const rounded = platform === 'windows'
+      applyWindowFrameDocumentState(resolveWindowFrameMode(mocks.platform, false).hasRoundedWindow)
+      const { container } = render(<WindowShell titleBar={<FrameControls />}>Content</WindowShell>)
+      const shell = container.firstElementChild
+
+      await act(async () => screen.getByText('System').click())
+      expect(mocks.setDecorations).toHaveBeenLastCalledWith(true)
+      expect(shell).not.toHaveClass('rounded-xl')
+      expect(document.documentElement.dataset.ucCustomWindowFrame).toBe('false')
+
+      await act(async () => screen.getByText('Custom').click())
+      expect(mocks.setDecorations).toHaveBeenLastCalledWith(false)
+      expect(shell?.classList.contains('rounded-xl')).toBe(rounded)
+      expect(document.documentElement.dataset.ucCustomWindowFrame).toBe(String(rounded))
+    }
+  )
+})

--- a/src/hooks/useWindowFrame.ts
+++ b/src/hooks/useWindowFrame.ts
@@ -27,9 +27,9 @@ export function useWindowFrame() {
 
       await getCurrentWindow().setDecorations(enabled)
       setStoredUseSystemWindowFrame(enabled)
-      applyWindowFrameDocumentState(!enabled)
+      applyWindowFrameDocumentState(resolveWindowFrameMode(platform, enabled).hasRoundedWindow)
     },
-    [mode.canChooseSystemFrame]
+    [mode.canChooseSystemFrame, platform]
   )
 
   return {

--- a/src/lib/__tests__/window-frame.test.ts
+++ b/src/lib/__tests__/window-frame.test.ts
@@ -32,8 +32,17 @@ describe('window frame preference', () => {
       canChooseSystemFrame: true,
       hasCustomTitleBar: true,
       hasCustomWindowControls: true,
-      hasRoundedWindow: true,
+      hasRoundedWindow: false,
       searchInTitleBar: true,
+    })
+  })
+
+  it('keeps custom frame rounding as a Windows-specific policy', () => {
+    expect(
+      resolveWindowFrameMode({ ...linuxPlatform, isLinux: false, isWindows: true }, false)
+    ).toMatchObject({
+      hasCustomWindowControls: true,
+      hasRoundedWindow: true,
     })
   })
 

--- a/src/lib/window-frame.ts
+++ b/src/lib/window-frame.ts
@@ -82,7 +82,7 @@ export const resolveWindowFrameMode = (
     canChooseSystemFrame,
     hasCustomTitleBar,
     hasCustomWindowControls: usesSelectableCustomFrame,
-    hasRoundedWindow: usesSelectableCustomFrame,
+    hasRoundedWindow: platform.isWindows && usesSelectableCustomFrame,
     searchInTitleBar:
       platform.isMac || ((platform.isWindows || platform.isLinux) && !useSystemWindowFrame),
   }


### PR DESCRIPTION
## Summary

- Keep Linux custom-frame corner shape under the compositor/window manager instead of applying application-side rounding.
- Preserve Windows custom-frame rounding and keep frame switching background state aligned with the platform policy.
- Add regression coverage for Linux and Windows frame switching.

Closes #1610.

## Test plan

- [x] `npx vitest run src/hooks/__tests__/useWindowFrame.test.tsx src/lib/__tests__/window-frame.test.ts src/layouts/__tests__/WindowShell.test.tsx src/components/__tests__/TitleBar.test.tsx src/components/setting/__tests__/AppearanceSection.test.tsx`
- [x] `npx tsc --noEmit`
- [x] `bun run build`
- [x] Browser verification of Linux and Windows frame switching in light and dark themes
- [x] React Doctor: 100/100, no issues
- [x] `docs-site` scan: no documentation update needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected custom window frame behavior so rounded corners are applied only on Windows.
  * Fixed window frame switching to consistently update window decorations and rounded-corner styling across supported platforms.
  * Updated custom frame defaults so non-Windows platforms no longer receive rounded window corners unintentionally.

* **Tests**
  * Added coverage for switching between system and custom window frames on Linux and Windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->