### PR TITLE
fix(startup): match titlebar and status backgrounds

### DIFF
--- a/src/components/app/AppContent.tsx
+++ b/src/components/app/AppContent.tsx
@@ -57,7 +57,7 @@ export function AppContent({
   useMainWindowPresentation(showFailure || !showStartup || needsAttention)
   if (showFailure) {
     return (
-      <div className="flex h-full w-full flex-col">
+      <div className="flex h-full w-full flex-col bg-background">
         {fullTitleBar}
         <AppStatusScreen
           detail={
@@ -74,7 +74,7 @@ export function AppContent({
 
   if (showStartup) {
     return (
-      <div className="flex h-full w-full flex-col">
+      <div className="flex h-full w-full flex-col bg-background">
         {fullTitleBar}
         <StartupProgressScreen
           snapshot={


### PR DESCRIPTION
## Summary

Match the titlebar background to the startup and failure screens in both themes. Their transparent wrappers exposed the outer window's different background color; give those two wrappers the same background token as their content. Ready, setup, and unlock screens keep their existing appearance.

This is a localized styling fix with no new state or alternate rendering flow. User docs and CONTEXT.md need no changes; no telemetry or Rust tracing surface changes.

## Validation

- Startup-frame, AppStatusScreen, and StartupProgressScreen tests pass on this independent branch.
- `bun run build` passes, including the macOS compatibility check.
- Browser checks of rendered startup and failure layouts confirmed matching computed colors in light and dark themes.
- Screenshot capture timed out; physical Windows appearance has not been verified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated failure and startup screens with an explicit background color for a more consistent full-screen appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->