### PR TITLE
chore(engine): pin latest main revision

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -399,12 +399,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arraydeque"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
-
-[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1473,26 +1467,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "config"
-version = "0.15.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b85f248a4de22d204ceabc6299d89d2c70fbd7f09fea53c06c852369652d8139"
-dependencies = [
- "async-trait",
- "convert_case 0.6.0",
- "json5",
- "pathdiff",
- "ron",
- "rust-ini",
- "serde-untagged",
- "serde_core",
- "serde_json",
- "toml 1.1.3+spec-1.1.0",
- "winnow 1.0.4",
- "yaml-rust2",
-]
-
-[[package]]
 name = "console"
 version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1518,39 +1492,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
-name = "const-random"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
-dependencies = [
- "const-random-macro",
-]
-
-[[package]]
-name = "const-random-macro"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
-dependencies = [
- "getrandom 0.2.17",
- "once_cell",
- "tiny-keccak",
-]
-
-[[package]]
 name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
-
-[[package]]
-name = "convert_case"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
-dependencies = [
- "unicode-segmentation",
-]
 
 [[package]]
 name = "convert_case"
@@ -2164,7 +2109,7 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
- "convert_case 0.10.0",
+ "convert_case",
  "proc-macro2",
  "quote",
  "rustc_version",
@@ -2344,15 +2289,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
-]
-
-[[package]]
-name = "dlv-list"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
-dependencies = [
- "const-random",
 ]
 
 [[package]]
@@ -3577,12 +3513,6 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-
-[[package]]
-name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
@@ -3599,15 +3529,6 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash",
-]
-
-[[package]]
-name = "hashlink"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824e001ac4f3012dd16a264bec811403a67ca9deb6c102fc5049b32c4574b35f"
-dependencies = [
- "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -4815,17 +4736,6 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 1.0.69",
-]
-
-[[package]]
-name = "json5"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b0db21af676c1ce64250b5f40f3ce2cf27e4e47cb91ed91eb6fe9350b430c1"
-dependencies = [
- "pest",
- "pest_derive",
- "serde",
 ]
 
 [[package]]
@@ -6700,16 +6610,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
-name = "ordered-multimap"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
-dependencies = [
- "dlv-list",
- "hashbrown 0.14.5",
-]
-
-[[package]]
 name = "ordered-stream"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6894,12 +6794,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
-name = "pathdiff"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
-
-[[package]]
 name = "pem"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6932,48 +6826,6 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
-
-[[package]]
-name = "pest"
-version = "2.8.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7df728be843c7070fab6ab7c328c4e9e9d78e23bf749c0669c86ee7ebfa050a2"
-dependencies = [
- "memchr",
- "ucd-trie",
-]
-
-[[package]]
-name = "pest_derive"
-version = "2.8.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e2dd6fc3b26b3462ee188aac870f5a41d398f1cd5e2408d16531bd71c9591fd"
-dependencies = [
- "pest",
- "pest_generator",
-]
-
-[[package]]
-name = "pest_generator"
-version = "2.8.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a7a9205cfb6f596a9e8b689c0a15f9ceb7a1aafae7aaf788150ac65b29975b6"
-dependencies = [
- "pest",
- "pest_meta",
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "pest_meta"
-version = "2.8.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85abd351c0de1e8384fc791a0737111a350394937e92b956b743dac12429f57c"
-dependencies = [
- "pest",
-]
 
 [[package]]
 name = "pharos"
@@ -8111,20 +7963,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ron"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81116b9531d61eabc41aeb228e4b6b2435bcca3233b98cf3b3077d4e6e9debb3"
-dependencies = [
- "bitflags 2.13.1",
- "once_cell",
- "serde",
- "serde_derive",
- "typeid",
- "unicode-ident",
-]
-
-[[package]]
 name = "rsa"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8187,16 +8025,6 @@ checksum = "42ffa149f6aa81b58a5b3011d01a857c4ed12c7a732d2c51947a4c7c692185f0"
 dependencies = [
  "sha2 0.11.0",
  "walkdir",
-]
-
-[[package]]
-name = "rust-ini"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "796e8d2b6696392a43bea58116b667fb4c29727dc5abd27d6acf338bb4f688c7"
-dependencies = [
- "cfg-if",
- "ordered-multimap",
 ]
 
 [[package]]
@@ -10173,15 +10001,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tiny-keccak"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
-dependencies = [
- "crunchy",
-]
-
-[[package]]
 name = "tinystr"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10688,20 +10507,15 @@ dependencies = [
 [[package]]
 name = "uc-application"
 version = "1.1.0-rc.14"
-source = "git+https://github.com/UniClipboard/Engine.git?rev=168a3ebd7c2701f2e9f8a0ebe0c4a0af4aa14543#168a3ebd7c2701f2e9f8a0ebe0c4a0af4aa14543"
+source = "git+https://github.com/UniClipboard/Engine.git?rev=68ff88a392f495b3906985d1c31d1dde8071dab3#68ff88a392f495b3906985d1c31d1dde8071dab3"
 dependencies = [
  "anyhow",
  "async-trait",
- "base64 0.22.1",
  "blake3",
  "bytes",
  "chrono",
  "dirs 6.0.0",
- "ed25519-dalek 2.2.0",
  "futures",
- "hex",
- "hmac",
- "libc",
  "moka",
  "postcard",
  "rand 0.9.5",
@@ -10785,7 +10599,7 @@ dependencies = [
 [[package]]
 name = "uc-content-hash"
 version = "1.1.0-rc.14"
-source = "git+https://github.com/UniClipboard/Engine.git?rev=168a3ebd7c2701f2e9f8a0ebe0c4a0af4aa14543#168a3ebd7c2701f2e9f8a0ebe0c4a0af4aa14543"
+source = "git+https://github.com/UniClipboard/Engine.git?rev=68ff88a392f495b3906985d1c31d1dde8071dab3#68ff88a392f495b3906985d1c31d1dde8071dab3"
 dependencies = [
  "blake3",
  "hex",
@@ -10794,17 +10608,15 @@ dependencies = [
 [[package]]
 name = "uc-core"
 version = "1.1.0-rc.14"
-source = "git+https://github.com/UniClipboard/Engine.git?rev=168a3ebd7c2701f2e9f8a0ebe0c4a0af4aa14543#168a3ebd7c2701f2e9f8a0ebe0c4a0af4aa14543"
+source = "git+https://github.com/UniClipboard/Engine.git?rev=68ff88a392f495b3906985d1c31d1dde8071dab3#68ff88a392f495b3906985d1c31d1dde8071dab3"
 dependencies = [
  "anyhow",
  "arrayvec",
  "async-trait",
- "base64 0.22.1",
  "bytes",
  "chrono",
  "hex",
  "postcard",
- "rand 0.9.5",
  "serde",
  "serde_json",
  "serde_with",
@@ -10945,7 +10757,7 @@ dependencies = [
 [[package]]
 name = "uc-engine"
 version = "1.1.0-rc.14"
-source = "git+https://github.com/UniClipboard/Engine.git?rev=168a3ebd7c2701f2e9f8a0ebe0c4a0af4aa14543#168a3ebd7c2701f2e9f8a0ebe0c4a0af4aa14543"
+source = "git+https://github.com/UniClipboard/Engine.git?rev=68ff88a392f495b3906985d1c31d1dde8071dab3#68ff88a392f495b3906985d1c31d1dde8071dab3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10964,14 +10776,13 @@ dependencies = [
  "uc-observability-contract",
  "uc-observability-runtime",
  "url",
- "uuid",
  "zeroize",
 ]
 
 [[package]]
 name = "uc-infra"
 version = "1.1.0-rc.14"
-source = "git+https://github.com/UniClipboard/Engine.git?rev=168a3ebd7c2701f2e9f8a0ebe0c4a0af4aa14543#168a3ebd7c2701f2e9f8a0ebe0c4a0af4aa14543"
+source = "git+https://github.com/UniClipboard/Engine.git?rev=68ff88a392f495b3906985d1c31d1dde8071dab3#68ff88a392f495b3906985d1c31d1dde8071dab3"
 dependencies = [
  "anyhow",
  "argon2",
@@ -10982,7 +10793,6 @@ dependencies = [
  "bytes",
  "chacha20poly1305",
  "chrono",
- "config",
  "diesel",
  "diesel_migrations",
  "futures-util",
@@ -11039,15 +10849,13 @@ dependencies = [
 [[package]]
 name = "uc-mobile-lan"
 version = "1.1.0-rc.14"
-source = "git+https://github.com/UniClipboard/Engine.git?rev=168a3ebd7c2701f2e9f8a0ebe0c4a0af4aa14543#168a3ebd7c2701f2e9f8a0ebe0c4a0af4aa14543"
+source = "git+https://github.com/UniClipboard/Engine.git?rev=68ff88a392f495b3906985d1c31d1dde8071dab3#68ff88a392f495b3906985d1c31d1dde8071dab3"
 dependencies = [
- "anyhow",
  "async-trait",
  "base64 0.22.1",
  "hex",
  "image",
  "qrcode",
- "serde",
  "sha2 0.10.9",
  "thiserror 2.0.19",
  "tokio",
@@ -11063,7 +10871,7 @@ dependencies = [
 [[package]]
 name = "uc-mobile-proto"
 version = "1.1.0-rc.14"
-source = "git+https://github.com/UniClipboard/Engine.git?rev=168a3ebd7c2701f2e9f8a0ebe0c4a0af4aa14543#168a3ebd7c2701f2e9f8a0ebe0c4a0af4aa14543"
+source = "git+https://github.com/UniClipboard/Engine.git?rev=68ff88a392f495b3906985d1c31d1dde8071dab3#68ff88a392f495b3906985d1c31d1dde8071dab3"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -11097,7 +10905,7 @@ dependencies = [
 [[package]]
 name = "uc-observability-contract"
 version = "1.1.0-rc.14"
-source = "git+https://github.com/UniClipboard/Engine.git?rev=168a3ebd7c2701f2e9f8a0ebe0c4a0af4aa14543#168a3ebd7c2701f2e9f8a0ebe0c4a0af4aa14543"
+source = "git+https://github.com/UniClipboard/Engine.git?rev=68ff88a392f495b3906985d1c31d1dde8071dab3#68ff88a392f495b3906985d1c31d1dde8071dab3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -11114,7 +10922,7 @@ dependencies = [
 [[package]]
 name = "uc-observability-runtime"
 version = "1.1.0-rc.14"
-source = "git+https://github.com/UniClipboard/Engine.git?rev=168a3ebd7c2701f2e9f8a0ebe0c4a0af4aa14543#168a3ebd7c2701f2e9f8a0ebe0c4a0af4aa14543"
+source = "git+https://github.com/UniClipboard/Engine.git?rev=68ff88a392f495b3906985d1c31d1dde8071dab3#68ff88a392f495b3906985d1c31d1dde8071dab3"
 dependencies = [
  "chrono",
  "jni 0.22.4",
@@ -11263,12 +11071,6 @@ dependencies = [
  "uuid",
  "zeroize",
 ]
-
-[[package]]
-name = "ucd-trie"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "uds_windows"
@@ -12822,17 +12624,6 @@ name = "y4m"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
-
-[[package]]
-name = "yaml-rust2"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "631a50d867fafb7093e709d75aaee9e0e0d5deb934021fcea25ac2fe09edc51e"
-dependencies = [
- "arraydeque",
- "encoding_rs",
- "hashlink",
-]
 
 [[package]]
 name = "yasna"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,8 +51,8 @@ dbg_macro = "warn"
 [workspace.dependencies]
 # All desktop consumers use one immutable Engine revision. Features remain
 # opt-in at each host boundary so LAN compatibility cannot become a default.
-uc-engine = { git = "https://github.com/UniClipboard/Engine.git", rev = "168a3ebd7c2701f2e9f8a0ebe0c4a0af4aa14543" }
-uc-observability-contract = { git = "https://github.com/UniClipboard/Engine.git", rev = "168a3ebd7c2701f2e9f8a0ebe0c4a0af4aa14543" }
+uc-engine = { git = "https://github.com/UniClipboard/Engine.git", rev = "68ff88a392f495b3906985d1c31d1dde8071dab3" }
+uc-observability-contract = { git = "https://github.com/UniClipboard/Engine.git", rev = "68ff88a392f495b3906985d1c31d1dde8071dab3" }
 
 # tauri 2.11 是 specta rc.25 兼容的最低版本 —— 2.10.x 及之前在
 # `tauri/src/ipc/channel.rs` 用了 `#[specta(remote=..., rename="...")]`


### PR DESCRIPTION
## Summary

- Pin both Engine dependencies to `68ff88a392f495b3906985d1c31d1dde8071dab3`, the latest Engine `main` revision verified for this update.
- Refresh Cargo.lock for that revision, removing dependencies no longer used by Engine.
- No desktop behavior, documentation, telemetry, or tracing changes are introduced in this PR. CONTEXT.md needs no update.

## Validation

- Passed Desktop Engine consumer preflight, including its negative fixtures, against the final PR branch with local Engine overrides excluded.
- Passed `git diff --check`.
- Full workspace compilation has not been completed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal workspace dependencies to newer revisions.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->