### PR TITLE
fix(window): restore history toolbar dragging

### DIFF
--- a/src/components/TitleBar.tsx
+++ b/src/components/TitleBar.tsx
@@ -181,7 +181,7 @@ export const ContentToolbar = ({ className, rightSlot }: ContentToolbarProps) =>
       {rightSlot && (
         <div
           className="relative z-10 flex min-w-0 flex-1 items-center px-3"
-          data-tauri-drag-region="false"
+          data-tauri-drag-region="deep"
         >
           {rightSlot}
         </div>

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -75,7 +75,10 @@ const LinuxMainLayout: React.FC<MainLayoutProps & SidebarAreaProps & ContentTool
       <SidebarArea />
 
       <main className="relative flex min-h-0 flex-1 flex-col overflow-hidden bg-card text-card-foreground">
-        <div data-tauri-drag-region className="flex h-10 shrink-0 items-center justify-end px-3">
+        <div
+          data-tauri-drag-region="deep"
+          className="flex h-10 shrink-0 items-center justify-end px-3"
+        >
           <div ref={toolbarHostRef} className="flex items-center" />
         </div>
         <div className="min-h-0 flex-1">{children}</div>


### PR DESCRIPTION
## Summary

Restore window dragging from empty space in the history toolbar. The toolbar slot disabled dragging across its full width; allow subtree dragging while retaining the existing opt-outs for search, filters, and window controls. Apply the same rule to the Linux system-frame content toolbar.

This is a localized interaction fix using the existing Tauri drag-region behavior. No new window-drag handler or parallel path is introduced. User docs and CONTEXT.md need no changes; no telemetry or Rust tracing surface changes.

## Validation

- MainLayout, TitleBar, and HistoryPage tests pass on this independent branch.
- `bun run build` passes, including the macOS compatibility check.
- During implementation, a temporary harness using the installed Tauri drag script reproduced failure before the fix and passed afterward for Windows, macOS, and both Linux frame layouts; controls remained excluded.
- Native Windows window dragging has not been verified on a physical machine.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved window dragging behavior on Linux system-frame layouts.
  * Toolbar areas now participate more reliably in window dragging, including nested content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->