### PR TITLE
fix(history): constrain virtualized list width

### DIFF
--- a/src/components/history/__tests__/history-scroll-components.test.tsx
+++ b/src/components/history/__tests__/history-scroll-components.test.tsx
@@ -27,7 +27,9 @@ describe('history overlay scrolling', () => {
     expect(screen.queryByText('Entry 99')).not.toBeInTheDocument()
     expect(scroller).not.toBeNull()
     const viewport = scroller as unknown as HTMLElement
-    expect(viewport.firstElementChild).toHaveStyle({ width: '100%', minWidth: '0px' })
+    const content = viewport.querySelector('[role="presentation"]')
+    expect(content).not.toBeNull()
+    expect(content).toHaveStyle({ width: '100%', minWidth: '0px' })
     Object.defineProperties(viewport, {
       scrollHeight: { value: 8000 },
       offsetHeight: { value: 400 },

--- a/src/components/history/__tests__/history-scroll-components.test.tsx
+++ b/src/components/history/__tests__/history-scroll-components.test.tsx
@@ -27,6 +27,7 @@ describe('history overlay scrolling', () => {
     expect(screen.queryByText('Entry 99')).not.toBeInTheDocument()
     expect(scroller).not.toBeNull()
     const viewport = scroller as unknown as HTMLElement
+    expect(viewport.firstElementChild).toHaveStyle({ width: '100%', minWidth: '0px' })
     Object.defineProperties(viewport, {
       scrollHeight: { value: 8000 },
       offsetHeight: { value: 400 },

--- a/src/components/history/history-scroll-components.tsx
+++ b/src/components/history/history-scroll-components.tsx
@@ -16,5 +16,5 @@ export function HistoryScroller({ ref, children, style, ...props }: ScrollerProp
 
 // Recompute the thumb when virtual list padding or content size changes.
 export function HistoryList(props: ListProps) {
-  return <ScrollArea.Content {...props} />
+  return <ScrollArea.Content {...props} style={{ ...props.style, width: '100%', minWidth: 0 }} />
 }


### PR DESCRIPTION
## Summary

- Prevent the history list content from expanding beyond its panel width.
- Keep the overlay scrollbar attached to the virtualized scrolling viewport.
- Add a regression check for the list width constraint.

## Test plan

- [x] `bun run build`
- [x] TypeScript, formatting, lint, and macOS compatibility checks
- [ ] Run the focused Vitest tests after the local jsdom dependency-loading conflict is resolved
- [ ] Verify history scrolling on Windows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the history list’s scrolling layout by ensuring its content spans the available width and can shrink within the viewport.
  * Added coverage to verify the history list remains properly constrained during virtualized scrolling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->