### PR TITLE
fix(hud): retire completed mobile upload notifications

### DIFF
--- a/src-tauri/crates/uc-tauri/src/activity_hud/emitter.rs
+++ b/src-tauri/crates/uc-tauri/src/activity_hud/emitter.rs
@@ -134,17 +134,15 @@ impl ActivityHudEmitter {
                 });
             }
             RealtimeEvent::FileTransferStatusChanged(event) => {
-                if event.attempt_id.is_none() {
-                    self.apply(|state| {
-                        state.apply_scoped_status_changed(
-                            &event.transfer_id,
-                            Some(&event.entry_id),
-                            None,
-                            &event.status,
-                            event.reason,
-                        )
-                    });
-                }
+                self.apply(|state| {
+                    state.apply_scoped_status_changed(
+                        &event.transfer_id,
+                        Some(&event.entry_id),
+                        event.attempt_id.as_deref(),
+                        &event.status,
+                        event.reason,
+                    )
+                });
             }
             RealtimeEvent::ClipboardIncomingPending(event) => {
                 self.apply(|state| {
@@ -196,7 +194,7 @@ mod tests {
 
     use uc_daemon_client::realtime::{
         ClipboardIncomingPendingEvent, FileTransferProgressEvent, FileTransferStatusChangedEvent,
-        RealtimeEvent,
+        RealtimeEvent, ReceiveAttemptStateChangedEvent,
     };
     use uc_daemon_contract::api::types::FileTransferDirection;
 
@@ -326,6 +324,73 @@ mod tests {
         emitter.tick();
         let last = recorder.snapshots().pop().unwrap();
         assert!(last.is_empty(), "sweep 后行应被清空");
+    }
+
+    #[test]
+    fn adopted_upload_terminal_event_retires_only_the_provisional_row() {
+        for status in ["completed", "failed", "cancelled"] {
+            for saved_row_expired in [false, true] {
+                let (emitter, recorder, clock) = make_emitter();
+                emitter.emit(RealtimeEvent::FileTransferProgress(
+                    FileTransferProgressEvent {
+                        transfer_id: "mobile-upload".into(),
+                        entry_id: None,
+                        attempt_id: None,
+                        peer_id: "phone".into(),
+                        direction: FileTransferDirection::Receiving,
+                        bytes_transferred: 100,
+                        total_bytes: Some(100),
+                    },
+                ));
+                emitter.emit(RealtimeEvent::ClipboardIncomingPending(
+                    ClipboardIncomingPendingEvent {
+                        entry_id: "entry".into(),
+                        attempt_id: Some("attempt".into()),
+                        from_device: "phone".into(),
+                        total_bytes: Some(200),
+                        filenames: vec![],
+                    },
+                ));
+                emitter.mark_cancel_pending("mobile-upload", None, "mobile-upload");
+                if saved_row_expired {
+                    emitter.emit(RealtimeEvent::ReceiveAttemptStateChanged(
+                        ReceiveAttemptStateChangedEvent {
+                            entry_id: "entry".into(),
+                            attempt_id: "attempt".into(),
+                            state: "completed".into(),
+                        },
+                    ));
+                    clock.advance(super::super::state::COMPLETED_RETAIN_MS + 1);
+                    emitter.tick();
+                }
+                for _ in 0..2 {
+                    emitter.emit(RealtimeEvent::FileTransferStatusChanged(
+                        FileTransferStatusChangedEvent {
+                            transfer_id: "mobile-upload".into(),
+                            entry_id: "entry".into(),
+                            attempt_id: Some("attempt".into()),
+                            status: status.into(),
+                            reason: None,
+                        },
+                    ));
+                }
+                let rows = recorder.snapshots().pop().unwrap();
+                if saved_row_expired {
+                    assert!(
+                        rows.is_empty(),
+                        "late completion must not recreate the saved row"
+                    );
+                } else {
+                    assert_eq!(rows.len(), 1, "the provisional upload must be retired");
+                    assert_eq!(rows[0].entry_id, "entry");
+                    assert_eq!(
+                        rows[0].state,
+                        super::super::state::RowState::Receiving,
+                        "one item's terminal event must not finish the whole attempt"
+                    );
+                }
+            }
+        }
     }
 
     #[test]

--- a/src-tauri/crates/uc-tauri/src/activity_hud/state.rs
+++ b/src-tauri/crates/uc-tauri/src/activity_hud/state.rs
@@ -303,10 +303,6 @@ impl ActivityHudState {
         reason: Option<String>,
     ) -> bool {
         let now_ms = self.clock.now_ms();
-        let key = row_key(entry_id.unwrap_or(transfer_id), attempt_id, transfer_id);
-        let Some(row) = self.rows.get_mut(&key) else {
-            return false;
-        };
         let new_state = match status {
             "completed" => RowState::Completed,
             "failed" => RowState::Failed { reason },
@@ -314,6 +310,16 @@ impl ActivityHudState {
             // "transferring" / "pending" 不在 HUD 关心范围内 —— 进度由
             // Progress 事件驱动,这里只用 StatusChanged 处理终态。
             _ => return false,
+        };
+        if attempt_id.is_some() {
+            // Adoption gives the upload an attempt owner. Retire its provisional
+            // row even if the attempt row has already expired. Only attempt
+            // events may finish the aggregate row, which can contain more items.
+            return self.dismiss_scoped(transfer_id, None, transfer_id);
+        }
+        let key = row_key(entry_id.unwrap_or(transfer_id), None, transfer_id);
+        let Some(row) = self.rows.get_mut(&key) else {
+            return false;
         };
         if row.state == new_state {
             return false;
@@ -718,6 +724,56 @@ mod tests {
         clock.advance(200);
         assert!(state.sweep());
         assert!(state.is_empty());
+    }
+
+    #[test]
+    fn adopted_upload_status_preserves_new_attempt_and_unfinished_uploads() {
+        let (mut state, _clock) = make_state();
+        state.apply_progress(
+            "upload",
+            "phone",
+            FileTransferDirection::Receiving,
+            100,
+            Some(100),
+        );
+        state.apply_scoped_incoming_pending("entry", Some("old"), "phone", vec![], Some(100));
+        state.apply_scoped_incoming_pending("entry", Some("new"), "phone", vec![], Some(200));
+        let before = state.snapshot();
+        assert!(!state.apply_scoped_status_changed(
+            "upload",
+            Some("entry"),
+            Some("old"),
+            "transferring",
+            None
+        ));
+        assert_eq!(state.snapshot(), before);
+        assert!(state.apply_scoped_status_changed(
+            "upload",
+            Some("entry"),
+            Some("old"),
+            "completed",
+            None
+        ));
+        let rows = state.snapshot();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].attempt_id.as_deref(), Some("new"));
+        assert_eq!(rows[0].state, RowState::Receiving);
+        assert!(!state.apply_scoped_status_changed(
+            "upload",
+            Some("entry"),
+            Some("old"),
+            "completed",
+            None
+        ));
+        assert_eq!(state.snapshot(), rows);
+        assert!(!state.apply_scoped_status_changed(
+            "another-item",
+            Some("entry"),
+            Some("new"),
+            "completed",
+            None
+        ));
+        assert_eq!(state.snapshot(), rows);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Mobile LAN uploads could leave the receive HUD at 100% after the clipboard entry was saved. The HUD ignored transfer terminal events carrying an attempt ID, leaving the provisional upload row alive after the saved entry's row disappeared.

Forward those events to the HUD state and retire the provisional row by transfer ID. Receive-attempt events remain responsible for the aggregate result, so finishing one item cannot finish a multi-item receive. Late and duplicate terminal events do not recreate expired rows or change a newer attempt.

No user documentation, telemetry, or tracing changes are required. This restores existing completion behavior without changing the transfer protocol or persistence.

## Validation

- Reproduced the failure with a regression test before applying the fix.
- Passed 26 focused tests by compiling the actual HUD clock, state, and emitter modules with `rustc --test` against cached project dependency libraries. Coverage includes completed/failed/cancelled uploads, cancellation pending, expired saved rows, duplicate terminal events, stale attempts, and aggregate completion ownership.
- Passed formatting and `git diff --check`.
- Full `cargo test -p uc-tauri --lib activity_hud --locked` could not run because Cargo required a lockfile update, including with an isolated Cargo home. The unrelated local lockfile change is excluded.
- Live phone-to-desktop verification on profile `a` has not been performed with the rebuilt application.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - File transfer activity status updates now display correctly when transfers are retried or resumed.
  - Terminal events retire only the relevant provisional activity entry, preventing outdated transfer rows from remaining visible.
  - Improved handling ensures aggregate transfer activity is completed by the appropriate attempt, reducing stale or misleading status displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->