### PR TITLE
fix(ui): restore window dragging while dialogs are open

### DIFF
--- a/src/components/ui/__tests__/modal-window-drag.test.tsx
+++ b/src/components/ui/__tests__/modal-window-drag.test.tsx
@@ -1,0 +1,54 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
+import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
+
+afterEach(cleanup)
+
+describe('modal window dragging', () => {
+  it.each(['dialog', 'alert-dialog'] as const)(
+    '%s exposes its backdrop to native dragging without making its controls draggable',
+    async kind => {
+      render(
+        kind === 'dialog' ? (
+          <Dialog defaultOpen>
+            <DialogContent>
+              <DialogTitle>Settings</DialogTitle>
+              <input aria-label="Name" />
+            </DialogContent>
+          </Dialog>
+        ) : (
+          <AlertDialog defaultOpen>
+            <AlertDialogContent>
+              <AlertDialogTitle>Confirm</AlertDialogTitle>
+              <input aria-label="Name" />
+              <AlertDialogCancel>Cancel</AlertDialogCancel>
+            </AlertDialogContent>
+          </AlertDialog>
+        )
+      )
+
+      const backdrop = document.querySelector(`[data-slot="${kind}-overlay"]`)
+      expect(backdrop).toHaveAttribute('data-tauri-drag-region')
+      expect(backdrop?.closest('[inert]')).toBeNull()
+      const input = screen.getByRole('textbox', { name: 'Name' })
+      expect(input.closest('[data-tauri-drag-region]')).toBeNull()
+      await userEvent.type(input, 'Example')
+      expect(input).toHaveValue('Example')
+      fireEvent.mouseDown(backdrop!, { button: 0, detail: 1 })
+      expect(screen.getByRole(kind === 'dialog' ? 'dialog' : 'alertdialog')).toBeVisible()
+      await userEvent.click(
+        screen.getByRole('button', { name: kind === 'dialog' ? 'Close' : 'Cancel' })
+      )
+      await waitFor(() =>
+        expect(screen.queryByRole(kind === 'dialog' ? 'dialog' : 'alertdialog')).toBeNull()
+      )
+    }
+  )
+})

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -22,6 +22,7 @@ function AlertDialogOverlay({ className, ...props }: AlertDialogPrimitive.Backdr
   return (
     <AlertDialogPrimitive.Backdrop
       data-slot="alert-dialog-overlay"
+      data-tauri-drag-region
       className={cn(
         'center-morph-backdrop fixed inset-0 isolate z-50 bg-background/10 supports-backdrop-filter:backdrop-blur-sm',
         className

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -25,6 +25,7 @@ function DialogOverlay({ className, ...props }: DialogPrimitive.Backdrop.Props) 
   return (
     <DialogPrimitive.Backdrop
       data-slot="dialog-overlay"
+      data-tauri-drag-region
       className={cn(
         'center-morph-backdrop fixed inset-0 isolate z-50 bg-background/10 supports-backdrop-filter:backdrop-blur-sm',
         className


### PR DESCRIPTION
## Summary

Opening a dialog covers the existing window drag regions with a backdrop that was not draggable. Mark the shared Dialog and AlertDialog backdrops as native drag regions, matching the existing Sheet behavior, so the window can be moved while a modal is open.

Add regression coverage for both dialog types, including editable inputs and close/cancel actions. No domain context or user-documentation updates are needed; this change adds no telemetry or Rust tracing surface.

## Validation

- `npx vitest run src/components/ui/__tests__`: 13 tests passed.
- `npx tsc --noEmit`: passed.
- `bun run build`: passed, including the macOS compatibility check; Vite reports bundle-size and mixed-import warnings.
- React Doctor: 100/100, no findings in the changed components.
- Native desktop dragging has not been manually verified because the running application window was unavailable to the UI automation tool. The tests verify the native drag attribute and dialog interactions, not operating-system window movement.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dialog and alert dialog backdrops now support native Tauri window dragging.
  * Dialog controls, including text inputs and action buttons, remain interactive and non-draggable.

* **Tests**
  * Added coverage confirming backdrop dragging, input interaction, and dialog dismissal behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->