### PR TITLE
fix(devices): prevent device check dialog flashing on startup

### DIFF
--- a/src/components/device/DeviceTrustDialogHost.tsx
+++ b/src/components/device/DeviceTrustDialogHost.tsx
@@ -11,13 +11,7 @@ export function DeviceTrustDialogHost() {
   const { t } = useTranslation()
   const state = useDeviceTrust()
   useDeviceTrustDesktopEffects(state.snapshot)
-  if (
-    state.deviceGroups &&
-    !state.deviceGroups.issues.length &&
-    !state.decision &&
-    !state.decisionError
-  )
-    return null
+  if (!state.deviceGroups?.issues.length && !state.decision && !state.decisionError) return null
   return (
     <Dialog open onOpenChange={(_open, details) => details.cancel()} disablePointerDismissal>
       <DialogContent

--- a/src/components/device/__tests__/DeviceTrustDialogHost.test.tsx
+++ b/src/components/device/__tests__/DeviceTrustDialogHost.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react'
-import { it, expect, vi } from 'vitest'
+import { beforeEach, it, expect, vi } from 'vitest'
 import { DeviceTrustDialogHost } from '@/components/device/DeviceTrustDialogHost'
 import type { DeviceTrustContextValue } from '@/contexts/device-trust-context'
 const { state } = vi.hoisted(() => ({
@@ -8,35 +8,35 @@ const { state } = vi.hoisted(() => ({
 vi.mock('@/hooks/useDeviceTrust', () => ({ useDeviceTrust: () => state.current }))
 vi.mock('@/hooks/useDeviceTrustDesktopEffects', () => ({ useDeviceTrustDesktopEffects: () => {} }))
 
-it('keeps the same dialog through selection, submission, and completion', () => {
-  const groups = {
+const groups = {
+  revision: 1,
+  deviceTrust: {
     revision: 1,
-    deviceTrust: {
-      revision: 1,
-      localDeviceId: 'local',
-      localMembership: 'active' as const,
-      currentChange: null,
-      devices: [],
-      allowedActions: [],
-      recovery: 'not_available_in_this_version',
-      updatedAtMs: 0,
-      blockedReason: null,
+    localDeviceId: 'local',
+    localMembership: 'active' as const,
+    currentChange: null,
+    devices: [],
+    allowedActions: [],
+    recovery: 'not_available_in_this_version',
+    updatedAtMs: 0,
+    blockedReason: null,
+  },
+  issues: [
+    {
+      issueId: 'issue',
+      choices: [
+        {
+          choiceId: 'choice',
+          isCurrentGroup: true,
+          requiresRePairing: false,
+          memberDeviceIds: ['local'],
+          membersComplete: true,
+        },
+      ],
     },
-    issues: [
-      {
-        issueId: 'issue',
-        choices: [
-          {
-            choiceId: 'choice',
-            isCurrentGroup: true,
-            requiresRePairing: false,
-            memberDeviceIds: ['local'],
-            membersComplete: true,
-          },
-        ],
-      },
-    ],
-  }
+  ],
+}
+beforeEach(() => {
   state.current = {
     deviceGroups: groups,
     snapshot: groups.deviceTrust,
@@ -51,6 +51,60 @@ it('keeps the same dialog through selection, submission, and completion', () => 
     refresh: vi.fn(),
     choose: vi.fn(),
   }
+})
+
+it('stays hidden throughout the initial check when no issues are found', () => {
+  state.current = { ...state.current, deviceGroups: null, snapshot: null }
+  const { rerender } = render(<DeviceTrustDialogHost />)
+  expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  state.current = { ...state.current, loading: true }
+  rerender(<DeviceTrustDialogHost />)
+  expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  state.current = { ...state.current, loading: false, deviceGroups: { ...groups, issues: [] } }
+  rerender(<DeviceTrustDialogHost />)
+  expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+})
+
+it('opens when the initial check finds an issue', () => {
+  state.current = { ...state.current, deviceGroups: null, snapshot: null, loading: true }
+  const { rerender } = render(<DeviceTrustDialogHost />)
+  expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  state.current = {
+    ...state.current,
+    deviceGroups: groups,
+    snapshot: groups.deviceTrust,
+    loading: false,
+  }
+  rerender(<DeviceTrustDialogHost />)
+  expect(screen.getByRole('dialog')).toBeInTheDocument()
+})
+
+it('shows an initial check failure and keeps retry available until recovery', () => {
+  state.current = {
+    ...state.current,
+    deviceGroups: null,
+    snapshot: null,
+    decisionError: 'runtime_unavailable',
+  }
+  const { rerender } = render(<DeviceTrustDialogHost />)
+  expect(screen.getByTestId('device-trust-error')).toBeVisible()
+  fireEvent.click(screen.getByTestId('device-trust-recheck'))
+  expect(state.current.refresh).toHaveBeenCalledOnce()
+  state.current = { ...state.current, loading: true }
+  rerender(<DeviceTrustDialogHost />)
+  expect(screen.getByRole('dialog')).toBeInTheDocument()
+  expect(screen.getByTestId('device-trust-recheck')).toBeDisabled()
+  state.current = {
+    ...state.current,
+    loading: false,
+    decisionError: null,
+    deviceGroups: { ...groups, issues: [] },
+  }
+  rerender(<DeviceTrustDialogHost />)
+  expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+})
+
+it('keeps the same dialog through selection, submission, and completion', () => {
   const { rerender } = render(<DeviceTrustDialogHost />)
   const dialog = screen.getByRole('dialog')
   state.current = {


### PR DESCRIPTION
## Summary

Starting the app briefly opened "Checking device relationships" before the first device response arrived. Keep that initial check silent and open the dialog only for a device issue, a pending decision, or an error. Error retry and the existing decision flow remain available.

This is a local rendering-condition defect: unknown device state previously fell through to an open dialog. The existing state remains authoritative; no timers, extra state, or alternate flow are added. User docs already describe prompting when a device decision is needed; no documentation, telemetry, or tracing changes are required.

## Validation

- Reproduced the startup flash with two failing regression tests before the fix.
- All 11 focused tests passed, covering startup, device decisions, failure/retry, and typography.
- TypeScript, scoped lint, formatting, and diff checks passed.
- React Doctor completed at 93/100 with one control-flow complexity warning in the existing dialog component.
- Native desktop launch was not manually verified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of device trust dialog state when device-group issues are unavailable, with no change to expected behavior.

* **Tests**
  * Expanded coverage for hidden initial checks, dialog opening after issues are detected, and retry behavior after an initial check fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->