### PR TITLE
fix(hud): settle completed cancellation requests

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -325,6 +325,8 @@ _Avoid_: lazy hash、pending entry、async capture
 **Tracked inbound file transfer**：
 接收设备本地为「一个正在/已经收下的文件」维护的一条投影记录（id、来源设备、
 缓存路径、状态、时间戳）。
+临时接收或重复内容也可能在生成本地历史记录前结束，因此终态通知允许没有
+`entry_id`；这类传输只负责结束临时 HUD，不创建历史记录。
 _Avoid_: download、file record
 
 **Receiver-side file transfer projection**：
@@ -399,6 +401,8 @@ _Avoid_: synced performance setting、background sync mode
 > **领域专家**：没有。先用占位 id seed 一条 **Tracked inbound file transfer**，
 > 等 SyncDoc apply 阶段生成真实 entry 后再 relink 过去。所以这条投影行的
 > entry_id 是会被改写的——这正是 `RecordReceiverTransferPort` 要 relink 的原因。
+> 如果 SyncDoc apply 发现内容已经存在，临时传输也可能直接以无 `entry_id` 的
+> 完成、失败或取消终态结束，只关闭 HUD，不新增历史记录。
 
 > **Dev**：那「接收进度百分比」算不算领域概念？
 > **领域专家**：目前不算。我们只跟 **In-flight transfer** 的状态枚举，不跟逐块

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -337,7 +337,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -348,7 +348,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2242,7 +2242,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2631,7 +2631,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3119,8 +3119,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
 ]
 
 [[package]]
@@ -3252,7 +3252,7 @@ dependencies = [
  "gobject-sys 0.21.5",
  "libc",
  "system-deps 7.0.8",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3935,7 +3935,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -3953,7 +3953,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.59.0",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -5437,7 +5437,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.19",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5795,7 +5795,7 @@ dependencies = [
  "pin-project-lite",
  "rustc-hash",
  "rustls",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "thiserror 2.0.19",
  "tokio",
  "tokio-stream",
@@ -5840,7 +5840,7 @@ checksum = "b3c1520eacd33fd6b009e2e70116b05508ade51db5e0d315ff8bf6b702148c2b"
 dependencies = [
  "cfg_aliases",
  "libc",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -5874,7 +5874,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6010,7 +6010,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 2.0.2",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -7423,7 +7423,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "thiserror 2.0.19",
  "tokio",
  "tracing",
@@ -7462,9 +7462,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7781,7 +7781,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "rustix 1.1.4",
- "windows 0.61.3",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -8081,7 +8081,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8140,7 +8140,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8340,7 +8340,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8898,7 +8898,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9887,7 +9887,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10459,7 +10459,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.19",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10508,7 +10508,7 @@ dependencies = [
 [[package]]
 name = "uc-application"
 version = "1.1.0-rc.14"
-source = "git+https://github.com/UniClipboard/Engine.git?rev=9149a875f389bfbf3c24dc9e3c9f7e50c517c07e#9149a875f389bfbf3c24dc9e3c9f7e50c517c07e"
+source = "git+https://github.com/UniClipboard/Engine.git?rev=ae0e2650#ae0e2650a01d80bff433914bf8abd350248de301"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10600,7 +10600,7 @@ dependencies = [
 [[package]]
 name = "uc-content-hash"
 version = "1.1.0-rc.14"
-source = "git+https://github.com/UniClipboard/Engine.git?rev=9149a875f389bfbf3c24dc9e3c9f7e50c517c07e#9149a875f389bfbf3c24dc9e3c9f7e50c517c07e"
+source = "git+https://github.com/UniClipboard/Engine.git?rev=ae0e2650#ae0e2650a01d80bff433914bf8abd350248de301"
 dependencies = [
  "blake3",
  "hex",
@@ -10609,7 +10609,7 @@ dependencies = [
 [[package]]
 name = "uc-core"
 version = "1.1.0-rc.14"
-source = "git+https://github.com/UniClipboard/Engine.git?rev=9149a875f389bfbf3c24dc9e3c9f7e50c517c07e#9149a875f389bfbf3c24dc9e3c9f7e50c517c07e"
+source = "git+https://github.com/UniClipboard/Engine.git?rev=ae0e2650#ae0e2650a01d80bff433914bf8abd350248de301"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -10760,7 +10760,7 @@ dependencies = [
 [[package]]
 name = "uc-engine"
 version = "1.1.0-rc.14"
-source = "git+https://github.com/UniClipboard/Engine.git?rev=9149a875f389bfbf3c24dc9e3c9f7e50c517c07e#9149a875f389bfbf3c24dc9e3c9f7e50c517c07e"
+source = "git+https://github.com/UniClipboard/Engine.git?rev=ae0e2650#ae0e2650a01d80bff433914bf8abd350248de301"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10786,7 +10786,7 @@ dependencies = [
 [[package]]
 name = "uc-infra"
 version = "1.1.0-rc.14"
-source = "git+https://github.com/UniClipboard/Engine.git?rev=9149a875f389bfbf3c24dc9e3c9f7e50c517c07e#9149a875f389bfbf3c24dc9e3c9f7e50c517c07e"
+source = "git+https://github.com/UniClipboard/Engine.git?rev=ae0e2650#ae0e2650a01d80bff433914bf8abd350248de301"
 dependencies = [
  "anyhow",
  "argon2",
@@ -10853,7 +10853,7 @@ dependencies = [
 [[package]]
 name = "uc-mobile-lan"
 version = "1.1.0-rc.14"
-source = "git+https://github.com/UniClipboard/Engine.git?rev=9149a875f389bfbf3c24dc9e3c9f7e50c517c07e#9149a875f389bfbf3c24dc9e3c9f7e50c517c07e"
+source = "git+https://github.com/UniClipboard/Engine.git?rev=ae0e2650#ae0e2650a01d80bff433914bf8abd350248de301"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -10875,7 +10875,7 @@ dependencies = [
 [[package]]
 name = "uc-mobile-proto"
 version = "1.1.0-rc.14"
-source = "git+https://github.com/UniClipboard/Engine.git?rev=9149a875f389bfbf3c24dc9e3c9f7e50c517c07e#9149a875f389bfbf3c24dc9e3c9f7e50c517c07e"
+source = "git+https://github.com/UniClipboard/Engine.git?rev=ae0e2650#ae0e2650a01d80bff433914bf8abd350248de301"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -10910,7 +10910,7 @@ dependencies = [
 [[package]]
 name = "uc-observability-contract"
 version = "1.1.0-rc.14"
-source = "git+https://github.com/UniClipboard/Engine.git?rev=9149a875f389bfbf3c24dc9e3c9f7e50c517c07e#9149a875f389bfbf3c24dc9e3c9f7e50c517c07e"
+source = "git+https://github.com/UniClipboard/Engine.git?rev=ae0e2650#ae0e2650a01d80bff433914bf8abd350248de301"
 dependencies = [
  "anyhow",
  "chrono",
@@ -10927,7 +10927,7 @@ dependencies = [
 [[package]]
 name = "uc-observability-runtime"
 version = "1.1.0-rc.14"
-source = "git+https://github.com/UniClipboard/Engine.git?rev=9149a875f389bfbf3c24dc9e3c9f7e50c517c07e#9149a875f389bfbf3c24dc9e3c9f7e50c517c07e"
+source = "git+https://github.com/UniClipboard/Engine.git?rev=ae0e2650#ae0e2650a01d80bff433914bf8abd350248de301"
 dependencies = [
  "chrono",
  "jni 0.22.4",
@@ -11085,7 +11085,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11827,7 +11827,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -12442,8 +12442,8 @@ dependencies = [
  "log",
  "serde",
  "thiserror 2.0.19",
- "windows 0.59.0",
- "windows-core 0.59.0",
+ "windows 0.62.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,8 +51,8 @@ dbg_macro = "warn"
 [workspace.dependencies]
 # All desktop consumers use one immutable Engine revision. Features remain
 # opt-in at each host boundary so LAN compatibility cannot become a default.
-uc-engine = { git = "https://github.com/UniClipboard/Engine.git", rev = "9149a875f389bfbf3c24dc9e3c9f7e50c517c07e" }
-uc-observability-contract = { git = "https://github.com/UniClipboard/Engine.git", rev = "9149a875f389bfbf3c24dc9e3c9f7e50c517c07e" }
+uc-engine = { git = "https://github.com/UniClipboard/Engine.git", rev = "ae0e2650" }
+uc-observability-contract = { git = "https://github.com/UniClipboard/Engine.git", rev = "ae0e2650" }
 
 # tauri 2.11 是 specta rc.25 兼容的最低版本 —— 2.10.x 及之前在
 # `tauri/src/ipc/channel.rs` 用了 `#[specta(remote=..., rename="...")]`

--- a/crates/uc-daemon-client/src/realtime.rs
+++ b/crates/uc-daemon-client/src/realtime.rs
@@ -104,7 +104,7 @@ pub struct ClipboardIncomingPendingEvent {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FileTransferStatusChangedEvent {
     pub transfer_id: String,
-    pub entry_id: String,
+    pub entry_id: Option<String>,
     pub attempt_id: Option<String>,
     pub status: String,
     pub reason: Option<String>,

--- a/crates/uc-daemon-client/src/ws_bridge.rs
+++ b/crates/uc-daemon-client/src/ws_bridge.rs
@@ -1277,7 +1277,7 @@ fn map_daemon_ws_event(event: DaemonWsEvent) -> Option<RealtimeEvent> {
             #[serde(rename_all = "camelCase")]
             struct StatusChangedPayload {
                 transfer_id: String,
-                entry_id: String,
+                entry_id: Option<String>,
                 #[serde(default)]
                 attempt_id: Option<String>,
                 status: String,
@@ -1293,7 +1293,7 @@ fn map_daemon_ws_event(event: DaemonWsEvent) -> Option<RealtimeEvent> {
                         session_id = session_id.as_deref().unwrap_or(""),
                         payload_type = "StatusChangedPayload",
                         transfer_id = %payload.transfer_id,
-                        entry_id = %payload.entry_id,
+                        entry_id = ?payload.entry_id,
                         status = %payload.status,
                         "decoded websocket payload"
                     );
@@ -1426,5 +1426,27 @@ fn lock_recover<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
     match mutex.lock() {
         Ok(guard) => guard,
         Err(poisoned) => poisoned.into_inner(),
+    }
+}
+
+#[cfg(test)]
+mod provisional_status_tests {
+    use super::*;
+
+    #[test]
+    fn terminal_transfer_without_entry_is_delivered() {
+        for status in ["completed", "failed", "cancelled"] {
+            let event = map_daemon_ws_event(DaemonWsEvent {
+                topic: ws_topic::FILE_TRANSFER.into(),
+                event_type: ws_event::FILE_TRANSFER_STATUS_CHANGED.into(),
+                session_id: None,
+                ts: 0,
+                payload: serde_json::json!({ "transferId": "mobile-lan:duplicate", "entryId": null, "status": status }),
+            });
+            assert!(
+                matches!(event, Some(RealtimeEvent::FileTransferStatusChanged(_))),
+                "unowned {status} event must reach the HUD"
+            );
+        }
     }
 }

--- a/src-tauri/crates/uc-tauri/src/activity_hud/actions.rs
+++ b/src-tauri/crates/uc-tauri/src/activity_hud/actions.rs
@@ -24,10 +24,11 @@
 use std::sync::Arc;
 
 use tauri::{AppHandle, Manager};
-use tracing::warn;
+use tracing::{warn, Instrument};
 use uc_daemon_client::{DaemonClipboardClient, DaemonConnectionState};
 
 use super::emitter::ActivityHudEmitter;
+use super::state::CancelResult;
 
 /// HUD 用户动作。所有方法都是 fire-and-forget:动作内部应自行处理
 /// 乐观 UI 状态、异步执行、错误日志。调用方不等待结果。
@@ -74,6 +75,7 @@ impl ActivityHudActions for DefaultActivityHudActions {
         let entry_id = entry_id.to_string();
         let attempt_id = attempt_id.map(str::to_owned);
         let app_handle = self.app_handle.clone();
+        let emitter = self.emitter.clone();
         tauri::async_runtime::spawn(async move {
             let connection_state = app_handle.state::<DaemonConnectionState>().inner().clone();
             let client = match DaemonClipboardClient::new(connection_state) {
@@ -86,6 +88,7 @@ impl ActivityHudActions for DefaultActivityHudActions {
                         transfer_id = %transfer_id,
                         "activity_hud: failed to build local daemon clipboard client"
                     );
+                    emitter.resolve_cancel(&entry_id, attempt_id.as_deref(), &transfer_id, CancelResult::NotCancelled);
                     return;
                 }
             };
@@ -95,23 +98,62 @@ impl ActivityHudActions for DefaultActivityHudActions {
                 Some(attempt_id) => client
                     .cancel_entry_receive(&entry_id, attempt_id)
                     .await
-                    .map(|_| ()),
+                    .map(|response| response.outcome),
                 None => client
                     .cancel_transfer(&transfer_id, "local_user")
                     .await
-                    .map(|_| ()),
+                    .map(|response| response.outcome),
             };
-            if let Err(err) = result {
-                warn!(
-                    error = %err,
-                    transfer_id = %transfer_id,
-                    "activity_hud: cancel_inbound_transfer failed"
-                );
-            }
-        });
+            let resolution = match result {
+                Ok(outcome) => cancel_result(&outcome),
+                Err(err) => {
+                    warn!(error = %err, transfer_id = %transfer_id, "activity_hud: cancel request failed");
+                    CancelResult::NotCancelled
+                }
+            };
+            emitter.resolve_cancel(&entry_id, attempt_id.as_deref(), &transfer_id, resolution);
+        }.in_current_span());
     }
 
     fn dismiss(&self, entry_id: &str, attempt_id: Option<&str>, transfer_id: &str) {
         self.emitter.dismiss(entry_id, attempt_id, transfer_id);
+    }
+}
+
+fn cancel_result(outcome: &str) -> CancelResult {
+    match outcome {
+        "cancelled" => CancelResult::Cancelled,
+        "not_inflight" | "not_receiving" | "already_terminal" | "superseded" => {
+            CancelResult::Inactive
+        }
+        "too_late" => CancelResult::NotCancelled,
+        _ => {
+            warn!(
+                error_kind = "unknown_cancel_outcome",
+                "activity_hud: unexpected cancellation response"
+            );
+            CancelResult::NotCancelled
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn daemon_cancel_outcomes_are_resolved() {
+        assert_eq!(cancel_result("cancelled"), CancelResult::Cancelled);
+        for outcome in [
+            "not_inflight",
+            "not_receiving",
+            "already_terminal",
+            "superseded",
+        ] {
+            assert_eq!(cancel_result(outcome), CancelResult::Inactive);
+        }
+        for outcome in ["too_late", "unexpected"] {
+            assert_eq!(cancel_result(outcome), CancelResult::NotCancelled);
+        }
     }
 }

--- a/src-tauri/crates/uc-tauri/src/activity_hud/emitter.rs
+++ b/src-tauri/crates/uc-tauri/src/activity_hud/emitter.rs
@@ -93,6 +93,16 @@ impl ActivityHudEmitter {
         });
     }
 
+    pub fn resolve_cancel(
+        &self,
+        entry_id: &str,
+        attempt_id: Option<&str>,
+        transfer_id: &str,
+        result: super::state::CancelResult,
+    ) {
+        self.apply(|state| state.resolve_cancel(entry_id, attempt_id, transfer_id, result));
+    }
+
     pub fn dismiss(&self, entry_id: &str, attempt_id: Option<&str>, transfer_id: &str) {
         self.apply(|state| state.dismiss_scoped(entry_id, attempt_id, transfer_id));
     }
@@ -137,7 +147,7 @@ impl ActivityHudEmitter {
                 self.apply(|state| {
                     state.apply_scoped_status_changed(
                         &event.transfer_id,
-                        Some(&event.entry_id),
+                        event.entry_id.as_deref(),
                         event.attempt_id.as_deref(),
                         &event.status,
                         event.reason,
@@ -302,6 +312,152 @@ mod tests {
     }
 
     #[test]
+    fn inactive_cancel_response_removes_stale_hud() {
+        let (emitter, recorder, _) = make_emitter();
+        emitter.emit(progress_event(
+            "stale",
+            "peer",
+            FileTransferDirection::Receiving,
+            100,
+            Some(100),
+        ));
+        emitter.mark_cancel_pending("stale", None, "stale");
+        emitter.resolve_cancel(
+            "stale",
+            None,
+            "stale",
+            super::super::state::CancelResult::Inactive,
+        );
+        assert!(recorder.snapshots().last().unwrap().is_empty());
+    }
+
+    #[test]
+    fn failed_cancel_response_reenables_cancel_without_overwriting_completion() {
+        let (emitter, recorder, _) = make_emitter();
+        emitter.emit(progress_event(
+            "t1",
+            "peer",
+            FileTransferDirection::Receiving,
+            50,
+            Some(100),
+        ));
+        emitter.mark_cancel_pending("t1", None, "t1");
+        emitter.resolve_cancel(
+            "t1",
+            None,
+            "t1",
+            super::super::state::CancelResult::NotCancelled,
+        );
+        assert_eq!(
+            recorder.snapshots().last().unwrap()[0].state,
+            super::super::state::RowState::Receiving
+        );
+        emitter.mark_cancel_pending("t1", None, "t1");
+        emitter.emit(RealtimeEvent::FileTransferStatusChanged(
+            FileTransferStatusChangedEvent {
+                transfer_id: "t1".into(),
+                entry_id: Some("t1".into()),
+                attempt_id: None,
+                status: "completed".into(),
+                reason: None,
+            },
+        ));
+        emitter.resolve_cancel(
+            "t1",
+            None,
+            "t1",
+            super::super::state::CancelResult::NotCancelled,
+        );
+        assert_eq!(
+            recorder.snapshots().last().unwrap()[0].state,
+            super::super::state::RowState::Completed
+        );
+    }
+
+    #[test]
+    fn late_cancel_response_preserves_newer_attempt() {
+        let (emitter, recorder, _) = make_emitter();
+        for attempt in ["old", "new"] {
+            emitter.emit(RealtimeEvent::ClipboardIncomingPending(
+                ClipboardIncomingPendingEvent {
+                    entry_id: "entry".into(),
+                    attempt_id: Some(attempt.into()),
+                    from_device: "peer".into(),
+                    total_bytes: Some(100),
+                    filenames: vec![],
+                },
+            ));
+            if attempt == "old" {
+                emitter.mark_cancel_pending("entry", Some("old"), "transfer-old");
+            }
+        }
+        emitter.resolve_cancel(
+            "entry",
+            Some("old"),
+            "transfer-old",
+            super::super::state::CancelResult::Inactive,
+        );
+        let rows = recorder.snapshots().pop().unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].attempt_id.as_deref(), Some("new"));
+        assert_eq!(rows[0].state, super::super::state::RowState::Receiving);
+    }
+
+    #[test]
+    fn unowned_completion_removes_duplicate_upload_hud() {
+        let (emitter, recorder, clock) = make_emitter();
+        emitter.emit(progress_event(
+            "mobile-lan:duplicate",
+            "peer",
+            FileTransferDirection::Receiving,
+            100,
+            Some(100),
+        ));
+        emitter.emit(RealtimeEvent::FileTransferStatusChanged(
+            FileTransferStatusChangedEvent {
+                transfer_id: "mobile-lan:duplicate".into(),
+                entry_id: None,
+                attempt_id: None,
+                status: "completed".into(),
+                reason: None,
+            },
+        ));
+        assert_eq!(
+            recorder.snapshots().last().unwrap()[0].state,
+            super::super::state::RowState::Completed
+        );
+        clock.advance(super::super::state::COMPLETED_RETAIN_MS + 1);
+        emitter.tick();
+        assert!(recorder.snapshots().last().unwrap().is_empty());
+    }
+
+    #[test]
+    fn successful_cancel_response_finishes_without_waiting_for_an_event() {
+        let (emitter, recorder, clock) = make_emitter();
+        emitter.emit(progress_event(
+            "t1",
+            "peer",
+            FileTransferDirection::Receiving,
+            50,
+            Some(100),
+        ));
+        emitter.mark_cancel_pending("t1", None, "t1");
+        emitter.resolve_cancel(
+            "t1",
+            None,
+            "t1",
+            super::super::state::CancelResult::Cancelled,
+        );
+        assert!(matches!(
+            recorder.snapshots().last().unwrap()[0].state,
+            super::super::state::RowState::Cancelled { .. }
+        ));
+        clock.advance(super::super::state::CANCELLED_RETAIN_MS + 1);
+        emitter.tick();
+        assert!(recorder.snapshots().last().unwrap().is_empty());
+    }
+
+    #[test]
     fn status_changed_completed_then_sweep_clears() {
         let (emitter, recorder, clock) = make_emitter();
         emitter.emit(progress_event(
@@ -314,7 +470,7 @@ mod tests {
         emitter.emit(RealtimeEvent::FileTransferStatusChanged(
             FileTransferStatusChangedEvent {
                 transfer_id: "t1".into(),
-                entry_id: "t1".into(),
+                entry_id: Some("t1".into()),
                 attempt_id: None,
                 status: "completed".into(),
                 reason: None,
@@ -367,7 +523,7 @@ mod tests {
                     emitter.emit(RealtimeEvent::FileTransferStatusChanged(
                         FileTransferStatusChangedEvent {
                             transfer_id: "mobile-upload".into(),
-                            entry_id: "entry".into(),
+                            entry_id: Some("entry".into()),
                             attempt_id: Some("attempt".into()),
                             status: status.into(),
                             reason: None,
@@ -401,7 +557,7 @@ mod tests {
         emitter.emit(RealtimeEvent::FileTransferStatusChanged(
             FileTransferStatusChangedEvent {
                 transfer_id: "t-outbound".into(),
-                entry_id: "t-outbound".into(),
+                entry_id: Some("t-outbound".into()),
                 attempt_id: None,
                 status: "cancelled".into(),
                 reason: Some("local_user".into()),
@@ -423,7 +579,7 @@ mod tests {
         emitter.emit(RealtimeEvent::FileTransferStatusChanged(
             FileTransferStatusChangedEvent {
                 transfer_id: "t1".into(),
-                entry_id: "t1".into(),
+                entry_id: Some("t1".into()),
                 attempt_id: None,
                 status: "failed".into(),
                 reason: Some("disk_full".into()),

--- a/src-tauri/crates/uc-tauri/src/activity_hud/state.rs
+++ b/src-tauri/crates/uc-tauri/src/activity_hud/state.rs
@@ -43,6 +43,14 @@ pub enum RowState {
     CancelPending,
 }
 
+/// The daemon's response to a user cancellation request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CancelResult {
+    Cancelled,
+    Inactive,
+    NotCancelled,
+}
+
 impl RowState {
     /// 终态:行最终会被 sweep 走,不应再被 progress 事件更新。
     pub fn is_terminal(&self) -> bool {
@@ -419,6 +427,36 @@ impl ActivityHudState {
         }
         row.state = RowState::CancelPending;
         row.state_entered_at_ms = now_ms;
+        true
+    }
+
+    /// Resolve only the pending request's row; late replies cannot change a terminal row.
+    pub fn resolve_cancel(
+        &mut self,
+        entry_id: &str,
+        attempt_id: Option<&str>,
+        transfer_id: &str,
+        result: CancelResult,
+    ) -> bool {
+        let key = row_key(entry_id, attempt_id, transfer_id);
+        let Some(row) = self.rows.get_mut(&key) else {
+            return false;
+        };
+        if row.state != RowState::CancelPending {
+            return false;
+        }
+        match result {
+            CancelResult::Inactive => {
+                return self.dismiss_scoped(entry_id, attempt_id, transfer_id)
+            }
+            CancelResult::Cancelled => {
+                row.state = RowState::Cancelled {
+                    reason: Some("local_user".into()),
+                }
+            }
+            CancelResult::NotCancelled => row.state = RowState::Receiving,
+        }
+        row.state_entered_at_ms = self.clock.now_ms();
         true
     }
 

--- a/src/hooks/__tests__/clipboardEventReducer.test.ts
+++ b/src/hooks/__tests__/clipboardEventReducer.test.ts
@@ -161,6 +161,23 @@ describe('clipboardEventReducer', () => {
     expect(duplicate.effects).toEqual([])
   })
 
+  it.each(['completed', 'cancelled', 'failed'])(
+    'settles an unowned %s transfer without creating a history entry',
+    status => {
+      const reduced = reduce(
+        createInitialClipboardEventReducerState(),
+        {
+          topic: 'file-transfer',
+          eventType: 'file-transfer.status_changed',
+          payload: { transferId: 'mobile-lan:duplicate', entryId: null, status },
+        },
+        1000
+      )
+      expect(reduced.actions).toHaveLength(1)
+      expect(reduced.actions[0].payload).toMatchObject({ transferId: 'mobile-lan:duplicate' })
+    }
+  )
+
   it('turns file-transfer status and progress events into store actions', () => {
     const state = createInitialClipboardEventReducerState()
 

--- a/src/hooks/clipboardEventReducer.ts
+++ b/src/hooks/clipboardEventReducer.ts
@@ -78,7 +78,7 @@ interface ClipboardInboundNoticePayload {
 
 interface FileTransferStatusEvent {
   transferId: string
-  entryId: string
+  entryId?: string | null
   attemptId?: string | null
   status: string
   reason?: string | null
@@ -340,11 +340,12 @@ function reduceRemoteNewContent(
 
 function reduceTransferStatus(payload: FileTransferStatusEvent): ClipboardEventReducerAction[] {
   if (payload.attemptId) return []
-  const actions: ClipboardEventReducerAction[] = [
-    linkTransferToEntry({ transferId: payload.transferId, entryId: payload.entryId }),
-  ]
+  const actions: ClipboardEventReducerAction[] = []
+  if (payload.entryId) {
+    actions.push(linkTransferToEntry({ transferId: payload.transferId, entryId: payload.entryId }))
+  }
 
-  if (isValidTransferStatus(payload.status)) {
+  if (payload.entryId && isValidTransferStatus(payload.status)) {
     actions.push(
       setEntryTransferStatus({
         entryId: payload.entryId,
@@ -362,8 +363,8 @@ function reduceTransferStatus(payload: FileTransferStatusEvent): ClipboardEventR
       })
     )
   } else if (payload.status === 'cancelled') {
+    if (payload.entryId) actions.push(removePendingEntry(payload.entryId))
     actions.push(
-      removePendingEntry(payload.entryId),
       markTransferCancelled({
         transferId: payload.transferId,
         reason: normalizeCancelReason(payload.reason),


### PR DESCRIPTION
## Summary

- Close the macOS transfer HUD when cancellation reports that the transfer is already finished or no longer active.
- Keep cancellation failures retryable and ignore late replies that belong to an older attempt.
- Accept terminal transfer events without an entry ID so duplicate mobile-LAN receives can finish their temporary HUD lifecycle without creating history rows.
- Update the Engine dependency to `ae0e2650` from [Engine PR #59](https://github.com/UniClipboard/Engine/pull/59).

## Test plan

- [x] `cargo test -p uc-daemon-client --lib --locked`
- [x] `cargo test -p uc-tauri activity_hud --lib --locked`
- [x] Frontend Vitest coverage for clipboard event reduction and transfer progress
- [x] `cargo check -p uc-webserver --all-targets --locked`
- [x] Manual macOS HUD test: clicked the cancel control against an already-finished simulated transfer and verified the HUD disappeared.
- [x] React Doctor score: 100/100

CONTEXT.md audit: updated the transfer glossary and mobile PUT /file example for unowned terminal transfers.
Docs-site: scanned; no docs-site content depends on this HUD behavior.
Telemetry: skipped; the diff does not add or change an application activation/reliability milestone.
Tracing: reviewed; the new async cancellation path preserves the existing span and privacy boundaries.

Depends on Engine PR #59.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - File transfers that finish, fail, or are cancelled before creating a history entry now close the temporary activity display without creating a history record.
  - Transfer status updates without a linked history entry are handled correctly.
  - Cancelling a transfer now updates the activity display based on the actual cancellation result.
  - Failed cancellation requests no longer leave transfers stuck in a pending state.

- **Documentation**
  - Added examples covering completion, failure, and cancellation flows for temporary or duplicate file transfers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->