### PR TITLE
fix(quick-panel): remove preview send action

### DIFF
--- a/src/components/clipboard/ClipboardActionBar.tsx
+++ b/src/components/clipboard/ClipboardActionBar.tsx
@@ -1,7 +1,10 @@
 import { Check, Copy, Star, Trash2 } from 'lucide-react'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
+import type { EntryDeliveryView } from '@/api/tauri-command/clipboard_delivery'
+import ClipboardSendMenu from '@/components/clipboard/ClipboardSendMenu'
 import { ExpandableActionBar } from '@/components/motion/expandable-action-bar'
+import type { DisplayClipboardItem } from '@/lib/clipboard-entry'
 import { cn } from '@/lib/utils'
 
 export interface ClipboardActionBarTransferStatus {
@@ -10,9 +13,9 @@ export interface ClipboardActionBarTransferStatus {
 }
 
 interface ClipboardActionBarProps {
-  hasActiveItem: boolean
+  item: DisplayClipboardItem | null
+  delivery: EntryDeliveryView | null
   copySuccess: boolean
-  isFavorited: boolean
   transferStatus?: ClipboardActionBarTransferStatus
   onCopy: () => void
   onDelete: () => void
@@ -20,9 +23,9 @@ interface ClipboardActionBarProps {
 }
 
 const ClipboardActionBar: React.FC<ClipboardActionBarProps> = ({
-  hasActiveItem,
+  item,
+  delivery,
   copySuccess,
-  isFavorited,
   transferStatus,
   onCopy,
   onDelete,
@@ -30,60 +33,71 @@ const ClipboardActionBar: React.FC<ClipboardActionBarProps> = ({
 }) => {
   const { isCopyBlocked, copyBlockedReason } = transferStatus ?? {}
   const { t } = useTranslation()
+  const hasActiveItem = item !== null
+  const isFavorited = item?.isFavorited === true
   const favoriteLabel = isFavorited
     ? t('clipboard.actionBar.unfavorite')
     : t('clipboard.actionBar.favorite')
 
   return (
-    <ExpandableActionBar
-      size="sm"
-      items={[
-        {
-          id: 'copy',
-          label:
-            copyBlockedReason ||
-            (copySuccess
-              ? t('clipboard.actionBar.copied', '已复制')
-              : t('clipboard.actionBar.copy')),
-          icon: copySuccess ? (
-            <Check className="size-3.5 text-green-600 dark:text-green-400" />
-          ) : (
-            <Copy className="size-3.5" />
-          ),
-          shortcut: !isCopyBlocked && hasActiveItem ? 'C' : undefined,
-          disabled: !hasActiveItem || isCopyBlocked,
-          onClick: onCopy,
-        },
-        {
-          id: 'favorite',
-          label: favoriteLabel,
-          icon: (
-            <Star
-              className={cn(
-                'size-3.5',
-                isFavorited && 'fill-current text-amber-600 dark:text-amber-400'
-              )}
-            />
-          ),
-          shortcut: hasActiveItem ? 'F' : undefined,
-          active: isFavorited,
-          disabled: !hasActiveItem,
-          onClick: onToggleFavorite,
-        },
-        {
-          id: 'delete',
-          label: t('clipboard.actionBar.delete'),
-          icon: <Trash2 className="size-3.5" />,
-          shortcut: hasActiveItem ? 'D' : undefined,
-          disabled: !hasActiveItem,
-          onClick: onDelete,
-        },
-      ]}
-      classNames={{
-        track: 'min-h-7 border-0 bg-transparent p-0 shadow-none backdrop-blur-none',
-        item: 'hover:text-foreground',
-      }}
-    />
+    <>
+      {item && (
+        <ClipboardSendMenu
+          key={item.id}
+          entryId={item.id}
+          disabled={item.isUnavailable || (delivery !== null && delivery.source.tag !== 'local')}
+        />
+      )}
+      <ExpandableActionBar
+        size="sm"
+        items={[
+          {
+            id: 'copy',
+            label:
+              copyBlockedReason ||
+              (copySuccess
+                ? t('clipboard.actionBar.copied', '已复制')
+                : t('clipboard.actionBar.copy')),
+            icon: copySuccess ? (
+              <Check className="size-3.5 text-green-600 dark:text-green-400" />
+            ) : (
+              <Copy className="size-3.5" />
+            ),
+            shortcut: !isCopyBlocked && hasActiveItem ? 'C' : undefined,
+            disabled: !hasActiveItem || isCopyBlocked,
+            onClick: onCopy,
+          },
+          {
+            id: 'favorite',
+            label: favoriteLabel,
+            icon: (
+              <Star
+                className={cn(
+                  'size-3.5',
+                  isFavorited && 'fill-current text-amber-600 dark:text-amber-400'
+                )}
+              />
+            ),
+            shortcut: hasActiveItem ? 'F' : undefined,
+            active: isFavorited,
+            disabled: !hasActiveItem,
+            onClick: onToggleFavorite,
+          },
+          {
+            id: 'delete',
+            label: t('clipboard.actionBar.delete'),
+            icon: <Trash2 className="size-3.5" />,
+            shortcut: hasActiveItem ? 'D' : undefined,
+            disabled: !hasActiveItem,
+            onClick: onDelete,
+          },
+        ]}
+        classNames={{
+          track: 'min-h-7 border-0 bg-transparent p-0 shadow-none backdrop-blur-none',
+          item: 'hover:text-foreground',
+        }}
+      />
+    </>
   )
 }
 

--- a/src/components/clipboard/ClipboardPreview.tsx
+++ b/src/components/clipboard/ClipboardPreview.tsx
@@ -2,7 +2,6 @@ import { Clipboard } from 'lucide-react'
 import React, { useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { cancelEntryReceive, cancelFileTransfer } from '@/api/file_transfer'
-import ClipboardSendMenu from '@/components/clipboard/ClipboardSendMenu'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { useClipboardPreviewState } from '@/hooks/useClipboardPreviewState'
 import { useEntryDelivery } from '@/hooks/useEntryDelivery'
@@ -25,7 +24,7 @@ import TransferProgressBar from './TransferProgressBar'
 
 interface ClipboardPreviewProps {
   item: DisplayClipboardItem | null
-  actions?: React.ReactNode
+  actions?: (delivery: ReturnType<typeof useEntryDelivery>['delivery']) => React.ReactNode
 }
 
 interface PreviewContentProps {
@@ -207,20 +206,13 @@ const ClipboardPreview: React.FC<ClipboardPreviewProps> = ({ item, actions }) =>
         </div>
       )}
       <div className="relative flex-1 min-h-0">
-        <div className="pointer-events-none absolute inset-x-4 bottom-4 z-10 flex flex-col items-center gap-2">
-          <div className="pointer-events-auto flex max-w-full items-center justify-center gap-1 rounded-full border border-border/60 bg-card/90 p-1 backdrop-blur-xl">
-            <div className="flex min-w-0 max-w-full items-center gap-1">
-              <ClipboardSendMenu
-                key={item.id}
-                entryId={item.id}
-                disabled={
-                  item.isUnavailable || (delivery !== null && delivery.source.tag !== 'local')
-                }
-              />
-              {actions}
+        {actions && (
+          <div className="pointer-events-none absolute inset-x-4 bottom-4 z-10 flex flex-col items-center gap-2">
+            <div className="pointer-events-auto flex max-w-full items-center justify-center gap-1 rounded-full border border-border/60 bg-card/90 p-1 backdrop-blur-xl">
+              <div className="flex min-w-0 max-w-full items-center gap-1">{actions(delivery)}</div>
             </div>
           </div>
-        </div>
+        )}
         {fillsParent ? (
           <div className="absolute inset-0">{content}</div>
         ) : (

--- a/src/components/clipboard/__tests__/ClipboardActionBar.test.tsx
+++ b/src/components/clipboard/__tests__/ClipboardActionBar.test.tsx
@@ -1,7 +1,19 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
+import type { EntrySourceView } from '@/api/tauri-command/clipboard_delivery'
 import ClipboardActionBar from '@/components/clipboard/ClipboardActionBar'
+import type { DisplayClipboardItem } from '@/lib/clipboard-entry'
+
+const item: DisplayClipboardItem = { id: 'entry-1', type: 'text', activeTime: 0, content: null }
+
+vi.mock('@/components/clipboard/ClipboardSendMenu', () => ({
+  default: ({ entryId, disabled }: { entryId: string; disabled?: boolean }) => (
+    <button type="button" disabled={disabled} data-entry-id={entryId}>
+      Send
+    </button>
+  ),
+}))
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
@@ -10,15 +22,46 @@ vi.mock('react-i18next', () => ({
 }))
 
 describe('ClipboardActionBar', () => {
+  it.each<{ source: EntrySourceView; unavailable: boolean; disabled: boolean }>([
+    { source: { tag: 'local' }, unavailable: false, disabled: false },
+    { source: { tag: 'local' }, unavailable: true, disabled: true },
+    {
+      source: { tag: 'remote', deviceId: 'peer-1', deviceName: null },
+      unavailable: false,
+      disabled: true,
+    },
+    { source: { tag: 'historical' }, unavailable: false, disabled: true },
+  ])(
+    'preserves send availability for $source.tag, unavailable=$unavailable',
+    ({ source, unavailable, disabled }) => {
+      render(
+        <ClipboardActionBar
+          item={{ ...item, isUnavailable: unavailable }}
+          delivery={{ entryId: item.id, source, deliveries: [] }}
+          copySuccess={false}
+          onCopy={vi.fn()}
+          onDelete={vi.fn()}
+          onToggleFavorite={vi.fn()}
+        />
+      )
+
+      expect(screen.getAllByRole('button')).toHaveLength(4)
+      const send = screen.getByRole('button', { name: 'Send' })
+      expect(send).toHaveAttribute('data-entry-id', item.id)
+      if (disabled) expect(send).toBeDisabled()
+      else expect(send).toBeEnabled()
+    }
+  )
+
   it('renders favorite action and toggles the active item', async () => {
     const user = userEvent.setup()
     const onToggleFavorite = vi.fn()
 
     render(
       <ClipboardActionBar
-        hasActiveItem
+        item={item}
+        delivery={null}
         copySuccess={false}
-        isFavorited={false}
         onCopy={vi.fn()}
         onDelete={vi.fn()}
         onToggleFavorite={onToggleFavorite}
@@ -38,9 +81,9 @@ describe('ClipboardActionBar', () => {
   it('labels an already favorited item as unfavorite', () => {
     render(
       <ClipboardActionBar
-        hasActiveItem
+        item={{ ...item, isFavorited: true }}
+        delivery={null}
         copySuccess={false}
-        isFavorited
         onCopy={vi.fn()}
         onDelete={vi.fn()}
         onToggleFavorite={vi.fn()}
@@ -56,9 +99,9 @@ describe('ClipboardActionBar', () => {
 it('reveals labels on hover and keeps them visible while keyboard focus stays inside', async () => {
   render(
     <ClipboardActionBar
-      hasActiveItem
+      item={item}
+      delivery={null}
       copySuccess={false}
-      isFavorited={false}
       onCopy={vi.fn()}
       onDelete={vi.fn()}
       onToggleFavorite={vi.fn()}
@@ -80,9 +123,9 @@ it('reveals labels on hover and keeps them visible while keyboard focus stays in
 it('expands only the pointed action', async () => {
   render(
     <ClipboardActionBar
-      hasActiveItem
+      item={item}
+      delivery={null}
       copySuccess={false}
-      isFavorited={false}
       onCopy={vi.fn()}
       onDelete={vi.fn()}
       onToggleFavorite={vi.fn()}
@@ -101,9 +144,9 @@ it('expands only the pointed action', async () => {
 it('does not attach native tooltips to actions', () => {
   render(
     <ClipboardActionBar
-      hasActiveItem
+      item={item}
+      delivery={null}
       copySuccess={false}
-      isFavorited={false}
       onCopy={vi.fn()}
       onDelete={vi.fn()}
       onToggleFavorite={vi.fn()}

--- a/src/components/clipboard/__tests__/ClipboardPreview.test.tsx
+++ b/src/components/clipboard/__tests__/ClipboardPreview.test.tsx
@@ -4,8 +4,6 @@ import ClipboardPreview from '@/components/clipboard/ClipboardPreview'
 import type { DisplayClipboardItem } from '@/lib/clipboard-entry'
 import type { ClipboardPreviewData } from '@/lib/clipboard-preview-cache'
 
-vi.mock('@/components/clipboard/ClipboardSendMenu', () => ({ default: () => null }))
-
 vi.mock('@tauri-apps/api/core', () => ({
   convertFileSrc: vi.fn((path: string) => `asset://localhost/${encodeURIComponent(path)}`),
 }))
@@ -82,6 +80,23 @@ describe('ClipboardPreview', () => {
       sizeBytes: 2048,
       imageBlobPath: '/clipboard/blobs/blob-image',
     }
+  })
+
+  it('omits the action bar when the caller supplies no actions', async () => {
+    render(<ClipboardPreview item={createImageFileItem()} />)
+
+    await screen.findByRole('img', { name: 'screenshot.png' })
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+    expect(screen.getByTestId('clipboard-detail').querySelector('.bottom-4')).toBeNull()
+  })
+
+  it('renders caller actions using the current delivery information', async () => {
+    const actions = vi.fn(() => <button type="button">Caller action</button>)
+    render(<ClipboardPreview item={createImageFileItem()} actions={actions} />)
+
+    await screen.findByRole('img', { name: 'screenshot.png' })
+    expect(screen.getByRole('button', { name: 'Caller action' })).toBeInTheDocument()
+    expect(actions).toHaveBeenCalledWith(null)
   })
 
   it('renders a direct image preview with filename for image files', async () => {

--- a/src/pages/HistoryPage.tsx
+++ b/src/pages/HistoryPage.tsx
@@ -205,11 +205,11 @@ const HistoryPage: React.FC = () => {
             >
               <ClipboardPreview
                 item={c.selectedItem}
-                actions={
+                actions={delivery => (
                   <ClipboardActionBar
-                    hasActiveItem={c.selectedItem !== null}
+                    item={c.selectedItem}
+                    delivery={delivery}
                     copySuccess={c.copySuccessId !== null && c.copySuccessId === c.selectedId}
-                    isFavorited={c.selectedItem?.isFavorited === true}
                     onCopy={() => {
                       if (c.selectedId) c.handleCopy(c.selectedId)
                     }}
@@ -225,7 +225,7 @@ const HistoryPage: React.FC = () => {
                       if (c.selectedId) c.requestDelete(c.selectedId)
                     }}
                   />
-                }
+                )}
               />
             </m.div>
           </ResizablePanel>


### PR DESCRIPTION
## Summary

Remove the send button and empty action bar from the Quick Panel preview. The main-window preview retains Send, Copy, Favorite, and Delete, all owned by `ClipboardActionBar`.

The shared preview renders caller-provided actions using its existing delivery information. Send-menu behavior and availability rules remain unchanged, including disabling unavailable and non-local entries. No extra visibility flag or duplicate delivery request is needed.

Existing Quick Panel documentation describes sending through the unchanged context menu, so no documentation update is required. No telemetry or Rust logging changes are involved.

## Validation

- 66 focused tests passed across the action bar, send menu, preview, History page, Quick Panel, and typography.
- `bun run build` passed, including the macOS compatibility check.
- React Doctor reported no issues in the changed files.
- Native-window visual verification was not performed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Send option to clipboard action controls.
  - The Send option is available for locally delivered clipboard items and disabled when no item is selected or when viewing remote or historical content.
  - Clipboard previews can now display actions based on the current delivery context.

- **Bug Fixes**
  - Improved action-bar state handling so copy, favorite, delete, and send controls reflect the selected clipboard item accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->