### PR TITLE
fix(history): overlay scrollbar without reserving width

### DIFF
--- a/src/components/history/HistoryGrid.tsx
+++ b/src/components/history/HistoryGrid.tsx
@@ -2,8 +2,11 @@ import { Loader2, Search } from 'lucide-react'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 import { Virtuoso, type StateSnapshot, type VirtuosoHandle } from 'react-virtuoso'
+import { HistoryScroller, HistoryList } from '@/components/history/history-scroll-components'
 import HistoryGridRow from '@/components/history/HistoryGridRow'
 import type { DisplayClipboardItem } from '@/lib/clipboard-entry'
+
+const historyScrollComponents = { Scroller: HistoryScroller, List: HistoryList }
 
 interface HistoryGridProps {
   items: DisplayClipboardItem[]
@@ -60,7 +63,7 @@ const HistoryGrid: React.FC<HistoryGridProps> = ({
   const { t } = useTranslation()
 
   return (
-    <div className="flex-1 min-h-0 overflow-y-auto">
+    <div className="flex-1 min-h-0 overflow-hidden">
       {searchLoading && items.length === 0 ? (
         <div className="flex flex-col items-center justify-center h-full text-muted-foreground gap-3 pb-10">
           <Loader2 className="size-5 text-muted-foreground/40 animate-spin" />
@@ -96,6 +99,7 @@ const HistoryGrid: React.FC<HistoryGridProps> = ({
       ) : (
         <Virtuoso
           ref={listRef}
+          components={historyScrollComponents}
           data={items}
           style={{ height: '100%' }}
           className="flex-1 min-h-0"

--- a/src/components/history/__tests__/history-scroll-components.test.tsx
+++ b/src/components/history/__tests__/history-scroll-components.test.tsx
@@ -1,0 +1,41 @@
+import { act, render, screen, waitFor } from '@testing-library/react'
+import { createRef } from 'react'
+import { Virtuoso, VirtuosoMockContext, type VirtuosoHandle } from 'react-virtuoso'
+import { describe, expect, it, vi } from 'vitest'
+import { HistoryScroller, HistoryList } from '@/components/history/history-scroll-components'
+
+const historyScrollComponents = { Scroller: HistoryScroller, List: HistoryList }
+
+describe('history overlay scrolling', () => {
+  it('keeps virtualized navigation attached to the actual scrolling viewport', async () => {
+    const ref = createRef<VirtuosoHandle>()
+    let scroller: HTMLElement | null = null
+    render(
+      <VirtuosoMockContext value={{ viewportHeight: 400, itemHeight: 80 }}>
+        <Virtuoso
+          ref={ref}
+          components={historyScrollComponents}
+          totalCount={100}
+          scrollerRef={element => {
+            scroller = element as HTMLElement | null
+          }}
+          itemContent={index => <div>Entry {index}</div>}
+        />
+      </VirtuosoMockContext>
+    )
+    await screen.findByText('Entry 0')
+    expect(screen.queryByText('Entry 99')).not.toBeInTheDocument()
+    expect(scroller).not.toBeNull()
+    const viewport = scroller as unknown as HTMLElement
+    Object.defineProperties(viewport, {
+      scrollHeight: { value: 8000 },
+      offsetHeight: { value: 400 },
+    })
+    const scrollTo = vi.fn()
+    viewport.scrollTo = scrollTo
+    act(() => ref.current?.scrollToIndex({ index: 70, align: 'start' }))
+    await waitFor(() =>
+      expect(scrollTo).toHaveBeenCalledWith(expect.objectContaining({ top: 5600 }))
+    )
+  })
+})

--- a/src/components/history/history-scroll-components.tsx
+++ b/src/components/history/history-scroll-components.tsx
@@ -1,0 +1,20 @@
+import { ScrollArea } from '@base-ui/react/scroll-area'
+import type { ListProps, ScrollerProps } from 'react-virtuoso'
+import { ScrollBar } from '@/components/ui/scroll-area'
+
+// Keep the virtual list ref on the actual scrolling viewport.
+export function HistoryScroller({ ref, children, style, ...props }: ScrollerProps) {
+  return (
+    <ScrollArea.Root className="relative h-full min-h-0">
+      <ScrollArea.Viewport ref={ref} style={style} {...props}>
+        {children}
+      </ScrollArea.Viewport>
+      <ScrollBar />
+    </ScrollArea.Root>
+  )
+}
+
+// Recompute the thumb when virtual list padding or content size changes.
+export function HistoryList(props: ListProps) {
+  return <ScrollArea.Content {...props} />
+}


### PR DESCRIPTION
## Summary

Keep the history list at full width when its scrollbar is visible. Replace Virtuoso's native scrollbar with the existing Base UI overlay scrollbar and remove the redundant outer scrolling container.

Keep Virtuoso's ref attached to the actual scroll viewport and observe list size changes so navigation, restoration, and scrollbar sizing continue working. This localized integration reuses the existing scrollbar appearance and visibility policy without adding a dependency or changing other pages. User docs and CONTEXT.md need no changes; no telemetry or Rust tracing surface changes.

## Validation

- HistoryGrid, overlay-scrolling, and HistoryPage tests pass on this independent branch; the new test verifies navigation reaches the actual viewport.
- `bun run build` passes, including the macOS compatibility check.
- Browser integration checks with real Virtuoso and the new scroll components verified wheel scrolling, thumb dragging, item navigation, growth, restoration, and equal viewport/content widths in both themes. A short list removed the scrollbar without changing width.
- Physical Windows/WebView2 behavior has not been verified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scrolling behavior in the history view.
  * Ensured virtualized history lists scroll to the correct entries.
  * Preserved efficient rendering by limiting the number of displayed entries.

* **Tests**
  * Added regression coverage for history scrolling, viewport sizing, and programmatic navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->